### PR TITLE
fix: resolve follower thread channels via broker (#95)

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -585,6 +585,56 @@ describe("BrokerClient — listThreads / listAgents", () => {
   });
 });
 
+describe("BrokerClient — resolveThread", () => {
+  let mock: MockServer;
+
+  beforeEach(async () => {
+    mock = await createMockServer();
+  });
+
+  afterEach(async () => {
+    await mock.close();
+  });
+
+  it("sends resolveThread RPC and returns the channelId", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const resolvePromise = client.resolveThread("1234.5678");
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { threadTs: string };
+    };
+    expect(req.method).toBe("resolveThread");
+    expect(req.params.threadTs).toBe("1234.5678");
+
+    mock.respondTo(mock.connections[0], req.id, { channelId: "C123" });
+
+    await expect(resolvePromise).resolves.toBe("C123");
+
+    client.disconnect();
+  });
+
+  it("returns null when the broker has no channel for the thread", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const resolvePromise = client.resolveThread("missing-thread");
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as { id: number };
+
+    mock.respondTo(mock.connections[0], req.id, { channelId: null });
+
+    await expect(resolvePromise).resolves.toBeNull();
+
+    client.disconnect();
+  });
+});
+
 describe("BrokerClient — sendAgentMessage", () => {
   let mock: MockServer;
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -213,6 +213,13 @@ export class BrokerClient {
     return result;
   }
 
+  async resolveThread(threadTs: string): Promise<string | null> {
+    const result = (await this.request("resolveThread", { threadTs })) as {
+      channelId?: string | null;
+    };
+    return typeof result.channelId === "string" ? result.channelId : null;
+  }
+
   // ─── Status ────────────────────────────────────────────
 
   async updateStatus(status: "working" | "idle"): Promise<void> {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -408,6 +408,19 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(thread!.channel).toBe("C-TEST-123");
   });
 
+  it("resolveThread returns the broker channel for an existing thread", async () => {
+    await client.register("resolver-agent", "🧭");
+    db.createThread("t-resolve", "slack", "C-THREAD-1", null);
+
+    await expect(client.resolveThread("t-resolve")).resolves.toBe("C-THREAD-1");
+  });
+
+  it("resolveThread returns null for unknown threads", async () => {
+    await client.register("resolver-agent", "🧭");
+
+    await expect(client.resolveThread("missing-thread")).resolves.toBeNull();
+  });
+
   it("slack.proxy chat.postMessage auto-claims thread for calling agent", async () => {
     client.disconnect();
     await server.stop();

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -312,6 +312,8 @@ export class BrokerSocketServer {
           return this.handleAgentsList(req);
         case "thread.claim":
           return this.handleThreadClaim(req, state);
+        case "resolveThread":
+          return this.handleResolveThread(req, state);
         case "agent.message":
           return this.handleAgentMessage(req, state);
         case "status.update":
@@ -486,6 +488,21 @@ export class BrokerSocketServer {
     const channel = typeof params.channel === "string" ? params.channel : undefined;
     const claimed = this.router.claimThread(threadId, state.agentId, channel);
     return rpcOk(req.id, { claimed });
+  }
+
+  private handleResolveThread(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
+    const params = req.params ?? {};
+    const threadTs = typeof params.threadTs === "string" ? params.threadTs : null;
+    if (!threadTs) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "threadTs is required");
+    }
+
+    const channelId = this.db.getThread(threadTs)?.channel || null;
+    return rpcOk(req.id, { channelId });
   }
 
   // ─── Agent-to-agent messaging ─────────────────────────

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -23,6 +23,7 @@ import {
   resolveAgentIdentity,
   trackBrokerInboundThread,
   syncFollowerInboxEntries,
+  resolveFollowerThreadChannel,
   isDirectMessageChannel,
   getFollowerReconnectUiUpdate,
   getFollowerOwnedThreadClaims,
@@ -926,6 +927,72 @@ describe("syncFollowerInboxEntries", () => {
       null,
     );
     expect(result.changed).toBe(false);
+  });
+});
+
+// ─── resolveFollowerThreadChannel ─────────────────────────
+
+describe("resolveFollowerThreadChannel", () => {
+  it("returns the local channel without calling the broker", async () => {
+    const resolveThread = async () => {
+      throw new Error("should not be called");
+    };
+
+    await expect(
+      resolveFollowerThreadChannel(
+        "1234.5678",
+        { channelId: "C123", threadTs: "1234.5678", userId: "U1", owner: "Bot" },
+        "follower",
+        resolveThread,
+      ),
+    ).resolves.toEqual({ channelId: "C123", changed: false });
+  });
+
+  it("asks the broker for the channel when the follower has no local thread", async () => {
+    const result = await resolveFollowerThreadChannel(
+      "1234.5678",
+      undefined,
+      "follower",
+      async (threadTs) => {
+        expect(threadTs).toBe("1234.5678");
+        return "C999";
+      },
+    );
+
+    expect(result).toEqual({
+      channelId: "C999",
+      changed: true,
+      threadUpdate: {
+        channelId: "C999",
+        threadTs: "1234.5678",
+        userId: "",
+        owner: undefined,
+      },
+    });
+  });
+
+  it("returns null when the broker cannot resolve the thread", async () => {
+    await expect(
+      resolveFollowerThreadChannel("1234.5678", undefined, "follower", async () => null),
+    ).resolves.toEqual({ channelId: null, changed: false });
+  });
+
+  it("returns null when the broker lookup throws", async () => {
+    await expect(
+      resolveFollowerThreadChannel("1234.5678", undefined, "follower", async () => {
+        throw new Error("broker offline");
+      }),
+    ).resolves.toEqual({ channelId: null, changed: false });
+  });
+
+  it("does not query the broker for non-followers", async () => {
+    const resolveThread = async () => {
+      throw new Error("should not be called");
+    };
+
+    await expect(
+      resolveFollowerThreadChannel("1234.5678", undefined, "broker", resolveThread),
+    ).resolves.toEqual({ channelId: null, changed: false });
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -648,6 +648,51 @@ export function syncFollowerInboxEntries(
   };
 }
 
+export interface FollowerThreadChannelResolution {
+  channelId: string | null;
+  threadUpdate?: FollowerThreadState;
+  changed: boolean;
+}
+
+export async function resolveFollowerThreadChannel(
+  threadTs: string | undefined,
+  existingThread: FollowerThreadState | undefined,
+  brokerRole: "broker" | "follower" | null,
+  resolveThread?: (threadTs: string) => Promise<string | null>,
+): Promise<FollowerThreadChannelResolution> {
+  if (!threadTs) {
+    return { channelId: null, changed: false };
+  }
+
+  if (existingThread?.channelId) {
+    return { channelId: existingThread.channelId, changed: false };
+  }
+
+  if (brokerRole !== "follower" || !resolveThread) {
+    return { channelId: null, changed: false };
+  }
+
+  try {
+    const channelId = await resolveThread(threadTs);
+    if (!channelId) {
+      return { channelId: null, changed: false };
+    }
+
+    return {
+      channelId,
+      changed: true,
+      threadUpdate: {
+        channelId,
+        threadTs,
+        userId: existingThread?.userId ?? "",
+        owner: existingThread?.owner,
+      },
+    };
+  } catch {
+    return { channelId: null, changed: false };
+  }
+}
+
 export interface FollowerReconnectUiUpdate {
   nextWasDisconnected: boolean;
   notify?: {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -25,6 +25,7 @@ import {
   buildWorkerPromptGuidelines,
   resolveAgentStableId,
   syncFollowerInboxEntries,
+  resolveFollowerThreadChannel,
   getFollowerReconnectUiUpdate,
   getFollowerOwnedThreadClaims,
   trackBrokerInboundThread,
@@ -347,6 +348,30 @@ export default function (pi: ExtensionAPI) {
     } while (cursor);
 
     throw new Error(`Channel "${name}" not found.`);
+  }
+
+  async function resolveFollowerReplyChannel(threadTs: string | undefined): Promise<string | null> {
+    if (!threadTs) return null;
+
+    const existingThread = threads.get(threadTs);
+    const resolved = await resolveFollowerThreadChannel(
+      threadTs,
+      existingThread,
+      brokerRole,
+      brokerRole === "follower" && brokerClient?.client
+        ? (nextThreadTs) => (brokerClient.client as BrokerClient).resolveThread(nextThreadTs)
+        : undefined,
+    );
+
+    if (resolved.threadUpdate && resolved.changed) {
+      threads.set(threadTs, {
+        ...(existingThread ?? {}),
+        ...resolved.threadUpdate,
+      });
+      persistState();
+    }
+
+    return resolved.channelId;
   }
 
   async function clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
@@ -850,8 +875,7 @@ export default function (pi: ExtensionAPI) {
     async execute(_id, params) {
       requireToolPolicy("slack_send", params.thread_ts);
 
-      const thread = params.thread_ts ? threads.get(params.thread_ts) : undefined;
-      const channel = thread?.channelId ?? lastDmChannel;
+      const channel = (await resolveFollowerReplyChannel(params.thread_ts)) ?? lastDmChannel;
 
       if (!channel) {
         throw new Error("No active Slack thread. Wait for an incoming message first.");
@@ -1020,11 +1044,17 @@ export default function (pi: ExtensionAPI) {
     async execute(_id, params) {
       requireToolPolicy("slack_post_channel", params.thread_ts);
 
+      const resolvedThreadChannel = await resolveFollowerReplyChannel(params.thread_ts);
       const channelInput = params.channel ?? settings.defaultChannel;
-      if (!channelInput) {
+      let channelId = params.channel ? await resolveChannel(params.channel) : resolvedThreadChannel;
+
+      if (!channelId && channelInput) {
+        channelId = await resolveChannel(channelInput);
+      }
+      if (!channelId) {
         throw new Error("No channel specified and no defaultChannel configured in settings.json.");
       }
-      const channelId = await resolveChannel(channelInput);
+
       const body: Record<string, unknown> = {
         channel: channelId,
         text: params.text,
@@ -1062,13 +1092,14 @@ export default function (pi: ExtensionAPI) {
         });
       }
 
+      const channelLabel = params.channel ?? resolvedThreadChannel ?? channelInput ?? channelId;
       return {
         content: [
           {
             type: "text",
             text: params.thread_ts
-              ? `Replied in thread ${params.thread_ts} in channel ${channelInput}.`
-              : `Posted to #${channelInput} (ts: ${ts}).`,
+              ? `Replied in thread ${params.thread_ts} in channel ${channelLabel}.`
+              : `Posted to #${channelLabel} (ts: ${ts}).`,
           },
         ],
         details: { ts, channel: channelId },


### PR DESCRIPTION
## Problem

Followers can't `slack_send` to threads they didn't originate — throws 'No active Slack thread' because the local `threads` map doesn't have the channelId.

Fixes #95.

## Fix

When a follower's `slack_send` can't find a thread locally, it asks the broker via a new `resolveThread` RPC call to get the channelId.

- New `resolveThread` method on `BrokerClient`
- New handler in `socket-server.ts`  
- Fallback in `slack_send` and `slack_post_channel` execute
- Tests for client, integration, and helpers

⚠️ Also includes unrelated neon-psql refactoring (same as #97).