### PR TITLE
feat: add Slack manifest deploy command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ dist/
 .nvimlog
 neon-psql/config.json
 __pycache__/
+.firecrawl/
 .env*

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "deploy:slack": "node --experimental-strip-types ./slack-bridge/deploy-manifest.ts",
     "check": "pnpm lint && pnpm typecheck && pnpm format:check",
     "prepush": "pnpm lint && pnpm typecheck && pnpm test",
     "lint-staged": "lint-staged",

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -60,6 +60,9 @@ paste `manifest.yaml` from this directory.
   with `connections:write` scope → copy the `xapp-...` token
 - **Bot Token:** OAuth & Permissions → Install to Workspace → copy the
   `xoxb-...` token
+- **App Config Token:** App settings page → **Your App Configuration Tokens** →
+  Generate Token → copy the `xoxe.xoxp-...` token
+- **App ID:** Basic Information → **App Credentials** → copy the `A...` app ID
 
 ### 3. Configure
 
@@ -70,6 +73,8 @@ Add to `~/.pi/agent/settings.json`:
   "slack-bridge": {
     "botToken": "xoxb-...",
     "appToken": "xapp-...",
+    "appId": "A0123456789",
+    "appConfigToken": "xoxe.xoxp-...",
     "allowedUsers": ["U09GWL270LA"],
     "defaultChannel": "C0APL58LB1R",
     "suggestedPrompts": [
@@ -80,16 +85,22 @@ Add to `~/.pi/agent/settings.json`:
 }
 ```
 
-| Key                | Required | Description                                  |
-| ------------------ | -------- | -------------------------------------------- |
-| `botToken`         | yes      | Bot User OAuth Token (`xoxb-...`)            |
-| `appToken`         | yes      | App-Level Token for Socket Mode (`xapp-...`) |
-| `allowedUsers`     | no       | Slack user IDs allowed to interact           |
-| `defaultChannel`   | no       | Default channel for `slack_post_channel`     |
-| `suggestedPrompts` | no       | Prompts shown on new assistant thread        |
+| Key                | Required | Description                                      |
+| ------------------ | -------- | ------------------------------------------------ |
+| `botToken`         | yes      | Bot User OAuth Token (`xoxb-...`)                |
+| `appToken`         | yes      | App-Level Token for Socket Mode (`xapp-...`)     |
+| `appId`            | deploy   | Slack app ID (`A...`) for manifest deploy/update |
+| `appConfigToken`   | deploy   | App configuration token (`xoxe.xoxp-...`)        |
+| `allowedUsers`     | no       | Slack user IDs allowed to interact               |
+| `defaultChannel`   | no       | Default channel for `slack_post_channel`         |
+| `suggestedPrompts` | no       | Prompts shown on new assistant thread            |
 
-> Tokens can also be set via `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` env vars
-> (settings.json takes priority).
+> Runtime tokens can also be set via `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`
+> env vars (settings.json takes priority).
+>
+> Manifest deploy also reads `SLACK_APP_ID` and `SLACK_APP_CONFIG_TOKEN`
+> (or `SLACK_CONFIG_TOKEN`). The Socket Mode `xapp-...` token cannot be used
+> with `apps.manifest.update`.
 
 ### 4. Install extension
 
@@ -104,6 +115,16 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 The `manifest.yaml` includes all required scopes and events. Use it when
 creating the app (**From a manifest**) or paste it into **App Manifest** in
 settings.
+
+To push the checked-in manifest back to Slack, run:
+
+```bash
+pnpm deploy:slack
+```
+
+The deploy command validates `slack-bridge/manifest.yaml`, updates the target
+Slack app through `apps.manifest.update`, and reports any bot/user scope
+changes.
 
 ## Security
 

--- a/slack-bridge/deploy-manifest.test.ts
+++ b/slack-bridge/deploy-manifest.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  diffManifestScopes,
+  formatScopeChangeSummary,
+  getDeployConfigError,
+  resolveDeployConfig,
+} from "./deploy-manifest.js";
+
+describe("resolveDeployConfig", () => {
+  it("prefers settings over environment values", () => {
+    expect(
+      resolveDeployConfig(
+        {
+          appId: "ASETTINGS",
+          appConfigToken: "xoxe-settings",
+          appToken: "xapp-settings",
+        },
+        {
+          SLACK_APP_ID: "AENV",
+          SLACK_APP_CONFIG_TOKEN: "xoxe-env",
+          SLACK_APP_TOKEN: "xapp-env",
+        },
+        "/repo",
+      ),
+    ).toEqual({
+      manifestPath: "/repo/slack-bridge/manifest.yaml",
+      appId: "ASETTINGS",
+      appConfigToken: "xoxe-settings",
+      appToken: "xapp-settings",
+    });
+  });
+
+  it("falls back to environment values", () => {
+    expect(
+      resolveDeployConfig({}, { SLACK_APP_ID: "AENV", SLACK_CONFIG_TOKEN: "xoxe-env" }, "/repo"),
+    ).toEqual({
+      manifestPath: "/repo/slack-bridge/manifest.yaml",
+      appId: "AENV",
+      appConfigToken: "xoxe-env",
+      appToken: undefined,
+    });
+  });
+});
+
+describe("getDeployConfigError", () => {
+  it("mentions the xapp token when a config token is missing", () => {
+    const error = getDeployConfigError({
+      manifestPath: "manifest.yaml",
+      appId: "A123",
+      appToken: "xapp-123",
+    });
+
+    expect(error).toContain("Missing Slack app configuration token");
+    expect(error).toContain("xapp token");
+  });
+});
+
+describe("diffManifestScopes", () => {
+  it("reports added and removed bot/user scopes", () => {
+    const changes = diffManifestScopes(
+      {
+        oauth_config: {
+          scopes: {
+            bot: ["chat:write", "channels:read"],
+            user: ["search:read"],
+          },
+        },
+      },
+      {
+        oauth_config: {
+          scopes: {
+            bot: ["chat:write", "channels:history", "groups:read"],
+            user: ["users:read"],
+          },
+        },
+      },
+    );
+
+    expect(changes).toEqual({
+      addedBotScopes: ["channels:history", "groups:read"],
+      removedBotScopes: ["channels:read"],
+      addedUserScopes: ["users:read"],
+      removedUserScopes: ["search:read"],
+    });
+  });
+});
+
+describe("formatScopeChangeSummary", () => {
+  it("returns a no-change summary when nothing changed", () => {
+    expect(
+      formatScopeChangeSummary({
+        addedBotScopes: [],
+        removedBotScopes: [],
+        addedUserScopes: [],
+        removedUserScopes: [],
+      }),
+    ).toEqual(["No scope changes."]);
+  });
+
+  it("formats added and removed scope lines", () => {
+    expect(
+      formatScopeChangeSummary({
+        addedBotScopes: ["chat:write"],
+        removedBotScopes: ["channels:read"],
+        addedUserScopes: [],
+        removedUserScopes: ["search:read"],
+      }),
+    ).toEqual([
+      "Bot scopes added: chat:write",
+      "Bot scopes removed: channels:read",
+      "User scopes removed: search:read",
+    ]);
+  });
+});

--- a/slack-bridge/deploy-manifest.ts
+++ b/slack-bridge/deploy-manifest.ts
@@ -1,0 +1,306 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+export interface SlackBridgeSettings {
+  appId?: string;
+  appToken?: string;
+  appConfigToken?: string;
+}
+
+const execFile = promisify(execFileCallback);
+
+export interface ManifestScopeChanges {
+  addedBotScopes: string[];
+  removedBotScopes: string[];
+  addedUserScopes: string[];
+  removedUserScopes: string[];
+}
+
+export interface ResolvedDeployConfig {
+  manifestPath: string;
+  appId?: string;
+  appConfigToken?: string;
+  appToken?: string;
+}
+
+export interface DeployResult {
+  appId: string;
+  scopeChanges: ManifestScopeChanges;
+}
+
+interface SlackErrorDetail {
+  message?: string;
+  pointer?: string;
+}
+
+interface SlackMethodPayload {
+  ok?: boolean;
+  error?: string;
+  errors?: SlackErrorDetail[];
+  app_id?: string;
+  manifest?: Record<string, unknown>;
+}
+
+class SlackMethodError extends Error {
+  readonly method: string;
+  readonly slackError: string;
+  readonly details: SlackErrorDetail[];
+
+  constructor(method: string, slackError: string, details: SlackErrorDetail[] = []) {
+    const detailMessage = details
+      .map((detail) => {
+        const pointer = detail.pointer ? `${detail.pointer}: ` : "";
+        return `- ${pointer}${detail.message ?? "unknown error"}`;
+      })
+      .join("\n");
+    super(
+      detailMessage
+        ? `Slack ${method}: ${slackError}\n${detailMessage}`
+        : `Slack ${method}: ${slackError}`,
+    );
+    this.name = "SlackMethodError";
+    this.method = method;
+    this.slackError = slackError;
+    this.details = details;
+  }
+}
+
+function loadSettings(settingsPath?: string): SlackBridgeSettings {
+  const resolvedPath =
+    settingsPath ??
+    path.join(process.env.HOME ?? process.env.USERPROFILE ?? "", ".pi", "agent", "settings.json");
+  try {
+    const content = fs.readFileSync(resolvedPath, "utf-8");
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return ((parsed["slack-bridge"] as Record<string, unknown> | undefined) ??
+      {}) as SlackBridgeSettings;
+  } catch {
+    return {};
+  }
+}
+
+function buildSlackRequest(
+  method: string,
+  token: string,
+  body?: Record<string, unknown>,
+): { url: string; init: RequestInit } {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+
+  let serialized: string | undefined;
+  if (body) {
+    headers["Content-Type"] = "application/json; charset=utf-8";
+    serialized = JSON.stringify(body);
+  }
+
+  return {
+    url: `https://slack.com/api/${method}`,
+    init: {
+      method: "POST",
+      headers,
+      ...(serialized ? { body: serialized } : {}),
+    },
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function readScopeList(
+  manifest: Record<string, unknown> | null | undefined,
+  scopeType: "bot" | "user",
+): string[] {
+  const oauthConfig = asRecord(manifest?.oauth_config);
+  const scopes = asRecord(oauthConfig?.scopes);
+  const raw = scopes?.[scopeType];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return [
+    ...new Set(raw.filter((item): item is string => typeof item === "string" && item.length > 0)),
+  ].sort();
+}
+
+export function diffManifestScopes(
+  beforeManifest: Record<string, unknown> | null | undefined,
+  afterManifest: Record<string, unknown> | null | undefined,
+): ManifestScopeChanges {
+  const beforeBot = new Set(readScopeList(beforeManifest, "bot"));
+  const afterBot = new Set(readScopeList(afterManifest, "bot"));
+  const beforeUser = new Set(readScopeList(beforeManifest, "user"));
+  const afterUser = new Set(readScopeList(afterManifest, "user"));
+
+  const diff = (next: Set<string>, prev: Set<string>): string[] =>
+    [...next].filter((scope) => !prev.has(scope)).sort();
+
+  return {
+    addedBotScopes: diff(afterBot, beforeBot),
+    removedBotScopes: diff(beforeBot, afterBot),
+    addedUserScopes: diff(afterUser, beforeUser),
+    removedUserScopes: diff(beforeUser, afterUser),
+  };
+}
+
+export function formatScopeChangeSummary(changes: ManifestScopeChanges): string[] {
+  const lines: string[] = [];
+
+  if (changes.addedBotScopes.length > 0) {
+    lines.push(`Bot scopes added: ${changes.addedBotScopes.join(", ")}`);
+  }
+  if (changes.removedBotScopes.length > 0) {
+    lines.push(`Bot scopes removed: ${changes.removedBotScopes.join(", ")}`);
+  }
+  if (changes.addedUserScopes.length > 0) {
+    lines.push(`User scopes added: ${changes.addedUserScopes.join(", ")}`);
+  }
+  if (changes.removedUserScopes.length > 0) {
+    lines.push(`User scopes removed: ${changes.removedUserScopes.join(", ")}`);
+  }
+
+  return lines.length > 0 ? lines : ["No scope changes."];
+}
+
+export function resolveDeployConfig(
+  settings: SlackBridgeSettings,
+  env: NodeJS.ProcessEnv,
+  cwd = process.cwd(),
+): ResolvedDeployConfig {
+  return {
+    manifestPath: path.join(cwd, "slack-bridge", "manifest.yaml"),
+    appId: settings.appId ?? env.SLACK_APP_ID,
+    appConfigToken: settings.appConfigToken ?? env.SLACK_APP_CONFIG_TOKEN ?? env.SLACK_CONFIG_TOKEN,
+    appToken: settings.appToken ?? env.SLACK_APP_TOKEN,
+  };
+}
+
+export function getDeployConfigError(config: ResolvedDeployConfig): string | null {
+  if (!fs.existsSync(config.manifestPath)) {
+    return `Slack manifest not found at ${config.manifestPath}`;
+  }
+
+  const messages: string[] = [];
+  if (!config.appId) {
+    messages.push(
+      "Missing Slack app ID. Set slack-bridge.appId in ~/.pi/agent/settings.json or SLACK_APP_ID.",
+    );
+  }
+  if (!config.appConfigToken) {
+    const appTokenNote = config.appToken
+      ? " Note: slack-bridge.appToken / SLACK_APP_TOKEN is a Socket Mode xapp token and cannot be used with apps.manifest.update."
+      : "";
+    messages.push(
+      "Missing Slack app configuration token. Set slack-bridge.appConfigToken in ~/.pi/agent/settings.json or SLACK_APP_CONFIG_TOKEN (or SLACK_CONFIG_TOKEN)." +
+        appTokenNote,
+    );
+  }
+
+  return messages.length > 0 ? messages.join(" ") : null;
+}
+
+async function parseManifestYaml(manifestPath: string): Promise<Record<string, unknown>> {
+  try {
+    const program = [
+      "require 'yaml'",
+      "require 'json'",
+      "data = YAML.load_file(ARGV[0])",
+      "puts JSON.generate(data)",
+    ].join("; ");
+    const { stdout } = await execFile("ruby", ["-e", program, manifestPath]);
+    return JSON.parse(stdout) as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse ${manifestPath} via Ruby YAML parser. Ensure Ruby is installed and the manifest is valid YAML. ${String(error)}`,
+    );
+  }
+}
+
+async function callSlackMethod(
+  method: string,
+  token: string,
+  body?: Record<string, unknown>,
+): Promise<SlackMethodPayload> {
+  const { url, init } = buildSlackRequest(method, token, body);
+  const response = await fetch(url, init);
+  const payload = (await response.json()) as SlackMethodPayload;
+
+  if (!response.ok || payload.ok !== true) {
+    throw new SlackMethodError(
+      method,
+      payload.error ?? `http_${response.status}`,
+      payload.errors ?? [],
+    );
+  }
+
+  return payload;
+}
+
+async function exportRemoteManifest(
+  appId: string,
+  token: string,
+): Promise<Record<string, unknown> | undefined> {
+  const payload = await callSlackMethod("apps.manifest.export", token, { app_id: appId });
+  return payload.manifest;
+}
+
+async function validateManifest(manifest: Record<string, unknown>, token: string): Promise<void> {
+  await callSlackMethod("apps.manifest.validate", token, {
+    manifest: JSON.stringify(manifest),
+  });
+}
+
+async function updateManifest(
+  appId: string,
+  manifest: Record<string, unknown>,
+  token: string,
+): Promise<void> {
+  await callSlackMethod("apps.manifest.update", token, {
+    app_id: appId,
+    manifest: JSON.stringify(manifest),
+  });
+}
+
+export async function deploySlackManifest(config: ResolvedDeployConfig): Promise<DeployResult> {
+  const configError = getDeployConfigError(config);
+  if (configError) {
+    throw new Error(configError);
+  }
+
+  const appId = config.appId as string;
+  const appConfigToken = config.appConfigToken as string;
+  const manifest = await parseManifestYaml(config.manifestPath);
+  const previousManifest = await exportRemoteManifest(appId, appConfigToken);
+
+  await validateManifest(manifest, appConfigToken);
+  await updateManifest(appId, manifest, appConfigToken);
+
+  const updatedManifest = await exportRemoteManifest(appId, appConfigToken);
+  return {
+    appId,
+    scopeChanges: diffManifestScopes(previousManifest, updatedManifest),
+  };
+}
+
+export async function run(): Promise<void> {
+  const settingsPath = process.env.PI_SETTINGS_PATH;
+  const settings = loadSettings(settingsPath);
+  const config = resolveDeployConfig(settings, process.env);
+  const result = await deploySlackManifest(config);
+
+  console.log(`Updated Slack app ${result.appId} from ${config.manifestPath}`);
+  for (const line of formatScopeChangeSummary(result.scopeChanges)) {
+    console.log(line);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -8,6 +8,8 @@ import { matchesToolPattern } from "./guardrails.js";
 export interface SlackBridgeSettings {
   botToken?: string;
   appToken?: string;
+  appId?: string;
+  appConfigToken?: string;
   allowedUsers?: string[];
   defaultChannel?: string;
   suggestedPrompts?: { title: string; message: string }[];


### PR DESCRIPTION
## Summary
- add `pnpm deploy:slack` at the repo root to push `slack-bridge/manifest.yaml` to Slack
- use the Slack App Manifest APIs directly (`apps.manifest.export`, `apps.manifest.validate`, `apps.manifest.update`) and report bot/user scope diffs
- document the required Slack app ID + app config token settings/env vars

## Research notes
- Slack CLI docs expose `slack manifest info` and `slack manifest validate`, but not a `slack manifest update` command.
- `slack deploy` exists for Slack CLI projects, but this repo is not a Slack CLI project and the docs do not provide a simple manifest-file update flow for this case.
- `apps.manifest.update` is the reliable route here, and it requires an **app configuration token** (`xoxe.xoxp-...`), not the Socket Mode `xapp-...` token.

## Verification
- `cd slack-bridge && pnpm test -- --run deploy-manifest.test.ts`
- `cd slack-bridge && pnpm typecheck`
- `cd slack-bridge && pnpm lint`
- `pnpm deploy:slack` (expected missing-config error path)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
