### PR TITLE
feat: enforce main-checkout worktree rule

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -43,6 +43,8 @@ If the agent is idle, incoming messages are processed immediately.
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
 - **Remote agent control** — send `/reload` or `/exit` to another Pinet agent
+- **Worktree-aware routing** — linked worktree agents keep the canonical repo identity, report their worktree path, and ghost worktrees are flagged for cleanup
+- **Main checkout protection** — source edits are blocked from the main checkout; feature work must happen in linked worktrees
 - **User allowlist** — restrict who can interact with the agent
 
 ## Setup

--- a/slack-bridge/git-metadata.test.ts
+++ b/slack-bridge/git-metadata.test.ts
@@ -23,15 +23,21 @@ describe("probeGitBranch", () => {
 });
 
 describe("probeGitContext", () => {
-  it("returns repo, repoRoot, and branch when git commands succeed", async () => {
+  it("returns canonical repo metadata for the main checkout", async () => {
     const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
-      if (args[0] === "rev-parse") {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
         return { stdout: "/Users/alice/src/extensions\n" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--absolute-git-dir") {
+        return { stdout: "/Users/alice/src/extensions/.git\n" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--git-common-dir") {
+        return { stdout: ".git\n" };
       }
       if (args[0] === "branch") {
         return { stdout: "main\n" };
       }
-      throw new Error("unexpected command");
+      throw new Error(`unexpected command: ${args.join(" ")}`);
     });
 
     await expect(
@@ -40,7 +46,38 @@ describe("probeGitContext", () => {
       cwd: "/Users/alice/src/extensions/slack-bridge",
       repo: "extensions",
       repoRoot: "/Users/alice/src/extensions",
+      worktreePath: "/Users/alice/src/extensions",
+      worktreeKind: "main",
       branch: "main",
+    });
+  });
+
+  it("keeps the canonical repo name when running from a linked worktree", async () => {
+    const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+        return { stdout: "/Users/alice/src/extensions/.worktrees/feat-87\n" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--absolute-git-dir") {
+        return { stdout: "/Users/alice/src/extensions/.git/worktrees/feat-87\n" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--git-common-dir") {
+        return { stdout: "/Users/alice/src/extensions/.git\n" };
+      }
+      if (args[0] === "branch") {
+        return { stdout: "feat/enforce-worktree-rule\n" };
+      }
+      throw new Error(`unexpected command: ${args.join(" ")}`);
+    });
+
+    await expect(
+      probeGitContext("/Users/alice/src/extensions/.worktrees/feat-87/slack-bridge", runner),
+    ).resolves.toEqual({
+      cwd: "/Users/alice/src/extensions/.worktrees/feat-87/slack-bridge",
+      repo: "extensions",
+      repoRoot: "/Users/alice/src/extensions",
+      worktreePath: "/Users/alice/src/extensions/.worktrees/feat-87",
+      worktreeKind: "linked",
+      branch: "feat/enforce-worktree-rule",
     });
   });
 
@@ -53,6 +90,8 @@ describe("probeGitContext", () => {
       cwd: "/tmp/scratch",
       repo: "scratch",
       repoRoot: undefined,
+      worktreePath: undefined,
+      worktreeKind: undefined,
       branch: undefined,
     });
   });
@@ -69,6 +108,8 @@ describe("probeGitContext", () => {
       cwd: "/tmp/scratch",
       repo: "scratch",
       repoRoot: undefined,
+      worktreePath: undefined,
+      worktreeKind: undefined,
       branch: undefined,
     });
   });
@@ -80,6 +121,8 @@ describe("createGitContextCache", () => {
       cwd: "/tmp/project",
       repo: "project",
       repoRoot: "/tmp/project",
+      worktreePath: "/tmp/project",
+      worktreeKind: "main" as const,
       branch: "main",
     }));
 

