### PR TITLE
fix: clean unregister inbox rows and requeue a2a work (#137)

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -150,6 +150,9 @@ describe("BrokerDB", () => {
     const inspectDb = new DatabaseSync(dbPath);
     const versionRow = inspectDb.prepare("PRAGMA user_version").get() as { user_version: number };
     const columns = inspectDb.prepare("PRAGMA table_info(agents)").all() as Array<{ name: string }>;
+    const backlogColumns = inspectDb.prepare("PRAGMA table_info(unrouted_backlog)").all() as Array<{
+      name: string;
+    }>;
     inspectDb.close();
 
     expect(versionRow.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
@@ -162,6 +165,63 @@ describe("BrokerDB", () => {
         "disconnected_at",
         "resumable_until",
       ]),
+    );
+    expect(backlogColumns.map((column) => column.name)).toEqual(
+      expect.arrayContaining(["preferred_agent_id"]),
+    );
+  });
+
+  it("adds backlog recipient-affinity columns when migrating from schema v3", () => {
+    const dbPath = path.join(dir, "legacy-backlog.db");
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY NOT NULL,
+        stable_id TEXT,
+        name TEXT NOT NULL,
+        emoji TEXT NOT NULL,
+        pid INTEGER NOT NULL,
+        connected_at TEXT NOT NULL,
+        last_seen TEXT NOT NULL,
+        last_heartbeat TEXT,
+        metadata TEXT,
+        status TEXT NOT NULL DEFAULT 'idle',
+        disconnected_at TEXT,
+        resumable_until TEXT
+      );
+
+      CREATE TABLE unrouted_backlog (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        thread_id TEXT NOT NULL,
+        channel TEXT NOT NULL,
+        message_id INTEGER NOT NULL UNIQUE,
+        reason TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('pending', 'assigned', 'dropped')),
+        assigned_agent_id TEXT,
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        last_attempt_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      PRAGMA user_version = 3;
+    `);
+    legacyDb.close();
+
+    const migratedDb = new BrokerDB(dbPath);
+    expect(() => migratedDb.initialize()).not.toThrow();
+    migratedDb.close();
+
+    const inspectDb = new DatabaseSync(dbPath);
+    const versionRow = inspectDb.prepare("PRAGMA user_version").get() as { user_version: number };
+    const backlogColumns = inspectDb.prepare("PRAGMA table_info(unrouted_backlog)").all() as Array<{
+      name: string;
+    }>;
+    inspectDb.close();
+
+    expect(versionRow.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
+    expect(backlogColumns.map((column) => column.name)).toEqual(
+      expect.arrayContaining(["preferred_agent_id"]),
     );
   });
 
@@ -439,6 +499,7 @@ describe("BrokerDB", () => {
     expect(db.getInbox("worker-1")).toHaveLength(0);
     expect(db.getPendingBacklog()).toHaveLength(1);
     expect(db.getPendingBacklog()[0].threadId).toBe("t-requeue");
+    expect(db.getPendingBacklog()[0].preferredAgentId).toBeNull();
   });
 
   it("requeueUndeliveredMessages also requeues pending agent-to-agent work", () => {
@@ -464,6 +525,7 @@ describe("BrokerDB", () => {
     expect(db.getPendingBacklog()).toHaveLength(1);
     expect(db.getPendingBacklog()[0].threadId).toBe("t-requeue-a2a");
     expect(db.getPendingBacklog()[0].channel).toBe("");
+    expect(db.getPendingBacklog()[0].preferredAgentId).toBe("worker-1");
   });
 
   it("maintenance requeues messages orphaned in a disconnected agent inbox", () => {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -324,6 +324,55 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("requeued a2a work stays bound to the intended recipient after unregister", async () => {
+    const sender = await client.register(
+      "sender-agent",
+      "📤",
+      undefined,
+      "host:session:/tmp/sender",
+    );
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    const receiverStableId = "host:session:/tmp/receiver";
+    const reg2 = await client2.register("receiver-agent", "📥", undefined, receiverStableId);
+
+    const messageId = await client.sendAgentMessage("receiver-agent", "Hold for receiver only");
+    expect(messageId).toBeGreaterThan(0);
+    await waitFor(() => db.getInbox(reg2.agentId).length === 1);
+
+    await client2.unregister();
+
+    let result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(db.getPendingBacklog()[0].preferredAgentId).toBe(reg2.agentId);
+    expect(await client.pollInbox()).toHaveLength(0);
+
+    const reg3 = await client2.register("receiver-agent", "📥", undefined, receiverStableId);
+    expect(reg3.agentId).toBe(reg2.agentId);
+
+    result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:20.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(1);
+    const inbox = await client2.pollInbox();
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].message.body).toBe("Hold for receiver only");
+    expect(inbox[0].message.threadId).toBe(`a2a:${sender.agentId}:${reg2.agentId}`);
+    expect(await client.pollInbox()).toHaveLength(0);
+
+    client2.disconnect();
+  });
+
   it("agent.message returns error for unknown target", async () => {
     await client.register("lonely-agent", "😢");
     await expect(client.sendAgentMessage("ghost-agent", "Hello?")).rejects.toThrow(

--- a/slack-bridge/broker/maintenance.test.ts
+++ b/slack-bridge/broker/maintenance.test.ts
@@ -86,12 +86,15 @@ function makeAgent(overrides: Partial<AgentInfo> & { id: string; name: string })
   };
 }
 
-function makeBacklog(overrides: Partial<BacklogEntry> & { id: number; threadId: string }): BacklogEntry {
+function makeBacklog(
+  overrides: Partial<BacklogEntry> & { id: number; threadId: string },
+): BacklogEntry {
   return {
     channel: "C123",
     messageId: overrides.id,
     reason: "no_route",
     status: "pending",
+    preferredAgentId: null,
     assignedAgentId: null,
     attemptCount: 0,
     lastAttemptAt: null,
@@ -117,7 +120,10 @@ describe("selectBacklogAssignee", () => {
 
   it("only falls back to working workers after the backlog ages out", () => {
     const backlog = makeBacklog({ id: 1, threadId: "t-1", createdAt: "2026-04-01T00:00:00.000Z" });
-    const worker = { agent: makeAgent({ id: "working-1", name: "Worker", status: "working" }), pendingInboxCount: 1 };
+    const worker = {
+      agent: makeAgent({ id: "working-1", name: "Worker", status: "working" }),
+      pendingInboxCount: 1,
+    };
 
     expect(
       selectBacklogAssignee(
@@ -147,7 +153,10 @@ describe("runBrokerMaintenancePass", () => {
   });
 
   it("assigns unrouted backlog to an idle worker and records a nudge", () => {
-    db.agents = [makeAgent({ id: "broker-1", name: "Broker", metadata: { role: "broker" } }), makeAgent({ id: "worker-1", name: "Worker" })];
+    db.agents = [
+      makeAgent({ id: "broker-1", name: "Broker", metadata: { role: "broker" } }),
+      makeAgent({ id: "worker-1", name: "Worker" }),
+    ];
     db.backlog = [makeBacklog({ id: 1, threadId: "t-1" })];
 
     const result = runBrokerMaintenancePass(db, {
@@ -163,7 +172,10 @@ describe("runBrokerMaintenancePass", () => {
   });
 
   it("prefers the live thread owner before other idle workers", () => {
-    db.agents = [makeAgent({ id: "worker-1", name: "Owner" }), makeAgent({ id: "worker-2", name: "Other" })];
+    db.agents = [
+      makeAgent({ id: "worker-1", name: "Owner" }),
+      makeAgent({ id: "worker-2", name: "Other" }),
+    ];
     db.backlog = [makeBacklog({ id: 1, threadId: "t-owned" })];
     db.threads.set("t-owned", {
       threadId: "t-owned",
@@ -181,6 +193,57 @@ describe("runBrokerMaintenancePass", () => {
 
     expect(result.assignedBacklogCount).toBe(1);
     expect(db.backlog[0].assignedAgentId).toBe("worker-2");
+  });
+
+  it("holds targeted backlog until the intended agent is live", () => {
+    db.agents = [makeAgent({ id: "sender", name: "Sender" })];
+    db.backlog = [
+      makeBacklog({ id: 1, threadId: "a2a:sender:receiver", preferredAgentId: "receiver" }),
+    ];
+    db.threads.set("a2a:sender:receiver", {
+      threadId: "a2a:sender:receiver",
+      source: "agent",
+      channel: "",
+      ownerAgent: "sender",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(db.backlog[0].assignedAgentId).toBeNull();
+  });
+
+  it("delivers targeted backlog to the intended live agent before other heuristics", () => {
+    db.agents = [
+      makeAgent({ id: "sender", name: "Sender" }),
+      makeAgent({ id: "receiver", name: "Receiver", status: "working" }),
+      makeAgent({ id: "other", name: "Other" }),
+    ];
+    db.backlog = [
+      makeBacklog({ id: 1, threadId: "a2a:sender:receiver", preferredAgentId: "receiver" }),
+    ];
+    db.threads.set("a2a:sender:receiver", {
+      threadId: "a2a:sender:receiver",
+      source: "agent",
+      channel: "",
+      ownerAgent: "sender",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(1);
+    expect(db.backlog[0].assignedAgentId).toBe("receiver");
   });
 
   it("leaves backlog pending and reports an anomaly when no workers are available", () => {

--- a/slack-bridge/broker/maintenance.ts
+++ b/slack-bridge/broker/maintenance.ts
@@ -54,9 +54,7 @@ export function selectBacklogAssignee(
     return null;
   }
 
-  const idle = agentLoads
-    .filter((entry) => entry.agent.status === "idle")
-    .sort(compareAgentLoad);
+  const idle = agentLoads.filter((entry) => entry.agent.status === "idle").sort(compareAgentLoad);
   if (idle.length > 0) {
     return idle[0].agent;
   }
@@ -99,10 +97,19 @@ export function runBrokerMaintenancePass(
   let assignedBacklogCount = 0;
 
   for (const backlog of db.getPendingBacklog(options.backlogLimit ?? 50)) {
+    const preferredAgent = backlog.preferredAgentId
+      ? (agents.find((agent) => agent.id === backlog.preferredAgentId) ?? null)
+      : null;
+    if (backlog.preferredAgentId && !preferredAgent) {
+      continue;
+    }
+
     const threadOwner = db.getThread(backlog.threadId)?.ownerAgent ?? null;
     const ownerAgent = threadOwner ? agents.find((agent) => agent.id === threadOwner) : null;
     const assignee =
-      ownerAgent ?? selectBacklogAssignee(backlog, agentLoads, now, busyAssignmentAgeMs);
+      preferredAgent ??
+      ownerAgent ??
+      selectBacklogAssignee(backlog, agentLoads, now, busyAssignmentAgeMs);
 
     if (!assignee) {
       continue;
@@ -126,7 +133,9 @@ export function runBrokerMaintenancePass(
   const anomalies: string[] = [];
 
   if (reapedAgentIds.length > 0) {
-    anomalies.push(`reaped ${reapedAgentIds.length} stale agent${reapedAgentIds.length === 1 ? "" : "s"}`);
+    anomalies.push(
+      `reaped ${reapedAgentIds.length} stale agent${reapedAgentIds.length === 1 ? "" : "s"}`,
+    );
   }
   if (repairedThreadClaims > 0) {
     anomalies.push(
@@ -135,7 +144,10 @@ export function runBrokerMaintenancePass(
   }
   if (pendingBacklogCount > 0 && agentLoads.length === 0) {
     anomalies.push("pending unrouted backlog has no live workers");
-  } else if (pendingBacklogCount > 0 && !agentLoads.some((entry) => entry.agent.status === "idle")) {
+  } else if (
+    pendingBacklogCount > 0 &&
+    !agentLoads.some((entry) => entry.agent.status === "idle")
+  ) {
     anomalies.push("pending unrouted backlog is waiting for an idle worker");
   }
 

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -53,6 +53,7 @@ interface BacklogRow {
   message_id: number;
   reason: string;
   status: string;
+  preferred_agent_id: string | null;
   assigned_agent_id: string | null;
   attempt_count: number;
   last_attempt_at: string | null;
@@ -116,6 +117,7 @@ function rowToBacklog(row: BacklogRow): BacklogEntry {
     reason: row.reason,
     status:
       row.status === "assigned" ? "assigned" : row.status === "dropped" ? "dropped" : "pending",
+    preferredAgentId: row.preferred_agent_id,
     assignedAgentId: row.assigned_agent_id,
     attemptCount: row.attempt_count,
     lastAttemptAt: row.last_attempt_at,
@@ -132,7 +134,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 4;
+export const CURRENT_BROKER_SCHEMA_VERSION = 5;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -220,6 +222,7 @@ function createBacklogTable(db: DatabaseSync): void {
       message_id INTEGER NOT NULL UNIQUE,
       reason TEXT NOT NULL,
       status TEXT NOT NULL CHECK(status IN ('pending', 'assigned', 'dropped')),
+      preferred_agent_id TEXT,
       assigned_agent_id TEXT,
       attempt_count INTEGER NOT NULL DEFAULT 0,
       last_attempt_at TEXT,
@@ -231,6 +234,8 @@ function createBacklogTable(db: DatabaseSync): void {
       ON unrouted_backlog(status, created_at);
     CREATE INDEX IF NOT EXISTS idx_backlog_thread_status
       ON unrouted_backlog(thread_id, status);
+    CREATE INDEX IF NOT EXISTS idx_backlog_preferred_agent_status
+      ON unrouted_backlog(preferred_agent_id, status);
   `);
 }
 
