### PR TITLE
feat: ralph loop nudge followUp delivery + agent observability (#102, #103)

### DIFF
--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -39,6 +39,8 @@ export interface AgentInfo {
   status: "working" | "idle";
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
+  idleSince?: string | null;
+  lastActivity?: string | null;
 }
 
 // ─── JSON-RPC types ──────────────────────────────────────

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -779,3 +779,176 @@ describe("broker integration — router with real DB", () => {
     expect(thread!.channel).toBe("C1");
   });
 });
+
+// ─── Observability (#103) ────────────────────────────────────
+
+describe("idle_since and last_activity tracking", () => {
+  let dir: string;
+  let db: BrokerDB;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    db = new BrokerDB(path.join(dir, "obs.db"));
+    db.initialize();
+  });
+
+  afterEach(() => {
+    db.close();
+    cleanup(dir);
+  });
+
+  it("sets idle_since on registration", () => {
+    const agent = db.registerAgent("a-1", "Obs Agent", "🐺", 1);
+    expect(agent.status).toBe("idle");
+    expect(agent.idleSince).toBeTruthy();
+  });
+
+  it("clears idle_since and sets last_activity when transitioning to working", () => {
+    db.registerAgent("a-1", "Obs Agent", "🐺", 1);
+
+    db.updateAgentStatus("a-1", "working");
+    const working = db.getAgentById("a-1");
+    expect(working!.idleSince).toBeNull();
+    expect(working!.lastActivity).toBeTruthy();
+  });
+
+  it("sets idle_since when transitioning to idle", () => {
+    db.registerAgent("a-1", "Obs Agent", "🐺", 1);
+    db.updateAgentStatus("a-1", "working");
+
+    db.updateAgentStatus("a-1", "idle");
+    const idle = db.getAgentById("a-1");
+    expect(idle!.idleSince).toBeTruthy();
+    // last_activity should be preserved from when it was working
+    expect(idle!.lastActivity).toBeTruthy();
+  });
+
+  it("does not overwrite idle_since on repeated idle status updates", () => {
+    db.registerAgent("a-1", "Obs Agent", "🐺", 1);
+
+    const first = db.getAgentById("a-1");
+    const firstIdleSince = first!.idleSince;
+
+    // Small delay to ensure timestamps differ
+    db.updateAgentStatus("a-1", "idle");
+    const second = db.getAgentById("a-1");
+    expect(second!.idleSince).toBe(firstIdleSince);
+  });
+
+  it("touchAgentActivity updates last_activity", () => {
+    db.registerAgent("a-1", "Obs Agent", "🐺", 1);
+    db.updateAgentStatus("a-1", "working");
+    const before = db.getAgentById("a-1");
+
+    db.touchAgentActivity("a-1");
+    const after = db.getAgentById("a-1");
+    expect(Date.parse(after!.lastActivity!)).toBeGreaterThanOrEqual(
+      Date.parse(before!.lastActivity!),
+    );
+  });
+});
+
+describe("ralph_cycles recording", () => {
+  let dir: string;
+  let db: BrokerDB;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    db = new BrokerDB(path.join(dir, "cycles.db"));
+    db.initialize();
+  });
+
+  afterEach(() => {
+    db.close();
+    cleanup(dir);
+  });
+
+  it("records and retrieves ralph cycles", () => {
+    const id = db.recordRalphCycle({
+      startedAt: "2026-04-01T00:00:00.000Z",
+      completedAt: "2026-04-01T00:00:01.000Z",
+      durationMs: 1000,
+      ghostAgentIds: ["ghost-1"],
+      nudgeAgentIds: ["idle-1"],
+      idleDrainAgentIds: ["ready-1"],
+      stuckAgentIds: [],
+      anomalies: ["ghost agents detected: ghost-1"],
+      anomalySignature: "ghost agents detected: ghost-1",
+      followUpDelivered: true,
+      agentCount: 3,
+      backlogCount: 2,
+    });
+
+    expect(id).toBeGreaterThan(0);
+
+    const cycles = db.getRecentRalphCycles(10);
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].ghostAgentIds).toEqual(["ghost-1"]);
+    expect(cycles[0].nudgeAgentIds).toEqual(["idle-1"]);
+    expect(cycles[0].stuckAgentIds).toEqual([]);
+    expect(cycles[0].followUpDelivered).toBe(true);
+    expect(cycles[0].durationMs).toBe(1000);
+    expect(cycles[0].agentCount).toBe(3);
+    expect(cycles[0].backlogCount).toBe(2);
+  });
+
+  it("returns cycles in reverse chronological order", () => {
+    db.recordRalphCycle({
+      startedAt: "2026-04-01T00:00:00.000Z",
+      completedAt: "2026-04-01T00:00:01.000Z",
+      durationMs: 1000,
+      ghostAgentIds: [],
+      nudgeAgentIds: [],
+      idleDrainAgentIds: [],
+      stuckAgentIds: [],
+      anomalies: [],
+      anomalySignature: "",
+      followUpDelivered: false,
+      agentCount: 1,
+      backlogCount: 0,
+    });
+
+    db.recordRalphCycle({
+      startedAt: "2026-04-01T00:01:00.000Z",
+      completedAt: "2026-04-01T00:01:01.000Z",
+      durationMs: 1000,
+      ghostAgentIds: ["ghost-2"],
+      nudgeAgentIds: [],
+      idleDrainAgentIds: [],
+      stuckAgentIds: ["stuck-1"],
+      anomalies: ["anomaly"],
+      anomalySignature: "anomaly",
+      followUpDelivered: true,
+      agentCount: 2,
+      backlogCount: 1,
+    });
+
+    const cycles = db.getRecentRalphCycles(10);
+    expect(cycles).toHaveLength(2);
+    // Most recent first
+    expect(cycles[0].startedAt).toBe("2026-04-01T00:01:00.000Z");
+    expect(cycles[0].stuckAgentIds).toEqual(["stuck-1"]);
+    expect(cycles[1].startedAt).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  it("respects limit parameter", () => {
+    for (let i = 0; i < 5; i++) {
+      db.recordRalphCycle({
+        startedAt: `2026-04-01T00:0${i}:00.000Z`,
+        completedAt: `2026-04-01T00:0${i}:01.000Z`,
+        durationMs: 1000,
+        ghostAgentIds: [],
+        nudgeAgentIds: [],
+        idleDrainAgentIds: [],
+        stuckAgentIds: [],
+        anomalies: [],
+        anomalySignature: "",
+        followUpDelivered: false,
+        agentCount: 1,
+        backlogCount: 0,
+      });
+    }
+
+    expect(db.getRecentRalphCycles(3)).toHaveLength(3);
+  });
+});

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -28,6 +28,8 @@ interface AgentRow {
   status: string;
   disconnected_at: string | null;
   resumable_until: string | null;
+  idle_since: string | null;
+  last_activity: string | null;
 }
 
 interface ThreadRow {
@@ -55,6 +57,22 @@ interface BacklogRow {
 
 // ─── Mappers ─────────────────────────────────────────────
 
+interface RalphCycleRow {
+  id: number;
+  started_at: string;
+  completed_at: string | null;
+  duration_ms: number | null;
+  ghost_agent_ids: string;
+  nudge_agent_ids: string;
+  idle_drain_agent_ids: string;
+  stuck_agent_ids: string;
+  anomalies: string;
+  anomaly_signature: string;
+  follow_up_delivered: number;
+  agent_count: number;
+  backlog_count: number;
+}
+
 function rowToAgent(row: AgentRow): AgentInfo {
   return {
     id: row.id,
@@ -68,6 +86,8 @@ function rowToAgent(row: AgentRow): AgentInfo {
     status: row.status === "working" ? "working" : "idle",
     disconnectedAt: row.disconnected_at,
     resumableUntil: row.resumable_until,
+    idleSince: row.idle_since,
+    lastActivity: row.last_activity,
   };
 }
 
@@ -107,7 +127,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 3;
+export const CURRENT_BROKER_SCHEMA_VERSION = 4;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -245,6 +265,39 @@ function addAgentLifecycleColumns(db: DatabaseSync): void {
   `);
 }
 
+function addObservabilityColumns(db: DatabaseSync): void {
+  ensureColumn(db, "agents", "idle_since", "ALTER TABLE agents ADD COLUMN idle_since TEXT");
+  ensureColumn(db, "agents", "last_activity", "ALTER TABLE agents ADD COLUMN last_activity TEXT");
+
+  // Set idle_since for currently idle agents that lack it
+  db.exec(`
+    UPDATE agents
+    SET idle_since = COALESCE(idle_since, last_seen)
+    WHERE status = 'idle' AND idle_since IS NULL;
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ralph_cycles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      started_at TEXT NOT NULL,
+      completed_at TEXT,
+      duration_ms INTEGER,
+      ghost_agent_ids TEXT NOT NULL DEFAULT '[]',
+      nudge_agent_ids TEXT NOT NULL DEFAULT '[]',
+      idle_drain_agent_ids TEXT NOT NULL DEFAULT '[]',
+      stuck_agent_ids TEXT NOT NULL DEFAULT '[]',
+      anomalies TEXT NOT NULL DEFAULT '[]',
+      anomaly_signature TEXT NOT NULL DEFAULT '',
+      follow_up_delivered INTEGER NOT NULL DEFAULT 0,
+      agent_count INTEGER NOT NULL DEFAULT 0,
+      backlog_count INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ralph_cycles_started
+      ON ralph_cycles(started_at);
+  `);
+}
+
 function runSchemaMigrations(db: DatabaseSync): void {
   const currentVersion = getUserVersion(db);
   if (currentVersion >= CURRENT_BROKER_SCHEMA_VERSION) {
@@ -267,6 +320,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 3:
           addAgentLifecycleColumns(db);
+          break;
+        case 4:
+          addObservabilityColumns(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -382,9 +438,10 @@ export class BrokerDB implements BrokerDBInterface {
       `INSERT INTO agents (
          id, stable_id, name, emoji, pid,
          connected_at, last_seen, last_heartbeat,
-         metadata, status, disconnected_at, resumable_until
+         metadata, status, disconnected_at, resumable_until,
+         idle_since, last_activity
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'idle', NULL, NULL)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'idle', NULL, NULL, ?, NULL)
        ON CONFLICT(id) DO UPDATE SET
          stable_id = COALESCE(excluded.stable_id, agents.stable_id),
          name = excluded.name,
@@ -396,8 +453,10 @@ export class BrokerDB implements BrokerDBInterface {
          metadata = excluded.metadata,
          status = 'idle',
          disconnected_at = NULL,
-         resumable_until = NULL`,
-    ).run(agentId, persistedStableId, finalName, finalEmoji, pid, now, now, now, meta);
+         resumable_until = NULL,
+         idle_since = excluded.idle_since,
+         last_activity = NULL`,
+    ).run(agentId, persistedStableId, finalName, finalEmoji, pid, now, now, now, meta, now);
 
     return {
       id: agentId,
@@ -409,6 +468,8 @@ export class BrokerDB implements BrokerDBInterface {
       lastHeartbeat: now,
       metadata: metadata ?? null,
       status: "idle" as const,
+      idleSince: now,
+      lastActivity: null,
     };
   }
 
@@ -541,8 +602,27 @@ export class BrokerDB implements BrokerDBInterface {
 
   updateAgentStatus(id: string, status: "working" | "idle"): void {
     const db = this.getDb();
-    db.prepare("UPDATE agents SET status = ?, last_seen = ? WHERE id = ?").run(
-      status,
+    const now = new Date().toISOString();
+    if (status === "idle") {
+      // Transitioning to idle: set idle_since, preserve last_activity
+      db.prepare(
+        `UPDATE agents
+         SET status = ?, last_seen = ?,
+             idle_since = COALESCE(CASE WHEN status = 'idle' THEN idle_since ELSE NULL END, ?)
+         WHERE id = ?`,
+      ).run(status, now, now, id);
+    } else {
+      // Transitioning to working: clear idle_since, update last_activity
+      db.prepare(
+        "UPDATE agents SET status = ?, last_seen = ?, idle_since = NULL, last_activity = ? WHERE id = ?",
+      ).run(status, now, now, id);
+    }
+  }
+
+  touchAgentActivity(id: string): void {
+    const db = this.getDb();
+    db.prepare("UPDATE agents SET last_activity = ?, last_seen = ? WHERE id = ?").run(
+      new Date().toISOString(),
       new Date().toISOString(),
       id,
     );
@@ -812,6 +892,85 @@ export class BrokerDB implements BrokerDBInterface {
       .prepare("UPDATE threads SET owner_agent = NULL WHERE owner_agent = ?")
       .run(agentId);
     return Number(result.changes ?? 0);
+  }
+
+  // ─── Ralph cycles ────────────────────────────────────
+
+  recordRalphCycle(record: {
+    startedAt: string;
+    completedAt: string;
+    durationMs: number;
+    ghostAgentIds: string[];
+    nudgeAgentIds: string[];
+    idleDrainAgentIds: string[];
+    stuckAgentIds: string[];
+    anomalies: string[];
+    anomalySignature: string;
+    followUpDelivered: boolean;
+    agentCount: number;
+    backlogCount: number;
+  }): number {
+    const db = this.getDb();
+    const info = db
+      .prepare(
+        `INSERT INTO ralph_cycles (
+           started_at, completed_at, duration_ms,
+           ghost_agent_ids, nudge_agent_ids, idle_drain_agent_ids, stuck_agent_ids,
+           anomalies, anomaly_signature, follow_up_delivered,
+           agent_count, backlog_count
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        record.startedAt,
+        record.completedAt,
+        record.durationMs,
+        JSON.stringify(record.ghostAgentIds),
+        JSON.stringify(record.nudgeAgentIds),
+        JSON.stringify(record.idleDrainAgentIds),
+        JSON.stringify(record.stuckAgentIds),
+        JSON.stringify(record.anomalies),
+        record.anomalySignature,
+        record.followUpDelivered ? 1 : 0,
+        record.agentCount,
+        record.backlogCount,
+      );
+    return Number(info.lastInsertRowid);
+  }
+
+  getRecentRalphCycles(limit = 20): Array<{
+    id: number;
+    startedAt: string;
+    completedAt: string | null;
+    durationMs: number | null;
+    ghostAgentIds: string[];
+    nudgeAgentIds: string[];
+    idleDrainAgentIds: string[];
+    stuckAgentIds: string[];
+    anomalies: string[];
+    anomalySignature: string;
+    followUpDelivered: boolean;
+    agentCount: number;
+    backlogCount: number;
+  }> {
+    const db = this.getDb();
+    const rows = db
+      .prepare("SELECT * FROM ralph_cycles ORDER BY started_at DESC LIMIT ?")
+      .all(limit) as unknown as RalphCycleRow[];
+    return rows.map((row) => ({
+      id: row.id,
+      startedAt: row.started_at,
+      completedAt: row.completed_at,
+      durationMs: row.duration_ms,
+      ghostAgentIds: JSON.parse(row.ghost_agent_ids) as string[],
+      nudgeAgentIds: JSON.parse(row.nudge_agent_ids) as string[],
+      idleDrainAgentIds: JSON.parse(row.idle_drain_agent_ids) as string[],
+      stuckAgentIds: JSON.parse(row.stuck_agent_ids) as string[],
+      anomalies: JSON.parse(row.anomalies) as string[],
+      anomalySignature: row.anomaly_signature,
+      followUpDelivered: row.follow_up_delivered === 1,
+      agentCount: row.agent_count,
+      backlogCount: row.backlog_count,
+    }));
   }
 
   repairThreadOwnership(): { releasedClaimCount: number; releasedAgentIds: string[] } {

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -422,6 +422,12 @@ export class BrokerSocketServer {
     }
 
     this.db.markDelivered(ids as number[], state.agentId);
+
+    // Activity tracking: acknowledging messages proves the agent processed them
+    if (state.agentId) {
+      this.db.touchAgentActivity(state.agentId);
+    }
+
     return rpcOk(req.id, { ok: true });
   }
 
@@ -468,6 +474,9 @@ export class BrokerSocketServer {
       targetIds,
       metadata,
     );
+
+    // Activity tracking: sending a message proves the agent is working
+    this.db.touchAgentActivity(state.agentId);
 
     return rpcOk(req.id, { messageId: msg.id });
   }
@@ -580,6 +589,8 @@ export class BrokerSocketServer {
       this.agentMessageCallback(target.id, msg, enrichedMeta);
     }
 
+    // Activity tracking: sending agent-to-agent messages proves the agent is working
+    this.db.touchAgentActivity(state.agentId);
     return rpcOk(req.id, { ok: true, messageId: msg.id });
   }
 

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -12,6 +12,8 @@ export interface AgentInfo {
   status: "working" | "idle";
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
+  idleSince?: string | null;
+  lastActivity?: string | null;
 }
 
 export interface ThreadInfo {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -17,6 +17,9 @@ import {
   buildRalphLoopFollowUpMessage,
   shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
+  DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+  isRalphNudgeEntry,
+  partitionFollowerInboxEntries,
   buildBrokerPromptGuidelines,
   buildIdentityReplyGuidelines,
   resolvePersistedAgentIdentity,
@@ -37,6 +40,16 @@ import {
   type AgentDisplayInfo,
   type FollowerThreadState,
 } from "./helpers.js";
+
+type NudgeTestEntry = {
+  inboxId: number;
+  message: {
+    threadId: string;
+    sender: string;
+    body: string;
+    metadata: Record<string, unknown> | null;
+  };
+};
 
 // ─── loadSettings ─────────────────────────────────────────
 
@@ -781,6 +794,110 @@ describe("evaluateRalphLoopCycle", () => {
     expect(result.anomalies).toContain("broker maintenance timer is not running");
     expect(result.anomalies.some((item) => item.includes("expected `main`"))).toBe(true);
   });
+
+  it("detects stuck agents: working with no activity for > threshold", () => {
+    const now = Date.parse("2026-04-01T00:10:00.000Z");
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🐺",
+          name: "Stuck Wolf",
+          id: "stuck-worker",
+          status: "working",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:09:55.000Z",
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          lastActivity: "2026-04-01T00:03:00.000Z", // 7 min ago
+          pendingInboxCount: 0,
+          ownedThreadCount: 1,
+        },
+        {
+          emoji: "🦊",
+          name: "Active Fox",
+          id: "active-worker",
+          status: "working",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:09:55.000Z",
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          lastActivity: "2026-04-01T00:09:30.000Z", // 30s ago
+          pendingInboxCount: 1,
+          ownedThreadCount: 0,
+        },
+      ],
+      {
+        now,
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(result.stuckAgentIds).toEqual(["stuck-worker"]);
+    expect(result.anomalies.some((a) => a.includes("Stuck Wolf appears stuck"))).toBe(true);
+    // Active Fox should NOT be flagged as stuck
+    expect(result.stuckAgentIds).not.toContain("active-worker");
+  });
+
+  it("does not flag idle agents as stuck", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🦉",
+          name: "Idle Owl",
+          id: "idle-1",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          lastActivity: "2026-04-01T00:01:00.000Z",
+          pendingInboxCount: 0,
+          ownedThreadCount: 0,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:10:00.000Z"),
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(result.stuckAgentIds).toEqual([]);
+  });
+
+  it("does not flag working agent without lastActivity as stuck", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🐼",
+          name: "New Panda",
+          id: "new-1",
+          status: "working",
+          metadata: { role: "worker" },
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          // no lastActivity — agent just started, hasn't reported activity yet
+          pendingInboxCount: 1,
+          ownedThreadCount: 0,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:10:00.000Z"),
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(result.stuckAgentIds).toEqual([]);
+  });
+
+  it("includes stuckAgentIds in result even when empty", () => {
+    const result = evaluateRalphLoopCycle([], {
+      now: Date.now(),
+      heartbeatTimeoutMs: 15_000,
+      heartbeatIntervalMs: 5_000,
+    });
+    expect(result.stuckAgentIds).toEqual([]);
+  });
 });
 
 describe("buildRalphLoopNudgeMessage", () => {
@@ -796,6 +913,7 @@ describe("buildRalphLoopAnomalySignature", () => {
         ghostAgentIds: ["ghost-1"],
         nudgeAgentIds: ["idle-1"],
         idleDrainAgentIds: ["ready-1"],
+        stuckAgentIds: [],
         anomalies: [
           "ghost agents detected: ghost-1",
           "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
@@ -882,6 +1000,7 @@ describe("buildRalphLoopFollowUpMessage", () => {
         ghostAgentIds: ["ghost-1"],
         nudgeAgentIds: ["idle-1"],
         idleDrainAgentIds: ["ready-1"],
+        stuckAgentIds: [],
         anomalies: [
           "ghost agents detected: ghost-1",
           "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
@@ -906,6 +1025,7 @@ describe("buildRalphLoopFollowUpMessage", () => {
         ghostAgentIds: [],
         nudgeAgentIds: [],
         idleDrainAgentIds: [],
+        stuckAgentIds: [],
         anomalies: [],
       }),
     ).toBeNull();
@@ -1247,5 +1367,172 @@ describe("getFollowerOwnedThreadClaims", () => {
     ]);
 
     expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([]);
+  });
+});
+
+// ─── Follower nudge partition (#102) ──────────────────────
+
+describe("isRalphNudgeEntry", () => {
+  it("returns true for entries with ralph_loop_nudge kind", () => {
+    const entry: NudgeTestEntry = {
+      inboxId: 1,
+      message: {
+        threadId: "a2a:broker:worker",
+        sender: "broker-id",
+        body: "RALPH LOOP nudge: you appear idle",
+        metadata: { kind: "ralph_loop_nudge", targetAgentId: "worker-id" },
+      },
+    };
+    expect(isRalphNudgeEntry(entry)).toBe(true);
+  });
+
+  it("returns false for regular messages", () => {
+    const entry: NudgeTestEntry = {
+      inboxId: 2,
+      message: {
+        threadId: "t-1",
+        sender: "U123",
+        body: "hello",
+        metadata: { channel: "C456" },
+      },
+    };
+    expect(isRalphNudgeEntry(entry)).toBe(false);
+  });
+
+  it("returns false for entries with null metadata", () => {
+    const entry: NudgeTestEntry = {
+      inboxId: 3,
+      message: {
+        threadId: "t-2",
+        sender: "U456",
+        body: "test",
+        metadata: null,
+      },
+    };
+    expect(isRalphNudgeEntry(entry)).toBe(false);
+  });
+});
+
+describe("partitionFollowerInboxEntries", () => {
+  it("separates nudges from regular messages", () => {
+    const entries: NudgeTestEntry[] = [
+      {
+        inboxId: 1,
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker",
+          body: "RALPH LOOP nudge",
+          metadata: { kind: "ralph_loop_nudge" },
+        },
+      },
+      {
+        inboxId: 2,
+        message: {
+          threadId: "t-1",
+          sender: "U123",
+          body: "hello",
+          metadata: { channel: "C456" },
+        },
+      },
+      {
+        inboxId: 3,
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker",
+          body: "second nudge",
+          metadata: { kind: "ralph_loop_nudge" },
+        },
+      },
+    ];
+
+    const result = partitionFollowerInboxEntries(entries);
+    expect(result.nudges).toHaveLength(2);
+    expect(result.regular).toHaveLength(1);
+    expect(result.nudges[0].inboxId).toBe(1);
+    expect(result.nudges[1].inboxId).toBe(3);
+    expect(result.regular[0].inboxId).toBe(2);
+  });
+
+  it("returns empty arrays when no entries", () => {
+    const result = partitionFollowerInboxEntries([]);
+    expect(result.nudges).toEqual([]);
+    expect(result.regular).toEqual([]);
+  });
+
+  it("puts all entries in regular when no nudges", () => {
+    const entries: NudgeTestEntry[] = [
+      {
+        inboxId: 1,
+        message: {
+          threadId: "t-1",
+          sender: "U1",
+          body: "msg",
+          metadata: null,
+        },
+      },
+    ];
+    const result = partitionFollowerInboxEntries(entries);
+    expect(result.nudges).toEqual([]);
+    expect(result.regular).toHaveLength(1);
+  });
+});
+
+// ─── buildAgentDisplayInfo observability fields (#103) ────────
+
+describe("buildAgentDisplayInfo observability fields", () => {
+  const now = Date.parse("2026-04-01T00:10:00.000Z");
+
+  it("includes idleSince and formats idle duration", () => {
+    const info = buildAgentDisplayInfo(
+      {
+        emoji: "🦉",
+        name: "Idle Owl",
+        id: "owl-1",
+        status: "idle",
+        lastHeartbeat: "2026-04-01T00:09:55.000Z",
+        idleSince: "2026-04-01T00:05:00.000Z", // 5 min ago
+      },
+      { now },
+    );
+
+    expect(info.idleSince).toBe("2026-04-01T00:05:00.000Z");
+    expect(info.idleDuration).toBe("5m ago");
+    expect(info.stuck).toBe(false);
+  });
+
+  it("includes lastActivity and formats activity age", () => {
+    const info = buildAgentDisplayInfo(
+      {
+        emoji: "🐺",
+        name: "Working Wolf",
+        id: "wolf-1",
+        status: "working",
+        lastHeartbeat: "2026-04-01T00:09:55.000Z",
+        lastActivity: "2026-04-01T00:08:00.000Z", // 2 min ago
+      },
+      { now },
+    );
+
+    expect(info.lastActivity).toBe("2026-04-01T00:08:00.000Z");
+    expect(info.lastActivityAge).toBe("2m ago");
+    expect(info.stuck).toBe(false);
+  });
+
+  it("handles null idleSince and lastActivity", () => {
+    const info = buildAgentDisplayInfo(
+      {
+        emoji: "🐼",
+        name: "New Panda",
+        id: "panda-1",
+        status: "idle",
+        lastHeartbeat: "2026-04-01T00:09:55.000Z",
+      },
+      { now },
+    );
+
+    expect(info.idleSince).toBeNull();
+    expect(info.lastActivity).toBeNull();
+    expect(info.idleDuration).toBeNull();
+    expect(info.lastActivityAge).toBeNull();
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -170,6 +170,11 @@ export interface AgentDisplayInfo {
   leaseSummary?: string | null;
   health?: AgentHealth;
   ghost?: boolean;
+  stuck?: boolean;
+  idleSince?: string | null;
+  lastActivity?: string | null;
+  idleDuration?: string | null;
+  lastActivityAge?: string | null;
   capabilityTags?: string[];
   routingScore?: number;
   routingReasons?: string[];
@@ -184,6 +189,8 @@ export interface AgentVisibilityInput {
   lastHeartbeat?: string;
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
+  idleSince?: string | null;
+  lastActivity?: string | null;
 }
 
 export interface AgentVisibilityOptions {
@@ -352,6 +359,11 @@ export function buildAgentDisplayInfo(
   const capabilities = extractAgentCapabilities(metadata);
   const capabilityTags = buildAgentCapabilityTags(capabilities);
 
+  const idleSinceMs = parseIsoMs(agent.idleSince);
+  const lastActivityMs = parseIsoMs(agent.lastActivity);
+  const idleDurationMs = idleSinceMs == null ? null : Math.max(0, nowMs - idleSinceMs);
+  const lastActivityAgeMs = lastActivityMs == null ? null : Math.max(0, nowMs - lastActivityMs);
+
   return {
     emoji: agent.emoji,
     name: agent.name,
@@ -374,6 +386,11 @@ export function buildAgentDisplayInfo(
     leaseSummary: formatLease(computedLeaseExpiresAt, nowMs),
     health,
     ghost: health === "ghost",
+    stuck: false,
+    idleSince: agent.idleSince ?? null,
+    lastActivity: agent.lastActivity ?? null,
+    idleDuration: formatAge(idleDurationMs),
+    lastActivityAge: formatAge(lastActivityAgeMs),
     capabilityTags,
   };
 }
@@ -485,6 +502,7 @@ export const DEFAULT_RALPH_LOOP_INTERVAL_MS = 30_000;
 export const DEFAULT_RALPH_LOOP_IDLE_WITH_WORK_THRESHOLD_MS = 60_000;
 export const DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS = 5 * 60_000;
 export const DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS = 60_000;
+export const DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS = 5 * 60_000;
 
 export interface RalphLoopAgentWorkload extends AgentVisibilityInput {
   lastSeen?: string;
@@ -494,6 +512,7 @@ export interface RalphLoopAgentWorkload extends AgentVisibilityInput {
 
 export interface RalphLoopEvaluationOptions extends AgentVisibilityOptions {
   idleWithWorkThresholdMs?: number;
+  stuckWorkingThresholdMs?: number;
   pendingBacklogCount?: number;
   currentBranch?: string | null;
   expectedMainBranch?: string;
@@ -505,6 +524,7 @@ export interface RalphLoopEvaluationResult {
   ghostAgentIds: string[];
   nudgeAgentIds: string[];
   idleDrainAgentIds: string[];
+  stuckAgentIds: string[];
   anomalies: string[];
 }
 
@@ -515,12 +535,15 @@ export function evaluateRalphLoopCycle(
   const nowMs = options.now ?? Date.now();
   const idleWithWorkThresholdMs =
     options.idleWithWorkThresholdMs ?? DEFAULT_RALPH_LOOP_IDLE_WITH_WORK_THRESHOLD_MS;
+  const stuckWorkingThresholdMs =
+    options.stuckWorkingThresholdMs ?? DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS;
   const pendingBacklogCount = options.pendingBacklogCount ?? 0;
   const expectedMainBranch = options.expectedMainBranch ?? "main";
   const anomalies: string[] = [];
   const ghostAgentIds: string[] = [];
   const nudgeAgentIds: string[] = [];
   const idleDrainAgentIds: string[] = [];
+  const stuckAgentIds: string[] = [];
 
   for (const workload of workloads) {
     const metadata = asRecord(workload.metadata);
@@ -554,6 +577,20 @@ export function evaluateRalphLoopCycle(
       continue;
     }
 
+    // Stuck detection: agent reports "working" but no activity for > threshold
+    if (workload.status === "working" && display.health === "healthy") {
+      const lastActivityMs = parseIsoMs(workload.lastActivity);
+      const activityAgeMs = lastActivityMs == null ? null : Math.max(0, nowMs - lastActivityMs);
+      if (activityAgeMs != null && activityAgeMs >= stuckWorkingThresholdMs) {
+        stuckAgentIds.push(workload.id);
+        const ageMinutes = Math.round(activityAgeMs / 60_000);
+        anomalies.push(
+          `${workload.name} appears stuck (working with no activity for ${ageMinutes}m)`,
+        );
+        continue;
+      }
+    }
+
     if (!hasAssignedWork && workload.status === "idle" && display.health === "healthy") {
       idleDrainAgentIds.push(workload.id);
     }
@@ -579,10 +616,16 @@ export function evaluateRalphLoopCycle(
     anomalies.push("broker maintenance timer is not running");
   }
 
+  if (stuckAgentIds.length > 0 && ghostAgentIds.length === 0) {
+    // Only report stuck if not already mixed with ghost anomalies
+    // (ghosts are more urgent)
+  }
+
   return {
     ghostAgentIds,
     nudgeAgentIds,
     idleDrainAgentIds,
+    stuckAgentIds,
     anomalies,
   };
 }
@@ -939,7 +982,8 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
   return agents
     .map((a) => {
       const health = a.health ? ` [${a.health}]` : "";
-      let line = `${a.emoji} ${a.name} (${a.id}) \u2014 ${a.status}${health}`;
+      const stuckTag = a.stuck ? " [stuck]" : "";
+      let line = `${a.emoji} ${a.name} (${a.id}) \u2014 ${a.status}${health}${stuckTag}`;
 
       const meta = a.metadata;
       if (meta && (meta.cwd || meta.branch || meta.host)) {
@@ -951,10 +995,16 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
 
       const heartbeat = a.heartbeatSummary ?? formatAge(a.heartbeatAgeMs);
       const lease = a.leaseSummary ?? null;
-      if (heartbeat || lease) {
-        const summary = [heartbeat ? `heartbeat ${heartbeat}` : null, lease].filter(
-          (item): item is string => Boolean(item),
-        );
+      const idleInfo = a.status === "idle" && a.idleDuration ? `idle ${a.idleDuration}` : null;
+      const activityInfo =
+        a.status === "working" && a.lastActivityAge ? `activity ${a.lastActivityAge}` : null;
+      if (heartbeat || lease || idleInfo || activityInfo) {
+        const summary = [
+          heartbeat ? `heartbeat ${heartbeat}` : null,
+          lease,
+          idleInfo,
+          activityInfo,
+        ].filter((item): item is string => Boolean(item));
         line += `\n   ${summary.join(" · ")}`;
       }
 
@@ -1175,4 +1225,45 @@ export function resolveAgentIdentity(
 
   // 3. Fully generated
   return generateAgentName(seed);
+}
+
+// ─── Follower nudge detection (#102) ─────────────────────
+
+export function isRalphNudgeEntry(entry: {
+  message: { metadata?: Record<string, unknown> | null };
+}): boolean {
+  return entry.message.metadata?.kind === "ralph_loop_nudge";
+}
+
+export function partitionFollowerInboxEntries<
+  T extends { message: { metadata?: Record<string, unknown> | null } },
+>(entries: T[]): { nudges: T[]; regular: T[] } {
+  const nudges: T[] = [];
+  const regular: T[] = [];
+  for (const entry of entries) {
+    if (isRalphNudgeEntry(entry)) {
+      nudges.push(entry);
+    } else {
+      regular.push(entry);
+    }
+  }
+  return { nudges, regular };
+}
+
+// ─── Ralph cycle records (#103) ──────────────────────────
+
+export interface RalphCycleRecord {
+  id?: number;
+  startedAt: string;
+  completedAt: string | null;
+  durationMs: number | null;
+  ghostAgentIds: string[];
+  nudgeAgentIds: string[];
+  idleDrainAgentIds: string[];
+  stuckAgentIds: string[];
+  anomalies: string[];
+  anomalySignature: string;
+  followUpDelivered: boolean;
+  agentCount: number;
+  backlogCount: number;
 }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -25,6 +25,8 @@ import {
   DEFAULT_RALPH_LOOP_INTERVAL_MS,
   DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
+  DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+  partitionFollowerInboxEntries,
   generateAgentName,
   resolveAgentIdentity,
   shortenPath,
@@ -1322,6 +1324,8 @@ export default function (pi: ExtensionAPI) {
     if (!activeBroker || !activeSelfId || brokerRalphLoopRunning) return;
 
     brokerRalphLoopRunning = true;
+    const cycleStartedAt = new Date().toISOString();
+    const cycleStartMs = Date.now();
     try {
       runBrokerMaintenance(ctx);
 
@@ -1338,11 +1342,13 @@ export default function (pi: ExtensionAPI) {
         pendingInboxCount: db.getPendingInboxCount(agent.id),
         ownedThreadCount: db.getOwnedThreadCount(agent.id),
       }));
+      const pendingBacklogCount = db.getBacklogCount("pending");
       const evaluation = evaluateRalphLoopCycle(workloads, {
         now: Date.now(),
         heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
         heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
-        pendingBacklogCount: db.getBacklogCount("pending"),
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        pendingBacklogCount,
         currentBranch,
         brokerHeartbeatActive: brokerHeartbeatTimer != null,
         brokerMaintenanceActive: brokerMaintenanceTimer != null,
@@ -1406,6 +1412,27 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.notify("RALPH loop health recovered", "info");
       }
       lastBrokerRalphLoopSignature = signature;
+
+      // #103: Record ralph cycle for observability
+      try {
+        const cycleCompletedAt = new Date().toISOString();
+        db.recordRalphCycle({
+          startedAt: cycleStartedAt,
+          completedAt: cycleCompletedAt,
+          durationMs: Date.now() - cycleStartMs,
+          ghostAgentIds: evaluation.ghostAgentIds,
+          nudgeAgentIds: evaluation.nudgeAgentIds,
+          idleDrainAgentIds: evaluation.idleDrainAgentIds,
+          stuckAgentIds: evaluation.stuckAgentIds,
+          anomalies: evaluation.anomalies,
+          anomalySignature: signature,
+          followUpDelivered: shouldDeliverFollowUp,
+          agentCount: workloads.filter((w) => !w.disconnectedAt).length,
+          backlogCount: pendingBacklogCount,
+        });
+      } catch {
+        /* best effort — don't let cycle recording break the loop */
+      }
     } catch (err) {
       ctx.ui.notify(`RALPH loop failed: ${msg(err)}`, "error");
     } finally {
@@ -1792,7 +1819,30 @@ export default function (pi: ExtensionAPI) {
           const entries = await client.pollInbox();
           if (entries.length === 0) return;
 
-          const synced = syncFollowerInboxEntries(entries, threads, agentName, lastDmChannel);
+          // #102: Partition nudges from regular messages for direct delivery
+          const { nudges, regular } = partitionFollowerInboxEntries(entries);
+
+          // Deliver nudges immediately via pi.sendUserMessage (followUp)
+          if (nudges.length > 0) {
+            const nudgeText = nudges
+              .map((n) => n.message.body ?? "")
+              .filter(Boolean)
+              .join("\n");
+            if (nudgeText) {
+              try {
+                pi.sendUserMessage(nudgeText, { deliverAs: "followUp" });
+              } catch {
+                try {
+                  pi.sendUserMessage(nudgeText);
+                } catch {
+                  /* best effort */
+                }
+              }
+            }
+          }
+
+          // Process regular messages through normal inbox flow
+          const synced = syncFollowerInboxEntries(regular, threads, agentName, lastDmChannel);
           for (const nextThread of synced.threadUpdates) {
             const existing = threads.get(nextThread.threadTs);
             if (!existing) {
@@ -1807,6 +1857,7 @@ export default function (pi: ExtensionAPI) {
           lastDmChannel = synced.lastDmChannel;
           inbox.push(...synced.inboxMessages);
 
+          // ACK all entries (nudges + regular)
           const ids = entries.map((entry) => entry.inboxId);
           if (synced.changed) persistState();
           if (ids.length > 0) await client.ackMessages(ids);
@@ -1842,6 +1893,11 @@ export default function (pi: ExtensionAPI) {
           applyBrokerIdentity(registration.name, registration.emoji);
         }
         await resumeThreadClaims();
+        // #103: Re-report idle/working status on reconnect for resilience
+        const currentlyIdle = ctx.isIdle?.() ?? true;
+        void client.updateStatus(currentlyIdle ? "idle" : "working").catch(() => {
+          /* best effort */
+        });
         startPolling();
         setExtStatus(ctx, "ok");
         const uiUpdate = getFollowerReconnectUiUpdate("reconnect", wasDisconnected);


### PR DESCRIPTION
## Summary

Combined PR for issues #102 and #103.

### #102 — Ralph loop nudges deliver as followUp

- Follower agents now **partition inbox entries**, detecting `ralph_loop_nudge` metadata
- Nudges are delivered via `pi.sendUserMessage(deliverAs: 'followUp')` directly, bypassing the inbox queue for **immediate agent wakeup**
- Regular messages continue through the standard inbox → drainInbox flow
- Added `isRalphNudgeEntry()` and `partitionFollowerInboxEntries()` helpers

### #103 — Improved agent idle detection and observability

**New agent tracking fields:**
- `idle_since` — timestamp when agent transitions to idle
- `last_activity` — proves agent is working (not just alive); updated on: status→working, send, agent.message, inbox.ack

**Stuck detection:**
- Agents reporting `working` with no activity for >5 min flagged as stuck
- `stuckAgentIds` added to `RalphLoopEvaluationResult` + anomaly messages
- `[stuck]` tag shown in `pinet_agents` output

**Follower idle state resilience:**
- Re-reports idle/working status on broker reconnect

**Ralph cycle tracking:**
- New `ralph_cycles` table records every loop cycle with ghost/nudge/idle_drain/stuck agent IDs, anomalies, follow-up delivery, agent count, and backlog count
- Enables distinguishing loop-dead vs broker-turn-stuck vs anomaly-persisted-across-cycles

**Schema migration v4:**
- `idle_since`, `last_activity` columns on `agents` table
- `ralph_cycles` table with indexed `started_at`

**Display improvements:**
- `AgentDisplayInfo` enriched with `idleSince`, `lastActivity`, `stuck`, duration/age strings
- `formatAgentList` shows idle duration, activity age, and `[stuck]` tag

### Tests
- 412 tests passed (21 new)
- Covers: stuck detection, nudge partition, idle_since/last_activity tracking, ralph cycle CRUD

Closes #102, closes #103