### PR TITLE
test: cover neon-psql core query helpers (#149)

### DIFF
--- a/neon-psql/helpers.test.ts
+++ b/neon-psql/helpers.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInjectedValues,
+  deriveEndpoint,
+  encodeConnectionUrl,
+  isReadOnlyQuery,
+  mergePathValue,
+  needsSsl,
+  type InjectedValuesState,
+  type SourceValues,
+} from "./helpers.js";
+
+const source: SourceValues = {
+  host: "ep-cool-river.us-east-1.aws.neon.tech",
+  port: "5432",
+  user: "user@example.com",
+  password: "pa:ss/word?",
+  database: "db/name",
+};
+
+const state: InjectedValuesState = {
+  port: 6543,
+  endpoint: "ep-cool-river",
+  logPath: "/tmp/neon.log",
+  source,
+  requiresSsl: true,
+};
+
+describe("needsSsl", () => {
+  it("disables ssl for local hosts", () => {
+    expect(needsSsl("localhost")).toBe(false);
+    expect(needsSsl("127.0.0.1")).toBe(false);
+    expect(needsSsl("::1")).toBe(false);
+  });
+
+  it("requires ssl for remote hosts", () => {
+    expect(needsSsl("example.neon.tech")).toBe(true);
+  });
+});
+
+describe("deriveEndpoint", () => {
+  it("derives the neon endpoint from remote hosts", () => {
+    expect(deriveEndpoint("ep-cool-river.us-east-1.aws.neon.tech")).toBe("ep-cool-river");
+  });
+
+  it("returns empty string for local hosts", () => {
+    expect(deriveEndpoint("localhost")).toBe("");
+  });
+});
+
+describe("mergePathValue", () => {
+  it("prepends values to an existing PATH-like value", () => {
+    expect(mergePathValue("/shim", "/usr/bin:/bin")).toBe("/shim:/usr/bin:/bin");
+  });
+
+  it("returns the new value when there is no existing path", () => {
+    expect(mergePathValue("/shim", undefined)).toBe("/shim");
+  });
+});
+
+describe("encodeConnectionUrl", () => {
+  it("encodes credentials, database names, sslmode, and endpoint", () => {
+    expect(encodeConnectionUrl("postgresql", source, 6543, "require", "ep-cool-river")).toBe(
+      "postgresql://user%40example.com:pa%3Ass%2Fword%3F@127.0.0.1:6543/db%2Fname?sslmode=require&options=endpoint%3Dep-cool-river",
+    );
+  });
+
+  it("omits query parameters when ssl and endpoint are absent", () => {
+    expect(encodeConnectionUrl("postgresql", source, 6543, null, "")).toBe(
+      "postgresql://user%40example.com:pa%3Ass%2Fword%3F@127.0.0.1:6543/db%2Fname",
+    );
+  });
+});
+
+describe("buildInjectedValues", () => {
+  it("builds the injected connection env values", () => {
+    const result = buildInjectedValues(
+      {
+        path: "/tmp/config.json",
+        injectPythonShim: true,
+        injectEnv: {
+          DATABASE_URL: "postgres_url",
+          ASYNCPG_DSN: "asyncpg_dsn",
+          PGOPTIONS: "pgoptions",
+          PGSSLMODE: "sslmode",
+          SOURCE_COPY: "source:CUSTOM_ENV",
+        },
+      },
+      state,
+      {
+        pythonShimDir: "/opt/pi/python",
+        env: { PYTHONPATH: "/workspace/site-packages", CUSTOM_ENV: "from-env" },
+      },
+    );
+
+    expect(result.DATABASE_URL).toBe(
+      "postgresql://user%40example.com:pa%3Ass%2Fword%3F@127.0.0.1:6543/db%2Fname?sslmode=require&options=endpoint%3Dep-cool-river",
+    );
+    expect(result.ASYNCPG_DSN).toBe(
+      "postgresql://user%40example.com:pa%3Ass%2Fword%3F@127.0.0.1:6543/db%2Fname?ssl=require&options=endpoint%3Dep-cool-river",
+    );
+    expect(result.PGOPTIONS).toBe("endpoint=ep-cool-river");
+    expect(result.PGSSLMODE).toBe("require");
+    expect(result.SOURCE_COPY).toBe("from-env");
+    expect(result.PYTHONPATH).toBe("/opt/pi/python:/workspace/site-packages");
+  });
+
+  it("uses disable ssl mode for local tunnels", () => {
+    const result = buildInjectedValues(
+      {
+        path: "/tmp/config.json",
+        injectPythonShim: false,
+        injectEnv: { PGSSLMODE: "sslmode", PGOPTIONS: "pgoptions" },
+      },
+      { ...state, endpoint: "", requiresSsl: false },
+    );
+
+    expect(result.PGSSLMODE).toBe("disable");
+    expect(result.PGOPTIONS).toBe("");
+  });
+});
+
+describe("isReadOnlyQuery", () => {
+  it("allows basic read-only statements", () => {
+    expect(isReadOnlyQuery("SELECT * FROM users")).toBe(true);
+    expect(isReadOnlyQuery("WITH t AS (SELECT 1) SELECT * FROM t")).toBe(true);
+    expect(isReadOnlyQuery("SHOW search_path")).toBe(true);
+    expect(isReadOnlyQuery("VALUES (1), (2)")).toBe(true);
+    expect(isReadOnlyQuery("TABLE pg_tables")).toBe(true);
+  });
+
+  it("allows explain for read-only statements", () => {
+    expect(isReadOnlyQuery("EXPLAIN SELECT 1")).toBe(true);
+    expect(isReadOnlyQuery("EXPLAIN ANALYZE SELECT 1")).toBe(true);
+    expect(isReadOnlyQuery("EXPLAIN (ANALYZE, FORMAT JSON) SELECT 1")).toBe(true);
+  });
+
+  it("allows read-only psql inspection meta commands", () => {
+    expect(isReadOnlyQuery("\\d users")).toBe(true);
+    expect(isReadOnlyQuery("/* comment */ \\dt+")).toBe(true);
+    expect(isReadOnlyQuery("\\conninfo")).toBe(true);
+  });
+
+  it("rejects empty and comment-only queries", () => {
+    expect(isReadOnlyQuery("")).toBe(false);
+    expect(isReadOnlyQuery("   ")).toBe(false);
+    expect(isReadOnlyQuery("-- just a comment")).toBe(false);
+  });
+
+  it("rejects write statements", () => {
+    expect(isReadOnlyQuery("INSERT INTO users VALUES (1)")).toBe(false);
+    expect(isReadOnlyQuery("UPDATE users SET admin = true")).toBe(false);
+    expect(isReadOnlyQuery("DELETE FROM users")).toBe(false);
+    expect(isReadOnlyQuery("CREATE TABLE users(id int)")).toBe(false);
+    expect(isReadOnlyQuery("ALTER TABLE users ADD COLUMN name text")).toBe(false);
+    expect(isReadOnlyQuery("DROP TABLE users")).toBe(false);
+    expect(isReadOnlyQuery("TRUNCATE users")).toBe(false);
+  });
+
+  it("rejects known read-only guard bypasses", () => {
+    expect(isReadOnlyQuery("SELECT 1; DELETE FROM users")).toBe(false);
+    expect(isReadOnlyQuery("WITH gone AS (DELETE FROM users RETURNING *) SELECT * FROM gone")).toBe(
+      false,
+    );
+    expect(isReadOnlyQuery("EXPLAIN ANALYZE DELETE FROM users")).toBe(false);
+    expect(isReadOnlyQuery("SELECT * INTO backup_users FROM users")).toBe(false);
+    expect(isReadOnlyQuery("SELECT * FROM users FOR UPDATE")).toBe(false);
+    expect(isReadOnlyQuery("SELECT 1 \\gexec")).toBe(false);
+    expect(isReadOnlyQuery("\\d users\nDELETE FROM users")).toBe(false);
+    expect(isReadOnlyQuery("\\gexec")).toBe(false);
+    expect(isReadOnlyQuery("\\! echo hacked")).toBe(false);
+    expect(isReadOnlyQuery("\\copy users to '/tmp/users.csv'")).toBe(false);
+  });
+
+  it("ignores comments and quoted content while validating", () => {
+    expect(isReadOnlyQuery("/* outer /* nested */ still comment */ SELECT ';' AS value")).toBe(
+      true,
+    );
+    expect(isReadOnlyQuery('SELECT "delete" FROM users')).toBe(true);
+    expect(isReadOnlyQuery("SELECT $$; DELETE FROM users$$")).toBe(true);
+  });
+});

