### PR TITLE
fix: deliver pinet messages to broker's own inbox

### DIFF
--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -5,6 +5,7 @@ import type { MessageAdapter } from "./types.js";
 
 export { BrokerDB } from "./schema.js";
 export { BrokerSocketServer } from "./socket-server.js";
+export type { AgentMessageCallback } from "./socket-server.js";
 export type {
   AgentInfo,
   ThreadInfo,

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -331,6 +331,84 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     );
   });
 
+  it("onAgentMessage callback fires when a message targets an agent", async () => {
+    await client.register("sender-worker", "📤");
+
+    // Register a second client as the target
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    const reg2 = await client2.register("target-agent", "🎯");
+
+    // Set up the callback
+    const received: { targetId: string; body: string; meta: Record<string, unknown> }[] = [];
+    server.onAgentMessage((targetId, msg, meta) => {
+      received.push({ targetId, body: msg.body, meta });
+    });
+
+    // Worker sends a message to the target
+    await client.sendAgentMessage("target-agent", "Hello broker!");
+
+    // Callback should have fired with the target agent's ID
+    expect(received).toHaveLength(1);
+    expect(received[0].targetId).toBe(reg2.agentId);
+    expect(received[0].body).toBe("Hello broker!");
+    expect(received[0].meta.senderAgent).toBe("sender-worker");
+    expect(received[0].meta.a2a).toBe(true);
+
+    client2.disconnect();
+  });
+
+  it("onAgentMessage callback not called for unrelated targets", async () => {
+    await client.register("worker-a", "🅰️");
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    await client2.register("worker-b", "🅱️");
+
+    // Callback that only fires for a specific agent
+    const brokerId = "fake-broker-id";
+    const received: string[] = [];
+    server.onAgentMessage((targetId, msg) => {
+      if (targetId === brokerId) received.push(msg.body);
+    });
+
+    // Message goes to worker-b, not fake-broker-id
+    await client.sendAgentMessage("worker-b", "Not for broker");
+    expect(received).toHaveLength(0);
+
+    client2.disconnect();
+  });
+
+  it("markDeliveredByMessageId marks DB inbox rows as delivered", async () => {
+    const reg = await client.register("sender", "📤");
+
+    // Register target directly in DB (simulating broker agent)
+    const brokerAgent = db.registerAgent("broker-self", "Broker", "🤖", process.pid, {});
+
+    // Insert a message targeting the broker
+    const threadId = `a2a:${reg.agentId}:${brokerAgent.id}`;
+    db.createThread(threadId, "agent", "", reg.agentId);
+    const msg = db.insertMessage(threadId, "agent", "inbound", reg.agentId, "Test", [
+      brokerAgent.id,
+    ]);
+
+    // Inbox should have an undelivered entry
+    const before = db.getInbox(brokerAgent.id);
+    expect(before).toHaveLength(1);
+    expect(before[0].entry.delivered).toBe(false);
+
+    // Mark delivered by message ID
+    db.markDeliveredByMessageId(msg.id, brokerAgent.id);
+
+    // Inbox should now be empty (delivered = 1)
+    const after = db.getInbox(brokerAgent.id);
+    expect(after).toHaveLength(0);
+  });
+
   it("slack.proxy returns error when not configured", async () => {
     await client.register("proxy-tester", "🔌");
     await expect(client.slackProxy("chat.postMessage", { channel: "C1" })).rejects.toThrow(

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -516,7 +516,7 @@ export class BrokerDB implements BrokerDBInterface {
           `SELECT id FROM agents
            WHERE disconnected_at IS NOT NULL
              AND disconnected_at <= ?
-             AND (resumable_until IS NULL OR resumable_until <= ?)`
+             AND (resumable_until IS NULL OR resumable_until <= ?)`,
         )
         .all(cutoff, nowIso) as Array<{ id: string }>;
 
@@ -532,7 +532,7 @@ export class BrokerDB implements BrokerDBInterface {
         `DELETE FROM agents
          WHERE disconnected_at IS NOT NULL
            AND disconnected_at <= ?
-           AND (resumable_until IS NULL OR resumable_until <= ?)`
+           AND (resumable_until IS NULL OR resumable_until <= ?)`,
       ).run(cutoff, nowIso);
 
       return rows.map((row) => row.id);
@@ -990,6 +990,14 @@ export class BrokerDB implements BrokerDBInterface {
         stmt.run(id);
       }
     }
+  }
+
+  /** Mark all undelivered inbox rows for a given message+agent as delivered. */
+  markDeliveredByMessageId(messageId: number, agentId: string): void {
+    const db = this.getDb();
+    db.prepare(
+      "UPDATE inbox SET delivered = 1 WHERE message_id = ? AND agent_id = ? AND delivered = 0",
+    ).run(messageId, agentId);
   }
 
   // ─── Internal ────────────────────────────────────────

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as crypto from "node:crypto";
 import type { BrokerDB } from "./schema.js";
 import { MessageRouter } from "./router.js";
-import type { JsonRpcRequest, JsonRpcResponse, JsonRpcError } from "./types.js";
+import type { BrokerMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcError } from "./types.js";
 import {
   RPC_PARSE_ERROR,
   RPC_INVALID_REQUEST,
@@ -33,6 +33,12 @@ export const DEFAULT_PRUNE_INTERVAL_MS = 5_000;
 export type ListenTarget =
   | { type: "unix"; path: string }
   | { type: "tcp"; host: string; port: number };
+
+export type AgentMessageCallback = (
+  targetAgentId: string,
+  msg: BrokerMessage,
+  metadata: Record<string, unknown>,
+) => void;
 
 export interface BrokerSocketServerOptions {
   heartbeatTimeoutMs?: number;
@@ -76,6 +82,7 @@ export class BrokerSocketServer {
   private readonly pruneIntervalMs: number;
   private pruneTimer: ReturnType<typeof setInterval> | null = null;
   private assignedPort: number | null = null;
+  private agentMessageCallback: AgentMessageCallback | null = null;
 
   constructor(
     db: BrokerDB,
@@ -181,6 +188,15 @@ export class BrokerSocketServer {
       host: this.target.host,
       port: this.assignedPort ?? this.target.port,
     };
+  }
+
+  /**
+   * Register a callback invoked whenever a worker sends an agent-to-agent
+   * message via the socket server.  The broker uses this to push messages
+   * targeting itself into its in-memory inbox.
+   */
+  onAgentMessage(cb: AgentMessageCallback): void {
+    this.agentMessageCallback = cb;
   }
 
   private startPruning(): void {
@@ -557,6 +573,12 @@ export class BrokerSocketServer {
       [target.id],
       enrichedMeta,
     );
+
+    // Notify callback so the broker can push to its in-memory inbox
+    // when the target is the broker itself.
+    if (this.agentMessageCallback) {
+      this.agentMessageCallback(target.id, msg, enrichedMeta);
+    }
 
     return rpcOk(req.id, { ok: true, messageId: msg.id });
   }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1719,6 +1719,27 @@ export default function (pi: ExtensionAPI) {
         activeBroker = broker;
         activeRouter = router;
         activeSelfId = selfId;
+
+        // When a worker sends a pinet_message targeting the broker, the
+        // socket server writes to the DB inbox but the broker only reads
+        // its in-memory inbox.  Bridge the gap here: push a2a messages
+        // targeting ourselves into the in-memory inbox and trigger drain.
+        broker.server.onAgentMessage((targetAgentId, brokerMsg, meta) => {
+          if (targetAgentId !== selfId) return;
+          const senderName = (meta.senderAgent as string) ?? brokerMsg.sender;
+          inbox.push({
+            channel: "",
+            threadTs: brokerMsg.threadId,
+            userId: senderName,
+            text: brokerMsg.body,
+            timestamp: brokerMsg.createdAt,
+          });
+          // Mark delivered so the DB row doesn't linger.
+          broker.db.markDeliveredByMessageId(brokerMsg.id, selfId);
+          updateBadge();
+          if (extCtx?.isIdle?.()) drainInbox();
+        });
+
         startBrokerHeartbeat();
         startBrokerMaintenance(ctx);
         startBrokerRalphLoop(ctx);


### PR DESCRIPTION
## Problem

When a worker agent sends a `pinet_message` reply to the broker, the message is correctly written to the `messages` and `inbox` tables in the broker DB, but the broker's `slack_inbox` / pinet polling never picks them up. The `delivered` column stays `0`.

## Root cause

The broker reads messages from an **in-memory** `inbox` array (populated from Slack adapter events). Workers read from the DB via `pollInbox()`. But when a worker sends a `pinet_message` targeting the broker, `handleAgentMessage()` in the socket server writes to the DB `inbox` table — which the broker never reads for itself.

## Fix

- Add an `onAgentMessage` callback to `BrokerSocketServer` that fires after `handleAgentMessage()` inserts a message
- Broker registers this callback at startup to detect messages targeting itself
- When triggered: push to in-memory inbox, mark DB row delivered, trigger `drainInbox()`
- Add `BrokerDB.markDeliveredByMessageId()` for efficient DB cleanup

## Changes

| File | Change |
|------|--------|
| `socket-server.ts` | `AgentMessageCallback` type + `onAgentMessage()` method + callback invocation in `handleAgentMessage()` |
| `schema.ts` | `markDeliveredByMessageId()` helper |
| `index.ts` | Wire callback in broker startup to bridge DB→in-memory inbox |
| `broker/index.ts` | Re-export `AgentMessageCallback` type |
| `integration.test.ts` | 3 new tests |

## Tests

All 394 tests pass (391 existing + 3 new).