### PR TITLE
fix: stop replaying stale RALPH ghost alerts

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -15,6 +15,7 @@ import {
   buildAgentDisplayInfo,
   rankAgentsForRouting,
   evaluateRalphLoopCycle,
+  rewriteRalphLoopGhostAnomalies,
   buildRalphLoopNudgeMessage,
   buildRalphLoopAnomalySignature,
   buildRalphLoopFollowUpMessage,
@@ -1029,6 +1030,48 @@ describe("evaluateRalphLoopCycle", () => {
       heartbeatIntervalMs: 5_000,
     });
     expect(result.stuckAgentIds).toEqual([]);
+  });
+});
+
+describe("rewriteRalphLoopGhostAnomalies", () => {
+  const buildEvaluation = (ghostAgentIds: string[], anomalies: string[]) => ({
+    ghostAgentIds,
+    nudgeAgentIds: [],
+    idleDrainAgentIds: [],
+    stuckAgentIds: [],
+    anomalies,
+  });
+
+  it("only surfaces ghost deltas while keeping non-ghost anomalies stable across cycles", () => {
+    const cycle1 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"], ["ghost agents detected: ghost-1"]),
+    );
+    expect(cycle1.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-1"]);
+    expect(cycle1.nextReportedGhostIds).toEqual(["ghost-1"]);
+
+    const cycle2 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"], ["ghost agents detected: ghost-1"]),
+      cycle1.nextReportedGhostIds,
+    );
+    expect(cycle2.evaluation.anomalies).toEqual([]);
+    expect(buildRalphLoopAnomalySignature(cycle2.evaluation)).toBe("");
+
+    const cycle3 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(
+        ["ghost-1"],
+        ["ghost agents detected: ghost-1", "pending backlog (3) with 1 idle worker"],
+      ),
+      cycle2.nextReportedGhostIds,
+    );
+    expect(cycle3.evaluation.anomalies).toEqual(["pending backlog (3) with 1 idle worker"]);
+    expect(cycle3.nonGhostAnomalies).toEqual(["pending backlog (3) with 1 idle worker"]);
+
+    const cycle4 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation([], []),
+      cycle3.nextReportedGhostIds,
+    );
+    expect(cycle4.evaluation.anomalies).toEqual(["ghost agents cleared from registry: ghost-1"]);
+    expect(cycle4.clearedGhostIds).toEqual(["ghost-1"]);
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -551,6 +551,14 @@ export interface RalphLoopEvaluationResult {
   anomalies: string[];
 }
 
+export interface RalphLoopGhostAnomalyRewriteResult {
+  evaluation: RalphLoopEvaluationResult;
+  nonGhostAnomalies: string[];
+  newGhostIds: string[];
+  clearedGhostIds: string[];
+  nextReportedGhostIds: string[];
+}
+
 export function evaluateRalphLoopCycle(
   workloads: RalphLoopAgentWorkload[],
   options: RalphLoopEvaluationOptions = {},
@@ -650,6 +658,39 @@ export function evaluateRalphLoopCycle(
     idleDrainAgentIds,
     stuckAgentIds,
     anomalies,
+  };
+}
+
+export function rewriteRalphLoopGhostAnomalies(
+  evaluation: RalphLoopEvaluationResult,
+  previousGhostIds: Iterable<string> = [],
+): RalphLoopGhostAnomalyRewriteResult {
+  const priorGhostIds = new Set(previousGhostIds);
+  const nextReportedGhostIds = [...evaluation.ghostAgentIds];
+  const newGhostIds = evaluation.ghostAgentIds.filter((id) => !priorGhostIds.has(id));
+  const currentGhostIds = new Set(evaluation.ghostAgentIds);
+  const clearedGhostIds = [...priorGhostIds].filter((id) => !currentGhostIds.has(id));
+  const nonGhostAnomalies = evaluation.anomalies.filter(
+    (anomaly) => !anomaly.startsWith("ghost agents detected:"),
+  );
+  const anomalies = [...nonGhostAnomalies];
+
+  if (newGhostIds.length > 0) {
+    anomalies.push(`NEW ghost agents detected: ${newGhostIds.join(", ")}`);
+  }
+  if (clearedGhostIds.length > 0) {
+    anomalies.push(`ghost agents cleared from registry: ${clearedGhostIds.join(", ")}`);
+  }
+
+  return {
+    evaluation: {
+      ...evaluation,
+      anomalies,
+    },
+    nonGhostAnomalies,
+    newGhostIds,
+    clearedGhostIds,
+    nextReportedGhostIds,
   };
 }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -18,6 +18,7 @@ import {
   buildAgentDisplayInfo,
   rankAgentsForRouting,
   evaluateRalphLoopCycle,
+  rewriteRalphLoopGhostAnomalies,
   buildRalphLoopNudgeMessage,
   buildRalphLoopAnomalySignature,
   buildRalphLoopFollowUpMessage,
@@ -850,9 +851,11 @@ export default function (pi: ExtensionAPI) {
   let brokerRalphLoopRunning = false;
   let lastBrokerMaintenance: BrokerMaintenanceResult | null = null;
   let lastBrokerMaintenanceSignature = "";
-  let lastBrokerRalphLoopSignature = "";
+  let lastBrokerRalphLoopNonGhostSignature = "";
+  let lastBrokerRalphLoopHadOutstandingAnomalies = false;
   let lastBrokerRalphLoopFollowUpAt = 0;
   let brokerRalphLoopFollowUpPending = false;
+  const lastReportedGhostIds = new Set<string>();
   const lastBrokerNudges = new Map<string, number>();
 
   function getPinetRegistrationBlockReason(): string {
@@ -987,14 +990,28 @@ export default function (pi: ExtensionAPI) {
         lastBrokerNudges.set(workload.id, now);
       }
 
-      const signature = buildRalphLoopAnomalySignature(evaluation);
-      const followUpPrompt = buildRalphLoopFollowUpMessage(evaluation);
+      const ghostRewrite = rewriteRalphLoopGhostAnomalies(evaluation, lastReportedGhostIds);
+      lastReportedGhostIds.clear();
+      for (const ghostId of ghostRewrite.nextReportedGhostIds) {
+        lastReportedGhostIds.add(ghostId);
+      }
+
+      const visibleEvaluation = ghostRewrite.evaluation;
+      const visibleSignature = buildRalphLoopAnomalySignature(visibleEvaluation);
+      const nonGhostSignature = ghostRewrite.nonGhostAnomalies.join("|");
+      const hasOutstandingAnomalies = evaluation.anomalies.length > 0;
+      const followUpPrompt =
+        ghostRewrite.newGhostIds.length === 0 &&
+        ghostRewrite.clearedGhostIds.length > 0 &&
+        ghostRewrite.nonGhostAnomalies.length === 0
+          ? null
+          : buildRalphLoopFollowUpMessage(visibleEvaluation);
       // Keep cooldown state across transient clean cycles so flapping anomalies
       // do not immediately re-notify when they return.
       const shouldDeliverFollowUp =
         followUpPrompt != null &&
         shouldDeliverRalphLoopFollowUp({
-          signature,
+          signature: visibleSignature,
           lastDeliveredAt: lastBrokerRalphLoopFollowUpAt,
           now,
           cooldownMs: DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
@@ -1019,12 +1036,22 @@ export default function (pi: ExtensionAPI) {
           }
         }
       }
-      if (signature && signature !== lastBrokerRalphLoopSignature) {
-        ctx.ui.notify(`RALPH loop: ${evaluation.anomalies.join("; ")}`, "warning");
-      } else if (!signature && lastBrokerRalphLoopSignature) {
+
+      const shouldWarn =
+        ghostRewrite.newGhostIds.length > 0 ||
+        (nonGhostSignature.length > 0 &&
+          nonGhostSignature !== lastBrokerRalphLoopNonGhostSignature);
+      const shouldInform =
+        ghostRewrite.clearedGhostIds.length > 0 && visibleEvaluation.anomalies.length > 0;
+      if (shouldWarn) {
+        ctx.ui.notify(`RALPH loop: ${visibleEvaluation.anomalies.join("; ")}`, "warning");
+      } else if (shouldInform) {
+        ctx.ui.notify(`RALPH loop: ${visibleEvaluation.anomalies.join("; ")}`, "info");
+      } else if (!hasOutstandingAnomalies && lastBrokerRalphLoopHadOutstandingAnomalies) {
         ctx.ui.notify("RALPH loop health recovered", "info");
       }
-      lastBrokerRalphLoopSignature = signature;
+      lastBrokerRalphLoopNonGhostSignature = nonGhostSignature;
+      lastBrokerRalphLoopHadOutstandingAnomalies = hasOutstandingAnomalies;
 
       // #103: Record ralph cycle for observability
       try {
@@ -1033,12 +1060,12 @@ export default function (pi: ExtensionAPI) {
           startedAt: cycleStartedAt,
           completedAt: cycleCompletedAt,
           durationMs: Date.now() - cycleStartMs,
-          ghostAgentIds: evaluation.ghostAgentIds,
-          nudgeAgentIds: evaluation.nudgeAgentIds,
-          idleDrainAgentIds: evaluation.idleDrainAgentIds,
-          stuckAgentIds: evaluation.stuckAgentIds,
-          anomalies: evaluation.anomalies,
-          anomalySignature: signature,
+          ghostAgentIds: visibleEvaluation.ghostAgentIds,
+          nudgeAgentIds: visibleEvaluation.nudgeAgentIds,
+          idleDrainAgentIds: visibleEvaluation.idleDrainAgentIds,
+          stuckAgentIds: visibleEvaluation.stuckAgentIds,
+          anomalies: visibleEvaluation.anomalies,
+          anomalySignature: visibleSignature,
           followUpDelivered: shouldDeliverFollowUp,
           agentCount: workloads.filter((w) => !w.disconnectedAt).length,
           backlogCount: pendingBacklogCount,
@@ -1068,7 +1095,9 @@ export default function (pi: ExtensionAPI) {
       brokerRalphLoopTimer = null;
     }
     lastBrokerNudges.clear();
-    lastBrokerRalphLoopSignature = "";
+    lastReportedGhostIds.clear();
+    lastBrokerRalphLoopNonGhostSignature = "";
+    lastBrokerRalphLoopHadOutstandingAnomalies = false;
     lastBrokerRalphLoopFollowUpAt = 0;
     brokerRalphLoopFollowUpPending = false;
   }
@@ -1811,7 +1840,9 @@ export default function (pi: ExtensionAPI) {
     activeSelfId = null;
     lastBrokerMaintenance = null;
     lastBrokerMaintenanceSignature = "";
-    lastBrokerRalphLoopSignature = "";
+    lastBrokerRalphLoopNonGhostSignature = "";
+    lastBrokerRalphLoopHadOutstandingAnomalies = false;
+    lastReportedGhostIds.clear();
     if (brokerClient) {
       try {
         if (brokerClient.pollInterval) {


### PR DESCRIPTION
Closes #128

Supersedes #165.

## Summary
- extract ghost anomaly rewrite into a helper that reports only ghost deltas
- keep persistent ghosts out of repeated RALPH warnings until something actually changes
- suppress misleading recovery/follow-up noise while a ghost still exists
- add a multi-cycle regression test for detect → persist → unrelated anomaly → clear

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test