### PR TITLE
feat: add Pinet broadcast channels

### DIFF
--- a/slack-bridge/broker/agent-messaging.test.ts
+++ b/slack-bridge/broker/agent-messaging.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import type { AgentInfo, BrokerMessage } from "./types.js";
+import {
+  agentSubscribesToBroadcastChannel,
+  dispatchBroadcastAgentMessage,
+  dispatchDirectAgentMessage,
+  getAgentBroadcastChannels,
+  resolveBroadcastTargets,
+  type AgentMessageStorage,
+} from "./agent-messaging.js";
+
+function createAgent(
+  id: string,
+  name: string,
+  metadata: Record<string, unknown> | null,
+): AgentInfo {
+  return {
+    id,
+    name,
+    emoji: "🤖",
+    pid: 1234,
+    connectedAt: "2026-04-02T00:00:00.000Z",
+    lastSeen: "2026-04-02T00:00:00.000Z",
+    lastHeartbeat: "2026-04-02T00:00:00.000Z",
+    metadata,
+    status: "idle",
+    disconnectedAt: null,
+    resumableUntil: null,
+    idleSince: null,
+    lastActivity: null,
+  };
+}
+
+function createStorage(agents: AgentInfo[]): AgentMessageStorage & {
+  threads: Set<string>;
+  inserted: Array<{
+    threadId: string;
+    sender: string;
+    body: string;
+    targetAgentIds: string[];
+    metadata: Record<string, unknown> | undefined;
+  }>;
+} {
+  const threads = new Set<string>();
+  const inserted: Array<{
+    threadId: string;
+    sender: string;
+    body: string;
+    targetAgentIds: string[];
+    metadata: Record<string, unknown> | undefined;
+  }> = [];
+
+  return {
+    threads,
+    inserted,
+    getAgents: () => agents,
+    getThread: (threadId) => (threads.has(threadId) ? { threadId } : null),
+    createThread: (threadId) => {
+      threads.add(threadId);
+    },
+    insertMessage: (
+      threadId,
+      _source,
+      _direction,
+      sender,
+      body,
+      targetAgentIds,
+      metadata,
+    ): BrokerMessage => {
+      inserted.push({ threadId, sender, body, targetAgentIds, metadata });
+      return {
+        id: inserted.length,
+        threadId,
+        source: "agent",
+        direction: "inbound",
+        sender,
+        body,
+        metadata: metadata ?? null,
+        createdAt: `2026-04-02T00:00:0${inserted.length}.000Z`,
+      };
+    },
+  };
+}
+
+describe("getAgentBroadcastChannels", () => {
+  it("derives built-in repo and standup subscriptions for workers", () => {
+    const agent = createAgent("worker-1", "worker-1", {
+      capabilities: {
+        repo: "extensions",
+        role: "worker",
+        tags: ["topic:frontend"],
+      },
+    });
+
+    expect(getAgentBroadcastChannels(agent)).toEqual(
+      expect.arrayContaining(["all", "extensions", "standup", "role:worker", "frontend"]),
+    );
+    expect(agentSubscribesToBroadcastChannel(agent, "#extensions")).toBe(true);
+    expect(agentSubscribesToBroadcastChannel(agent, "#standup")).toBe(true);
+    expect(agentSubscribesToBroadcastChannel(agent, "#topic:frontend")).toBe(true);
+    expect(agentSubscribesToBroadcastChannel(agent, "#frontend")).toBe(true);
+  });
+
+  it("does not auto-subscribe brokers to standup, but honors explicit channels", () => {
+    const broker = createAgent("broker-1", "broker-1", {
+      capabilities: {
+        repo: "extensions",
+        role: "broker",
+      },
+      channels: ["ops"],
+    });
+
+    expect(getAgentBroadcastChannels(broker)).toEqual(
+      expect.arrayContaining(["all", "extensions", "role:broker", "ops"]),
+    );
+    expect(agentSubscribesToBroadcastChannel(broker, "#standup")).toBe(false);
+    expect(agentSubscribesToBroadcastChannel(broker, "#ops")).toBe(true);
+  });
+});
+
+describe("resolveBroadcastTargets", () => {
+  it("matches subscribers and excludes the sender", () => {
+    const agents = [
+      createAgent("sender", "sender", {
+        capabilities: { repo: "extensions", role: "worker" },
+      }),
+      createAgent("worker-b", "worker-b", {
+        capabilities: { repo: "extensions", role: "worker" },
+      }),
+      createAgent("worker-a", "worker-a", {
+        capabilities: { repo: "extensions", role: "worker" },
+      }),
+      createAgent("other", "other", {
+        capabilities: { repo: "elsewhere", role: "worker" },
+      }),
+    ];
+
+    const targets = resolveBroadcastTargets(agents, "sender", "#extensions");
+    expect(targets.map((agent) => agent.id)).toEqual(["worker-a", "worker-b"]);
+  });
+});
+
+describe("dispatchDirectAgentMessage", () => {
+  it("creates the pair thread and inserts a direct a2a message", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", { capabilities: { repo: "extensions", role: "worker" } }),
+      createAgent("target", "target", { capabilities: { repo: "extensions", role: "worker" } }),
+    ]);
+    const delivered: string[] = [];
+
+    const result = dispatchDirectAgentMessage(
+      storage,
+      {
+        senderAgentId: "sender",
+        senderAgentName: "Sender Agent",
+        target: "target",
+        body: "hello there",
+        metadata: { workflow: "ack/work/ask/report" },
+      },
+      (target, message, metadata) => {
+        delivered.push(`${target.id}:${message.id}:${String(metadata.senderAgent)}`);
+      },
+    );
+
+    expect(result).toEqual({
+      target: { id: "target", name: "target" },
+      messageId: 1,
+      threadId: "a2a:sender:target",
+    });
+    expect(storage.threads.has("a2a:sender:target")).toBe(true);
+    expect(storage.inserted).toHaveLength(1);
+    expect(storage.inserted[0]).toMatchObject({
+      threadId: "a2a:sender:target",
+      sender: "sender",
+      body: "hello there",
+      targetAgentIds: ["target"],
+      metadata: {
+        workflow: "ack/work/ask/report",
+        senderAgent: "Sender Agent",
+        a2a: true,
+      },
+    });
+    expect(delivered).toEqual(["target:1:Sender Agent"]);
+  });
+});
+
+describe("dispatchBroadcastAgentMessage", () => {
+  it("fans out to all matching subscribers with broadcast metadata", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", { capabilities: { repo: "extensions", role: "broker" } }),
+      createAgent("worker-a", "worker-a", {
+        capabilities: { repo: "extensions", role: "worker" },
+      }),
+      createAgent("worker-b", "worker-b", {
+        capabilities: { repo: "extensions", role: "worker" },
+      }),
+      createAgent("worker-c", "worker-c", {
+        capabilities: { repo: "elsewhere", role: "worker" },
+      }),
+    ]);
+    const delivered: string[] = [];
+
+    const result = dispatchBroadcastAgentMessage(
+      storage,
+      {
+        senderAgentId: "sender",
+        senderAgentName: "Broker Agent",
+        channel: "#extensions",
+        body: "Heads up, team",
+      },
+      (target, message) => {
+        delivered.push(`${target.id}:${message.threadId}`);
+      },
+    );
+
+    expect(result.channel).toBe("#extensions");
+    expect(result.targets).toEqual([
+      { id: "worker-a", name: "worker-a" },
+      { id: "worker-b", name: "worker-b" },
+    ]);
+    expect(result.messageIds).toEqual([1, 2]);
+    expect(result.threadIds).toEqual(["a2a:sender:worker-a", "a2a:sender:worker-b"]);
+    expect(storage.inserted).toHaveLength(2);
+    expect(storage.inserted[0]?.metadata).toMatchObject({
+      senderAgent: "Broker Agent",
+      a2a: true,
+      broadcast: true,
+      broadcastChannel: "#extensions",
+    });
+    expect(storage.inserted[1]?.metadata).toMatchObject({
+      senderAgent: "Broker Agent",
+      a2a: true,
+      broadcast: true,
+      broadcastChannel: "#extensions",
+    });
+    expect(delivered).toEqual(["worker-a:a2a:sender:worker-a", "worker-b:a2a:sender:worker-b"]);
+  });
+
+  it("fails when nobody else is subscribed to the channel", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", { capabilities: { repo: "extensions", role: "broker" } }),
+    ]);
+
+    expect(() =>
+      dispatchBroadcastAgentMessage(storage, {
+        senderAgentId: "sender",
+        senderAgentName: "Sender Agent",
+        channel: "#extensions",
+        body: "anyone there?",
+      }),
+    ).toThrow("No agents subscribed to #extensions other than the sender.");
+  });
+});

