### PR TITLE
feat: add Slack file upload tool (#34)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -21,16 +21,21 @@ If the agent is idle, incoming messages are processed immediately.
 
 ## Tools
 
-| Tool                                                              | Description                                |
-| ----------------------------------------------------------------- | ------------------------------------------ |
-| `slack_send(text, thread_ts?)`                                    | Reply in a thread or start new             |
-| `slack_read(thread_ts, limit?)`                                   | Read thread messages                       |
-| `slack_inbox()`                                                   | Check pending messages manually            |
-| `slack_create_channel(name, topic?, purpose?)`                    | Create a project channel                   |
-| `slack_post_channel(channel?, text, thread_ts?)`                  | Post to a channel                          |
-| `slack_read_channel(channel, thread_ts?, limit?)`                 | Read channel history or thread             |
-| `slack_canvas_create(title?, markdown?, channel?, kind?)`         | Create standalone or channel canvases      |
-| `slack_canvas_update(canvas_id?, channel?, markdown, mode?, ...)` | Append, prepend, or replace canvas content |
+| Tool                                                                                | Description                                  |
+| ----------------------------------------------------------------------------------- | -------------------------------------------- |
+| `slack_send(text, thread_ts?)`                                                      | Reply in a thread or start new               |
+| `slack_upload(content?, path?, filename?, filetype?, title?, channel?, thread_ts?)` | Upload a file/snippet into Slack or a thread |
+| `slack_read(thread_ts, limit?)`                                                     | Read thread messages                         |
+| `slack_inbox()`                                                                     | Check pending messages manually              |
+| `slack_create_channel(name, topic?, purpose?)`                                      | Create a project channel                     |
+| `slack_post_channel(channel?, text, thread_ts?)`                                    | Post to a channel                            |
+| `slack_read_channel(channel, thread_ts?, limit?)`                                   | Read channel history or thread               |
+| `slack_canvas_create(title?, markdown?, channel?, kind?)`                           | Create standalone or channel canvases        |
+| `slack_canvas_update(canvas_id?, channel?, markdown, mode?, ...)`                   | Append, prepend, or replace canvas content   |
+
+`slack_upload` supports either inline `content` or a guarded local `path`. For
+safety, local uploads are limited to files inside the current working directory
+or the system temp directory.
 
 ## Features
 
@@ -42,6 +47,7 @@ If the agent is idle, incoming messages are processed immediately.
 - **Multi-user** — handles concurrent conversations from different users
 - **@mentions** — tag Pinet in any channel and it responds in-thread
 - **Channel & canvas tools** — create/read/post in channels and maintain persistent Slack canvases
+- **File & snippet uploads** — share diffs, logs, screenshots, exports, and long code snippets without pasting giant messages
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
 - **Remote agent control** — send `/reload` or `/exit` to another Pinet agent
@@ -114,9 +120,9 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 
 ## Manifest
 
-The `manifest.yaml` includes all required scopes and events. Use it when
-creating the app (**From a manifest**) or paste it into **App Manifest** in
-settings.
+The `manifest.yaml` includes all required scopes and events, including `files:write`
+for `slack_upload`. Use it when creating the app (**From a manifest**) or paste
+it into **App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:
 

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -92,11 +92,13 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("edit", g)).toBe(false);
   });
 
