### PR TITLE
fix: bound in-memory caches with TTL + max-size eviction (#129)

### DIFF
--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -4,6 +4,7 @@ import {
   isUserAllowed,
   stripBotMention,
 } from "../../helpers.js";
+import { TtlCache } from "../../ttl-cache.js";
 import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
 
 // ─── Config ──────────────────────────────────────────────
@@ -214,7 +215,10 @@ export class SlackAdapter implements MessageAdapter {
   private inboundHandler: ((msg: InboundMessage) => void) | null = null;
 
   private readonly threads = new Map<string, SlackThreadInfo>();
-  private readonly userNames = new Map<string, string>();
+  private readonly userNames = new TtlCache<string, string>({
+    maxSize: 2000,
+    ttlMs: 60 * 60 * 1000,
+  });
   private readonly pendingEyes = new Map<string, { channel: string; messageTs: string }[]>();
 
   constructor(config: SlackAdapterConfig) {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -66,7 +66,7 @@ export interface InboxMessage {
 
 export function formatInboxMessages(
   messages: InboxMessage[],
-  userNames: Map<string, string>,
+  userNames: { get(key: string): string | undefined },
 ): string {
   const lines = messages.map((m) => {
     const n = userNames.get(m.userId) ?? m.userId;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -47,6 +47,7 @@ import {
   toolNeedsConfirmation,
   type SecurityGuardrails,
 } from "./guardrails.js";
+import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { startBroker, type BrokerDB } from "./broker/index.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
@@ -216,10 +217,10 @@ export default function (pi: ExtensionAPI) {
   const threads = new Map<string, ThreadInfo>();
   const thinking = new Set<string>();
   const pendingEyes = new Map<string, { channel: string; messageTs: string }[]>(); // thread_ts → message ts list // thread_ts values showing "is thinking…"
-  const userNames = new Map<string, string>();
+  const userNames = new TtlCache<string, string>({ maxSize: 2000, ttlMs: 60 * 60 * 1000 });
   let lastDmChannel: string | null = null;
-  const channelCache = new Map<string, string>();
-  const unclaimedThreads = new Set<string>(); // negative cache for resolveThreadOwner
+  const channelCache = new TtlCache<string, string>({ maxSize: 500, ttlMs: 30 * 60 * 1000 });
+  const unclaimedThreads = new TtlSet<string>({ maxSize: 5000, ttlMs: 5 * 60 * 1000 });
 
   interface ConfirmationRequest {
     toolPattern: string;

--- a/slack-bridge/ttl-cache.test.ts
+++ b/slack-bridge/ttl-cache.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { TtlCache, TtlSet } from "./ttl-cache.js";
+
+// ─── TtlCache ────────────────────────────────────────────
+
+describe("TtlCache", () => {
+  it("stores and retrieves values", () => {
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 1000 });
+    cache.set("a", 1);
+    expect(cache.get("a")).toBe(1);
+    expect(cache.has("a")).toBe(true);
+    expect(cache.size).toBe(1);
+  });
+
+  it("returns undefined for missing keys", () => {
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 1000 });
+    expect(cache.get("missing")).toBeUndefined();
+    expect(cache.has("missing")).toBe(false);
+  });
+
+  it("expires entries after TTL", () => {
+    let time = 0;
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 100, now: () => time });
+
+    cache.set("a", 1);
+    expect(cache.get("a")).toBe(1);
+
+    time = 101;
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.has("a")).toBe(false);
+  });
+
+  it("entries at exactly TTL boundary are still valid", () => {
+    let time = 0;
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 100, now: () => time });
+    cache.set("a", 1);
+
+    time = 100;
+    expect(cache.get("a")).toBe(1);
+  });
+
+  it("evicts oldest when exceeding maxSize", () => {
+    const cache = new TtlCache<string, number>({ maxSize: 3, ttlMs: 60_000 });
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    cache.set("d", 4); // "a" should be evicted
+
+    expect(cache.has("a")).toBe(false);
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("d")).toBe(4);
+    expect(cache.size).toBe(3);
+  });
+
+  it("re-setting a key refreshes its position (not evicted first)", () => {
+    const cache = new TtlCache<string, number>({ maxSize: 3, ttlMs: 60_000 });
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    // Touch "a" — moves it to the end
+    cache.set("a", 10);
+    cache.set("d", 4); // "b" should be evicted (oldest now)
+
+    expect(cache.has("b")).toBe(false);
+    expect(cache.get("a")).toBe(10);
+    expect(cache.size).toBe(3);
+  });
+
+  it("delete removes entries", () => {
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 1000 });
+    cache.set("a", 1);
+    expect(cache.delete("a")).toBe(true);
+    expect(cache.has("a")).toBe(false);
+    expect(cache.delete("a")).toBe(false);
+  });
+
+  it("entries() skips expired items", () => {
+    let time = 0;
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 100, now: () => time });
+    cache.set("a", 1);
+    time = 50;
+    cache.set("b", 2);
+
+    time = 101; // "a" expired, "b" still valid
+    const entries = Array.from(cache.entries());
+    expect(entries).toEqual([["b", 2]]);
+  });
+
+  it("sweep removes all expired entries", () => {
+    let time = 0;
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 100, now: () => time });
+    cache.set("a", 1);
+    cache.set("b", 2);
+    time = 50;
+    cache.set("c", 3);
+
+    time = 101; // "a" and "b" expired, "c" still valid
+    const swept = cache.sweep();
+    expect(swept).toBe(2);
+    expect(cache.size).toBe(1);
+    expect(cache.get("c")).toBe(3);
+  });
+
+  it("clear removes everything", () => {
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 1000 });
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+
+  it("set returns this for chaining", () => {
+    const cache = new TtlCache<string, number>({ maxSize: 10, ttlMs: 1000 });
+    const ret = cache.set("a", 1);
+    expect(ret).toBe(cache);
+  });
+});
+
+// ─── TtlSet ─────────────────────────────────────────────
+
+describe("TtlSet", () => {
+  it("add and has", () => {
+    const set = new TtlSet<string>({ maxSize: 10, ttlMs: 1000 });
+    set.add("x");
+    expect(set.has("x")).toBe(true);
+    expect(set.has("y")).toBe(false);
+    expect(set.size).toBe(1);
+  });
+
+  it("expires entries after TTL", () => {
+    let time = 0;
+    const set = new TtlSet<string>({ maxSize: 10, ttlMs: 100, now: () => time });
+    set.add("x");
+
+    time = 101;
+    expect(set.has("x")).toBe(false);
+  });
+
+  it("evicts oldest when exceeding maxSize", () => {
+    const set = new TtlSet<string>({ maxSize: 2, ttlMs: 60_000 });
+    set.add("a");
+    set.add("b");
+    set.add("c"); // "a" evicted
+
+    expect(set.has("a")).toBe(false);
+    expect(set.has("b")).toBe(true);
+    expect(set.has("c")).toBe(true);
+  });
+
+  it("delete removes entries", () => {
+    const set = new TtlSet<string>({ maxSize: 10, ttlMs: 1000 });
+    set.add("x");
+    expect(set.delete("x")).toBe(true);
+    expect(set.has("x")).toBe(false);
+  });
+
+  it("sweep removes expired entries", () => {
+    let time = 0;
+    const set = new TtlSet<string>({ maxSize: 10, ttlMs: 100, now: () => time });
+    set.add("a");
+    set.add("b");
+    time = 101;
+    expect(set.sweep()).toBe(2);
+    expect(set.size).toBe(0);
+  });
+
+  it("add returns this for chaining", () => {
+    const set = new TtlSet<string>({ maxSize: 10, ttlMs: 1000 });
+    const ret = set.add("x");
+    expect(ret).toBe(set);
+  });
+});

