### PR TITLE
fix: abort in-flight Slack API calls on shutdown (#135)

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -709,6 +709,19 @@ describe("SlackAdapter — connect", () => {
 // ─── SlackAdapter — disconnect ───────────────────────────
 
 describe("SlackAdapter — disconnect", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn<typeof fetch>();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   it("can disconnect without prior connect", async () => {
     const adapter = new SlackAdapter({
       botToken: "xoxb-test",
@@ -717,6 +730,41 @@ describe("SlackAdapter — disconnect", () => {
     // Should not throw
     await adapter.disconnect();
     expect(adapter.isConnected()).toBe(false);
+  });
+
+  it("aborts in-flight Slack API calls during shutdown", async () => {
+    fetchMock.mockImplementation((_input, init) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        const rejectAbort = () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        };
+
+        if (signal?.aborted) {
+          rejectAbort();
+          return;
+        }
+
+        signal?.addEventListener("abort", rejectAbort, { once: true });
+      });
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+
+    const sendPromise = adapter.send({
+      channel: "C123",
+      threadId: "123.456",
+      text: "hello",
+    });
+
+    await adapter.disconnect();
+
+    await expect(sendPromise).rejects.toMatchObject({ name: "AbortError" });
   });
 });
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -1,4 +1,11 @@
-import { callSlackAPI, buildAllowlist, isUserAllowed, stripBotMention } from "../../helpers.js";
+import {
+  callSlackAPI,
+  createAbortableOperationTracker,
+  isAbortError,
+  buildAllowlist,
+  isUserAllowed,
+  stripBotMention,
+} from "../../helpers.js";
 import { TtlCache } from "../../ttl-cache.js";
 import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
 
@@ -168,6 +175,7 @@ export class SlackAdapter implements MessageAdapter {
 
   private readonly config: SlackAdapterConfig;
   private readonly allowlist: Set<string> | null;
+  private slackRequests = createAbortableOperationTracker();
   private botUserId: string | null = null;
   private ws: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -186,11 +194,16 @@ export class SlackAdapter implements MessageAdapter {
     this.allowlist = buildAllowlist({ allowedUsers: config.allowedUsers }, undefined);
   }
 
+  private async callSlack(method: string, token: string, body?: Record<string, unknown>) {
+    return this.slackRequests.run((signal) => callSlackAPI(method, token, body, { signal }));
+  }
+
   // ─── MessageAdapter interface ─────────────────────────
 
   async connect(): Promise<void> {
     this.shuttingDown = false;
-    const auth = await callSlackAPI("auth.test", this.config.botToken);
+    this.slackRequests = createAbortableOperationTracker();
+    const auth = await this.callSlack("auth.test", this.config.botToken);
     this.botUserId = auth.user_id as string;
     await this.connectSocketMode();
   }
@@ -207,6 +220,7 @@ export class SlackAdapter implements MessageAdapter {
       /* ignore close errors */
     }
     this.ws = null;
+    await this.slackRequests.abortAndWait();
   }
 
   onInbound(handler: (msg: InboundMessage) => void): void {
@@ -231,7 +245,8 @@ export class SlackAdapter implements MessageAdapter {
       };
     }
 
-    await callSlackAPI("chat.postMessage", this.config.botToken, body);
+    await this.callSlack("chat.postMessage", this.config.botToken, body);
+    if (this.shuttingDown) return;
 
     // Remove pending eyes for this thread
     const pending = this.pendingEyes.get(msg.threadId);
@@ -266,7 +281,7 @@ export class SlackAdapter implements MessageAdapter {
     if (this.shuttingDown) return;
 
     try {
-      const res = await callSlackAPI("apps.connections.open", this.config.appToken);
+      const res = await this.callSlack("apps.connections.open", this.config.appToken);
       this.ws = new WebSocket(res.url as string);
 
       this.ws.addEventListener("message", (event) => {
@@ -281,12 +296,16 @@ export class SlackAdapter implements MessageAdapter {
         /* close fires after error — handled there */
       });
     } catch (err) {
-      console.error(`[slack-adapter] Socket Mode: ${errorMsg(err)}`);
+      if (!isAbortError(err)) {
+        console.error(`[slack-adapter] Socket Mode: ${errorMsg(err)}`);
+      }
       this.scheduleReconnect();
     }
   }
 
   private async handleFrame(raw: string): Promise<void> {
+    if (this.shuttingDown) return;
+
     const envelope = parseSocketFrame(raw);
     if (!envelope) return;
 
@@ -323,6 +342,8 @@ export class SlackAdapter implements MessageAdapter {
   // ─── Event handlers ────────────────────────────────────
 
   private async onThreadStarted(evt: Record<string, unknown>): Promise<void> {
+    if (this.shuttingDown) return;
+
     const parsed = extractThreadStarted(evt);
     if (!parsed) return;
 
@@ -341,6 +362,8 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   private onContextChanged(evt: Record<string, unknown>): void {
+    if (this.shuttingDown) return;
+
     const t = evt.assistant_thread as Record<string, unknown> | undefined;
     if (!t) return;
 
@@ -357,6 +380,8 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   private async onMessage(evt: Record<string, unknown>): Promise<void> {
+    if (this.shuttingDown) return;
+
     const classified = classifyMessage(
       evt,
       this.botUserId,
@@ -387,6 +412,7 @@ export class SlackAdapter implements MessageAdapter {
 
     // Resolve user name
     const userName = await this.resolveUser(userId);
+    if (this.shuttingDown) return;
 
     // Emit inbound message
     this.inboundHandler?.({
@@ -419,7 +445,7 @@ export class SlackAdapter implements MessageAdapter {
 
   private async addReaction(channel: string, ts: string, emoji: string): Promise<void> {
     try {
-      await callSlackAPI("reactions.add", this.config.botToken, {
+      await this.callSlack("reactions.add", this.config.botToken, {
         channel,
         timestamp: ts,
         name: emoji,
@@ -431,7 +457,7 @@ export class SlackAdapter implements MessageAdapter {
 
   private async removeReaction(channel: string, ts: string, emoji: string): Promise<void> {
     try {
-      await callSlackAPI("reactions.remove", this.config.botToken, {
+      await this.callSlack("reactions.remove", this.config.botToken, {
         channel,
         timestamp: ts,
         name: emoji,
@@ -445,9 +471,10 @@ export class SlackAdapter implements MessageAdapter {
     const cached = this.userNames.get(userId);
     if (cached) return cached;
     try {
-      const res = await callSlackAPI("users.info", this.config.botToken, {
+      const res = await this.callSlack("users.info", this.config.botToken, {
         user: userId,
       });
+      if (this.shuttingDown) return userId;
       const u = res.user as { real_name?: string; name?: string };
       const name = u.real_name ?? u.name ?? userId;
       this.userNames.set(userId, name);
@@ -460,7 +487,7 @@ export class SlackAdapter implements MessageAdapter {
 
   private async clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
     try {
-      await callSlackAPI("assistant.threads.setStatus", this.config.botToken, {
+      await this.callSlack("assistant.threads.setStatus", this.config.botToken, {
         channel_id: channelId,
         thread_ts: threadTs,
         status: "",
@@ -477,7 +504,7 @@ export class SlackAdapter implements MessageAdapter {
       { title: "Review", message: "Summarise the recent changes" },
     ];
     try {
-      await callSlackAPI("assistant.threads.setSuggestedPrompts", this.config.botToken, {
+      await this.callSlack("assistant.threads.setSuggestedPrompts", this.config.botToken, {
         channel_id: channelId,
         thread_ts: threadTs,
         prompts,

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -30,6 +30,8 @@ import {
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
   buildSlackRequest,
+  createAbortableOperationTracker,
+  abortableDelay,
   stripBotMention,
   isChannelId,
   FORM_METHODS,
@@ -333,6 +335,40 @@ describe("buildSlackRequest", () => {
         "application/x-www-form-urlencoded",
       );
     }
+  });
+});
+
+// ─── abort / shutdown helpers ───────────────────────────
+
+describe("abortableDelay", () => {
+  it("rejects with AbortError when the signal is aborted", async () => {
+    const controller = new AbortController();
+    const pending = abortableDelay(1_000, controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+});
+
+describe("createAbortableOperationTracker", () => {
+  it("aborts pending operations and waits for them to settle", async () => {
+    const tracker = createAbortableOperationTracker();
+    const pending = tracker.run(async (signal) => {
+      await abortableDelay(60_000, signal);
+    });
+
+    await tracker.abortAndWait();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(tracker.isAborting()).toBe(true);
+  });
+
+  it("rejects new operations after shutdown begins", async () => {
+    const tracker = createAbortableOperationTracker();
+    await tracker.abortAndWait();
+
+    await expect(tracker.run(async () => Promise.resolve())).rejects.toThrow(
+      "shutdown in progress",
+    );
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -145,6 +145,84 @@ export function buildSlackRequest(
   };
 }
 
+// ─── Abort / shutdown helpers ────────────────────────────
+
+export interface AbortableOperationTracker {
+  run<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T>;
+  abortAndWait(): Promise<void>;
+  isAborting(): boolean;
+}
+
+export function createAbortError(message = "Operation aborted"): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(createAbortError());
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    function onAbort(): void {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export function createAbortableOperationTracker(): AbortableOperationTracker {
+  let aborting = false;
+  const controllers = new Set<AbortController>();
+  const operations = new Set<Promise<unknown>>();
+
+  return {
+    async run<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+      if (aborting) {
+        throw createAbortError("Operation rejected: shutdown in progress");
+      }
+
+      const controller = new AbortController();
+      const tracked = Promise.resolve().then(() => operation(controller.signal));
+      controllers.add(controller);
+      operations.add(tracked);
+
+      try {
+        return await tracked;
+      } finally {
+        controllers.delete(controller);
+        operations.delete(tracked);
+      }
+    },
+
+    async abortAndWait(): Promise<void> {
+      aborting = true;
+      for (const controller of controllers) {
+        controller.abort();
+      }
+      if (operations.size === 0) return;
+      await Promise.allSettled(Array.from(operations));
+    },
+
+    isAborting(): boolean {
+      return aborting;
+    },
+  };
+}
+
 // ─── Mention stripping ───────────────────────────────────
 
 export function stripBotMention(text: string, botUserId: string): string {
@@ -1320,6 +1398,11 @@ export interface SlackResult {
   [key: string]: unknown;
 }
 
+export interface CallSlackAPIOptions {
+  signal?: AbortSignal;
+  retryCount?: number;
+}
+
 /**
  * Call Slack API with bounded retry logic (max 3 retries on rate limit).
  * Handles 429 rate-limit responses by waiting retry-after duration and retrying.
@@ -1329,19 +1412,24 @@ export async function callSlackAPI(
   method: string,
   token: string,
   body?: Record<string, unknown>,
-  _retryCount = 0,
+  options: CallSlackAPIOptions = {},
 ): Promise<SlackResult> {
+  const { signal, retryCount = 0 } = options;
   const { url, init } = buildSlackRequest(method, token, body);
-  const res = await fetch(url, init);
+  const res = await fetch(url, signal ? { ...init, signal } : init);
 
   if (res.status === 429) {
     const maxRetries = 3;
-    if (_retryCount >= maxRetries) {
+    if (retryCount >= maxRetries) {
       throw new Error(`Slack ${method}: rate limited after ${maxRetries} retries`);
     }
     const wait = Number(res.headers.get("retry-after") ?? "3");
-    await new Promise((r) => setTimeout(r, wait * 1000));
-    return callSlackAPI(method, token, body, _retryCount + 1);
+    if (signal) {
+      await abortableDelay(wait * 1000, signal);
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, wait * 1000));
+    }
+    return callSlackAPI(method, token, body, { signal, retryCount: retryCount + 1 });
   }
 
   const data = (await res.json()) as SlackResult;

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import slackBridge from "./index.js";
+
+type ToolDefinition = {
+  name: string;
+  execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+type CommandDefinition = {
+  description: string;
+  handler: (args: string, ctx: ExtensionContext) => Promise<void> | void;
+};
+
+type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+describe("slack-bridge top-level shutdown", () => {
+  const originalBotToken = process.env.SLACK_BOT_TOKEN;
+  const originalAppToken = process.env.SLACK_APP_TOKEN;
+  const originalHome = process.env.HOME;
+
+  beforeEach(() => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    process.env.SLACK_APP_TOKEN = "xapp-test";
+    process.env.HOME = "/tmp/slack-bridge-test-home";
+  });
+
+  afterEach(() => {
+    if (originalBotToken === undefined) {
+      delete process.env.SLACK_BOT_TOKEN;
+    } else {
+      process.env.SLACK_BOT_TOKEN = originalBotToken;
+    }
+
+    if (originalAppToken === undefined) {
+      delete process.env.SLACK_APP_TOKEN;
+    } else {
+      process.env.SLACK_APP_TOKEN = originalAppToken;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("aborts in-flight top-level Slack calls during session shutdown", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        const rejectAbort = () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        };
+
+        if (signal?.aborted) {
+          rejectAbort();
+          return;
+        }
+
+        signal?.addEventListener("abort", rejectAbort, { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const createChannel = tools.get("slack_create_channel");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(createChannel).toBeDefined();
+    expect(commands.has("pinet-start")).toBe(true);
+
+    await sessionStart?.({}, ctx);
+
+    const pending = createChannel!.execute("tool-call-1", { name: "shutdown-test" });
+
+    await sessionShutdown?.({}, ctx);
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(notify).not.toHaveBeenCalled();
+    expect(setStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -15,6 +15,8 @@ import {
   stripBotMention,
   isChannelId,
   callSlackAPI,
+  createAbortableOperationTracker,
+  isAbortError,
   buildAgentDisplayInfo,
   rankAgentsForRouting,
   evaluateRalphLoopCycle,
@@ -83,6 +85,12 @@ export default function (pi: ExtensionAPI) {
   const appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
 
   if (!botToken || !appToken) return;
+
+  let slackRequests = createAbortableOperationTracker();
+
+  async function slack(method: string, token: string, body?: Record<string, unknown>) {
+    return slackRequests.run((signal) => callSlackAPI(method, token, body, { signal }));
+  }
 
   // allowedUsers: settings.json takes priority, env var as fallback
   const allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
@@ -281,7 +289,7 @@ export default function (pi: ExtensionAPI) {
 
   async function addReaction(channel: string, ts: string, emoji: string): Promise<void> {
     try {
-      await callSlackAPI("reactions.add", botToken!, { channel, timestamp: ts, name: emoji });
+      await slack("reactions.add", botToken!, { channel, timestamp: ts, name: emoji });
     } catch {
       /* already_reacted or non-critical */
     }
@@ -289,7 +297,7 @@ export default function (pi: ExtensionAPI) {
 
   async function removeReaction(channel: string, ts: string, emoji: string): Promise<void> {
     try {
-      await callSlackAPI("reactions.remove", botToken!, { channel, timestamp: ts, name: emoji });
+      await slack("reactions.remove", botToken!, { channel, timestamp: ts, name: emoji });
     } catch {
       /* not_reacted or non-critical */
     }
@@ -299,7 +307,8 @@ export default function (pi: ExtensionAPI) {
     const cached = userNames.get(userId);
     if (cached) return cached;
     try {
-      const res = await callSlackAPI("users.info", botToken!, { user: userId });
+      const res = await slack("users.info", botToken!, { user: userId });
+      if (shuttingDown) return userId;
       const u = res.user as { real_name?: string; name?: string };
       const name = u.real_name ?? u.name ?? userId;
       userNames.set(userId, name);
@@ -323,7 +332,7 @@ export default function (pi: ExtensionAPI) {
         limit: 200,
       };
       if (cursor) body.cursor = cursor;
-      const res = await callSlackAPI("conversations.list", botToken!, body);
+      const res = await slack("conversations.list", botToken!, body);
       const channels = res.channels as { id: string; name: string }[];
       for (const ch of channels) {
         channelCache.set(ch.name, ch.id);
@@ -361,7 +370,7 @@ export default function (pi: ExtensionAPI) {
 
   async function clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
     try {
-      await callSlackAPI("assistant.threads.setStatus", botToken!, {
+      await slack("assistant.threads.setStatus", botToken!, {
         channel_id: channelId,
         thread_ts: threadTs,
         status: "",
@@ -378,7 +387,7 @@ export default function (pi: ExtensionAPI) {
       { title: "Review", message: `${agentName}, summarise the recent changes` },
     ];
     try {
-      await callSlackAPI("assistant.threads.setSuggestedPrompts", botToken!, {
+      await slack("assistant.threads.setSuggestedPrompts", botToken!, {
         channel_id: channelId,
         thread_ts: threadTs,
         prompts,
@@ -499,7 +508,7 @@ export default function (pi: ExtensionAPI) {
 
   async function resolveThreadOwner(channel: string, threadTs: string): Promise<string | null> {
     try {
-      const res = await callSlackAPI("conversations.replies", botToken!, {
+      const res = await slack("conversations.replies", botToken!, {
         channel,
         ts: threadTs,
         limit: 50,
@@ -527,7 +536,7 @@ export default function (pi: ExtensionAPI) {
     if (shuttingDown) return;
 
     try {
-      const res = await callSlackAPI("apps.connections.open", appToken!);
+      const res = await slack("apps.connections.open", appToken!);
       ws = new WebSocket(res.url as string);
 
       ws.addEventListener("open", () => setExtStatus(ctx, "ok"));
@@ -544,12 +553,16 @@ export default function (pi: ExtensionAPI) {
         /* close fires after */
       });
     } catch (err) {
-      console.error(`[slack-bridge] Socket Mode: ${msg(err)}`);
+      if (!isAbortError(err)) {
+        console.error(`[slack-bridge] Socket Mode: ${msg(err)}`);
+      }
       scheduleReconnect(ctx);
     }
   }
 
   async function handleFrame(raw: string, ctx: ExtensionContext): Promise<void> {
+    if (shuttingDown) return;
+
     try {
       const data = JSON.parse(raw) as Record<string, unknown>;
 
@@ -601,6 +614,8 @@ export default function (pi: ExtensionAPI) {
   // ─── Assistant events ───────────────────────────────
 
   async function onThreadStarted(evt: Record<string, unknown>): Promise<void> {
+    if (shuttingDown) return;
+
     const t = evt.assistant_thread as Record<string, unknown>;
     if (!t) return;
 
@@ -623,6 +638,8 @@ export default function (pi: ExtensionAPI) {
   }
 
   function onContextChanged(evt: Record<string, unknown>): void {
+    if (shuttingDown) return;
+
     const t = evt.assistant_thread as Record<string, unknown>;
     if (!t) return;
 
@@ -637,6 +654,8 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function onMessage(evt: Record<string, unknown>, ctx: ExtensionContext): Promise<void> {
+    if (shuttingDown) return;
+
     const text = (evt.text as string) ?? "";
     const user = evt.user as string;
     const threadTs = evt.thread_ts as string | undefined;
@@ -662,6 +681,7 @@ export default function (pi: ExtensionAPI) {
 
     if (!localOwner && !unclaimedThreads.has(effectiveTs)) {
       const remoteOwner = await resolveThreadOwner(channel, effectiveTs);
+      if (shuttingDown) return;
       if (remoteOwner && remoteOwner !== agentName) {
         const t = threads.get(effectiveTs);
         if (t) t.owner = remoteOwner; // cache so we skip instantly next time
@@ -678,7 +698,7 @@ export default function (pi: ExtensionAPI) {
 
     // ── User allowlist check ──
     if (!isUserAllowed(user)) {
-      await callSlackAPI("chat.postMessage", botToken!, {
+      await slack("chat.postMessage", botToken!, {
         channel,
         thread_ts: effectiveTs,
         text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
@@ -703,6 +723,7 @@ export default function (pi: ExtensionAPI) {
           : `${cleanText}\n\n❌ User denied security confirmation request in this thread.`;
 
     const name = await resolveUser(user);
+    if (shuttingDown) return;
     ctx.ui.notify(`${name}: ${cleanText.slice(0, 100)}`, "info");
 
     // React with 👀 to acknowledge (no chat lock)
@@ -740,7 +761,7 @@ export default function (pi: ExtensionAPI) {
     }, 5000);
   }
 
-  function disconnect(): void {
+  async function disconnect(): Promise<void> {
     shuttingDown = true;
     if (reconnectTimer) clearTimeout(reconnectTimer);
     reconnectTimer = null;
@@ -750,6 +771,7 @@ export default function (pi: ExtensionAPI) {
       /* ignore */
     }
     ws = null;
+    await slackRequests.abortAndWait();
   }
 
   function setExtStatus(
@@ -781,7 +803,7 @@ export default function (pi: ExtensionAPI) {
     securityPrompt,
     guardrails,
     inbox,
-    slack: callSlackAPI,
+    slack,
     getAgentName: () => agentName,
     getAgentEmoji: () => agentEmoji,
     getLastDmChannel: () => lastDmChannel,
@@ -1627,6 +1649,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     shuttingDown = false;
+    slackRequests = createAbortableOperationTracker();
     extCtx = ctx;
     const sessionHeader = (
       ctx.sessionManager as { getHeader?: () => { parentSession?: string } | null }
@@ -1792,10 +1815,12 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
-    flushPersist();
+    shuttingDown = true;
     stopBrokerHeartbeat();
     stopBrokerMaintenance();
     stopBrokerRalphLoop();
+    await disconnect();
+    flushPersist();
     if (activeBroker) {
       try {
         if (activeSelfId) {
@@ -1826,7 +1851,6 @@ export default function (pi: ExtensionAPI) {
       }
       brokerClient = null;
     }
-    disconnect();
     brokerRole = null;
     pinetEnabled = false;
     pinetRegistrationBlocked = false;

--- a/slack-bridge/slack-api.test.ts
+++ b/slack-bridge/slack-api.test.ts
@@ -32,9 +32,10 @@ describe("callSlackApi", () => {
     const fetchSpy = vi.fn(async () => makeResponse(200, { ok: true, channel: "C1" }));
     vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
 
-    await expect(callSlackApi("chat.postMessage", "xoxb-token", { text: "hi" })).resolves.toEqual(
-      { ok: true, channel: "C1" },
-    );
+    await expect(callSlackApi("chat.postMessage", "xoxb-token", { text: "hi" })).resolves.toEqual({
+      ok: true,
+      channel: "C1",
+    });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -51,10 +52,28 @@ describe("callSlackApi", () => {
       .mockResolvedValueOnce(makeResponse(200, { ok: true, channel: "C2" }));
     vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
 
-    await expect(callSlackApi("chat.postMessage", "xoxb-token", { text: "hi" })).resolves.toEqual(
-      { ok: true, channel: "C2" },
-    );
+    await expect(callSlackApi("chat.postMessage", "xoxb-token", { text: "hi" })).resolves.toEqual({
+      ok: true,
+      channel: "C2",
+    });
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts during 429 retry backoff when the signal is aborted", async () => {
+    const controller = new AbortController();
+    const fetchSpy = vi.fn(async () => makeResponse(429, { ok: false }, "10"));
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    const pending = callSlackApi(
+      "chat.postMessage",
+      "xoxb-token",
+      { text: "hi" },
+      { signal: controller.signal },
+    );
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("throws on Slack API errors", async () => {


### PR DESCRIPTION
## Summary
- add abortable Slack request tracking shared by the top-level slack-bridge and broker Slack adapter
- abort and await in-flight Slack API calls during disconnect/session shutdown
- add regression coverage for shutdown abort behavior and abortable helper utilities

Closes #135