### PR TITLE
feat: add pinet-unfollow command (#176)

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -305,6 +305,64 @@ describe("BrokerClient — heartbeat / unregister", () => {
 
     client.disconnect();
   });
+
+  it("disconnectGracefully unregisters, stops heartbeat, and closes the socket", async () => {
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const registerPromise = client.register("GracefulBot", "👋");
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as { id: number };
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "grace-2",
+      name: "GracefulBot",
+      emoji: "👋",
+    });
+    await registerPromise;
+
+    const disconnectPromise = client.disconnectGracefully();
+    await waitFor(() => mock.received.length > 1);
+
+    const unregisterReq = JSON.parse(mock.received[1]) as { id: number; method: string };
+    expect(unregisterReq.method).toBe("unregister");
+
+    mock.respondTo(mock.connections[0], unregisterReq.id, { ok: true });
+    await disconnectPromise;
+
+    await waitFor(() => mock.connections[0]?.destroyed === true);
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(client.isConnected()).toBe(false);
+
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("disconnectGracefully still disconnects locally when unregister fails", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const registerPromise = client.register("GracefulBot", "👋");
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as { id: number };
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "grace-3",
+      name: "GracefulBot",
+      emoji: "👋",
+    });
+    await registerPromise;
+
+    const disconnectPromise = client.disconnectGracefully();
+    await waitFor(() => mock.received.length > 1);
+
+    const unregisterReq = JSON.parse(mock.received[1]) as { id: number; method: string };
+    expect(unregisterReq.method).toBe("unregister");
+
+    mock.respondError(mock.connections[0], unregisterReq.id, -32000, "broker unavailable");
+    await expect(disconnectPromise).rejects.toThrow("broker unavailable");
+    await waitFor(() => mock.connections[0]?.destroyed === true);
+    expect(client.isConnected()).toBe(false);
+  });
 });
 
 describe("BrokerClient — pollInbox", () => {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -154,6 +154,20 @@ export class BrokerClient {
     this.connected = false;
   }
 
+  async disconnectGracefully(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.stopHeartbeat();
+    try {
+      await this.unregister();
+    } finally {
+      this.disconnect();
+    }
+  }
+
   isConnected(): boolean {
     return this.connected;
   }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1541,6 +1541,33 @@ export default function (pi: ExtensionAPI) {
     setExtStatus(ctx, "ok");
   }
 
+  async function disconnectFollower(
+    ctx: ExtensionContext,
+  ): Promise<{ unregisterError: string | null }> {
+    const current = brokerClient;
+    brokerClient = null;
+
+    if (current?.pollInterval) {
+      clearInterval(current.pollInterval);
+      current.pollInterval = null;
+    }
+
+    let unregisterError: string | null = null;
+    if (current) {
+      try {
+        await current.client.disconnectGracefully();
+      } catch (err) {
+        unregisterError = msg(err);
+      }
+    }
+
+    brokerRole = null;
+    pinetEnabled = false;
+    setExtStatus(ctx, "off");
+
+    return { unregisterError };
+  }
+
   pi.registerCommand("pinet-follow", {
     description: "Connect to an existing Pinet broker as a follower",
     handler: async (_args, ctx) => {
@@ -1561,6 +1588,38 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.notify(`Pinet follow failed: ${msg(err)}`, "error");
         setExtStatus(ctx, "error");
       }
+    },
+  });
+
+  pi.registerCommand("pinet-unfollow", {
+    description: "Disconnect from the Pinet broker and keep working locally",
+    handler: async (_args, ctx) => {
+      if (!pinetEnabled || brokerRole == null) {
+        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
+        return;
+      }
+
+      if (brokerRole !== "follower") {
+        ctx.ui.notify(
+          "Pinet is running as broker; /pinet-unfollow only applies to followers.",
+          "warning",
+        );
+        return;
+      }
+
+      const { unregisterError } = await disconnectFollower(ctx);
+      if (unregisterError) {
+        ctx.ui.notify(
+          `Pinet follower disconnected locally, but broker deregistration failed: ${unregisterError}`,
+          "warning",
+        );
+        return;
+      }
+
+      ctx.ui.notify(
+        `${agentEmoji} ${agentName} — disconnected from broker; local session still running`,
+        "info",
+      );
     },
   });
 
@@ -1813,18 +1872,9 @@ export default function (pi: ExtensionAPI) {
     lastBrokerMaintenanceSignature = "";
     lastBrokerRalphLoopSignature = "";
     if (brokerClient) {
-      try {
-        if (brokerClient.pollInterval) {
-          clearInterval(brokerClient.pollInterval);
-        }
-        await brokerClient.client.unregister().catch(() => {
-          /* best effort */
-        });
-        brokerClient.client.disconnect();
-      } catch {
+      await disconnectFollower(ctx).catch(() => {
         /* best effort */
-      }
-      brokerClient = null;
+      });
     }
     disconnect();
     brokerRole = null;


### PR DESCRIPTION
## Summary
- add `/pinet-unfollow` for follower agents so they can cleanly leave the Pinet mesh and keep working locally
- add `BrokerClient.disconnectGracefully()` to stop heartbeats, unregister from the broker, and close the socket without reconnecting
- reuse the same follower disconnect path during session shutdown and cover the new broker client behavior with tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test