-  it("classifies create/post channel tools as write-only", () => {
+  it("classifies Slack mutation tools as write-only", () => {
     expect(WRITE_TOOLS.has("slack_create_channel")).toBe(true);
     expect(WRITE_TOOLS.has("slack_post_channel")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_upload")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_post_channel")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_upload")).toBe(false);
   });
 
   it("combines readOnly and blockedTools", () => {

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -34,6 +34,7 @@ export const WRITE_TOOLS = new Set([
   "memory_init",
   "slack_create_channel",
   "slack_post_channel",
+  "slack_upload",
   "pinet_schedule",
 ]);
 

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -23,6 +23,7 @@ oauth_config:
       - channels:history
       - channels:read
       - chat:write
+      - files:write
       - groups:history
       - groups:read
       - im:history

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@gugu91/pi-ext-types/typebox";
 import type { InboxMessage } from "./helpers.js";
@@ -10,6 +11,7 @@ import {
   normalizeSlackCanvasUpdateMode,
   pickSlackCanvasSectionId,
 } from "./canvases.js";
+import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
 
 export interface RegisterSlackToolsDeps {
   getBotToken: () => string;
@@ -45,6 +47,8 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "When you receive messages: ACK briefly, do the work, report blockers immediately, report the outcome when done.",
     "Security guardrails may be active for Slack-triggered actions. Check the current security prompt in each message for restrictions.",
     "When a tool requires confirmation, call slack_confirm_action first and wait for approval in the same thread.",
+    "Use slack_upload instead of giant inline code blocks when sharing diffs, logs, screenshots, generated files, or long snippets.",
+    "When uploading from a local path, only files inside the current working directory or the system temp directory are allowed.",
   ];
 }
 
@@ -105,6 +109,39 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       channelId,
       channelLabel: channelInput,
     };
+  }
+
+  async function resolveUploadChannel(
+    threadTs: string | undefined,
+    channel: string | undefined,
+  ): Promise<string> {
+    const trackedThreadChannel = threadTs ? await resolveFollowerReplyChannel(threadTs) : null;
+    if (trackedThreadChannel) {
+      return trackedThreadChannel;
+    }
+
+    const channelInput = channel?.trim();
+    if (channelInput) {
+      return resolveChannel(channelInput);
+    }
+
+    if (!threadTs) {
+      const dmChannel = getLastDmChannel();
+      if (dmChannel) {
+        return dmChannel;
+      }
+
+      const defaultChannel = getDefaultChannel();
+      if (defaultChannel) {
+        return resolveChannel(defaultChannel);
+      }
+    }
+
+    throw new Error(
+      threadTs
+        ? "Unknown Slack thread. If you know the destination channel, pass channel explicitly."
+        : "No active Slack thread. Provide channel or configure defaultChannel in settings.json.",
+    );
   }
 
   pi.registerTool({
@@ -216,6 +253,105 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           },
         ],
         details: { ts, channel },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_upload",
+    label: "Slack Upload",
+    description:
+      "Upload a file or snippet into Slack using the external upload flow. Supports inline content and guarded local file paths.",
+    promptSnippet:
+      "Upload files, snippets, diffs, logs, screenshots, or generated artifacts into Slack threads when inline text would be awkward or too long.",
+    parameters: Type.Object({
+      content: Type.Optional(
+        Type.String({
+          description:
+            "Inline content to upload as a snippet or file. Provide exactly one of content or path.",
+        }),
+      ),
+      path: Type.Optional(
+        Type.String({
+          description:
+            "Local file path to upload. For safety, only files inside the current working directory or system temp directory are allowed.",
+        }),
+      ),
+      filename: Type.Optional(
+        Type.String({
+          description:
+            "Filename shown in Slack. Required for inline content, optional for path uploads.",
+        }),
+      ),
+      filetype: Type.Optional(
+        Type.String({
+          description: "Optional filetype/snippet language override, e.g. diff, typescript, json.",
+        }),
+      ),
+      title: Type.Optional(
+        Type.String({ description: "Optional Slack title for the uploaded file" }),
+      ),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Optional channel name or ID. Omit to use the current thread channel, active DM, or defaultChannel.",
+        }),
+      ),
+      thread_ts: Type.Optional(
+        Type.String({ description: "Optional thread timestamp to attach the upload to" }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_upload",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts ?? ""} | channel=${params.channel ?? getDefaultChannel() ?? ""} | filename=${params.filename ?? ""} | path=${params.path ?? ""} | content_length=${params.content?.length ?? 0}`,
+      );
+
+      const upload = await prepareSlackUpload(params, process.cwd(), os.tmpdir());
+      const channelId = await resolveUploadChannel(params.thread_ts, params.channel);
+      const { fileId, response } = await performSlackUpload({
+        upload,
+        channelId,
+        threadTs: params.thread_ts,
+        slack,
+        token: getBotToken(),
+      });
+
+      if (params.thread_ts) {
+        trackOutboundThread(params.thread_ts, channelId);
+        claimThreadOwnership(params.thread_ts, channelId);
+        clearPendingEyes(params.thread_ts);
+      }
+
+      const uploadedFiles = Array.isArray(response.files)
+        ? (response.files as Record<string, unknown>[])
+        : [];
+      const uploadedFile = uploadedFiles[0];
+      const permalink =
+        uploadedFile && typeof uploadedFile.permalink === "string"
+          ? uploadedFile.permalink
+          : undefined;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: params.thread_ts
+              ? `Uploaded \`${upload.filename}\` to thread ${params.thread_ts}.`
+              : `Uploaded \`${upload.filename}\` to channel ${params.channel ?? channelId}.`,
+          },
+        ],
+        details: {
+          fileId,
+          channel: channelId,
+          filename: upload.filename,
+          title: upload.title,
+          source: upload.source,
+          ...(params.thread_ts ? { thread_ts: params.thread_ts } : {}),
+          ...(permalink ? { permalink } : {}),
+          ...(upload.resolvedPath ? { path: upload.resolvedPath } : {}),
+        },
       };
     },
   });

