### PR TITLE
fix: clean up stale agent rows and orphaned threads on purge (issue #140)

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -374,6 +374,9 @@ describe("BrokerDB", () => {
     expect(db.getAgentById("ghost")).toBeNull();
     expect(db.getAgentById("gone")).toBeNull();
     expect(db.getInbox("gone")).toHaveLength(0);
+    // Thread ownership should be released after purge
+    expect(db.getThread("t-gone")?.ownerAgent).toBeNull();
+    // Messages should be moved to backlog for reassignment
     expect(db.getPendingBacklog().map((entry) => entry.threadId)).toContain("t-gone");
   });
 
@@ -455,9 +458,7 @@ describe("BrokerDB", () => {
 
     const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
     sqlite
-      .prepare(
-        "UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?",
-      )
+      .prepare("UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?")
       .run(new Date(Date.now() - 2 * 60 * 60_000).toISOString(), "gone");
 
     runBrokerMaintenancePass(db, {

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -524,8 +524,18 @@ export class BrokerDB implements BrokerDBInterface {
         return [];
       }
 
+      const releaseThreads = db.prepare(
+        "UPDATE threads SET owner_agent = NULL WHERE owner_agent = ?",
+      );
+      const deleteInbox = db.prepare("DELETE FROM inbox WHERE agent_id = ?");
+
       for (const row of rows) {
+        // Requeue undelivered messages to the backlog
         this.requeueUndeliveredMessagesInternal(row.id, "agent_disconnected");
+        // Release thread ownership for the purged agent
+        releaseThreads.run(row.id);
+        // Clean up all inbox entries (both delivered and undelivered) for the agent
+        deleteInbox.run(row.id);
       }
 
       db.prepare(


### PR DESCRIPTION
**P1 Issue:** Stale agent rows and orphaned threads linger in DB indefinitely, causing RALPH ghost alerts.

**Root Cause:** When agents disconnect, rows remain with `disconnected_at` set. Thread ownership stays pointed at dead agents even after purge grace period.

**Solution:** When purging disconnected agents after grace period (`resumable_until`), also:
1. Release thread ownership for any threads claiming the purged agent
2. Delete all inbox entries (both delivered and undelivered) for the agent
3. Requeue undelivered messages to backlog for reassignment (already done)

**Changes:**
- Updated `purgeDisconnectedAgents()` to:
  - Release thread claims: `UPDATE threads SET owner_agent = NULL WHERE owner_agent = ?`
  - Clean inbox entries: `DELETE FROM inbox WHERE agent_id = ?`
  - Still requeue undelivered messages to backlog
  
- Enhanced test to verify thread ownership is released after purge

**Result:** Complete cleanup of stale agents:
- No orphaned threads
- No stale inbox entries  
- All undelivered messages recovered
- Full DB cleanup after grace period

**Testing:**
- ✅ Lint: all packages pass
- ✅ Typecheck: strict TypeScript
- ✅ Tests: 394 tests pass (includes enhanced purge test)