### PR TITLE
fix: cap Slack API retry at 3 attempts to prevent infinite recursion (#124)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -67,18 +67,24 @@ interface SlackResult {
   [k: string]: unknown;
 }
 
+const SLACK_MAX_RETRIES = 3;
+
 async function slack(
   method: string,
   token: string,
   body?: Record<string, unknown>,
+  _retryCount = 0,
 ): Promise<SlackResult> {
   const { url, init } = buildSlackRequest(method, token, body);
   const res = await fetch(url, init);
 
   if (res.status === 429) {
+    if (_retryCount >= SLACK_MAX_RETRIES) {
+      throw new Error(`Slack ${method}: rate limited after ${SLACK_MAX_RETRIES} retries`);
+    }
     const wait = Number(res.headers.get("retry-after") ?? "3");
     await new Promise((r) => setTimeout(r, wait * 1000));
-    return slack(method, token, body);
+    return slack(method, token, body, _retryCount + 1);
   }
 
   const data = (await res.json()) as SlackResult;


### PR DESCRIPTION
## Problem

The top-level `slack()` wrapper in `index.ts` retried 429 responses recursively with **no maximum retry count**. Under sustained rate limiting, this would cause a stack overflow.

The adapter's `callSlack()` in `adapters/slack.ts` already caps at `SLACK_MAX_RETRIES = 3`, but the main extension's `slack()` didn't.

## Fix

Added a `_retryCount` parameter and `SLACK_MAX_RETRIES = 3` constant. After 3 retries, throws an error instead of recursing.

Matches the existing behavior in `callSlack()`.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (394 tests pass)

## Files changed

- `slack-bridge/index.ts` — 7 insertions, 1 deletion

Closes #124