--- a/slack-bridge/slack-upload.test.ts
+++ b/slack-bridge/slack-upload.test.ts
@@ -1,0 +1,286 @@
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  chooseSlackSnippetType,
+  inferSlackUploadFiletype,
+  performSlackUpload,
+  prepareSlackUpload,
+  resolveSlackUploadPath,
+} from "./slack-upload.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("inferSlackUploadFiletype", () => {
+  it("normalizes common extensions", () => {
+    expect(inferSlackUploadFiletype("report.ts")).toBe("typescript");
+    expect(inferSlackUploadFiletype("config.yml")).toBe("yaml");
+    expect(inferSlackUploadFiletype("script.sh")).toBe("shell");
+  });
+
+  it("prefers an explicit filetype", () => {
+    expect(inferSlackUploadFiletype("report.txt", "diff")).toBe("diff");
+  });
+});
+
+describe("chooseSlackSnippetType", () => {
+  it("uses syntax-aware snippet types for inline content", () => {
+    expect(
+      chooseSlackSnippetType({
+        source: "content",
+        byteLength: 128,
+        filename: "helpers.ts",
+      }),
+    ).toBe("typescript");
+  });
+
+  it("does not enable snippet mode for path uploads or oversized content", () => {
+    expect(
+      chooseSlackSnippetType({
+        source: "path",
+        byteLength: 128,
+        filename: "helpers.ts",
+      }),
+    ).toBeUndefined();
+    expect(
+      chooseSlackSnippetType({
+        source: "content",
+        byteLength: 1_000_001,
+        filename: "helpers.ts",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveSlackUploadPath", () => {
+  it("allows files inside the current working directory", async () => {
+    const root = await makeTempDir("slack-upload-root-");
+    const cwd = path.join(root, "repo");
+    const tmpdir = path.join(root, "tmp");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(tmpdir, { recursive: true });
+    await writeFile(path.join(cwd, "artifact.log"), "hello");
+
+    await expect(resolveSlackUploadPath("artifact.log", cwd, tmpdir)).resolves.toBe(
+      await realpath(path.join(cwd, "artifact.log")),
+    );
+  });
+
+  it("allows files inside the configured temp directory", async () => {
+    const root = await makeTempDir("slack-upload-temp-");
+    const cwd = path.join(root, "repo");
+    const tmpdir = path.join(root, "tmp");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(tmpdir, { recursive: true });
+    await writeFile(path.join(tmpdir, "screenshot.png"), "png-bytes");
+
+    await expect(
+      resolveSlackUploadPath(path.join(tmpdir, "screenshot.png"), cwd, tmpdir),
+    ).resolves.toBe(await realpath(path.join(tmpdir, "screenshot.png")));
+  });
+
+  it("rejects paths outside the working directory and temp directory", async () => {
+    const root = await makeTempDir("slack-upload-outside-");
+    const cwd = path.join(root, "repo");
+    const tmpdir = path.join(root, "tmp");
+    const outside = path.join(root, "outside");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(tmpdir, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await writeFile(path.join(outside, "secret.txt"), "nope");
+
+    await expect(
+      resolveSlackUploadPath(path.join(outside, "secret.txt"), cwd, tmpdir),
+    ).rejects.toThrow("only allows local file paths inside the current working directory");
+  });
+
+  it("rejects symlinks that escape the allowed roots", async () => {
+    const root = await makeTempDir("slack-upload-symlink-");
+    const cwd = path.join(root, "repo");
+    const tmpdir = path.join(root, "tmp");
+    const outside = path.join(root, "outside");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(tmpdir, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await writeFile(path.join(outside, "secret.txt"), "nope");
+    await symlink(path.join(outside, "secret.txt"), path.join(cwd, "secret-link.txt"));
+
+    await expect(resolveSlackUploadPath("secret-link.txt", cwd, tmpdir)).rejects.toThrow(
+      "only allows local file paths inside the current working directory",
+    );
+  });
+});
+
+describe("prepareSlackUpload", () => {
+  it("prepares inline content as a syntax-highlighted snippet", async () => {
+    const root = await makeTempDir("slack-upload-inline-");
+    const cwd = path.join(root, "repo");
+    const tmpdir = path.join(root, "tmp");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(tmpdir, { recursive: true });
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "console.log('hi');\n",
+        filename: "example.ts",
+        title: "TypeScript example",
+      },
+      cwd,
+      tmpdir,
+    );
+
+    expect(upload.source).toBe("content");
+    expect(upload.filename).toBe("example.ts");
+    expect(upload.title).toBe("TypeScript example");
+    expect(upload.filetype).toBe("typescript");
+    expect(upload.snippetType).toBe("typescript");
+    expect(Buffer.from(upload.bytes).toString("utf8")).toContain("console.log");
+  });
+
+  it("prepares a local file upload and derives the filename", async () => {
+    const root = await makeTempDir("slack-upload-file-");
+    const cwd = path.join(root, "repo");
+    const tmpdir = path.join(root, "tmp");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(tmpdir, { recursive: true });
+    await writeFile(path.join(cwd, "diff.patch"), "@@ -1 +1 @@\n");
+
+    const upload = await prepareSlackUpload({ path: "diff.patch" }, cwd, tmpdir);
+
+    expect(upload.source).toBe("path");
+    expect(upload.filename).toBe("diff.patch");
+    expect(upload.title).toBe("diff.patch");
+    expect(upload.filetype).toBe("patch");
+    expect(upload.snippetType).toBeUndefined();
+    expect(upload.resolvedPath).toBe(await realpath(path.join(cwd, "diff.patch")));
+  });
+
+  it("requires exactly one source and a filename for inline content", async () => {
+    const root = await makeTempDir("slack-upload-errors-");
+    const cwd = path.join(root, "repo");
+    const tmpdir = path.join(root, "tmp");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(tmpdir, { recursive: true });
+
+    await expect(prepareSlackUpload({}, cwd, tmpdir)).rejects.toThrow(
+      "Provide exactly one of content or path.",
+    );
+    await expect(
+      prepareSlackUpload({ content: "hello", path: "artifact.txt" }, cwd, tmpdir),
+    ).rejects.toThrow("Provide exactly one of content or path.");
+    await expect(prepareSlackUpload({ content: "hello" }, cwd, tmpdir)).rejects.toThrow(
+      "filename is required when uploading inline content.",
+    );
+  });
+});
+
+describe("performSlackUpload", () => {
+  it("uses Slack's external upload flow", async () => {
+    const slack = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        upload_url: "https://uploads.slack.test/file",
+        file_id: "F123",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        files: [{ id: "F123", permalink: "https://slack.test/F123" }],
+      });
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "",
+    }));
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "diff --git a/file b/file\n",
+        filename: "changes.diff",
+        title: "Latest diff",
+      },
+      "/repo",
+      "/tmp",
+    );
+
+    const result = await performSlackUpload({
+      upload,
+      channelId: "C123",
+      threadTs: "171234.5678",
+      slack,
+      token: "xoxb-token",
+      fetchImpl,
+    });
+
+    expect(slack).toHaveBeenNthCalledWith(1, "files.getUploadURLExternal", "xoxb-token", {
+      filename: "changes.diff",
+      length: upload.byteLength,
+      snippet_type: "diff",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith("https://uploads.slack.test/file", {
+      method: "POST",
+      headers: {
+        "Content-Length": String(upload.byteLength),
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+      body: expect.any(Blob),
+    });
+
+    const rawUploadCalls = fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>;
+    expect(rawUploadCalls[0]).toBeTruthy();
+    const rawUploadInit = rawUploadCalls[0][1];
+    expect(await (rawUploadInit.body as Blob).text()).toBe("diff --git a/file b/file\n");
+    expect(slack).toHaveBeenNthCalledWith(2, "files.completeUploadExternal", "xoxb-token", {
+      files: [{ id: "F123", title: "Latest diff" }],
+      channel_id: "C123",
+      thread_ts: "171234.5678",
+    });
+    expect(result.fileId).toBe("F123");
+  });
+
+  it("surfaces raw upload failures", async () => {
+    const slack = vi.fn().mockResolvedValue({
+      ok: true,
+      upload_url: "https://uploads.slack.test/file",
+      file_id: "F123",
+    });
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "boom",
+    }));
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "hello",
+        filename: "hello.txt",
+      },
+      "/repo",
+      "/tmp",
+    );
+
+    await expect(
+      performSlackUpload({
+        upload,
+        channelId: "C123",
+        slack,
+        token: "xoxb-token",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Slack raw upload failed (500 Internal Server Error): boom");
+  });
+});