--- a/slack-bridge/git-metadata.ts
+++ b/slack-bridge/git-metadata.ts
@@ -14,7 +14,12 @@ export type ExecFileAsyncLike = (
 export interface GitContext {
   cwd: string;
   repo: string;
+  /** Canonical repository root (main checkout root when inside a linked worktree) */
   repoRoot?: string;
+  /** Current checkout root (`git rev-parse --show-toplevel`) */
+  worktreePath?: string;
+  /** `main` for the primary checkout, `linked` for a linked worktree */
+  worktreeKind?: "main" | "linked";
   branch?: string;
 }
 
@@ -44,14 +49,28 @@ export async function probeGitContext(
   cwd = process.cwd(),
   runner: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike,
 ): Promise<GitContext> {
-  const repoRoot = await runGitCommand(["rev-parse", "--show-toplevel"], cwd, runner);
+  const worktreePath = await runGitCommand(["rev-parse", "--show-toplevel"], cwd, runner);
   const branch = await probeGitBranch(cwd, runner);
-  const resolvedRepoRoot = repoRoot ?? cwd;
+  const gitDir = await runGitCommand(["rev-parse", "--absolute-git-dir"], cwd, runner);
+  const commonDirRaw = await runGitCommand(["rev-parse", "--git-common-dir"], cwd, runner);
+  const resolvedBase = worktreePath ?? cwd;
+  const commonDir = commonDirRaw ? path.resolve(resolvedBase, commonDirRaw) : undefined;
+  const repoRoot =
+    commonDir && path.basename(commonDir) === ".git" ? path.dirname(commonDir) : worktreePath;
+  const worktreeKind =
+    worktreePath && gitDir && commonDir
+      ? path.resolve(gitDir) === path.resolve(commonDir)
+        ? "main"
+        : "linked"
+      : undefined;
+  const resolvedRepoRoot = repoRoot ?? worktreePath ?? cwd;
 
   return {
     cwd,
     repo: path.basename(resolvedRepoRoot),
     repoRoot,
+    worktreePath,
+    worktreeKind,
     branch,
   };
 }

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -728,6 +728,14 @@ describe("buildBrokerPromptGuidelines", () => {
     const joined = guidelines.join(" ");
     expect(joined).toContain("NEVER do the work yourself");
   });
+
+  it("includes explicit main-checkout and worktree lifecycle rules", () => {
+    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("NEVER checkout a branch in the main repo");
+    expect(joined).toContain("git worktree add .worktrees/<name> -b <branch>");
+    expect(joined).toContain("git worktree remove .worktrees/<name>");
+  });
 });
 
 // ─── buildIdentityReplyGuidelines ─────────────────────────────
@@ -983,6 +991,7 @@ describe("formatAgentList", () => {
             repo: "extensions",
             branch: "main",
             role: "worker",
+            worktreeKind: "main",
             tools: ["test", "lint"],
           },
         },
@@ -998,8 +1007,49 @@ describe("formatAgentList", () => {
     expect(result).toContain("Visible Bot (agent-1) — idle [stale]");
     expect(result).toContain("heartbeat 12s ago · lease in 3s");
     expect(result).toContain(
-      "caps: role:worker, repo:extensions, branch:main, tool:test, tool:lint",
+      "caps: role:worker, repo:extensions, branch:main, checkout:main, tool:test, tool:lint",
     );
+  });
+
+  it("shows linked worktree metadata and cleanup guidance for ghost agents", () => {
+    const agent = buildAgentDisplayInfo(
+      {
+        emoji: "👻",
+        name: "Ghost Worker",
+        id: "ghost-2",
+        status: "idle",
+        lastHeartbeat: "2026-01-01T00:00:00.000Z",
+        metadata: {
+          cwd: "/Users/alice/src/extensions/.worktrees/feat-87/slack-bridge",
+          branch: "feat/enforce-worktree-rule",
+          host: "macbook",
+          repo: "extensions",
+          repoRoot: "/Users/alice/src/extensions",
+          worktreePath: "/Users/alice/src/extensions/.worktrees/feat-87",
+          worktreeKind: "linked",
+          capabilities: {
+            repo: "extensions",
+            repoRoot: "/Users/alice/src/extensions",
+            branch: "feat/enforce-worktree-rule",
+            role: "worker",
+            worktreePath: "/Users/alice/src/extensions/.worktrees/feat-87",
+            worktreeKind: "linked",
+            tools: ["test"],
+          },
+        },
+      },
+      {
+        now: Date.parse("2026-01-01T00:00:20.000Z"),
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    const result = formatAgentList([agent], homedir);
+    expect(result).toContain(
+      "worktree: ~/src/extensions/.worktrees/feat-87 (main: ~/src/extensions)",
+    );
+    expect(result).toContain("cleanup: git worktree remove ~/src/extensions/.worktrees/feat-87");
   });
 });
 
@@ -1060,6 +1110,38 @@ describe("buildAgentDisplayInfo", () => {
     expect(agent.health).toBe("ghost");
     expect(agent.ghost).toBe(true);
     expect(agent.leaseSummary).toBe("lease expired 5s ago");
+  });
+
+  it("flags ghost linked worktrees for cleanup", () => {
+    const agent = buildAgentDisplayInfo(
+      {
+        emoji: "👻",
+        name: "Ghost Bot",
+        id: "ghost-worktree",
+        status: "idle",
+        lastHeartbeat: "2026-01-01T00:00:00.000Z",
+        metadata: {
+          role: "worker",
+          repoRoot: "/Users/alice/src/extensions",
+          worktreePath: "/Users/alice/src/extensions/.worktrees/feat-87",
+          worktreeKind: "linked",
+          capabilities: {
+            role: "worker",
+            repo: "extensions",
+            repoRoot: "/Users/alice/src/extensions",
+            worktreePath: "/Users/alice/src/extensions/.worktrees/feat-87",
+            worktreeKind: "linked",
+          },
+        },
+      },
+      {
+        now: Date.parse("2026-01-01T00:00:20.000Z"),
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(agent.cleanupWorktreePath).toBe("/Users/alice/src/extensions/.worktrees/feat-87");
   });
 });
 
