### PR TITLE
feat: user allowlist security guardrails (#14)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -56,6 +56,7 @@ paste `manifest.yaml` from this directory.
 ```bash
 export SLACK_BOT_TOKEN="xoxb-..."   # Bot User OAuth Token
 export SLACK_APP_TOKEN="xapp-..."   # App-Level Token (Socket Mode)
+export SLACK_ALLOWED_USERS="U01ABC,U02DEF"  # Optional: comma-separated Slack user IDs
 ```
 
 Use direnv for convenience:
@@ -64,6 +65,7 @@ Use direnv for convenience:
 # .env.personal.local (gitignored)
 SLACK_BOT_TOKEN="xoxb-..."
 SLACK_APP_TOKEN="xapp-..."
+SLACK_ALLOWED_USERS="U01ABC,U02DEF"
 
 # .envrc
 dotenv_if_exists .env.personal.local
@@ -93,6 +95,18 @@ Current scopes: `app_mentions:read`, `assistant:write`, `canvases:read`,
 Current events: `app_mention`, `assistant_thread_started`,
 `assistant_thread_context_changed`, `member_joined_channel`,
 `message.channels`, `message.groups`, `message.im`
+
+## Security
+
+Set `SLACK_ALLOWED_USERS` to a comma-separated list of Slack user IDs to
+restrict who can interact with the agent. Only listed users' messages are
+queued; others receive a polite rejection reply.
+
+If the variable is not set, all users are allowed (backward compatible).
+
+Find user IDs in Slack: click a user's profile → **More** → **Copy member ID**.
+
+The `/slack` command shows the current allowlist.
 
 ## Architecture
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -70,6 +70,18 @@ export default function (pi: ExtensionAPI) {
 
   if (!botToken || !appToken) return;
 
+  const allowedUsers: Set<string> | null = process.env.SLACK_ALLOWED_USERS
+    ? new Set(
+        process.env.SLACK_ALLOWED_USERS.split(",")
+          .map((id) => id.trim())
+          .filter(Boolean),
+      )
+    : null;
+
+  function isUserAllowed(userId: string): boolean {
+    return allowedUsers === null || allowedUsers.has(userId);
+  }
+
   interface ThreadInfo {
     channelId: string;
     threadTs: string;
@@ -312,6 +324,16 @@ export default function (pi: ExtensionAPI) {
 
     const effectiveTs = threadTs ?? (evt.ts as string);
 
+    // ── User allowlist check ──
+    if (!isUserAllowed(user)) {
+      await slack("chat.postMessage", botToken!, {
+        channel,
+        thread_ts: effectiveTs,
+        text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
+      });
+      return;
+    }
+
     // track if new
     if (!threads.has(effectiveTs)) {
       threads.set(effectiveTs, { channelId: channel, threadTs: effectiveTs, userId: user });
@@ -528,12 +550,16 @@ export default function (pi: ExtensionAPI) {
     description: "Show Slack assistant status",
     handler: async (_args, ctx) => {
       const socket = ws?.readyState === WebSocket.OPEN ? "connected" : "disconnected";
+      const allowlistInfo = allowedUsers
+        ? `Allowed users: ${[...allowedUsers].join(", ")}`
+        : "Allowed users: all (no allowlist set)";
       ctx.ui.notify(
         [
           `Bot: ${botUserId ?? "unknown"}`,
           `Socket Mode: ${socket}`,
           `Threads: ${threads.size}`,
           `DM channel: ${lastDmChannel ?? "none yet"}`,
+          allowlistInfo,
         ].join("\n"),
         "info",
       );


### PR DESCRIPTION
Closes #14. Adds SLACK_ALLOWED_USERS env var — comma-separated Slack user IDs. Non-allowed users get a polite rejection. Backward compatible (no env var = allow all).