### PR TITLE
fix: report initial RALPH task status (#197)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -95,8 +95,8 @@ import {
   resetFollowerDeliveryState,
 } from "./follower-delivery.js";
 import {
-  buildTaskAssignmentReport,
   extractTaskAssignmentsFromMessage,
+  getPendingTaskAssignmentReport,
   hasTaskAssignmentStatusChange,
   resolveTaskAssignments,
 } from "./task-assignments.js";
@@ -1196,10 +1196,8 @@ export default function (pi: ExtensionAPI) {
         lastBrokerTaskAssignmentReport = "";
       } else {
         const resolvedAssignments = await resolveTaskAssignments(trackedAssignments, process.cwd());
-        let taskAssignmentChanged = false;
         const projectedAssignments = resolvedAssignments.map((assignment) => {
           if (hasTaskAssignmentStatusChange(assignment)) {
-            taskAssignmentChanged = true;
             db.updateTaskAssignmentProgress(
               assignment.id,
               assignment.nextStatus,
@@ -1214,12 +1212,11 @@ export default function (pi: ExtensionAPI) {
           };
         });
 
-        if (taskAssignmentChanged) {
-          pendingBrokerTaskAssignmentReport = buildTaskAssignmentReport(
-            projectedAssignments,
-            agentsById,
-          );
-        }
+        pendingBrokerTaskAssignmentReport = getPendingTaskAssignmentReport(
+          projectedAssignments,
+          agentsById,
+          lastBrokerTaskAssignmentReport,
+        );
       }
       // Keep cooldown state across transient clean cycles so flapping anomalies
       // do not immediately re-notify when they return.

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -3,6 +3,7 @@ import type { AgentInfo, TaskAssignmentInfo } from "./broker/types.js";
 import {
   buildTaskAssignmentReport,
   extractTaskAssignmentsFromMessage,
+  getPendingTaskAssignmentReport,
   hasTaskAssignmentStatusChange,
   resolveTaskAssignments,
   type CommandRunner,
@@ -244,5 +245,54 @@ describe("buildTaskAssignmentReport", () => {
         "- 🐎 Hyper Horse: #106 → PR #109 MERGED ✅",
       ].join("\n"),
     );
+  });
+});
+
+describe("getPendingTaskAssignmentReport", () => {
+  const agentsById = new Map([
+    ["worker-1", makeAgent("worker-1", "Hyper Horse", "🐎")],
+    ["worker-2", makeAgent("worker-2", "Frozen Raven", "🐦‍⬛")],
+  ]);
+
+  it("queues an initial report for newly assigned tasks with no progress", () => {
+    const report = getPendingTaskAssignmentReport(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-2",
+          issueNumber: 103,
+          status: "assigned",
+        }),
+      ],
+      agentsById,
+      "",
+    );
+
+    expect(report).toBe(
+      ["RALPH LOOP — WORKER STATUS:", "- 🐦‍⬛ Frozen Raven: #103 → no commits, no PR ⚠️"].join("\n"),
+    );
+  });
+
+  it("does not queue a report when it matches the last delivered summary", () => {
+    const lastDeliveredReport = [
+      "RALPH LOOP — WORKER STATUS:",
+      "- 🐎 Hyper Horse: #106 → PR #109 MERGED ✅",
+    ].join("\n");
+
+    const report = getPendingTaskAssignmentReport(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 106,
+          status: "pr_merged",
+          prNumber: 109,
+        }),
+      ],
+      agentsById,
+      lastDeliveredReport,
+    );
+
+    expect(report).toBeNull();
   });
 });

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -426,3 +426,17 @@ export function buildTaskAssignmentReport(
 
   return `RALPH LOOP — WORKER STATUS:\n${lines.join("\n")}`;
 }
+
+export function getPendingTaskAssignmentReport(
+  assignments: Array<
+    Pick<TaskAssignmentInfo, "agentId" | "issueNumber" | "branch" | "status" | "prNumber">
+  >,
+  agentsById: ReadonlyMap<string, Pick<AgentInfo, "emoji" | "name">>,
+  lastDeliveredReport: string,
+): string | null {
+  const report = buildTaskAssignmentReport(assignments, agentsById);
+  if (!report || report === lastDeliveredReport) {
+    return null;
+  }
+  return report;
+}


### PR DESCRIPTION
## Summary
- report an initial RALPH worker-status summary for newly assigned tasks with no progress
- suppress duplicate follow-ups by comparing against the last delivered assignment report
- add task-assignment coverage for first-report and duplicate-report behavior

## Testing
- pnpm --filter @gugu91/pi-slack-bridge lint
- pnpm --filter @gugu91/pi-slack-bridge typecheck
- pnpm --filter @gugu91/pi-slack-bridge test -- --run task-assignments.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test