### PR TITLE
fix: restore follower reconnect flow when broker restarts (#78)

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -27,7 +27,7 @@ interface MockServer {
   connectOpts: BrokerConnectOpts;
 }
 
-function createMockServer(): Promise<MockServer> {
+function createMockServer(port = 0): Promise<MockServer> {
   return new Promise((resolve, reject) => {
     const connections: net.Socket[] = [];
     const received: string[] = [];
@@ -47,8 +47,8 @@ function createMockServer(): Promise<MockServer> {
 
     server.on("error", reject);
 
-    // Use TCP on localhost with a random port (Unix sockets may be blocked in CI/sandbox)
-    server.listen(0, "127.0.0.1", () => {
+    // Use TCP on localhost (Unix sockets may be blocked in CI/sandbox)
+    server.listen(port, "127.0.0.1", () => {
       const addr = server.address() as net.AddressInfo;
       const opts: BrokerConnectOpts = { host: "127.0.0.1", port: addr.port };
       resolve({
@@ -938,6 +938,80 @@ describe("BrokerClient — onReconnect callback", () => {
     client.disconnect();
     const server2 = (client as unknown as { _testServer2: net.Server })._testServer2;
     await new Promise<void>((res) => server2.close(() => res()));
+  }, 20000);
+
+  it("keeps retrying until it can reconnect and re-register with stable identity", async () => {
+    let mock = await createMockServer();
+    const port = mock.port;
+    const client = new BrokerClient(mock.connectOpts);
+    let disconnectFired = false;
+    let reconnectFired = false;
+
+    client.onDisconnect(() => {
+      disconnectFired = true;
+    });
+    client.onReconnect(() => {
+      reconnectFired = true;
+    });
+
+    await client.connect();
+    const registerPromise = client.register(
+      "RetryBot",
+      "🔁",
+      { cwd: "/repo", branch: "main" },
+      "host:session:/tmp/retry",
+    );
+
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { stableId?: string };
+    };
+    expect(registerReq.method).toBe("register");
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "retry-agent",
+      name: "RetryBot",
+      emoji: "🔁",
+    });
+    await registerPromise;
+
+    await mock.close();
+    await waitFor(() => disconnectFired, 2000);
+    await waitFor(() => client.getReconnectAttempt() >= 2, 5000);
+
+    mock = await createMockServer(port);
+    await waitFor(() => mock.received.length > 0, 5000);
+
+    const reRegisterReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(reRegisterReq.method).toBe("register");
+    expect(reRegisterReq.params.name).toBe("RetryBot");
+    expect(reRegisterReq.params.emoji).toBe("🔁");
+    expect(reRegisterReq.params.stableId).toBe("host:session:/tmp/retry");
+    expect(reconnectFired).toBe(false);
+
+    mock.respondTo(mock.connections[0], reRegisterReq.id, {
+      agentId: "retry-agent",
+      name: "RetryBot",
+      emoji: "🔁",
+    });
+
+    await waitFor(() => reconnectFired, 5000);
+    expect(reconnectFired).toBe(true);
+    expect(client.isConnected()).toBe(true);
+    expect(client.getReconnectAttempt()).toBe(0);
+    expect(client.getRegisteredIdentity()).toEqual({
+      agentId: "retry-agent",
+      name: "RetryBot",
+      emoji: "🔁",
+    });
+
+    client.disconnect();
+    await mock.close();
   }, 20000);
 });
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -81,6 +81,19 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
+interface RegistrationSnapshot {
+  name: string;
+  emoji: string;
+  metadata?: Record<string, unknown>;
+  stableId?: string;
+}
+
+interface RegistrationResult {
+  agentId: string;
+  name: string;
+  emoji: string;
+}
+
 // ─── Connection options ──────────────────────────────────
 
 export type BrokerConnectOpts = { path: string } | { host: string; port: number };
@@ -97,6 +110,8 @@ export class BrokerClient {
   private disconnectHandler: (() => void) | null = null;
   private reconnectHandler: (() => void) | null = null;
   private reconnectAttempt = 0;
+  private registrationSnapshot: RegistrationSnapshot | null = null;
+  private registeredIdentity: RegistrationResult | null = null;
 
   private nextId = 1;
   private readonly pending = new Map<number, PendingRequest>();
@@ -116,39 +131,7 @@ export class BrokerClient {
 
   connect(): Promise<void> {
     this.shuttingDown = false;
-    return new Promise<void>((resolve, reject) => {
-      const sock = net.createConnection(this.connectOpts);
-
-      sock.on("connect", () => {
-        this.socket = sock;
-        this.connected = true;
-        this.buffer = "";
-        resolve();
-      });
-
-      sock.on("data", (chunk: Buffer) => {
-        this.onData(chunk.toString("utf-8"));
-      });
-
-      sock.on("close", () => {
-        const wasConnected = this.connected;
-        this.connected = false;
-        this.socket = null;
-        this.stopHeartbeat();
-        this.rejectAllPending(new Error("Socket closed"));
-        if (wasConnected && !this.shuttingDown) {
-          this.disconnectHandler?.();
-          this.scheduleReconnect();
-        }
-      });
-
-      sock.on("error", (err: Error) => {
-        if (!this.connected) {
-          reject(err);
-        }
-        // If already connected, the close event handles cleanup
-      });
-    });
+    return this.connectSocket();
   }
 
   disconnect(): void {
@@ -180,19 +163,8 @@ export class BrokerClient {
     metadata?: Record<string, unknown>,
     stableId?: string,
   ): Promise<{ agentId: string; name: string; emoji: string }> {
-    const result = (await this.request("register", {
-      name,
-      emoji,
-      pid: process.pid,
-      ...(metadata ? { metadata } : {}),
-      ...(stableId ? { stableId } : {}),
-    })) as {
-      agentId: string;
-      name: string;
-      emoji: string;
-    };
-    this.startHeartbeat();
-    return result;
+    this.registrationSnapshot = { name, emoji, ...(metadata ? { metadata } : {}), ...(stableId ? { stableId } : {}) };
+    return this.performRegister(this.registrationSnapshot);
   }
 
   async unregister(): Promise<void> {
@@ -201,6 +173,8 @@ export class BrokerClient {
       await this.request("unregister");
     } finally {
       this.stopHeartbeat();
+      this.registrationSnapshot = null;
+      this.registeredIdentity = null;
     }
   }
 
@@ -287,6 +261,10 @@ export class BrokerClient {
     return this.reconnectAttempt;
   }
 
+  getRegisteredIdentity(): { agentId: string; name: string; emoji: string } | null {
+    return this.registeredIdentity ? { ...this.registeredIdentity } : null;
+  }
+
   // ─── JSON-RPC transport ──────────────────────────────
 
   private request(method: string, params?: Record<string, unknown>): Promise<unknown> {
@@ -360,15 +338,88 @@ export class BrokerClient {
     this.reconnectAttempt++;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
-      void this.connect()
-        .then(() => {
-          this.reconnectAttempt = 0;
-          this.reconnectHandler?.();
-        })
-        .catch(() => {
-          /* reconnect failed — will retry on next close */
-        });
+      void this.reconnectOnce();
     }, delay);
+    this.reconnectTimer.unref?.();
+  }
+
+  private connectSocket(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const sock = net.createConnection(this.connectOpts);
+
+      sock.on("connect", () => {
+        this.socket = sock;
+        this.connected = true;
+        this.buffer = "";
+        resolve();
+      });
+
+      sock.on("data", (chunk: Buffer) => {
+        this.onData(chunk.toString("utf-8"));
+      });
+
+      sock.on("close", () => {
+        const wasConnected = this.connected;
+        this.connected = false;
+        this.socket = null;
+        this.stopHeartbeat();
+        this.rejectAllPending(new Error("Socket closed"));
+        if (wasConnected && !this.shuttingDown) {
+          this.disconnectHandler?.();
+          this.scheduleReconnect();
+        }
+      });
+
+      sock.on("error", (err: Error) => {
+        if (!this.connected) {
+          reject(err);
+        }
+        // If already connected, the close event handles cleanup
+      });
+    });
+  }
+
+  private async performRegister(
+    snapshot: RegistrationSnapshot,
+  ): Promise<{ agentId: string; name: string; emoji: string }> {
+    const result = (await this.request("register", {
+      name: snapshot.name,
+      emoji: snapshot.emoji,
+      pid: process.pid,
+      ...(snapshot.metadata ? { metadata: snapshot.metadata } : {}),
+      ...(snapshot.stableId ? { stableId: snapshot.stableId } : {}),
+    })) as RegistrationResult;
+    this.registrationSnapshot = {
+      ...snapshot,
+      name: result.name,
+      emoji: result.emoji,
+    };
+    this.registeredIdentity = result;
+    this.startHeartbeat();
+    return result;
+  }
+
+  private async reconnectOnce(): Promise<void> {
+    try {
+      await this.connectSocket();
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+
+    try {
+      if (this.registrationSnapshot) {
+        await this.performRegister(this.registrationSnapshot);
+      }
+      this.reconnectAttempt = 0;
+      this.reconnectHandler?.();
+    } catch {
+      try {
+        this.socket?.destroy();
+      } catch {
+        /* ignore */
+      }
+    }
   }
 
   private startHeartbeat(): void {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -21,6 +21,7 @@ import {
   syncFollowerInboxEntries,
   isDirectMessageChannel,
   getFollowerReconnectUiUpdate,
+  getFollowerOwnedThreadClaims,
   type InboxMessage,
   type AgentDisplayInfo,
   type FollowerThreadState,
@@ -726,5 +727,29 @@ describe("getFollowerReconnectUiUpdate", () => {
     const result = getFollowerReconnectUiUpdate("reconnect", false);
     expect(result.nextWasDisconnected).toBe(false);
     expect(result.notify).toBeUndefined();
+  });
+});
+
+// ─── getFollowerOwnedThreadClaims ────────────────────────
+
+describe("getFollowerOwnedThreadClaims", () => {
+  it("returns only threads owned by the agent", () => {
+    const threads = new Map<string, FollowerThreadState>([
+      ["t-1", { threadTs: "t-1", channelId: "C1", userId: "U1", owner: "Sonic Gecko" }],
+      ["t-2", { threadTs: "t-2", channelId: "C2", userId: "U2", owner: "Other Agent" }],
+    ]);
+
+    expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([
+      { threadTs: "t-1", channelId: "C1" },
+    ]);
+  });
+
+  it("ignores incomplete thread records", () => {
+    const threads = new Map<string, FollowerThreadState>([
+      ["t-1", { threadTs: "t-1", channelId: "", userId: "U1", owner: "Sonic Gecko" }],
+      ["t-2", { threadTs: "", channelId: "C2", userId: "U2", owner: "Sonic Gecko" }],
+    ]);
+
+    expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([]);
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -320,6 +320,18 @@ export function getFollowerReconnectUiUpdate(
   };
 }
 
+export function getFollowerOwnedThreadClaims(
+  threads: ReadonlyMap<string, Pick<FollowerThreadState, "threadTs" | "channelId" | "owner">>,
+  agentName: string,
+): Array<{ threadTs: string; channelId: string }> {
+  return [...threads.values()]
+    .filter((thread) => thread.owner === agentName && Boolean(thread.threadTs) && Boolean(thread.channelId))
+    .map((thread) => ({
+      threadTs: thread.threadTs,
+      channelId: thread.channelId,
+    }));
+}
+
 /**
  * Track a thread from a broker inbound message in the threads map.
  * Used by the broker onInbound callback so that slack_send can resolve

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -22,6 +22,7 @@ import {
   buildAgentStableId,
   syncFollowerInboxEntries,
   getFollowerReconnectUiUpdate,
+  getFollowerOwnedThreadClaims,
   trackBrokerInboundThread,
 } from "./helpers.js";
 import {
@@ -120,8 +121,14 @@ export default function (pi: ExtensionAPI) {
 
   function applyBrokerIdentity(nextName: string, nextEmoji: string): void {
     if (agentName === nextName && agentEmoji === nextEmoji) return;
+    const previousName = agentName;
     agentName = nextName;
     agentEmoji = nextEmoji;
+    for (const thread of threads.values()) {
+      if (thread.owner === previousName) {
+        thread.owner = nextName;
+      }
+    }
     persistState();
     updateBadge();
   }
@@ -1407,6 +1414,16 @@ export default function (pi: ExtensionAPI) {
     };
     let wasDisconnected = false;
 
+    async function resumeThreadClaims(): Promise<void> {
+      for (const thread of getFollowerOwnedThreadClaims(threads, agentName)) {
+        try {
+          await client.claimThread(thread.threadTs, thread.channelId);
+        } catch {
+          break;
+        }
+      }
+    }
+
     function startPolling(): void {
       if (brokerClientRef.pollInterval) return;
       brokerClientRef.pollInterval = setInterval(async () => {
@@ -1460,27 +1477,22 @@ export default function (pi: ExtensionAPI) {
 
     client.onReconnect(() => {
       void (async () => {
-        try {
-          const registration = await client.register(
-            agentName,
-            agentEmoji,
-            getAgentMetadata("worker"),
-            agentStableId,
-          );
+        const registration = client.getRegisteredIdentity();
+        if (registration) {
           applyBrokerIdentity(registration.name, registration.emoji);
-          startPolling();
-          setExtStatus(ctx, "ok");
-          const uiUpdate = getFollowerReconnectUiUpdate("reconnect", wasDisconnected);
-          wasDisconnected = uiUpdate.nextWasDisconnected;
-          if (uiUpdate.notify) {
-            ctx.ui.notify(uiUpdate.notify.message, uiUpdate.notify.level);
-          }
-        } catch {
-          // Re-registration failed; the next close event will trigger another reconnect
+        }
+        await resumeThreadClaims();
+        startPolling();
+        setExtStatus(ctx, "ok");
+        const uiUpdate = getFollowerReconnectUiUpdate("reconnect", wasDisconnected);
+        wasDisconnected = uiUpdate.nextWasDisconnected;
+        if (uiUpdate.notify) {
+          ctx.ui.notify(uiUpdate.notify.message, uiUpdate.notify.level);
         }
       })();
     });
 
+    await resumeThreadClaims();
     startPolling();
     brokerClient = brokerClientRef;
     brokerRole = "follower";


### PR DESCRIPTION
## Problem

When the broker restarts, follower agents stay disconnected. The mesh collapses.

Fixes #78.

## Changes (+247/-73 across 5 files)

- `slack-bridge/broker/client.ts` — robust reconnect with backoff, re-registration with stable identity
- `slack-bridge/index.ts` — improved onDisconnect/onReconnect handlers
- `slack-bridge/helpers.ts` — reconnect helpers
- Tests for reconnect scenarios

## Verification

Needs review — branch pushed by Gecko.