### PR TITLE
fix: expire stale Slack confirmation state (#143)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -33,9 +33,14 @@ import {
   isDirectMessageChannel,
   getFollowerReconnectUiUpdate,
   getFollowerOwnedThreadClaims,
+  normalizeThreadConfirmationState,
+  isThreadConfirmationStateEmpty,
+  DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
+  MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD,
   type InboxMessage,
   type AgentDisplayInfo,
   type FollowerThreadState,
+  type ThreadConfirmationState,
 } from "./helpers.js";
 
 // ─── loadSettings ─────────────────────────────────────────
@@ -1247,5 +1252,79 @@ describe("getFollowerOwnedThreadClaims", () => {
     ]);
 
     expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([]);
+  });
+});
+
+// ─── confirmation state cleanup ─────────────────────────
+
+describe("normalizeThreadConfirmationState", () => {
+  function makeState(): ThreadConfirmationState {
+    return {
+      pending: [],
+      approved: [],
+      rejected: [],
+    };
+  }
+
+  it("expires stale pending, approved, and rejected requests", () => {
+    const now = Date.now();
+    const fresh = now - 1_000;
+    const stale = now - DEFAULT_CONFIRMATION_REQUEST_TTL_MS - 1_000;
+    const state: ThreadConfirmationState = {
+      pending: [
+        { toolPattern: "bash", action: "fresh pending", requestedAt: fresh },
+        { toolPattern: "edit", action: "stale pending", requestedAt: stale },
+      ],
+      approved: [
+        { toolPattern: "write", action: "fresh approved", requestedAt: fresh },
+        { toolPattern: "memory_write", action: "stale approved", requestedAt: stale },
+      ],
+      rejected: [
+        { toolPattern: "bash", action: "fresh rejected", requestedAt: fresh },
+        { toolPattern: "edit", action: "stale rejected", requestedAt: stale },
+      ],
+    };
+
+    expect(normalizeThreadConfirmationState(state, now)).toEqual({
+      pending: [{ toolPattern: "bash", action: "fresh pending", requestedAt: fresh }],
+      approved: [{ toolPattern: "write", action: "fresh approved", requestedAt: fresh }],
+      rejected: [{ toolPattern: "bash", action: "fresh rejected", requestedAt: fresh }],
+    });
+  });
+
+  it("caps pending requests per thread to the newest entries", () => {
+    const now = Date.now();
+    const state: ThreadConfirmationState = {
+      pending: Array.from(
+        { length: MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD + 2 },
+        (_, idx) => ({
+          toolPattern: `tool-${idx}`,
+          action: `action-${idx}`,
+          requestedAt: now - (MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD + 2 - idx) * 1_000,
+        }),
+      ),
+      approved: [],
+      rejected: [],
+    };
+
+    const result = normalizeThreadConfirmationState(state, now);
+
+    expect(result.pending).toHaveLength(MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD);
+    expect(result.pending.map((request) => request.toolPattern)).toEqual([
+      `tool-2`,
+      `tool-3`,
+      `tool-4`,
+    ]);
+  });
+
+  it("detects when a confirmation state is empty", () => {
+    expect(isThreadConfirmationStateEmpty(makeState())).toBe(true);
+    expect(
+      isThreadConfirmationStateEmpty({
+        pending: [{ toolPattern: "bash", action: "run", requestedAt: Date.now() }],
+        approved: [],
+        rejected: [],
+      }),
+    ).toBe(false);
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1176,3 +1176,39 @@ export function resolveAgentIdentity(
   // 3. Fully generated
   return generateAgentName(seed);
 }
+
+// ─── Confirmation state cleanup ─────────────────────────
+
+export interface ConfirmationRequest {
+  toolPattern: string;
+  action: string;
+  requestedAt: number;
+}
+
+export interface ThreadConfirmationState {
+  pending: ConfirmationRequest[];
+  approved: ConfirmationRequest[];
+  rejected: ConfirmationRequest[];
+}
+
+export const DEFAULT_CONFIRMATION_REQUEST_TTL_MS = 5 * 60_000;
+export const MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD = 3;
+
+export function normalizeThreadConfirmationState(
+  state: ThreadConfirmationState,
+  now = Date.now(),
+  ttlMs = DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
+  maxPending = MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD,
+): ThreadConfirmationState {
+  const keepFresh = (request: ConfirmationRequest) => now - request.requestedAt < ttlMs;
+
+  return {
+    pending: state.pending.filter(keepFresh).slice(-maxPending),
+    approved: state.approved.filter(keepFresh),
+    rejected: state.rejected.filter(keepFresh),
+  };
+}
+
+export function isThreadConfirmationStateEmpty(state: ThreadConfirmationState): boolean {
+  return state.pending.length === 0 && state.approved.length === 0 && state.rejected.length === 0;
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -7,6 +7,8 @@ import { Type } from "@sinclair/typebox";
 import {
   type InboxMessage,
   type AgentDisplayInfo,
+  type ConfirmationRequest,
+  type ThreadConfirmationState,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
   isUserAllowed as checkUserAllowed,
@@ -25,6 +27,8 @@ import {
   DEFAULT_RALPH_LOOP_INTERVAL_MS,
   DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
+  DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
+  MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD,
   generateAgentName,
   resolveAgentIdentity,
   shortenPath,
@@ -36,6 +40,8 @@ import {
   resolveFollowerThreadChannel,
   getFollowerReconnectUiUpdate,
   getFollowerOwnedThreadClaims,
+  normalizeThreadConfirmationState,
+  isThreadConfirmationStateEmpty,
   trackBrokerInboundThread,
 } from "./helpers.js";
 import {
@@ -221,21 +227,38 @@ export default function (pi: ExtensionAPI) {
   const channelCache = new Map<string, string>();
   const unclaimedThreads = new Set<string>(); // negative cache for resolveThreadOwner
 
-  interface ConfirmationRequest {
-    toolPattern: string;
-    action: string;
-    requestedAt: number;
-  }
-
-  interface ThreadConfirmationState {
-    pending: ConfirmationRequest[];
-    approved: ConfirmationRequest[];
-    rejected: ConfirmationRequest[];
-  }
-
   const threadConfirmationStates = new Map<string, ThreadConfirmationState>();
 
+  function storeThreadConfirmationState(
+    threadTs: string,
+    state: ThreadConfirmationState,
+    now = Date.now(),
+  ): ThreadConfirmationState | null {
+    const normalized = normalizeThreadConfirmationState(
+      state,
+      now,
+      DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
+      MAX_PENDING_CONFIRMATION_REQUESTS_PER_THREAD,
+    );
+
+    if (isThreadConfirmationStateEmpty(normalized)) {
+      threadConfirmationStates.delete(threadTs);
+      return null;
+    }
+
+    threadConfirmationStates.set(threadTs, normalized);
+    return normalized;
+  }
+
+  function sweepThreadConfirmationStates(now = Date.now()): void {
+    for (const [threadTs, state] of threadConfirmationStates) {
+      storeThreadConfirmationState(threadTs, state, now);
+    }
+  }
+
   function getThreadConfirmationState(threadTs: string): ThreadConfirmationState {
+    sweepThreadConfirmationStates();
+
     let state = threadConfirmationStates.get(threadTs);
     if (!state) {
       state = { pending: [], approved: [], rejected: [] };
@@ -247,9 +270,7 @@ export default function (pi: ExtensionAPI) {
   function cleanupThreadConfirmationState(threadTs: string): void {
     const state = threadConfirmationStates.get(threadTs);
     if (!state) return;
-    if (state.pending.length === 0 && state.approved.length === 0 && state.rejected.length === 0) {
-      threadConfirmationStates.delete(threadTs);
-    }
+    storeThreadConfirmationState(threadTs, state);
   }
 
   // ─── State persistence ──────────────────────────────
@@ -422,14 +443,17 @@ export default function (pi: ExtensionAPI) {
   }
 
   function registerConfirmationRequest(threadTs: string, tool: string, action: string): void {
-    getThreadConfirmationState(threadTs).pending.push({
+    const state = getThreadConfirmationState(threadTs);
+    state.pending.push({
       toolPattern: tool,
       action,
       requestedAt: Date.now(),
     });
+    storeThreadConfirmationState(threadTs, state);
   }
 
   function consumeConfirmationReply(threadTs: string, text: string): { approved: boolean } | null {
+    sweepThreadConfirmationStates();
     const state = threadConfirmationStates.get(threadTs);
     if (!state || state.pending.length === 0) return null;
 
@@ -453,6 +477,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   function getConfirmationDecision(threadTs: string, toolName: string): boolean | null {
+    sweepThreadConfirmationStates();
     const state = threadConfirmationStates.get(threadTs);
     if (!state) return null;
 


### PR DESCRIPTION
## Problem

`threadConfirmationStates` in `slack-bridge/index.ts` never expired confirmation data.

That meant:
- pending requests stayed pending forever if the user never replied
- approved / rejected entries accumulated in long-lived threads
- abandoned threads kept their confirmation state indefinitely

## Fix

Added lightweight confirmation-state cleanup:

- **5 minute TTL** for pending, approved, and rejected confirmation entries
- **pending cap of 3 per thread**, keeping the newest requests
- **opportunistic sweep** whenever the confirmation flow is touched
- **delete empty thread entries** after normalization

The normalization logic was extracted into `helpers.ts` so it can be unit tested.

## Files

- `slack-bridge/helpers.ts`
- `slack-bridge/helpers.test.ts`
- `slack-bridge/index.ts`

## Checks

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` ✅ 397 passing

Closes #143
