### PR TITLE
feat: steer delegation through Pinet

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -24,6 +24,7 @@ import {
   isRalphNudgeEntry,
   partitionFollowerInboxEntries,
   buildBrokerPromptGuidelines,
+  buildWorkerPromptGuidelines,
   buildIdentityReplyGuidelines,
   resolvePersistedAgentIdentity,
   buildAgentStableId,
@@ -466,6 +467,32 @@ describe("buildBrokerPromptGuidelines", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
     expect(joined).toContain("NEVER do the work yourself");
+  });
+});
+
+// ─── buildIdentityReplyGuidelines ─────────────────────────────
+
+describe("buildWorkerPromptGuidelines", () => {
+  it("includes Pinet delegation guidance for connected workers", () => {
+    const guidelines = buildWorkerPromptGuidelines();
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("PINET DELEGATION RULES");
+    expect(joined).toContain("pinet_agents");
+    expect(joined).toContain("pinet_message");
+  });
+
+  it("tells workers not to use the Agent tool for mesh delegation", () => {
+    const guidelines = buildWorkerPromptGuidelines();
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("do NOT use the Agent tool");
+    expect(joined).toContain("local subagent");
+  });
+
+  it("requires delegated work to report status back through the thread", () => {
+    const guidelines = buildWorkerPromptGuidelines();
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("ACKs, blockers, status updates, and final results");
+    expect(joined).toContain("ack/work/ask/report");
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -750,6 +750,12 @@ export function buildWorkerPromptGuidelines(): string[] {
     "- If you received a task via `pinet_message`, reply via `pinet_message` to the sender.",
     "- If you received a task in a Slack thread, reply via `slack_send` in that thread.",
     "- Never use `slack_post_channel` with a pinet thread ID (e.g. `a2a:...`) — it will fail. Pinet threads are not Slack channels.",
+    "",
+    "PINET DELEGATION RULES:",
+    "- When you need another connected agent to take work or parallelize, do NOT use the Agent tool to spawn a local subagent for delegation.",
+    "- Prefer Pinet delegation: first use `pinet_agents` to find a suitable connected worker, then delegate via `pinet_message`.",
+    "- Keep delegation inside the Pinet or Slack thread so ACKs, blockers, status updates, and final results flow back to the original sender.",
+    "- When delegating, include the workflow (`ack/work/ask/report`), the task, relevant issue/PR numbers, repo/branch/worktree setup, important files, acceptance criteria, and where to reply.",
   ];
 }
 


### PR DESCRIPTION
## Summary
- extend worker prompt guidance so connected Pinet workers prefer mesh delegation over spawning local subagents
- tell workers to use `pinet_agents` + `pinet_message` for delegation and to keep status/completion flowing back through the originating thread
- add regression coverage for the new worker delegation guidance

## Context
PR #169 stopped local subagents from auto-registering into the mesh, but workers could still be prompted to delegate via the local `Agent` tool. This change nudges connected workers toward the intended delegation path: Pinet threads, not ad hoc local subagents.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #71
