### PR TITLE
fix: warn when SQLite WAL mode falls back (#142)

### DIFF
--- a/nvim-bridge/comments-sqlite.ts
+++ b/nvim-bridge/comments-sqlite.ts
@@ -44,6 +44,15 @@ interface IdRow {
   id: string;
 }
 
+interface SqliteJournalModeResult {
+  journal_mode?: string | null;
+}
+
+function getSqliteJournalMode(result?: SqliteJournalModeResult): string {
+  const mode = result?.journal_mode?.trim().toLowerCase();
+  return mode && mode.length > 0 ? mode : "unknown";
+}
+
 function rowToCommentRecord(row: CommentRow): CommentRecord {
   const context: CommentContext | undefined =
     row.context_file != null
@@ -84,7 +93,14 @@ export class SqliteCommentStore implements ICommentStore {
 
     this.db = new DatabaseSync(this.dbPath, { timeout: 5000 });
 
-    this.db.exec("PRAGMA journal_mode=WAL");
+    const journalMode = this.db.prepare("PRAGMA journal_mode=WAL").get() as
+      | SqliteJournalModeResult
+      | undefined;
+    if (getSqliteJournalMode(journalMode) !== "wal") {
+      console.warn(
+        `[SqliteCommentStore] SQLite WAL mode not available, using ${getSqliteJournalMode(journalMode)} journal mode fallback`,
+      );
+    }
 
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS comments (

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -12,6 +12,11 @@ import type {
   InboundMessage,
   ChannelAssignment,
 } from "./types.js";
+import {
+  buildSqliteWalFallbackWarning,
+  isSqliteWalEnabled,
+  type SqliteJournalModeResult,
+} from "../helpers.js";
 
 // ─── Row types (raw SQLite rows) ─────────────────────────
 
@@ -1119,7 +1124,12 @@ export class BrokerDB implements BrokerDBInterface {
 
   private openDatabase(): DatabaseSync {
     const db = new DatabaseSync(this.dbPath, { timeout: 5000 });
-    db.exec("PRAGMA journal_mode=WAL");
+    const journalMode = db.prepare("PRAGMA journal_mode=WAL").get() as
+      | SqliteJournalModeResult
+      | undefined;
+    if (!isSqliteWalEnabled(journalMode)) {
+      console.warn(buildSqliteWalFallbackWarning("BrokerDB", journalMode));
+    }
     db.exec("PRAGMA busy_timeout=5000");
     return db;
   }

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -7,6 +7,9 @@ import {
   buildAllowlist,
   isUserAllowed,
   formatInboxMessages,
+  getSqliteJournalMode,
+  isSqliteWalEnabled,
+  buildSqliteWalFallbackWarning,
   formatAgentList,
   shortenPath,
   buildAgentDisplayInfo,
@@ -244,6 +247,32 @@ describe("formatInboxMessages", () => {
     const result = formatInboxMessages(msgs, names);
     expect(result).toContain("will: first");
     expect(result).toContain("will: second");
+  });
+});
+
+// ─── SQLite journal mode helpers ─────────────────────────
+
+describe("SQLite journal mode helpers", () => {
+  it("parses the reported journal mode", () => {
+    expect(getSqliteJournalMode({ journal_mode: "wal" })).toBe("wal");
+    expect(getSqliteJournalMode({ journal_mode: "DELETE" })).toBe("delete");
+    expect(getSqliteJournalMode({ journal_mode: null })).toBe("unknown");
+    expect(getSqliteJournalMode(undefined)).toBe("unknown");
+  });
+
+  it("detects whether WAL is enabled", () => {
+    expect(isSqliteWalEnabled({ journal_mode: "wal" })).toBe(true);
+    expect(isSqliteWalEnabled({ journal_mode: "delete" })).toBe(false);
+    expect(isSqliteWalEnabled(undefined)).toBe(false);
+  });
+
+  it("builds a helpful fallback warning", () => {
+    expect(buildSqliteWalFallbackWarning("BrokerDB", { journal_mode: "delete" })).toBe(
+      "[BrokerDB] SQLite WAL mode not available, using delete journal mode fallback",
+    );
+    expect(buildSqliteWalFallbackWarning("SqliteCommentStore", undefined)).toContain(
+      "using unknown journal mode fallback",
+    );
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -64,6 +64,26 @@ export interface InboxMessage {
   isChannelMention?: boolean;
 }
 
+export interface SqliteJournalModeResult {
+  journal_mode?: string | null;
+}
+
+export function getSqliteJournalMode(result?: SqliteJournalModeResult): string {
+  const mode = result?.journal_mode?.trim().toLowerCase();
+  return mode && mode.length > 0 ? mode : "unknown";
+}
+
+export function isSqliteWalEnabled(result?: SqliteJournalModeResult): boolean {
+  return getSqliteJournalMode(result) === "wal";
+}
+
+export function buildSqliteWalFallbackWarning(
+  component: string,
+  result?: SqliteJournalModeResult,
+): string {
+  return `[${component}] SQLite WAL mode not available, using ${getSqliteJournalMode(result)} journal mode fallback`;
+}
+
 export function formatInboxMessages(
   messages: InboxMessage[],
   userNames: Map<string, string>,


### PR DESCRIPTION
## Problem

Both `BrokerDB` and `SqliteCommentStore` used:

```ts
db.exec("PRAGMA journal_mode=WAL")
```

SQLite does not throw if WAL cannot be enabled. It silently returns the actual journal mode instead, so the code failed open with no signal when it fell back to `delete` or another mode.

That makes WAL-related concurrency problems much harder to diagnose.

## Fix

Switched both call sites to inspect the PRAGMA result directly:

- `slack-bridge/broker/schema.ts`
- `nvim-bridge/comments-sqlite.ts`

If the returned journal mode is not `wal`, we now emit an explicit warning including the actual fallback mode.

I also added small helper functions + tests in `slack-bridge/helpers.ts` / `helpers.test.ts` for parsing and warning on journal-mode fallback.

## Checks

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ 397 passing

Closes #142
