### PR TITLE
fix: keep broker db authoritative for thread tracking (#131)

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -305,31 +305,31 @@ describe("classifyMessage", () => {
     }
   });
 
-  // ─── isOwnedThread callback ─────────────────────────────
+  // ─── isKnownThread callback ─────────────────────────────
 
-  it("accepts thread replies in broker-owned threads without @mention", () => {
-    const isOwnedThread = (ts: string) => ts === "500.600";
+  it("accepts thread replies in broker-known threads without @mention", () => {
+    const isKnownThread = (ts: string) => ts === "500.600";
     const evt = {
       type: "message",
       user: "U1",
-      text: "follow up in owned thread",
+      text: "follow up in known thread",
       channel: "C1",
       channel_type: "channel",
       thread_ts: "500.600",
       ts: "500.700",
     };
-    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    const result = classifyMessage(evt, botId, emptyTracked, isKnownThread);
     expect(result.relevant).toBe(true);
     if (result.relevant) {
       expect(result.threadTs).toBe("500.600");
       expect(result.isChannelMention).toBe(false);
-      expect(result.text).toBe("follow up in owned thread");
+      expect(result.text).toBe("follow up in known thread");
       expect(result.isDM).toBe(false);
     }
   });
 
-  it("rejects thread replies in non-owned threads without @mention", () => {
-    const isOwnedThread = () => false;
+  it("rejects thread replies in unknown threads without @mention", () => {
+    const isKnownThread = () => false;
     const evt = {
       type: "message",
       user: "U1",
@@ -339,12 +339,12 @@ describe("classifyMessage", () => {
       thread_ts: "600.700",
       ts: "600.800",
     };
-    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    const result = classifyMessage(evt, botId, emptyTracked, isKnownThread);
     expect(result).toEqual({ relevant: false });
   });
 
-  it("does not set isChannelMention for @mention in broker-owned thread", () => {
-    const isOwnedThread = (ts: string) => ts === "700.800";
+  it("does not set isChannelMention for @mention in broker-known thread", () => {
+    const isKnownThread = (ts: string) => ts === "700.800";
     const evt = {
       type: "message",
       user: "U1",
@@ -354,7 +354,7 @@ describe("classifyMessage", () => {
       thread_ts: "700.800",
       ts: "700.900",
     };
-    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    const result = classifyMessage(evt, botId, emptyTracked, isKnownThread);
     expect(result.relevant).toBe(true);
     if (result.relevant) {
       expect(result.isChannelMention).toBe(false);
@@ -363,26 +363,25 @@ describe("classifyMessage", () => {
     }
   });
 
-  it("prefers local tracked set over isOwnedThread callback", () => {
-    const isOwnedThread = vi.fn(() => true);
+  it("uses the broker-known callback as the source of truth when provided", () => {
+    const isKnownThread = vi.fn(() => false);
     const tracked = new Set(["800.900"]);
     const evt = {
       type: "message",
       user: "U1",
-      text: "reply in tracked thread",
+      text: "reply in stale locally tracked thread",
       channel: "C1",
       channel_type: "channel",
       thread_ts: "800.900",
       ts: "800.950",
     };
-    const result = classifyMessage(evt, botId, tracked, isOwnedThread);
-    expect(result.relevant).toBe(true);
-    // isOwnedThread should NOT be called because isTracked was true first
-    expect(isOwnedThread).not.toHaveBeenCalled();
+    const result = classifyMessage(evt, botId, tracked, isKnownThread);
+    expect(result).toEqual({ relevant: false });
+    expect(isKnownThread).toHaveBeenCalledWith("800.900");
   });
 
-  it("does not call isOwnedThread for messages without thread_ts", () => {
-    const isOwnedThread = vi.fn(() => true);
+  it("does not call isKnownThread for messages without thread_ts", () => {
+    const isKnownThread = vi.fn(() => true);
     const evt = {
       type: "message",
       user: "U1",
@@ -391,12 +390,12 @@ describe("classifyMessage", () => {
       channel_type: "channel",
       ts: "900.100",
     };
-    const result = classifyMessage(evt, botId, emptyTracked, isOwnedThread);
+    const result = classifyMessage(evt, botId, emptyTracked, isKnownThread);
     expect(result).toEqual({ relevant: false });
-    expect(isOwnedThread).not.toHaveBeenCalled();
+    expect(isKnownThread).not.toHaveBeenCalled();
   });
 
-  it("works without isOwnedThread callback (backward compatible)", () => {
+  it("works without isKnownThread callback (backward compatible)", () => {
     const evt = {
       type: "message",
       user: "U1",
@@ -485,12 +484,39 @@ describe("SlackAdapter", () => {
     expect(adapter.name).toBe("slack");
   });
 
-  it("can be constructed with isOwnedThread callback", () => {
+  it("can be constructed with isKnownThread callback", () => {
     const adapter = new SlackAdapter({
       ...baseConfig,
-      isOwnedThread: () => false,
+      isKnownThread: () => false,
     });
     expect(adapter.name).toBe("slack");
+  });
+
+  it("records known threads on assistant_thread_started without claiming ownership", async () => {
+    const rememberKnownThread = vi.fn();
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      rememberKnownThread,
+    });
+    vi.spyOn(
+      adapter as unknown as { setSuggestedPrompts: () => Promise<void> },
+      "setSuggestedPrompts",
+    ).mockResolvedValue(undefined);
+
+    await (
+      adapter as unknown as {
+        onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onThreadStarted({
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "C123",
+        thread_ts: "123.456",
+        user_id: "U123",
+      },
+    });
+
+    expect(rememberKnownThread).toHaveBeenCalledWith("123.456", "C123");
   });
 
   it("registers an inbound handler", () => {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -16,8 +16,10 @@ export interface SlackAdapterConfig {
   appToken: string;
   allowedUsers?: string[];
   suggestedPrompts?: { title: string; message: string }[];
-  /** Check whether a thread_ts belongs to a thread the bot owns in the broker DB. */
-  isOwnedThread?: (threadTs: string) => boolean;
+  /** Check whether a thread_ts belongs to a known thread in the broker DB. */
+  isKnownThread?: (threadTs: string) => boolean;
+  /** Persist thread metadata in the broker DB without claiming ownership. */
+  rememberKnownThread?: (threadTs: string, channelId: string) => void;
 }
 
 interface SlackThreadInfo {
@@ -108,14 +110,14 @@ export type MessageClassification =
 
 /**
  * Classify an incoming Slack message event. Determines whether the
- * message is relevant (DM, tracked thread, or bot mention) and
+ * message is relevant (DM, known thread, or bot mention) and
  * extracts the cleaned fields.
  */
 export function classifyMessage(
   evt: Record<string, unknown>,
   botUserId: string | null,
   trackedThreadIds: Set<string>,
-  isOwnedThread?: (threadTs: string) => boolean,
+  isKnownThread?: (threadTs: string) => boolean,
 ): MessageClassification {
   // Skip bot messages and messages with subtypes (joins, edits, etc.)
   if (evt.subtype || evt.bot_id) return { relevant: false };
@@ -126,15 +128,14 @@ export function classifyMessage(
   const channel = evt.channel as string;
   const channelType = evt.channel_type as string | undefined;
 
-  const isTracked = !!threadTs && trackedThreadIds.has(threadTs);
-  const isOwned = !isTracked && !!threadTs && (isOwnedThread?.(threadTs) ?? false);
+  const isKnown = !!threadTs && (isKnownThread?.(threadTs) ?? trackedThreadIds.has(threadTs));
   const isDM = channelType === "im";
   const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
 
-  if (!isTracked && !isOwned && !isDM && !isMention) return { relevant: false };
+  if (!isKnown && !isDM && !isMention) return { relevant: false };
 
   const effectiveTs = threadTs ?? (evt.ts as string);
-  const isChannelMention = isMention && !isDM && !isTracked && !isOwned;
+  const isChannelMention = isMention && !isDM && !isKnown;
 
   const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
 
@@ -358,6 +359,11 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     this.threads.set(info.threadTs, info);
+    try {
+      this.config.rememberKnownThread?.(info.threadTs, info.channelId);
+    } catch {
+      /* best effort — DB cache sync must not break Slack event handling */
+    }
     await this.setSuggestedPrompts(info.channelId, info.threadTs);
   }
 
@@ -386,7 +392,7 @@ export class SlackAdapter implements MessageAdapter {
       evt,
       this.botUserId,
       this.getTrackedThreadIds(),
-      this.config.isOwnedThread,
+      this.config.isKnownThread,
     );
     if (!classified.relevant) return;
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -1473,31 +1473,49 @@ describe("syncFollowerInboxEntries", () => {
 // ─── resolveFollowerThreadChannel ─────────────────────────
 
 describe("resolveFollowerThreadChannel", () => {
-  it("returns the local channel without calling the broker", async () => {
-    const resolveThread = async () => {
-      throw new Error("should not be called");
-    };
+  it("prefers the resolver result over a stale local channel cache", async () => {
+    const resolveThread = vi.fn(async (threadTs: string) => {
+      expect(threadTs).toBe("1234.5678");
+      return "C999";
+    });
 
     await expect(
       resolveFollowerThreadChannel(
         "1234.5678",
         { channelId: "C123", threadTs: "1234.5678", userId: "U1", owner: "Bot" },
-        "follower",
+        resolveThread,
+      ),
+    ).resolves.toEqual({
+      channelId: "C999",
+      changed: true,
+      threadUpdate: {
+        channelId: "C999",
+        threadTs: "1234.5678",
+        userId: "U1",
+        owner: "Bot",
+      },
+    });
+    expect(resolveThread).toHaveBeenCalledWith("1234.5678");
+  });
+
+  it("returns the resolver result without a cache update when it matches local state", async () => {
+    const resolveThread = vi.fn(async () => "C123");
+
+    await expect(
+      resolveFollowerThreadChannel(
+        "1234.5678",
+        { channelId: "C123", threadTs: "1234.5678", userId: "U1", owner: "Bot" },
         resolveThread,
       ),
     ).resolves.toEqual({ channelId: "C123", changed: false });
+    expect(resolveThread).toHaveBeenCalledWith("1234.5678");
   });
 
-  it("asks the broker for the channel when the follower has no local thread", async () => {
-    const result = await resolveFollowerThreadChannel(
-      "1234.5678",
-      undefined,
-      "follower",
-      async (threadTs) => {
-        expect(threadTs).toBe("1234.5678");
-        return "C999";
-      },
-    );
+  it("asks the resolver for the channel when there is no local thread cache", async () => {
+    const result = await resolveFollowerThreadChannel("1234.5678", undefined, async (threadTs) => {
+      expect(threadTs).toBe("1234.5678");
+      return "C999";
+    });
 
     expect(result).toEqual({
       channelId: "C999",
@@ -1511,28 +1529,46 @@ describe("resolveFollowerThreadChannel", () => {
     });
   });
 
-  it("returns null when the broker cannot resolve the thread", async () => {
+  it("returns null when the resolver cannot find the thread, even if local cache exists", async () => {
     await expect(
-      resolveFollowerThreadChannel("1234.5678", undefined, "follower", async () => null),
-    ).resolves.toEqual({ channelId: null, changed: false });
+      resolveFollowerThreadChannel(
+        "1234.5678",
+        { channelId: "C123", threadTs: "1234.5678", userId: "U1", owner: "Bot" },
+        async () => null,
+      ),
+    ).resolves.toEqual({
+      channelId: null,
+      changed: false,
+    });
   });
 
-  it("returns null when the broker lookup throws", async () => {
+  it("returns null when the resolver throws", async () => {
     await expect(
-      resolveFollowerThreadChannel("1234.5678", undefined, "follower", async () => {
+      resolveFollowerThreadChannel("1234.5678", undefined, async () => {
         throw new Error("broker offline");
       }),
     ).resolves.toEqual({ channelId: null, changed: false });
   });
 
-  it("does not query the broker for non-followers", async () => {
-    const resolveThread = async () => {
-      throw new Error("should not be called");
-    };
-
+  it("falls back to the local cache when no resolver is available", async () => {
     await expect(
-      resolveFollowerThreadChannel("1234.5678", undefined, "broker", resolveThread),
-    ).resolves.toEqual({ channelId: null, changed: false });
+      resolveFollowerThreadChannel("1234.5678", {
+        channelId: "C123",
+        threadTs: "1234.5678",
+        userId: "U1",
+        owner: "Bot",
+      }),
+    ).resolves.toEqual({
+      channelId: "C123",
+      changed: false,
+    });
+  });
+
+  it("returns null when no resolver or local cache is available", async () => {
+    await expect(resolveFollowerThreadChannel("1234.5678", undefined)).resolves.toEqual({
+      channelId: null,
+      changed: false,
+    });
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1042,25 +1042,26 @@ export interface FollowerThreadChannelResolution {
 export async function resolveFollowerThreadChannel(
   threadTs: string | undefined,
   existingThread: FollowerThreadState | undefined,
-  brokerRole: "broker" | "follower" | null,
   resolveThread?: (threadTs: string) => Promise<string | null>,
 ): Promise<FollowerThreadChannelResolution> {
   if (!threadTs) {
     return { channelId: null, changed: false };
   }
 
-  if (existingThread?.channelId) {
-    return { channelId: existingThread.channelId, changed: false };
-  }
-
-  if (brokerRole !== "follower" || !resolveThread) {
-    return { channelId: null, changed: false };
+  if (!resolveThread) {
+    return existingThread?.channelId
+      ? { channelId: existingThread.channelId, changed: false }
+      : { channelId: null, changed: false };
   }
 
   try {
     const channelId = await resolveThread(threadTs);
     if (!channelId) {
       return { channelId: null, changed: false };
+    }
+
+    if (existingThread?.channelId === channelId) {
+      return { channelId, changed: false };
     }
 
     return {
@@ -1131,9 +1132,9 @@ export function getFollowerOwnedThreadClaims(
 }
 
 /**
- * Track a thread from a broker inbound message in the threads map.
- * Used by the broker onInbound callback so that slack_send can resolve
- * the channel for channel-mention messages.
+ * Cache a thread from a broker inbound message in the local threads map.
+ * The broker DB remains the source of truth; this is only a read-through
+ * cache so Slack tools can resolve channels without hitting the DB every time.
  */
 export function trackBrokerInboundThread(
   threads: Map<string, FollowerThreadState>,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -376,13 +376,14 @@ export default function (pi: ExtensionAPI) {
     if (!threadTs) return null;
 
     const existingThread = threads.get(threadTs);
-    const followerClient = brokerRole === "follower" ? brokerClient?.client : undefined;
-    const resolved = await resolveFollowerThreadChannel(
-      threadTs,
-      existingThread,
-      brokerRole,
-      followerClient ? (nextThreadTs) => followerClient.resolveThread(nextThreadTs) : undefined,
-    );
+    const brokerRef = brokerRole === "broker" ? activeBroker : null;
+    const followerClient = brokerRole === "follower" ? brokerClient?.client : null;
+    const resolveThread = brokerRef
+      ? async (nextThreadTs: string) => brokerRef.db.getThread(nextThreadTs)?.channel ?? null
+      : followerClient
+        ? (nextThreadTs: string) => followerClient.resolveThread(nextThreadTs)
+        : undefined;
+    const resolved = await resolveFollowerThreadChannel(threadTs, existingThread, resolveThread);
 
     if (resolved.threadUpdate && resolved.changed) {
       threads.set(threadTs, {
@@ -901,7 +902,6 @@ export default function (pi: ExtensionAPI) {
       }
       pendingEyes.delete(threadTs);
     },
-    getThreadChannel: (threadTs) => threads.get(threadTs)?.channelId ?? null,
     registerConfirmationRequest,
   });
 
@@ -1474,9 +1474,9 @@ export default function (pi: ExtensionAPI) {
           appToken: appToken!,
           allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
           suggestedPrompts: settings.suggestedPrompts,
-          isOwnedThread: (threadTs: string) => {
-            const thread = broker.db.getThread(threadTs);
-            return thread?.ownerAgent != null;
+          isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
+          rememberKnownThread: (threadTs: string, channelId: string) => {
+            broker.db.updateThread(threadTs, { source: "slack", channel: channelId });
           },
         });
 
@@ -1505,10 +1505,18 @@ export default function (pi: ExtensionAPI) {
         }
 
         adapter.onInbound((inMsg) => {
-          // Track thread metadata without claiming broker ownership.
+          // Track thread metadata locally as a cache without claiming broker ownership.
           trackBrokerInboundThread(threads, inMsg);
 
           const decision = router.route(inMsg);
+
+          if (inMsg.threadId && inMsg.channel) {
+            broker.db.updateThread(inMsg.threadId, {
+              source: inMsg.source,
+              channel: inMsg.channel,
+            });
+          }
+
           if (decision.action === "deliver" && decision.agentId !== selfId) {
             broker.db.queueMessage(decision.agentId, inMsg);
             return;

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerSlackTools } from "./slack-tools.js";
+import type { InboxMessage } from "./helpers.js";
+import type { SlackResult } from "./slack-api.js";
+
+type ToolResponse = {
+  content?: Array<{ type: string; text: string }>;
+  details?: Record<string, unknown>;
+};
+
+type ToolDefinition = {
+  name: string;
+  execute: (id: string, params: Record<string, unknown>) => Promise<ToolResponse>;
+};
+
+describe("registerSlackTools", () => {
+  it("uses read-through thread resolution for slack_read", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const pi = {
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+    } as unknown as ExtensionAPI;
+
+    const inbox: InboxMessage[] = [];
+    const slack = vi.fn<
+      (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>
+    >(async () => ({ ok: true, messages: [] }) as SlackResult);
+    const resolveFollowerReplyChannel = vi.fn(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+
+    registerSlackTools(pi, {
+      botToken: "xoxb-test-token",
+      defaultChannel: undefined,
+      securityPrompt: "",
+      guardrails: {},
+      inbox,
+      slack,
+      getAgentName: () => "Radiant Koala",
+      getAgentEmoji: () => "🐨",
+      getLastDmChannel: () => null,
+      updateBadge: () => {},
+      resolveUser: async (userId) => userId,
+      resolveFollowerReplyChannel,
+      resolveChannel: async (nameOrId) => nameOrId,
+      rememberChannel: () => {},
+      requireToolPolicy: () => {},
+      trackOutboundThread: () => {},
+      claimThreadOwnership: () => {},
+      clearPendingEyes: () => {},
+      registerConfirmationRequest: () => ({ status: "created" }),
+    });
+
+    const tool = tools.get("slack_read");
+    expect(tool).toBeDefined();
+
+    await tool!.execute("tool-1", { thread_ts: "123.456" });
+
+    expect(slack).toHaveBeenCalledWith("conversations.replies", "xoxb-test-token", {
+      channel: "C-DB",
+      ts: "123.456",
+      limit: 20,
+    });
+  });
+});

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -23,7 +23,6 @@ export interface RegisterSlackToolsDeps {
   trackOutboundThread: (threadTs: string, channelId: string) => void;
   claimThreadOwnership: (threadTs: string, channelId: string) => void;
   clearPendingEyes: (threadTs: string) => void;
-  getThreadChannel: (threadTs: string) => string | null;
   registerConfirmationRequest: (
     threadTs: string,
     tool: string,
@@ -79,7 +78,6 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     trackOutboundThread,
     claimThreadOwnership,
     clearPendingEyes,
-    getThreadChannel,
     registerConfirmationRequest,
   } = deps;
 
@@ -211,7 +209,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         `thread_ts=${params.thread_ts} | limit=${params.limit ?? 20}`,
       );
 
-      const channel = getThreadChannel(params.thread_ts) ?? getLastDmChannel();
+      const channel = (await resolveFollowerReplyChannel(params.thread_ts)) ?? getLastDmChannel();
       if (!channel) {
         throw new Error("Unknown thread.");
       }
@@ -417,7 +415,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       tool: Type.String({ description: "Name of the tool that requires confirmation" }),
     }),
     async execute(_id, params) {
-      const channelId = getThreadChannel(params.thread_ts);
+      const channelId = await resolveFollowerReplyChannel(params.thread_ts);
       if (!channelId) {
         throw new Error(`No active Slack thread for thread_ts: ${params.thread_ts}`);
       }


### PR DESCRIPTION
## Summary\n- persist broker-known Slack threads in the broker DB before ownership is claimed\n- use broker thread lookups as the read-through source of truth for Slack thread channel resolution\n- update adapter/helper/tool tests to cover known-but-unowned threads and DB-backed thread reads\n\n## Context\nThis replaces the stale approach in #157 with a focused fix on top of current `main`. It keeps known threads and owned threads separate so pre-claim follow-up replies are still accepted without letting local in-memory thread state drift away from the broker DB.\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm test