### PR TITLE
fix: add timestamp to RALPH loop messages (#191)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -19,7 +19,9 @@ import {
   rewriteRalphLoopGhostAnomalies,
   buildRalphLoopNudgeMessage,
   buildRalphLoopAnomalySignature,
+  buildRalphLoopCycleNotifications,
   buildRalphLoopFollowUpMessage,
+  buildRalphLoopStatusMessage,
   shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -1276,23 +1278,72 @@ describe("shouldDeliverRalphLoopFollowUp", () => {
   });
 });
 
+describe("buildRalphLoopStatusMessage", () => {
+  it("formats inline Ralph notifications with the captured cycle timestamp", () => {
+    expect(
+      buildRalphLoopStatusMessage(
+        "ghost agents detected: ghost-1; Idle Gecko idle with assigned work",
+        "2026-04-02T14:10:00.000Z",
+      ),
+    ).toBe(
+      "RALPH loop (2026-04-02T14:10:00.000Z): ghost agents detected: ghost-1; Idle Gecko idle with assigned work",
+    );
+  });
+});
+
+describe("buildRalphLoopCycleNotifications", () => {
+  it("threads the captured cycle timestamp through follow-up and inline status output", () => {
+    expect(
+      buildRalphLoopCycleNotifications(
+        {
+          ghostAgentIds: ["ghost-1"],
+          nudgeAgentIds: ["idle-1"],
+          idleDrainAgentIds: ["ready-1"],
+          stuckAgentIds: [],
+          anomalies: [
+            "ghost agents detected: ghost-1",
+            "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
+          ],
+        },
+        "2026-04-02T14:10:00.000Z",
+      ),
+    ).toEqual({
+      followUpPrompt: [
+        "RALPH LOOP CYCLE:",
+        "Timestamp: 2026-04-02T14:10:00.000Z",
+        "- ghost agents detected: ghost-1",
+        "- Idle Gecko idle with assigned work (2 inbox, 1 threads)",
+        "",
+        "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
+      ].join("\n"),
+      anomalyStatus:
+        "RALPH loop (2026-04-02T14:10:00.000Z): ghost agents detected: ghost-1; Idle Gecko idle with assigned work (2 inbox, 1 threads)",
+      recoveryStatus: "RALPH loop (2026-04-02T14:10:00.000Z): health recovered",
+    });
+  });
+});
+
 describe("buildRalphLoopFollowUpMessage", () => {
   it("formats actionable anomalies into a broker follow-up prompt", () => {
     expect(
-      buildRalphLoopFollowUpMessage({
-        ghostAgentIds: ["ghost-1"],
-        nudgeAgentIds: ["idle-1"],
-        idleDrainAgentIds: ["ready-1"],
-        stuckAgentIds: [],
-        anomalies: [
-          "ghost agents detected: ghost-1",
-          "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
-          "main checkout is on `feat/not-main`, expected `main`",
-        ],
-      }),
+      buildRalphLoopFollowUpMessage(
+        {
+          ghostAgentIds: ["ghost-1"],
+          nudgeAgentIds: ["idle-1"],
+          idleDrainAgentIds: ["ready-1"],
+          stuckAgentIds: [],
+          anomalies: [
+            "ghost agents detected: ghost-1",
+            "Idle Gecko idle with assigned work (2 inbox, 1 threads)",
+            "main checkout is on `feat/not-main`, expected `main`",
+          ],
+        },
+        "2026-04-02T14:10:00.000Z",
+      ),
     ).toBe(
       [
         "RALPH LOOP CYCLE:",
+        "Timestamp: 2026-04-02T14:10:00.000Z",
         "- ghost agents detected: ghost-1",
         "- Idle Gecko idle with assigned work (2 inbox, 1 threads)",
         "- main checkout is on `feat/not-main`, expected `main`",
@@ -1304,13 +1355,16 @@ describe("buildRalphLoopFollowUpMessage", () => {
 
   it("returns null when there is nothing actionable", () => {
     expect(
-      buildRalphLoopFollowUpMessage({
-        ghostAgentIds: [],
-        nudgeAgentIds: [],
-        idleDrainAgentIds: [],
-        stuckAgentIds: [],
-        anomalies: [],
-      }),
+      buildRalphLoopFollowUpMessage(
+        {
+          ghostAgentIds: [],
+          nudgeAgentIds: [],
+          idleDrainAgentIds: [],
+          stuckAgentIds: [],
+          anomalies: [],
+        },
+        "2026-04-02T14:10:00.000Z",
+      ),
     ).toBeNull();
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -815,6 +815,10 @@ export function buildRalphLoopAnomalySignature(evaluation: RalphLoopEvaluationRe
   return evaluation.anomalies.join("|");
 }
 
+export function buildRalphLoopStatusMessage(summary: string, cycleStartedAt: string): string {
+  return `RALPH loop (${cycleStartedAt}): ${summary}`;
+}
+
 export interface RalphLoopFollowUpDeliveryOptions {
   signature: string;
   lastDeliveredAt?: number;
@@ -845,6 +849,7 @@ export function shouldDeliverRalphLoopFollowUp(options: RalphLoopFollowUpDeliver
 
 export function buildRalphLoopFollowUpMessage(
   evaluation: RalphLoopEvaluationResult,
+  cycleStartedAt: string,
 ): string | null {
   if (evaluation.anomalies.length === 0) {
     return null;
@@ -852,10 +857,31 @@ export function buildRalphLoopFollowUpMessage(
 
   return [
     "RALPH LOOP CYCLE:",
+    `Timestamp: ${cycleStartedAt}`,
     ...evaluation.anomalies.map((anomaly) => `- ${anomaly}`),
     "",
     "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
   ].join("\n");
+}
+
+export interface RalphLoopCycleNotifications {
+  followUpPrompt: string | null;
+  anomalyStatus: string | null;
+  recoveryStatus: string;
+}
+
+export function buildRalphLoopCycleNotifications(
+  evaluation: RalphLoopEvaluationResult,
+  cycleStartedAt: string,
+): RalphLoopCycleNotifications {
+  return {
+    followUpPrompt: buildRalphLoopFollowUpMessage(evaluation, cycleStartedAt),
+    anomalyStatus:
+      evaluation.anomalies.length > 0
+        ? buildRalphLoopStatusMessage(evaluation.anomalies.join("; "), cycleStartedAt)
+        : null,
+    recoveryStatus: buildRalphLoopStatusMessage("health recovered", cycleStartedAt),
+  };
 }
 
 export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: string): string[] {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -26,7 +26,8 @@ import {
   rewriteRalphLoopGhostAnomalies,
   buildRalphLoopNudgeMessage,
   buildRalphLoopAnomalySignature,
-  buildRalphLoopFollowUpMessage,
+  buildRalphLoopCycleNotifications,
+  buildRalphLoopStatusMessage,
   shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_INTERVAL_MS,
   DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
@@ -1104,12 +1105,16 @@ export default function (pi: ExtensionAPI) {
       const visibleSignature = buildRalphLoopAnomalySignature(visibleEvaluation);
       const nonGhostSignature = ghostRewrite.nonGhostAnomalies.join("|");
       const hasOutstandingAnomalies = evaluation.anomalies.length > 0;
+      const ralphNotifications = buildRalphLoopCycleNotifications(
+        visibleEvaluation,
+        cycleStartedAt,
+      );
       const followUpPrompt =
         ghostRewrite.newGhostIds.length === 0 &&
         ghostRewrite.clearedGhostIds.length > 0 &&
         ghostRewrite.nonGhostAnomalies.length === 0
           ? null
-          : buildRalphLoopFollowUpMessage(visibleEvaluation);
+          : ralphNotifications.followUpPrompt;
 
       const agentsById = new Map(
         workloads.map((workload) => [workload.id, { emoji: workload.emoji, name: workload.name }]),
@@ -1184,11 +1189,11 @@ export default function (pi: ExtensionAPI) {
       const shouldInform =
         ghostRewrite.clearedGhostIds.length > 0 && visibleEvaluation.anomalies.length > 0;
       if (shouldWarn) {
-        ctx.ui.notify(`RALPH loop: ${visibleEvaluation.anomalies.join("; ")}`, "warning");
+        ctx.ui.notify(ralphNotifications.anomalyStatus ?? "RALPH loop anomaly detected", "warning");
       } else if (shouldInform) {
-        ctx.ui.notify(`RALPH loop: ${visibleEvaluation.anomalies.join("; ")}`, "info");
+        ctx.ui.notify(ralphNotifications.anomalyStatus ?? "RALPH loop anomaly detected", "info");
       } else if (!hasOutstandingAnomalies && lastBrokerRalphLoopHadOutstandingAnomalies) {
-        ctx.ui.notify("RALPH loop health recovered", "info");
+        ctx.ui.notify(ralphNotifications.recoveryStatus, "info");
       }
       lastBrokerRalphLoopNonGhostSignature = nonGhostSignature;
       lastBrokerRalphLoopHadOutstandingAnomalies = hasOutstandingAnomalies;
@@ -1214,7 +1219,7 @@ export default function (pi: ExtensionAPI) {
         /* best effort — don't let cycle recording break the loop */
       }
     } catch (err) {
-      ctx.ui.notify(`RALPH loop failed: ${msg(err)}`, "error");
+      ctx.ui.notify(buildRalphLoopStatusMessage(`failed: ${msg(err)}`, cycleStartedAt), "error");
     } finally {
       brokerRalphLoopRunning = false;
     }


### PR DESCRIPTION
## Summary\n- add the Ralph loop cycle start timestamp to broker follow-up messages\n- pass the actual cycle start time from the loop runner instead of generating it later\n- cover the new message format in helpers tests\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n\nCloses #191