### PR TITLE
fix: outbound messages establish thread ownership (#45)

### DIFF
--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -176,6 +176,15 @@ export class BrokerClient {
     await this.request("send", { threadId, body: text, ...(metadata ? { metadata } : {}) });
   }
 
+  // ─── Thread ownership ─────────────────────────────────
+
+  async claimThread(threadId: string, channel?: string): Promise<{ claimed: boolean }> {
+    const params: Record<string, unknown> = { threadId };
+    if (channel) params.channel = channel;
+    const result = (await this.request("thread.claim", params)) as { claimed: boolean };
+    return result;
+  }
+
   // ─── Queries ─────────────────────────────────────────
 
   async listThreads(): Promise<ThreadInfo[]> {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -152,6 +152,149 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(result.method).toBe("conversations.history");
     expect((result.echo as Record<string, unknown>).channel).toBe("C123");
   });
+
+  it("thread.claim claims ownership for the calling agent", async () => {
+    await client.register("claimer-agent", "🏷️");
+
+    const result = await client.claimThread("t-claim-rpc");
+    expect(result.claimed).toBe(true);
+
+    const thread = db.getThread("t-claim-rpc");
+    expect(thread).not.toBeNull();
+    expect(thread!.ownerAgent).toBeDefined();
+  });
+
+  it("thread.claim rejects when another agent already owns", async () => {
+    const reg1 = await client.register("first-agent", "1️⃣");
+
+    // First agent claims
+    const first = await client.claimThread("t-contested");
+    expect(first.claimed).toBe(true);
+
+    // Second agent tries to claim the same thread
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    await client2.register("second-agent", "2️⃣");
+
+    const second = await client2.claimThread("t-contested");
+    expect(second.claimed).toBe(false);
+
+    // Original owner unchanged
+    const thread = db.getThread("t-contested");
+    expect(thread!.ownerAgent).toBe(reg1.agentId);
+
+    client2.disconnect();
+  });
+
+  it("thread.claim with channel stores channel on new thread", async () => {
+    await client.register("ch-claimer", "📺");
+
+    await client.claimThread("t-with-channel", "C-TEST-123");
+
+    const thread = db.getThread("t-with-channel");
+    expect(thread).not.toBeNull();
+    expect(thread!.channel).toBe("C-TEST-123");
+  });
+
+  it("slack.proxy chat.postMessage auto-claims thread for calling agent", async () => {
+    client.disconnect();
+    await server.stop();
+
+    const slackProxy = async (_method: string, params: Record<string, unknown>) => {
+      // Simulate Slack chat.postMessage response
+      return {
+        ok: true,
+        ts: "new-msg-ts",
+        channel: params.channel,
+        message: { ts: "new-msg-ts", text: params.text },
+      };
+    };
+
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, slackProxy);
+    await server.start();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    client = new BrokerClient({ host: info.host, port: info.port });
+    await client.connect();
+
+    const reg = await client.register("auto-claimer", "🤖");
+
+    // Post a new message (no thread_ts) — the response ts becomes the thread
+    await client.slackProxy("chat.postMessage", {
+      channel: "C-AUTO",
+      text: "starting a thread",
+    });
+
+    const thread = db.getThread("new-msg-ts");
+    expect(thread).not.toBeNull();
+    expect(thread!.ownerAgent).toBe(reg.agentId);
+  });
+
+  it("slack.proxy chat.postMessage with thread_ts claims the existing thread", async () => {
+    client.disconnect();
+    await server.stop();
+
+    const slackProxy = async (_method: string, params: Record<string, unknown>) => {
+      return {
+        ok: true,
+        ts: "reply-ts",
+        channel: params.channel,
+        message: { ts: "reply-ts", text: params.text },
+      };
+    };
+
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, slackProxy);
+    await server.start();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    client = new BrokerClient({ host: info.host, port: info.port });
+    await client.connect();
+
+    const reg = await client.register("thread-replier", "💬");
+
+    // Reply to an existing thread
+    await client.slackProxy("chat.postMessage", {
+      channel: "C-REPLY",
+      text: "replying here",
+      thread_ts: "existing-thread-ts",
+    });
+
+    // Should claim the parent thread, not the reply ts
+    const thread = db.getThread("existing-thread-ts");
+    expect(thread).not.toBeNull();
+    expect(thread!.ownerAgent).toBe(reg.agentId);
+
+    // The reply ts itself should NOT create a separate thread
+    expect(db.getThread("reply-ts")).toBeNull();
+  });
+
+  it("slack.proxy non-postMessage methods do not claim threads", async () => {
+    client.disconnect();
+    await server.stop();
+
+    const slackProxy = async (method: string, _params: Record<string, unknown>) => {
+      return { ok: true, method, ts: "some-ts" };
+    };
+
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, slackProxy);
+    await server.start();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    client = new BrokerClient({ host: info.host, port: info.port });
+    await client.connect();
+
+    await client.register("readonly-agent", "👀");
+
+    await client.slackProxy("conversations.history", { channel: "C1" });
+
+    // No thread should be created
+    expect(db.getThread("some-ts")).toBeNull();
+  });
 });
 
 // ─── Integration: router with real DB ────────────────────