--- a/slack-bridge/ttl-cache.ts
+++ b/slack-bridge/ttl-cache.ts
@@ -1,0 +1,121 @@
+/**
+ * Lightweight TTL + max-size cache.
+ *
+ * Entries expire after `ttlMs` milliseconds and are lazily evicted on
+ * access.  When the cache exceeds `maxSize`, the oldest entry (by
+ * insertion / last-update order) is dropped — Map iteration order
+ * guarantees FIFO.
+ */
+export class TtlCache<K, V> {
+  private readonly map = new Map<K, { value: V; touchedAt: number }>();
+  private readonly maxSize: number;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: { maxSize: number; ttlMs: number; now?: () => number }) {
+    this.maxSize = options.maxSize;
+    this.ttlMs = options.ttlMs;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (this.now() - entry.touchedAt > this.ttlMs) {
+      this.map.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: K, value: V): this {
+    // Delete first so re-insertion moves the key to the end (Map ordering).
+    this.map.delete(key);
+    this.map.set(key, { value, touchedAt: this.now() });
+    this.evictOverflow();
+    return this;
+  }
+
+  has(key: K): boolean {
+    return this.get(key) !== undefined;
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  /** Iterate live (non-expired) entries. */
+  *entries(): IterableIterator<[K, V]> {
+    const now = this.now();
+    for (const [key, entry] of this.map) {
+      if (now - entry.touchedAt <= this.ttlMs) {
+        yield [key, entry.value];
+      }
+    }
+  }
+
+  /** Sweep all expired entries in one pass. */
+  sweep(): number {
+    const now = this.now();
+    let swept = 0;
+    for (const [key, entry] of this.map) {
+      if (now - entry.touchedAt > this.ttlMs) {
+        this.map.delete(key);
+        swept++;
+      }
+    }
+    return swept;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  private evictOverflow(): void {
+    while (this.map.size > this.maxSize) {
+      const oldest = this.map.keys().next();
+      if (oldest.done) break;
+      this.map.delete(oldest.value);
+    }
+  }
+}
+
+/**
+ * TTL + max-size Set — thin wrapper around TtlCache<V, true>.
+ */
+export class TtlSet<V> {
+  private readonly cache: TtlCache<V, true>;
+
+  constructor(options: { maxSize: number; ttlMs: number; now?: () => number }) {
+    this.cache = new TtlCache(options);
+  }
+
+  add(value: V): this {
+    this.cache.set(value, true);
+    return this;
+  }
+
+  has(value: V): boolean {
+    return this.cache.has(value);
+  }
+
+  delete(value: V): boolean {
+    return this.cache.delete(value);
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  sweep(): number {
+    return this.cache.sweep();
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Replace unbounded `Map`/`Set` caches (`userNames`, `channelCache`, `unclaimedThreads`) with `TtlCache`/`TtlSet` that enforce both a max entry count and time-to-live expiry. Prevents silent memory growth under load.

Closes #129

## What changed

### New: `ttl-cache.ts`
Lightweight `TtlCache<K,V>` and `TtlSet<V>` — wrappers around `Map` with:
- **Lazy TTL expiry** on `get()`/`has()` — expired entries removed on access
- **FIFO overflow eviction** — oldest entry dropped when `maxSize` exceeded
- **`sweep()`** for batch cleanup
- **`entries()`** iterator that skips expired items (compatible with `Array.from()`)
- Injectable `now()` for deterministic tests

### Cache limits

| Cache | Max Size | TTL | Rationale |
|-------|----------|-----|-----------|
| `userNames` (index + SlackAdapter) | 2,000 | 1 hour | Workspace user count; names rarely change |
| `channelCache` | 500 | 30 min | Channel count; renames possible |
| `unclaimedThreads` | 5,000 | 5 min | Negative cache; short-lived |

### Other changes
- `helpers.ts`: widened `formatInboxMessages` param from `Map<string, string>` to `{ get(key: string): string | undefined }` (structural typing, backwards compatible)

### Tests: `ttl-cache.test.ts` (17 tests)
- TTL expiry, boundary behavior, max-size eviction, refresh-on-update, sweep, entries iterator, clear, delete, chaining

## Checks
```
pnpm lint      ✅
pnpm typecheck ✅
pnpm test      ✅ (411 tests, 0 failures)
```