### PR TITLE
fix: deliver Ralph loop nudges as follow-ups (#104)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -28,6 +28,7 @@ import {
   FORM_METHODS,
   resolveAgentIdentity,
   trackBrokerInboundThread,
+  extractFollowerFollowUpMessages,
   syncFollowerInboxEntries,
   resolveFollowerThreadChannel,
   isDirectMessageChannel,
@@ -772,6 +773,7 @@ describe("evaluateRalphLoopCycle", () => {
     expect(result.ghostAgentIds).toEqual(["ghost-worker"]);
     expect(result.nudgeAgentIds).toEqual(["idle-worker"]);
     expect(result.idleDrainAgentIds).toEqual(["ready-worker"]);
+    expect(result.pendingBacklogCount).toBe(3);
     expect(result.anomalies).toContain("Idle Gecko idle with assigned work (2 inbox, 1 threads)");
     expect(result.anomalies).toContain("ghost agents detected: ghost-worker");
     expect(result.anomalies).toContain("pending backlog (3) with 1 idle worker");
@@ -794,6 +796,7 @@ describe("buildRalphLoopAnomalySignature", () => {
         ghostAgentIds: ["ghost-1"],
         nudgeAgentIds: ["idle-1"],
         idleDrainAgentIds: ["ready-1"],
+        pendingBacklogCount: 0,
         anomalies: [
           "ghost agents detected: ghost-1",
           "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
@@ -860,6 +863,7 @@ describe("buildRalphLoopFollowUpMessage", () => {
         ghostAgentIds: ["ghost-1"],
         nudgeAgentIds: ["idle-1"],
         idleDrainAgentIds: ["ready-1"],
+        pendingBacklogCount: 1,
         anomalies: [
           "ghost agents detected: ghost-1",
           "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
@@ -872,6 +876,26 @@ describe("buildRalphLoopFollowUpMessage", () => {
         "- ghost agents detected: ghost-1",
         "- Idle Gecko idle with assigned work (2 inbox, 1 threads)",
         "- main checkout is on `feat/not-main`, expected `main`",
+        "- pending backlog (1) still needs attention",
+        "",
+        "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
+      ].join("\n"),
+    );
+  });
+
+  it("returns a backlog-only follow-up when pending backlog remains", () => {
+    expect(
+      buildRalphLoopFollowUpMessage({
+        ghostAgentIds: [],
+        nudgeAgentIds: [],
+        idleDrainAgentIds: [],
+        pendingBacklogCount: 2,
+        anomalies: [],
+      }),
+    ).toBe(
+      [
+        "RALPH LOOP CYCLE:",
+        "- pending backlog (2) still needs attention",
         "",
         "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
       ].join("\n"),
@@ -884,6 +908,7 @@ describe("buildRalphLoopFollowUpMessage", () => {
         ghostAgentIds: [],
         nudgeAgentIds: [],
         idleDrainAgentIds: [],
+        pendingBacklogCount: 0,
         anomalies: [],
       }),
     ).toBeNull();
@@ -1034,6 +1059,57 @@ describe("isDirectMessageChannel", () => {
 
   it("rejects empty string", () => {
     expect(isDirectMessageChannel("")).toBe(false);
+  });
+});
+
+// ─── extractFollowerFollowUpMessages ──────────────────────
+
+describe("extractFollowerFollowUpMessages", () => {
+  it("pulls Ralph loop nudges out for direct follow-up delivery", () => {
+    const result = extractFollowerFollowUpMessages([
+      {
+        inboxId: 1,
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker",
+          body: "RALPH LOOP nudge: please wake up",
+          metadata: { kind: "ralph_loop_nudge" },
+        },
+      },
+      {
+        inboxId: 2,
+        message: {
+          threadId: "123.4",
+          sender: "U1",
+          body: "hello",
+          metadata: { channel: "C1" },
+        },
+      },
+    ]);
+
+    expect(result.followUpMessages).toEqual([
+      { inboxId: 1, text: "RALPH LOOP nudge: please wake up" },
+    ]);
+    expect(result.remainingEntries).toHaveLength(1);
+    expect(result.remainingEntries[0].inboxId).toBe(2);
+  });
+
+  it("leaves normal inbox entries alone", () => {
+    const result = extractFollowerFollowUpMessages([
+      {
+        inboxId: 2,
+        message: {
+          threadId: "123.4",
+          sender: "U1",
+          body: "hello",
+          metadata: { channel: "C1" },
+        },
+      },
+    ]);
+
+    expect(result.followUpMessages).toEqual([]);
+    expect(result.remainingEntries).toHaveLength(1);
+    expect(result.remainingEntries[0].inboxId).toBe(2);
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -505,6 +505,7 @@ export interface RalphLoopEvaluationResult {
   ghostAgentIds: string[];
   nudgeAgentIds: string[];
   idleDrainAgentIds: string[];
+  pendingBacklogCount: number;
   anomalies: string[];
 }
 
@@ -583,6 +584,7 @@ export function evaluateRalphLoopCycle(
     ghostAgentIds,
     nudgeAgentIds,
     idleDrainAgentIds,
+    pendingBacklogCount,
     anomalies,
   };
 }
@@ -639,13 +641,24 @@ export function shouldDeliverRalphLoopFollowUp(options: RalphLoopFollowUpDeliver
 export function buildRalphLoopFollowUpMessage(
   evaluation: RalphLoopEvaluationResult,
 ): string | null {
-  if (evaluation.anomalies.length === 0) {
+  const actionableLines = [...evaluation.anomalies];
+
+  if (
+    evaluation.pendingBacklogCount > 0 &&
+    !actionableLines.some((line) => line.includes("pending backlog"))
+  ) {
+    actionableLines.push(
+      `pending backlog (${evaluation.pendingBacklogCount}) still needs attention`,
+    );
+  }
+
+  if (actionableLines.length === 0) {
     return null;
   }
 
   return [
     "RALPH LOOP CYCLE:",
-    ...evaluation.anomalies.map((anomaly) => `- ${anomaly}`),
+    ...actionableLines.map((anomaly) => `- ${anomaly}`),
     "",
     "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
   ].join("\n");
@@ -739,6 +752,7 @@ export interface FollowerThreadState {
 }
 
 export interface FollowerInboxEntry {
+  inboxId?: number;
   message: {
     threadId?: string;
     sender?: string;
@@ -746,6 +760,11 @@ export interface FollowerInboxEntry {
     createdAt?: string;
     metadata: Record<string, unknown> | null;
   };
+}
+
+export interface FollowerFollowUpMessage {
+  inboxId?: number;
+  text: string;
 }
 
 export interface FollowerInboxSyncResult {
@@ -757,6 +776,26 @@ export interface FollowerInboxSyncResult {
 
 export function isDirectMessageChannel(channel: string): boolean {
   return /^D[A-Z0-9]+$/.test(channel);
+}
+
+export function extractFollowerFollowUpMessages(entries: FollowerInboxEntry[]): {
+  remainingEntries: FollowerInboxEntry[];
+  followUpMessages: FollowerFollowUpMessage[];
+} {
+  const remainingEntries: FollowerInboxEntry[] = [];
+  const followUpMessages: FollowerFollowUpMessage[] = [];
+
+  for (const entry of entries) {
+    const meta = entry.message.metadata ?? {};
+    if (meta.kind === "ralph_loop_nudge" && entry.message.body) {
+      followUpMessages.push({ inboxId: entry.inboxId, text: entry.message.body });
+      continue;
+    }
+
+    remainingEntries.push(entry);
+  }
+
+  return { remainingEntries, followUpMessages };
 }
 
 export function syncFollowerInboxEntries(

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -32,6 +32,7 @@ import {
   buildBrokerPromptGuidelines,
   buildWorkerPromptGuidelines,
   resolveAgentStableId,
+  extractFollowerFollowUpMessages,
   syncFollowerInboxEntries,
   resolveFollowerThreadChannel,
   getFollowerReconnectUiUpdate,
@@ -1319,6 +1320,22 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
+  function sendFollowUpMessage(prompt: string, onDelivered?: () => void): boolean {
+    try {
+      pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+      onDelivered?.();
+      return true;
+    } catch {
+      try {
+        pi.sendUserMessage(prompt);
+        onDelivered?.();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+
   function runBrokerRalphLoop(ctx: ExtensionContext): void {
     if (!activeBroker || !activeSelfId || brokerRalphLoopRunning) return;
 
@@ -1369,12 +1386,13 @@ export default function (pi: ExtensionAPI) {
         lastBrokerNudges.set(workload.id, now);
       }
 
-      const signature = buildRalphLoopAnomalySignature(evaluation);
+      const anomalySignature = buildRalphLoopAnomalySignature(evaluation);
       const followUpPrompt = buildRalphLoopFollowUpMessage(evaluation);
+      const followUpSignature = followUpPrompt ?? "";
       const shouldDeliverFollowUp =
         followUpPrompt != null &&
         shouldDeliverRalphLoopFollowUp({
-          signature,
+          signature: followUpSignature,
           previousSignature: lastBrokerRalphLoopFollowUpSignature,
           lastDeliveredAt: lastBrokerRalphLoopFollowUpAt,
           now,
@@ -1383,34 +1401,22 @@ export default function (pi: ExtensionAPI) {
           idle: ctx.isIdle?.() ?? true,
         });
       if (shouldDeliverFollowUp && followUpPrompt) {
-        const markFollowUpDelivered = () => {
+        sendFollowUpMessage(followUpPrompt, () => {
           brokerRalphLoopFollowUpPending = true;
           lastBrokerRalphLoopFollowUpAt = now;
-          lastBrokerRalphLoopFollowUpSignature = signature;
-        };
-
-        try {
-          pi.sendUserMessage(followUpPrompt, { deliverAs: "followUp" });
-          markFollowUpDelivered();
-        } catch {
-          try {
-            pi.sendUserMessage(followUpPrompt);
-            markFollowUpDelivered();
-          } catch {
-            /* best effort */
-          }
-        }
+          lastBrokerRalphLoopFollowUpSignature = followUpSignature;
+        });
       }
-      if (!signature) {
+      if (!followUpPrompt) {
         lastBrokerRalphLoopFollowUpSignature = "";
       }
 
-      if (signature && signature !== lastBrokerRalphLoopSignature) {
+      if (anomalySignature && anomalySignature !== lastBrokerRalphLoopSignature) {
         ctx.ui.notify(`RALPH loop: ${evaluation.anomalies.join("; ")}`, "warning");
-      } else if (!signature && lastBrokerRalphLoopSignature) {
+      } else if (!anomalySignature && lastBrokerRalphLoopSignature) {
         ctx.ui.notify("RALPH loop health recovered", "info");
       }
-      lastBrokerRalphLoopSignature = signature;
+      lastBrokerRalphLoopSignature = anomalySignature;
     } catch (err) {
       ctx.ui.notify(`RALPH loop failed: ${msg(err)}`, "error");
     } finally {
@@ -1775,7 +1781,13 @@ export default function (pi: ExtensionAPI) {
           const entries = await client.pollInbox();
           if (entries.length === 0) return;
 
-          const synced = syncFollowerInboxEntries(entries, threads, agentName, lastDmChannel);
+          const { remainingEntries, followUpMessages } = extractFollowerFollowUpMessages(entries);
+          const synced = syncFollowerInboxEntries(
+            remainingEntries,
+            threads,
+            agentName,
+            lastDmChannel,
+          );
           for (const nextThread of synced.threadUpdates) {
             const existing = threads.get(nextThread.threadTs);
             if (!existing) {
@@ -1790,7 +1802,14 @@ export default function (pi: ExtensionAPI) {
           lastDmChannel = synced.lastDmChannel;
           inbox.push(...synced.inboxMessages);
 
-          const ids = entries.map((entry) => entry.inboxId);
+          const ids = remainingEntries
+            .map((entry) => entry.inboxId)
+            .filter((inboxId): inboxId is number => typeof inboxId === "number");
+          for (const followUp of followUpMessages) {
+            if (sendFollowUpMessage(followUp.text) && typeof followUp.inboxId === "number") {
+              ids.push(followUp.inboxId);
+            }
+          }
           if (synced.changed) persistState();
           if (ids.length > 0) await client.ackMessages(ids);
           updateBadge();
@@ -2027,15 +2046,9 @@ export default function (pi: ExtensionAPI) {
       prompt = securityPrompt + "\n\n" + prompt;
     }
 
-    try {
-      pi.sendUserMessage(prompt, { deliverAs: "followUp" });
-    } catch {
-      try {
-        pi.sendUserMessage(prompt);
-      } catch {
-        inbox.push(...pending);
-        updateBadge();
-      }
+    if (!sendFollowUpMessage(prompt)) {
+      inbox.push(...pending);
+      updateBadge();
     }
   }
 


### PR DESCRIPTION
## Summary
- deliver broker Ralph loop summaries from actionable cycles, including backlog-only cases, as follow-up prompts
- route follower `ralph_loop_nudge` inbox items through local `pi.sendUserMessage()` delivery instead of leaving them in the polled inbox
- add helper coverage for backlog follow-ups and follower nudge extraction

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #104
Related: #102