@@ -301,5 +444,37 @@ describe("broker integration — router with real DB", () => {
 
   it("getChannelAssignment returns null (unconfigured)", () => {
     expect(db.getChannelAssignment("C123")).toBeNull();
+  });
+
+  it("updateThread upserts when thread does not exist", () => {
+    // Thread does not exist yet — updateThread should create it
+    db.updateThread("t-upsert", { ownerAgent: "agent-1", channel: "C-UPSERT" });
+
+    const thread = db.getThread("t-upsert");
+    expect(thread).not.toBeNull();
+    expect(thread!.ownerAgent).toBe("agent-1");
+    expect(thread!.channel).toBe("C-UPSERT");
+    expect(thread!.source).toBe("slack");
+  });
+
+  it("updateThread upsert defaults source to slack and channel to empty", () => {
+    db.updateThread("t-upsert-defaults", { ownerAgent: "agent-2" });
+
+    const thread = db.getThread("t-upsert-defaults");
+    expect(thread).not.toBeNull();
+    expect(thread!.source).toBe("slack");
+    expect(thread!.channel).toBe("");
+    expect(thread!.ownerAgent).toBe("agent-2");
+  });
+
+  it("updateThread still works normally for existing threads", () => {
+    db.createThread("t-existing", "slack", "C1", "agent-x");
+
+    db.updateThread("t-existing", { ownerAgent: "agent-y" });
+
+    const thread = db.getThread("t-existing");
+    expect(thread!.ownerAgent).toBe("agent-y");
+    // channel should be unchanged
+    expect(thread!.channel).toBe("C1");
   });
 });

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -39,9 +39,20 @@ class StubBrokerDBInterface implements BrokerDBInterface {
 
   updateThread(threadId: string, updates: Partial<ThreadInfo>): void {
     const existing = this.threads.get(threadId);
-    if (existing) {
-      this.threads.set(threadId, { ...existing, ...updates });
+    if (!existing) {
+      // Upsert: create with defaults
+      const now = new Date().toISOString();
+      this.threads.set(threadId, {
+        threadId,
+        source: updates.source ?? "slack",
+        channel: updates.channel ?? "",
+        ownerAgent: updates.ownerAgent !== undefined ? updates.ownerAgent : null,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return;
     }
+    this.threads.set(threadId, { ...existing, ...updates });
   }
 
   queueMessage(agentId: string, message: InboundMessage): void {
@@ -283,6 +294,39 @@ describe("MessageRouter — getThreadOwner", () => {
 
   it("returns null for nonexistent thread", () => {
     expect(router.getThreadOwner("t-unknown")).toBeNull();
+  });
+});
+
+describe("MessageRouter — claimThread with upsert", () => {
+  let db: StubBrokerDBInterface;
+  let router: MessageRouter;
+
+  beforeEach(() => {
+    db = new StubBrokerDBInterface();
+    router = new MessageRouter(db);
+  });
+
+  it("updateThread upserts a non-existent thread", () => {
+    db.updateThread("t-new", { ownerAgent: "a1" });
+
+    const thread = db.threads.get("t-new");
+    expect(thread).toBeDefined();
+    expect(thread?.ownerAgent).toBe("a1");
+    expect(thread?.source).toBe("slack");
+  });
+
+  it("updateThread upsert preserves provided channel", () => {
+    db.updateThread("t-new", { ownerAgent: "a1", channel: "C999" });
+
+    const thread = db.threads.get("t-new");
+    expect(thread?.channel).toBe("C999");
+  });
+
+  it("claimThread works via updateThread upsert path", () => {
+    // Thread doesn't exist — claimThread creates it
+    const claimed = router.claimThread("t-fresh", "a1");
+    expect(claimed).toBe(true);
+    expect(db.threads.get("t-fresh")?.ownerAgent).toBe("a1");
   });
 });
 

--- a/slack-bridge/broker/router.ts
+++ b/slack-bridge/broker/router.ts
@@ -84,9 +84,10 @@ export class MessageRouter {
 
   /**
    * Claim a thread for an agent (first-responder-wins).
+   * Optionally provide a channel to set when creating a new thread.
    * Returns true if the claim succeeded, false if another agent already owns it.
    */
-  claimThread(threadId: string, agentId: string): boolean {
+  claimThread(threadId: string, agentId: string, channel?: string): boolean {
     const existing = this.db.getThread(threadId);
 
     if (existing) {
@@ -104,7 +105,7 @@ export class MessageRouter {
     this.db.createThread({
       threadId,
       source: "slack",
-      channel: "",
+      channel: channel ?? "",
       ownerAgent: agentId,
       createdAt: now,
       updatedAt: now,

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -248,6 +248,25 @@ export class BrokerDB implements BrokerDBInterface {
 
   updateThread(threadId: string, updates: Partial<ThreadInfo>): void {
     const db = this.getDb();
+    const now = new Date().toISOString();
+
+    // Upsert: create the thread if it doesn't exist yet
+    const existing = this.getThread(threadId);
+    if (!existing) {
+      db.prepare(
+        `INSERT INTO threads (thread_id, source, channel, owner_agent, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(
+        threadId,
+        updates.source ?? "slack",
+        updates.channel ?? "",
+        updates.ownerAgent !== undefined ? updates.ownerAgent : null,
+        now,
+        now,
+      );
+      return;
+    }
+
     const sets: string[] = [];
     const values: (string | null)[] = [];
 
@@ -265,7 +284,7 @@ export class BrokerDB implements BrokerDBInterface {
     }
 
     sets.push("updated_at = ?");
-    values.push(new Date().toISOString());
+    values.push(now);
     values.push(threadId);
 
     db.prepare(`UPDATE threads SET ${sets.join(", ")} WHERE thread_id = ?`).run(...values);

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import * as crypto from "node:crypto";
 import type { BrokerDB } from "./schema.js";
+import { MessageRouter } from "./router.js";
 import type { JsonRpcRequest, JsonRpcResponse, JsonRpcError } from "./types.js";
 import {
   RPC_PARSE_ERROR,
@@ -61,12 +62,14 @@ export class BrokerSocketServer {
   private server: net.Server | null = null;
   private readonly target: ListenTarget;
   private readonly db: BrokerDB;
+  private readonly router: MessageRouter;
   private readonly slackProxyFn: SlackProxyFn | null;
   private readonly connections = new Map<net.Socket, ConnectionState>();
   private assignedPort: number | null = null;
 
   constructor(db: BrokerDB, target?: ListenTarget | string, slackProxyFn?: SlackProxyFn) {
     this.db = db;
+    this.router = new MessageRouter(db);
     this.slackProxyFn = slackProxyFn ?? null;
     if (typeof target === "string") {
       this.target = { type: "unix", path: target };
@@ -255,8 +258,10 @@ export class BrokerSocketServer {
           return this.handleThreadsList(req, state);
         case "agents.list":
           return this.handleAgentsList(req);
+        case "thread.claim":
+          return this.handleThreadClaim(req, state);
         case "slack.proxy":
-          return await this.handleSlackProxy(req);
+          return await this.handleSlackProxy(req, state);
         default:
           return rpcError(req.id, RPC_METHOD_NOT_FOUND, `Unknown method: ${req.method}`);
       }
@@ -387,9 +392,30 @@ export class BrokerSocketServer {
     return rpcOk(req.id, agents);
   }
 
+  // ─── Thread claim handler ─────────────────────────────
+
+  private handleThreadClaim(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
+    const params = req.params ?? {};
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    if (!threadId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "threadId is required");
+    }
+
+    const channel = typeof params.channel === "string" ? params.channel : undefined;
+    const claimed = this.router.claimThread(threadId, state.agentId, channel);
+    return rpcOk(req.id, { claimed });
+  }
+
   // ─── Slack proxy handler ──────────────────────────────
 
-  private async handleSlackProxy(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+  private async handleSlackProxy(
+    req: JsonRpcRequest,
+    state: ConnectionState,
+  ): Promise<JsonRpcResponse> {
     if (!this.slackProxyFn) {
       return rpcError(req.id, RPC_METHOD_NOT_FOUND, "slack.proxy is not configured on this broker");
     }
@@ -407,6 +433,17 @@ export class BrokerSocketServer {
 
     try {
       const result = await this.slackProxyFn(method, apiParams);
+
+      // Auto-claim thread ownership when a registered agent posts a message
+      if (method === "chat.postMessage" && state.agentId) {
+        const threadTs = typeof apiParams.thread_ts === "string" ? apiParams.thread_ts : null;
+        const messageTs = typeof result.ts === "string" ? (result.ts as string) : null;
+        const effectiveTs = threadTs ?? messageTs;
+        if (effectiveTs) {
+          this.router.claimThread(effectiveTs, state.agentId);
+        }
+      }
+
       return rpcOk(req.id, result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -626,6 +626,13 @@ export default function (pi: ExtensionAPI) {
       unclaimedThreads.delete(actualTs);
       persistState();
 
+      // Claim in broker DB so inbound replies route back to us
+      if (brokerRole === "broker" && activeRouter && activeSelfId) {
+        activeRouter.claimThread(actualTs, activeSelfId);
+      } else if (brokerRole === "follower" && brokerClient?.client) {
+        void (brokerClient.client as BrokerClient).claimThread(actualTs, channel);
+      }
+
       // Remove 👀 from all messages in this thread
       if (params.thread_ts) {
         const pending = pendingEyes.get(params.thread_ts);
@@ -753,11 +760,37 @@ export default function (pi: ExtensionAPI) {
       const body: Record<string, unknown> = {
         channel: channelId,
         text: params.text,
+        metadata: {
+          event_type: "pi_agent_msg",
+          event_payload: { agent: agentName },
+        },
       };
       if (params.thread_ts) body.thread_ts = params.thread_ts;
 
       const res = await slack("chat.postMessage", botToken!, body);
       const ts = (res.message as { ts: string }).ts;
+      const actualTs = params.thread_ts ?? ts;
+
+      // Track + claim ownership so inbound replies route back to us
+      if (!threads.has(actualTs)) {
+        threads.set(actualTs, {
+          channelId,
+          threadTs: actualTs,
+          userId: "",
+          owner: agentName,
+        });
+      } else {
+        const t = threads.get(actualTs)!;
+        if (!t.owner) t.owner = agentName;
+      }
+      unclaimedThreads.delete(actualTs);
+      persistState();
+
+      if (brokerRole === "broker" && activeRouter && activeSelfId) {
+        activeRouter.claimThread(actualTs, activeSelfId);
+      } else if (brokerRole === "follower" && brokerClient?.client) {
+        void (brokerClient.client as BrokerClient).claimThread(actualTs, channelId);
+      }
 
       return {
         content: [
@@ -829,6 +862,8 @@ export default function (pi: ExtensionAPI) {
   let activeBroker: any = null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let brokerClient: any = null;
+  let activeRouter: MessageRouter | null = null;
+  let activeSelfId: string | null = null;
 
   pi.registerCommand("pinet-start", {
     description: "Start Pinet as the broker (Slack connection + message routing)",
@@ -873,6 +908,8 @@ export default function (pi: ExtensionAPI) {
         botUserId = adapter.getBotUserId();
 
         activeBroker = broker;
+        activeRouter = router;
+        activeSelfId = selfId;
         brokerRole = "broker";
         pinetEnabled = true;
         setExtStatus(ctx, "ok");
@@ -1068,6 +1105,8 @@ export default function (pi: ExtensionAPI) {
       }
       activeBroker = null;
     }
+    activeRouter = null;
+    activeSelfId = null;
     if (brokerClient) {
       try {
         clearInterval(brokerClient.pollInterval);


### PR DESCRIPTION
## Problem

When an agent sends a Slack message that starts a new thread (via `slack.proxy` RPC or the `slack_send`/`slack_post_channel` tools), the broker doesn't record thread ownership for that agent. So when users reply to that thread, the message goes to "unrouted" instead of back to the agent that started the conversation.

## Changes

### `slack-bridge/broker/schema.ts`
- `updateThread` now upserts: if the thread doesn't exist, it creates it with the provided updates and sensible defaults (`source: "slack"`, `channel: ""`)

### `slack-bridge/broker/socket-server.ts`
- New `thread.claim` RPC method — follower agents call this to claim thread ownership through the broker
- `slack.proxy` handler now auto-claims thread ownership when `chat.postMessage` is called by a registered agent (extracts `thread_ts` from params or `ts` from the response)

### `slack-bridge/broker/client.ts`
- New `claimThread(threadId, channel?)` method on `BrokerClient`

### `slack-bridge/broker/router.ts`
- `claimThread` now accepts an optional `channel` parameter, passed through when creating new threads

### `slack-bridge/index.ts`
- `slack_send`: after posting, claims the thread in broker DB (broker mode uses router directly, follower mode sends `thread.claim` RPC)
- `slack_post_channel`: now includes `pi_agent_msg` metadata, tracks thread ownership locally, and claims in broker DB (same dual-mode approach)
- Stores `activeRouter` and `activeSelfId` at module scope for broker-mode claims
- Cleans up router/selfId on session shutdown

## Tests

197 tests passing (12 new):
- **router.test.ts**: `updateThread` upsert behavior, `claimThread` via upsert path
- **integration.test.ts**: `thread.claim` RPC (success + rejection), channel passthrough, `slack.proxy` auto-claim for new threads and replies, non-postMessage methods don't claim, `updateThread` upsert with real DB

Closes #45