### PR TITLE
fix: clear broken reconnect state after re-register failure (#139)

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -966,6 +966,42 @@ describe("BrokerClient — onReconnect callback", () => {
     await mock.close();
   });
 
+  it("reconnectOnce clears broken connected state and reschedules when re-register fails", async () => {
+    const client = new BrokerClient({ host: "127.0.0.1", port: 1 });
+    const failedSocket = { destroy: vi.fn() } as unknown as net.Socket;
+    const scheduleReconnect = vi.fn();
+
+    (
+      client as unknown as { registrationSnapshot: { name: string; emoji: string } }
+    ).registrationSnapshot = {
+      name: "RetryBot",
+      emoji: "🔁",
+    };
+    (
+      client as unknown as {
+        connectSocket: () => Promise<void>;
+        socket: net.Socket | null;
+        connected: boolean;
+      }
+    ).connectSocket = vi.fn(async () => {
+      (client as unknown as { socket: net.Socket | null }).socket = failedSocket;
+      (client as unknown as { connected: boolean }).connected = true;
+    });
+    (client as unknown as { performRegister: () => Promise<unknown> }).performRegister = vi.fn(
+      async () => {
+        throw new Error("register failed");
+      },
+    );
+    (client as unknown as { scheduleReconnect: () => void }).scheduleReconnect = scheduleReconnect;
+
+    await (client as unknown as { reconnectOnce: () => Promise<void> }).reconnectOnce();
+
+    expect(failedSocket.destroy).toHaveBeenCalledTimes(1);
+    expect(client.isConnected()).toBe(false);
+    expect((client as unknown as { socket: net.Socket | null }).socket).toBeNull();
+    expect(scheduleReconnect).toHaveBeenCalledTimes(1);
+  });
+
   it("scheduleReconnect fires onDisconnect then onReconnect after server restart", async () => {
     const mock = await createMockServer();
     const port = mock.port;

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -431,11 +431,22 @@ export class BrokerClient {
       this.reconnectAttempt = 0;
       this.reconnectHandler?.();
     } catch {
+      // Re-registration failed after the socket connected. Clear the connection
+      // state immediately instead of waiting for the async "close" event so the
+      // client cannot stay in a broken "connected but not registered" state.
+      // Then schedule the next reconnect attempt ourselves. (#139)
+      const failedSocket = this.socket;
+      this.socket = null;
+      this.connected = false;
+      this.buffer = "";
+      this.stopHeartbeat();
+      this.rejectAllPending(new Error("Socket closed"));
       try {
-        this.socket?.destroy();
+        failedSocket?.destroy();
       } catch {
         /* ignore */
       }
+      this.scheduleReconnect();
     }
   }
 


### PR DESCRIPTION
## Problem

`BrokerClient.reconnectOnce()` handled re-registration failures by destroying the socket and swallowing the error:

```ts
try {
  if (this.registrationSnapshot) {
    await this.performRegister(this.registrationSnapshot);
  }
  this.reconnectAttempt = 0;
  this.reconnectHandler?.();
} catch {
  try {
    this.socket?.destroy();
  } catch {
    /* ignore */
  }
}
```

That left a broken transient state where the client had already set `connected = true` in `connectSocket()`, but failed to register with the broker. Until the async `close` event ran, the client could still appear connected even though the socket had been torn down.

## Fix

On re-registration failure, clear the connection state immediately instead of waiting for the socket `close` event:

- set `socket = null`
- set `connected = false`
- clear the read buffer
- stop heartbeats
- reject any pending requests
- destroy the failed socket
- explicitly `scheduleReconnect()`

This prevents the broken `connected but not registered` state and guarantees another reconnect attempt is queued.

## Tests

Added a regression test that exercises `reconnectOnce()` directly and verifies that when `performRegister()` fails, the client:

- destroys the failed socket
- reports `isConnected() === false`
- clears `socket`
- schedules another reconnect

All checks pass:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (395 passing)

Closes #139