@@ -1212,6 +1294,47 @@ describe("evaluateRalphLoopCycle", () => {
     expect(result.anomalies).toContain("broker heartbeat timer is not running");
     expect(result.anomalies).toContain("broker maintenance timer is not running");
     expect(result.anomalies.some((item) => item.includes("expected `main`"))).toBe(true);
+  });
+
+  it("flags orphaned linked worktrees for cleanup", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "👻",
+          name: "Ghost Fox",
+          id: "ghost-worker",
+          status: "idle",
+          metadata: {
+            role: "worker",
+            repo: "extensions",
+            repoRoot: "/Users/alice/src/extensions",
+            worktreePath: "/Users/alice/src/extensions/.worktrees/feat-87",
+            worktreeKind: "linked",
+            capabilities: {
+              role: "worker",
+              repo: "extensions",
+              repoRoot: "/Users/alice/src/extensions",
+              worktreePath: "/Users/alice/src/extensions/.worktrees/feat-87",
+              worktreeKind: "linked",
+            },
+          },
+          lastSeen: "2026-04-01T00:00:00.000Z",
+          lastHeartbeat: "2026-04-01T00:00:00.000Z",
+          disconnectedAt: "2026-04-01T00:00:10.000Z",
+          pendingInboxCount: 0,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:02:00.000Z"),
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(result.anomalies).toContain(
+      "orphaned worktree cleanup: Ghost Fox at `/Users/alice/src/extensions/.worktrees/feat-87`",
+    );
   });
 
   it("detects stuck agents: working with no activity for > threshold", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -417,6 +417,8 @@ export interface AgentCapabilities {
   role?: string;
   tools?: string[];
   tags?: string[];
+  worktreePath?: string;
+  worktreeKind?: "main" | "linked";
 }
 
 export type AgentHealth = "healthy" | "stale" | "ghost" | "resumable";
@@ -432,9 +434,13 @@ export interface AgentDisplayInfo {
     branch?: string;
     host?: string;
     repo?: string;
+    repoRoot?: string;
     role?: string;
+    worktreePath?: string;
+    worktreeKind?: "main" | "linked";
     capabilities?: AgentCapabilities | null;
   } | null;
+  cleanupWorktreePath?: string | null;
   lastHeartbeat?: string;
   leaseExpiresAt?: string | null;
   heartbeatAgeMs?: number | null;
@@ -578,7 +584,31 @@ export function extractAgentCapabilities(
     role: asString(capabilitiesRecord?.role) ?? asString(record?.role),
     tools: asStringArray(capabilitiesRecord?.tools),
     tags: asStringArray(capabilitiesRecord?.tags),
+    worktreePath: asString(capabilitiesRecord?.worktreePath) ?? asString(record?.worktreePath),
+    worktreeKind:
+      (asString(capabilitiesRecord?.worktreeKind) ?? asString(record?.worktreeKind)) === "linked"
+        ? "linked"
+        : (asString(capabilitiesRecord?.worktreeKind) ?? asString(record?.worktreeKind)) === "main"
+          ? "main"
+          : undefined,
   };
+}
+
+function getCleanupWorktreePath(
+  metadata: Record<string, unknown> | null,
+  capabilities: AgentCapabilities,
+  health: AgentHealth,
+): string | null {
+  const worktreeKind =
+    ((asString(metadata?.worktreeKind) ?? capabilities.worktreeKind) as
+      | "main"
+      | "linked"
+      | undefined) ?? undefined;
+  const worktreePath = asString(metadata?.worktreePath) ?? capabilities.worktreePath;
+  if (health !== "ghost" || worktreeKind !== "linked" || !worktreePath) {
+    return null;
+  }
+  return worktreePath;
 }
 
 export function buildAgentCapabilityTags(capabilities: AgentCapabilities): string[] {
@@ -587,6 +617,7 @@ export function buildAgentCapabilityTags(capabilities: AgentCapabilities): strin
   if (capabilities.role) tags.add(`role:${capabilities.role}`);
   if (capabilities.repo) tags.add(`repo:${capabilities.repo}`);
   if (capabilities.branch) tags.add(`branch:${capabilities.branch}`);
+  if (capabilities.worktreeKind) tags.add(`checkout:${capabilities.worktreeKind}`);
   for (const tool of capabilities.tools ?? []) {
     tags.add(`tool:${tool}`);
   }
@@ -636,6 +667,7 @@ export function buildAgentDisplayInfo(
   const lastActivityMs = parseIsoMs(agent.lastActivity);
   const idleDurationMs = idleSinceMs == null ? null : Math.max(0, nowMs - idleSinceMs);
   const lastActivityAgeMs = lastActivityMs == null ? null : Math.max(0, nowMs - lastActivityMs);
+  const cleanupWorktreePath = getCleanupWorktreePath(metadata, capabilities, health);
 
   return {
     emoji: agent.emoji,
@@ -649,7 +681,14 @@ export function buildAgentDisplayInfo(
           branch: asString(metadata.branch),
           host: asString(metadata.host),
           repo: asString(metadata.repo) ?? capabilities.repo,
+          repoRoot: asString(metadata.repoRoot) ?? capabilities.repoRoot,
           role: asString(metadata.role) ?? capabilities.role,
+          worktreePath: asString(metadata.worktreePath) ?? capabilities.worktreePath,
+          worktreeKind:
+            ((asString(metadata.worktreeKind) ?? capabilities.worktreeKind) as
+              | "main"
+              | "linked"
+              | undefined) ?? undefined,
           capabilities,
         }
       : null,
@@ -666,6 +705,7 @@ export function buildAgentDisplayInfo(
     idleDuration: formatAge(idleDurationMs),
     lastActivityAge: formatAge(lastActivityAgeMs),
     capabilityTags,
+    cleanupWorktreePath,
   };
 }
 
@@ -838,6 +878,11 @@ export function evaluateRalphLoopCycle(
     const display = buildAgentDisplayInfo(workload, options);
     if (display.health === "ghost") {
       ghostAgentIds.push(workload.id);
+      if (display.cleanupWorktreePath) {
+        anomalies.push(
+          `orphaned worktree cleanup: ${workload.name} at \`${display.cleanupWorktreePath}\``,
+        );
+      }
       continue;
     }
 
@@ -1047,10 +1092,10 @@ export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: strin
     "When a human asks for work to be done, ALWAYS check `pinet_agents` for idle workers and delegate via `pinet_message`. Pick the agent on the right repo/branch when possible.",
     "When delegating, include: the task description, relevant issue/PR numbers, branch to work on, and where to report back (Slack thread_ts).",
     "If no workers are available, tell the human and suggest they spin up a new agent. NEVER do the work yourself as a fallback.",
-    "WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.",
+    "WORKTREE RULE: NEVER checkout a branch in the main repo. The main checkout must always stay on the `main` branch.",
     "For feature work, ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>`. Tell delegated agents to do the same.",
     "When delegating to an agent, include the worktree setup command. Example: `git worktree add .worktrees/fix-foo-123 -b fix/foo-123 && cd .worktrees/fix-foo-123`",
-    "Clean up worktrees after PRs merge: `git worktree remove .worktrees/<name>`. Flag orphaned worktrees from dead agents for cleanup.",
+    "When work is done, ALWAYS run `git worktree remove .worktrees/<name>`. Flag orphaned worktrees from dead agents for cleanup.",
     "RALPH LOOP: Run autonomous maintenance every cycle. Don't wait to be asked. Proactively: (1) REAP — ping idle agents, mark non-responders as ghost. (2) NUDGE — check assigned work, poll branches for commits, escalate stalled agents. (3) REASSIGN — if an assigned agent is dead, reassign to next idle agent immediately. (4) DRAIN — find idle agents with no work, assign queued tasks. (5) SELF-REPAIR — verify main is on `main`, check mesh health, report anomalies.",
   ];
 }
@@ -1376,6 +1421,13 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
         line += `\n   ${cwd}${branch}${host}`;
       }
 
