### PR TITLE
fix: tighten broker client typing (#126)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -53,7 +53,7 @@ import {
   type SecurityGuardrails,
 } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
-import { startBroker, type Broker, type BrokerDB } from "./broker/index.js";
+import { startBroker, type Broker } from "./broker/index.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { MessageRouter } from "./broker/router.js";
@@ -339,13 +339,12 @@ export default function (pi: ExtensionAPI) {
     if (!threadTs) return null;
 
     const existingThread = threads.get(threadTs);
+    const followerClient = brokerRole === "follower" ? brokerClient?.client : undefined;
     const resolved = await resolveFollowerThreadChannel(
       threadTs,
       existingThread,
       brokerRole,
-      brokerRole === "follower" && brokerClient?.client
-        ? (nextThreadTs) => brokerClient!.client.resolveThread(nextThreadTs)
-        : undefined,
+      followerClient ? (nextThreadTs) => followerClient.resolveThread(nextThreadTs) : undefined,
     );
 
     if (resolved.threadUpdate && resolved.changed) {
@@ -885,7 +884,7 @@ export default function (pi: ExtensionAPI) {
 
     brokerMaintenanceRunning = true;
     try {
-      const result = runBrokerMaintenancePass(activeBroker.db as BrokerDB, {
+      const result = runBrokerMaintenancePass(activeBroker.db, {
         brokerAgentId: activeSelfId,
         staleAfterMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
         busyAssignmentAgeMs: DEFAULT_BUSY_ASSIGNMENT_AGE_MS,
@@ -923,7 +922,7 @@ export default function (pi: ExtensionAPI) {
 
   function sendBrokerMaintenanceMessage(targetAgentId: string, body: string): void {
     if (!activeBroker || !activeSelfId) return;
-    const db = activeBroker.db as BrokerDB;
+    const db = activeBroker.db;
     const target = db.getAgentById(targetAgentId);
     if (!target) return;
 
@@ -947,7 +946,7 @@ export default function (pi: ExtensionAPI) {
     try {
       runBrokerMaintenance(ctx);
 
-      const db = activeBroker.db as BrokerDB;
+      const db = activeBroker.db;
       const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
 
       const workloads = db.getAllAgents().map((agent) => ({
@@ -1092,7 +1091,7 @@ export default function (pi: ExtensionAPI) {
 
       if (brokerRole === "broker" && activeBroker) {
         // Direct DB access for broker mode
-        const db = activeBroker.db as BrokerDB;
+        const db = activeBroker.db;
         const allAgents = db.getAgents();
         const target =
           allAgents.find((a: { id: string }) => a.id === params.to) ??
@@ -1132,7 +1131,7 @@ export default function (pi: ExtensionAPI) {
           details: { messageId: msg.id, target: target.name },
         };
       } else if (brokerRole === "follower" && brokerClient) {
-        const client = brokerClient.client as BrokerClient;
+        const client = brokerClient.client;
         const messageId = await client.sendAgentMessage(params.to, params.message);
 
         return {
@@ -1417,10 +1416,7 @@ export default function (pi: ExtensionAPI) {
     );
     applyBrokerIdentity(registration.name, registration.emoji);
 
-    const brokerClientRef: {
-      client: BrokerClient;
-      pollInterval: ReturnType<typeof setInterval> | null;
-    } = {
+    const brokerClientRef: BrokerClientRef = {
       client,
       pollInterval: null,
     };


### PR DESCRIPTION
## Summary
- remove redundant BrokerDB and BrokerClient casts from slack-bridge broker state handling
- reuse the existing Broker and BrokerClientRef types end-to-end instead of bypassing them with assertions
- keep follower broker client refs strongly typed when wiring polling state

Closes #126