### PR TITLE
feat: add scheduled Pinet wake-ups

### DIFF
--- a/slack-bridge/broker-delivery.test.ts
+++ b/slack-bridge/broker-delivery.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBrokerDeliveryState,
+  getBrokerInboxIds,
+  isBrokerInboxIdTracked,
+  markBrokerInboxIdsHandled,
+  queueBrokerInboxIds,
+  resetBrokerDeliveryState,
+} from "./broker-delivery.js";
+
+describe("broker delivery state", () => {
+  it("tracks broker inbox ids until they are handled", () => {
+    const state = createBrokerDeliveryState();
+
+    queueBrokerInboxIds(state, [101, 102]);
+    expect(isBrokerInboxIdTracked(state, 101)).toBe(true);
+    expect(isBrokerInboxIdTracked(state, 102)).toBe(true);
+
+    markBrokerInboxIdsHandled(state, [101]);
+    expect(isBrokerInboxIdTracked(state, 101)).toBe(false);
+    expect(isBrokerInboxIdTracked(state, 102)).toBe(true);
+  });
+
+  it("deduplicates broker inbox ids extracted from pending messages", () => {
+    expect(
+      getBrokerInboxIds([
+        {
+          channel: "",
+          threadTs: "a2a:1",
+          userId: "broker",
+          text: "one",
+          timestamp: "2026-04-02T14:05:00.000Z",
+          brokerInboxId: 201,
+        },
+        {
+          channel: "",
+          threadTs: "a2a:1",
+          userId: "broker",
+          text: "two",
+          timestamp: "2026-04-02T14:05:01.000Z",
+          brokerInboxId: 201,
+        },
+        {
+          channel: "C1",
+          threadTs: "1712073599.123456",
+          userId: "U1",
+          text: "human",
+          timestamp: "2026-04-02T14:05:02.000Z",
+        },
+      ]),
+    ).toEqual([201]);
+  });
+
+  it("resets broker delivery state", () => {
+    const state = createBrokerDeliveryState();
+
+    queueBrokerInboxIds(state, [301]);
+    resetBrokerDeliveryState(state);
+
+    expect(isBrokerInboxIdTracked(state, 301)).toBe(false);
+  });
+});

--- a/slack-bridge/broker-delivery.ts
+++ b/slack-bridge/broker-delivery.ts
@@ -1,0 +1,42 @@
+import type { InboxMessage } from "./helpers.js";
+
+export interface BrokerDeliveryState {
+  pendingInboxIds: Set<number>;
+}
+
+export function createBrokerDeliveryState(): BrokerDeliveryState {
+  return {
+    pendingInboxIds: new Set<number>(),
+  };
+}
+
+export function resetBrokerDeliveryState(state: BrokerDeliveryState): void {
+  state.pendingInboxIds.clear();
+}
+
+export function isBrokerInboxIdTracked(state: BrokerDeliveryState, inboxId: number): boolean {
+  return state.pendingInboxIds.has(inboxId);
+}
+
+export function queueBrokerInboxIds(state: BrokerDeliveryState, inboxIds: Iterable<number>): void {
+  for (const inboxId of inboxIds) {
+    state.pendingInboxIds.add(inboxId);
+  }
+}
+
+export function markBrokerInboxIdsHandled(
+  state: BrokerDeliveryState,
+  inboxIds: Iterable<number>,
+): void {
+  for (const inboxId of inboxIds) {
+    state.pendingInboxIds.delete(inboxId);
+  }
+}
+
+export function getBrokerInboxIds(messages: InboxMessage[]): number[] {
+  return [
+    ...new Set(
+      messages.flatMap((message) => (message.brokerInboxId ? [message.brokerInboxId] : [])),
+    ),
+  ];
+}

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -799,6 +799,48 @@ describe("BrokerClient — sendAgentBroadcast", () => {
   });
 });
 
