### PR TITLE
feat: add ralph runtime maintenance loop (#91)

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -445,6 +445,16 @@ describe("BrokerDB", () => {
     expect(allThreads).toHaveLength(3);
   });
 
+  it("getOwnedThreadCount returns the number of claimed threads", () => {
+    db.createThread("t1", "slack", "#a", "agent-1");
+    db.createThread("t2", "slack", "#b", "agent-2");
+    db.createThread("t3", "slack", "#c", "agent-1");
+
+    expect(db.getOwnedThreadCount("agent-1")).toBe(2);
+    expect(db.getOwnedThreadCount("agent-2")).toBe(1);
+    expect(db.getOwnedThreadCount("missing")).toBe(0);
+  });
+
   it("insertMessage and getInbox", () => {
     db.registerAgent("a1", "Agent1", "🔵", 1);
     db.registerAgent("a2", "Agent2", "🔴", 2);

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -762,6 +762,14 @@ export class BrokerDB implements BrokerDBInterface {
     return row.count;
   }
 
+  getOwnedThreadCount(agentId: string): number {
+    const db = this.getDb();
+    const row = db
+      .prepare("SELECT COUNT(*) AS count FROM threads WHERE owner_agent = ?")
+      .get(agentId) as { count: number };
+    return row.count;
+  }
+
   releaseThreadClaims(agentId: string): number {
     const db = this.getDb();
     const result = db

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -11,6 +11,8 @@ import {
   shortenPath,
   buildAgentDisplayInfo,
   rankAgentsForRouting,
+  evaluateRalphLoopCycle,
+  buildRalphLoopNudgeMessage,
   buildBrokerPromptGuidelines,
   buildIdentityReplyGuidelines,
   resolvePersistedAgentIdentity,
@@ -707,6 +709,77 @@ describe("rankAgentsForRouting", () => {
     expect(ranked[ranked.length - 1]?.id).toBe("ghost");
     expect(ranked[0]?.routingReasons).toContain("repo:extensions");
     expect(ranked[0]?.routingReasons).toContain("tools:1/1");
+  });
+});
+
+// ─── Ralph loop helpers ────────────────────────────────
+
+describe("evaluateRalphLoopCycle", () => {
+  it("flags ghost agents, nudges idle agents with work, and reports self-repair anomalies", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🦎",
+          name: "Idle Gecko",
+          id: "idle-worker",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:00:00.000Z",
+          lastHeartbeat: "2026-04-01T00:01:55.000Z",
+          pendingInboxCount: 2,
+          ownedThreadCount: 1,
+        },
+        {
+          emoji: "🦉",
+          name: "Ready Owl",
+          id: "ready-worker",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:01:20.000Z",
+          lastHeartbeat: "2026-04-01T00:01:55.000Z",
+          pendingInboxCount: 0,
+          ownedThreadCount: 0,
+        },
+        {
+          emoji: "👻",
+          name: "Ghost Fox",
+          id: "ghost-worker",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:00:00.000Z",
+          lastHeartbeat: "2026-04-01T00:00:00.000Z",
+          disconnectedAt: "2026-04-01T00:00:10.000Z",
+          pendingInboxCount: 0,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:02:00.000Z"),
+        idleWithWorkThresholdMs: 60_000,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+        pendingBacklogCount: 3,
+        currentBranch: "feat/not-main",
+        brokerHeartbeatActive: false,
+        brokerMaintenanceActive: false,
+      },
+    );
+
+    expect(result.ghostAgentIds).toEqual(["ghost-worker"]);
+    expect(result.nudgeAgentIds).toEqual(["idle-worker"]);
+    expect(result.idleDrainAgentIds).toEqual(["ready-worker"]);
+    expect(result.anomalies).toContain("Idle Gecko idle with assigned work (2 inbox, 1 threads)");
+    expect(result.anomalies).toContain("ghost agents detected: ghost-worker");
+    expect(result.anomalies).toContain("pending backlog (3) with 1 idle worker");
+    expect(result.anomalies).toContain("broker heartbeat timer is not running");
+    expect(result.anomalies).toContain("broker maintenance timer is not running");
+    expect(result.anomalies.some((item) => item.includes("expected `main`"))).toBe(true);
+  });
+});
+
+describe("buildRalphLoopNudgeMessage", () => {
+  it("formats pending inbox and claimed thread counts", () => {
+    expect(buildRalphLoopNudgeMessage(2, 1)).toContain("2 inbox items and 1 claimed thread");
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -481,6 +481,126 @@ export function rankAgentsForRouting(
   return ranked.sort(compareRouting);
 }
 
+export const DEFAULT_RALPH_LOOP_INTERVAL_MS = 30_000;
+export const DEFAULT_RALPH_LOOP_IDLE_WITH_WORK_THRESHOLD_MS = 60_000;
+export const DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS = 5 * 60_000;
+
+export interface RalphLoopAgentWorkload extends AgentVisibilityInput {
+  lastSeen?: string;
+  pendingInboxCount: number;
+  ownedThreadCount: number;
+}
+
+export interface RalphLoopEvaluationOptions extends AgentVisibilityOptions {
+  idleWithWorkThresholdMs?: number;
+  pendingBacklogCount?: number;
+  currentBranch?: string | null;
+  expectedMainBranch?: string;
+  brokerHeartbeatActive?: boolean;
+  brokerMaintenanceActive?: boolean;
+}
+
+export interface RalphLoopEvaluationResult {
+  ghostAgentIds: string[];
+  nudgeAgentIds: string[];
+  idleDrainAgentIds: string[];
+  anomalies: string[];
+}
+
+export function evaluateRalphLoopCycle(
+  workloads: RalphLoopAgentWorkload[],
+  options: RalphLoopEvaluationOptions = {},
+): RalphLoopEvaluationResult {
+  const nowMs = options.now ?? Date.now();
+  const idleWithWorkThresholdMs =
+    options.idleWithWorkThresholdMs ?? DEFAULT_RALPH_LOOP_IDLE_WITH_WORK_THRESHOLD_MS;
+  const pendingBacklogCount = options.pendingBacklogCount ?? 0;
+  const expectedMainBranch = options.expectedMainBranch ?? "main";
+  const anomalies: string[] = [];
+  const ghostAgentIds: string[] = [];
+  const nudgeAgentIds: string[] = [];
+  const idleDrainAgentIds: string[] = [];
+
+  for (const workload of workloads) {
+    const metadata = asRecord(workload.metadata);
+    const capabilities = extractAgentCapabilities(metadata);
+    const role = (capabilities.role ?? asString(metadata?.role) ?? "worker").toLowerCase();
+    if (role === "broker") {
+      continue;
+    }
+
+    const display = buildAgentDisplayInfo(workload, options);
+    if (display.health === "ghost") {
+      ghostAgentIds.push(workload.id);
+      continue;
+    }
+
+    const hasAssignedWork = workload.pendingInboxCount > 0 || workload.ownedThreadCount > 0;
+    const lastSeenMs = parseIsoMs(workload.lastSeen) ?? parseIsoMs(workload.lastHeartbeat);
+    const idleAgeMs = lastSeenMs == null ? null : Math.max(0, nowMs - lastSeenMs);
+
+    if (
+      hasAssignedWork &&
+      workload.status === "idle" &&
+      display.health !== "resumable" &&
+      idleAgeMs != null &&
+      idleAgeMs >= idleWithWorkThresholdMs
+    ) {
+      nudgeAgentIds.push(workload.id);
+      anomalies.push(
+        `${workload.name} idle with assigned work (${workload.pendingInboxCount} inbox, ${workload.ownedThreadCount} threads)`,
+      );
+      continue;
+    }
+
+    if (!hasAssignedWork && workload.status === "idle" && display.health === "healthy") {
+      idleDrainAgentIds.push(workload.id);
+    }
+  }
+
+  if (ghostAgentIds.length > 0) {
+    anomalies.push(`ghost agents detected: ${ghostAgentIds.join(", ")}`);
+  }
+  if (pendingBacklogCount > 0 && idleDrainAgentIds.length > 0) {
+    anomalies.push(
+      `pending backlog (${pendingBacklogCount}) with ${idleDrainAgentIds.length} idle worker${idleDrainAgentIds.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (options.currentBranch && options.currentBranch !== expectedMainBranch) {
+    anomalies.push(
+      `main checkout is on \`${options.currentBranch}\`, expected \`${expectedMainBranch}\``,
+    );
+  }
+  if (options.brokerHeartbeatActive === false) {
+    anomalies.push("broker heartbeat timer is not running");
+  }
+  if (options.brokerMaintenanceActive === false) {
+    anomalies.push("broker maintenance timer is not running");
+  }
+
+  return {
+    ghostAgentIds,
+    nudgeAgentIds,
+    idleDrainAgentIds,
+    anomalies,
+  };
+}
+
+export function buildRalphLoopNudgeMessage(
+  pendingInboxCount: number,
+  ownedThreadCount: number,
+): string {
+  const parts = [];
+  if (pendingInboxCount > 0) {
+    parts.push(`${pendingInboxCount} inbox item${pendingInboxCount === 1 ? "" : "s"}`);
+  }
+  if (ownedThreadCount > 0) {
+    parts.push(`${ownedThreadCount} claimed thread${ownedThreadCount === 1 ? "" : "s"}`);
+  }
+  const workload = parts.length > 0 ? parts.join(" and ") : "assigned work";
+  return `RALPH LOOP nudge: you appear idle but still have ${workload}. Please pick it up, post a status update, or release ownership so the broker can reassign it.`;
+}
+
 export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: string): string[] {
   return [
     `You are ${agentEmoji} ${agentName}, the Pinet BROKER. Your role is coordination, not coding.`,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -17,6 +17,10 @@ import {
   buildSlackRequest,
   buildAgentDisplayInfo,
   rankAgentsForRouting,
+  evaluateRalphLoopCycle,
+  buildRalphLoopNudgeMessage,
+  DEFAULT_RALPH_LOOP_INTERVAL_MS,
+  DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
   generateAgentName,
   resolveAgentIdentity,
   shortenPath,
@@ -1223,9 +1227,13 @@ export default function (pi: ExtensionAPI) {
   let activeSelfId: string | null = null;
   let brokerHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let brokerMaintenanceTimer: ReturnType<typeof setInterval> | null = null;
+  let brokerRalphLoopTimer: ReturnType<typeof setInterval> | null = null;
   let brokerMaintenanceRunning = false;
+  let brokerRalphLoopRunning = false;
   let lastBrokerMaintenance: BrokerMaintenanceResult | null = null;
   let lastBrokerMaintenanceSignature = "";
+  let lastBrokerRalphLoopSignature = "";
+  const lastBrokerNudges = new Map<string, number>();
 
   function startBrokerHeartbeat(): void {
     stopBrokerHeartbeat();
@@ -1285,6 +1293,105 @@ export default function (pi: ExtensionAPI) {
     if (!brokerMaintenanceTimer) return;
     clearInterval(brokerMaintenanceTimer);
     brokerMaintenanceTimer = null;
+  }
+
+  function sendBrokerMaintenanceMessage(targetAgentId: string, body: string): void {
+    if (!activeBroker || !activeSelfId) return;
+    const db = activeBroker.db as BrokerDB;
+    const target = db.getAgentById(targetAgentId);
+    if (!target) return;
+
+    const threadId = `a2a:${activeSelfId}:${target.id}`;
+    if (!db.getThread(threadId)) {
+      db.createThread(threadId, "agent", "", activeSelfId);
+    }
+
+    db.insertMessage(threadId, "agent", "outbound", activeSelfId, body, [target.id], {
+      kind: "ralph_loop_nudge",
+      targetAgentId,
+    });
+  }
+
+  function runBrokerRalphLoop(ctx: ExtensionContext): void {
+    if (!activeBroker || !activeSelfId || brokerRalphLoopRunning) return;
+
+    brokerRalphLoopRunning = true;
+    try {
+      runBrokerMaintenance(ctx);
+
+      const db = activeBroker.db as BrokerDB;
+      let currentBranch: string | null = null;
+      try {
+        currentBranch = execSync("git branch --show-current", { encoding: "utf-8" }).trim() || null;
+      } catch {
+        /* best effort */
+      }
+
+      const workloads = db.getAllAgents().map((agent) => ({
+        ...agent,
+        pendingInboxCount: db.getPendingInboxCount(agent.id),
+        ownedThreadCount: db.getOwnedThreadCount(agent.id),
+      }));
+      const evaluation = evaluateRalphLoopCycle(workloads, {
+        now: Date.now(),
+        heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
+        heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+        pendingBacklogCount: db.getBacklogCount("pending"),
+        currentBranch,
+        brokerHeartbeatActive: brokerHeartbeatTimer != null,
+        brokerMaintenanceActive: brokerMaintenanceTimer != null,
+      });
+
+      const now = Date.now();
+      const nudgeAgentIds = new Set(evaluation.nudgeAgentIds);
+      for (const workload of workloads) {
+        if (!nudgeAgentIds.has(workload.id)) {
+          lastBrokerNudges.delete(workload.id);
+          continue;
+        }
+
+        const lastNudgeAt = lastBrokerNudges.get(workload.id) ?? 0;
+        if (now - lastNudgeAt < DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS) {
+          continue;
+        }
+
+        sendBrokerMaintenanceMessage(
+          workload.id,
+          buildRalphLoopNudgeMessage(workload.pendingInboxCount, workload.ownedThreadCount),
+        );
+        lastBrokerNudges.set(workload.id, now);
+      }
+
+      const signature = evaluation.anomalies.join("|");
+      if (signature && signature !== lastBrokerRalphLoopSignature) {
+        ctx.ui.notify(`RALPH loop: ${evaluation.anomalies.join("; ")}`, "warning");
+      } else if (!signature && lastBrokerRalphLoopSignature) {
+        ctx.ui.notify("RALPH loop health recovered", "info");
+      }
+      lastBrokerRalphLoopSignature = signature;
+    } catch (err) {
+      ctx.ui.notify(`RALPH loop failed: ${msg(err)}`, "error");
+    } finally {
+      brokerRalphLoopRunning = false;
+    }
+  }
+
+  function startBrokerRalphLoop(ctx: ExtensionContext): void {
+    stopBrokerRalphLoop();
+    brokerRalphLoopTimer = setInterval(() => {
+      runBrokerRalphLoop(ctx);
+    }, DEFAULT_RALPH_LOOP_INTERVAL_MS);
+    brokerRalphLoopTimer.unref?.();
+    runBrokerRalphLoop(ctx);
+  }
+
+  function stopBrokerRalphLoop(): void {
+    if (brokerRalphLoopTimer) {
+      clearInterval(brokerRalphLoopTimer);
+      brokerRalphLoopTimer = null;
+    }
+    lastBrokerNudges.clear();
+    lastBrokerRalphLoopSignature = "";
   }
 
   pi.registerTool({
@@ -1573,6 +1680,7 @@ export default function (pi: ExtensionAPI) {
         activeSelfId = selfId;
         startBrokerHeartbeat();
         startBrokerMaintenance(ctx);
+        startBrokerRalphLoop(ctx);
         brokerRole = "broker";
         pinetEnabled = true;
         setExtStatus(ctx, "ok");
@@ -1915,6 +2023,7 @@ export default function (pi: ExtensionAPI) {
     flushPersist();
     stopBrokerHeartbeat();
     stopBrokerMaintenance();
+    stopBrokerRalphLoop();
     if (activeBroker) {
       try {
         if (activeSelfId) {
@@ -1930,6 +2039,7 @@ export default function (pi: ExtensionAPI) {
     activeSelfId = null;
     lastBrokerMaintenance = null;
     lastBrokerMaintenanceSignature = "";
+    lastBrokerRalphLoopSignature = "";
     if (brokerClient) {
       try {
         clearInterval(brokerClient.pollInterval);


### PR DESCRIPTION
## Summary\n- add a 30s broker-side Ralph loop runtime timer\n- evaluate ghost/idle/drain/self-repair conditions and nudge idle agents that still own work\n- add broker workload helpers/tests for owned threads and Ralph loop evaluation\n\n## Validation\n- pnpm install\n- pnpm lint\n- pnpm typecheck\n- pnpm test