### PR TITLE
fix: enforce single-broker lock to prevent split-brain (#119)

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -6,6 +6,7 @@ import * as os from "node:os";
 import * as net from "node:net";
 import { BrokerDB, CURRENT_BROKER_SCHEMA_VERSION } from "./schema.js";
 import { LeaderLock } from "./leader.js";
+import { startBroker, type Broker } from "./index.js";
 import { runBrokerMaintenancePass } from "./maintenance.js";
 import { BrokerSocketServer } from "./socket-server.js";
 import type { JsonRpcRequest, JsonRpcResponse } from "./types.js";
@@ -455,9 +456,7 @@ describe("BrokerDB", () => {
 
     const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
     sqlite
-      .prepare(
-        "UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?",
-      )
+      .prepare("UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?")
       .run(new Date(Date.now() - 2 * 60 * 60_000).toISOString(), "gone");
 
     runBrokerMaintenancePass(db, {
@@ -983,5 +982,104 @@ describe("BrokerSocketServer", () => {
     expect(res.error!.message).toContain("array");
 
     client.destroy();
+  });
+});
+
+// ─── startBroker leader lock integration ─────────────────
+// Use TCP with port 0 (auto-assign) since Unix sockets may be
+// blocked in sandboxed environments.
+
+describe("startBroker leader lock", () => {
+  const TCP_TARGET = { type: "tcp" as const, host: "127.0.0.1", port: 0 };
+  let dir: string;
+  const brokers: Broker[] = [];
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(async () => {
+    for (const b of brokers.splice(0)) {
+      await b.stop();
+    }
+    cleanup(dir);
+  });
+
+  /** Helper: start a broker with TCP + per-test dir, track for cleanup */
+  async function launch(overrides: { lockPath?: string; dbSuffix?: string } = {}): Promise<Broker> {
+    const b = await startBroker({
+      dbPath: path.join(dir, `${overrides.dbSuffix ?? "test"}.db`),
+      listenTarget: TCP_TARGET,
+      lockPath: overrides.lockPath ?? path.join(dir, "broker.lock"),
+    });
+    brokers.push(b);
+    return b;
+  }
+
+  it("acquires lock on startup and releases on stop", async () => {
+    const lockPath = path.join(dir, "broker.lock");
+    const broker = await launch({ lockPath });
+
+    // Lock file should exist with our PID
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(fs.readFileSync(lockPath, "utf-8").trim()).toBe(String(process.pid));
+
+    await broker.stop();
+    brokers.length = 0;
+
+    // Lock file should be cleaned up
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("rejects second broker while first is running", async () => {
+    const lockPath = path.join(dir, "broker.lock");
+    await launch({ lockPath });
+
+    await expect(
+      startBroker({
+        dbPath: path.join(dir, "test2.db"),
+        listenTarget: TCP_TARGET,
+        lockPath,
+      }),
+    ).rejects.toThrow("Another pinet broker is already running");
+  });
+
+  it("second broker starts after first stops", async () => {
+    const lockPath = path.join(dir, "broker.lock");
+    const broker1 = await launch({ lockPath });
+    await broker1.stop();
+    brokers.length = 0;
+
+    const broker2 = await launch({ lockPath, dbSuffix: "test2" });
+    expect(broker2.lock.isLeader()).toBe(true);
+  });
+
+  it("reclaims stale lock from dead process", async () => {
+    const lockPath = path.join(dir, "broker.lock");
+
+    // Simulate a crashed broker by writing a dead PID
+    fs.writeFileSync(lockPath, "2147483647", "utf-8");
+
+    const broker = await launch({ lockPath });
+    expect(broker.lock.isLeader()).toBe(true);
+  });
+
+  it("releases lock when db initialization fails", async () => {
+    const lockPath = path.join(dir, "broker.lock");
+
+    // Make the db path a directory so SQLite open fails
+    const badDbPath = path.join(dir, "bad.db");
+    fs.mkdirSync(badDbPath, { recursive: true });
+
+    await expect(
+      startBroker({
+        dbPath: badDbPath,
+        listenTarget: TCP_TARGET,
+        lockPath,
+      }),
+    ).rejects.toThrow();
+
+    // Lock should have been cleaned up on failure
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 });

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -1,10 +1,14 @@
 import * as fs from "node:fs";
 import { BrokerDB } from "./schema.js";
 import { BrokerSocketServer, defaultSocketPath } from "./socket-server.js";
+import type { ListenTarget } from "./socket-server.js";
+import { LeaderLock } from "./leader.js";
 import type { MessageAdapter } from "./types.js";
 
 export { BrokerDB } from "./schema.js";
 export { BrokerSocketServer } from "./socket-server.js";
+export { LeaderLock } from "./leader.js";
+export type { ListenTarget } from "./socket-server.js";
 export type { AgentMessageCallback } from "./socket-server.js";
 export type {
   AgentInfo,
@@ -22,39 +26,67 @@ export type {
 
 export interface BrokerOptions {
   dbPath?: string;
+  /** Unix socket path (shorthand for { type: "unix", path }) */
   socketPath?: string;
+  /** Full listen target — overrides socketPath when provided */
+  listenTarget?: ListenTarget;
+  lockPath?: string;
 }
 
 export interface Broker {
   db: BrokerDB;
   server: BrokerSocketServer;
+  lock: LeaderLock;
   adapters: MessageAdapter[];
   addAdapter(adapter: MessageAdapter): void;
   stop(): Promise<void>;
 }
 
 /**
- * Start the broker: initialize SQLite, start the Unix socket server.
- * Only one broker should run at a time — use /pinet-start explicitly.
+ * Start the broker: acquire leader lock, initialize SQLite, start the Unix socket server.
+ * Only one broker may run at a time — enforced by a PID lock file.
+ *
+ * Throws if another broker process already holds the lock.
  */
 export async function startBroker(options: BrokerOptions = {}): Promise<Broker> {
-  const db = new BrokerDB(options.dbPath);
-  db.initialize();
-
-  // Clean up stale socket file
-  const socketPath = options.socketPath ?? defaultSocketPath();
-  try {
-    const stat = fs.statSync(socketPath);
-    if (stat.isSocket()) fs.unlinkSync(socketPath);
-  } catch {
-    /* doesn't exist — fine */
+  // ── Leader lock: prevent split-brain (issue #119) ────
+  const lock = new LeaderLock(options.lockPath);
+  if (!lock.tryAcquire()) {
+    throw new Error(
+      "Another pinet broker is already running. Only one broker may be active at a time.",
+    );
   }
 
-  const server = new BrokerSocketServer(db, socketPath);
+  const db = new BrokerDB(options.dbPath);
+  try {
+    db.initialize();
+  } catch (err) {
+    lock.release();
+    throw err;
+  }
+
+  // Resolve listen target: explicit target > socketPath > default
+  const target: ListenTarget = options.listenTarget ?? {
+    type: "unix" as const,
+    path: options.socketPath ?? defaultSocketPath(),
+  };
+
+  // Clean up stale socket file (Unix only)
+  if (target.type === "unix") {
+    try {
+      const stat = fs.statSync(target.path);
+      if (stat.isSocket()) fs.unlinkSync(target.path);
+    } catch {
+      /* doesn't exist — fine */
+    }
+  }
+
+  const server = new BrokerSocketServer(db, target);
   try {
     await server.start();
   } catch (err) {
     db.close();
+    lock.release();
     throw err;
   }
 
@@ -63,6 +95,7 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
   const broker: Broker = {
     db,
     server,
+    lock,
     adapters,
 
     addAdapter(adapter: MessageAdapter): void {
@@ -80,6 +113,7 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
       adapters.length = 0;
       await server.stop();
       db.close();
+      lock.release();
     },
   };
 


### PR DESCRIPTION
## Summary

Wires the existing `LeaderLock` (PID lockfile at `~/.pi/pinet-broker.lock`) into `startBroker()`. A second broker startup now **fails fast** with a clear error instead of silently competing for Slack messages.

Closes #119

## What changed

### `broker/index.ts`
- Acquire `LeaderLock` as the **first step** in `startBroker()`
- Release lock on `broker.stop()` and on any init failure (DB or socket)
- `BrokerOptions`: added `lockPath` (custom lock location) and `listenTarget` (TCP support for tests)
- `Broker` interface: exposes `lock` for introspection

### `broker/helpers.test.ts`
5 new integration tests:
- ✅ Acquires lock on startup and releases on stop
- ✅ Rejects second broker while first is running
- ✅ Second broker starts after first stops
- ✅ Reclaims stale lock from dead process (crashed broker)
- ✅ Releases lock when DB initialization fails

## Design

Chose **PID lockfile** — simplest reliable approach:
- `LeaderLock` already existed in `leader.ts` with full test coverage (8 unit tests) — just needed wiring
- Atomic write + verify guards against race conditions
- Stale locks (dead PID) are automatically reclaimed
- Lock is released in all failure paths (DB init, socket bind) and on clean shutdown

## Checks
```
pnpm lint     ✅
pnpm typecheck ✅
pnpm test     ✅ (399 tests, 0 failures)
```