### PR TITLE
fix: keep local subagents out of the Pinet mesh (#156)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -25,6 +25,7 @@ import {
   resolvePersistedAgentIdentity,
   buildAgentStableId,
   resolveAgentStableId,
+  isLikelyLocalSubagentContext,
   buildSlackRequest,
   stripBotMention,
   isChannelId,
@@ -496,6 +497,35 @@ describe("resolveAgentStableId", () => {
     expect(resolveAgentStableId(undefined, "/tmp/pi/session.json", "macbook", "/repo")).toBe(
       `macbook:session:${path.resolve("/tmp/pi/session.json")}`,
     );
+  });
+});
+
+describe("isLikelyLocalSubagentContext", () => {
+  it("detects branched or child sessions via parentSession header", () => {
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionHeader: { parentSession: "/tmp/pi/parent-session.jsonl" },
+        argv: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("detects headless no-session subagents from argv fallback", () => {
+    expect(isLikelyLocalSubagentContext({ argv: ["--mode", "json", "-p", "--no-session"] })).toBe(
+      true,
+    );
+    expect(isLikelyLocalSubagentContext({ argv: ["--mode", "rpc", "--no-session"] })).toBe(true);
+  });
+
+  it("does not classify regular interactive sessions as subagents", () => {
+    expect(isLikelyLocalSubagentContext({ argv: [] })).toBe(false);
+    expect(
+      isLikelyLocalSubagentContext({ argv: ["--continue"], sessionHeader: { parentSession: "" } }),
+    ).toBe(false);
+  });
+
+  it("does not classify plain no-session interactive use as a subagent", () => {
+    expect(isLikelyLocalSubagentContext({ argv: ["--no-session"] })).toBe(false);
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -783,6 +783,29 @@ export function resolveAgentStableId(
   return persistedStableId || buildAgentStableId(sessionFile, host, cwd, leafId);
 }
 
+export interface PinetRegistrationContext {
+  sessionHeader?: {
+    parentSession?: string;
+  } | null;
+  argv?: string[];
+}
+
+export function isLikelyLocalSubagentContext(context: PinetRegistrationContext = {}): boolean {
+  const parentSession = context.sessionHeader?.parentSession;
+  if (typeof parentSession === "string" && parentSession.trim().length > 0) {
+    return true;
+  }
+
+  const argv = context.argv ?? process.argv.slice(2);
+  const hasNoSession = argv.includes("--no-session");
+  const hasPrint = argv.includes("--print") || argv.includes("-p");
+  const modeIndex = argv.indexOf("--mode");
+  const mode = modeIndex >= 0 ? argv[modeIndex + 1] : undefined;
+  const hasHeadlessMode = mode === "json" || mode === "rpc";
+
+  return hasNoSession && (hasPrint || hasHeadlessMode);
+}
+
 export interface FollowerThreadState {
   channelId: string;
   threadTs: string;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -34,6 +34,7 @@ import {
   buildBrokerPromptGuidelines,
   buildWorkerPromptGuidelines,
   resolveAgentStableId,
+  isLikelyLocalSubagentContext,
   syncFollowerInboxEntries,
   resolveFollowerThreadChannel,
   getFollowerReconnectUiUpdate,
@@ -1240,6 +1241,7 @@ export default function (pi: ExtensionAPI) {
   // Forward-declared — assigned in the Commands section below.
   let pinetEnabled = false;
   let brokerRole: "broker" | "follower" | null = null;
+  let pinetRegistrationBlocked = false;
   let activeBroker: Broker | null = null;
   let brokerClient: BrokerClientRef | null = null;
   let activeRouter: MessageRouter | null = null;
@@ -1255,6 +1257,10 @@ export default function (pi: ExtensionAPI) {
   let lastBrokerRalphLoopFollowUpAt = 0;
   let brokerRalphLoopFollowUpPending = false;
   const lastBrokerNudges = new Map<string, number>();
+
+  function getPinetRegistrationBlockReason(): string {
+    return "Pinet is disabled in local subagent sessions to avoid polluting the agent mesh.";
+  }
 
   function startBrokerHeartbeat(): void {
     stopBrokerHeartbeat();
@@ -1686,6 +1692,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand("pinet-start", {
     description: "Start Pinet as the broker (Slack connection + message routing)",
     handler: async (_args, ctx) => {
+      if (pinetRegistrationBlocked) {
+        ctx.ui.notify(getPinetRegistrationBlockReason(), "warning");
+        return;
+      }
       if (pinetEnabled) {
         ctx.ui.notify(`Pinet already running (${brokerRole})`, "info");
         return;
@@ -1801,6 +1811,10 @@ export default function (pi: ExtensionAPI) {
   });
 
   async function connectAsFollower(ctx: ExtensionContext): Promise<void> {
+    if (pinetRegistrationBlocked) {
+      throw new Error(getPinetRegistrationBlockReason());
+    }
+
     const client = new BrokerClient();
     await client.connect();
     const registration = await client.register(
@@ -1938,6 +1952,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand("pinet-follow", {
     description: "Connect to an existing Pinet broker as a follower",
     handler: async (_args, ctx) => {
+      if (pinetRegistrationBlocked) {
+        ctx.ui.notify(getPinetRegistrationBlockReason(), "warning");
+        return;
+      }
       if (pinetEnabled) {
         ctx.ui.notify(`Pinet already running (${brokerRole})`, "info");
         return;
@@ -2018,6 +2036,13 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     shuttingDown = false;
     extCtx = ctx;
+    const sessionHeader = (
+      ctx.sessionManager as { getHeader?: () => { parentSession?: string } | null }
+    ).getHeader?.();
+    pinetRegistrationBlocked = isLikelyLocalSubagentContext({
+      sessionHeader,
+      argv: process.argv.slice(2),
+    });
 
     // Restore persisted thread state (always restore, even before /pinet)
     interface PersistedState {
@@ -2070,6 +2095,12 @@ export default function (pi: ExtensionAPI) {
       persistStateNow();
     } catch (err) {
       console.error(`[slack-bridge] restore failed: ${msg(err)}`);
+    }
+
+    if (pinetRegistrationBlocked) {
+      console.log("[slack-bridge] detected local subagent context; skipping Pinet registration");
+      setExtStatus(ctx, "off");
+      return;
     }
 
     // Auto-follow: if enabled and broker socket exists, connect as follower
@@ -2206,6 +2237,7 @@ export default function (pi: ExtensionAPI) {
     disconnect();
     brokerRole = null;
     pinetEnabled = false;
+    pinetRegistrationBlocked = false;
     setExtStatus(ctx, "off");
   });
 }


### PR DESCRIPTION
## Problem

When a local pi subagent inherits the `slack-bridge` extension, it can auto-follow the broker and register as a normal Pinet agent.

That pollutes the mesh with phantom workers that:
- appear healthy and idle even though they are just local helper processes
- later become ghosts when the subagent exits
- can confuse routing and operator visibility

## Fix

Added explicit subagent-context detection and blocked Pinet registration for those sessions.

### Detection
Primary signal:
- `ctx.sessionManager.getHeader()?.parentSession`

This uses pi's session API to detect branched/child sessions created from a parent session.

Fallback heuristic:
- `--no-session` plus headless child-process argv (`--mode json` / `--mode rpc` / `-p`)

### Behavior changes
In `slack-bridge/index.ts`:
- subagent sessions now skip `autoFollow` during `session_start`
- `pinet-start` is blocked in subagent sessions
- `pinet-follow` is blocked in subagent sessions

This keeps local subagents out of the live Pinet mesh entirely.

## Tests
Added helper coverage for:
- parent-session detection
- headless no-session argv fallback
- normal interactive sessions are not misclassified
- plain interactive `--no-session` is not misclassified

## Verification
- ✅ `pnpm lint`
- ✅ `pnpm typecheck`
- ✅ `pnpm test` (398 passing)

Closes #156
