### PR TITLE
fix: channel thread replies to bot messages without @mention (#53)

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -305,6 +305,112 @@ describe("classifyMessage", () => {
     }
   });
 
+  // ─── isOwnedThread callback ─────────────────────────────
+
+  it("accepts thread replies in broker-owned threads without @mention", () => {
+    const isOwnedThread = (ts: string) => ts === "500.600";
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "follow up in owned thread",
+      channel: "C1",
+      channel_type: "channel",
+      thread_ts: "500.600",
+      ts: "500.700",
+    };
+    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.threadTs).toBe("500.600");
+      expect(result.isChannelMention).toBe(false);
+      expect(result.text).toBe("follow up in owned thread");
+      expect(result.isDM).toBe(false);
+    }
+  });
+
+  it("rejects thread replies in non-owned threads without @mention", () => {
+    const isOwnedThread = () => false;
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "random thread reply",
+      channel: "C1",
+      channel_type: "channel",
+      thread_ts: "600.700",
+      ts: "600.800",
+    };
+    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    expect(result).toEqual({ relevant: false });
+  });
+
+  it("does not set isChannelMention for @mention in broker-owned thread", () => {
+    const isOwnedThread = (ts: string) => ts === "700.800";
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "<@U_BOT> check this",
+      channel: "C1",
+      channel_type: "channel",
+      thread_ts: "700.800",
+      ts: "700.900",
+    };
+    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.isChannelMention).toBe(false);
+      // Text is NOT stripped since it's not a channel mention
+      expect(result.text).toBe("<@U_BOT> check this");
+    }
+  });
+
+  it("prefers local tracked set over isOwnedThread callback", () => {
+    const isOwnedThread = vi.fn(() => true);
+    const tracked = new Set(["800.900"]);
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "reply in tracked thread",
+      channel: "C1",
+      channel_type: "channel",
+      thread_ts: "800.900",
+      ts: "800.950",
+    };
+    const result = classifyMessage(evt, botId, tracked, isOwnedThread);
+    expect(result.relevant).toBe(true);
+    // isOwnedThread should NOT be called because isTracked was true first
+    expect(isOwnedThread).not.toHaveBeenCalled();
+  });
+
+  it("does not call isOwnedThread for messages without thread_ts", () => {
+    const isOwnedThread = vi.fn(() => true);
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "top-level channel message",
+      channel: "C1",
+      channel_type: "channel",
+      ts: "900.100",
+    };
+    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    expect(result).toEqual({ relevant: false });
+    expect(isOwnedThread).not.toHaveBeenCalled();
+  });
+
+  it("works without isOwnedThread callback (backward compatible)", () => {
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "reply in unknown thread",
+      channel: "C1",
+      channel_type: "channel",
+      thread_ts: "999.111",
+      ts: "999.222",
+    };
+    // No callback passed — same behavior as before
+    const result = classifyMessage(evt, botId, emptyTracked);
+    expect(result).toEqual({ relevant: false });
+  });
+
   it("handles null botUserId (no mention detection)", () => {
     const evt = {
       type: "message",
@@ -375,6 +481,14 @@ describe("SlackAdapter", () => {
     const adapter = new SlackAdapter({
       ...baseConfig,
       suggestedPrompts: [{ title: "Hello", message: "Hi there" }],
+    });
+    expect(adapter.name).toBe("slack");
+  });
+
+  it("can be constructed with isOwnedThread callback", () => {
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      isOwnedThread: () => false,
     });
     expect(adapter.name).toBe("slack");
   });

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -13,6 +13,8 @@ export interface SlackAdapterConfig {
   appToken: string;
   allowedUsers?: string[];
   suggestedPrompts?: { title: string; message: string }[];
+  /** Check whether a thread_ts belongs to a thread the bot owns in the broker DB. */
+  isOwnedThread?: (threadTs: string) => boolean;
 }
 
 // ─── Slack API result ────────────────────────────────────
@@ -145,6 +147,7 @@ export function classifyMessage(
   evt: Record<string, unknown>,
   botUserId: string | null,
   trackedThreadIds: Set<string>,
+  isOwnedThread?: (threadTs: string) => boolean,
 ): MessageClassification {
   // Skip bot messages and messages with subtypes (joins, edits, etc.)
   if (evt.subtype || evt.bot_id) return { relevant: false };
@@ -156,13 +159,14 @@ export function classifyMessage(
   const channelType = evt.channel_type as string | undefined;
 
   const isTracked = !!threadTs && trackedThreadIds.has(threadTs);
+  const isOwned = !isTracked && !!threadTs && (isOwnedThread?.(threadTs) ?? false);
   const isDM = channelType === "im";
   const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
 
-  if (!isTracked && !isDM && !isMention) return { relevant: false };
+  if (!isTracked && !isOwned && !isDM && !isMention) return { relevant: false };
 
   const effectiveTs = threadTs ?? (evt.ts as string);
-  const isChannelMention = isMention && !isDM && !isTracked;
+  const isChannelMention = isMention && !isDM && !isTracked && !isOwned;
 
   const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
 
@@ -389,7 +393,12 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   private async onMessage(evt: Record<string, unknown>): Promise<void> {
-    const classified = classifyMessage(evt, this.botUserId, this.getTrackedThreadIds());
+    const classified = classifyMessage(
+      evt,
+      this.botUserId,
+      this.getTrackedThreadIds(),
+      this.config.isOwnedThread,
+    );
     if (!classified.relevant) return;
 
     const { threadTs, channel, userId, text, isChannelMention, messageTs } = classified;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -988,6 +988,10 @@ export default function (pi: ExtensionAPI) {
           appToken: appToken!,
           allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
           suggestedPrompts: settings.suggestedPrompts,
+          isOwnedThread: (threadTs: string) => {
+            const thread = broker.db.getThread(threadTs);
+            return thread?.ownerAgent != null;
+          },
         });
 
         const router = new MessageRouter(broker.db);


### PR DESCRIPTION
## Problem

When the bot posts a message in a channel (via `slack_post_channel`) and a user replies in the thread, the reply is **not** picked up by the broker unless the user @mentions the bot.

## Root cause

`classifyMessage()` only checked the adapter's local `trackedThreadIds` (the in-memory `threads` map). Threads created via `slack_post_channel` are tracked in the broker DB but not in the adapter's in-memory map — so thread replies were silently dropped.

## Changes

### `slack-bridge/broker/adapters/slack.ts`
- Added optional `isOwnedThread` callback to `SlackAdapterConfig`
- `classifyMessage()` now accepts an optional 4th parameter `isOwnedThread`
- When a channel message has a `thread_ts` that isn't locally tracked, it checks `isOwnedThread` before rejecting
- Owned-thread replies are treated as relevant with `isChannelMention: false` (direct thread reply, not a channel mention)

### `slack-bridge/index.ts`
- Wired up the `isOwnedThread` callback in `pinet-start` to check `broker.db.getThread(threadTs)?.ownerAgent \!= null`

### `slack-bridge/broker/adapters/slack.test.ts`
- 7 new tests covering the new behavior and backward compatibility

## Test results

All 212 tests pass. Lint and typecheck clean.

Closes #53