### PR TITLE
fix: keep follower a2a traffic out of the Slack inbox (#175)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   buildAllowlist,
   isUserAllowed,
   formatInboxMessages,
+  formatPinetInboxMessages,
   getSqliteJournalMode,
   isSqliteWalEnabled,
   buildSqliteWalFallbackWarning,
@@ -22,6 +23,7 @@ import {
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
   isRalphNudgeEntry,
+  isAgentToAgentEntry,
   partitionFollowerInboxEntries,
   buildBrokerPromptGuidelines,
   buildIdentityReplyGuidelines,
@@ -261,6 +263,42 @@ describe("formatInboxMessages", () => {
     const result = formatInboxMessages(msgs, names);
     expect(result).toContain("will: first");
     expect(result).toContain("will: second");
+  });
+});
+
+describe("formatPinetInboxMessages", () => {
+  it("formats agent messages with reply guidance", () => {
+    const result = formatPinetInboxMessages([
+      {
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker-id",
+          body: "Take issue #175",
+          metadata: { senderAgent: "Broker Bunny", a2a: true },
+        },
+      },
+    ]);
+
+    expect(result).toContain("New Pinet messages:");
+    expect(result).toContain(
+      "[thread a2a:broker:worker] broker-id (Broker Bunny): Take issue #175",
+    );
+    expect(result).toContain("Reply via pinet_message.");
+  });
+
+  it("falls back to the sender id when no senderAgent metadata exists", () => {
+    const result = formatPinetInboxMessages([
+      {
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker-id",
+          body: "hello",
+          metadata: { a2a: true },
+        },
+      },
+    ]);
+
+    expect(result).toContain("[thread a2a:broker:worker] broker-id: hello");
   });
 });
 
@@ -1545,8 +1583,52 @@ describe("isRalphNudgeEntry", () => {
   });
 });
 
