### PR TITLE
fix: harden broker JSON-RPC request validation (#147)

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -455,9 +455,7 @@ describe("BrokerDB", () => {
 
     const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
     sqlite
-      .prepare(
-        "UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?",
-      )
+      .prepare("UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?")
       .run(new Date(Date.now() - 2 * 60 * 60_000).toISOString(), "gone");
 
     runBrokerMaintenancePass(db, {
@@ -734,6 +732,22 @@ describe("BrokerSocketServer", () => {
     return server.getConnectInfo() as { type: "tcp"; host: string; port: number };
   }
 
+  async function sendRawLine(line: string): Promise<JsonRpcResponse> {
+    const socket = await connectRawSocket(getInfo());
+
+    const response = new Promise<JsonRpcResponse>((resolve) => {
+      socket.once("data", (chunk) => {
+        const payload = chunk.toString("utf-8").trim();
+        resolve(JSON.parse(payload) as JsonRpcResponse);
+      });
+    });
+
+    socket.write(line + "\n");
+    const result = await response;
+    socket.destroy();
+    return result;
+  }
+
   it("accepts connections", async () => {
     const client = await connectClient(getInfo());
     client.destroy();
@@ -932,22 +946,51 @@ describe("BrokerSocketServer", () => {
   });
 
   it("invalid JSON returns parse error", async () => {
-    const socket = await connectRawSocket(getInfo());
-
-    const response = new Promise<JsonRpcResponse>((resolve) => {
-      socket.on("data", (chunk) => {
-        const line = chunk.toString("utf-8").trim();
-        resolve(JSON.parse(line) as JsonRpcResponse);
-      });
-    });
-
-    socket.write("not valid json\n");
-    const res = await response;
+    const res = await sendRawLine("not valid json");
 
     expect(res.error).toBeDefined();
     expect(res.error!.code).toBe(-32700);
+    expect(res.id).toBeNull();
+  });
 
-    socket.destroy();
+  it("rejects non-object JSON-RPC payloads as invalid requests", async () => {
+    for (const payload of ["null", "[]", "true", "123"]) {
+      const res = await sendRawLine(payload);
+      expect(res.error).toBeDefined();
+      expect(res.error!.code).toBe(-32600);
+      expect(res.id).toBeNull();
+    }
+  });
+
+  it("rejects requests with the wrong jsonrpc version", async () => {
+    const res = await sendRawLine(
+      JSON.stringify({ jsonrpc: "1.0", id: 7, method: "register", params: {} }),
+    );
+
+    expect(res.error).toBeDefined();
+    expect(res.error!.code).toBe(-32600);
+    expect(res.id).toBe(7);
+  });
+
+  it("rejects requests with invalid ids", async () => {
+    for (const id of [null, false, 0, ""]) {
+      const res = await sendRawLine(
+        JSON.stringify({ jsonrpc: "2.0", id, method: "register", params: {} }),
+      );
+      expect(res.error).toBeDefined();
+      expect(res.error!.code).toBe(-32600);
+      expect(res.id).toBeNull();
+    }
+  });
+
+  it("rejects requests with non-object params", async () => {
+    const res = await sendRawLine(
+      JSON.stringify({ jsonrpc: "2.0", id: 9, method: "register", params: [] }),
+    );
+
+    expect(res.error).toBeDefined();
+    expect(res.error!.code).toBe(-32600);
+    expect(res.id).toBe(9);
   });
 
   it("cleans up agent on disconnect", async () => {

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -69,6 +69,47 @@ function rpcError(
   return { jsonrpc: "2.0", id, error };
 }
 
+function isJsonRpcRequestId(value: unknown): value is number | string {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value !== 0;
+  }
+  return typeof value === "string" && value.length > 0;
+}
+
+function isJsonRpcRequestPayload(value: unknown): value is JsonRpcRequest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const request = value as Record<string, unknown>;
+  if (request.jsonrpc !== "2.0") {
+    return false;
+  }
+  if (typeof request.method !== "string" || request.method.length === 0) {
+    return false;
+  }
+  if (!isJsonRpcRequestId(request.id)) {
+    return false;
+  }
+  if (
+    request.params !== undefined &&
+    (typeof request.params !== "object" || request.params === null || Array.isArray(request.params))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function extractJsonRpcRequestId(value: unknown): number | string | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const id = (value as Record<string, unknown>).id;
+  return isJsonRpcRequestId(id) ? id : null;
+}
+
 // ─── Socket server ───────────────────────────────────────
 
 export class BrokerSocketServer {
@@ -258,24 +299,23 @@ export class BrokerSocketServer {
 
       if (!line) continue;
 
-      let request: JsonRpcRequest;
+      let parsed: unknown;
       try {
-        request = JSON.parse(line) as JsonRpcRequest;
+        parsed = JSON.parse(line) as unknown;
       } catch {
         this.send(socket, rpcError(null, RPC_PARSE_ERROR, "Parse error"));
         continue;
       }
 
-      if (
-        request.jsonrpc !== "2.0" ||
-        typeof request.method !== "string" ||
-        request.id === undefined
-      ) {
-        this.send(socket, rpcError(null, RPC_INVALID_REQUEST, "Invalid request"));
+      if (!isJsonRpcRequestPayload(parsed)) {
+        this.send(
+          socket,
+          rpcError(extractJsonRpcRequestId(parsed), RPC_INVALID_REQUEST, "Invalid request"),
+        );
         continue;
       }
 
-      void this.dispatchRequest(request, state, socket);
+      void this.dispatchRequest(parsed, state, socket);
     }
   }
 


### PR DESCRIPTION
## Problem

`BrokerSocketServer.processBuffer()` parsed JSON and then only checked:

- `request.jsonrpc === "2.0"`
- `typeof request.method === "string"`
- `request.id \!== undefined`

That left a few gaps:
- non-object payloads like `null`, `[]`, `true`, `123` could make validation brittle
- invalid IDs like `null`, `false`, `0`, and `""` were accepted
- malformed requests with invalid `params` shapes were not rejected early

## Fix

Added explicit request validation helpers in `socket-server.ts`:
- `isJsonRpcRequestId()`
- `isJsonRpcRequestPayload()`
- `extractJsonRpcRequestId()`

The socket server now rejects invalid requests before dispatch unless all of these are true:
- payload is a non-null object (not an array)
- `jsonrpc === "2.0"`
- `method` is a non-empty string
- `id` is a valid request ID for this broker protocol
- `params`, if present, is an object (not an array / primitive / null)

Also improved invalid-request responses to echo a valid request ID when one can be safely extracted.

## Tests

Added broker socket-server coverage for:
- parse errors on invalid JSON
- invalid non-object payloads
- wrong JSON-RPC version
- invalid request IDs
- non-object params

## Verification

- ✅ `pnpm lint`
- ✅ `pnpm typecheck`
- ✅ `pnpm test` (398 passing)

## Scope note

This PR fixes the JSON-RPC validation bug from #147. It does **not** add socket auth/shared-secret protection yet.

Closes #147
