### PR TITLE
fix: detect psql binary path across platforms (#141)

### DIFF
--- a/neon-psql/README.md
+++ b/neon-psql/README.md
@@ -34,6 +34,7 @@ Global (`~/.pi/agent/settings.json`):
     "injectIntoBash": true,
     "injectPythonShim": true,
     "logPath": ".pi/neon-psql-tunnel.log",
+    "psqlBin": "/custom/path/to/psql",
     "sourceEnv": {
       "host": "DB_HOST",
       "port": "DB_PORT",
@@ -100,5 +101,16 @@ cp ~/.pi/agent/extensions/neon-psql/config.example.json ~/.pi/agent/extensions/n
 - `source_database`
 
 Unknown values are treated as literals. `source:ENV_NAME` copies from an arbitrary source env var.
+
+## psql binary lookup
+
+By default the extension resolves `psql` in this order:
+
+1. `psql` on `PATH`
+2. `/opt/homebrew/opt/libpq/bin/psql`
+3. `/usr/local/opt/libpq/bin/psql`
+4. `/usr/bin/psql`
+
+If your installation lives elsewhere, set `neon-psql.psqlBin` in settings.
 
 See `config.example.json`.

--- a/neon-psql/config.example.json
+++ b/neon-psql/config.example.json
@@ -3,6 +3,7 @@
   "injectIntoBash": true,
   "injectPythonShim": true,
   "logPath": ".pi/neon-psql-tunnel.log",
+  "psqlBin": "/custom/path/to/psql",
   "sourceEnv": {
     "host": "DB_HOST",
     "port": "DB_PORT",

--- a/neon-psql/index.ts
+++ b/neon-psql/index.ts
@@ -18,12 +18,12 @@ import {
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@gugu91/pi-ext-types/typebox";
 
+import { resolvePsqlBin } from "./psql-bin.js";
 import { loadConfig, type ResolvedConfig } from "./settings.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TUNNEL_SCRIPT = join(__dirname, "neon_socks_tunnel.py");
 const PYTHON_SHIM_DIR = join(__dirname, "python");
-const PSQL_BIN = "/opt/homebrew/opt/libpq/bin/psql";
 
 const SANDBOX_RUNTIME_ENTRY = join(
   getAgentDir(),
@@ -508,7 +508,7 @@ async function runPsqlQuery(
     });
   };
 
-  const child = spawn(PSQL_BIN, args, {
+  const child = spawn(resolvePsqlBin({ configuredPath: config.psqlBin }), args, {
     env: {
       ...process.env,
       ...injected,

--- a/neon-psql/package.json
+++ b/neon-psql/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@gugu91/pi-ext-types": "workspace:*"

--- a/neon-psql/psql-bin.test.ts
+++ b/neon-psql/psql-bin.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PSQL_FALLBACK_PATHS, findExecutableOnPath, resolvePsqlBin } from "./psql-bin.js";
+
+describe("findExecutableOnPath", () => {
+  it("returns the first executable found on PATH", () => {
+    const result = findExecutableOnPath(
+      "psql",
+      { PATH: "/bin:/custom/bin:/usr/bin" },
+      (candidatePath) => candidatePath === "/custom/bin/psql",
+    );
+
+    expect(result).toBe("/custom/bin/psql");
+  });
+
+  it("returns null when PATH is empty", () => {
+    expect(findExecutableOnPath("psql", { PATH: "" }, () => true)).toBeNull();
+  });
+});
+
+describe("resolvePsqlBin", () => {
+  it("uses the configured path when it is executable", () => {
+    const result = resolvePsqlBin({
+      configuredPath: " /custom/psql ",
+      isExecutable: (candidatePath) => candidatePath === "/custom/psql",
+    });
+
+    expect(result).toBe("/custom/psql");
+  });
+
+  it("throws when the configured path is not executable", () => {
+    expect(() =>
+      resolvePsqlBin({
+        configuredPath: "/missing/psql",
+        isExecutable: () => false,
+      }),
+    ).toThrow("Configured psql binary is not executable: /missing/psql");
+  });
+
+  it("prefers PATH before fallback locations", () => {
+    const result = resolvePsqlBin({
+      env: { PATH: "/bin:/usr/local/bin" },
+      isExecutable: (candidatePath) => candidatePath === "/usr/local/bin/psql",
+      fallbackPaths: ["/opt/homebrew/opt/libpq/bin/psql"],
+    });
+
+    expect(result).toBe("/usr/local/bin/psql");
+  });
+
+  it("falls back to known install locations when PATH lookup fails", () => {
+    const result = resolvePsqlBin({
+      env: { PATH: "/bin:/usr/local/bin" },
+      isExecutable: (candidatePath) => candidatePath === DEFAULT_PSQL_FALLBACK_PATHS[1],
+    });
+
+    expect(result).toBe(DEFAULT_PSQL_FALLBACK_PATHS[1]);
+  });
+
+  it("throws a helpful error when no binary can be found", () => {
+    expect(() =>
+      resolvePsqlBin({
+        env: { PATH: "/bin:/usr/local/bin" },
+        isExecutable: () => false,
+        fallbackPaths: ["/custom/fallback/psql"],
+      }),
+    ).toThrow(
+      "Unable to find a psql binary. Checked PATH and fallback paths: /custom/fallback/psql. Configure neon-psql.psqlBin if psql is installed elsewhere.",
+    );
+  });
+});

--- a/neon-psql/psql-bin.ts
+++ b/neon-psql/psql-bin.ts
@@ -1,0 +1,77 @@
+import * as fs from "node:fs";
+import { delimiter, join } from "node:path";
+
+export const DEFAULT_PSQL_FALLBACK_PATHS = [
+  "/opt/homebrew/opt/libpq/bin/psql",
+  "/usr/local/opt/libpq/bin/psql",
+  "/usr/bin/psql",
+] as const;
+
+export interface ResolvePsqlBinOptions {
+  configuredPath?: string;
+  env?: NodeJS.ProcessEnv;
+  isExecutable?: (candidatePath: string) => boolean;
+  fallbackPaths?: readonly string[];
+}
+
+function isExecutableFile(candidatePath: string): boolean {
+  try {
+    fs.accessSync(candidatePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeConfiguredPath(configuredPath?: string): string | undefined {
+  const trimmed = configuredPath?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function findExecutableOnPath(
+  binaryName: string,
+  env: NodeJS.ProcessEnv = process.env,
+  isExecutable: (candidatePath: string) => boolean = isExecutableFile,
+): string | null {
+  const pathValue = env.PATH ?? "";
+  for (const entry of pathValue.split(delimiter)) {
+    const dir = entry.trim();
+    if (!dir) continue;
+
+    const candidatePath = join(dir, binaryName);
+    if (isExecutable(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return null;
+}
+
+export function resolvePsqlBin(options: ResolvePsqlBinOptions = {}): string {
+  const isExecutable = options.isExecutable ?? isExecutableFile;
+  const configuredPath = normalizeConfiguredPath(options.configuredPath);
+
+  if (configuredPath) {
+    if (isExecutable(configuredPath)) {
+      return configuredPath;
+    }
+
+    throw new Error(`Configured psql binary is not executable: ${configuredPath}`);
+  }
+
+  const pathMatch = findExecutableOnPath("psql", options.env, isExecutable);
+  if (pathMatch) {
+    return pathMatch;
+  }
+
+  const fallbackPaths = options.fallbackPaths ?? DEFAULT_PSQL_FALLBACK_PATHS;
+  for (const candidatePath of fallbackPaths) {
+    if (isExecutable(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  throw new Error(
+    `Unable to find a psql binary. Checked PATH and fallback paths: ${fallbackPaths.join(", ")}. Configure neon-psql.psqlBin if psql is installed elsewhere.`,
+  );
+}

--- a/neon-psql/settings.test.ts
+++ b/neon-psql/settings.test.ts
@@ -149,4 +149,15 @@ describe("loadConfig", () => {
 
     expect(result?.logPath).toBe(absoluteLogPath);
   });
+
+  it("loads an optional psql binary override", () => {
+    fs.writeFileSync(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({ "neon-psql": { psqlBin: " /custom/psql " } }),
+    );
+
+    const result = loadConfig({ cwd, agentDir, extensionDir, env: {} });
+
+    expect(result?.psqlBin).toBe("/custom/psql");
+  });
 });

--- a/neon-psql/settings.ts
+++ b/neon-psql/settings.ts
@@ -55,6 +55,7 @@ export interface FileConfig {
   injectIntoBash?: boolean;
   injectPythonShim?: boolean;
   logPath?: string;
+  psqlBin?: string;
   sourceEnv?: Partial<SourceEnvConfig>;
   injectEnv?: Record<string, string>;
 }
@@ -64,6 +65,7 @@ export interface ResolvedConfig {
   injectIntoBash: boolean;
   injectPythonShim: boolean;
   logPath: string;
+  psqlBin?: string;
   sourceEnv: SourceEnvConfig;
   injectEnv: Record<string, string>;
 }
@@ -129,6 +131,7 @@ function normalizeConfig(cwd: string, source: RawConfigSource): ResolvedConfig |
     injectIntoBash: raw.injectIntoBash ?? true,
     injectPythonShim: raw.injectPythonShim ?? true,
     logPath: resolveLogPath(cwd, raw.logPath),
+    psqlBin: raw.psqlBin?.trim() || undefined,
     sourceEnv: {
       host: raw.sourceEnv?.host ?? DEFAULT_SOURCE_ENV.host,
       port: raw.sourceEnv?.port ?? DEFAULT_SOURCE_ENV.port,


### PR DESCRIPTION
## Summary
- replace the hardcoded Homebrew `psql` path with PATH lookup plus portable fallback locations
- add optional `neon-psql.psqlBin` config override for custom installs
- add neon-psql tests for binary resolution and enable the package test script in Turborepo

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test