### PR TITLE
fix: store follower actual PID during registration (#44)

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -174,11 +174,12 @@ describe("BrokerClient — register", () => {
     const req = JSON.parse(mock.received[0]) as {
       id: number;
       method: string;
-      params: { name: string; emoji: string };
+      params: { name: string; emoji: string; pid: number };
     };
     expect(req.method).toBe("register");
     expect(req.params.name).toBe("TestAgent");
     expect(req.params.emoji).toBe("🤖");
+    expect(req.params.pid).toBe(process.pid);
 
     // Respond
     mock.respondTo(mock.connections[0], req.id, { agentId: "agent-001" });

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -155,7 +155,7 @@ export class BrokerClient {
   // ─── Registration ────────────────────────────────────
 
   async register(name: string, emoji: string): Promise<{ agentId: string }> {
-    const result = (await this.request("register", { name, emoji })) as {
+    const result = (await this.request("register", { name, emoji, pid: process.pid })) as {
       agentId: string;
     };
     return result;

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -104,6 +104,18 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(ids).toEqual(["t-alpha", "t-beta"]);
   });
 
+  it("register stores the follower's actual PID, not the broker's", async () => {
+    const reg = await client.register("pid-agent", "🔢");
+
+    const agents = db.getAgents();
+    const agent = agents.find((a) => a.id === reg.agentId);
+    expect(agent).toBeDefined();
+    // Client and server run in the same process during tests, so PIDs match.
+    // The key assertion: the stored PID equals process.pid (what the client sent),
+    // not some hardcoded or different value.
+    expect(agent!.pid).toBe(process.pid);
+  });
+
   it("agents.list returns all connected agents", async () => {
     await client.register("agent-alpha", "🅰️");
 

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -272,9 +272,10 @@ export class BrokerSocketServer {
     const params = req.params ?? {};
     const name = typeof params.name === "string" ? params.name : "anonymous";
     const emoji = typeof params.emoji === "string" ? params.emoji : "";
+    const pid = typeof params.pid === "number" ? params.pid : 0;
 
     const agentId = state.agentId ?? crypto.randomUUID();
-    const agent = this.db.registerAgent(agentId, name, emoji, process.pid);
+    const agent = this.db.registerAgent(agentId, name, emoji, pid);
     state.agentId = agentId;
 
     return rpcOk(req.id, { agentId: agent.id, name: agent.name, emoji: agent.emoji });


### PR DESCRIPTION
## Problem

When a follower agent connected via Unix socket and registered, the broker stored its own `process.pid` instead of the follower's actual PID. This broke stale agent cleanup since all agents appeared to have the same PID.

## Changes

- **`slack-bridge/broker/client.ts`** -- send `process.pid` in the `register` RPC params
- **`slack-bridge/broker/socket-server.ts`** -- read `pid` from client params instead of using `process.pid`
- **`slack-bridge/broker/client.test.ts`** -- assert `pid` is included in the register request
- **`slack-bridge/broker/integration.test.ts`** -- new test verifying the stored PID matches the client's PID

## Testing

All 186 tests pass. No lint or type errors.

Closes #44