### PR TITLE
feat: add worktree-first guidelines to broker prompt (#87)

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -491,6 +491,10 @@ export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: strin
     "When a human asks for work to be done, check `pinet_agents` for idle workers and delegate via `pinet_message`. Pick the agent on the right repo/branch when possible.",
     "When delegating, include: the task description, relevant issue/PR numbers, branch to work on, and where to report back (Slack thread_ts).",
     "If no workers are available, tell the human and suggest they spin up a new agent rather than doing the work yourself.",
+    "WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.",
+    "For feature work, ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>`. Tell delegated agents to do the same.",
+    "When delegating to an agent, include the worktree setup command. Example: `git worktree add .worktrees/fix-foo-123 -b fix/foo-123 && cd .worktrees/fix-foo-123`",
+    "Clean up worktrees after PRs merge: `git worktree remove .worktrees/<name>`. Flag orphaned worktrees from dead agents for cleanup.",
   ];
 }
 
@@ -650,7 +654,10 @@ export function getFollowerOwnedThreadClaims(
   agentName: string,
 ): Array<{ threadTs: string; channelId: string }> {
   return [...threads.values()]
-    .filter((thread) => thread.owner === agentName && Boolean(thread.threadTs) && Boolean(thread.channelId))
+    .filter(
+      (thread) =>
+        thread.owner === agentName && Boolean(thread.threadTs) && Boolean(thread.channelId),
+    )
     .map((thread) => ({
       threadTs: thread.threadTs,
       channelId: thread.channelId,


### PR DESCRIPTION
## Problem

Agents keep checking out feature branches in the main repo, leaving it in inconsistent state. Worktree agents die and become untrackable.

Partial fix for #87.

## Changes

Adds 4 new broker prompt guidelines:
1. Main checkout must ALWAYS stay on `main` — never checkout a branch
2. Feature work goes in worktrees: `git worktree add .worktrees/<name> -b <branch>`
3. Delegation messages must include worktree setup command
4. Clean up worktrees after PRs merge

## What's left (#87)

- Hard enforcement (intercept `git checkout` in bash calls) — deferred
- Worktree agent Pinet reliability (autoFollow from worktree paths)
- Stale worktree cleanup

## Verification

2412 tests ✅, lint ✅, typecheck ✅