### PR TITLE
fix: add hard broker guardrails to prevent coding (#107)

### DIFF
--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -6,6 +6,9 @@ import {
   buildSecurityPrompt,
   isConfirmationApproval,
   isConfirmationRejection,
+  isBrokerForbiddenTool,
+  buildBrokerToolGuardrailsPrompt,
+  BROKER_FORBIDDEN_TOOLS,
   READ_ONLY_TOOLS,
   WRITE_TOOLS,
   type SecurityGuardrails,
@@ -252,6 +255,51 @@ describe("isConfirmationApproval", () => {
     expect(isConfirmationApproval("maybe")).toBe(false);
     expect(isConfirmationApproval("let me think")).toBe(false);
     expect(isConfirmationApproval("")).toBe(false);
+  });
+});
+
+// ─── Broker role guardrails ───────────────────────────────
+
+describe("BROKER_FORBIDDEN_TOOLS", () => {
+  it("blocks the Agent tool", () => {
+    expect(BROKER_FORBIDDEN_TOOLS.has("Agent")).toBe(true);
+  });
+});
+
+describe("isBrokerForbiddenTool", () => {
+  it("returns true for Agent tool", () => {
+    expect(isBrokerForbiddenTool("Agent")).toBe(true);
+  });
+
+  it("returns false for allowed tools", () => {
+    expect(isBrokerForbiddenTool("pinet_message")).toBe(false);
+    expect(isBrokerForbiddenTool("pinet_agents")).toBe(false);
+    expect(isBrokerForbiddenTool("slack_send")).toBe(false);
+    expect(isBrokerForbiddenTool("read")).toBe(false);
+    expect(isBrokerForbiddenTool("bash")).toBe(false);
+  });
+
+  it("is case-sensitive", () => {
+    expect(isBrokerForbiddenTool("agent")).toBe(false);
+    expect(isBrokerForbiddenTool("AGENT")).toBe(false);
+  });
+});
+
+describe("buildBrokerToolGuardrailsPrompt", () => {
+  it("mentions the Agent tool as blocked", () => {
+    const prompt = buildBrokerToolGuardrailsPrompt();
+    expect(prompt).toContain("Agent");
+    expect(prompt).toContain("BLOCKED");
+  });
+
+  it("recommends pinet_message as the alternative", () => {
+    const prompt = buildBrokerToolGuardrailsPrompt();
+    expect(prompt).toContain("pinet_message");
+  });
+
+  it("explains why the Agent tool is forbidden", () => {
+    const prompt = buildBrokerToolGuardrailsPrompt();
+    expect(prompt).toContain("no Slack/Pinet connectivity");
   });
 });
 

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -132,6 +132,38 @@ export function buildSecurityPrompt(guardrails: SecurityGuardrails): string {
   return sections.join("\n\n");
 }
 