--- a/slack-bridge/broker/agent-messaging.ts
+++ b/slack-bridge/broker/agent-messaging.ts
@@ -1,0 +1,291 @@
+import { buildAgentCapabilityTags, extractAgentCapabilities } from "../helpers.js";
+import type { AgentInfo, BrokerMessage } from "./types.js";
+
+export interface AgentMessageStorage {
+  getAgents(): AgentInfo[];
+  getThread(threadId: string): { threadId: string } | null;
+  createThread(threadId: string, source: string, channel: string, ownerAgent: string | null): void;
+  insertMessage(
+    threadId: string,
+    source: string,
+    direction: "inbound" | "outbound",
+    sender: string,
+    body: string,
+    targetAgentIds: string[],
+    metadata?: Record<string, unknown>,
+  ): BrokerMessage;
+}
+
+export interface AgentDispatchTarget {
+  id: string;
+  name: string;
+}
+
+export interface DirectAgentDispatchInput {
+  senderAgentId: string;
+  senderAgentName: string;
+  target: string;
+  body: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BroadcastAgentDispatchInput {
+  senderAgentId: string;
+  senderAgentName: string;
+  channel: string;
+  body: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DirectAgentDispatchResult {
+  target: AgentDispatchTarget;
+  messageId: number;
+  threadId: string;
+}
+
+export interface BroadcastAgentDispatchResult {
+  channel: string;
+  targets: AgentDispatchTarget[];
+  messageIds: number[];
+  threadIds: string[];
+}
+
+export type AgentDispatchCallback = (
+  target: AgentDispatchTarget,
+  message: BrokerMessage,
+  metadata: Record<string, unknown>,
+) => void;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeChannelName(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const withoutHash = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  const normalized = withoutHash.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function addChannel(set: Set<string>, rawValue: string): void {
+  const normalized = normalizeChannelName(rawValue);
+  if (!normalized) return;
+  set.add(normalized);
+
+  if (normalized.startsWith("channel:") || normalized.startsWith("topic:")) {
+    const derived = normalized.slice(normalized.indexOf(":") + 1).trim();
+    if (derived) {
+      set.add(derived);
+    }
+  }
+}
+
+function ensurePairThread(
+  storage: AgentMessageStorage,
+  senderAgentId: string,
+  targetAgentId: string,
+): string {
+  const threadId = `a2a:${senderAgentId}:${targetAgentId}`;
+  if (!storage.getThread(threadId)) {
+    storage.createThread(threadId, "agent", "", senderAgentId);
+  }
+  return threadId;
+}
+
+function buildAgentMessageMetadata(
+  senderAgentName: string,
+  metadata?: Record<string, unknown>,
+  broadcastChannel?: string,
+): Record<string, unknown> {
+  return {
+    ...metadata,
+    senderAgent: senderAgentName,
+    a2a: true,
+    ...(broadcastChannel ? { broadcast: true, broadcastChannel } : {}),
+  };
+}
+
+function deliverAgentMessage(
+  storage: AgentMessageStorage,
+  senderAgentId: string,
+  senderAgentName: string,
+  target: AgentDispatchTarget,
+  body: string,
+  metadata: Record<string, unknown>,
+  onDispatch?: AgentDispatchCallback,
+): { threadId: string; messageId: number } {
+  const threadId = ensurePairThread(storage, senderAgentId, target.id);
+  const msg = storage.insertMessage(
+    threadId,
+    "agent",
+    "inbound",
+    senderAgentId,
+    body,
+    [target.id],
+    metadata,
+  );
+  onDispatch?.(target, msg, metadata);
+  return { threadId, messageId: msg.id };
+}
+
+export function isBroadcastChannelTarget(target: string): boolean {
+  return target.trim().startsWith("#");
+}
+
+export function normalizeBroadcastChannel(channel: string): string | null {
+  return normalizeChannelName(channel);
+}
+
+export function getAgentBroadcastChannels(agent: Pick<AgentInfo, "metadata">): string[] {
+  const subscriptions = new Set<string>(["all"]);
+  const metadata = asRecord(agent.metadata);
+  const capabilities = extractAgentCapabilities(metadata);
+
+  if (capabilities.repo) {
+    addChannel(subscriptions, capabilities.repo);
+  }
+
+  const role = capabilities.role?.trim().toLowerCase();
+  if (role) {
+    addChannel(subscriptions, `role:${role}`);
+  }
+
+  if (role !== "broker") {
+    addChannel(subscriptions, "standup");
+  }
+
+  for (const tag of buildAgentCapabilityTags(capabilities)) {
+    addChannel(subscriptions, tag);
+  }
+
+  for (const channel of asStringArray(metadata?.broadcastChannels)) {
+    addChannel(subscriptions, channel);
+  }
+
+  for (const channel of asStringArray(metadata?.channels)) {
+    addChannel(subscriptions, channel);
+  }
+
+  for (const topic of asStringArray(metadata?.topics)) {
+    addChannel(subscriptions, `topic:${topic}`);
+  }
+
+  return [...subscriptions].sort();
+}
+
+export function agentSubscribesToBroadcastChannel(
+  agent: Pick<AgentInfo, "metadata">,
+  channel: string,
+): boolean {
+  const normalized = normalizeBroadcastChannel(channel);
+  if (!normalized) return false;
+  return getAgentBroadcastChannels(agent).includes(normalized);
+}
+
+export function resolveDirectAgentTarget(agents: AgentInfo[], target: string): AgentInfo | null {
+  return (
+    agents.find((agent) => agent.id === target) ??
+    agents.find((agent) => agent.name === target) ??
+    null
+  );
+}
+
+export function resolveBroadcastTargets(
+  agents: AgentInfo[],
+  senderAgentId: string,
+  channel: string,
+): AgentInfo[] {
+  return agents
+    .filter((agent) => agent.id !== senderAgentId)
+    .filter((agent) => agentSubscribesToBroadcastChannel(agent, channel))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function dispatchDirectAgentMessage(
+  storage: AgentMessageStorage,
+  input: DirectAgentDispatchInput,
+  onDispatch?: AgentDispatchCallback,
+): DirectAgentDispatchResult {
+  const target = resolveDirectAgentTarget(storage.getAgents(), input.target);
+  if (!target) {
+    throw new Error(`Agent not found: ${input.target}`);
+  }
+
+  const resolvedTarget: AgentDispatchTarget = { id: target.id, name: target.name };
+  const metadata = buildAgentMessageMetadata(input.senderAgentName, input.metadata);
+  const { threadId, messageId } = deliverAgentMessage(
+    storage,
+    input.senderAgentId,
+    input.senderAgentName,
+    resolvedTarget,
+    input.body,
+    metadata,
+    onDispatch,
+  );
+
+  return {
+    target: resolvedTarget,
+    messageId,
+    threadId,
+  };
+}
+
+export function dispatchBroadcastAgentMessage(
+  storage: AgentMessageStorage,
+  input: BroadcastAgentDispatchInput,
+  onDispatch?: AgentDispatchCallback,
+): BroadcastAgentDispatchResult {
+  const normalizedChannel = normalizeBroadcastChannel(input.channel);
+  if (!normalizedChannel) {
+    throw new Error("Broadcast channel is required");
+  }
+
+  const agents = storage.getAgents();
+  const targets = resolveBroadcastTargets(agents, input.senderAgentId, normalizedChannel).map(
+    (agent) => ({ id: agent.id, name: agent.name }),
+  );
+
+  if (targets.length === 0) {
+    throw new Error(`No agents subscribed to #${normalizedChannel} other than the sender.`);
+  }
+
+  const broadcastChannel = `#${normalizedChannel}`;
+  const metadata = buildAgentMessageMetadata(
+    input.senderAgentName,
+    input.metadata,
+    broadcastChannel,
+  );
+
+  const messageIds: number[] = [];
+  const threadIds: string[] = [];
+
+  for (const target of targets) {
+    const delivery = deliverAgentMessage(
+      storage,
+      input.senderAgentId,
+      input.senderAgentName,
+      target,
+      input.body,
+      metadata,
+      onDispatch,
+    );
+    messageIds.push(delivery.messageId);
+    threadIds.push(delivery.threadId);
+  }
+
+  return {
+    channel: broadcastChannel,
+    targets,
+    messageIds,
+    threadIds,
+  };
+}

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -749,6 +749,56 @@ describe("BrokerClient — sendAgentMessage", () => {
   });
 });
 
+describe("BrokerClient — sendAgentBroadcast", () => {
+  let mock: MockServer;
+
+  beforeEach(async () => {
+    mock = await createMockServer();
+  });
+
+  afterEach(async () => {
+    await mock.close();
+  });
+
+  it("sends agent.broadcast RPC and returns recipient details", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const broadcastPromise = client.sendAgentBroadcast("#extensions", "Hello everyone");
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { channel: string; body: string };
+    };
+    expect(req.method).toBe("agent.broadcast");
+    expect(req.params.channel).toBe("#extensions");
+    expect(req.params.body).toBe("Hello everyone");
+
+    mock.respondTo(mock.connections[0], req.id, {
+      ok: true,
+      channel: "#extensions",
+      messageIds: [11, 12],
+      recipients: [
+        { id: "agent-a", name: "Alpha" },
+        { id: "agent-b", name: "Beta" },
+      ],
+    });
+
+    await expect(broadcastPromise).resolves.toEqual({
+      channel: "#extensions",
+      messageIds: [11, 12],
+      recipients: [
+        { id: "agent-a", name: "Alpha" },
+        { id: "agent-b", name: "Beta" },
+      ],
+    });
+
+    client.disconnect();
+  });
+});
+
 describe("BrokerClient — slackProxy", () => {
   let mock: MockServer;
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -97,6 +97,12 @@ interface RegistrationResult {
   emoji: string;
 }
 
+export interface AgentBroadcastResult {
+  channel: string;
+  messageIds: number[];
+  recipients: Array<{ id: string; name: string }>;
+}
+
 // ─── Connection options ──────────────────────────────────
 
 export type BrokerConnectOpts = { path: string } | { host: string; port: number };
@@ -254,6 +260,23 @@ export class BrokerClient {
       ...(metadata ? { metadata } : {}),
     })) as { ok: boolean; messageId: number };
     return result.messageId;