+      if (meta?.worktreeKind === "linked" && meta.worktreePath) {
+        const worktree = shortenPath(meta.worktreePath, homedir);
+        const mainRoot = meta.repoRoot ? shortenPath(meta.repoRoot, homedir) : "";
+        const mainSuffix = mainRoot && mainRoot !== worktree ? ` (main: ${mainRoot})` : "";
+        line += `\n   worktree: ${worktree}${mainSuffix}`;
+      }
+
       const heartbeat = a.heartbeatSummary ?? formatAge(a.heartbeatAgeMs);
       const lease = a.leaseSummary ?? null;
       const idleInfo = a.status === "idle" && a.idleDuration ? `idle ${a.idleDuration}` : null;
@@ -1395,6 +1447,10 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
       if (tags.length > 0) {
         const suffix = (a.capabilityTags?.length ?? 0) > tags.length ? " …" : "";
         line += `\n   caps: ${tags.join(", ")}${suffix}`;
+      }
+
+      if (a.cleanupWorktreePath) {
+        line += `\n   cleanup: git worktree remove ${shortenPath(a.cleanupWorktreePath, homedir)}`;
       }
 
       if (a.routingScore != null) {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -100,6 +100,7 @@ import {
   hasTaskAssignmentStatusChange,
   resolveTaskAssignments,
 } from "./task-assignments.js";
+import { getMainCheckoutToolBlockReason } from "./worktree-policy.js";
 
 // Settings and helpers imported from ./helpers.js
 
@@ -223,13 +224,14 @@ export default function (pi: ExtensionAPI) {
     role: "broker" | "worker" = "worker",
   ): Promise<Record<string, unknown>> {
     const gitContext = await gitContextCache.get();
-    const { cwd, repo, repoRoot, branch } = gitContext;
-    const resolvedRepoRoot = repoRoot ?? cwd;
-    const tools = detectProjectTools(resolvedRepoRoot, cwd);
+    const { cwd, repo, repoRoot, worktreePath, worktreeKind, branch } = gitContext;
+    const resolvedProjectRoot = worktreePath ?? repoRoot ?? cwd;
+    const tools = detectProjectTools(resolvedProjectRoot, cwd);
     const tags = [
       `role:${role}`,
       `repo:${repo}`,
       ...(branch ? [`branch:${branch}`] : []),
+      ...(worktreeKind ? [`checkout:${worktreeKind}`] : []),
       ...tools.map((tool) => `tool:${tool}`),
     ];
 
@@ -240,6 +242,8 @@ export default function (pi: ExtensionAPI) {
       role,
       repo,
       repoRoot,
+      worktreePath,
+      worktreeKind,
       capabilities: {
         repo,
         repoRoot,
@@ -247,6 +251,8 @@ export default function (pi: ExtensionAPI) {
         role,
         tools,
         tags,
+        worktreePath,
+        worktreeKind,
       },
     };
   }
@@ -2329,6 +2335,18 @@ export default function (pi: ExtensionAPI) {
       console.error(`[slack-bridge] restore failed: ${msg(err)}`);
     }
 
+    try {
+      const gitContext = await gitContextCache.get();
+      if (gitContext.worktreeKind === "main" && gitContext.branch && gitContext.branch !== "main") {
+        ctx.ui.notify(
+          `Main checkout drift detected: on ${gitContext.branch}, expected main. Use a worktree for feature work.`,
+          "warning",
+        );
+      }
+    } catch {
+      /* best effort */
+    }
+
     if (pinetRegistrationBlocked) {
       console.log("[slack-bridge] detected local subagent context; skipping Pinet registration");
       setExtStatus(ctx, "off");
@@ -2437,13 +2455,29 @@ export default function (pi: ExtensionAPI) {
     updateBadge();
   }
 
-  // Hard-block forbidden tools when broker role is active.
-  pi.on("tool_call", async (event) => {
+  // Hard-block forbidden tools when broker role is active, and enforce worktree-only coding.
+  pi.on("tool_call", async (event, ctx) => {
     if (brokerRole === "broker" && isBrokerForbiddenTool(event.toolName)) {
       return {
         block: true,
         reason: `Tool "${event.toolName}" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.`,
       };
+    }
+
+    if (event.toolName === "edit" || event.toolName === "write" || event.toolName === "bash") {
+      const gitContext = await probeGitContext(ctx.cwd);
+      const worktreeBlockReason = getMainCheckoutToolBlockReason(event.toolName, event.input, {
+        worktreeKind: gitContext.worktreeKind,
+        branch: gitContext.branch,
+        cwd: ctx.cwd,
+        repoRoot: gitContext.repoRoot,
+      });
+      if (worktreeBlockReason) {
+        return {
+          block: true,
+          reason: worktreeBlockReason,
+        };
+      }
     }
   });
 

--- a/slack-bridge/worktree-policy.test.ts
+++ b/slack-bridge/worktree-policy.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMainCheckoutBranchSwitchBlockReason,
+  buildMainCheckoutEditBlockReason,
+  containsGitBranchSwitch,
+  getMainCheckoutToolBlockReason,
+} from "./worktree-policy.js";
+
+describe("containsGitBranchSwitch", () => {
+  it("detects git checkout commands", () => {
+    expect(containsGitBranchSwitch("git checkout feat/foo")).toBe(true);
+  });
+
+  it("detects git switch commands in compound bash", () => {
+    expect(containsGitBranchSwitch("pwd && git switch feat/foo")).toBe(true);
+  });
+
+  it("ignores non-switch commands", () => {
+    expect(containsGitBranchSwitch("git status && pnpm test")).toBe(false);
+  });
+});
+
+describe("main checkout block reasons", () => {
+  it("builds an edit/write refusal that points agents to worktrees", () => {
+    const reason = buildMainCheckoutEditBlockReason();
+    expect(reason).toContain("Refusing to modify files from the main checkout");
+    expect(reason).toContain("git worktree add .worktrees/<name> -b <branch>");
+  });
+
+  it("mentions drift when the main checkout is already off main", () => {
+    const reason = buildMainCheckoutBranchSwitchBlockReason("feat/not-main");
+    expect(reason).toContain("currently on `feat/not-main`, expected `main`");
+  });
+});
+
+describe("getMainCheckoutToolBlockReason", () => {
+  it("blocks editing files in the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "edit",
+        { path: "slack-bridge/index.ts" },
+        {
+          worktreeKind: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("git worktree add .worktrees/<name> -b <branch>");
+  });
+
+  it("allows editing files inside linked worktrees even when launched from the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "edit",
+        { path: ".worktrees/feat-87/slack-bridge/index.ts" },
+        {
+          worktreeKind: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("blocks git branch switching in bash from the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "git switch feat/work" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to run `git checkout` or `git switch` in the main checkout");
+  });
+
+  it("allows branch switching after cd into a linked worktree", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "cd .worktrees/feat-87 && git switch feat/next" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("allows branch switching with git -C into a linked worktree", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "git -C .worktrees/feat-87 switch feat/next" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("allows ordinary bash tooling after cd into a linked worktree", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        {
+          command:
+            "git worktree add .worktrees/feat-87 -b feat/87 && cd .worktrees/feat-87 && pnpm lint && pnpm test",
+        },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("resolves .worktrees paths against repoRoot when cwd is nested", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "edit",
+        { path: ".worktrees/feat-87/slack-bridge/index.ts" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions/slack-bridge",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("allows cd into a linked worktree from a nested repo cwd", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "cd .worktrees/feat-87 && pnpm test" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions/slack-bridge",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("blocks obvious shell mutations in the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "echo hello > slack-bridge/index.ts" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("blocks interpreter-based writes in the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "node -e \"require('node:fs').writeFileSync('foo.ts', 'x')\"" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("blocks non-redirection writers in the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "dd if=/dev/null of=foo.ts" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("allows git worktree management commands in the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "git worktree add .worktrees/feat-87 -b feat/87" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("blocks worktree-targeted shell commands that can escape back into the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "cd .worktrees/feat-87 && rm -rf ../../slack-bridge" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("blocks worktree-targeted git commands that redirect work-tree back to main", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        {
+          command:
+            "cd .worktrees/feat-87 && git --work-tree=../.. --git-dir=../../.git checkout -- slack-bridge/index.ts",
+        },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("blocks git -C worktree commands that override git-dir back to main", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        {
+          command:
+            "git -C .worktrees/feat-87 --git-dir=../../.git --work-tree=../.. clean -fd slack-bridge",
+        },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("blocks explicit path escapes from a linked worktree via embedded script strings", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        {
+          command:
+            "cd .worktrees/feat-87 && node -e \"require('node:fs').writeFileSync('../../slack-bridge/index.ts', 'x')\"",
+        },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("blocks absolute main-checkout paths embedded inside interpreter strings", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        {
+          command:
+            "cd .worktrees/feat-87 && node -e \"require('node:fs').writeFileSync('/Users/alice/src/extensions/slack-bridge/index.ts', 'x')\"",
+        },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toContain("Refusing to modify files from the main checkout");
+  });
+
+  it("allows safe bash inspection commands in the main checkout", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "bash",
+        { command: "git status && rg worktree slack-bridge" },
+        {
+          worktreeKind: "main",
+          branch: "main",
+          cwd: "/Users/alice/src/extensions",
+          repoRoot: "/Users/alice/src/extensions",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("allows edit/write tools in linked worktrees", () => {
+    expect(
+      getMainCheckoutToolBlockReason(
+        "write",
+        { path: "foo.ts", content: "x" },
+        { worktreeKind: "linked" },
+      ),
+    ).toBeNull();
+  });
+});

--- a/slack-bridge/worktree-policy.ts
+++ b/slack-bridge/worktree-policy.ts
@@ -1,0 +1,278 @@
+import * as path from "node:path";
+
+export type CheckoutKind = "main" | "linked";
+
+export interface WorktreePolicyContext {
+  worktreeKind?: CheckoutKind;
+  branch?: string;
+  cwd?: string;
+  repoRoot?: string;
+}
+
+const WORKTREE_SETUP_COMMAND =
+  "git worktree add .worktrees/<name> -b <branch> && cd .worktrees/<name>";
+const GIT_BRANCH_SWITCH_RE =
+  /(^|[\n;&|]\s*)git\s+(?:(?:-C\s+(?:"[^"]+"|'[^']+'|\S+)\s+)|(?:-[^\s]+\s+))*?(checkout|switch)\b/m;
+const GIT_WORKTREE_COMMAND_RE = /^git\s+worktree\s+(add|remove|list|prune)\b/;
+const GIT_PATH_REDIRECTION_RE =
+  /(^|\s)(--work-tree|--git-dir)=?\S*|(^|\s)(GIT_WORK_TREE|GIT_DIR)=\S+/;
+const MAIN_CHECKOUT_READ_ONLY_RES = [
+  /^pwd$/,
+  /^ls\b/,
+  /^find\b/,
+  /^rg\b/,
+  /^grep\b/,
+  /^cat\b/,
+  /^head\b/,
+  /^tail\b/,
+  /^wc\b/,
+  /^sort\b/,
+  /^cut\b/,
+  /^awk\b/,
+  /^sed\b(?!.*\s-i\b)/,
+  /^(test|\[)\b/,
+  /^(basename|dirname|realpath|readlink|stat)\b/,
+  /^git\s+(?:-C\s+(?:"[^"]+"|'[^']+'|\S+)\s+)?(status|log|diff|show|branch\b|rev-parse|ls-files|remote\b|worktree\s+list)\b/,
+];
+
+function describeMainCheckout(branch?: string): string {
+  if (branch && branch !== "main") {
+    return ` The main checkout is currently on \`${branch}\`, expected \`main\`.`;
+  }
+  return " The main checkout must stay on `main`.";
+}
+
+export function containsGitBranchSwitch(command: string): boolean {
+  return GIT_BRANCH_SWITCH_RE.test(command);
+}
+
+export function buildMainCheckoutEditBlockReason(branch?: string): string {
+  return [
+    `Refusing to modify files from the main checkout.${describeMainCheckout(branch)}`,
+    `Feature work must happen in a git worktree. Create one first: \`${WORKTREE_SETUP_COMMAND}\`.`,
+  ].join(" ");
+}
+
+export function buildMainCheckoutBranchSwitchBlockReason(branch?: string): string {
+  return [
+    `Refusing to run \`git checkout\` or \`git switch\` in the main checkout.${describeMainCheckout(branch)}`,
+    `Create or enter a linked worktree instead: \`${WORKTREE_SETUP_COMMAND}\`.`,
+  ].join(" ");
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function splitShellSegments(command: string): string[] {
+  return command
+    .split(/&&|\|\||;|\n/g)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function extractCdTarget(segment: string): string | null {
+  const match = /^cd\s+(.+)$/.exec(segment.trim());
+  return match?.[1] ? stripQuotes(match[1]) : null;
+}
+
+function extractGitCTarget(segment: string): string | null {
+  const match = /^git\s+-C\s+("[^"]+"|'[^']+'|\S+)\s+/.exec(segment.trim());
+  return match?.[1] ? stripQuotes(match[1]) : null;
+}
+
+function getPolicyRoot(context: WorktreePolicyContext): string {
+  return path.resolve(context.repoRoot ?? context.cwd ?? process.cwd());
+}
+
+function isRepoRootRelativeWorktreePath(candidate: string): boolean {
+  const normalized = candidate.replace(/\\/g, "/");
+  return (
+    normalized === ".worktrees" ||
+    normalized.startsWith(".worktrees/") ||
+    normalized === "./.worktrees" ||
+    normalized.startsWith("./.worktrees/")
+  );
+}
+
+function resolvePolicyPath(
+  candidate: string,
+  baseDir: string,
+  context: WorktreePolicyContext,
+): string {
+  const trimmed = stripQuotes(candidate.trim());
+  if (path.isAbsolute(trimmed)) {
+    return path.resolve(trimmed);
+  }
+  if (isRepoRootRelativeWorktreePath(trimmed)) {
+    const repoRelative = trimmed.replace(/^\.\//, "");
+    return path.resolve(getPolicyRoot(context), repoRelative);
+  }
+  return path.resolve(baseDir, trimmed);
+}
+
+function resolveToolPath(
+  input: unknown,
+  context: WorktreePolicyContext,
+  cwd = process.cwd(),
+): string | null {
+  if (typeof input !== "object" || input === null) return null;
+  const candidate = (input as { path?: unknown }).path;
+  if (typeof candidate !== "string" || candidate.trim().length === 0) return null;
+  return resolvePolicyPath(candidate, cwd, context);
+}
+
+function getLinkedWorktreeRoot(
+  targetPath: string | null,
+  context: WorktreePolicyContext,
+): string | null {
+  if (!targetPath) return null;
+  const worktreesDir = path.join(getPolicyRoot(context), ".worktrees");
+  if (!isPathInside(worktreesDir, targetPath)) {
+    return null;
+  }
+  const relative = path.relative(worktreesDir, targetPath);
+  const [worktreeName] = relative.split(path.sep);
+  if (!worktreeName) {
+    return null;
+  }
+  return path.join(worktreesDir, worktreeName);
+}
+
+function isLinkedWorktreePath(targetPath: string | null, context: WorktreePolicyContext): boolean {
+  return getLinkedWorktreeRoot(targetPath, context) != null;
+}
+
+function isAllowedMainCheckoutSegment(segment: string): boolean {
+  return MAIN_CHECKOUT_READ_ONLY_RES.some((pattern) => pattern.test(segment));
+}
+
+function containsGitPathRedirection(segment: string): boolean {
+  return GIT_PATH_REDIRECTION_RE.test(segment);
+}
+
+function extractPathCandidates(segment: string): string[] {
+  const candidates = new Set<string>();
+  const tokens = segment.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+
+  for (const token of tokens) {
+    const stripped = stripQuotes(token);
+    const values = [stripped];
+    const equalsIndex = stripped.indexOf("=");
+    if (equalsIndex > 0 && equalsIndex < stripped.length - 1) {
+      values.push(stripQuotes(stripped.slice(equalsIndex + 1)));
+    }
+
+    for (const value of values) {
+      if (!value) continue;
+      if (path.isAbsolute(value) || isRepoRootRelativeWorktreePath(value)) {
+        candidates.add(value);
+      }
+      for (const match of value.matchAll(/(?:\.\.?)(?:[\\/][^'"`\s),]+)+/g)) {
+        candidates.add(match[0]);
+      }
+      for (const match of value.matchAll(/(?:\/[^'"`\s),]+)+/g)) {
+        candidates.add(match[0]);
+      }
+      for (const match of value.matchAll(/[A-Za-z]:\\[^'"`\s),]+(?:\\[^'"`\s),]+)*/g)) {
+        candidates.add(match[0]);
+      }
+    }
+  }
+
+  return [...candidates];
+}
+
+function containsWorktreeEscape(
+  segment: string,
+  effectiveDir: string,
+  linkedWorktreeRoot: string,
+  context: WorktreePolicyContext,
+): boolean {
+  const repoRoot = getPolicyRoot(context);
+  return extractPathCandidates(segment).some((candidate) => {
+    const resolved = resolvePolicyPath(candidate, effectiveDir, context);
+    return isPathInside(repoRoot, resolved) && !isPathInside(linkedWorktreeRoot, resolved);
+  });
+}
+
+function getMainCheckoutBashBlockReason(
+  command: string,
+  context: WorktreePolicyContext,
+): string | null {
+  let currentDir = path.resolve(context.cwd ?? context.repoRoot ?? process.cwd());
+
+  for (const segment of splitShellSegments(command)) {
+    const cdTarget = extractCdTarget(segment);
+    if (cdTarget) {
+      currentDir = resolvePolicyPath(cdTarget, currentDir, context);
+      continue;
+    }
+
+    const effectiveDir = resolvePolicyPath(extractGitCTarget(segment) ?? ".", currentDir, context);
+    const linkedWorktreeRoot = getLinkedWorktreeRoot(effectiveDir, context);
+
+    if (containsGitPathRedirection(segment)) {
+      return buildMainCheckoutEditBlockReason(context.branch);
+    }
+
+    if (linkedWorktreeRoot) {
+      if (containsWorktreeEscape(segment, effectiveDir, linkedWorktreeRoot, context)) {
+        return buildMainCheckoutEditBlockReason(context.branch);
+      }
+      continue;
+    }
+
+    if (containsGitBranchSwitch(segment)) {
+      return buildMainCheckoutBranchSwitchBlockReason(context.branch);
+    }
+
+    if (GIT_WORKTREE_COMMAND_RE.test(segment) || isAllowedMainCheckoutSegment(segment)) {
+      continue;
+    }
+
+    return buildMainCheckoutEditBlockReason(context.branch);
+  }
+
+  return null;
+}
+
+export function getMainCheckoutToolBlockReason(
+  toolName: string,
+  input: unknown,
+  context: WorktreePolicyContext,
+): string | null {
+  if (context.worktreeKind !== "main") {
+    return null;
+  }
+
+  if (toolName === "edit" || toolName === "write") {
+    if (isLinkedWorktreePath(resolveToolPath(input, context, context.cwd), context)) {
+      return null;
+    }
+    return buildMainCheckoutEditBlockReason(context.branch);
+  }
+
+  if (
+    toolName === "bash" &&
+    typeof input === "object" &&
+    input !== null &&
+    typeof (input as { command?: unknown }).command === "string"
+  ) {
+    return getMainCheckoutBashBlockReason((input as { command: string }).command, context);
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Closes #87.

Enforces the repo worktree policy in `slack-bridge` and makes linked worktree agents more visible/reliable in Pinet.

## What changed

- canonicalized git metadata so linked worktrees still report the parent repo (`extensions`) instead of the worktree directory name
- added explicit `worktreePath` / `worktreeKind` metadata to agent registration and capability tags
- show linked worktree location in `pinet_agents`, and flag ghost linked worktrees with a cleanup command
- add Ralph-loop anomaly for orphaned linked worktrees
- enforce the main-checkout rule in `tool_call`:
  - block `git checkout` / `git switch` from the main checkout
  - block `edit` / `write` against main-checkout files while still allowing `.worktrees/...` targets
- strengthen broker prompt guidelines with explicit worktree lifecycle instructions
- warn on session start if the main checkout has drifted off `main`

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
