### PR TITLE
feat: expose agent PIDs in pinet_agents tool output (#117)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -490,6 +490,29 @@ describe("formatAgentList", () => {
     );
   });
 
+  it("includes pid when present", () => {
+    const agents: AgentDisplayInfo[] = [
+      {
+        emoji: "\u{1F916}",
+        name: "Bot",
+        id: "abc",
+        pid: 12345,
+        status: "idle",
+        metadata: null,
+      },
+    ];
+    const result = formatAgentList(agents, homedir);
+    expect(result).toBe("\u{1F916} Bot (abc) \u2014 idle pid:12345");
+  });
+
+  it("omits pid when not present", () => {
+    const agents: AgentDisplayInfo[] = [
+      { emoji: "\u{1F916}", name: "Bot", id: "abc", status: "idle", metadata: null },
+    ];
+    const result = formatAgentList(agents, homedir);
+    expect(result).not.toContain("pid:");
+  });
+
   it("formats multiple agents", () => {
     const agents: AgentDisplayInfo[] = [
       {
@@ -601,6 +624,22 @@ describe("formatAgentList", () => {
 });
 
 describe("buildAgentDisplayInfo", () => {
+  it("passes pid through to display info", () => {
+    const agent = buildAgentDisplayInfo(
+      { emoji: "\u{1F916}", name: "Bot", id: "a1", pid: 42, status: "idle" },
+      { now: Date.now() },
+    );
+    expect(agent.pid).toBe(42);
+  });
+
+  it("omits pid when not provided", () => {
+    const agent = buildAgentDisplayInfo(
+      { emoji: "\u{1F916}", name: "Bot", id: "a1", status: "idle" },
+      { now: Date.now() },
+    );
+    expect(agent.pid).toBeUndefined();
+  });
+
   it("marks a disconnected agent with resumable lease as resumable", () => {
     const agent = buildAgentDisplayInfo(
       {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -154,6 +154,7 @@ export interface AgentDisplayInfo {
   emoji: string;
   name: string;
   id: string;
+  pid?: number;
   status: "working" | "idle";
   metadata?: {
     cwd?: string;
@@ -184,6 +185,7 @@ export interface AgentVisibilityInput {
   emoji: string;
   name: string;
   id: string;
+  pid?: number;
   status: "working" | "idle";
   metadata?: Record<string, unknown> | null;
   lastHeartbeat?: string;
@@ -368,6 +370,7 @@ export function buildAgentDisplayInfo(
     emoji: agent.emoji,
     name: agent.name,
     id: agent.id,
+    ...(agent.pid != null ? { pid: agent.pid } : {}),
     status: agent.status,
     metadata: metadata
       ? {
@@ -988,7 +991,8 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
     .map((a) => {
       const health = a.health ? ` [${a.health}]` : "";
       const stuckTag = a.stuck ? " [stuck]" : "";
-      let line = `${a.emoji} ${a.name} (${a.id}) \u2014 ${a.status}${health}${stuckTag}`;
+      const pid = a.pid != null ? ` pid:${a.pid}` : "";
+      let line = `${a.emoji} ${a.name} (${a.id}) \u2014 ${a.status}${health}${stuckTag}${pid}`;
 
       const meta = a.metadata;
       if (meta && (meta.cwd || meta.branch || meta.host)) {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1576,6 +1576,7 @@ export default function (pi: ExtensionAPI) {
         emoji: string;
         name: string;
         id: string;
+        pid?: number;
         status: "working" | "idle";
         metadata: Record<string, unknown> | null;
         lastHeartbeat: string;
@@ -1592,6 +1593,7 @@ export default function (pi: ExtensionAPI) {
         emoji: string;
         name: string;
         id: string;
+        pid?: number;
         status: "working" | "idle";
         metadata: Record<string, unknown> | null;
         lastHeartbeat: string;
@@ -1607,6 +1609,7 @@ export default function (pi: ExtensionAPI) {
             emoji: agent.emoji,
             name: agent.name,
             id: agent.id,
+            pid: agent.pid,
             status: agent.status,
             metadata: agent.metadata,
             lastHeartbeat: agent.lastHeartbeat,
@@ -1621,6 +1624,7 @@ export default function (pi: ExtensionAPI) {
             emoji: agent.emoji,
             name: agent.name,
             id: agent.id,
+            pid: agent.pid,
             status: agent.status ?? "idle",
             metadata: agent.metadata,
             lastHeartbeat: agent.lastHeartbeat,


### PR DESCRIPTION
## Summary

Threads the `pid` field (already stored in DB and present in `AgentInfo`) through to the `pinet_agents` tool output so operators can `kill` rogue agents without querying the DB manually.

Closes #117

## What changed

### `helpers.ts`
- Added `pid?: number` to `AgentVisibilityInput` and `AgentDisplayInfo`
- `buildAgentDisplayInfo` now passes `pid` through
- `formatAgentList` displays `pid:NNNNN` after the status tag

### `index.ts`
- Both broker and follower code paths now include `pid` in the `rawAgents` mapping

### Tests (4 new)
- `formatAgentList`: includes pid when present / omits when absent
- `buildAgentDisplayInfo`: passes pid through / omits when not provided

## Example output

```
🦁 Stellar Lion (bf1d0bdc) — working [healthy] pid:12345
   ~/src/extensions (main) @ macbook
   heartbeat 3s ago · lease in 12s
   caps: role:worker, repo:extensions, branch:main, tool:git
```

## Checks
```
pnpm lint      ✅
pnpm typecheck ✅
pnpm test      ✅ (398 tests, 0 failures)
```