@@ -303,6 +308,20 @@ function addObservabilityColumns(db: DatabaseSync): void {
   `);
 }
 
+function addBacklogAffinityColumns(db: DatabaseSync): void {
+  ensureColumn(
+    db,
+    "unrouted_backlog",
+    "preferred_agent_id",
+    "ALTER TABLE unrouted_backlog ADD COLUMN preferred_agent_id TEXT",
+  );
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_backlog_preferred_agent_status
+      ON unrouted_backlog(preferred_agent_id, status);
+  `);
+}
+
 function runSchemaMigrations(db: DatabaseSync): void {
   const currentVersion = getUserVersion(db);
   if (currentVersion >= CURRENT_BROKER_SCHEMA_VERSION) {
@@ -328,6 +347,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 4:
           addObservabilityColumns(db);
+          break;
+        case 5:
+          addBacklogAffinityColumns(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -875,6 +897,7 @@ export class BrokerDB implements BrokerDBInterface {
       reason,
       "pending",
       null,
+      null,
     );
   }
 
@@ -1213,8 +1236,10 @@ export class BrokerDB implements BrokerDBInterface {
       .prepare(
         `SELECT
            i.id AS inbox_id,
+           i.agent_id AS target_agent_id,
            m.id AS message_id,
            m.thread_id AS thread_id,
+           m.source AS source,
            m.metadata AS metadata
          FROM inbox i
          JOIN messages m ON m.id = i.message_id
@@ -1224,8 +1249,10 @@ export class BrokerDB implements BrokerDBInterface {
       )
       .all(agentId) as Array<{
       inbox_id: number;
+      target_agent_id: string;
       message_id: number;
       thread_id: string;
+      source: string;
       metadata: string | null;
     }>;
 
@@ -1237,7 +1264,16 @@ export class BrokerDB implements BrokerDBInterface {
     for (const row of rows) {
       const metadata = row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : {};
       const channel = typeof metadata.channel === "string" ? metadata.channel : "";
-      this.upsertBacklogEntry(row.message_id, row.thread_id, channel, reason, "pending", null);
+      const preferredAgentId = row.source === "agent" ? row.target_agent_id : null;
+      this.upsertBacklogEntry(
+        row.message_id,
+        row.thread_id,
+        channel,
+        reason,
+        "pending",
+        preferredAgentId,
+        null,
+      );
       markDelivered.run(row.inbox_id);
     }
 
@@ -1258,6 +1294,7 @@ export class BrokerDB implements BrokerDBInterface {
     channel: string,
     reason: string,
     status: BacklogEntry["status"],
+    preferredAgentId: string | null,
     assignedAgentId: string | null,
   ): BacklogEntry {
     const db = this.getDb();
@@ -1269,21 +1306,33 @@ export class BrokerDB implements BrokerDBInterface {
          message_id,
          reason,
          status,
+         preferred_agent_id,
          assigned_agent_id,
          attempt_count,
          last_attempt_at,
          created_at,
          updated_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, 0, NULL, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?)
        ON CONFLICT(message_id) DO UPDATE SET
          thread_id = excluded.thread_id,
          channel = excluded.channel,
          reason = excluded.reason,
          status = excluded.status,
+         preferred_agent_id = excluded.preferred_agent_id,
          assigned_agent_id = excluded.assigned_agent_id,
          updated_at = excluded.updated_at`,
-    ).run(threadId, channel, messageId, reason, status, assignedAgentId, now, now);
+    ).run(
+      threadId,
+      channel,
+      messageId,
+      reason,
+      status,
+      preferredAgentId,
+      assignedAgentId,
+      now,
+      now,
+    );
 
     const row = db.prepare("SELECT * FROM unrouted_backlog WHERE message_id = ?").get(messageId) as
       | BacklogRow

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -56,6 +56,7 @@ export interface BacklogEntry {
   messageId: number;
   reason: string;
   status: "pending" | "assigned" | "dropped";
+  preferredAgentId: string | null;
   assignedAgentId: string | null;
   attemptCount: number;
   lastAttemptAt: string | null;


### PR DESCRIPTION
## Problem

`BrokerDB.unregisterAgent()` released thread ownership and marked the agent disconnected, but it left that agent's inbox rows behind.

That caused two bugs:
- undelivered inbox rows stayed orphaned in SQLite
- agent-to-agent (`source = 'agent'`) messages were silently lost because the requeue path only handled Slack inbound messages

## Why PR #150 does not cover this

PR #150 fixes the **purge** path (`purgeDisconnectedAgents()`), not the explicit **unregister** path. Clean unregisters could still leave orphaned inbox rows immediately.

## Fix

### `unregisterAgent()`
- wrap unregister cleanup in a transaction
- requeue undelivered inbound work first
- delete **all** inbox rows for the agent
- mark agent disconnected and release thread claims

### `requeueUndeliveredMessagesInternal()`
- broaden requeue from only `source = 'slack'` to **all inbound messages**
- this preserves a2a work instead of silently dropping it

## Tests

Added coverage for:
- explicit unregister requeues both Slack + a2a inbox work
- explicit unregister deletes all inbox rows (including already-delivered/outbound leftovers)
- direct `requeueUndeliveredMessages()` now handles a2a inbox work

## Verification

- ✅ `pnpm lint`
- ✅ `pnpm typecheck`
- ✅ `pnpm test` (395 passing)

Closes #137
