### PR TITLE
feat: move config from env vars to settings.json (#22)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -56,7 +56,6 @@ paste `manifest.yaml` from this directory.
 ```bash
 export SLACK_BOT_TOKEN="xoxb-..."   # Bot User OAuth Token
 export SLACK_APP_TOKEN="xapp-..."   # App-Level Token (Socket Mode)
-export SLACK_ALLOWED_USERS="U01ABC,U02DEF"  # Optional: comma-separated Slack user IDs
 ```
 
 Use direnv for convenience:
@@ -65,11 +64,13 @@ Use direnv for convenience:
 # .env.personal.local (gitignored)
 SLACK_BOT_TOKEN="xoxb-..."
 SLACK_APP_TOKEN="xapp-..."
-SLACK_ALLOWED_USERS="U01ABC,U02DEF"
 
 # .envrc
 dotenv_if_exists .env.personal.local
 ```
+
+> **Note:** The `SLACK_ALLOWED_USERS` env var still works as a fallback for
+> `allowedUsers`, but `settings.json` is the preferred approach (see step 5).
 
 ### 4. Install extension
 
@@ -78,6 +79,31 @@ ln -s /path/to/extensions/slack-bridge ~/.pi/agent/extensions/slack-bridge
 ```
 
 Then `/reload` in pi.
+
+### 5. Configure (optional)
+
+Add a `"slack-bridge"` key to `~/.pi/agent/settings.json`:
+
+```json
+{
+  "slack-bridge": {
+    "allowedUsers": ["U01ABC", "U02DEF"],
+    "defaultChannel": "C0APL58LB1R",
+    "suggestedPrompts": [
+      { "title": "Status", "message": "What are you working on?" },
+      { "title": "Help", "message": "I need help with something" }
+    ]
+  }
+}
+```
+
+| Key                | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `allowedUsers`     | Slack user IDs allowed to interact with the agent               |
+| `defaultChannel`   | Default channel for `slack_post_channel` when none is specified |
+| `suggestedPrompts` | Prompts shown when a user opens a new assistant thread          |
+
+Tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`) remain env vars only.
 
 That's it — Pinet appears in Slack's sidebar automatically.
 
@@ -98,11 +124,12 @@ Current events: `app_mention`, `assistant_thread_started`,
 
 ## Security
 
-Set `SLACK_ALLOWED_USERS` to a comma-separated list of Slack user IDs to
-restrict who can interact with the agent. Only listed users' messages are
-queued; others receive a polite rejection reply.
+Set `allowedUsers` in `settings.json` (preferred) or the `SLACK_ALLOWED_USERS`
+env var (fallback) to restrict who can interact with the agent. Only listed
+users' messages are queued; others receive a polite rejection reply.
 
-If the variable is not set, all users are allowed (backward compatible).
+`settings.json` takes priority over the env var. If neither is set, all users
+are allowed (backward compatible).
 
 Find user IDs in Slack: click a user's profile → **More** → **Copy member ID**.
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
@@ -62,6 +65,25 @@ async function slack(
   return data;
 }
 
+// ─── Settings ────────────────────────────────────────────
+
+interface SlackBridgeSettings {
+  allowedUsers?: string[];
+  defaultChannel?: string;
+  suggestedPrompts?: { title: string; message: string }[];
+}
+
+function loadSettings(): SlackBridgeSettings {
+  const settingsPath = path.join(os.homedir(), ".pi", "agent", "settings.json");
+  try {
+    const content = fs.readFileSync(settingsPath, "utf-8");
+    const parsed = JSON.parse(content);
+    return (parsed["slack-bridge"] as SlackBridgeSettings) ?? {};
+  } catch {
+    return {};
+  }
+}
+
 // ─── Extension ───────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
@@ -70,13 +92,22 @@ export default function (pi: ExtensionAPI) {
 
   if (!botToken || !appToken) return;
 
-  const allowedUsers: Set<string> | null = process.env.SLACK_ALLOWED_USERS
-    ? new Set(
+  const settings = loadSettings();
+
+  // allowedUsers: settings.json takes priority, env var as fallback
+  const allowedUsers: Set<string> | null = (() => {
+    if (settings.allowedUsers && settings.allowedUsers.length > 0) {
+      return new Set(settings.allowedUsers);
+    }
+    if (process.env.SLACK_ALLOWED_USERS) {
+      return new Set(
         process.env.SLACK_ALLOWED_USERS.split(",")
           .map((id) => id.trim())
           .filter(Boolean),
-      )
-    : null;
+      );
+    }
+    return null;
+  })();
 
   function isUserAllowed(userId: string): boolean {
     return allowedUsers === null || allowedUsers.has(userId);
@@ -242,15 +273,16 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function setSuggestedPrompts(channelId: string, threadTs: string): Promise<void> {
+    const prompts = settings.suggestedPrompts ?? [
+      { title: "Status", message: `Hey ${agentName}, what are you working on right now?` },
+      { title: "Help", message: `${agentName}, I need help with something in the codebase` },
+      { title: "Review", message: `${agentName}, summarise the recent changes` },
+    ];
     try {
       await slack("assistant.threads.setSuggestedPrompts", botToken!, {
         channel_id: channelId,
         thread_ts: threadTs,
-        prompts: [
-          { title: "Status", message: `Hey ${agentName}, what are you working on right now?` },
-          { title: "Help", message: `${agentName}, I need help with something in the codebase` },
-          { title: "Review", message: `${agentName}, summarise the recent changes` },
-        ],
+        prompts,
       });
     } catch {
       /* non-critical */
@@ -731,15 +763,24 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "slack_post_channel",
     label: "Slack Post Channel",
-    description: "Post a message to a Slack channel (by name or ID), optionally in a thread.",
+    description:
+      "Post a message to a Slack channel (by name or ID), optionally in a thread. Uses defaultChannel from settings if channel is omitted.",
     promptSnippet: "Post a message to a Slack channel.",
     parameters: Type.Object({
-      channel: Type.String({ description: "Channel name or ID" }),
+      channel: Type.Optional(
+        Type.String({
+          description: "Channel name or ID (uses defaultChannel from settings if omitted)",
+        }),
+      ),
       text: Type.String({ description: "Message text (Slack markdown)" }),
       thread_ts: Type.Optional(Type.String({ description: "Thread timestamp to reply in" })),
     }),
     async execute(_id, params) {
-      const channelId = await resolveChannel(params.channel);
+      const channelInput = params.channel ?? settings.defaultChannel;
+      if (!channelInput) {
+        throw new Error("No channel specified and no defaultChannel configured in settings.json.");
+      }
+      const channelId = await resolveChannel(channelInput);
       const body: Record<string, unknown> = {
         channel: channelId,
         text: params.text,
@@ -754,8 +795,8 @@ export default function (pi: ExtensionAPI) {
           {
             type: "text",
             text: params.thread_ts
-              ? `Replied in thread ${params.thread_ts} in channel ${params.channel}.`
-              : `Posted to #${params.channel} (ts: ${ts}).`,
+              ? `Replied in thread ${params.thread_ts} in channel ${channelInput}.`
+              : `Posted to #${channelInput} (ts: ${ts}).`,
           },
         ],
         details: { ts, channel: channelId },
@@ -821,6 +862,9 @@ export default function (pi: ExtensionAPI) {
       const allowlistInfo = allowedUsers
         ? `Allowed users: ${[...allowedUsers].join(", ")}`
         : "Allowed users: all (no allowlist set)";
+      const defaultChInfo = settings.defaultChannel
+        ? `Default channel: ${settings.defaultChannel}`
+        : "Default channel: none";
       ctx.ui.notify(
         [
           `Agent: ${agentName}`,
@@ -829,6 +873,7 @@ export default function (pi: ExtensionAPI) {
           `Threads: ${threads.size} (${ownedCount} owned by ${agentName})`,
           `DM channel: ${lastDmChannel ?? "none yet"}`,
           allowlistInfo,
+          defaultChInfo,
         ].join("\n"),
         "info",
       );


### PR DESCRIPTION
Closes #22. Reads config from settings.json under slack-bridge key. Supports allowedUsers, defaultChannel, suggestedPrompts. Env vars still work as fallback. Tokens stay as env vars.