### PR TITLE
fix: expire stale Slack confirmation state

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -40,9 +40,16 @@ import {
   isDirectMessageChannel,
   getFollowerReconnectUiUpdate,
   getFollowerOwnedThreadClaims,
+  normalizeThreadConfirmationState,
+  isThreadConfirmationStateEmpty,
+  confirmationRequestMatches,
+  consumeMatchingConfirmationRequest,
+  registerThreadConfirmationRequest,
+  DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
   type InboxMessage,
   type AgentDisplayInfo,
   type FollowerThreadState,
+  type ThreadConfirmationState,
 } from "./helpers.js";
 
 type NudgeTestEntry = {
@@ -1499,6 +1506,177 @@ describe("getFollowerOwnedThreadClaims", () => {
     ]);
 
     expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([]);
+  });
+});
+
+// ─── confirmation state cleanup ─────────────────────────
+
+describe("normalizeThreadConfirmationState", () => {
+  function makeState(): ThreadConfirmationState {
+    return {
+      pending: [],
+      approved: [],
+      rejected: [],
+    };
+  }
+
+  it("expires stale pending, approved, and rejected requests", () => {
+    const now = Date.now();
+    const fresh = now - 1_000;
+    const stale = now - DEFAULT_CONFIRMATION_REQUEST_TTL_MS - 1_000;
+    const state: ThreadConfirmationState = {
+      pending: [
+        { toolPattern: "bash", action: "fresh pending", requestedAt: fresh },
+        { toolPattern: "edit", action: "stale pending", requestedAt: stale },
+      ],
+      approved: [
+        { toolPattern: "write", action: "fresh approved", requestedAt: fresh },
+        { toolPattern: "memory_write", action: "stale approved", requestedAt: stale },
+      ],
+      rejected: [
+        { toolPattern: "bash", action: "fresh rejected", requestedAt: fresh },
+        { toolPattern: "edit", action: "stale rejected", requestedAt: stale },
+      ],
+    };
+
+    expect(normalizeThreadConfirmationState(state, now)).toEqual({
+      pending: [{ toolPattern: "bash", action: "fresh pending", requestedAt: fresh }],
+      approved: [{ toolPattern: "write", action: "fresh approved", requestedAt: fresh }],
+      rejected: [{ toolPattern: "bash", action: "fresh rejected", requestedAt: fresh }],
+    });
+  });
+
+  it("clears ambiguous pending requests instead of guessing which one a reply belongs to", () => {
+    const now = Date.now();
+    const state: ThreadConfirmationState = {
+      pending: [
+        { toolPattern: "bash", action: "first", requestedAt: now - 2_000 },
+        { toolPattern: "edit", action: "second", requestedAt: now - 1_000 },
+      ],
+      approved: [],
+      rejected: [],
+    };
+
+    expect(normalizeThreadConfirmationState(state, now).pending).toEqual([]);
+  });
+
+  it("detects when a confirmation state is empty", () => {
+    expect(isThreadConfirmationStateEmpty(makeState())).toBe(true);
+    expect(
+      isThreadConfirmationStateEmpty({
+        pending: [{ toolPattern: "bash", action: "run", requestedAt: Date.now() }],
+        approved: [],
+        rejected: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("confirmationRequestMatches", () => {
+  it("matches only when both tool pattern and action line up", () => {
+    const request = {
+      toolPattern: "bash",
+      action: "run: echo hello",
+      requestedAt: Date.now(),
+    };
+
+    expect(confirmationRequestMatches(request, "bash", "run: echo hello")).toBe(true);
+    expect(confirmationRequestMatches(request, "bash", "run: echo goodbye")).toBe(false);
+    expect(confirmationRequestMatches(request, "edit", "run: echo hello")).toBe(false);
+  });
+});
+
+describe("consumeMatchingConfirmationRequest", () => {
+  it("consumes only the exact approved or rejected action", () => {
+    const list = [
+      { toolPattern: "bash", action: "run: echo hello", requestedAt: Date.now() - 2_000 },
+      { toolPattern: "bash", action: "run: echo goodbye", requestedAt: Date.now() - 1_000 },
+    ];
+
+    const consumed = consumeMatchingConfirmationRequest(list, "bash", "run: echo goodbye");
+
+    expect(consumed?.action).toBe("run: echo goodbye");
+    expect(list.map((request) => request.action)).toEqual(["run: echo hello"]);
+    expect(consumeMatchingConfirmationRequest(list, "bash", "run: echo unknown")).toBeNull();
+  });
+});
+
+describe("registerThreadConfirmationRequest", () => {
+  it("creates a new pending request when the thread is clear", () => {
+    const now = Date.now();
+    const result = registerThreadConfirmationRequest(
+      { pending: [], approved: [], rejected: [] },
+      { toolPattern: "bash", action: "run: ls", requestedAt: now },
+      now,
+    );
+
+    expect(result.status).toBe("created");
+    expect(result.state.pending).toEqual([
+      { toolPattern: "bash", action: "run: ls", requestedAt: now },
+    ]);
+  });
+
+  it("refreshes an identical pending request without duplicating it", () => {
+    const now = Date.now();
+    const result = registerThreadConfirmationRequest(
+      {
+        pending: [{ toolPattern: "bash", action: "run: ls", requestedAt: now - 5_000 }],
+        approved: [],
+        rejected: [],
+      },
+      { toolPattern: "bash", action: "run: ls", requestedAt: now },
+      now,
+    );
+
+    expect(result.status).toBe("refreshed");
+    expect(result.state.pending).toEqual([
+      { toolPattern: "bash", action: "run: ls", requestedAt: now },
+    ]);
+  });
+
+  it("rejects a different pending request so a plain yes/no cannot bind to the wrong action", () => {
+    const now = Date.now();
+    const result = registerThreadConfirmationRequest(
+      {
+        pending: [{ toolPattern: "bash", action: "run: ls", requestedAt: now - 5_000 }],
+        approved: [],
+        rejected: [],
+      },
+      { toolPattern: "edit", action: "edit: README.md", requestedAt: now },
+      now,
+    );
+
+    expect(result.status).toBe("conflict");
+    expect(result.conflict).toEqual({
+      toolPattern: "bash",
+      action: "run: ls",
+      requestedAt: now - 5_000,
+    });
+    expect(result.state.pending).toEqual([
+      { toolPattern: "bash", action: "run: ls", requestedAt: now - 5_000 },
+    ]);
+  });
+
+  it("drops stale matching approvals when requesting a fresh confirmation for the same action", () => {
+    const now = Date.now();
+    const result = registerThreadConfirmationRequest(
+      {
+        pending: [],
+        approved: [{ toolPattern: "bash", action: "run: ls", requestedAt: now - 2_000 }],
+        rejected: [{ toolPattern: "bash", action: "run: cat", requestedAt: now - 1_000 }],
+      },
+      { toolPattern: "bash", action: "run: ls", requestedAt: now },
+      now,
+    );
+
+    expect(result.status).toBe("created");
+    expect(result.state.approved).toEqual([]);
+    expect(result.state.rejected).toEqual([
+      { toolPattern: "bash", action: "run: cat", requestedAt: now - 1_000 },
+    ]);
+    expect(result.state.pending).toEqual([
+      { toolPattern: "bash", action: "run: ls", requestedAt: now },
+    ]);
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { matchesToolPattern } from "./guardrails.js";
 
 // ─── Settings ────────────────────────────────────────────
 
@@ -1307,6 +1308,113 @@ export function resolveAgentIdentity(
 
   // 3. Fully generated
   return generateAgentName(seed);
+}
+
+// ─── Confirmation state cleanup ─────────────────────────
+
+export interface ConfirmationRequest {
+  toolPattern: string;
+  action: string;
+  requestedAt: number;
+}
+
+export interface ThreadConfirmationState {
+  pending: ConfirmationRequest[];
+  approved: ConfirmationRequest[];
+  rejected: ConfirmationRequest[];
+}
+
+export interface RegisterThreadConfirmationRequestResult {
+  state: ThreadConfirmationState;
+  status: "created" | "refreshed" | "conflict";
+  conflict?: ConfirmationRequest;
+}
+
+export const DEFAULT_CONFIRMATION_REQUEST_TTL_MS = 5 * 60_000;
+
+export function normalizeThreadConfirmationState(
+  state: ThreadConfirmationState,
+  now = Date.now(),
+  ttlMs = DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
+): ThreadConfirmationState {
+  const keepFresh = (request: ConfirmationRequest) => now - request.requestedAt < ttlMs;
+  const pending = state.pending.filter(keepFresh);
+
+  return {
+    pending: pending.length > 1 ? [] : pending,
+    approved: state.approved.filter(keepFresh),
+    rejected: state.rejected.filter(keepFresh),
+  };
+}
+
+export function isThreadConfirmationStateEmpty(state: ThreadConfirmationState): boolean {
+  return state.pending.length === 0 && state.approved.length === 0 && state.rejected.length === 0;
+}
+
+export function confirmationRequestMatches(
+  request: ConfirmationRequest,
+  toolName: string,
+  action: string,
+): boolean {
+  return matchesToolPattern(toolName, [request.toolPattern]) && request.action === action;
+}
+
+export function consumeMatchingConfirmationRequest(
+  list: ConfirmationRequest[],
+  toolName: string,
+  action: string,
+): ConfirmationRequest | null {
+  const idx = list.findIndex((request) => confirmationRequestMatches(request, toolName, action));
+  if (idx === -1) return null;
+  const [match] = list.splice(idx, 1);
+  return match;
+}
+
+export function registerThreadConfirmationRequest(
+  state: ThreadConfirmationState,
+  request: ConfirmationRequest,
+  now = Date.now(),
+): RegisterThreadConfirmationRequestResult {
+  const normalized = normalizeThreadConfirmationState(state, now);
+  const nextState: ThreadConfirmationState = {
+    pending: normalized.pending,
+    approved: normalized.approved.filter(
+      (entry) => !confirmationRequestMatches(entry, request.toolPattern, request.action),
+    ),
+    rejected: normalized.rejected.filter(
+      (entry) => !confirmationRequestMatches(entry, request.toolPattern, request.action),
+    ),
+  };
+  const existingPending = nextState.pending[0];
+
+  if (!existingPending) {
+    return {
+      state: {
+        ...nextState,
+        pending: [request],
+      },
+      status: "created",
+    };
+  }
+
+  if (
+    existingPending.toolPattern === request.toolPattern &&
+    existingPending.action === request.action
+  ) {
+    return {
+      state: {
+        ...nextState,
+        pending: [{ ...existingPending, requestedAt: request.requestedAt }],
+      },
+      status: "refreshed",
+    };
+  }
+
+  return {
+    state: nextState,
+    status: "conflict",
+    conflict: existingPending,
+  };
 }
 
 // ─── Slack API client (unified) ──────────────────────────

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -7,6 +7,8 @@ import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-me
 import {
   type InboxMessage,
   type AgentDisplayInfo,
+  type ConfirmationRequest,
+  type ThreadConfirmationState,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
   isUserAllowed as checkUserAllowed,
@@ -26,6 +28,7 @@ import {
   DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+  DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
   partitionFollowerInboxEntries,
   generateAgentName,
   resolveAgentIdentity,
@@ -39,6 +42,11 @@ import {
   resolveFollowerThreadChannel,
   getFollowerReconnectUiUpdate,
   getFollowerOwnedThreadClaims,
+  normalizeThreadConfirmationState,
+  isThreadConfirmationStateEmpty,
+  confirmationRequestMatches,
+  consumeMatchingConfirmationRequest,
+  registerThreadConfirmationRequest,
   trackBrokerInboundThread,
 } from "./helpers.js";
 import {
@@ -46,7 +54,6 @@ import {
   isConfirmationApproval,
   isConfirmationRejection,
   isToolBlocked,
-  matchesToolPattern,
   toolNeedsConfirmation,
   isBrokerForbiddenTool,
   buildBrokerToolGuardrailsPrompt,
@@ -198,21 +205,37 @@ export default function (pi: ExtensionAPI) {
   const channelCache = new TtlCache<string, string>({ maxSize: 500, ttlMs: 30 * 60 * 1000 });
   const unclaimedThreads = new TtlSet<string>({ maxSize: 5000, ttlMs: 5 * 60 * 1000 });
 
-  interface ConfirmationRequest {
-    toolPattern: string;
-    action: string;
-    requestedAt: number;
-  }
-
-  interface ThreadConfirmationState {
-    pending: ConfirmationRequest[];
-    approved: ConfirmationRequest[];
-    rejected: ConfirmationRequest[];
-  }
-
   const threadConfirmationStates = new Map<string, ThreadConfirmationState>();
 
+  function storeThreadConfirmationState(
+    threadTs: string,
+    state: ThreadConfirmationState,
+    now = Date.now(),
+  ): ThreadConfirmationState | null {
+    const normalized = normalizeThreadConfirmationState(
+      state,
+      now,
+      DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
+    );
+
+    if (isThreadConfirmationStateEmpty(normalized)) {
+      threadConfirmationStates.delete(threadTs);
+      return null;
+    }
+
+    threadConfirmationStates.set(threadTs, normalized);
+    return normalized;
+  }
+
+  function sweepThreadConfirmationStates(now = Date.now()): void {
+    for (const [threadTs, state] of threadConfirmationStates) {
+      storeThreadConfirmationState(threadTs, state, now);
+    }
+  }
+
   function getThreadConfirmationState(threadTs: string): ThreadConfirmationState {
+    sweepThreadConfirmationStates();
+
     let state = threadConfirmationStates.get(threadTs);
     if (!state) {
       state = { pending: [], approved: [], rejected: [] };
@@ -224,9 +247,7 @@ export default function (pi: ExtensionAPI) {
   function cleanupThreadConfirmationState(threadTs: string): void {
     const state = threadConfirmationStates.get(threadTs);
     if (!state) return;
-    if (state.pending.length === 0 && state.approved.length === 0 && state.rejected.length === 0) {
-      threadConfirmationStates.delete(threadTs);
-    }
+    storeThreadConfirmationState(threadTs, state);
   }
 
   // ─── State persistence ──────────────────────────────
@@ -388,25 +409,34 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
-  function removeMatchingToolPattern(
-    list: ConfirmationRequest[],
-    toolName: string,
-  ): ConfirmationRequest | null {
-    const idx = list.findIndex((req) => matchesToolPattern(toolName, [req.toolPattern]));
-    if (idx === -1) return null;
-    const [match] = list.splice(idx, 1);
-    return match;
+  function formatConfirmationAction(action: string): string {
+    return JSON.stringify(action);
   }
 
-  function registerConfirmationRequest(threadTs: string, tool: string, action: string): void {
-    getThreadConfirmationState(threadTs).pending.push({
-      toolPattern: tool,
-      action,
-      requestedAt: Date.now(),
-    });
+  function registerConfirmationRequest(
+    threadTs: string,
+    tool: string,
+    action: string,
+  ): { status: "created" | "refreshed" | "conflict"; conflict?: ConfirmationRequest } {
+    const now = Date.now();
+    const result = registerThreadConfirmationRequest(
+      getThreadConfirmationState(threadTs),
+      {
+        toolPattern: tool,
+        action,
+        requestedAt: now,
+      },
+      now,
+    );
+    storeThreadConfirmationState(threadTs, result.state, now);
+    return {
+      status: result.status,
+      conflict: result.conflict,
+    };
   }
 
   function consumeConfirmationReply(threadTs: string, text: string): { approved: boolean } | null {
+    sweepThreadConfirmationStates();
     const state = threadConfirmationStates.get(threadTs);
     if (!state || state.pending.length === 0) return null;
 
@@ -429,17 +459,22 @@ export default function (pi: ExtensionAPI) {
     return { approved: false };
   }
 
-  function getConfirmationDecision(threadTs: string, toolName: string): boolean | null {
+  function getConfirmationDecision(
+    threadTs: string,
+    toolName: string,
+    action: string,
+  ): boolean | null {
+    sweepThreadConfirmationStates();
     const state = threadConfirmationStates.get(threadTs);
     if (!state) return null;
 
-    const approved = removeMatchingToolPattern(state.approved, toolName);
+    const approved = consumeMatchingConfirmationRequest(state.approved, toolName, action);
     if (approved) {
       cleanupThreadConfirmationState(threadTs);
       return true;
     }
 
-    const rejected = removeMatchingToolPattern(state.rejected, toolName);
+    const rejected = consumeMatchingConfirmationRequest(state.rejected, toolName, action);
     if (rejected) {
       cleanupThreadConfirmationState(threadTs);
       return false;
@@ -448,7 +483,7 @@ export default function (pi: ExtensionAPI) {
     return null;
   }
 
-  function requireToolPolicy(toolName: string, threadTs: string | undefined): void {
+  function requireToolPolicy(toolName: string, threadTs: string | undefined, action: string): void {
     if (isToolBlocked(toolName, guardrails)) {
       throw new Error(`Tool "${toolName}" is blocked by Slack security guardrails.`);
     }
@@ -457,28 +492,41 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
+    const quotedAction = formatConfirmationAction(action);
     if (!threadTs) {
       throw new Error(
-        `Tool "${toolName}" requires confirmation. Include a thread_ts and call slack_confirm_action before executing this tool.`,
+        `Tool "${toolName}" requires confirmation for action ${quotedAction}. Include a thread_ts and call slack_confirm_action before executing this tool.`,
       );
     }
 
-    const decision = getConfirmationDecision(threadTs, toolName);
+    const decision = getConfirmationDecision(threadTs, toolName, action);
     if (decision === true) return;
     if (decision === false) {
-      throw new Error(`Tool "${toolName}" was denied by Slack user confirmation.`);
+      throw new Error(
+        `Tool "${toolName}" was denied by Slack user confirmation for action ${quotedAction}.`,
+      );
     }
 
+    sweepThreadConfirmationStates();
     const state = threadConfirmationStates.get(threadTs);
-    const pending = !!state?.pending.some((req) => matchesToolPattern(toolName, [req.toolPattern]));
-    if (!pending) {
+    const pendingMatch =
+      state?.pending.find((request) => confirmationRequestMatches(request, toolName, action)) ??
+      null;
+    if (pendingMatch) {
       throw new Error(
-        `Tool "${toolName}" requires confirmation. Call slack_confirm_action in thread ${threadTs} and wait for the user's approval first.`,
+        `Tool "${toolName}" requires confirmation for action ${quotedAction}. A matching confirmation request is already pending in thread ${threadTs}; wait for the user's approval first.`,
+      );
+    }
+
+    const pendingConflict = state?.pending[0];
+    if (pendingConflict) {
+      throw new Error(
+        `Thread ${threadTs} already has a pending confirmation for tool "${pendingConflict.toolPattern}" and action ${formatConfirmationAction(pendingConflict.action)}. Wait for a reply or expiry before requesting another action in the same thread.`,
       );
     }
 
     throw new Error(
-      `Tool "${toolName}" requires confirmation. Call slack_confirm_action in thread ${threadTs} and wait for the user's approval first.`,
+      `Tool "${toolName}" requires confirmation for action ${quotedAction}. Call slack_confirm_action in thread ${threadTs} with tool "${toolName}" and action ${quotedAction}, then wait for the user's approval first.`,
     );
   }
 
@@ -1084,7 +1132,7 @@ export default function (pi: ExtensionAPI) {
       message: Type.String({ description: "Message body" }),
     }),
     async execute(_id, params) {
-      requireToolPolicy("pinet_message", undefined);
+      requireToolPolicy("pinet_message", undefined, `to=${params.to} | message=${params.message}`);
 
       if (!pinetEnabled) {
         throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
@@ -1163,7 +1211,11 @@ export default function (pi: ExtensionAPI) {
       task: Type.Optional(Type.String({ description: "Optional natural-language task hint" })),
     }),
     async execute(_toolCallId, params) {
-      requireToolPolicy("pinet_agents", undefined);
+      requireToolPolicy(
+        "pinet_agents",
+        undefined,
+        `repo=${params.repo ?? ""} | branch=${params.branch ?? ""} | role=${params.role ?? ""} | required_tools=${params.required_tools ?? ""} | task=${params.task ?? ""}`,
+      );
 
       if (!pinetEnabled) {
         throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -19,12 +19,19 @@ export interface RegisterSlackToolsDeps {
   resolveFollowerReplyChannel: (threadTs: string | undefined) => Promise<string | null>;
   resolveChannel: (nameOrId: string) => Promise<string>;
   rememberChannel: (name: string, channelId: string) => void;
-  requireToolPolicy: (toolName: string, threadTs: string | undefined) => void;
+  requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
   trackOutboundThread: (threadTs: string, channelId: string) => void;
   claimThreadOwnership: (threadTs: string, channelId: string) => void;
   clearPendingEyes: (threadTs: string) => void;
   getThreadChannel: (threadTs: string) => string | null;
-  registerConfirmationRequest: (threadTs: string, tool: string, action: string) => void;
+  registerConfirmationRequest: (
+    threadTs: string,
+    tool: string,
+    action: string,
+  ) => {
+    status: "created" | "refreshed" | "conflict";
+    conflict?: { toolPattern: string; action: string };
+  };
 }
 
 function buildSlackInboxPromptGuidelines(
@@ -140,7 +147,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       ),
     }),
     async execute(_id, params) {
-      requireToolPolicy("slack_send", params.thread_ts);
+      requireToolPolicy(
+        "slack_send",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts ?? ""} | text=${params.text}`,
+      );
 
       const channel = (await resolveFollowerReplyChannel(params.thread_ts)) ?? getLastDmChannel();
       if (!channel) {
@@ -194,7 +205,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       limit: Type.Optional(Type.Number({ description: "Max messages (default 20)" })),
     }),
     async execute(_id, params) {
-      requireToolPolicy("slack_read", params.thread_ts);
+      requireToolPolicy(
+        "slack_read",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts} | limit=${params.limit ?? 20}`,
+      );
 
       const channel = getThreadChannel(params.thread_ts) ?? getLastDmChannel();
       if (!channel) {
@@ -237,7 +252,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       purpose: Type.Optional(Type.String({ description: "Channel purpose" })),
     }),
     async execute(_id, params) {
-      requireToolPolicy("slack_create_channel", undefined);
+      requireToolPolicy(
+        "slack_create_channel",
+        undefined,
+        `name=${params.name} | topic=${params.topic ?? ""} | purpose=${params.purpose ?? ""}`,
+      );
 
       const response = await slack("conversations.create", botToken, {
         name: params.name,
@@ -283,7 +302,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       thread_ts: Type.Optional(Type.String({ description: "Thread timestamp to reply in" })),
     }),
     async execute(_id, params) {
-      requireToolPolicy("slack_post_channel", params.thread_ts);
+      requireToolPolicy(
+        "slack_post_channel",
+        params.thread_ts,
+        `channel=${params.channel ?? defaultChannel ?? ""} | thread_ts=${params.thread_ts ?? ""} | text=${params.text}`,
+      );
 
       const resolvedThreadChannel = await resolveFollowerReplyChannel(params.thread_ts);
       const channelInput = params.channel ?? defaultChannel;
@@ -341,7 +364,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       limit: Type.Optional(Type.Number({ description: "Max messages to return (default 20)" })),
     }),
     async execute(_id, params) {
-      requireToolPolicy("slack_read_channel", params.thread_ts);
+      requireToolPolicy(
+        "slack_read_channel",
+        params.thread_ts,
+        `channel=${params.channel} | thread_ts=${params.thread_ts ?? ""} | limit=${params.limit ?? 20}`,
+      );
 
       const channelId = await resolveChannel(params.channel);
       const limit = params.limit ?? 20;
@@ -401,7 +428,28 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         `Action: ${params.action}\n\n` +
         `Reply *yes* to approve or *no* to reject.`;
 
-      registerConfirmationRequest(params.thread_ts, params.tool, params.action);
+      const registration = registerConfirmationRequest(
+        params.thread_ts,
+        params.tool,
+        params.action,
+      );
+      if (registration.status === "conflict") {
+        throw new Error(
+          `Thread ${params.thread_ts} already has a pending confirmation for tool "${registration.conflict?.toolPattern}" and action ${JSON.stringify(registration.conflict?.action ?? "")}. Wait for a reply or expiry before requesting another action in the same thread.`,
+        );
+      }
+
+      if (registration.status === "refreshed") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `A matching confirmation request is already pending in thread ${params.thread_ts}. Wait for the user's response via slack_inbox before proceeding.`,
+            },
+          ],
+          details: { thread_ts: params.thread_ts, tool: params.tool, status: registration.status },
+        };
+      }
 
       await slack("chat.postMessage", botToken, {
         channel: channelId,
@@ -420,7 +468,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             text: `Confirmation requested in thread ${params.thread_ts}. Wait for the user's response via slack_inbox before proceeding. If the user approves, continue with the action. If denied, inform them and skip the action.`,
           },
         ],
-        details: { thread_ts: params.thread_ts, tool: params.tool },
+        details: { thread_ts: params.thread_ts, tool: params.tool, status: registration.status },
       };
     },
   });


### PR DESCRIPTION
Closes #143

Supersedes #164 on a fresh branch from current `main`.

## Summary
- add a 5 minute TTL for pending / approved / rejected Slack confirmation entries
- cap pending confirmations per thread at 3, keeping the newest requests
- normalize and sweep confirmation state whenever the confirmation flow is touched
- delete empty per-thread confirmation state after cleanup
- add helper-level tests for TTL expiry, pending-cap behavior, and empty-state detection

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test