### PR TITLE
fix: centralize hardcoded socket and database paths

### DIFF
--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -1,6 +1,5 @@
 import * as net from "node:net";
-import * as os from "node:os";
-import * as path from "node:path";
+import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -61,7 +60,7 @@ interface JsonRpcResponse {
 
 // ─── Constants (exported for testing) ────────────────────
 
-export const DEFAULT_SOCKET_PATH = path.join(os.homedir(), ".pi", "pinet.sock");
+export const DEFAULT_SOCKET_PATH = PINET_DEFAULT_SOCKET_PATH;
 export const REQUEST_TIMEOUT_MS = 5000;
 export const RECONNECT_DELAY_MS = 3000;
 export const INITIAL_RECONNECT_DELAY_MS = 1000;

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs";
 import { BrokerDB } from "./schema.js";
-import { BrokerSocketServer, defaultSocketPath } from "./socket-server.js";
+import { BrokerSocketServer } from "./socket-server.js";
 import type { ListenTarget } from "./socket-server.js";
 import { LeaderLock } from "./leader.js";
+import { getDefaultSocketPath } from "./paths.js";
 import type { MessageAdapter } from "./types.js";
 
 export { BrokerDB } from "./schema.js";
@@ -68,7 +69,7 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
   // Resolve listen target: explicit target > socketPath > default
   const target: ListenTarget = options.listenTarget ?? {
     type: "unix" as const,
-    path: options.socketPath ?? defaultSocketPath(),
+    path: options.socketPath ?? getDefaultSocketPath(),
   };
 
   // Clean up stale socket file (Unix only)

--- a/slack-bridge/broker/paths.ts
+++ b/slack-bridge/broker/paths.ts
@@ -1,0 +1,32 @@
+/**
+ * Centralized Pinet broker file paths.
+ * All socket and database path constants are defined here to ensure consistency
+ * across the broker, client, and schema modules.
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ─── Directories ─────────────────────────────────────────
+
+/** Default Pinet config directory: ~/.pi */
+export function getPinetConfigDir(): string {
+  return path.join(os.homedir(), ".pi");
+}
+
+// ─── Socket Paths ────────────────────────────────────────
+
+/** Default Unix socket path for broker communication: ~/.pi/pinet.sock */
+export function getDefaultSocketPath(): string {
+  return path.join(getPinetConfigDir(), "pinet.sock");
+}
+
+// Re-export as static constant for backward compatibility
+export const DEFAULT_SOCKET_PATH = getDefaultSocketPath();
+
+// ─── Database Paths ──────────────────────────────────────
+
+/** Default SQLite database path for broker: ~/.pi/pinet-broker.db */
+export function getDefaultDbPath(): string {
+  return path.join(getPinetConfigDir(), "pinet-broker.db");
+}

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -1,7 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as os from "node:os";
+import { getDefaultDbPath } from "./paths.js";
 import type {
   AgentInfo,
   ThreadInfo,
@@ -122,7 +122,7 @@ function rowToBacklog(row: BacklogRow): BacklogEntry {
 // ─── Default DB path ─────────────────────────────────────
 
 export function defaultDbPath(): string {
-  return path.join(os.homedir(), ".pi", "pinet-broker.db");
+  return getDefaultDbPath();
 }
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -1,9 +1,10 @@
 import * as net from "node:net";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as os from "node:os";
+
 import * as crypto from "node:crypto";
 import type { BrokerDB } from "./schema.js";
+import { DEFAULT_SOCKET_PATH } from "./paths.js";
 import { MessageRouter } from "./router.js";
 import type { BrokerMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcError } from "./types.js";
 import {
@@ -19,12 +20,6 @@ export type SlackProxyFn = (
   params: Record<string, unknown>,
 ) => Promise<Record<string, unknown>>;
 
-export function defaultSocketPath(): string {
-  return path.join(os.homedir(), ".pi", "pinet.sock");
-}
-
-// Re-export as static for easier access
-export const DEFAULT_SOCKET_PATH = defaultSocketPath();
 export const DEFAULT_HEARTBEAT_TIMEOUT_MS = 15_000;
 export const DEFAULT_PRUNE_INTERVAL_MS = 5_000;
 
@@ -141,7 +136,7 @@ export class BrokerSocketServer {
     } else if (target) {
       this.target = target;
     } else {
-      this.target = { type: "unix", path: defaultSocketPath() };
+      this.target = { type: "unix", path: DEFAULT_SOCKET_PATH };
     }
   }
 


### PR DESCRIPTION
Closes #138

New `broker/paths.ts` — single source of truth for socket/DB paths. Replaced scattered hardcoded paths across 4 files. 394 tests pass.