### PR TITLE
fix: harden follower inbox delivery across restart

### DIFF
--- a/slack-bridge/follower-delivery.test.ts
+++ b/slack-bridge/follower-delivery.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  createFollowerDeliveryState,
+  drainFollowerAckBatches,
+  getFollowerShutdownAckIds,
+  hasDeliveredFollowerInboxIds,
+  isFollowerInboxIdTracked,
+  markFollowerAckBatchFailed,
+  markFollowerAckBatchSucceeded,
+  markFollowerInboxIdsDelivered,
+  queueFollowerInboxIds,
+  resetFollowerDeliveryState,
+  takeFollowerAckBatch,
+} from "./follower-delivery.js";
+
+describe("follower delivery state", () => {
+  it("keeps queued messages out of shutdown ACKs", () => {
+    const state = createFollowerDeliveryState();
+
+    queueFollowerInboxIds(state, [101, 102]);
+    markFollowerInboxIdsDelivered(state, [201]);
+
+    expect(getFollowerShutdownAckIds(state)).toEqual([201]);
+    expect(isFollowerInboxIdTracked(state, 101)).toBe(true);
+    expect(isFollowerInboxIdTracked(state, 102)).toBe(true);
+    expect(isFollowerInboxIdTracked(state, 201)).toBe(true);
+  });
+
+  it("keeps IDs tracked while ACK is in flight and clears them only on success", () => {
+    const state = createFollowerDeliveryState();
+
+    queueFollowerInboxIds(state, [301]);
+    markFollowerInboxIdsDelivered(state, [301]);
+
+    const batch = takeFollowerAckBatch(state);
+    expect(batch).toEqual([301]);
+    expect(isFollowerInboxIdTracked(state, 301)).toBe(true);
+    expect(hasDeliveredFollowerInboxIds(state)).toBe(false);
+
+    markFollowerAckBatchSucceeded(state, batch);
+    expect(isFollowerInboxIdTracked(state, 301)).toBe(false);
+  });
+
+  it("restores delivered IDs after an ACK failure so they can be retried", () => {
+    const state = createFollowerDeliveryState();
+
+    queueFollowerInboxIds(state, [401, 402]);
+    markFollowerInboxIdsDelivered(state, [401, 402]);
+
+    const batch = takeFollowerAckBatch(state);
+    markFollowerAckBatchFailed(state, batch);
+
+    expect(hasDeliveredFollowerInboxIds(state)).toBe(true);
+    expect(takeFollowerAckBatch(state)).toEqual([401, 402]);
+  });
+
+  it("waits for chained ACK batches before resolving", async () => {
+    const state = createFollowerDeliveryState();
+
+    markFollowerInboxIdsDelivered(state, [601]);
+
+    const batches: number[][] = [];
+    let releaseFirstBatch!: () => void;
+    const firstBatchReleased = new Promise<void>((resolve) => {
+      releaseFirstBatch = () => resolve();
+    });
+
+    const drainPromise = drainFollowerAckBatches(state, async (ids) => {
+      batches.push(ids);
+      if (ids[0] === 601) {
+        markFollowerInboxIdsDelivered(state, [602]);
+        await firstBatchReleased;
+      }
+    });
+
+    await Promise.resolve();
+    expect(isFollowerInboxIdTracked(state, 602)).toBe(true);
+
+    releaseFirstBatch();
+    await drainPromise;
+
+    expect(batches).toEqual([[601], [602]]);
+    expect(isFollowerInboxIdTracked(state, 601)).toBe(false);
+    expect(isFollowerInboxIdTracked(state, 602)).toBe(false);
+  });
+
+  it("resets all follower delivery state", () => {
+    const state = createFollowerDeliveryState();
+
+    queueFollowerInboxIds(state, [501]);
+    markFollowerInboxIdsDelivered(state, [502]);
+    const batch = takeFollowerAckBatch(state);
+    expect(batch).toEqual([502]);
+
+    resetFollowerDeliveryState(state);
+    expect(isFollowerInboxIdTracked(state, 501)).toBe(false);
+    expect(isFollowerInboxIdTracked(state, 502)).toBe(false);
+    expect(hasDeliveredFollowerInboxIds(state)).toBe(false);
+  });
+});

