### PR TITLE
feat: deliver Ralph loop findings as follow-up prompt (#104)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -15,6 +15,8 @@ import {
   buildRalphLoopNudgeMessage,
   buildRalphLoopAnomalySignature,
   buildRalphLoopFollowUpMessage,
+  shouldDeliverRalphLoopFollowUp,
+  DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   buildBrokerPromptGuidelines,
   buildIdentityReplyGuidelines,
   resolvePersistedAgentIdentity,
@@ -803,6 +805,54 @@ describe("buildRalphLoopAnomalySignature", () => {
   });
 });
 
+describe("shouldDeliverRalphLoopFollowUp", () => {
+  it("delivers new actionable findings", () => {
+    expect(
+      shouldDeliverRalphLoopFollowUp({
+        signature: "ghost agents detected: ghost-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not repeat the same signature", () => {
+    expect(
+      shouldDeliverRalphLoopFollowUp({
+        signature: "ghost agents detected: ghost-1",
+        previousSignature: "ghost agents detected: ghost-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not send while a Ralph prompt is already pending", () => {
+    expect(
+      shouldDeliverRalphLoopFollowUp({
+        signature: "ghost agents detected: ghost-1",
+        pending: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not send while the broker is busy", () => {
+    expect(
+      shouldDeliverRalphLoopFollowUp({
+        signature: "ghost agents detected: ghost-1",
+        idle: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("throttles repeated Ralph follow-ups", () => {
+    expect(
+      shouldDeliverRalphLoopFollowUp({
+        signature: "ghost agents detected: ghost-2",
+        previousSignature: "ghost agents detected: ghost-1",
+        lastDeliveredAt: 10_000,
+        now: 10_000 + DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS - 1,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("buildRalphLoopFollowUpMessage", () => {
   it("formats actionable anomalies into a broker follow-up prompt", () => {
     expect(
@@ -836,25 +886,6 @@ describe("buildRalphLoopFollowUpMessage", () => {
         idleDrainAgentIds: [],
         anomalies: [],
       }),
-    ).toBeNull();
-  });
-
-  it("returns null when the anomaly signature has not changed", () => {
-    const evaluation = {
-      ghostAgentIds: ["ghost-1"],
-      nudgeAgentIds: ["idle-1"],
-      idleDrainAgentIds: [],
-      anomalies: [
-        "ghost agents detected: ghost-1",
-        "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
-      ],
-    };
-
-    expect(
-      buildRalphLoopFollowUpMessage(
-        evaluation,
-        "ghost agents detected: ghost-1|Idle Gecko idle with assigned work (2 inbox, 1 threads)",
-      ),
     ).toBeNull();
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -484,6 +484,7 @@ export function rankAgentsForRouting(
 export const DEFAULT_RALPH_LOOP_INTERVAL_MS = 30_000;
 export const DEFAULT_RALPH_LOOP_IDLE_WITH_WORK_THRESHOLD_MS = 60_000;
 export const DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS = 5 * 60_000;
+export const DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS = 60_000;
 
 export interface RalphLoopAgentWorkload extends AgentVisibilityInput {
   lastSeen?: string;
@@ -605,12 +606,40 @@ export function buildRalphLoopAnomalySignature(evaluation: RalphLoopEvaluationRe
   return evaluation.anomalies.join("|");
 }
 
+export interface RalphLoopFollowUpDeliveryOptions {
+  signature: string;
+  previousSignature?: string;
+  lastDeliveredAt?: number;
+  now?: number;
+  cooldownMs?: number;
+  pending?: boolean;
+  idle?: boolean;
+}
+
+export function shouldDeliverRalphLoopFollowUp(options: RalphLoopFollowUpDeliveryOptions): boolean {
+  const now = options.now ?? Date.now();
+  const previousSignature = options.previousSignature ?? "";
+  const lastDeliveredAt = options.lastDeliveredAt ?? 0;
+  const cooldownMs = options.cooldownMs ?? DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS;
+  const pending = options.pending ?? false;
+  const idle = options.idle ?? true;
+
+  if (!options.signature || options.signature === previousSignature) {
+    return false;
+  }
+  if (pending || !idle) {
+    return false;
+  }
+  if (lastDeliveredAt > 0 && now - lastDeliveredAt < cooldownMs) {
+    return false;
+  }
+  return true;
+}
+
 export function buildRalphLoopFollowUpMessage(
   evaluation: RalphLoopEvaluationResult,
-  previousSignature = "",
 ): string | null {
-  const signature = buildRalphLoopAnomalySignature(evaluation);
-  if (!signature || signature === previousSignature) {
+  if (evaluation.anomalies.length === 0) {
     return null;
   }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -21,8 +21,10 @@ import {
   buildRalphLoopNudgeMessage,
   buildRalphLoopAnomalySignature,
   buildRalphLoopFollowUpMessage,
+  shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_INTERVAL_MS,
   DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
+  DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   generateAgentName,
   resolveAgentIdentity,
   shortenPath,
@@ -1235,6 +1237,9 @@ export default function (pi: ExtensionAPI) {
   let lastBrokerMaintenance: BrokerMaintenanceResult | null = null;
   let lastBrokerMaintenanceSignature = "";
   let lastBrokerRalphLoopSignature = "";
+  let lastBrokerRalphLoopFollowUpSignature = "";
+  let lastBrokerRalphLoopFollowUpAt = 0;
+  let brokerRalphLoopFollowUpPending = false;
   const lastBrokerNudges = new Map<string, number>();
 
   function startBrokerHeartbeat(): void {
@@ -1365,20 +1370,39 @@ export default function (pi: ExtensionAPI) {
       }
 
       const signature = buildRalphLoopAnomalySignature(evaluation);
-      const followUpPrompt = buildRalphLoopFollowUpMessage(
-        evaluation,
-        lastBrokerRalphLoopSignature,
-      );
-      if (followUpPrompt) {
+      const followUpPrompt = buildRalphLoopFollowUpMessage(evaluation);
+      const shouldDeliverFollowUp =
+        followUpPrompt != null &&
+        shouldDeliverRalphLoopFollowUp({
+          signature,
+          previousSignature: lastBrokerRalphLoopFollowUpSignature,
+          lastDeliveredAt: lastBrokerRalphLoopFollowUpAt,
+          now,
+          cooldownMs: DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
+          pending: brokerRalphLoopFollowUpPending,
+          idle: ctx.isIdle?.() ?? true,
+        });
+      if (shouldDeliverFollowUp && followUpPrompt) {
+        const markFollowUpDelivered = () => {
+          brokerRalphLoopFollowUpPending = true;
+          lastBrokerRalphLoopFollowUpAt = now;
+          lastBrokerRalphLoopFollowUpSignature = signature;
+        };
+
         try {
           pi.sendUserMessage(followUpPrompt, { deliverAs: "followUp" });
+          markFollowUpDelivered();
         } catch {
           try {
             pi.sendUserMessage(followUpPrompt);
+            markFollowUpDelivered();
           } catch {
             /* best effort */
           }
         }
+      }
+      if (!signature) {
+        lastBrokerRalphLoopFollowUpSignature = "";
       }
 
       if (signature && signature !== lastBrokerRalphLoopSignature) {
@@ -1410,6 +1434,9 @@ export default function (pi: ExtensionAPI) {
     }
     lastBrokerNudges.clear();
     lastBrokerRalphLoopSignature = "";
+    lastBrokerRalphLoopFollowUpSignature = "";
+    lastBrokerRalphLoopFollowUpAt = 0;
+    brokerRalphLoopFollowUpPending = false;
   }
 
   pi.registerTool({
@@ -2032,6 +2059,7 @@ export default function (pi: ExtensionAPI) {
       if (thread) await clearThreadStatus(thread.channelId, ts);
     }
     thinking.clear();
+    brokerRalphLoopFollowUpPending = false;
 
     reportStatus("idle");
     drainInbox();


### PR DESCRIPTION
## Summary

- wake the broker agent with a follow-up prompt when the Ralph loop finds actionable anomalies
- factor the Ralph loop summary into a helper for consistent formatting
- add tests covering follow-up prompt formatting and the no-op case

## Validation

- pnpm lint
- pnpm typecheck
- pnpm test
