### PR TITLE
fix: make claimThread atomic to prevent TOCTOU race (#125)

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -455,9 +455,7 @@ describe("BrokerDB", () => {
 
     const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
     sqlite
-      .prepare(
-        "UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?",
-      )
+      .prepare("UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?")
       .run(new Date(Date.now() - 2 * 60 * 60_000).toISOString(), "gone");
 
     runBrokerMaintenancePass(db, {
@@ -507,6 +505,46 @@ describe("BrokerDB", () => {
     expect(db.getOwnedThreadCount("agent-1")).toBe(2);
     expect(db.getOwnedThreadCount("agent-2")).toBe(1);
     expect(db.getOwnedThreadCount("missing")).toBe(0);
+  });
+
+  it("claimThread creates a new thread and claims it", () => {
+    const claimed = db.claimThread("t-new", "agent-1", "slack", "#general");
+    expect(claimed).toBe(true);
+    const thread = db.getThread("t-new");
+    expect(thread).not.toBeNull();
+    expect(thread!.ownerAgent).toBe("agent-1");
+  });
+
+  it("claimThread succeeds on unclaimed existing thread", () => {
+    db.createThread("t-unclaimed", "slack", "#general", null);
+    const claimed = db.claimThread("t-unclaimed", "agent-1");
+    expect(claimed).toBe(true);
+    expect(db.getThread("t-unclaimed")!.ownerAgent).toBe("agent-1");
+  });
+
+  it("claimThread allows re-claim by same agent", () => {
+    db.claimThread("t-mine", "agent-1");
+    const reclaimed = db.claimThread("t-mine", "agent-1");
+    expect(reclaimed).toBe(true);
+    expect(db.getThread("t-mine")!.ownerAgent).toBe("agent-1");
+  });
+
+  it("claimThread rejects claim when another agent owns the thread", () => {
+    db.claimThread("t-taken", "agent-1");
+    const claimed = db.claimThread("t-taken", "agent-2");
+    expect(claimed).toBe(false);
+    expect(db.getThread("t-taken")!.ownerAgent).toBe("agent-1");
+  });
+
+  it("claimThread is atomic — no TOCTOU window between read and write", () => {
+    // Simulate the race: agent-1 claims, then agent-2 tries to claim.
+    // With the old read-then-write pattern, a race could let both succeed.
+    // The atomic INSERT...ON CONFLICT...WHERE ensures only one wins.
+    const first = db.claimThread("t-race", "agent-1");
+    const second = db.claimThread("t-race", "agent-2");
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(db.getThread("t-race")!.ownerAgent).toBe("agent-1");
   });
 
   it("insertMessage and getInbox", () => {

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -59,6 +59,27 @@ class StubBrokerDBInterface implements BrokerDBInterface {
     this.threads.set(threadId, { ...existing, ...updates });
   }
 
+  claimThread(threadId: string, agentId: string, source = "slack", channel = ""): boolean {
+    const existing = this.threads.get(threadId);
+    if (existing) {
+      if (existing.ownerAgent && existing.ownerAgent !== agentId) {
+        return false;
+      }
+      this.threads.set(threadId, { ...existing, ownerAgent: agentId });
+      return true;
+    }
+    const now = new Date().toISOString();
+    this.threads.set(threadId, {
+      threadId,
+      source,
+      channel,
+      ownerAgent: agentId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return true;
+  }
+
   queueMessage(agentId: string, message: InboundMessage): void {
     this.inbox.push({ agentId, message });
   }

--- a/slack-bridge/broker/router.ts
+++ b/slack-bridge/broker/router.ts
@@ -96,31 +96,12 @@ export class MessageRouter {
    * Claim a thread for an agent (first-responder-wins).
    * Optionally provide a channel to set when creating a new thread.
    * Returns true if the claim succeeded, false if another agent already owns it.
+   *
+   * Delegates to the DB layer which performs the claim atomically
+   * (single SQL statement) to avoid TOCTOU races. (#125)
    */
   claimThread(threadId: string, agentId: string, channel?: string): boolean {
-    const existing = this.db.getThread(threadId);
-
-    if (existing) {
-      // Already owned by someone else
-      if (existing.ownerAgent && existing.ownerAgent !== agentId) {
-        return false;
-      }
-      // Unclaimed or already owned by this agent — claim it
-      this.db.updateThread(threadId, { ownerAgent: agentId });
-      return true;
-    }
-
-    // Thread doesn't exist yet — create and claim
-    const now = new Date().toISOString();
-    this.db.createThread({
-      threadId,
-      source: "slack",
-      channel: channel ?? "",
-      ownerAgent: agentId,
-      createdAt: now,
-      updatedAt: now,
-    });
-    return true;
+    return this.db.claimThread(threadId, agentId, "slack", channel ?? "");
   }
 
   /**

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -663,6 +663,29 @@ export class BrokerDB implements BrokerDBInterface {
     db.prepare(`UPDATE threads SET ${sets.join(", ")} WHERE thread_id = ?`).run(...values);
   }
 
+  claimThread(threadId: string, agentId: string, source = "slack", channel = ""): boolean {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+
+    // Atomic claim: insert the thread if new, or update the owner only
+    // if the thread is currently unclaimed or already owned by this agent.
+    // A single statement avoids the TOCTOU race of read-then-write. (#125)
+    db.prepare(
+      `INSERT INTO threads (thread_id, source, channel, owner_agent, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(thread_id) DO UPDATE SET
+         owner_agent = excluded.owner_agent,
+         updated_at = excluded.updated_at
+       WHERE threads.owner_agent IS NULL OR threads.owner_agent = excluded.owner_agent`,
+    ).run(threadId, source, channel, agentId, now, now);
+
+    // Verify: read back the owner.  If the WHERE clause above didn't
+    // match (another agent owns the thread), the row was not updated
+    // and the owner will differ from agentId.
+    const thread = this.getThread(threadId);
+    return thread?.ownerAgent === agentId;
+  }
+
   getAllowedUsers(): Set<string> | null {
     return null;
   }

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -122,5 +122,12 @@ export interface BrokerDBInterface {
   createThread(thread: ThreadInfo): void;
   updateThread(threadId: string, updates: Partial<ThreadInfo>): void;
 
+  /**
+   * Atomically claim a thread for an agent (first-responder-wins).
+   * Creates the thread if it doesn't exist. Returns true if the claim
+   * succeeded, false if another agent already owns the thread.
+   */
+  claimThread(threadId: string, agentId: string, source?: string, channel?: string): boolean;
+
   queueMessage(agentId: string, message: InboundMessage): void;
 }


### PR DESCRIPTION
## Problem

`claimThread` in `router.ts` used a read-then-write pattern:

```typescript
const existing = this.db.getThread(threadId);  // READ
if (existing?.ownerAgent && existing.ownerAgent \!== agentId) return false;  // CHECK
this.db.updateThread(threadId, { ownerAgent: agentId });  // WRITE
```

Between the READ and WRITE, another agent could claim the thread (TOCTOU race). With 15+ concurrent agents, this was a real risk for thread ownership collisions.

## Fix

Added an atomic `claimThread` method to the DB layer (`BrokerDB`) that uses a **single SQL statement**:

```sql
INSERT INTO threads (...) VALUES (...)
ON CONFLICT(thread_id) DO UPDATE SET
  owner_agent = excluded.owner_agent,
  updated_at = excluded.updated_at
WHERE threads.owner_agent IS NULL
   OR threads.owner_agent = excluded.owner_agent
```

The `WHERE` clause ensures the update only succeeds if the thread is unclaimed or already owned by the requesting agent. No read-then-write, no race window.

The router's `claimThread` now delegates directly to the DB layer instead of doing its own read-check-write logic.

## Changes

| File | Change |
|------|--------|
| `broker/types.ts` | Added `claimThread` to `BrokerDBInterface` |
| `broker/schema.ts` | Atomic `claimThread` impl with single SQL |
| `broker/router.ts` | Simplified to delegate to `db.claimThread()` |
| `broker/helpers.test.ts` | +5 tests for atomic claim behavior |
| `broker/router.test.ts` | Updated stub with `claimThread` impl |

## Tests

399 tests pass (5 new). Lint and typecheck clean.

Closes #125