--- a/slack-bridge/follower-delivery.ts
+++ b/slack-bridge/follower-delivery.ts
@@ -1,0 +1,103 @@
+export interface FollowerDeliveryState {
+  queuedButUndeliveredIds: Set<number>;
+  deliveredAwaitingAckIds: Set<number>;
+  ackInFlightIds: Set<number>;
+}
+
+export function createFollowerDeliveryState(): FollowerDeliveryState {
+  return {
+    queuedButUndeliveredIds: new Set<number>(),
+    deliveredAwaitingAckIds: new Set<number>(),
+    ackInFlightIds: new Set<number>(),
+  };
+}
+
+export function resetFollowerDeliveryState(state: FollowerDeliveryState): void {
+  state.queuedButUndeliveredIds.clear();
+  state.deliveredAwaitingAckIds.clear();
+  state.ackInFlightIds.clear();
+}
+
+export function isFollowerInboxIdTracked(state: FollowerDeliveryState, inboxId: number): boolean {
+  return (
+    state.queuedButUndeliveredIds.has(inboxId) ||
+    state.deliveredAwaitingAckIds.has(inboxId) ||
+    state.ackInFlightIds.has(inboxId)
+  );
+}
+
+export function queueFollowerInboxIds(
+  state: FollowerDeliveryState,
+  inboxIds: Iterable<number>,
+): void {
+  for (const inboxId of inboxIds) {
+    state.queuedButUndeliveredIds.add(inboxId);
+  }
+}
+
+export function markFollowerInboxIdsDelivered(
+  state: FollowerDeliveryState,
+  inboxIds: Iterable<number>,
+): void {
+  for (const inboxId of inboxIds) {
+    state.queuedButUndeliveredIds.delete(inboxId);
+    state.deliveredAwaitingAckIds.add(inboxId);
+  }
+}
+
+export function hasDeliveredFollowerInboxIds(state: FollowerDeliveryState): boolean {
+  return state.deliveredAwaitingAckIds.size > 0;
+}
+
+export function takeFollowerAckBatch(state: FollowerDeliveryState): number[] {
+  const batch = [...state.deliveredAwaitingAckIds];
+  for (const inboxId of batch) {
+    state.deliveredAwaitingAckIds.delete(inboxId);
+    state.ackInFlightIds.add(inboxId);
+  }
+  return batch;
+}
+
+export function markFollowerAckBatchSucceeded(
+  state: FollowerDeliveryState,
+  inboxIds: Iterable<number>,
+): void {
+  for (const inboxId of inboxIds) {
+    state.ackInFlightIds.delete(inboxId);
+  }
+}
+
+export function markFollowerAckBatchFailed(
+  state: FollowerDeliveryState,
+  inboxIds: Iterable<number>,
+): void {
+  for (const inboxId of inboxIds) {
+    if (state.ackInFlightIds.delete(inboxId)) {
+      state.deliveredAwaitingAckIds.add(inboxId);
+    }
+  }
+}
+
+export async function drainFollowerAckBatches(
+  state: FollowerDeliveryState,
+  ackBatch: (inboxIds: number[]) => Promise<void>,
+): Promise<void> {
+  while (true) {
+    const batch = takeFollowerAckBatch(state);
+    if (batch.length === 0) {
+      return;
+    }
+
+    try {
+      await ackBatch(batch);
+      markFollowerAckBatchSucceeded(state, batch);
+    } catch {
+      markFollowerAckBatchFailed(state, batch);
+      return;
+    }
+  }
+}
+
+export function getFollowerShutdownAckIds(state: FollowerDeliveryState): number[] {
+  return [...state.deliveredAwaitingAckIds];
+}

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1443,6 +1443,7 @@ describe("syncFollowerInboxEntries", () => {
     const result = syncFollowerInboxEntries(
       [
         {
+          inboxId: 17,
           message: {
             threadId: "100.1",
             sender: "U_SENDER",
@@ -1458,6 +1459,7 @@ describe("syncFollowerInboxEntries", () => {
     );
     expect(result.inboxMessages).toHaveLength(1);
     expect(result.inboxMessages[0].channel).toBe("C_CHAN");
+    expect(result.inboxMessages[0].brokerInboxId).toBe(17);
     expect(result.threadUpdates).toHaveLength(1);
     expect(result.threadUpdates[0].channelId).toBe("C_CHAN");
     expect(result.changed).toBe(true);

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -63,6 +63,7 @@ export interface InboxMessage {
   text: string;
   timestamp: string;
   isChannelMention?: boolean;
+  brokerInboxId?: number;
 }
 
 export interface SqliteJournalModeResult {
@@ -976,6 +977,7 @@ export interface FollowerThreadState {
 }
 
 export interface FollowerInboxEntry {
+  inboxId?: number;
   message: {
     threadId?: string;
     sender?: string;
@@ -1044,6 +1046,7 @@ export function syncFollowerInboxEntries(
       userId: sender,
       text: entry.message.body ?? "",
       timestamp: entry.message.createdAt ?? "",
+      brokerInboxId: entry.inboxId,
     };
   });
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -77,6 +77,15 @@ import {
 import { BrokerClient, DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
 import { registerSlackTools } from "./slack-tools.js";
 import {
+  createFollowerDeliveryState,
+  drainFollowerAckBatches,
+  hasDeliveredFollowerInboxIds,
+  isFollowerInboxIdTracked,
+  markFollowerInboxIdsDelivered,
+  queueFollowerInboxIds,
+  resetFollowerDeliveryState,
+} from "./follower-delivery.js";
+import {
   buildTaskAssignmentReport,
   extractTaskAssignmentsFromMessage,
   hasTaskAssignmentStatusChange,
@@ -918,6 +927,8 @@ export default function (pi: ExtensionAPI) {
   let pinetRegistrationBlocked = false;
   let activeBroker: Broker | null = null;
   let brokerClient: BrokerClientRef | null = null;
+  const followerDeliveryState = createFollowerDeliveryState();
+  let followerAckPromise: Promise<void> | null = null;
   let activeRouter: MessageRouter | null = null;
   let activeSelfId: string | null = null;
   let brokerHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -1603,7 +1614,10 @@ export default function (pi: ExtensionAPI) {
       client,
       pollInterval: null,
     };
+    resetFollowerDeliveryState(followerDeliveryState);
+    followerAckPromise = null;
     let wasDisconnected = false;
+    let followerPollRunning = false;
 
     async function resumeThreadClaims(): Promise<void> {
       for (const thread of getFollowerOwnedThreadClaims(threads, agentName)) {
@@ -1618,70 +1632,83 @@ export default function (pi: ExtensionAPI) {
     function startPolling(): void {
       if (brokerClientRef.pollInterval) return;
       brokerClientRef.pollInterval = setInterval(async () => {
-        if (!pinetEnabled) return;
+        if (!pinetEnabled || followerPollRunning) return;
+
+        followerPollRunning = true;
         try {
           const entries = await client.pollInbox();
-          if (entries.length === 0) return;
+          const newEntries = entries.filter(
+            (entry) => !isFollowerInboxIdTracked(followerDeliveryState, entry.inboxId),
+          );
+          if (newEntries.length === 0) {
+            if (hasDeliveredFollowerInboxIds(followerDeliveryState)) {
+              void flushDeliveredFollowerAcks();
+            }
+            return;
+          }
 
           // Partition nudges and a2a traffic out of the human Slack inbox flow.
-          const { nudges, agentMessages, regular } = partitionFollowerInboxEntries(entries);
+          const { nudges, agentMessages, regular } = partitionFollowerInboxEntries(newEntries);
 
-          // Deliver nudges immediately via pi.sendUserMessage (followUp)
           if (nudges.length > 0) {
             const nudgeText = nudges
               .map((n) => n.message.body ?? "")
               .filter(Boolean)
               .join("\n");
-            if (nudgeText) {
-              try {
-                pi.sendUserMessage(nudgeText, { deliverAs: "followUp" });
-              } catch {
-                try {
-                  pi.sendUserMessage(nudgeText);
-                } catch {
-                  /* best effort */
-                }
-              }
+            if (nudgeText && deliverFollowUpMessage(nudgeText)) {
+              markFollowerInboxIdsDelivered(
+                followerDeliveryState,
+                nudges.flatMap((entry) =>
+                  typeof entry.inboxId === "number" ? [entry.inboxId] : [],
+                ),
+              );
+              void flushDeliveredFollowerAcks();
             }
           }
 
           if (agentMessages.length > 0) {
             const pinetPrompt = formatPinetInboxMessages(agentMessages);
-            try {
-              pi.sendUserMessage(pinetPrompt, { deliverAs: "followUp" });
-            } catch {
-              try {
-                pi.sendUserMessage(pinetPrompt);
-              } catch {
-                /* best effort */
-              }
+            if (deliverFollowUpMessage(pinetPrompt)) {
+              markFollowerInboxIdsDelivered(
+                followerDeliveryState,
+                agentMessages.flatMap((entry) =>
+                  typeof entry.inboxId === "number" ? [entry.inboxId] : [],
+                ),
+              );
+              void flushDeliveredFollowerAcks();
             }
           }
 
           // Process human Slack messages through the normal inbox flow.
-          const synced = syncFollowerInboxEntries(regular, threads, agentName, lastDmChannel);
-          for (const nextThread of synced.threadUpdates) {
-            const existing = threads.get(nextThread.threadTs);
-            if (!existing) {
-              threads.set(nextThread.threadTs, { ...nextThread });
-              continue;
+          if (regular.length > 0) {
+            const synced = syncFollowerInboxEntries(regular, threads, agentName, lastDmChannel);
+            for (const nextThread of synced.threadUpdates) {
+              const existing = threads.get(nextThread.threadTs);
+              if (!existing) {
+                threads.set(nextThread.threadTs, { ...nextThread });
+                continue;
+              }
+              existing.channelId = nextThread.channelId;
+              existing.threadTs = nextThread.threadTs;
+              existing.userId = nextThread.userId;
+              existing.owner = nextThread.owner;
             }
-            existing.channelId = nextThread.channelId;
-            existing.threadTs = nextThread.threadTs;
-            existing.userId = nextThread.userId;
-            existing.owner = nextThread.owner;
+            lastDmChannel = synced.lastDmChannel;
+            inbox.push(...synced.inboxMessages);
+            queueFollowerInboxIds(
+              followerDeliveryState,
+              regular.flatMap((entry) =>
+                typeof entry.inboxId === "number" ? [entry.inboxId] : [],
+              ),
+            );
+            if (synced.changed) persistState();
+            updateBadge();
+            if (ctx.isIdle?.()) drainInbox();
           }
-          lastDmChannel = synced.lastDmChannel;
-          inbox.push(...synced.inboxMessages);
-
-          // ACK all entries (nudges + regular)
-          const ids = entries.map((entry) => entry.inboxId);
-          if (synced.changed) persistState();
-          if (ids.length > 0) await client.ackMessages(ids);
-          updateBadge();
-          if (ctx.isIdle?.()) drainInbox();
         } catch {
           /* broker may be restarting */
+        } finally {
+          followerPollRunning = false;
         }
       }, 2000);
     }
@@ -1691,6 +1718,7 @@ export default function (pi: ExtensionAPI) {
         clearInterval(brokerClientRef.pollInterval);
         brokerClientRef.pollInterval = null;
       }
+      followerPollRunning = false;
     }
 
     client.onDisconnect(() => {
@@ -1716,6 +1744,9 @@ export default function (pi: ExtensionAPI) {
           /* best effort */
         });
         startPolling();
+        if (hasDeliveredFollowerInboxIds(followerDeliveryState)) {
+          void flushDeliveredFollowerAcks();
+        }
         setExtStatus(ctx, "ok");
         const uiUpdate = getFollowerReconnectUiUpdate("reconnect", wasDisconnected);
         wasDisconnected = uiUpdate.nextWasDisconnected;
@@ -1737,12 +1768,15 @@ export default function (pi: ExtensionAPI) {
     ctx: ExtensionContext,
   ): Promise<{ unregisterError: string | null }> {
     const current = brokerClient;
-    brokerClient = null;
 
     if (current?.pollInterval) {
       clearInterval(current.pollInterval);
       current.pollInterval = null;
     }
+
+    await flushDeliveredFollowerAcks().catch(() => {
+      /* best effort */
+    });
 
     let unregisterError: string | null = null;
     if (current) {
@@ -1753,6 +1787,9 @@ export default function (pi: ExtensionAPI) {
       }
     }
 
+    brokerClient = null;
+    resetFollowerDeliveryState(followerDeliveryState);
+    followerAckPromise = null;
     brokerRole = null;
     pinetEnabled = false;
     setExtStatus(ctx, "off");
@@ -1979,11 +2016,54 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  function deliverFollowUpMessage(text: string): boolean {
+    try {
+      pi.sendUserMessage(text, { deliverAs: "followUp" });
+      return true;
+    } catch {
+      try {
+        pi.sendUserMessage(text);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  function getFollowerBrokerInboxIds(messages: InboxMessage[]): number[] {
+    return [
+      ...new Set(
+        messages.flatMap((message) => (message.brokerInboxId ? [message.brokerInboxId] : [])),
+      ),
+    ];
+  }
+
+  async function flushDeliveredFollowerAcks(): Promise<void> {
+    if (followerAckPromise) {
+      await followerAckPromise;
+      return;
+    }
+    if (brokerRole !== "follower" || !brokerClient?.client) return;
+
+    const client = brokerClient.client;
+    const promise = drainFollowerAckBatches(followerDeliveryState, async (ids) => {
+      await client.ackMessages(ids);
+    }).finally(() => {
+      if (followerAckPromise === promise) {
+        followerAckPromise = null;
+      }
+    });
+
+    followerAckPromise = promise;
+    await promise;
+  }
+
   // Drain inbox: set thinking status, send to agent
   function drainInbox(): void {
     if (inbox.length === 0) return;
 
     const pending = inbox.splice(0, inbox.length);
+    const deliveredFollowerIds = getFollowerBrokerInboxIds(pending);
     updateBadge();
     reportStatus("working");
 
@@ -1994,16 +2074,16 @@ export default function (pi: ExtensionAPI) {
       prompt = securityPrompt + "\n\n" + prompt;
     }
 
-    try {
-      pi.sendUserMessage(prompt, { deliverAs: "followUp" });
-    } catch {
-      try {
-        pi.sendUserMessage(prompt);
-      } catch {
-        inbox.push(...pending);
-        updateBadge();
+    if (deliverFollowUpMessage(prompt)) {
+      if (deliveredFollowerIds.length > 0) {
+        markFollowerInboxIdsDelivered(followerDeliveryState, deliveredFollowerIds);
+        void flushDeliveredFollowerAcks();
       }
+      return;
     }
+
+    inbox.push(...pending);
+    updateBadge();
   }
 
   // Hard-block forbidden tools when broker role is active.
@@ -2073,6 +2153,9 @@ export default function (pi: ExtensionAPI) {
         /* best effort */
       });
     }
+    resetFollowerDeliveryState(followerDeliveryState);
+    followerAckPromise = null;
+    disconnect();
     brokerRole = null;
     pinetEnabled = false;
     pinetRegistrationBlocked = false;


### PR DESCRIPTION
## Summary
- replace the PR #158 approach with a fresh follower delivery state machine that separates queued, delivered, and ack-in-flight inbox IDs
- defer follower ACKs until messages are actually handed to `pi.sendUserMessage()`, keep dedup active until the ACK round-trip completes, and only flush delivered IDs on shutdown
- add focused follower delivery tests plus broker inbox ID coverage in `syncFollowerInboxEntries`

## Why fresh instead of salvaging PR #158
PR #158 had the right direction but the review correctly pointed out two remaining races:
- queued-but-undrained messages could still be ACKed on shutdown and lost
- IDs stopped being deduped before `ackMessages()` finished, so a slow ACK could re-enqueue duplicates

This PR keeps the same at-least-once goal but reworks the lifecycle to address those review findings directly.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #136
