### PR TITLE
feat: worker prompt guidelines + ralph loop broker instructions (#87)

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -495,6 +495,19 @@ export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: strin
     "For feature work, ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>`. Tell delegated agents to do the same.",
     "When delegating to an agent, include the worktree setup command. Example: `git worktree add .worktrees/fix-foo-123 -b fix/foo-123 && cd .worktrees/fix-foo-123`",
     "Clean up worktrees after PRs merge: `git worktree remove .worktrees/<name>`. Flag orphaned worktrees from dead agents for cleanup.",
+    "RALPH LOOP: Run autonomous maintenance every cycle. Don't wait to be asked. Proactively: (1) REAP — ping idle agents, mark non-responders as ghost. (2) NUDGE — check assigned work, poll branches for commits, escalate stalled agents. (3) REASSIGN — if an assigned agent is dead, reassign to next idle agent immediately. (4) DRAIN — find idle agents with no work, assign queued tasks. (5) SELF-REPAIR — verify main is on `main`, check mesh health, report anomalies.",
+  ];
+}
+
+export function buildWorkerPromptGuidelines(): string[] {
+  return [
+    "WORKTREE RULE: NEVER work directly on the `main` branch or checkout feature branches in the main repo directory.",
+    "ALWAYS create a git worktree for your work: `git worktree add .worktrees/<name> -b <branch>` and `cd` into it before making changes.",
+    "If you are already in a worktree, stay there. Do not `cd` back to the main checkout to run git commands.",
+    "When your PR is merged, clean up: `git worktree remove .worktrees/<name>` from the main checkout.",
+    "NEVER run `git checkout <branch>` or `git switch <branch>` in the main repo checkout. The main checkout must always be on `main`.",
+    "Always run validation before pushing: `pnpm lint && pnpm typecheck && pnpm test`.",
+    "Report progress in your assigned Slack thread. If you hit a blocker, say so immediately — don't go silent.",
   ];
 }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -22,6 +22,7 @@ import {
   shortenPath,
   buildIdentityReplyGuidelines,
   buildBrokerPromptGuidelines,
+  buildWorkerPromptGuidelines,
   buildAgentStableId,
   syncFollowerInboxEntries,
   getFollowerReconnectUiUpdate,
@@ -1833,8 +1834,14 @@ export default function (pi: ExtensionAPI) {
 
   // Inject broker-specific prompt guidelines when running as broker
   pi.on("before_agent_start", async (event) => {
-    if (brokerRole !== "broker") return;
-    const guidelines = buildBrokerPromptGuidelines(agentEmoji, agentName);
+    let guidelines: string[];
+    if (brokerRole === "broker") {
+      guidelines = buildBrokerPromptGuidelines(agentEmoji, agentName);
+    } else if (brokerRole === "follower") {
+      guidelines = buildWorkerPromptGuidelines();
+    } else {
+      return;
+    }
     return {
       systemPrompt: event.systemPrompt + "\n\n" + guidelines.join("\n"),
     };


### PR DESCRIPTION
## Changes

1. **Worker guidelines** — new `buildWorkerPromptGuidelines()` injected into ALL follower agents via `before_agent_start`. Workers now get told:
   - Never work in main checkout, always use worktrees
   - Never checkout branches in main repo
   - Always validate before pushing
   - Report progress, don't go silent

2. **Ralph loop instructions** — broker guidelines now include the full maintenance cycle: reap, nudge, reassign, drain, self-repair. Broker should run this proactively, not wait to be asked.

3. **`before_agent_start` now fires for both broker AND follower** — previously only injected guidelines for brokers.

Partial fix for #87, #91.

## Verification

2413 tests ✅, lint ✅, typecheck ✅