+describe("BrokerClient — scheduleWakeup", () => {
+  let mock: MockServer;
+
+  beforeEach(async () => {
+    mock = await createMockServer();
+  });
+
+  afterEach(async () => {
+    await mock.close();
+  });
+
+  it("sends schedule.create RPC and returns the scheduled wake-up", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const wakeupPromise = client.scheduleWakeup("2026-04-02T14:05:00.000Z", "Check PR #62");
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { fireAt: string; body: string };
+    };
+    expect(req.method).toBe("schedule.create");
+    expect(req.params.fireAt).toBe("2026-04-02T14:05:00.000Z");
+    expect(req.params.body).toBe("Check PR #62");
+
+    mock.respondTo(mock.connections[0], req.id, {
+      id: 7,
+      threadId: "wakeup:agent-1",
+      fireAt: "2026-04-02T14:05:00.000Z",
+    });
+
+    await expect(wakeupPromise).resolves.toEqual({
+      id: 7,
+      threadId: "wakeup:agent-1",
+      fireAt: "2026-04-02T14:05:00.000Z",
+    });
+
+    client.disconnect();
+  });
+});
 describe("BrokerClient — slackProxy", () => {
   let mock: MockServer;
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -42,6 +42,12 @@ export interface AgentInfo {
   lastActivity?: string | null;
 }
 
+export interface ScheduledWakeupInfo {
+  id: number;
+  threadId: string;
+  fireAt: string;
+}
+
 // ─── JSON-RPC types ──────────────────────────────────────
 
 interface JsonRpcRequest {
@@ -279,6 +285,17 @@ export class BrokerClient {
     };
   }
 
+  async scheduleWakeup(fireAt: string, body: string): Promise<ScheduledWakeupInfo> {
+    const result = (await this.request("schedule.create", {
+      fireAt,
+      body,
+    })) as { id: number; threadId: string; fireAt: string };
+    return {
+      id: result.id,
+      threadId: result.threadId,
+      fireAt: result.fireAt,
+    };
+  }
   // ─── Queries ─────────────────────────────────────────
 
   async listThreads(): Promise<ThreadInfo[]> {

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -414,6 +414,153 @@ describe("BrokerDB", () => {
     expect(versionRow.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
   });
 
+  it("adds scheduled wake-up tracking when migrating from schema v7", () => {
+    const dbPath = path.join(dir, "legacy-scheduled-wakeups.db");
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY NOT NULL,
+        stable_id TEXT,
+        name TEXT NOT NULL,
+        emoji TEXT NOT NULL,
+        pid INTEGER NOT NULL,
+        connected_at TEXT NOT NULL,
+        last_seen TEXT NOT NULL,
+        last_heartbeat TEXT,
+        metadata TEXT,
+        status TEXT NOT NULL DEFAULT 'idle',
+        disconnected_at TEXT,
+        resumable_until TEXT,
+        idle_since TEXT,
+        last_activity TEXT
+      );
+
+      CREATE TABLE task_assignments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent_id TEXT NOT NULL,
+        issue_number INTEGER NOT NULL,
+        branch TEXT,
+        pr_number INTEGER,
+        status TEXT NOT NULL DEFAULT 'assigned'
+          CHECK(status IN ('assigned', 'branch_pushed', 'pr_open', 'pr_merged', 'pr_closed')),
+        thread_id TEXT NOT NULL,
+        source_message_id INTEGER,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(issue_number)
+      );
+
+      PRAGMA user_version = 7;
+    `);
+    legacyDb.close();
+
+    const migratedDb = new BrokerDB(dbPath);
+    expect(() => migratedDb.initialize()).not.toThrow();
+    migratedDb.close();
+
+    const inspectDb = new DatabaseSync(dbPath);
+    const versionRow = inspectDb.prepare("PRAGMA user_version").get() as { user_version: number };
+    const columns = inspectDb.prepare("PRAGMA table_info(scheduled_wakeups)").all() as Array<{
+      name: string;
+    }>;
+    inspectDb.close();
+
+    expect(versionRow.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "agent_id",
+        "agent_stable_id",
+        "thread_id",
+        "body",
+        "fire_at",
+        "created_at",
+      ]),
+    );
+  });
+
+  it("backfills scheduled wake-up stable ids when migrating from schema v8", () => {
+    const dbPath = path.join(dir, "legacy-scheduled-wakeups-v8.db");
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY NOT NULL,
+        stable_id TEXT,
+        name TEXT NOT NULL,
+        emoji TEXT NOT NULL,
+        pid INTEGER NOT NULL,
+        connected_at TEXT NOT NULL,
+        last_seen TEXT NOT NULL,
+        last_heartbeat TEXT,
+        metadata TEXT,
+        status TEXT NOT NULL DEFAULT 'idle',
+        disconnected_at TEXT,
+        resumable_until TEXT,
+        idle_since TEXT,
+        last_activity TEXT
+      );
+
+      CREATE TABLE task_assignments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent_id TEXT NOT NULL,
+        issue_number INTEGER NOT NULL,
+        branch TEXT,
+        pr_number INTEGER,
+        status TEXT NOT NULL DEFAULT 'assigned'
+          CHECK(status IN ('assigned', 'branch_pushed', 'pr_open', 'pr_merged', 'pr_closed')),
+        thread_id TEXT NOT NULL,
+        source_message_id INTEGER,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(issue_number)
+      );
+
+      CREATE TABLE scheduled_wakeups (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent_id TEXT NOT NULL,
+        thread_id TEXT NOT NULL,
+        body TEXT NOT NULL,
+        fire_at TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      INSERT INTO agents (
+        id, stable_id, name, emoji, pid,
+        connected_at, last_seen, last_heartbeat,
+        metadata, status, disconnected_at, resumable_until,
+        idle_since, last_activity
+      ) VALUES (
+        'worker-1', 'host:session:/tmp/worker-1', 'Worker', '⏰', 1,
+        '2026-04-02T14:00:00.000Z', '2026-04-02T14:00:00.000Z', '2026-04-02T14:00:00.000Z',
+        NULL, 'idle', NULL, NULL,
+        '2026-04-02T14:00:00.000Z', NULL
+      );
+
+      INSERT INTO scheduled_wakeups (agent_id, thread_id, body, fire_at, created_at)
+      VALUES (
+        'worker-1',
+        'wakeup:worker-1',
+        'Wake me later',
+        '2026-04-02T14:05:00.000Z',
+        '2026-04-02T14:00:00.000Z'
+      );
+
+      PRAGMA user_version = 8;
+    `);
+    legacyDb.close();
+
+    const migratedDb = new BrokerDB(dbPath);
+    expect(() => migratedDb.initialize()).not.toThrow();
+    migratedDb.close();
+
+    const inspectDb = new DatabaseSync(dbPath);
+    const row = inspectDb
+      .prepare("SELECT agent_stable_id FROM scheduled_wakeups WHERE agent_id = ?")
+      .get("worker-1") as { agent_stable_id: string | null };
+    inspectDb.close();
+
+    expect(row.agent_stable_id).toBe("host:session:/tmp/worker-1");
+  });
+
   it("recreates an invalid database file from scratch instead of crashing", () => {
     const dbPath = path.join(dir, "invalid.db");
     fs.writeFileSync(dbPath, "not a sqlite database", "utf-8");
@@ -681,6 +828,95 @@ describe("BrokerDB", () => {
         count: number;
       },
     ).toEqual({ count: 0 });
+  });
+
+  it("schedules wake-ups and delivers them when due", () => {
+    db.registerAgent("worker-1", "Worker", "⏰", 1);
+
+    const scheduled = db.scheduleWakeup(
+      "worker-1",
+      "Check whether PR #62 merged",
+      "2026-04-02T14:05:00.000Z",
+    );
+
+    expect(db.listScheduledWakeups("worker-1")).toHaveLength(1);
+    expect(db.deliverDueScheduledWakeups("2026-04-02T14:04:59.000Z")).toHaveLength(0);
+
+    const deliveries = db.deliverDueScheduledWakeups("2026-04-02T14:05:00.000Z");
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].wakeup.id).toBe(scheduled.id);
+    expect(deliveries[0].message.body).toBe("Check whether PR #62 merged");
+    expect(deliveries[0].message.threadId).toBe("wakeup:worker-1");
+    expect((deliveries[0].message.metadata as Record<string, unknown>).scheduledWakeup).toBe(true);
+    expect(db.listScheduledWakeups("worker-1")).toHaveLength(0);
+
+    const inbox = db.getInbox("worker-1");
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].message.body).toBe("Check whether PR #62 merged");
+  });
+
+  it("keeps due wake-ups pending until the target agent reconnects", () => {
+    db.registerAgent("worker-1", "Worker", "⏰", 1, undefined, "host:session:/tmp/worker-1");
+    db.disconnectAgent("worker-1", 60_000);
+    db.scheduleWakeup("worker-1", "Wake me when CI is done", "2026-04-02T14:05:00.000Z");
+
+    expect(db.deliverDueScheduledWakeups("2026-04-02T14:05:00.000Z")).toHaveLength(0);
+    expect(db.listScheduledWakeups("worker-1")).toHaveLength(1);
+
+    db.registerAgent("worker-1b", "Worker", "⏰", 2, undefined, "host:session:/tmp/worker-1");
+
+    const deliveries = db.deliverDueScheduledWakeups("2026-04-02T14:05:01.000Z");
+    expect(deliveries).toHaveLength(1);
+    expect(db.listScheduledWakeups("worker-1")).toHaveLength(0);
+    expect(db.getInbox("worker-1")).toHaveLength(1);
+  });
+
+  it("persists scheduled wake-ups across broker restart", () => {
+    const dbPath = path.join(dir, "scheduled-restart.db");
+    const firstDb = new BrokerDB(dbPath);
+    firstDb.initialize();
+    firstDb.registerAgent("worker-1", "Worker", "⏰", 1, undefined, "host:session:/tmp/restart");
+    firstDb.scheduleWakeup("worker-1", "Wake me after restart", "2026-04-02T14:05:00.000Z");
+    firstDb.close();
+
+    const restartedDb = new BrokerDB(dbPath);
+    restartedDb.initialize();
+    expect(restartedDb.listScheduledWakeups("worker-1")).toHaveLength(1);
+
+    const resumed = restartedDb.registerAgent(
+      "worker-2",
+      "Different Worker",
+      "🦎",
+      2,
+      undefined,
+      "host:session:/tmp/restart",
+    );
+    expect(resumed.id).toBe("worker-1");
+
+    const deliveries = restartedDb.deliverDueScheduledWakeups("2026-04-02T14:05:00.000Z");
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].message.body).toBe("Wake me after restart");
+    restartedDb.close();
+  });
+
+  it("keeps scheduled wake-ups after purge and rebinds them by stable id", () => {
+    const stableId = "host:session:/tmp/purge-reconnect";
+    db.registerAgent("worker-1", "Worker", "⏰", 1, undefined, stableId);
+    db.scheduleWakeup("worker-1", "Wake me after purge", "2026-04-02T14:05:00.000Z");
+    db.unregisterAgent("worker-1");
+
+    expect(db.purgeDisconnectedAgents(0)).toEqual(["worker-1"]);
+    expect(db.listScheduledWakeups()).toHaveLength(1);
+
+    const resumed = db.registerAgent("worker-2", "Worker", "🦎", 2, undefined, stableId);
+    expect(resumed.id).toBe("worker-2");
+    expect(db.listScheduledWakeups(resumed.id)).toHaveLength(1);
+
+    const deliveries = db.deliverDueScheduledWakeups("2026-04-02T14:05:00.000Z");
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].message.body).toBe("Wake me after purge");
+    expect(db.getInbox(resumed.id)).toHaveLength(1);
+    expect(db.listScheduledWakeups(resumed.id)).toHaveLength(0);
   });
 
   it("getAllAgents includes recently disconnected agents for visibility", () => {

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -14,6 +14,8 @@ export type { AgentMessageCallback } from "./socket-server.js";
 export type {
   AgentInfo,
   ThreadInfo,
+  ScheduledWakeupInfo,
+  ScheduledWakeupDelivery,
   BrokerMessage,
   InboxEntry,
   InboundMessage,

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -144,6 +144,34 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("schedule.create persists a wake-up and delivers it once due", async () => {
+    const reg = await client.register("worker-agent", "⏰");
+
+    const wakeup = await client.scheduleWakeup(
+      "2026-04-02T14:05:00.000Z",
+      "Check whether PR #62 merged",
+    );
+
+    expect(wakeup.id).toBeGreaterThan(0);
+    expect(db.listScheduledWakeups(reg.agentId)).toHaveLength(1);
+
+    const earlyDeliveries = db.deliverDueScheduledWakeups("2026-04-02T14:04:59.000Z");
+    expect(earlyDeliveries).toHaveLength(0);
+
+    const deliveries = db.deliverDueScheduledWakeups("2026-04-02T14:05:00.000Z");
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].wakeup.id).toBe(wakeup.id);
+    expect(deliveries[0].message.body).toBe("Check whether PR #62 merged");
+
+    const inbox = await client.pollInbox();
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].message.body).toBe("Check whether PR #62 merged");
+    expect((inbox[0].message.metadata as Record<string, unknown>).scheduledWakeup).toBe(true);
+
+    await client.ackMessages([inbox[0].inboxId]);
+    expect(db.listScheduledWakeups(reg.agentId)).toHaveLength(0);
+  });
+
   it("maintenance assigns unrouted backlog into a follower inbox", async () => {
     const info = server.getConnectInfo();
     if (info.type !== "tcp") throw new Error("Expected TCP");

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -13,6 +13,8 @@ import type {
   ChannelAssignment,
   TaskAssignmentInfo,
   TaskAssignmentStatus,
+  ScheduledWakeupInfo,
+  ScheduledWakeupDelivery,
 } from "./types.js";
 import {
   buildSqliteWalFallbackWarning,
@@ -74,6 +76,16 @@ interface TaskAssignmentRow {
   source_message_id: number | null;
   created_at: string;
   updated_at: string;
+}
+
+interface ScheduledWakeupRow {
+  id: number;
+  agent_id: string;
+  agent_stable_id: string | null;
+  thread_id: string;
+  body: string;
+  fire_at: string;
+  created_at: string;
 }
 
 // ─── Mappers ─────────────────────────────────────────────
@@ -156,6 +168,17 @@ function rowToTaskAssignment(row: TaskAssignmentRow): TaskAssignmentInfo {
   };
 }
 
+function rowToScheduledWakeup(row: ScheduledWakeupRow): ScheduledWakeupInfo {
+  return {
+    id: row.id,
+    agentId: row.agent_id,
+    threadId: row.thread_id,
+    body: row.body,
+    fireAt: row.fire_at,
+    createdAt: row.created_at,
+  };
+}
+
 // ─── Default DB path ─────────────────────────────────────
 
 export function defaultDbPath(): string {
@@ -164,7 +187,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 7;
+export const CURRENT_BROKER_SCHEMA_VERSION = 9;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -428,6 +451,45 @@ function migrateTaskAssignmentsToIssueOwnership(db: DatabaseSync): void {
   `);
 }
 
+function createScheduledWakeupsTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS scheduled_wakeups (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL,
+      agent_stable_id TEXT,
+      thread_id TEXT NOT NULL,
+      body TEXT NOT NULL,
+      fire_at TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_scheduled_wakeups_fire_target
+      ON scheduled_wakeups(fire_at, agent_stable_id, agent_id);
+  `);
+}
+
+function addScheduledWakeupStableIdColumn(db: DatabaseSync): void {
+  ensureColumn(
+    db,
+    "scheduled_wakeups",
+    "agent_stable_id",
+    "ALTER TABLE scheduled_wakeups ADD COLUMN agent_stable_id TEXT",
+  );
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_scheduled_wakeups_fire_target
+      ON scheduled_wakeups(fire_at, agent_stable_id, agent_id);
+  `);
+
+  db.prepare(
+    `UPDATE scheduled_wakeups
+     SET agent_stable_id = (
+       SELECT stable_id FROM agents WHERE agents.id = scheduled_wakeups.agent_id
+     )
+     WHERE agent_stable_id IS NULL`,
+  ).run();
+}
+
 function runSchemaMigrations(db: DatabaseSync): void {
   const currentVersion = getUserVersion(db);
   if (currentVersion >= CURRENT_BROKER_SCHEMA_VERSION) {
@@ -462,6 +524,12 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 7:
           migrateTaskAssignmentsToIssueOwnership(db);
+          break;
+        case 8:
+          createScheduledWakeupsTable(db);
+          break;
+        case 9:
+          addScheduledWakeupStableIdColumn(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -1163,6 +1231,137 @@ export class BrokerDB implements BrokerDBInterface {
            updated_at = ?
        WHERE id = ?`,
     ).run(status, prNumber, new Date().toISOString(), id);
+  }
+
+  // ─── Scheduled wake-ups ──────────────────────────────
+
+  scheduleWakeup(
+    agentId: string,
+    body: string,
+    fireAt: string,
+    threadId = `wakeup:${agentId}`,
+  ): ScheduledWakeupInfo {
+    const db = this.getDb();
+    const createdAt = new Date().toISOString();
+    const canonicalFireAt = new Date(fireAt).toISOString();
+    const agentStableId = this.getAgentRowById(agentId)?.stable_id ?? null;
+
+    const info = db
+      .prepare(
+        `INSERT INTO scheduled_wakeups (
+           agent_id,
+           agent_stable_id,
+           thread_id,
+           body,
+           fire_at,
+           created_at
+         )
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(agentId, agentStableId, threadId, body, canonicalFireAt, createdAt);
+
+    const row = db
+      .prepare("SELECT * FROM scheduled_wakeups WHERE id = ?")
+      .get(Number(info.lastInsertRowid)) as ScheduledWakeupRow | undefined;
+    if (!row) {
+      throw new Error(`Failed to create scheduled wake-up for ${agentId}`);
+    }
+    return rowToScheduledWakeup(row);
+  }
+
+  listScheduledWakeups(agentId?: string): ScheduledWakeupInfo[] {
+    const db = this.getDb();
+    const agentStableId = agentId ? (this.getAgentRowById(agentId)?.stable_id ?? null) : null;
+    const rows = (agentId
+      ? agentStableId
+        ? db
+            .prepare(
+              `SELECT * FROM scheduled_wakeups
+               WHERE agent_stable_id = ?
+                  OR (agent_stable_id IS NULL AND agent_id = ?)
+               ORDER BY fire_at ASC, id ASC`,
+            )
+            .all(agentStableId, agentId)
+        : db
+            .prepare(
+              `SELECT * FROM scheduled_wakeups
+               WHERE agent_id = ?
+               ORDER BY fire_at ASC, id ASC`,
+            )
+            .all(agentId)
+      : db
+          .prepare(
+            `SELECT * FROM scheduled_wakeups
+             ORDER BY fire_at ASC, id ASC`,
+          )
+          .all()) as unknown as ScheduledWakeupRow[];
+    return rows.map(rowToScheduledWakeup);
+  }
+
+  deliverDueScheduledWakeups(
+    now = new Date().toISOString(),
+    limit = 50,
+  ): ScheduledWakeupDelivery[] {
+    const db = this.getDb();
+
+    return this.withTransaction(() => {
+      const rows = db
+        .prepare(
+          `SELECT
+             sw.*,
+             COALESCE(stable_agent.id, direct_agent.id) AS target_agent_id
+           FROM scheduled_wakeups sw
+           LEFT JOIN agents stable_agent
+             ON sw.agent_stable_id IS NOT NULL
+            AND stable_agent.stable_id = sw.agent_stable_id
+            AND stable_agent.disconnected_at IS NULL
+           LEFT JOIN agents direct_agent
+             ON sw.agent_stable_id IS NULL
+            AND direct_agent.id = sw.agent_id
+            AND direct_agent.disconnected_at IS NULL
+           WHERE sw.fire_at <= ?
+             AND COALESCE(stable_agent.id, direct_agent.id) IS NOT NULL
+           ORDER BY sw.fire_at ASC, sw.id ASC
+           LIMIT ?`,
+        )
+        .all(now, limit) as unknown as Array<ScheduledWakeupRow & { target_agent_id: string }>;
+
+      if (rows.length === 0) {
+        return [];
+      }
+
+      const deleteWakeup = db.prepare("DELETE FROM scheduled_wakeups WHERE id = ?");
+      const deliveries: ScheduledWakeupDelivery[] = [];
+
+      for (const row of rows) {
+        const targetAgentId = row.target_agent_id;
+
+        if (!this.getThread(row.thread_id)) {
+          this.createThread(row.thread_id, "agent", "", targetAgentId);
+        } else {
+          this.updateThread(row.thread_id, { ownerAgent: targetAgentId });
+        }
+
+        const message = this.insertMessage(
+          row.thread_id,
+          "agent",
+          "inbound",
+          "scheduler",
+          row.body,
+          [targetAgentId],
+          {
+            senderAgent: "Pinet Scheduler",
+            scheduledWakeup: true,
+            wakeupId: row.id,
+            fireAt: row.fire_at,
+          },
+        );
+        deleteWakeup.run(row.id);
+        deliveries.push({ wakeup: rowToScheduledWakeup(row), message });
+      }
+
+      return deliveries;
+    });
   }
 
   // ─── Ralph cycles ────────────────────────────────────

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -370,6 +370,8 @@ export class BrokerSocketServer {
           return this.handleAgentMessage(req, state);
         case "agent.broadcast":
           return this.handleAgentBroadcast(req, state);
+        case "schedule.create":
+          return this.handleScheduleCreate(req, state);
         case "status.update":
           return this.handleStatusUpdate(req, state);
         case "slack.proxy":
@@ -633,6 +635,31 @@ export class BrokerSocketServer {
       RPC_INVALID_PARAMS,
       "Broadcast channels are broker-only and cannot be sent by connected clients.",
     );
+  }
+
+  private handleScheduleCreate(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
+    const params = req.params ?? {};
+    const fireAt = typeof params.fireAt === "string" ? params.fireAt : null;
+    const body = typeof params.body === "string" ? params.body.trim() : null;
+
+    if (!fireAt || !body) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "fireAt and body are required");
+    }
+
+    if (Number.isNaN(Date.parse(fireAt))) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "fireAt must be a valid ISO timestamp");
+    }
+
+    const wakeup = this.db.scheduleWakeup(state.agentId, body, fireAt);
+    return rpcOk(req.id, {
+      id: wakeup.id,
+      threadId: wakeup.threadId,
+      fireAt: wakeup.fireAt,
+    });
   }
 
   // ─── Status update handler ─────────────────────────────

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -84,6 +84,19 @@ export interface TaskAssignmentInfo {
   updatedAt: string;
 }
 
+export interface ScheduledWakeupInfo {
+  id: number;
+  agentId: string;
+  threadId: string;
+  body: string;
+  fireAt: string;
+  createdAt: string;
+}
+
+export interface ScheduledWakeupDelivery {
+  wakeup: ScheduledWakeupInfo;
+  message: BrokerMessage;
+}
 // ─── Routing ──────────────────────────────────────────────
 
 export type RoutingDecision =

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -34,6 +34,7 @@ export const WRITE_TOOLS = new Set([
   "memory_init",
   "slack_create_channel",
   "slack_post_channel",
+  "pinet_schedule",
 ]);
 
 /**

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -74,6 +74,7 @@ import {
 } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { startBroker, type Broker } from "./broker/index.js";
+import type { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { MessageRouter } from "./broker/router.js";
@@ -105,6 +106,15 @@ import {
   hasTaskAssignmentStatusChange,
   resolveTaskAssignments,
 } from "./task-assignments.js";
+import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
+import {
+  createBrokerDeliveryState,
+  getBrokerInboxIds,
+  isBrokerInboxIdTracked,
+  markBrokerInboxIdsHandled,
+  queueBrokerInboxIds,
+  resetBrokerDeliveryState,
+} from "./broker-delivery.js";
 import { getMainCheckoutToolBlockReason } from "./worktree-policy.js";
 
 // Settings and helpers imported from ./helpers.js
@@ -383,6 +393,7 @@ export default function (pi: ExtensionAPI) {
   // ─── Inbox queue ────────────────────────────────────
 
   const inbox: InboxMessage[] = [];
+  const brokerDeliveryState = createBrokerDeliveryState();
   let extCtx: ExtensionContext | null = null; // cached for badge updates
 
   function updateBadge(): void {
@@ -1011,8 +1022,10 @@ export default function (pi: ExtensionAPI) {
   let brokerHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let brokerMaintenanceTimer: ReturnType<typeof setInterval> | null = null;
   let brokerRalphLoopTimer: ReturnType<typeof setInterval> | null = null;
+  let brokerScheduledWakeupTimer: ReturnType<typeof setInterval> | null = null;
   let brokerMaintenanceRunning = false;
   let brokerRalphLoopRunning = false;
+  let brokerScheduledWakeupRunning = false;
   let lastBrokerMaintenance: BrokerMaintenanceResult | null = null;
   let lastBrokerMaintenanceSignature = "";
   let lastBrokerRalphLoopNonGhostSignature = "";
@@ -1026,6 +1039,39 @@ export default function (pi: ExtensionAPI) {
 
   function getPinetRegistrationBlockReason(): string {
     return "Pinet is disabled in local subagent sessions to avoid polluting the agent mesh.";
+  }
+
+  function syncBrokerDbInbox(agentId: string, db: BrokerDB): void {
+    const pending = db
+      .getInbox(agentId)
+      .filter((item) => !isBrokerInboxIdTracked(brokerDeliveryState, item.entry.id));
+    if (pending.length === 0) {
+      return;
+    }
+
+    queueBrokerInboxIds(
+      brokerDeliveryState,
+      pending.map((item) => item.entry.id),
+    );
+
+    for (const item of pending) {
+      const meta = item.message.metadata ?? {};
+      const senderName =
+        typeof meta.senderAgent === "string" ? meta.senderAgent : item.message.sender;
+      inbox.push({
+        channel: "",
+        threadTs: item.message.threadId,
+        userId: senderName,
+        text: item.message.body,
+        timestamp: item.message.createdAt,
+        brokerInboxId: item.entry.id,
+      });
+    }
+
+    updateBadge();
+    if (extCtx?.isIdle?.()) {
+      drainInbox();
+    }
   }
 
   function startBrokerHeartbeat(): void {
@@ -1088,6 +1134,38 @@ export default function (pi: ExtensionAPI) {
     if (!brokerMaintenanceTimer) return;
     clearInterval(brokerMaintenanceTimer);
     brokerMaintenanceTimer = null;
+  }
+
+  function runBrokerScheduledWakeups(ctx: ExtensionContext): void {
+    if (!activeBroker || brokerScheduledWakeupRunning) return;
+
+    brokerScheduledWakeupRunning = true;
+    try {
+      const deliveries = (activeBroker.db as BrokerDB).deliverDueScheduledWakeups();
+      if (deliveries.length > 0 && activeSelfId) {
+        syncBrokerDbInbox(activeSelfId, activeBroker.db as BrokerDB);
+      }
+    } catch (err) {
+      ctx.ui.notify(`Pinet scheduled wake-ups failed: ${msg(err)}`, "error");
+    } finally {
+      brokerScheduledWakeupRunning = false;
+    }
+  }
+
+  function startBrokerScheduledWakeups(ctx: ExtensionContext): void {
+    stopBrokerScheduledWakeups();
+    brokerScheduledWakeupTimer = setInterval(() => {
+      runBrokerScheduledWakeups(ctx);
+    }, 1000);
+    brokerScheduledWakeupTimer.unref?.();
+    runBrokerScheduledWakeups(ctx);
+  }
+
+  function stopBrokerScheduledWakeups(): void {
+    brokerScheduledWakeupRunning = false;
+    if (!brokerScheduledWakeupTimer) return;
+    clearInterval(brokerScheduledWakeupTimer);
+    brokerScheduledWakeupTimer = null;
   }
 
   function sendBrokerMaintenanceMessage(targetAgentId: string, body: string): void {
@@ -1402,6 +1480,7 @@ export default function (pi: ExtensionAPI) {
     stopBrokerHeartbeat();
     stopBrokerMaintenance();
     stopBrokerRalphLoop();
+    stopBrokerScheduledWakeups();
 
     if (activeBroker) {
       try {
@@ -1421,6 +1500,7 @@ export default function (pi: ExtensionAPI) {
     lastBrokerRalphLoopNonGhostSignature = "";
     lastBrokerRalphLoopHadOutstandingAnomalies = false;
     lastReportedGhostIds.clear();
+    resetBrokerDeliveryState(brokerDeliveryState);
 
     if (brokerClient) {
       if (options.releaseIdentity) {
@@ -1604,6 +1684,69 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerTool({
+    name: "pinet_schedule",
+    label: "Pinet Schedule",
+    description: "Schedule a future wake-up message for the current Pinet agent.",
+    promptSnippet:
+      "Schedule a future wake-up for yourself via the Pinet broker. Use this instead of busy-waiting when you need to check back later.",
+    parameters: Type.Object({
+      delay: Type.Optional(
+        Type.String({ description: "Relative delay like 5m, 30s, 1h30m, or 1d" }),
+      ),
+      at: Type.Optional(
+        Type.String({ description: "Absolute ISO-8601 UTC time, e.g. 2026-04-02T14:30:00Z" }),
+      ),
+      message: Type.String({ description: "Reminder or wake-up message to deliver later" }),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "pinet_schedule",
+        undefined,
+        `delay=${params.delay ?? ""} | at=${params.at ?? ""} | message=${params.message}`,
+      );
+
+      if (!pinetEnabled) {
+        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      }
+
+      const message = params.message.trim();
+      if (!message) {
+        throw new Error("message is required");
+      }
+
+      const fireAt = resolveScheduledWakeupFireAt({ delay: params.delay, at: params.at });
+
+      if (brokerRole === "broker" && activeBroker && activeSelfId) {
+        const wakeup = (activeBroker.db as BrokerDB).scheduleWakeup(activeSelfId, message, fireAt);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
+            },
+          ],
+          details: wakeup,
+        };
+      }
+
+      if (brokerRole === "follower" && brokerClient) {
+        const wakeup = await (brokerClient.client as BrokerClient).scheduleWakeup(fireAt, message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
+            },
+          ],
+          details: wakeup,
+        };
+      }
+
+      throw new Error("Pinet is in an unexpected state.");
+    },
+  });
+
+  pi.registerTool({
     name: "pinet_agents",
     label: "Pinet Agents",
     description: "List Pinet agents, including liveness and capability visibility.",
@@ -1744,14 +1887,10 @@ export default function (pi: ExtensionAPI) {
   // ─── Commands ───────────────────────────────────────
 
   async function connectAsBroker(ctx: ExtensionContext): Promise<void> {
-    if (!botToken || !appToken) {
-      throw new Error("Slack tokens are not configured. Update settings and try again.");
-    }
-
     const broker = await startBroker();
     const adapter = new SlackAdapter({
-      botToken,
-      appToken,
+      botToken: botToken!,
+      appToken: appToken!,
       allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
       suggestedPrompts: settings.suggestedPrompts,
       isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
@@ -1774,14 +1913,12 @@ export default function (pi: ExtensionAPI) {
       selfId = selfAgent.id;
       applyBrokerIdentity(selfAgent.name, selfAgent.emoji);
 
-      const recoveredBrokerMessages = broker.db.requeueUndeliveredMessages(
-        selfId,
-        "broker_delegate",
-      );
+      resetBrokerDeliveryState(brokerDeliveryState);
+      const recoveredBrokerMessages = broker.db.getPendingInboxCount(selfId);
       const releasedBrokerClaims = broker.db.releaseThreadClaims(selfId);
       if (recoveredBrokerMessages > 0 || releasedBrokerClaims > 0) {
         ctx.ui.notify(
-          `Pinet broker reclaimed ${recoveredBrokerMessages} message${recoveredBrokerMessages === 1 ? "" : "s"} and released ${releasedBrokerClaims} broker-owned thread claim${releasedBrokerClaims === 1 ? "" : "s"}`,
+          `Pinet broker recovered ${recoveredBrokerMessages} pending message${recoveredBrokerMessages === 1 ? "" : "s"} and released ${releasedBrokerClaims} broker-owned thread claim${releasedBrokerClaims === 1 ? "" : "s"}`,
           "info",
         );
       }
@@ -1806,11 +1943,6 @@ export default function (pi: ExtensionAPI) {
 
         if (decision.action === "deliver" || decision.action === "unrouted") {
           // Message routed to broker itself (or unrouted) — deliver to broker's own inbox.
-          // Previously, broker-routed messages were queued to `unrouted_backlog` with
-          // reason "broker_delegate" and then assigned to random workers by maintenance.
-          // Since maintenance explicitly excludes the broker from assignment candidates,
-          // the messages ended up on the wrong agent. Fix: always deliver to the broker
-          // in-memory inbox so it can handle them directly. (#121)
           inbox.push({
             channel: inMsg.channel,
             threadTs: inMsg.threadId,
@@ -1830,11 +1962,11 @@ export default function (pi: ExtensionAPI) {
       activeBroker = broker;
       activeRouter = router;
       activeSelfId = selfId;
+      syncBrokerDbInbox(selfId, broker.db);
 
-      // When a worker sends a pinet_message targeting the broker, the
-      // socket server writes to the DB inbox but the broker only reads
-      // its in-memory inbox. Bridge the gap here: push a2a messages
-      // targeting ourselves into the in-memory inbox and trigger drain.
+      // When a worker sends a pinet_message targeting the broker, the socket server writes to the
+      // DB inbox but the broker only reads its in-memory inbox. Sync the durable inbox into memory
+      // without acknowledging the row until the broker has actually consumed it.
       broker.server.onAgentMessage((targetAgentId, brokerMsg, meta) => {
         if (targetAgentId !== selfId) return;
 
@@ -1855,22 +1987,13 @@ export default function (pi: ExtensionAPI) {
           return;
         }
 
-        const senderName = (meta.senderAgent as string) ?? brokerMsg.sender;
-        inbox.push({
-          channel: "",
-          threadTs: brokerMsg.threadId,
-          userId: senderName,
-          text: brokerMsg.body,
-          timestamp: brokerMsg.createdAt,
-        });
-        broker.db.markDeliveredByMessageId(brokerMsg.id, selfId);
-        updateBadge();
-        if (extCtx?.isIdle?.()) drainInbox();
+        syncBrokerDbInbox(selfId, broker.db);
       });
 
       startBrokerHeartbeat();
       startBrokerMaintenance(ctx);
       startBrokerRalphLoop(ctx);
+      startBrokerScheduledWakeups(ctx);
       brokerRole = "broker";
       pinetEnabled = true;
       setExtStatus(ctx, "ok");
@@ -2433,14 +2556,6 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
-  function getFollowerBrokerInboxIds(messages: InboxMessage[]): number[] {
-    return [
-      ...new Set(
-        messages.flatMap((message) => (message.brokerInboxId ? [message.brokerInboxId] : [])),
-      ),
-    ];
-  }
-
   async function flushDeliveredFollowerAcks(): Promise<void> {
     if (followerAckPromise) {
       await followerAckPromise;
@@ -2466,7 +2581,7 @@ export default function (pi: ExtensionAPI) {
     if (inbox.length === 0) return;
 
     const pending = inbox.splice(0, inbox.length);
-    const deliveredFollowerIds = getFollowerBrokerInboxIds(pending);
+    const brokerInboxIds = getBrokerInboxIds(pending);
     updateBadge();
     reportStatus("working");
 
@@ -2478,9 +2593,18 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (deliverFollowUpMessage(prompt)) {
-      if (deliveredFollowerIds.length > 0) {
-        markFollowerInboxIdsDelivered(followerDeliveryState, deliveredFollowerIds);
-        void flushDeliveredFollowerAcks();
+      if (brokerInboxIds.length > 0) {
+        if (brokerRole === "follower") {
+          markFollowerInboxIdsDelivered(followerDeliveryState, brokerInboxIds);
+          void flushDeliveredFollowerAcks();
+        } else if (brokerRole === "broker" && activeBroker && activeSelfId) {
+          try {
+            activeBroker.db.markDelivered(brokerInboxIds, activeSelfId);
+            markBrokerInboxIdsHandled(brokerDeliveryState, brokerInboxIds);
+          } catch {
+            /* best effort */
+          }
+        }
       }
       return;
     }

--- a/slack-bridge/scheduled-wakeups.test.ts
+++ b/slack-bridge/scheduled-wakeups.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildScheduledWakeupThreadId,
+  parseScheduledWakeupDelay,
+  resolveScheduledWakeupFireAt,
+} from "./scheduled-wakeups.js";
+
+describe("parseScheduledWakeupDelay", () => {
+  it("parses simple unit delays", () => {
+    expect(parseScheduledWakeupDelay("5m")).toBe(5 * 60_000);
+    expect(parseScheduledWakeupDelay("30s")).toBe(30_000);
+    expect(parseScheduledWakeupDelay("1d")).toBe(24 * 60 * 60_000);
+  });
+
+  it("parses compound delays", () => {
+    expect(parseScheduledWakeupDelay("1h30m")).toBe(90 * 60_000);
+    expect(parseScheduledWakeupDelay("2h 15m 10s")).toBe(2 * 60 * 60_000 + 15 * 60_000 + 10_000);
+  });
+
+  it("rejects invalid or empty delays", () => {
+    expect(parseScheduledWakeupDelay("")).toBeNull();
+    expect(parseScheduledWakeupDelay("0m")).toBeNull();
+    expect(parseScheduledWakeupDelay("five minutes")).toBeNull();
+    expect(parseScheduledWakeupDelay("5x")).toBeNull();
+    expect(parseScheduledWakeupDelay("m5")).toBeNull();
+  });
+});
+
+describe("resolveScheduledWakeupFireAt", () => {
+  const now = Date.parse("2026-04-02T14:00:00.000Z");
+
+  it("resolves a delay relative to now", () => {
+    expect(resolveScheduledWakeupFireAt({ delay: "5m" }, now)).toBe("2026-04-02T14:05:00.000Z");
+  });
+
+  it("normalizes explicit timestamps", () => {
+    expect(resolveScheduledWakeupFireAt({ at: "2026-04-02T14:10:00Z" }, now)).toBe(
+      "2026-04-02T14:10:00.000Z",
+    );
+  });
+
+  it("requires exactly one scheduling mode", () => {
+    expect(() => resolveScheduledWakeupFireAt({}, now)).toThrow(
+      "Provide exactly one of delay or at.",
+    );
+    expect(() =>
+      resolveScheduledWakeupFireAt({ delay: "5m", at: "2026-04-02T14:10:00Z" }, now),
+    ).toThrow("Provide exactly one of delay or at.");
+  });
+
+  it("rejects invalid or past timestamps", () => {
+    expect(() => resolveScheduledWakeupFireAt({ delay: "nope" }, now)).toThrow("Invalid delay.");
+    expect(() => resolveScheduledWakeupFireAt({ at: "not-a-time" }, now)).toThrow(
+      "Invalid timestamp.",
+    );
+    expect(() => resolveScheduledWakeupFireAt({ at: "2026-04-02T13:59:59Z" }, now)).toThrow(
+      "Scheduled wake-up time must be in the future.",
+    );
+  });
+});
+
+describe("buildScheduledWakeupThreadId", () => {
+  it("builds a stable self-thread id for wakeups", () => {
+    expect(buildScheduledWakeupThreadId("agent-1")).toBe("wakeup:agent-1");
+  });
+});

--- a/slack-bridge/scheduled-wakeups.ts
+++ b/slack-bridge/scheduled-wakeups.ts
@@ -1,0 +1,90 @@
+export interface ScheduledWakeupInput {
+  delay?: string;
+  at?: string;
+}
+
+const DELAY_UNITS_MS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 60 * 60_000,
+  d: 24 * 60 * 60_000,
+};
+
+export function parseScheduledWakeupDelay(delay: string): number | null {
+  const normalized = delay.trim().toLowerCase().replace(/\s+/g, "");
+  if (!normalized) {
+    return null;
+  }
+
+  const tokenRegex = /(\d+)(ms|s|m|h|d)/g;
+  let totalMs = 0;
+  let matchedLength = 0;
+
+  for (const match of normalized.matchAll(tokenRegex)) {
+    const [token, amountText, unit] = match;
+    if (!token || !amountText || !unit || match.index !== matchedLength) {
+      return null;
+    }
+
+    const amount = Number.parseInt(amountText, 10);
+    if (!Number.isFinite(amount) || amount < 0) {
+      return null;
+    }
+
+    totalMs += amount * DELAY_UNITS_MS[unit];
+    matchedLength += token.length;
+  }
+
+  if (matchedLength !== normalized.length || totalMs <= 0) {
+    return null;
+  }
+
+  return totalMs;
+}
+
+export function resolveScheduledWakeupFireAt(
+  input: ScheduledWakeupInput,
+  now = Date.now(),
+): string {
+  const hasDelay = typeof input.delay === "string" && input.delay.trim().length > 0;
+  const hasAt = typeof input.at === "string" && input.at.trim().length > 0;
+
+  if (hasDelay === hasAt) {
+    throw new Error("Provide exactly one of delay or at.");
+  }
+
+  if (hasDelay) {
+    const delayMs = parseScheduledWakeupDelay(input.delay!);
+    if (delayMs == null) {
+      throw new Error("Invalid delay. Use values like 5m, 30s, 1h30m, or 1d.");
+    }
+    return new Date(now + delayMs).toISOString();
+  }
+
+  const fireAtMs = Date.parse(input.at!);
+  if (Number.isNaN(fireAtMs)) {
+    throw new Error("Invalid timestamp. Use an ISO-8601 time like 2026-04-02T14:30:00Z.");
+  }
+  if (fireAtMs <= now) {
+    throw new Error("Scheduled wake-up time must be in the future.");
+  }
+
+  return new Date(fireAtMs).toISOString();
+}
+
+export function buildScheduledWakeupThreadId(agentId: string): string {
+  return `wakeup:${agentId}`;
+}
+
+export function buildScheduledWakeupMetadata(
+  wakeupId: number,
+  fireAt: string,
+): Record<string, unknown> {
+  return {
+    senderAgent: "Pinet Scheduler",
+    scheduledWakeup: true,
+    wakeupId,
+    fireAt,
+  };
+}


### PR DESCRIPTION
## Summary
- add a new `pinet_schedule` tool so connected agents can ask the broker for a future wake-up instead of busy-waiting
- persist scheduled wake-ups in the broker SQLite DB and deliver due reminders into the target agent inbox once the target is connected
- add broker loop, RPC plumbing, guardrail coverage, and tests for parsing, migration, persistence, and end-to-end delivery

## Details
- `slack-bridge/scheduled-wakeups.ts`: parses relative delays (`5m`, `1h30m`) and resolves absolute fire times
- `slack-bridge/index.ts`: registers `pinet_schedule`, starts a broker wake-up loop, and bridges broker-self wake-ups from the DB inbox into the broker's in-memory inbox
- `slack-bridge/broker/schema.ts`: adds `scheduled_wakeups` persistence + delivery APIs and schema migration v6
- `slack-bridge/broker/socket-server.ts` / `broker/client.ts`: add `schedule.create` RPC support
- `slack-bridge/broker/*.test.ts`: cover client RPC, schema migration, persistence across restart, delayed delivery, and full integration flow

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #62
