### PR TITLE
feat: add Slack canvas tools (#26)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -21,14 +21,16 @@ If the agent is idle, incoming messages are processed immediately.
 
 ## Tools
 
-| Tool                                              | Description                     |
-| ------------------------------------------------- | ------------------------------- |
-| `slack_send(text, thread_ts?)`                    | Reply in a thread or start new  |
-| `slack_read(thread_ts, limit?)`                   | Read thread messages            |
-| `slack_inbox()`                                   | Check pending messages manually |
-| `slack_create_channel(name, topic?, purpose?)`    | Create a project channel        |
-| `slack_post_channel(channel?, text, thread_ts?)`  | Post to a channel               |
-| `slack_read_channel(channel, thread_ts?, limit?)` | Read channel history or thread  |
+| Tool                                                              | Description                                |
+| ----------------------------------------------------------------- | ------------------------------------------ |
+| `slack_send(text, thread_ts?)`                                    | Reply in a thread or start new             |
+| `slack_read(thread_ts, limit?)`                                   | Read thread messages                       |
+| `slack_inbox()`                                                   | Check pending messages manually            |
+| `slack_create_channel(name, topic?, purpose?)`                    | Create a project channel                   |
+| `slack_post_channel(channel?, text, thread_ts?)`                  | Post to a channel                          |
+| `slack_read_channel(channel, thread_ts?, limit?)`                 | Read channel history or thread             |
+| `slack_canvas_create(title?, markdown?, channel?, kind?)`         | Create standalone or channel canvases      |
+| `slack_canvas_update(canvas_id?, channel?, markdown, mode?, ...)` | Append, prepend, or replace canvas content |
 
 ## Features
 
@@ -39,7 +41,7 @@ If the agent is idle, incoming messages are processed immediately.
 - **Suggested prompts** — shown when a user opens a new conversation
 - **Multi-user** — handles concurrent conversations from different users
 - **@mentions** — tag Pinet in any channel and it responds in-thread
-- **Channel tools** — create, post to, and read from channels
+- **Channel & canvas tools** — create/read/post in channels and maintain persistent Slack canvases
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
 - **User allowlist** — restrict who can interact with the agent

--- a/slack-bridge/canvases.test.ts
+++ b/slack-bridge/canvases.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackCanvasCreateRequest,
+  buildSlackCanvasEditRequest,
+  buildSlackCanvasSectionsLookupRequest,
+  extractSlackChannelCanvasId,
+  normalizeSlackCanvasCreateKind,
+  normalizeSlackCanvasSectionType,
+  normalizeSlackCanvasUpdateMode,
+  pickSlackCanvasSectionId,
+} from "./canvases.js";
+
+describe("normalizeSlackCanvasCreateKind", () => {
+  it("defaults to standalone", () => {
+    expect(normalizeSlackCanvasCreateKind()).toBe("standalone");
+  });
+
+  it("accepts channel", () => {
+    expect(normalizeSlackCanvasCreateKind("channel")).toBe("channel");
+  });
+
+  it("rejects unsupported kinds", () => {
+    expect(() => normalizeSlackCanvasCreateKind("thread")).toThrow(
+      "Unsupported canvas kind. Use 'standalone' or 'channel'.",
+    );
+  });
+});
+
+describe("normalizeSlackCanvasUpdateMode", () => {
+  it("defaults to append", () => {
+    expect(normalizeSlackCanvasUpdateMode()).toBe("append");
+  });
+
+  it("accepts prepend and replace", () => {
+    expect(normalizeSlackCanvasUpdateMode("prepend")).toBe("prepend");
+    expect(normalizeSlackCanvasUpdateMode("replace")).toBe("replace");
+  });
+
+  it("rejects unsupported modes", () => {
+    expect(() => normalizeSlackCanvasUpdateMode("rename")).toThrow(
+      "Unsupported canvas update mode. Use 'append', 'prepend', or 'replace'.",
+    );
+  });
+});
+
+describe("normalizeSlackCanvasSectionType", () => {
+  it("accepts supported section types", () => {
+    expect(normalizeSlackCanvasSectionType("h1")).toBe("h1");
+    expect(normalizeSlackCanvasSectionType("any_header")).toBe("any_header");
+  });
+
+  it("returns undefined when omitted", () => {
+    expect(normalizeSlackCanvasSectionType()).toBeUndefined();
+  });
+
+  it("rejects unsupported section types", () => {
+    expect(() => normalizeSlackCanvasSectionType("paragraph")).toThrow(
+      "Unsupported canvas section type. Use 'h1', 'h2', 'h3', or 'any_header'.",
+    );
+  });
+});
+
+describe("buildSlackCanvasCreateRequest", () => {
+  it("builds standalone canvas requests by default", () => {
+    expect(buildSlackCanvasCreateRequest({ title: "Runbook", markdown: "# Hello" })).toEqual({
+      kind: "standalone",
+      method: "canvases.create",
+      body: {
+        title: "Runbook",
+        document_content: { type: "markdown", markdown: "# Hello" },
+      },
+    });
+  });
+
+  it("attaches standalone canvases to a channel when provided", () => {
+    expect(buildSlackCanvasCreateRequest({ channelId: "C123", markdown: "Attached" })).toEqual({
+      kind: "standalone",
+      method: "canvases.create",
+      body: {
+        channel_id: "C123",
+        document_content: { type: "markdown", markdown: "Attached" },
+      },
+    });
+  });
+
+  it("builds channel canvas requests when requested", () => {
+    expect(
+      buildSlackCanvasCreateRequest({
+        kind: "channel",
+        channelId: "C123",
+        title: "Project Status",
+        markdown: "# Status",
+      }),
+    ).toEqual({
+      kind: "channel",
+      method: "conversations.canvases.create",
+      body: {
+        channel_id: "C123",
+        title: "Project Status",
+        document_content: { type: "markdown", markdown: "# Status" },
+      },
+    });
+  });
+
+  it("rejects channel canvases without a channel", () => {
+    expect(() => buildSlackCanvasCreateRequest({ kind: "channel" })).toThrow(
+      "Channel canvases require a channel.",
+    );
+  });
+});
+
+describe("buildSlackCanvasEditRequest", () => {
+  it("appends content by default", () => {
+    expect(buildSlackCanvasEditRequest({ canvasId: "F123", markdown: "More" })).toEqual({
+      canvas_id: "F123",
+      changes: [
+        {
+          operation: "insert_at_end",
+          document_content: { type: "markdown", markdown: "More" },
+        },
+      ],
+    });
+  });
+
+  it("prepends content when requested", () => {
+    expect(
+      buildSlackCanvasEditRequest({ canvasId: "F123", markdown: "Top", mode: "prepend" }),
+    ).toEqual({
+      canvas_id: "F123",
+      changes: [
+        {
+          operation: "insert_at_start",
+          document_content: { type: "markdown", markdown: "Top" },
+        },
+      ],
+    });
+  });
+
+  it("replaces the whole canvas when no section is provided", () => {
+    expect(
+      buildSlackCanvasEditRequest({ canvasId: "F123", markdown: "Fresh", mode: "replace" }),
+    ).toEqual({
+      canvas_id: "F123",
+      changes: [
+        {
+          operation: "replace",
+          document_content: { type: "markdown", markdown: "Fresh" },
+        },
+      ],
+    });
+  });
+
+  it("replaces a matched section when given a section id", () => {
+    expect(
+      buildSlackCanvasEditRequest({
+        canvasId: "F123",
+        markdown: "Fresh",
+        mode: "replace",
+        sectionId: "temp:C:123",
+      }),
+    ).toEqual({
+      canvas_id: "F123",
+      changes: [
+        {
+          operation: "replace",
+          section_id: "temp:C:123",
+          document_content: { type: "markdown", markdown: "Fresh" },
+        },
+      ],
+    });
+  });
+
+  it("rejects missing canvas ids", () => {
+    expect(() => buildSlackCanvasEditRequest({ canvasId: "", markdown: "x" })).toThrow(
+      "Canvas updates require a canvas ID.",
+    );
+  });
+});
+
+describe("buildSlackCanvasSectionsLookupRequest", () => {
+  it("builds lookup criteria from text only", () => {
+    expect(
+      buildSlackCanvasSectionsLookupRequest({ canvasId: "F123", containsText: "Status" }),
+    ).toEqual({
+      canvas_id: "F123",
+      criteria: {
+        contains_text: "Status",
+      },
+    });
+  });
+
+  it("includes section type when provided", () => {
+    expect(
+      buildSlackCanvasSectionsLookupRequest({
+        canvasId: "F123",
+        containsText: "Status",
+        sectionType: "h2",
+      }),
+    ).toEqual({
+      canvas_id: "F123",
+      criteria: {
+        contains_text: "Status",
+        section_types: ["h2"],
+      },
+    });
+  });
+});
+
+describe("pickSlackCanvasSectionId", () => {
+  it("returns the only match", () => {
+    expect(pickSlackCanvasSectionId([{ id: "temp:C:1" }])).toBe("temp:C:1");
+  });
+
+  it("allows selecting a specific match with section_index", () => {
+    expect(pickSlackCanvasSectionId([{ id: "temp:C:1" }, { id: "temp:C:2" }], 2)).toBe("temp:C:2");
+  });
+
+  it("rejects ambiguous lookups without section_index", () => {
+    expect(() => pickSlackCanvasSectionId([{ id: "temp:C:1" }, { id: "temp:C:2" }])).toThrow(
+      "Canvas section lookup matched 2 sections. Provide section_index to choose one result or narrow the lookup.",
+    );
+  });
+
+  it("rejects out-of-range section indexes", () => {
+    expect(() => pickSlackCanvasSectionId([{ id: "temp:C:1" }], 2)).toThrow(
+      "Canvas section lookup matched 1 sections; section_index 2 is out of range.",
+    );
+  });
+});
+
+describe("extractSlackChannelCanvasId", () => {
+  it("reads the id from properties.canvas.id", () => {
+    expect(
+      extractSlackChannelCanvasId({
+        channel: {
+          properties: {
+            canvas: { id: "F123" },
+          },
+        },
+      }),
+    ).toBe("F123");
+  });
+
+  it("falls back to channel_solutions.canvas_ids", () => {
+    expect(
+      extractSlackChannelCanvasId({
+        channel: {
+          properties: {
+            channel_solutions: { canvas_ids: ["F234"] },
+          },
+        },
+      }),
+    ).toBe("F234");
+  });
+
+  it("returns null when only undocumented tab metadata is present", () => {
+    expect(
+      extractSlackChannelCanvasId({
+        channel: {
+          properties: {
+            tabs: [{ id: "F345", type: "channel_canvas" }],
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the channel has no canvas metadata", () => {
+    expect(extractSlackChannelCanvasId({ channel: { properties: {} } })).toBeNull();
+  });
+});

--- a/slack-bridge/canvases.ts
+++ b/slack-bridge/canvases.ts
@@ -1,0 +1,249 @@
+export interface SlackCanvasDocumentContent {
+  type: "markdown";
+  markdown: string;
+}
+
+export type SlackCanvasCreateMethod = "canvases.create" | "conversations.canvases.create";
+export type SlackCanvasCreateKind = "standalone" | "channel";
+export type SlackCanvasUpdateMode = "append" | "prepend" | "replace";
+export type SlackCanvasSectionType = "h1" | "h2" | "h3" | "any_header";
+export type SlackCanvasEditOperation = "insert_at_end" | "insert_at_start" | "replace";
+
+export interface SlackCanvasCreateInput {
+  kind?: string;
+  title?: string;
+  markdown?: string;
+  channelId?: string;
+}
+
+export interface SlackCanvasCreateRequest {
+  kind: SlackCanvasCreateKind;
+  method: SlackCanvasCreateMethod;
+  body: {
+    title?: string;
+    channel_id?: string;
+    document_content?: SlackCanvasDocumentContent;
+  };
+}
+
+export interface SlackCanvasEditRequest {
+  canvas_id: string;
+  changes: [
+    {
+      operation: SlackCanvasEditOperation;
+      document_content: SlackCanvasDocumentContent;
+      section_id?: string;
+    },
+  ];
+}
+
+export interface SlackCanvasSectionLookupRequest {
+  canvas_id: string;
+  criteria: {
+    contains_text: string;
+    section_types?: SlackCanvasSectionType[];
+  };
+}
+
+export interface SlackCanvasSectionLookupResult {
+  id?: string;
+}
+
+function normalizeOptionalString(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function buildDocumentContent(markdown?: string): SlackCanvasDocumentContent | undefined {
+  if (markdown == null || markdown.length === 0) return undefined;
+  return { type: "markdown", markdown };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.map(asString).filter((item): item is string => Boolean(item));
+  return strings.length > 0 ? strings : undefined;
+}
+
+export function normalizeSlackCanvasCreateKind(kind?: string): SlackCanvasCreateKind {
+  const normalized = kind?.trim().toLowerCase();
+  if (!normalized) return "standalone";
+  if (normalized === "standalone" || normalized === "channel") {
+    return normalized;
+  }
+  throw new Error("Unsupported canvas kind. Use 'standalone' or 'channel'.");
+}
+
+export function normalizeSlackCanvasUpdateMode(mode?: string): SlackCanvasUpdateMode {
+  const normalized = mode?.trim().toLowerCase();
+  if (!normalized) return "append";
+  if (normalized === "append" || normalized === "prepend" || normalized === "replace") {
+    return normalized;
+  }
+  throw new Error("Unsupported canvas update mode. Use 'append', 'prepend', or 'replace'.");
+}
+
+export function normalizeSlackCanvasSectionType(type?: string): SlackCanvasSectionType | undefined {
+  const normalized = type?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (
+    normalized === "h1" ||
+    normalized === "h2" ||
+    normalized === "h3" ||
+    normalized === "any_header"
+  ) {
+    return normalized;
+  }
+  throw new Error("Unsupported canvas section type. Use 'h1', 'h2', 'h3', or 'any_header'.");
+}
+
+export function buildSlackCanvasCreateRequest(
+  input: SlackCanvasCreateInput,
+): SlackCanvasCreateRequest {
+  const kind = normalizeSlackCanvasCreateKind(input.kind);
+  const channelId = normalizeOptionalString(input.channelId);
+  const title = normalizeOptionalString(input.title);
+  const documentContent = buildDocumentContent(input.markdown);
+
+  if (kind === "channel") {
+    if (!channelId) {
+      throw new Error("Channel canvases require a channel.");
+    }
+    return {
+      kind,
+      method: "conversations.canvases.create",
+      body: {
+        ...(title ? { title } : {}),
+        ...(documentContent ? { document_content: documentContent } : {}),
+        channel_id: channelId,
+      },
+    };
+  }
+
+  return {
+    kind,
+    method: "canvases.create",
+    body: {
+      ...(title ? { title } : {}),
+      ...(documentContent ? { document_content: documentContent } : {}),
+      ...(channelId ? { channel_id: channelId } : {}),
+    },
+  };
+}
+
+export function buildSlackCanvasEditRequest(input: {
+  canvasId: string;
+  markdown: string;
+  mode?: string;
+  sectionId?: string;
+}): SlackCanvasEditRequest {
+  const canvasId = normalizeOptionalString(input.canvasId);
+  if (!canvasId) {
+    throw new Error("Canvas updates require a canvas ID.");
+  }
+  if (input.markdown.length === 0) {
+    throw new Error("Canvas updates require markdown content.");
+  }
+
+  const sectionId = normalizeOptionalString(input.sectionId);
+  const mode = normalizeSlackCanvasUpdateMode(input.mode);
+  const operation: SlackCanvasEditOperation =
+    mode === "append" ? "insert_at_end" : mode === "prepend" ? "insert_at_start" : "replace";
+
+  return {
+    canvas_id: canvasId,
+    changes: [
+      {
+        operation,
+        document_content: { type: "markdown", markdown: input.markdown },
+        ...(sectionId ? { section_id: sectionId } : {}),
+      },
+    ],
+  };
+}
+
+export function buildSlackCanvasSectionsLookupRequest(input: {
+  canvasId: string;
+  containsText: string;
+  sectionType?: string;
+}): SlackCanvasSectionLookupRequest {
+  const canvasId = normalizeOptionalString(input.canvasId);
+  if (!canvasId) {
+    throw new Error("Canvas section lookups require a canvas ID.");
+  }
+
+  const containsText = normalizeOptionalString(input.containsText);
+  if (!containsText) {
+    throw new Error("Canvas section lookups require text to match.");
+  }
+
+  const sectionType = normalizeSlackCanvasSectionType(input.sectionType);
+  return {
+    canvas_id: canvasId,
+    criteria: {
+      contains_text: containsText,
+      ...(sectionType ? { section_types: [sectionType] } : {}),
+    },
+  };
+}
+
+export function pickSlackCanvasSectionId(
+  sections: SlackCanvasSectionLookupResult[] | undefined,
+  sectionIndex?: number,
+): string {
+  const matches = (sections ?? [])
+    .map((section) => normalizeOptionalString(section.id))
+    .filter((id): id is string => Boolean(id));
+
+  if (matches.length === 0) {
+    throw new Error("No canvas sections matched the lookup.");
+  }
+
+  if (sectionIndex != null) {
+    if (!Number.isInteger(sectionIndex) || sectionIndex < 1) {
+      throw new Error("section_index must be a positive integer.");
+    }
+    const selected = matches[sectionIndex - 1];
+    if (!selected) {
+      throw new Error(
+        `Canvas section lookup matched ${matches.length} sections; section_index ${sectionIndex} is out of range.`,
+      );
+    }
+    return selected;
+  }
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Canvas section lookup matched ${matches.length} sections. Provide section_index to choose one result or narrow the lookup.`,
+    );
+  }
+
+  return matches[0];
+}
+
+export function extractSlackChannelCanvasId(response: Record<string, unknown>): string | null {
+  const channel = asRecord(response.channel);
+  const properties = asRecord(channel?.properties);
+  if (!properties) return null;
+
+  const directCanvas = asString(properties.canvas);
+  if (directCanvas) return directCanvas;
+
+  const canvasRecord = asRecord(properties.canvas);
+  const canvasId = asString(canvasRecord?.id) ?? asString(canvasRecord?.canvas_id);
+  if (canvasId) return canvasId;
+
+  const channelSolutions = asRecord(properties.channel_solutions);
+  const canvasIds = asStringArray(channelSolutions?.canvas_ids);
+  if (canvasIds?.[0]) return canvasIds[0];
+
+  return null;
+}

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -3,6 +3,14 @@ import { Type } from "@gugu91/pi-ext-types/typebox";
 import type { InboxMessage } from "./helpers.js";
 import type { SecurityGuardrails } from "./guardrails.js";
 import type { SlackResult } from "./slack-api.js";
+import {
+  buildSlackCanvasCreateRequest,
+  buildSlackCanvasEditRequest,
+  buildSlackCanvasSectionsLookupRequest,
+  extractSlackChannelCanvasId,
+  normalizeSlackCanvasUpdateMode,
+  pickSlackCanvasSectionId,
+} from "./canvases.js";
 
 export interface RegisterSlackToolsDeps {
   botToken: string;
@@ -52,6 +60,13 @@ function buildSlackInboxPromptGuidelines(
   ];
 }
 
+function getSlackCanvasSummary(markdown?: string): string {
+  if (markdown == null || markdown.length === 0) return "(empty canvas)";
+  const collapsed = markdown.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= 80) return collapsed;
+  return `${collapsed.slice(0, 77)}...`;
+}
+
 export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDeps): void {
   const {
     botToken,
@@ -75,6 +90,36 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     getThreadChannel,
     registerConfirmationRequest,
   } = deps;
+
+  async function resolveCanvasTarget(
+    canvasId: string | undefined,
+    channel: string | undefined,
+  ): Promise<{ canvasId: string; channelId?: string; channelLabel?: string }> {
+    const trimmedCanvasId = canvasId?.trim();
+    if (trimmedCanvasId) {
+      return { canvasId: trimmedCanvasId };
+    }
+
+    const channelInput = channel?.trim();
+    if (!channelInput) {
+      throw new Error("Provide either canvas_id or channel.");
+    }
+
+    const channelId = await resolveChannel(channelInput);
+    const info = await slack("conversations.info", botToken, { channel: channelId });
+    const resolvedCanvasId = extractSlackChannelCanvasId(info);
+    if (!resolvedCanvasId) {
+      throw new Error(
+        `Slack did not expose a channel canvas ID in conversations.info for ${channelInput}. Provide canvas_id directly.`,
+      );
+    }
+
+    return {
+      canvasId: resolvedCanvasId,
+      channelId,
+      channelLabel: channelInput,
+    };
+  }
 
   pi.registerTool({
     name: "slack_inbox",
@@ -374,6 +419,168 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       return {
         content: [{ type: "text", text: lines.join("\n") || "(no messages)" }],
         details: { count: messages.length, channel: channelId },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_canvas_create",
+    label: "Slack Canvas Create",
+    description:
+      "Create a Slack canvas with markdown content, either standalone or as a channel canvas.",
+    promptSnippet:
+      "Create a Slack canvas for long-lived documentation. Use standalone canvases for shared docs and kind='channel' for a channel's main canvas.",
+    parameters: Type.Object({
+      title: Type.Optional(Type.String({ description: "Canvas title" })),
+      markdown: Type.Optional(
+        Type.String({
+          description: "Initial canvas content in markdown. Omit for an empty canvas.",
+        }),
+      ),
+      channel: Type.Optional(
+        Type.String({ description: "Channel name or ID to attach the canvas to" }),
+      ),
+      kind: Type.Optional(
+        Type.String({ description: "Canvas kind: 'standalone' (default) or 'channel'" }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy("slack_canvas_create", undefined);
+
+      const channelInput = params.channel?.trim();
+      const channelId = channelInput ? await resolveChannel(channelInput) : undefined;
+      const request = buildSlackCanvasCreateRequest({
+        kind: params.kind,
+        title: params.title,
+        markdown: params.markdown,
+        channelId,
+      });
+
+      if (channelInput && channelId) {
+        rememberChannel(channelInput.replace(/^#/, ""), channelId);
+      }
+
+      const response = await slack(request.method, botToken, request.body);
+      const canvasId = response.canvas_id as string;
+      const channelLabel = channelInput ?? channelId;
+      const targetSummary =
+        request.kind === "channel"
+          ? `Created channel canvas ${canvasId}${channelLabel ? ` for ${channelLabel}` : ""}.`
+          : `Created standalone canvas ${canvasId}${channelLabel ? ` attached to ${channelLabel}` : ""}.`;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${targetSummary} Initial content: ${getSlackCanvasSummary(params.markdown)}`,
+          },
+        ],
+        details: {
+          canvas_id: canvasId,
+          kind: request.kind,
+          channel: channelId,
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_canvas_update",
+    label: "Slack Canvas Update",
+    description:
+      "Append, prepend, or replace content in an existing Slack canvas by canvas ID or channel canvas lookup.",
+    promptSnippet:
+      "Update a Slack canvas. Use mode='append' or 'prepend' for additive updates, or mode='replace' to replace the whole canvas or a matched section.",
+    parameters: Type.Object({
+      canvas_id: Type.Optional(Type.String({ description: "Canvas ID to update" })),
+      channel: Type.Optional(
+        Type.String({ description: "Channel name or ID whose channel canvas should be updated" }),
+      ),
+      markdown: Type.String({ description: "Canvas content in markdown" }),
+      mode: Type.Optional(
+        Type.String({ description: "Update mode: 'append' (default), 'prepend', or 'replace'" }),
+      ),
+      section_contains_text: Type.Optional(
+        Type.String({
+          description: "When mode='replace', replace the first section matching this text",
+        }),
+      ),
+      section_type: Type.Optional(
+        Type.String({
+          description: "Optional section type for lookups: 'h1', 'h2', 'h3', or 'any_header'",
+        }),
+      ),
+      section_index: Type.Optional(
+        Type.Number({
+          description:
+            "Optional 1-based section index to choose when the lookup matches multiple sections",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy("slack_canvas_update", undefined);
+
+      const mode = normalizeSlackCanvasUpdateMode(params.mode);
+      if (params.section_contains_text && mode !== "replace") {
+        throw new Error("section_contains_text can only be used with mode='replace'.");
+      }
+      if (params.section_index != null && !params.section_contains_text) {
+        throw new Error("section_index can only be used together with section_contains_text.");
+      }
+
+      const target = await resolveCanvasTarget(params.canvas_id, params.channel);
+      let sectionId: string | undefined;
+
+      if (params.section_contains_text) {
+        const lookup = buildSlackCanvasSectionsLookupRequest({
+          canvasId: target.canvasId,
+          containsText: params.section_contains_text,
+          sectionType: params.section_type,
+        });
+        const response = await slack(
+          "canvases.sections.lookup",
+          botToken,
+          lookup as unknown as Record<string, unknown>,
+        );
+        const sections = response.sections as Array<{ id?: string }> | undefined;
+        try {
+          sectionId = pickSlackCanvasSectionId(sections, params.section_index);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new Error(
+            `Canvas section lookup for '${params.section_contains_text}' failed: ${message}`,
+          );
+        }
+      }
+
+      const request = buildSlackCanvasEditRequest({
+        canvasId: target.canvasId,
+        markdown: params.markdown,
+        mode,
+        sectionId,
+      });
+      await slack("canvases.edit", botToken, request as unknown as Record<string, unknown>);
+
+      const sectionSummary = params.section_contains_text
+        ? ` Replaced section matching '${params.section_contains_text}'.`
+        : "";
+      const targetSummary = target.channelLabel
+        ? `Updated channel canvas ${target.canvasId} for ${target.channelLabel}.`
+        : `Updated canvas ${target.canvasId}.`;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${targetSummary} Mode: ${mode}.${sectionSummary} Content: ${getSlackCanvasSummary(params.markdown)}`,
+          },
+        ],
+        details: {
+          canvas_id: target.canvasId,
+          channel: target.channelId,
+          mode,
+          section_id: sectionId,
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
- add `slack_canvas_create` for standalone and channel canvases
- add `slack_canvas_update` for append/prepend/replace flows, including section lookup for targeted replaces
- add canvas helper coverage and README docs

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test