+  }
+
+  async sendAgentBroadcast(channel: string, body: string): Promise<AgentBroadcastResult> {
+    const result = (await this.request("agent.broadcast", {
+      channel,
+      body,
+    })) as {
+      ok: boolean;
+      channel: string;
+      messageIds: number[];
+      recipients: AgentBroadcastResult["recipients"];
+    };
+    return {
+      channel: result.channel,
+      messageIds: result.messageIds,
+      recipients: result.recipients,
+    };
   }
 
   // ─── Queries ─────────────────────────────────────────

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -351,6 +351,29 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("agent.broadcast rejects connected clients, even with spoofed broker metadata", async () => {
+    await client.register("spoofed-broker", "🎭", {
+      capabilities: { repo: "extensions", role: "broker", tags: ["repo:extensions"] },
+    });
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    await client2.register("worker-target", "🎯", {
+      capabilities: { repo: "extensions", role: "worker", tags: ["repo:extensions"] },
+    });
+
+    await expect(client.sendAgentBroadcast("#extensions", "No fan-out")).rejects.toThrow(
+      "Broadcast channels are broker-only and cannot be sent by connected clients.",
+    );
+    expect(await client2.pollInbox()).toHaveLength(0);
+    expect(await client.pollInbox()).toHaveLength(0);
+
+    client2.disconnect();
+  });
+
   it("requeued a2a work stays bound to the intended recipient after unregister", async () => {
     const sender = await client.register(
       "sender-agent",

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -6,6 +6,7 @@ import * as crypto from "node:crypto";
 import type { BrokerDB } from "./schema.js";
 import { DEFAULT_SOCKET_PATH } from "./paths.js";
 import { MessageRouter } from "./router.js";
+import { dispatchDirectAgentMessage } from "./agent-messaging.js";
 import type { BrokerMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcError } from "./types.js";
 import {
   RPC_PARSE_ERROR,
@@ -367,6 +368,8 @@ export class BrokerSocketServer {
           return this.handleResolveThread(req, state);
         case "agent.message":
           return this.handleAgentMessage(req, state);
+        case "agent.broadcast":
+          return this.handleAgentBroadcast(req, state);
         case "status.update":
           return this.handleStatusUpdate(req, state);
         case "slack.proxy":
@@ -585,48 +588,51 @@ export class BrokerSocketServer {
         ? (params.metadata as Record<string, unknown>)
         : undefined;
 
-    // Resolve target: try by ID first, then by name
-    const allAgents = this.db.getAgents();
-    const target =
-      allAgents.find((a) => a.id === targetAgent) ?? allAgents.find((a) => a.name === targetAgent);
-
-    if (!target) {
-      return rpcError(req.id, RPC_INVALID_PARAMS, `Agent not found: ${targetAgent}`);
-    }
-
-    // Look up sender name for metadata
-    const sender = allAgents.find((a) => a.id === state.agentId);
+    const sender = this.db.getAgents().find((agent) => agent.id === state.agentId);
     const senderName = sender?.name ?? state.agentId;
 
-    // Use a synthetic thread ID for agent-to-agent messages
-    const threadId = `a2a:${state.agentId}:${target.id}`;
+    try {
+      const result = dispatchDirectAgentMessage(
+        this.db,
+        {
+          senderAgentId: state.agentId,
+          senderAgentName: senderName,
+          target: targetAgent,
+          body,
+          metadata,
+        },
+        (target, msg, enrichedMeta) => {
+          this.agentMessageCallback?.(target.id, msg, enrichedMeta);
+        },
+      );
 
-    // Ensure thread exists
-    if (!this.db.getThread(threadId)) {
-      this.db.createThread(threadId, "agent", "", state.agentId);
+      // Activity tracking: sending agent-to-agent messages proves the agent is working
+      this.db.touchAgentActivity(state.agentId);
+      return rpcOk(req.id, { ok: true, messageId: result.messageId });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return rpcError(req.id, RPC_INVALID_PARAMS, message);
+    }
+  }
+
+  private handleAgentBroadcast(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
     }
 
-    const enrichedMeta = { ...metadata, senderAgent: senderName, a2a: true };
+    const params = req.params ?? {};
+    const channel = typeof params.channel === "string" ? params.channel : null;
+    const body = typeof params.body === "string" ? params.body : null;
 
-    const msg = this.db.insertMessage(
-      threadId,
-      "agent",
-      "inbound",
-      state.agentId,
-      body,
-      [target.id],
-      enrichedMeta,
+    if (!channel || !body) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "channel and body are required");
+    }
+
+    return rpcError(
+      req.id,
+      RPC_INVALID_PARAMS,
+      "Broadcast channels are broker-only and cannot be sent by connected clients.",
     );
-
-    // Notify callback so the broker can push to its in-memory inbox
-    // when the target is the broker itself.
-    if (this.agentMessageCallback) {
-      this.agentMessageCallback(target.id, msg, enrichedMeta);
-    }
-
-    // Activity tracking: sending agent-to-agent messages proves the agent is working
-    this.db.touchAgentActivity(state.agentId);
-    return rpcOk(req.id, { ok: true, messageId: msg.id });
   }
 
   // ─── Status update handler ─────────────────────────────

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -84,6 +84,11 @@ import {
   type BrokerMaintenanceResult,
 } from "./broker/maintenance.js";
 import { BrokerClient, DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import {
+  dispatchBroadcastAgentMessage,
+  dispatchDirectAgentMessage,
+  isBroadcastChannelTarget,
+} from "./broker/agent-messaging.js";
 import { registerSlackTools } from "./slack-tools.js";
 import {
   createFollowerDeliveryState,
@@ -1335,6 +1340,12 @@ export default function (pi: ExtensionAPI) {
       throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
     }
 
+    if (isBroadcastChannelTarget(targetRef)) {
+      throw new Error(
+        "Broadcast channels are broker-only. Send the request to the broker instead.",
+      );
+    }
+
     const effectiveMetadata = {
       ...(getOutgoingPinetMessageMetadata(body) ?? {}),
       ...(metadata ?? {}),
@@ -1343,42 +1354,30 @@ export default function (pi: ExtensionAPI) {
 
     if (brokerRole === "broker" && activeBroker) {
       const db = activeBroker.db;
-      const allAgents = db.getAgents();
-      const target =
-        allAgents.find((a: { id: string }) => a.id === targetRef) ??
-        allAgents.find((a: { name: string }) => a.name === targetRef);
-
-      if (!target) {
-        throw new Error(`Agent not found: ${targetRef}`);
-      }
-
       const selfId = activeSelfId;
       if (!selfId) {
         throw new Error("Broker agent identity is unavailable.");
       }
-      const threadId = `a2a:${selfId}:${target.id}`;
 
-      if (!db.getThread(threadId)) {
-        db.createThread(threadId, "agent", "", selfId);
-      }
-
-      const msg = db.insertMessage(threadId, "agent", "inbound", selfId, body, [target.id], {
-        senderAgent: agentName,
-        a2a: true,
-        ...(finalMetadata ?? {}),
+      const result = dispatchDirectAgentMessage(db, {
+        senderAgentId: selfId,
+        senderAgentName: agentName,
+        target: targetRef,
+        body,
+        metadata: finalMetadata,
       });
 
       for (const assignment of extractTaskAssignmentsFromMessage(body)) {
         db.recordTaskAssignment(
-          target.id,
+          result.target.id,
           assignment.issueNumber,
           assignment.branch,
-          threadId,
-          msg.id,
+          result.threadId,
+          result.messageId,
         );
       }
 
-      return { messageId: msg.id, target: target.name };
+      return { messageId: result.messageId, target: result.target.name };
     }
 
     if (brokerRole === "follower" && brokerClient) {
@@ -1549,15 +1548,50 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "pinet_message",
     label: "Pinet Message",
-    description: "Send a message to another connected Pinet agent.",
+    description:
+      "Send a message to another connected Pinet agent, or from the broker to a broadcast channel.",
     promptSnippet:
-      "Send a message to another connected Pinet agent. When you send a task, sepcify the desired workflow, ideally something like `ack/work/ask/report`: ACK briefly, do the work, report blockers or questions immediately, report the outcome when done. Always reply where the task came from. To trigger remote agent control, send the exact message `/reload` or `/exit`.",
+      "Send a message to another connected Pinet agent. When you send a task, sepcify the desired workflow, ideally something like `ack/work/ask/report`: ACK briefly, do the work, report blockers or questions immediately, report the outcome when done. Always reply where the task came from. To trigger remote agent control, send the exact message `/reload` or `/exit`. Broadcast channels like `#all` or `#extensions` are broker-only.",
     parameters: Type.Object({
-      to: Type.String({ description: "Target agent name or ID" }),
+      to: Type.String({
+        description:
+          "Target agent name/ID, or a broker-only broadcast channel like #all or #extensions",
+      }),
       message: Type.String({ description: "Message body" }),
     }),
     async execute(_id, params) {
       requireToolPolicy("pinet_message", undefined, `to=${params.to} | message=${params.message}`);
+
+      if (brokerRole === "broker" && activeBroker && isBroadcastChannelTarget(params.to)) {
+        const selfId = activeSelfId;
+        if (!selfId) {
+          throw new Error("Broker agent identity is unavailable.");
+        }
+
+        const result = dispatchBroadcastAgentMessage(activeBroker.db, {
+          senderAgentId: selfId,
+          senderAgentName: agentName,
+          channel: params.to,
+          body: params.message,
+        });
+        const recipients = result.targets.map((target) => target.name);
+        const preview = recipients.slice(0, 5).join(", ");
+        const suffix = recipients.length > 5 ? ", …" : "";
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Broadcast sent to ${result.channel} (${result.targets.length} agents: ${preview}${suffix}).`,
+            },
+          ],
+          details: {
+            channel: result.channel,
+            messageIds: result.messageIds,
+            recipients,
+          },
+        };
+      }
 
       const result = await sendPinetAgentMessage(params.to, params.message);
       return {


### PR DESCRIPTION
## Summary
- add broker-side broadcast channel resolution and fan-out for agent-to-agent messaging
- support `pinet_message(to: "#channel")` for broker and follower modes with built-in channels like `#all`, `#<repo>`, and `#standup`
- cover the new broadcast flow with unit, client, and integration tests

Closes #89

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test