+// ─── Broker Role Guardrails ──────────────────────────────
+
+/**
+ * Tools that the broker agent must NEVER use.
+ * The broker is infrastructure — it coordinates, not codes.
+ * Spawning local subagents (Agent) is forbidden because they
+ * have no Slack/Pinet connectivity and can't be monitored.
+ */
+export const BROKER_FORBIDDEN_TOOLS = new Set(["Agent"]);
+
+/**
+ * Check if a tool is forbidden for the broker role.
+ * Returns true if the broker must not use this tool.
+ */
+export function isBrokerForbiddenTool(toolName: string): boolean {
+  return BROKER_FORBIDDEN_TOOLS.has(toolName);
+}
+
+/**
+ * Build a prompt snippet describing broker tool restrictions.
+ * Injected into the system prompt when the broker role is active.
+ */
+export function buildBrokerToolGuardrailsPrompt(): string {
+  const forbidden = [...BROKER_FORBIDDEN_TOOLS].join(", ");
+  return [
+    "🚫 BROKER TOOL RESTRICTION:",
+    `The following tools are BLOCKED for the broker role: ${forbidden}.`,
+    "The Agent tool spawns local subagents with no Slack/Pinet connectivity — they can't be monitored, can't own threads, and can't coordinate with humans.",
+    "Use pinet_message to delegate to connected Pinet agents instead.",
+  ].join("\n");
+}
+
 /**
  * Parse whether a user message is approving a confirmation request.
  * Case-insensitive, trimmed.

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -372,23 +372,57 @@ describe("buildBrokerPromptGuidelines", () => {
     expect(guidelines[0]).toContain("Solar Mantis");
   });
 
-  it("instructs not to pick up coding tasks", () => {
+  it("contains a hard rule against writing code", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
-    expect(joined).toContain("DO NOT pick up coding tasks");
+    expect(joined).toContain("HARD RULE");
+    expect(joined).toContain("NEVER WRITE CODE");
+  });
+
+  it("lists forbidden actions explicitly", () => {
+    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("FORBIDDEN");
+    expect(joined).toContain("Agent tool");
+    expect(joined).toContain("edit");
+    expect(joined).toContain("write");
+    expect(joined).toContain("bash");
+  });
+
+  it("lists allowed actions explicitly", () => {
+    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("ALLOWED");
+    expect(joined).toContain("Route messages");
+    expect(joined).toContain("pinet_agents");
+    expect(joined).toContain("pinet_message");
+  });
+
+  it("includes a refusal template for coding requests", () => {
+    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("IF ASKED TO CODE");
+    expect(joined).toContain("Refuse");
+    expect(joined).toContain("delegate");
+  });
+
+  it("explains why the constraint exists (mesh stalls)", () => {
+    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("mesh");
+    expect(joined).toContain("stall");
   });
 
   it("instructs to use pinet_message instead of Agent tool", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
     expect(joined).toContain("pinet_message");
-    expect(joined).toContain("DO NOT use the Agent tool");
   });
 
-  it("instructs to check pinet_agents for idle workers", () => {
+  it("tells broker to never do the work as a fallback", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
-    expect(joined).toContain("pinet_agents");
+    expect(joined).toContain("NEVER do the work yourself");
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -651,14 +651,18 @@ export function buildRalphLoopFollowUpMessage(
 
 export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: string): string[] {
   return [
-    `You are ${agentEmoji} ${agentName}, the Pinet BROKER. Your role is coordination, not coding.`,
-    "WHY: You are the only process routing messages, monitoring agent health, and keeping the mesh alive. If you get stuck in a long coding task, Slack messages stop flowing, dead agents don't get reaped, and the whole multi-agent system stalls. Stay light and fast.",
-    "DO NOT pick up coding tasks, bug fixes, or implementation work yourself. Delegate to connected workers instead.",
-    "DO NOT use the Agent tool to spawn local subagents. Local subagents have no Slack/Pinet connectivity and can't be monitored. Use `pinet_message` to delegate to connected Pinet agents who can respond in Slack, own threads, and coordinate with humans directly.",
-    "Your job is: relay messages between humans and agents, route work to idle followers, file issues, create/merge PRs, run reviews, and monitor agent health.",
-    "When a human asks for work to be done, check `pinet_agents` for idle workers and delegate via `pinet_message`. Pick the agent on the right repo/branch when possible.",
+    `You are ${agentEmoji} ${agentName}, the Pinet BROKER. Your ONLY role is coordination and infrastructure — NEVER implementation.`,
+    // ── HARD GUARDRAIL ──────────────────────────────────────────
+    "🚫 HARD RULE — NEVER WRITE CODE: You MUST NOT implement features, fix bugs, write tests, edit source files, or do any coding task. This is a non-negotiable constraint, not a preference. Violations stall the entire multi-agent mesh.",
+    "WHY THIS RULE EXISTS: You are the ONLY process routing Slack messages, monitoring agent health, and keeping the mesh alive. If you spend even one turn writing code, messages stop flowing, dead agents don't get reaped, backlog piles up, and the whole system stalls. Workers are computation, broker is infrastructure.",
+    // ── FORBIDDEN ACTIONS ───────────────────────────────────────
+    "FORBIDDEN — Do NOT do any of these, even if explicitly asked: (1) Use the Agent tool to spawn local subagents — they have no Slack/Pinet connectivity and can't be monitored. (2) Use edit, write, or bash to modify source code. (3) Pick up coding tasks, bug fixes, refactors, or implementation work. (4) Run test suites, linters, or build commands as part of implementation work. (5) Create or modify source files in any worktree.",
+    "IF ASKED TO CODE: Refuse politely and immediately delegate. Say: 'I'm the broker — I coordinate, not code. Let me find a worker for this.' Then check pinet_agents and delegate via pinet_message.",
+    // ── ALLOWED ACTIONS ─────────────────────────────────────────
+    "ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check pinet_agents for idle workers and delegate tasks via pinet_message. (3) File GitHub issues, create/merge PRs, run code reviews via the code-reviewer subagent. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection: git log, git status, gh pr list, ls, cat — never for code changes.",
+    "When a human asks for work to be done, ALWAYS check `pinet_agents` for idle workers and delegate via `pinet_message`. Pick the agent on the right repo/branch when possible.",
     "When delegating, include: the task description, relevant issue/PR numbers, branch to work on, and where to report back (Slack thread_ts).",
-    "If no workers are available, tell the human and suggest they spin up a new agent rather than doing the work yourself.",
+    "If no workers are available, tell the human and suggest they spin up a new agent. NEVER do the work yourself as a fallback.",
     "WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.",
     "For feature work, ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>`. Tell delegated agents to do the same.",
     "When delegating to an agent, include the worktree setup command. Example: `git worktree add .worktrees/fix-foo-123 -b fix/foo-123 && cd .worktrees/fix-foo-123`",

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -45,6 +45,8 @@ import {
   isToolBlocked,
   matchesToolPattern,
   toolNeedsConfirmation,
+  isBrokerForbiddenTool,
+  buildBrokerToolGuardrailsPrompt,
   type SecurityGuardrails,
 } from "./guardrails.js";
 import { startBroker, type BrokerDB } from "./broker/index.js";
@@ -2056,11 +2058,22 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  // Hard-block forbidden tools when broker role is active.
+  pi.on("tool_call", async (event) => {
+    if (brokerRole === "broker" && isBrokerForbiddenTool(event.toolName)) {
+      return {
+        block: true,
+        reason: `Tool "${event.toolName}" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.`,
+      };
+    }
+  });
+
   // Inject dynamic identity guidance every turn so reload/session restore keeps prompts in sync.
   pi.on("before_agent_start", async (event) => {
     const guidelines = [...getIdentityGuidelines()];
     if (brokerRole === "broker") {
       guidelines.push(...buildBrokerPromptGuidelines(agentEmoji, agentName));
+      guidelines.push(buildBrokerToolGuardrailsPrompt());
     } else if (brokerRole === "follower") {
       guidelines.push(...buildWorkerPromptGuidelines());
     }


### PR DESCRIPTION
## Problem

The broker agent keeps picking up coding tasks instead of delegating to workers via Pinet (Issue #107, P0). When the broker codes, Slack messages stop flowing, dead agents don't get reaped, and the whole multi-agent mesh stalls.

## Solution — Three-layer defense

### 1. System prompt guardrails (`helpers.ts`)
- **HARD RULE** block: `NEVER WRITE CODE` with mesh-stall justification
- **FORBIDDEN** actions list: Agent tool, edit, write, bash for code changes
- **ALLOWED** actions list: route, delegate, review, inspect
- **Refusal template**: 'I'm the broker — I coordinate, not code.'
- **No fallback**: 'NEVER do the work yourself as a fallback'

### 2. Tool-level guardrails (`guardrails.ts`)
- `BROKER_FORBIDDEN_TOOLS` set blocks the `Agent` tool
- `isBrokerForbiddenTool()` check function
- `buildBrokerToolGuardrailsPrompt()` for system prompt injection

### 3. Runtime enforcement (`index.ts`)
- `tool_call` event handler returns `{ block: true }` for Agent tool when broker role is active — hard block, can't be bypassed by prompt
- Broker tool guardrails prompt injected via `before_agent_start`

## Principle
> Workers are computation, broker is infrastructure. — `plans/pinet-vision.md` #6

## Tests
- 405 tests passing (lint ✅ typecheck ✅ test ✅)
- New tests for `isBrokerForbiddenTool`, `BROKER_FORBIDDEN_TOOLS`, `buildBrokerToolGuardrailsPrompt`
- Updated tests for strengthened `buildBrokerPromptGuidelines`

Closes #107