### PR TITLE
docs: update slack-bridge README with current features

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -1,89 +1,108 @@
-# slack-bridge
+# slack-bridge (Pinet)
 
-Pi extension that turns the agent into a Slack assistant app. Users open the
-assistant from Slack's sidebar, type a message, and the pi agent responds — no
+Pi extension that turns the agent into a Slack assistant app. Users open
+Pinet from Slack's sidebar, type a message, and the pi agent responds — no
 channel setup required.
 
 ## How it works
 
 ```
-User opens assistant in Slack
+User opens Pinet in Slack
   └─► types a message
-        └─► "is thinking…" status shown
-              └─► forwarded to pi agent
+        └─► 👀 reaction appears
+              └─► message queued for pi agent
                     └─► agent responds via slack_send
-                          └─► reply appears in Slack thread
+                          └─► 👀 removed, reply appears in thread
 ```
 
-- **`slack_send`** — reply in an assistant thread (or start a new one)
-- **`slack_read`** — read messages from a thread
-- **Socket Mode** — real-time bidirectional via WebSocket
-- **Suggested prompts** — shown when a user opens a new thread
-- **Thinking status** — shown while the agent works, cleared on reply
+**Hybrid inbox model:** Messages queue up while the agent is busy. When the
+agent finishes its current task, it automatically drains the inbox and responds.
+If the agent is idle, incoming messages are processed immediately.
+
+## Tools
+
+| Tool                            | Description                     |
+| ------------------------------- | ------------------------------- |
+| `slack_send(text, thread_ts?)`  | Reply in a thread or start new  |
+| `slack_read(thread_ts, limit?)` | Read thread messages            |
+| `slack_inbox()`                 | Check pending messages manually |
+
+## Features
+
+- **Slack Assistant** — appears in Slack's sidebar, native conversation UI
+- **Queued inbox** — messages don't interrupt the agent mid-task
+- **Auto-drain** — inbox processed when agent is idle or finishes a task
+- **Reactions** — 👀 on receive, removed on reply
+- **Suggested prompts** — shown when a user opens a new conversation
+- **Multi-user** — handles concurrent conversations from different users
+- **Channel awareness** — notified when added to channels
 
 ## Setup
 
 ### 1. Create a Slack App
 
-https://api.slack.com/apps → **Create New App** → **From scratch**.
+https://api.slack.com/apps → **Create New App** → **From a manifest** →
+paste `manifest.yaml` from this directory.
 
-### 2. Enable the Assistant
+### 2. Generate tokens
 
-**Agents & Assistants** → toggle on.
+- **App-Level Token:** Basic Information → App-Level Tokens → Generate
+  with `connections:write` scope → copy the `xapp-...` token
+- **Bot Token:** OAuth & Permissions → Install to Workspace → copy the
+  `xoxb-...` token
 
-### 3. Enable Socket Mode
-
-**Socket Mode** → Enable.
-**Basic Information → App-Level Tokens** → Generate one with `connections:write` scope.
-
-### 4. Bot token scopes
-
-**OAuth & Permissions → Bot Token Scopes:**
-
-| Scope             | Why                           |
-| ----------------- | ----------------------------- |
-| `assistant:write` | Set status, suggested prompts |
-| `chat:write`      | Send messages                 |
-| `im:history`      | Read DM messages              |
-| `im:read`         | Receive DM events             |
-| `users:read`      | Resolve user names            |
-
-### 5. Event subscriptions
-
-**Event Subscriptions** → Enable → **Subscribe to bot events:**
-
-- `assistant_thread_started`
-- `assistant_thread_context_changed`
-- `message.im`
-
-### 6. Install to workspace
-
-**Install App** → Install to your workspace.
-
-### 7. Set env vars
+### 3. Set env vars
 
 ```bash
 export SLACK_BOT_TOKEN="xoxb-..."   # Bot User OAuth Token
 export SLACK_APP_TOKEN="xapp-..."   # App-Level Token (Socket Mode)
 ```
 
-That's it. No channel config — the assistant appears in Slack's sidebar automatically.
+Use direnv for convenience:
 
-## Usage
+```bash
+# .env.personal.local (gitignored)
+SLACK_BOT_TOKEN="xoxb-..."
+SLACK_APP_TOKEN="xapp-..."
 
-The agent gets two tools:
-
+# .envrc
+dotenv_if_exists .env.personal.local
 ```
-slack_send(text, thread_ts?)   — reply in a thread or start new
-slack_read(thread_ts, limit?)  — read thread messages
+
+### 4. Install extension
+
+```bash
+ln -s /path/to/extensions/slack-bridge ~/.pi/agent/extensions/slack-bridge
 ```
 
-When a user messages the assistant, the message is forwarded to the pi session.
-The agent responds by calling `slack_send` with the `thread_ts` from the
-incoming message.
+Then `/reload` in pi.
 
-`/slack` in pi shows connection status.
+That's it — Pinet appears in Slack's sidebar automatically.
 
-## Zero dependencies
+## Manifest
 
-Native `fetch` + `WebSocket` (Node 22+). No npm packages.
+The `manifest.yaml` includes all required scopes and events. Use it when
+creating the app (**From a manifest**) or paste it into **App Manifest** in
+settings.
+
+Current scopes: `app_mentions:read`, `assistant:write`, `canvases:read`,
+`canvases:write`, `channels:history`, `channels:read`, `chat:write`,
+`groups:history`, `groups:read`, `im:history`, `im:read`, `im:write`,
+`reactions:write`, `users:read`
+
+Current events: `app_mention`, `assistant_thread_started`,
+`assistant_thread_context_changed`, `member_joined_channel`,
+`message.channels`, `message.groups`, `message.im`
+
+## Architecture
+
+- **Socket Mode** — outbound WebSocket from pi to Slack (no public URL needed)
+- **Zero npm deps** — native `fetch` + `WebSocket` (Node 22+)
+- **Hybrid inbox** — queue when busy, auto-process when idle
+- **Reactions** — 👀 as lightweight "thinking" indicator (no chat lock)
+
+## Status
+
+Use `/slack` in pi to check connection status, active threads, and DM channel.
+
+Footer shows `slack ✦` when connected, with unread count (e.g. `slack ✦ 3`).


### PR DESCRIPTION
Updates the README to reflect the current state of the extension:

- Renamed to Pinet
- Hybrid inbox model (queue when busy, auto-drain when idle)
- Reactions instead of thinking status
- Multi-user support
- Channel awareness
- Manifest-based setup instructions
- direnv setup
- Architecture overview