--- a/slack-bridge/slack-upload.ts
+++ b/slack-bridge/slack-upload.ts
@@ -1,0 +1,237 @@
+import { readFile, realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import type { SlackResult } from "./slack-api.js";
+
+const FILETYPE_ALIASES: Record<string, string> = {
+  cjs: "javascript",
+  htm: "html",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  md: "markdown",
+  py: "python",
+  rb: "ruby",
+  sh: "shell",
+  ts: "typescript",
+  tsx: "typescript",
+  yml: "yaml",
+  zsh: "shell",
+};
+
+const DEFAULT_SNIPPET_TYPE = "text";
+const MAX_SNIPPET_BYTES = 1_000_000;
+
+export interface SlackUploadParams {
+  content?: string;
+  path?: string;
+  filename?: string;
+  filetype?: string;
+  title?: string;
+}
+
+export interface PreparedSlackUpload {
+  bytes: Buffer;
+  byteLength: number;
+  filename: string;
+  title: string;
+  filetype?: string;
+  snippetType?: string;
+  source: "content" | "path";
+  resolvedPath?: string;
+}
+
+export interface SlackUploadDeps {
+  slack: (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>;
+  token: string;
+  fetchImpl?: (
+    url: string,
+    init: RequestInit,
+  ) => Promise<Pick<Response, "ok" | "status" | "statusText" | "text">>;
+}
+
+export interface PerformSlackUploadOptions extends SlackUploadDeps {
+  upload: PreparedSlackUpload;
+  channelId: string;
+  threadTs?: string;
+}
+
+export interface CompletedSlackUpload {
+  fileId: string;
+  response: SlackResult;
+}
+
+interface PrepareSlackUploadFs {
+  readFileImpl?: typeof readFile;
+  realpathImpl?: typeof realpath;
+  statImpl?: typeof stat;
+}
+
+export function inferSlackUploadFiletype(
+  filename: string | undefined,
+  explicitFiletype?: string,
+): string | undefined {
+  const raw = (explicitFiletype ?? path.extname(filename ?? "").slice(1)).trim().toLowerCase();
+  if (!raw) return undefined;
+  return FILETYPE_ALIASES[raw] ?? raw;
+}
+
+export function chooseSlackSnippetType(upload: {
+  source: "content" | "path";
+  byteLength: number;
+  filename: string;
+  filetype?: string;
+}): string | undefined {
+  if (upload.source !== "content") return undefined;
+  if (upload.byteLength > MAX_SNIPPET_BYTES) return undefined;
+  return inferSlackUploadFiletype(upload.filename, upload.filetype) ?? DEFAULT_SNIPPET_TYPE;
+}
+
+function isWithinRoot(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+export async function resolveSlackUploadPath(
+  inputPath: string,
+  cwd: string,
+  tmpdir: string,
+  fsDeps: PrepareSlackUploadFs = {},
+): Promise<string> {
+  const { realpathImpl = realpath, statImpl = stat } = fsDeps;
+  const requestedPath = inputPath.trim();
+  if (!requestedPath) {
+    throw new Error("path is required when uploading from a local file.");
+  }
+
+  const candidate = path.isAbsolute(requestedPath)
+    ? requestedPath
+    : path.resolve(cwd, requestedPath);
+
+  const [resolvedCandidate, resolvedCwd, resolvedTmpdir] = await Promise.all([
+    realpathImpl(candidate),
+    realpathImpl(cwd),
+    realpathImpl(tmpdir),
+  ]);
+
+  if (
+    !isWithinRoot(resolvedCandidate, resolvedCwd) &&
+    !isWithinRoot(resolvedCandidate, resolvedTmpdir)
+  ) {
+    throw new Error(
+      "For safety, slack_upload only allows local file paths inside the current working directory or the system temp directory. For other files, read the content explicitly and upload it via the content parameter.",
+    );
+  }
+
+  const fileStats = await statImpl(resolvedCandidate);
+  if (!fileStats.isFile()) {
+    throw new Error(`Local upload path is not a file: ${requestedPath}`);
+  }
+
+  return resolvedCandidate;
+}
+
+export async function prepareSlackUpload(
+  params: SlackUploadParams,
+  cwd: string,
+  tmpdir: string,
+  fsDeps: PrepareSlackUploadFs = {},
+): Promise<PreparedSlackUpload> {
+  const { readFileImpl = readFile } = fsDeps;
+  const hasContent = typeof params.content === "string";
+  const hasPath = typeof params.path === "string" && params.path.trim().length > 0;
+
+  if (hasContent === hasPath) {
+    throw new Error("Provide exactly one of content or path.");
+  }
+
+  let bytes: Buffer;
+  let filename = params.filename?.trim();
+  let resolvedPath: string | undefined;
+  let source: PreparedSlackUpload["source"];
+
+  if (hasContent) {
+    if (!filename) {
+      throw new Error("filename is required when uploading inline content.");
+    }
+    bytes = Buffer.from(params.content ?? "", "utf8");
+    source = "content";
+  } else {
+    resolvedPath = await resolveSlackUploadPath(params.path!, cwd, tmpdir, fsDeps);
+    bytes = await readFileImpl(resolvedPath);
+    filename = filename || path.basename(resolvedPath);
+    source = "path";
+  }
+
+  const sanitizedFilename = filename?.trim();
+  if (!sanitizedFilename) {
+    throw new Error("filename is required.");
+  }
+
+  const filetype = inferSlackUploadFiletype(sanitizedFilename, params.filetype);
+  const title = params.title?.trim() || sanitizedFilename;
+
+  return {
+    bytes,
+    byteLength: bytes.byteLength,
+    filename: sanitizedFilename,
+    title,
+    filetype,
+    snippetType: chooseSlackSnippetType({
+      source,
+      byteLength: bytes.byteLength,
+      filename: sanitizedFilename,
+      filetype,
+    }),
+    source,
+    ...(resolvedPath ? { resolvedPath } : {}),
+  };
+}
+
+export async function performSlackUpload({
+  upload,
+  channelId,
+  threadTs,
+  slack,
+  token,
+  fetchImpl = fetch,
+}: PerformSlackUploadOptions): Promise<CompletedSlackUpload> {
+  const getUploadResponse = await slack("files.getUploadURLExternal", token, {
+    filename: upload.filename,
+    length: upload.byteLength,
+    ...(upload.snippetType ? { snippet_type: upload.snippetType } : {}),
+  });
+
+  const uploadUrl =
+    typeof getUploadResponse.upload_url === "string" ? getUploadResponse.upload_url : null;
+  const fileId = typeof getUploadResponse.file_id === "string" ? getUploadResponse.file_id : null;
+  if (!uploadUrl || !fileId) {
+    throw new Error("Slack files.getUploadURLExternal did not return an upload URL and file ID.");
+  }
+
+  const rawBody = new Uint8Array(upload.bytes.byteLength);
+  rawBody.set(upload.bytes);
+
+  const rawUploadResponse = await fetchImpl(uploadUrl, {
+    method: "POST",
+    headers: {
+      "Content-Length": String(upload.byteLength),
+      "Content-Type":
+        upload.source === "content" ? "text/plain; charset=utf-8" : "application/octet-stream",
+    },
+    body: new Blob([rawBody]),
+  });
+
+  if (!rawUploadResponse.ok) {
+    const details = (await rawUploadResponse.text()).trim();
+    throw new Error(
+      `Slack raw upload failed (${rawUploadResponse.status}${rawUploadResponse.statusText ? ` ${rawUploadResponse.statusText}` : ""})${details ? `: ${details}` : ""}`,
+    );
+  }
+
+  const response = await slack("files.completeUploadExternal", token, {
+    files: [{ id: fileId, title: upload.title }],
+    channel_id: channelId,
+    ...(threadTs ? { thread_ts: threadTs } : {}),
+  });
+
+  return { fileId, response };
+}


### PR DESCRIPTION
## Summary
- add a `slack_upload` tool for inline snippets and guarded local file uploads
- use Slack's modern external upload flow (`files.getUploadURLExternal` -> raw upload -> `files.completeUploadExternal`)
- add `files:write` scope and document upload usage + local-path safety limits

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test