+describe("isAgentToAgentEntry", () => {
+  it("returns true for a2a thread ids", () => {
+    const entry: NudgeTestEntry = {
+      inboxId: 1,
+      message: {
+        threadId: "a2a:broker:worker",
+        sender: "broker",
+        body: "do work",
+        metadata: null,
+      },
+    };
+
+    expect(isAgentToAgentEntry(entry)).toBe(true);
+  });
+
+  it("returns true when a2a metadata is set", () => {
+    const entry: NudgeTestEntry = {
+      inboxId: 2,
+      message: {
+        threadId: "thread-1",
+        sender: "broker",
+        body: "do work",
+        metadata: { a2a: true },
+      },
+    };
+
+    expect(isAgentToAgentEntry(entry)).toBe(true);
+  });
+
+  it("returns false for regular slack threads", () => {
+    const entry: NudgeTestEntry = {
+      inboxId: 3,
+      message: {
+        threadId: "1712073599.123456",
+        sender: "U123",
+        body: "hello",
+        metadata: { channel: "C456" },
+      },
+    };
+
+    expect(isAgentToAgentEntry(entry)).toBe(false);
+  });
+});
+
 describe("partitionFollowerInboxEntries", () => {
-  it("separates nudges from regular messages", () => {
+  it("separates nudges, agent messages, and regular slack messages", () => {
     const entries: NudgeTestEntry[] = [
       {
         inboxId: 1,
@@ -1560,7 +1642,7 @@ describe("partitionFollowerInboxEntries", () => {
       {
         inboxId: 2,
         message: {
-          threadId: "t-1",
+          threadId: "1712073599.123456",
           sender: "U123",
           body: "hello",
           metadata: { channel: "C456" },
@@ -1571,27 +1653,29 @@ describe("partitionFollowerInboxEntries", () => {
         message: {
           threadId: "a2a:broker:worker",
           sender: "broker",
-          body: "second nudge",
-          metadata: { kind: "ralph_loop_nudge" },
+          body: "please take #175",
+          metadata: { a2a: true, senderAgent: "Broker Bunny" },
         },
       },
     ];
 
     const result = partitionFollowerInboxEntries(entries);
-    expect(result.nudges).toHaveLength(2);
+    expect(result.nudges).toHaveLength(1);
+    expect(result.agentMessages).toHaveLength(1);
     expect(result.regular).toHaveLength(1);
     expect(result.nudges[0].inboxId).toBe(1);
-    expect(result.nudges[1].inboxId).toBe(3);
+    expect(result.agentMessages[0].inboxId).toBe(3);
     expect(result.regular[0].inboxId).toBe(2);
   });
 
   it("returns empty arrays when no entries", () => {
     const result = partitionFollowerInboxEntries([]);
     expect(result.nudges).toEqual([]);
+    expect(result.agentMessages).toEqual([]);
     expect(result.regular).toEqual([]);
   });
 
-  it("puts all entries in regular when no nudges", () => {
+  it("puts all entries in regular when no nudges or agent messages", () => {
     const entries: NudgeTestEntry[] = [
       {
         inboxId: 1,
@@ -1605,6 +1689,7 @@ describe("partitionFollowerInboxEntries", () => {
     ];
     const result = partitionFollowerInboxEntries(entries);
     expect(result.nudges).toEqual([]);
+    expect(result.agentMessages).toEqual([]);
     expect(result.regular).toHaveLength(1);
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -99,6 +99,28 @@ export function formatInboxMessages(
   return `New Slack messages:\n${lines.join("\n")}\n\nACK briefly, do the work, report blockers immediately, report the outcome when done.`;
 }
 
+function getPinetSenderLabel(message: FollowerInboxEntry["message"]): string {
+  const senderId = message.sender?.trim() ?? "";
+  const senderAgent =
+    typeof message.metadata?.senderAgent === "string" ? message.metadata.senderAgent.trim() : "";
+
+  if (senderId && senderAgent && senderAgent !== senderId) {
+    return `${senderId} (${senderAgent})`;
+  }
+
+  return senderId || senderAgent || "unknown-agent";
+}
+
+export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string {
+  const lines = entries.map((entry) => {
+    const threadTs = entry.message.threadId ?? "";
+    const sender = getPinetSenderLabel(entry.message);
+    return `[thread ${threadTs}] ${sender}: ${entry.message.body ?? ""}`;
+  });
+
+  return `New Pinet messages:\n${lines.join("\n")}\n\nReply via pinet_message. ACK briefly, do the work, report blockers immediately, report the outcome when done.`;
+}
+
 // ─── Slack API encoding ──────────────────────────────────
 
 export const FORM_METHODS = new Set([
@@ -1349,7 +1371,7 @@ export async function callSlackAPI(
   return data;
 }
 
-// ─── Follower nudge detection (#102) ─────────────────────
+// ─── Follower inbox partitioning (#102, #175) ───────────
 
 export function isRalphNudgeEntry(entry: {
   message: { metadata?: Record<string, unknown> | null };
@@ -1357,19 +1379,29 @@ export function isRalphNudgeEntry(entry: {
   return entry.message.metadata?.kind === "ralph_loop_nudge";
 }
 
+export function isAgentToAgentEntry(entry: {
+  message: { threadId?: string; metadata?: Record<string, unknown> | null };
+}): boolean {
+  const threadId = entry.message.threadId ?? "";
+  return threadId.startsWith("a2a:") || entry.message.metadata?.a2a === true;
+}
+
 export function partitionFollowerInboxEntries<
-  T extends { message: { metadata?: Record<string, unknown> | null } },
->(entries: T[]): { nudges: T[]; regular: T[] } {
+  T extends { message: { threadId?: string; metadata?: Record<string, unknown> | null } },
+>(entries: T[]): { nudges: T[]; agentMessages: T[]; regular: T[] } {
   const nudges: T[] = [];
+  const agentMessages: T[] = [];
   const regular: T[] = [];
   for (const entry of entries) {
     if (isRalphNudgeEntry(entry)) {
       nudges.push(entry);
+    } else if (isAgentToAgentEntry(entry)) {
+      agentMessages.push(entry);
     } else {
       regular.push(entry);
     }
   }
-  return { nudges, regular };
+  return { nudges, agentMessages, regular };
 }
 
 // ─── Ralph cycle records (#103) ──────────────────────────

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -11,6 +11,7 @@ import {
   buildAllowlist,
   isUserAllowed as checkUserAllowed,
   formatInboxMessages,
+  formatPinetInboxMessages,
   formatAgentList,
   stripBotMention,
   isChannelId,
@@ -1444,8 +1445,8 @@ export default function (pi: ExtensionAPI) {
           const entries = await client.pollInbox();
           if (entries.length === 0) return;
 
-          // #102: Partition nudges from regular messages for direct delivery
-          const { nudges, regular } = partitionFollowerInboxEntries(entries);
+          // Partition nudges and a2a traffic out of the human Slack inbox flow.
+          const { nudges, agentMessages, regular } = partitionFollowerInboxEntries(entries);
 
           // Deliver nudges immediately via pi.sendUserMessage (followUp)
           if (nudges.length > 0) {
@@ -1466,7 +1467,20 @@ export default function (pi: ExtensionAPI) {
             }
           }
 
-          // Process regular messages through normal inbox flow
+          if (agentMessages.length > 0) {
+            const pinetPrompt = formatPinetInboxMessages(agentMessages);
+            try {
+              pi.sendUserMessage(pinetPrompt, { deliverAs: "followUp" });
+            } catch {
+              try {
+                pi.sendUserMessage(pinetPrompt);
+              } catch {
+                /* best effort */
+              }
+            }
+          }
+
+          // Process human Slack messages through the normal inbox flow.
           const synced = syncFollowerInboxEntries(regular, threads, agentName, lastDmChannel);
           for (const nextThread of synced.threadUpdates) {
             const existing = threads.get(nextThread.threadTs);


### PR DESCRIPTION
## Summary
- partition follower inbox polling into Ralph nudges, a2a Pinet traffic, and human Slack traffic
- deliver a2a follower messages as direct Pinet follow-ups instead of enqueueing them in the human Slack inbox flow
- add helper coverage for a2a detection, partitioning, and Pinet message formatting

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test