### PR TITLE
test: add nvim-bridge coverage (#134)

### DIFF
--- a/nvim-bridge/comments-sqlite.test.ts
+++ b/nvim-bridge/comments-sqlite.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SqliteCommentStore } from "./comments-sqlite.js";
+
+describe("SqliteCommentStore", () => {
+  let repoRoot: string;
+  let store: SqliteCommentStore | null;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nvim-sqlite-test-"));
+    store = null;
+  });
+
+  afterEach(() => {
+    store?.close();
+    store = null;
+    vi.useRealTimers();
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("stores comments in sqlite with contextual thread ids and summaries", async () => {
+    store = new SqliteCommentStore(repoRoot);
+    store.initialize();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+
+    const first = await store.addComment({
+      body: "First sqlite note",
+      actorId: "reviewer",
+      context: { file: "src/app.ts", startLine: 4, endLine: 6 },
+    });
+
+    vi.setSystemTime(new Date("2024-01-01T00:00:01.000Z"));
+
+    const second = await store.addComment({
+      body: "Second sqlite note",
+      actorId: "reviewer",
+      context: { file: "src/app.ts", startLine: 4, endLine: 6 },
+    });
+
+    const listed = store.listComments({ threadId: first.threadId, limit: 1 });
+    expect(listed.total).toBe(2);
+    expect(listed.comments).toHaveLength(1);
+    expect(listed.comments[0]?.body).toBe("Second sqlite note");
+    expect(store.getThreadSummary(first.threadId)).toEqual({
+      threadId: first.threadId,
+      total: 2,
+      latestId: second.id,
+    });
+  });
+
+  it("migrates existing JSON comments into sqlite on initialize", () => {
+    const legacyDir = path.join(repoRoot, ".pi", "a2a", "comments");
+    const itemsDir = path.join(legacyDir, "items");
+    fs.mkdirSync(itemsDir, { recursive: true });
+
+    fs.writeFileSync(path.join(itemsDir, "legacy-1.md"), "Migrated body\n", "utf-8");
+    fs.writeFileSync(
+      path.join(legacyDir, "index.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          comments: [
+            {
+              id: "legacy-1",
+              threadId: "legacy-thread",
+              actorType: "human",
+              actorId: "alice",
+              createdAt: "2024-01-01T00:00:00.000Z",
+              bodyPath: "items/legacy-1.md",
+              context: {
+                file: "src/legacy.ts",
+                startLine: 10,
+                endLine: 12,
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    store = new SqliteCommentStore(repoRoot);
+    store.initialize();
+
+    const listed = store.listComments({ threadId: "legacy-thread" });
+    expect(listed.total).toBe(1);
+    expect(listed.comments).toHaveLength(1);
+    expect(listed.comments[0]).toMatchObject({
+      id: "legacy-1",
+      threadId: "legacy-thread",
+      actorType: "human",
+      actorId: "alice",
+      body: "Migrated body",
+      bodyPath: "items/legacy-1.md",
+      context: {
+        file: "src/legacy.ts",
+        startLine: 10,
+        endLine: 12,
+      },
+    });
+    expect(fs.existsSync(path.join(repoRoot, ".pi", "picomms.db"))).toBe(true);
+  });
+
+  it("wipes all comments from sqlite", async () => {
+    store = new SqliteCommentStore(repoRoot);
+    store.initialize();
+
+    await store.addComment({
+      body: "Delete me",
+      actorId: "reviewer",
+      threadId: "cleanup",
+    });
+
+    const result = await store.wipeAllComments();
+    expect(result).toEqual({ removed: 1, remaining: 0 });
+    expect(store.listAllComments()).toEqual({ total: 0, comments: [] });
+  });
+});

--- a/nvim-bridge/comments.test.ts
+++ b/nvim-bridge/comments.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  CommentStore,
+  buildContextThreadId,
+  normalizeContext,
+  resolveThreadId,
+} from "./comments.js";
+
+describe("normalizeContext", () => {
+  it("normalizes blank and reversed ranges", () => {
+    expect(normalizeContext(undefined)).toBeUndefined();
+    expect(normalizeContext({ file: "   " })).toBeUndefined();
+
+    expect(
+      normalizeContext({
+        file: "src/app.ts",
+        startLine: 20,
+        endLine: 10,
+      }),
+    ).toEqual({
+      file: "src/app.ts",
+      startLine: 10,
+      endLine: 20,
+    });
+  });
+
+  it("fills in a missing bound from the other side", () => {
+    expect(
+      normalizeContext({
+        file: "src/app.ts",
+        endLine: 7,
+      }),
+    ).toEqual({
+      file: "src/app.ts",
+      startLine: 7,
+      endLine: 7,
+    });
+  });
+});
+
+describe("buildContextThreadId", () => {
+  it("builds a stable context thread id only for complete ranges", () => {
+    expect(
+      buildContextThreadId({
+        file: "src/app.ts",
+        startLine: 3,
+        endLine: 5,
+      }),
+    ).toBe("ctx:src/app.ts:3-5");
+    expect(buildContextThreadId({ file: "src/app.ts" })).toBeNull();
+  });
+});
+
+describe("resolveThreadId", () => {
+  it("prefers explicit threads, then contextual threads, then global", () => {
+    expect(resolveThreadId("review-123", { file: "src/app.ts", startLine: 3, endLine: 5 })).toBe(
+      "review-123",
+    );
+    expect(resolveThreadId(undefined, { file: "src/app.ts", startLine: 3, endLine: 5 })).toBe(
+      "ctx:src/app.ts:3-5",
+    );
+    expect(resolveThreadId(undefined, undefined)).toBe("global");
+  });
+});
+
+describe("CommentStore", () => {
+  let repoRoot: string;
+  let store: CommentStore | null;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nvim-comments-test-"));
+    store = new CommentStore(repoRoot);
+    store.initialize();
+  });
+
+  afterEach(() => {
+    store?.close();
+    store = null;
+    vi.useRealTimers();
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("stores contextual comments and returns newest-per-thread when limited", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+
+    const first = await store!.addComment({
+      body: "First note",
+      actorId: "reviewer",
+      context: { file: "src/app.ts", startLine: 12 },
+    });
+
+    vi.setSystemTime(new Date("2024-01-01T00:00:01.000Z"));
+
+    const second = await store!.addComment({
+      body: "Second note",
+      actorId: "reviewer",
+      context: { file: "src/app.ts", startLine: 12 },
+    });
+
+    expect(first.threadId).toBe("ctx:src/app.ts:12-12");
+    expect(second.threadId).toBe(first.threadId);
+
+    const listed = store!.listComments({ threadId: first.threadId, limit: 1 });
+    expect(listed.total).toBe(2);
+    expect(listed.comments).toHaveLength(1);
+    expect(listed.comments[0]?.body).toBe("Second note");
+    expect(store!.getThreadSummary(first.threadId)).toEqual({
+      threadId: first.threadId,
+      total: 2,
+      latestId: second.id,
+    });
+  });
+
+  it("serializes concurrent writes without losing comments", async () => {
+    await Promise.all([
+      store!.addComment({ body: "one", actorId: "tester", threadId: "thread-a" }),
+      store!.addComment({ body: "two", actorId: "tester", threadId: "thread-a" }),
+      store!.addComment({ body: "three", actorId: "tester", threadId: "thread-a" }),
+    ]);
+
+    const listed = store!.listComments({ threadId: "thread-a" });
+    expect(listed.total).toBe(3);
+    expect(listed.comments.map((comment) => comment.body).sort()).toEqual(["one", "three", "two"]);
+  });
+
+  it("rebuilds its index from metadata when the index file is missing", async () => {
+    const comment = await store!.addComment({
+      body: "Needs index rebuild",
+      actorId: "tester",
+      context: { file: "src/app.ts", startLine: 8, endLine: 9 },
+    });
+
+    store!.close();
+    fs.rmSync(path.join(repoRoot, ".pi", "a2a", "comments", "index.json"), { force: true });
+
+    store = new CommentStore(repoRoot);
+    store.initialize();
+
+    const listed = store.listComments({ threadId: comment.threadId });
+    expect(listed.total).toBe(1);
+    expect(listed.comments[0]?.body).toBe("Needs index rebuild");
+    expect(listed.comments[0]?.context).toEqual({
+      file: "src/app.ts",
+      startLine: 8,
+      endLine: 9,
+    });
+  });
+
+  it("wipes all comments and recreates an empty store layout", async () => {
+    await store!.addComment({ body: "To be removed", actorId: "tester", threadId: "cleanup" });
+
+    const result = await store!.wipeAllComments();
+
+    expect(result).toEqual({ removed: 1, remaining: 0 });
+    expect(store!.listAllComments()).toEqual({ total: 0, comments: [] });
+    expect(fs.existsSync(path.join(repoRoot, ".pi", "a2a", "comments", "index.json"))).toBe(true);
+  });
+});

--- a/nvim-bridge/index.test.ts
+++ b/nvim-bridge/index.test.ts
@@ -1,0 +1,232 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { CommentRecord } from "./comments.js";
+
+vi.mock("@sinclair/typebox", () => ({
+  Type: {
+    Object: () => ({}),
+    String: () => ({}),
+    Number: () => ({}),
+    Optional: (value: unknown) => value,
+    Boolean: () => ({}),
+  },
+}));
+
+type EditorStateShape = {
+  file: string | null;
+  line: number | null;
+  visibleStart: number | null;
+  visibleEnd: number | null;
+  selectionStart: number | null;
+  selectionEnd: number | null;
+};
+
+let buildPiCommsReadPrompt: (
+  state: EditorStateShape,
+  comments: CommentRecord[],
+  totalCount: number,
+  maxChars?: number,
+) => {
+  prompt: string;
+  included: number;
+  truncated: boolean;
+};
+let formatContext: (state: EditorStateShape) => string;
+let parseCommentRpcRequest: (value: unknown) => unknown;
+let parseNvimEvent: (value: unknown) => unknown;
+
+beforeAll(async () => {
+  const mod = await import("./index.js");
+  buildPiCommsReadPrompt = mod.buildPiCommsReadPrompt;
+  formatContext = mod.formatContext;
+  parseCommentRpcRequest = mod.parseCommentRpcRequest;
+  parseNvimEvent = mod.parseNvimEvent;
+});
+
+function createState(overrides: Partial<EditorStateShape> = {}): EditorStateShape {
+  return {
+    file: null,
+    line: null,
+    visibleStart: null,
+    visibleEnd: null,
+    selectionStart: null,
+    selectionEnd: null,
+    ...overrides,
+  };
+}
+
+function createComment(overrides: Partial<CommentRecord> = {}): CommentRecord {
+  return {
+    id: "c1",
+    threadId: "global",
+    actorType: "agent",
+    actorId: "pi",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    bodyPath: "items/c1.md",
+    body: "Comment body",
+    ...overrides,
+  };
+}
+
+describe("formatContext", () => {
+  it("formats the current editor viewport, cursor, and selection", () => {
+    expect(
+      formatContext(
+        createState({
+          file: "src/app.ts",
+          visibleStart: 10,
+          visibleEnd: 20,
+          line: 15,
+          selectionStart: 16,
+          selectionEnd: 18,
+        }),
+      ),
+    ).toBe(
+      "User is viewing src/app.ts, lines 10-20 (cursor at line 15), selection on lines 16-18.",
+    );
+  });
+
+  it("returns an empty string when no file is focused", () => {
+    expect(formatContext(createState())).toBe("");
+  });
+});
+
+describe("parseNvimEvent", () => {
+  it("parses valid editor events", () => {
+    expect(parseNvimEvent({ type: "buffer_focus", file: "src/app.ts", line: 12 })).toEqual({
+      type: "buffer_focus",
+      file: "src/app.ts",
+      line: 12,
+    });
+    expect(parseNvimEvent({ type: "selection", file: "src/app.ts", start: 4, end: 8 })).toEqual({
+      type: "selection",
+      file: "src/app.ts",
+      start: 4,
+      end: 8,
+    });
+  });
+
+  it("rejects malformed or unknown events", () => {
+    expect(parseNvimEvent({ type: "buffer_focus", file: "src/app.ts", line: 0 })).toBeNull();
+    expect(parseNvimEvent({ type: "unknown", file: "src/app.ts" })).toBeNull();
+    expect(parseNvimEvent(null)).toBeNull();
+  });
+});
+
+describe("parseCommentRpcRequest", () => {
+  it("parses comment.add requests with optional context", () => {
+    expect(
+      parseCommentRpcRequest({
+        id: "req-1",
+        type: "comment.add",
+        payload: {
+          body: "Please revisit this block",
+          threadId: "review-thread",
+          actorType: "human",
+          actorId: "alice",
+          context: {
+            file: "src/app.ts",
+            startLine: 30,
+            endLine: 32,
+          },
+        },
+      }),
+    ).toEqual({
+      id: "req-1",
+      type: "comment.add",
+      payload: {
+        body: "Please revisit this block",
+        threadId: "review-thread",
+        actorType: "human",
+        actorId: "alice",
+        context: {
+          file: "src/app.ts",
+          startLine: 30,
+          endLine: 32,
+        },
+      },
+    });
+  });
+
+  it("parses list requests and rejects invalid payloads", () => {
+    expect(
+      parseCommentRpcRequest({
+        id: "req-2",
+        type: "comment.list",
+        payload: { threadId: "thread-1", limit: 5 },
+      }),
+    ).toEqual({
+      id: "req-2",
+      type: "comment.list",
+      payload: { threadId: "thread-1", limit: 5 },
+    });
+    expect(parseCommentRpcRequest({ id: "", type: "comment.list", payload: {} })).toBeNull();
+    expect(parseCommentRpcRequest({ id: "req-3", type: "comment.add", payload: {} })).toBeNull();
+  });
+});
+
+describe("buildPiCommsReadPrompt", () => {
+  it("prioritizes comments matching the current editor context", () => {
+    const state = createState({
+      file: "src/app.ts",
+      line: 15,
+    });
+    const comments = [
+      createComment({
+        id: "other",
+        bodyPath: "items/other.md",
+        body: "General repo note",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      }),
+      createComment({
+        id: "relevant",
+        threadId: "ctx:src/app.ts:15-15",
+        bodyPath: "items/relevant.md",
+        body: "Relevant line-specific guidance",
+        createdAt: "2024-01-02T00:00:00.000Z",
+        context: {
+          file: "src/app.ts",
+          startLine: 15,
+          endLine: 15,
+        },
+      }),
+    ];
+
+    const result = buildPiCommsReadPrompt(state, comments, comments.length, 5000);
+
+    expect(result.included).toBe(2);
+    expect(result.truncated).toBe(false);
+    expect(result.prompt).toContain("Most relevant PiComms:");
+    expect(result.prompt.indexOf("Relevant line-specific guidance")).toBeLessThan(
+      result.prompt.indexOf("General repo note"),
+    );
+  });
+
+  it("marks the prompt as truncated when not all comments fit", () => {
+    const state = createState({ file: "src/app.ts", line: 10 });
+    const comments = [
+      createComment({
+        id: "c1",
+        bodyPath: "items/c1.md",
+        threadId: "ctx:src/app.ts:10-10",
+        body: "This is the highest priority comment and it is deliberately long to consume space.",
+        context: { file: "src/app.ts", startLine: 10, endLine: 10 },
+      }),
+      createComment({
+        id: "c2",
+        bodyPath: "items/c2.md",
+        body: "Secondary note that should fall off once the prompt budget is exhausted.",
+      }),
+      createComment({
+        id: "c3",
+        bodyPath: "items/c3.md",
+        body: "Tertiary note that should also be omitted.",
+      }),
+    ];
+
+    const result = buildPiCommsReadPrompt(state, comments, comments.length, 180);
+
+    expect(result.truncated).toBe(true);
+    expect(result.included).toBeLessThan(comments.length);
+    expect(result.prompt).toContain("Some comments were omitted due to prompt size limits.");
+  });
+});

--- a/nvim-bridge/index.ts
+++ b/nvim-bridge/index.ts
@@ -13,7 +13,7 @@ import {
   type CommentRecord,
 } from "./comments.js";
 
-interface EditorState {
+export interface EditorState {
   file: string | null;
   line: number | null;
   visibleStart: number | null;
@@ -22,7 +22,7 @@ interface EditorState {
   selectionEnd: number | null;
 }
 
-type NvimEvent =
+export type NvimEvent =
   | { type: "buffer_focus"; file: string; line: number }
   | { type: "visible_range"; file: string; start: number; end: number }
   | { type: "selection"; file: string; start: number; end: number }
@@ -30,7 +30,7 @@ type NvimEvent =
 
 type NvimCommand = { type: "open_file"; file: string; line?: number };
 
-type CommentRpcRequest =
+export type CommentRpcRequest =
   | {
       id: string;
       type: "comment.list" | "comment.sync";
@@ -93,7 +93,7 @@ function computeSocketPath(repoInfo: RepoInfo): string {
   return path.join(dir, `${hash}.sock`);
 }
 
-function formatContext(state: EditorState): string {
+export function formatContext(state: EditorState): string {
   if (!state.file) return "";
 
   let msg = `User is viewing ${state.file}`;
@@ -114,7 +114,7 @@ function formatContext(state: EditorState): string {
   return msg;
 }
 
-function parseNvimEvent(value: unknown): NvimEvent | null {
+export function parseNvimEvent(value: unknown): NvimEvent | null {
   const event = asObject(value);
   if (!event || typeof event.type !== "string") return null;
 
@@ -166,7 +166,7 @@ function parseNvimEvent(value: unknown): NvimEvent | null {
   }
 }
 
-function parseCommentRpcRequest(value: unknown): CommentRpcRequest | null {
+export function parseCommentRpcRequest(value: unknown): CommentRpcRequest | null {
   const request = asObject(value);
   if (
     !request ||
@@ -326,7 +326,7 @@ function formatCommentForRead(comment: CommentRecord): string {
   return `${chunk}\n`;
 }
 
-function buildPiCommsReadPrompt(
+export function buildPiCommsReadPrompt(
   state: EditorState,
   comments: CommentRecord[],
   totalCount: number,

--- a/nvim-bridge/package.json
+++ b/nvim-bridge/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@gugu91/pi-ext-types": "workspace:*"


### PR DESCRIPTION
## Summary

Adds the first real test coverage for `nvim-bridge` and wires the package into the repo test pipeline.

## What changed

### `nvim-bridge/package.json`
- added a `test` script so Turborepo includes `nvim-bridge` in `pnpm test`

### `nvim-bridge/comments.test.ts`
Covers JSON comment-store behavior:
- `normalizeContext`
- `buildContextThreadId`
- `resolveThreadId`
- `CommentStore` add/list/summary behavior
- concurrent write serialization
- index rebuild from metadata when `index.json` is missing
- wipe-all behavior

### `nvim-bridge/comments-sqlite.test.ts`
Covers SQLite-backed comment-store behavior:
- `SqliteCommentStore` add/list/summary behavior
- JSON → SQLite migration on initialize
- wipe-all behavior

### `nvim-bridge/index.test.ts`
Covers pure Neovim bridge helpers:
- `formatContext`
- `parseNvimEvent`
- `parseCommentRpcRequest`
- `buildPiCommsReadPrompt` prioritization and truncation

### `nvim-bridge/index.ts`
- exported a few pure helper types/functions so they can be exercised directly in tests

## Verification
- ✅ `pnpm lint`
- ✅ `pnpm typecheck`
- ✅ `pnpm test`

Closes #134