--- a/neon-psql/helpers.ts
+++ b/neon-psql/helpers.ts
@@ -1,0 +1,397 @@
+import { delimiter } from "node:path";
+
+import type { ResolvedConfig } from "./settings.js";
+
+const READ_ONLY_LEAD_KEYWORDS = new Set(["select", "with", "show", "values", "table"]);
+const SAFE_PSQL_INSPECTION_COMMANDS = new Set([
+  "conninfo",
+  "d",
+  "da",
+  "db",
+  "dc",
+  "dd",
+  "dD",
+  "df",
+  "dFd",
+  "dFp",
+  "dFt",
+  "dg",
+  "di",
+  "dl",
+  "dm",
+  "dn",
+  "do",
+  "dp",
+  "ds",
+  "dt",
+  "dT",
+  "du",
+  "dv",
+  "dx",
+  "l",
+  "list",
+]);
+const MUTATING_SQL_TOKENS = new Set([
+  "insert",
+  "update",
+  "delete",
+  "merge",
+  "into",
+  "create",
+  "alter",
+  "drop",
+  "truncate",
+  "copy",
+  "grant",
+  "revoke",
+  "comment",
+  "refresh",
+  "reindex",
+  "cluster",
+  "vacuum",
+  "analyze",
+  "call",
+  "do",
+  "lock",
+  "discard",
+  "set",
+  "reset",
+  "begin",
+  "start",
+  "commit",
+  "rollback",
+  "savepoint",
+  "release",
+  "prepare",
+  "execute",
+  "deallocate",
+  "checkpoint",
+  "listen",
+  "unlisten",
+  "notify",
+]);
+
+export interface SourceValues {
+  host: string;
+  port: string;
+  user: string;
+  password: string;
+  database: string;
+}
+
+export interface InjectedValuesState {
+  port: number;
+  endpoint: string;
+  logPath: string;
+  source: SourceValues;
+  requiresSsl: boolean;
+}
+
+export interface BuildInjectedValuesOptions {
+  env?: NodeJS.ProcessEnv;
+  pythonShimDir?: string;
+  readEnv?: (envName: string) => string | undefined;
+}
+
+export function needsSsl(host: string): boolean {
+  return !["localhost", "127.0.0.1", "::1"].includes(host);
+}
+
+export function deriveEndpoint(host: string): string {
+  if (!needsSsl(host) || !host.includes(".")) return "";
+  return host.split(".")[0] ?? "";
+}
+
+export function mergePathValue(prependValue: string, existingValue: string | undefined): string {
+  if (!existingValue) return prependValue;
+  return `${prependValue}${delimiter}${existingValue}`;
+}
+
+export function encodeConnectionUrl(
+  scheme: string,
+  source: SourceValues,
+  port: number,
+  sslValue: string | null,
+  endpoint: string,
+): string {
+  const user = encodeURIComponent(source.user);
+  const password = encodeURIComponent(source.password);
+  const database = encodeURIComponent(source.database);
+  const params = new URLSearchParams();
+  if (sslValue) {
+    if (sslValue === "require") params.set("sslmode", sslValue);
+    else params.set("ssl", sslValue);
+  }
+  if (endpoint) params.set("options", `endpoint=${endpoint}`);
+  const query = params.toString();
+  return `${scheme}://${user}:${password}@127.0.0.1:${port}/${database}${query ? `?${query}` : ""}`;
+}
+
+export function buildInjectedValues(
+  config: Pick<ResolvedConfig, "injectEnv" | "injectPythonShim" | "path">,
+  state: InjectedValuesState,
+  options: BuildInjectedValuesOptions = {},
+): Record<string, string> {
+  const env = options.env ?? process.env;
+  const readEnv = options.readEnv ?? ((envName: string) => env[envName]);
+  const source = state.source;
+  const postgresUrl = encodeConnectionUrl(
+    "postgresql",
+    source,
+    state.port,
+    state.requiresSsl ? "require" : null,
+    state.endpoint,
+  );
+  const sqlalchemyUrl = encodeConnectionUrl(
+    "postgresql+psycopg2",
+    source,
+    state.port,
+    state.requiresSsl ? "require" : null,
+    state.endpoint,
+  );
+  const asyncpgDsn = encodeConnectionUrl(
+    "postgresql",
+    source,
+    state.port,
+    state.requiresSsl ? "require" : null,
+    state.endpoint,
+  ).replace("sslmode=require", "ssl=require");
+  const sqlalchemyAsyncUrl = asyncpgDsn.replace("postgresql://", "postgresql+asyncpg://");
+
+  const tokens: Record<string, string> = {
+    postgres_url: postgresUrl,
+    psql_url: postgresUrl,
+    sqlalchemy_url: sqlalchemyUrl,
+    sqlalchemy_async_url: sqlalchemyAsyncUrl,
+    psycopg2_url: sqlalchemyUrl,
+    asyncpg_dsn: asyncpgDsn,
+    tunnel_host: "127.0.0.1",
+    tunnel_port: String(state.port),
+    endpoint: state.endpoint,
+    pgoptions: state.endpoint ? `endpoint=${state.endpoint}` : "",
+    sslmode: state.requiresSsl ? "require" : "disable",
+    source_host: source.host,
+    source_port: source.port,
+    source_user: source.user,
+    source_password: source.password,
+    source_database: source.database,
+    config_path: config.path,
+    log_path: state.logPath,
+    "1": "1",
+  };
+
+  const resolved: Record<string, string> = {};
+  for (const [envName, spec] of Object.entries(config.injectEnv)) {
+    if (spec.startsWith("source:")) {
+      resolved[envName] = readEnv(spec.slice("source:".length)) ?? "";
+      continue;
+    }
+    resolved[envName] = tokens[spec] ?? spec;
+  }
+
+  if (config.injectPythonShim && options.pythonShimDir) {
+    resolved.PYTHONPATH = mergePathValue(
+      options.pythonShimDir,
+      resolved.PYTHONPATH ?? env.PYTHONPATH,
+    );
+  }
+
+  return resolved;
+}
+
+function readDollarQuoteTag(sql: string, index: number): string | null {
+  const match = /^(\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$)/.exec(sql.slice(index));
+  return match?.[0] ?? null;
+}
+
+function replacementChar(char: string): string {
+  return char === "\n" || char === "\r" || char === "\t" ? char : " ";
+}
+
+function sanitizeSql(sql: string): string {
+  let result = "";
+  let index = 0;
+
+  while (index < sql.length) {
+    const char = sql[index] ?? "";
+    const next = sql[index + 1] ?? "";
+
+    if (char === "-" && next === "-") {
+      result += "  ";
+      index += 2;
+      while (index < sql.length && sql[index] !== "\n") {
+        result += replacementChar(sql[index] ?? " ");
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      result += "  ";
+      index += 2;
+      let depth = 1;
+      while (index < sql.length && depth > 0) {
+        const current = sql[index] ?? "";
+        const following = sql[index + 1] ?? "";
+        if (current === "/" && following === "*") {
+          depth += 1;
+          result += "  ";
+          index += 2;
+          continue;
+        }
+        if (current === "*" && following === "/") {
+          depth -= 1;
+          result += "  ";
+          index += 2;
+          continue;
+        }
+        result += replacementChar(current);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "'") {
+      result += " ";
+      index += 1;
+      while (index < sql.length) {
+        const current = sql[index] ?? "";
+        result += replacementChar(current);
+        index += 1;
+        if (current === "'") {
+          if (sql[index] === "'") {
+            result += replacementChar(sql[index] ?? " ");
+            index += 1;
+            continue;
+          }
+          break;
+        }
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      result += " ";
+      index += 1;
+      while (index < sql.length) {
+        const current = sql[index] ?? "";
+        result += replacementChar(current);
+        index += 1;
+        if (current === '"') {
+          if (sql[index] === '"') {
+            result += replacementChar(sql[index] ?? " ");
+            index += 1;
+            continue;
+          }
+          break;
+        }
+      }
+      continue;
+    }
+
+    if (char === "$") {
+      const tag = readDollarQuoteTag(sql, index);
+      if (tag) {
+        result += " ".repeat(tag.length);
+        index += tag.length;
+        while (index < sql.length && !sql.startsWith(tag, index)) {
+          result += replacementChar(sql[index] ?? " ");
+          index += 1;
+        }
+        if (sql.startsWith(tag, index)) {
+          result += " ".repeat(tag.length);
+          index += tag.length;
+        }
+        continue;
+      }
+    }
+
+    result += char;
+    index += 1;
+  }
+
+  return result;
+}
+
+function splitSqlStatements(sql: string): string[] {
+  return sanitizeSql(sql)
+    .split(";")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+}
+
+function findFirstTokenIndex(statement: string, tokens: readonly string[]): number {
+  const lower = statement.toLowerCase();
+  let bestIndex = -1;
+  for (const token of tokens) {
+    const pattern = new RegExp(`\\b${token}\\b`, "i");
+    const match = pattern.exec(lower);
+    if (!match) continue;
+    if (bestIndex === -1 || match.index < bestIndex) {
+      bestIndex = match.index;
+    }
+  }
+  return bestIndex;
+}
+
+function stripExplainPrefix(statement: string): string | null {
+  const remainder = statement.replace(/^explain\b/i, "").trimStart();
+  if (!remainder) return null;
+
+  if (remainder.startsWith("(")) {
+    let depth = 0;
+    let index = 0;
+    while (index < remainder.length) {
+      const char = remainder[index] ?? "";
+      if (char === "(") depth += 1;
+      if (char === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          return remainder.slice(index + 1).trimStart() || null;
+        }
+      }
+      index += 1;
+    }
+    return null;
+  }
+
+  const nestedIndex = findFirstTokenIndex(remainder, [...READ_ONLY_LEAD_KEYWORDS, "explain"]);
+  return nestedIndex >= 0 ? remainder.slice(nestedIndex).trimStart() : null;
+}
+
+function isAllowedPsqlInspectionCommand(statement: string): boolean {
+  const trimmed = statement.trim();
+  if (!trimmed.startsWith("\\")) return false;
+  if (/[\r\n;]/.test(trimmed)) return false;
+
+  const match = /^\\([A-Za-z]+)(\+?)([ \t].*)?$/.exec(trimmed);
+  if (!match) return false;
+
+  const command = match[1] ?? "";
+  const args = match[3] ?? "";
+  if (!SAFE_PSQL_INSPECTION_COMMANDS.has(command)) return false;
+  return !args.includes("\\");
+}
+
+export function isReadOnlyQuery(query: string): boolean {
+  const statements = splitSqlStatements(query);
+  if (statements.length !== 1) return false;
+
+  const statement = statements[0] ?? "";
+  if (!statement) return false;
+  if (statement.startsWith("\\")) return isAllowedPsqlInspectionCommand(statement);
+  if (statement.includes("\\")) return false;
+
+  const lower = statement.toLowerCase();
+  const tokens = lower.match(/[a-z_][a-z0-9_$]*/g) ?? [];
+  const lead = tokens[0];
+  if (!lead) return false;
+
+  if (lead === "explain") {
+    const explained = stripExplainPrefix(statement);
+    return explained ? isReadOnlyQuery(explained) : false;
+  }
+
+  if (!READ_ONLY_LEAD_KEYWORDS.has(lead)) return false;
+  return !tokens.some((token) => MUTATING_SQL_TOKENS.has(token));
+}

--- a/neon-psql/index.ts
+++ b/neon-psql/index.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { StringEnum } from "@mariozechner/pi-ai";
@@ -18,6 +18,13 @@ import {
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@gugu91/pi-ext-types/typebox";
 
+import {
+  buildInjectedValues as computeInjectedValues,
+  deriveEndpoint,
+  isReadOnlyQuery,
+  needsSsl,
+  type SourceValues,
+} from "./helpers.js";
 import { resolvePsqlBin } from "./psql-bin.js";
 import { loadConfig, type ResolvedConfig } from "./settings.js";
 
@@ -35,14 +42,6 @@ const SANDBOX_RUNTIME_ENTRY = join(
   "dist",
   "index.js",
 );
-
-interface SourceValues {
-  host: string;
-  port: string;
-  user: string;
-  password: string;
-  database: string;
-}
 
 interface TunnelState {
   child: ChildProcess;
@@ -90,20 +89,6 @@ let injectedEnvBackup = new Map<string, string | undefined>();
 let warnedBashTunnelUnavailable = false;
 let sandboxManagerPromise: Promise<SandboxManagerLike | null> | null = null;
 
-function needsSsl(host: string): boolean {
-  return !["localhost", "127.0.0.1", "::1"].includes(host);
-}
-
-function deriveEndpoint(host: string): string {
-  if (!needsSsl(host) || !host.includes(".")) return "";
-  return host.split(".")[0] ?? "";
-}
-
-function mergePathValue(prependValue: string, existingValue: string | undefined): string {
-  if (!existingValue) return prependValue;
-  return `${prependValue}${delimiter}${existingValue}`;
-}
-
 function readRuntimeEnv(envName: string): string | undefined {
   if (injectedEnvBackup.has(envName)) return injectedEnvBackup.get(envName);
   return process.env[envName];
@@ -125,90 +110,12 @@ function requireSourceEnv(config: ResolvedConfig): SourceValues {
   };
 }
 
-function encodeConnectionUrl(
-  scheme: string,
-  source: SourceValues,
-  port: number,
-  sslValue: string | null,
-  endpoint: string,
-): string {
-  const user = encodeURIComponent(source.user);
-  const password = encodeURIComponent(source.password);
-  const database = encodeURIComponent(source.database);
-  const params = new URLSearchParams();
-  if (sslValue) {
-    if (sslValue === "require") params.set("sslmode", sslValue);
-    else params.set("ssl", sslValue);
-  }
-  if (endpoint) params.set("options", `endpoint=${endpoint}`);
-  const query = params.toString();
-  return `${scheme}://${user}:${password}@127.0.0.1:${port}/${database}${query ? `?${query}` : ""}`;
-}
-
 function buildInjectedValues(config: ResolvedConfig, state: TunnelState): Record<string, string> {
-  const source = state.source;
-  const postgresUrl = encodeConnectionUrl(
-    "postgresql",
-    source,
-    state.port,
-    state.requiresSsl ? "require" : null,
-    state.endpoint,
-  );
-  const sqlalchemyUrl = encodeConnectionUrl(
-    "postgresql+psycopg2",
-    source,
-    state.port,
-    state.requiresSsl ? "require" : null,
-    state.endpoint,
-  );
-  const asyncpgDsn = encodeConnectionUrl(
-    "postgresql",
-    source,
-    state.port,
-    state.requiresSsl ? "require" : null,
-    state.endpoint,
-  ).replace("sslmode=require", "ssl=require");
-  const sqlalchemyAsyncUrl = asyncpgDsn.replace("postgresql://", "postgresql+asyncpg://");
-
-  const tokens: Record<string, string> = {
-    postgres_url: postgresUrl,
-    psql_url: postgresUrl,
-    sqlalchemy_url: sqlalchemyUrl,
-    sqlalchemy_async_url: sqlalchemyAsyncUrl,
-    psycopg2_url: sqlalchemyUrl,
-    asyncpg_dsn: asyncpgDsn,
-    tunnel_host: "127.0.0.1",
-    tunnel_port: String(state.port),
-    endpoint: state.endpoint,
-    pgoptions: state.endpoint ? `endpoint=${state.endpoint}` : "",
-    sslmode: state.requiresSsl ? "require" : "disable",
-    source_host: source.host,
-    source_port: source.port,
-    source_user: source.user,
-    source_password: source.password,
-    source_database: source.database,
-    config_path: config.path,
-    log_path: state.logPath,
-    "1": "1",
-  };
-
-  const resolved: Record<string, string> = {};
-  for (const [envName, spec] of Object.entries(config.injectEnv)) {
-    if (spec.startsWith("source:")) {
-      resolved[envName] = readRuntimeEnv(spec.slice("source:".length)) ?? "";
-      continue;
-    }
-    resolved[envName] = tokens[spec] ?? spec;
-  }
-
-  if (config.injectPythonShim) {
-    resolved.PYTHONPATH = mergePathValue(
-      PYTHON_SHIM_DIR,
-      resolved.PYTHONPATH ?? process.env.PYTHONPATH,
-    );
-  }
-
-  return resolved;
+  return computeInjectedValues(config, state, {
+    env: process.env,
+    pythonShimDir: PYTHON_SHIM_DIR,
+    readEnv: readRuntimeEnv,
+  });
 }
 
 function applyInjectedEnvToProcess(config: ResolvedConfig, state: TunnelState): void {
@@ -421,21 +328,6 @@ async function prepareBashTunnel(config: ResolvedConfig, ctx: ExtensionContext):
       warnedBashTunnelUnavailable = true;
     }
   }
-}
-
-function isReadOnlyQuery(query: string): boolean {
-  const stripped = query
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/--.*$/gm, " ")
-    .trim()
-    .toLowerCase();
-
-  if (!stripped) return false;
-  if (stripped.startsWith("\\")) return true;
-
-  return ["select", "with", "show", "explain", "values", "table"].some((prefix) =>
-    stripped.startsWith(prefix),
-  );
 }
 
 async function writeFullOutput(output: string): Promise<string> {


### PR DESCRIPTION
## Summary
- start fresh instead of reusing #172 because that PR duplicated the validator in tests and missed known read-only bypass cases
- extract neon-psql query/injection helpers into `helpers.ts` so tests exercise the production implementation
- add adversarial coverage for multi-statement input, data-modifying CTEs, `SELECT INTO`, and `EXPLAIN ANALYZE DELETE`, plus connection/env helper tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test