### PR TITLE
fix: use broker-specific generated names (#202)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -39,6 +39,7 @@ import {
   buildWorkerPromptGuidelines,
   buildIdentityReplyGuidelines,
   resolvePersistedAgentIdentity,
+  resolveRuntimeAgentIdentity,
   buildAgentStableId,
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
@@ -48,7 +49,9 @@ import {
   stripBotMention,
   isChannelId,
   FORM_METHODS,
+  generateAgentName,
   resolveAgentIdentity,
+  alignAgentIdentityToRole,
   trackBrokerInboundThread,
   syncFollowerInboxEntries,
   resolveFollowerThreadChannel,
@@ -1721,12 +1724,25 @@ describe("resolveAgentIdentity", () => {
     expect(first.emoji).toBe(second.emoji);
   });
 
-  it("generates a name when nothing else is available", () => {
+  it("generates a worker name when nothing else is available", () => {
     const result = resolveAgentIdentity({});
     expect(typeof result.name).toBe("string");
     expect(result.name.length).toBeGreaterThan(0);
     expect(result.name).toMatch(/^\w+ \w+ \w+$/); // "Adjective Color Animal"
     expect(typeof result.emoji).toBe("string");
+  });
+
+  it("generates a broker name when requested", () => {
+    const result = resolveAgentIdentity({}, undefined, "/tmp/pi/session-a.json", "broker");
+    expect(result.name).toMatch(/^The Broker \w+$/);
+    expect(typeof result.emoji).toBe("string");
+  });
+
+  it("keeps the same animal and emoji across worker and broker generated names", () => {
+    const worker = generateAgentName("/tmp/pi/session-a.json");
+    const broker = generateAgentName("/tmp/pi/session-a.json", "broker");
+    expect(broker.name).toBe(`The Broker ${worker.name.split(" ").at(-1)}`);
+    expect(broker.emoji).toBe(worker.emoji);
   });
 
   it("ignores settings when only agentName is set (no emoji)", () => {
@@ -1743,6 +1759,53 @@ describe("resolveAgentIdentity", () => {
     const result = resolveAgentIdentity({ agentEmoji: "🤖" }, undefined, "/tmp/pi/session-a.json");
     // Should fall through to generated name since agentName is missing
     expect(result.emoji).not.toBe("🤖");
+  });
+});
+
+describe("alignAgentIdentityToRole", () => {
+  it("switches generated identities to the broker format", () => {
+    const seed = "/tmp/pi/session-a.json";
+    const workerIdentity = resolveAgentIdentity({}, undefined, seed, "worker");
+
+    expect(alignAgentIdentityToRole(workerIdentity, {}, undefined, seed, "broker")).toEqual(
+      resolveAgentIdentity({}, undefined, seed, "broker"),
+    );
+  });
+
+  it("preserves custom renamed identities when the role changes", () => {
+    const currentIdentity = { name: "Custom Bot", emoji: "🤖" };
+
+    expect(
+      alignAgentIdentityToRole(currentIdentity, {}, undefined, "/tmp/pi/session-a.json", "broker"),
+    ).toEqual(currentIdentity);
+  });
+});
+
+describe("resolveRuntimeAgentIdentity", () => {
+  it("preserves custom runtime names when no explicit config overrides exist", () => {
+    const currentIdentity = { name: "Custom Bot", emoji: "🤖" };
+
+    expect(
+      resolveRuntimeAgentIdentity(
+        currentIdentity,
+        {},
+        undefined,
+        "/tmp/pi/session-a.json",
+        "broker",
+      ),
+    ).toEqual(currentIdentity);
+  });
+
+  it("still honors explicit configured identities", () => {
+    expect(
+      resolveRuntimeAgentIdentity(
+        { name: "Custom Bot", emoji: "🤖" },
+        { agentName: "Config Bot", agentEmoji: "🛠️" },
+        undefined,
+        "/tmp/pi/session-a.json",
+        "broker",
+      ),
+    ).toEqual({ name: "Config Bot", emoji: "🛠️" });
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1139,12 +1139,14 @@ export function resolvePersistedAgentIdentity(
   persistedName?: string,
   persistedEmoji?: string,
   envNickname?: string,
+  seed?: string,
+  role: AgentIdentityRole = "worker",
 ): { name: string; emoji: string } {
   if (persistedName && persistedEmoji) {
     return { name: persistedName, emoji: persistedEmoji };
   }
 
-  return resolveAgentIdentity(settings, envNickname);
+  return resolveAgentIdentity(settings, envNickname, seed, role);
 }
 
 export function buildAgentStableId(
@@ -1653,20 +1655,34 @@ function hashString(value: string): number {
   return hash >>> 0;
 }
 
-export function generateAgentName(seed?: string): { name: string; emoji: string } {
+export type AgentIdentityRole = "broker" | "worker";
+
+export function generateAgentName(
+  seed?: string,
+  role: AgentIdentityRole = "worker",
+): { name: string; emoji: string } {
+  const animalIndex = seed
+    ? hashString(`${seed}:animal`) % ANIMALS.length
+    : Math.floor(Math.random() * ANIMALS.length);
+  const emoji = EMOJIS[animalIndex];
+
+  if (role === "broker") {
+    return {
+      name: `The Broker ${ANIMALS[animalIndex]}`,
+      emoji,
+    };
+  }
+
   const adjectiveIndex = seed
     ? hashString(`${seed}:adjective`) % ADJECTIVES.length
     : Math.floor(Math.random() * ADJECTIVES.length);
   const colorIndex = seed
     ? hashString(`${seed}:color`) % COLORS.length
     : Math.floor(Math.random() * COLORS.length);
-  const animalIndex = seed
-    ? hashString(`${seed}:animal`) % ANIMALS.length
-    : Math.floor(Math.random() * ANIMALS.length);
 
   return {
     name: `${ADJECTIVES[adjectiveIndex]} ${COLORS[colorIndex]} ${ANIMALS[animalIndex]}`,
-    emoji: EMOJIS[animalIndex],
+    emoji,
   };
 }
 
@@ -1676,6 +1692,7 @@ export function resolveAgentIdentity(
   settings: SlackBridgeSettings,
   envNickname?: string,
   seed?: string,
+  role: AgentIdentityRole = "worker",
 ): { name: string; emoji: string } {
   // 1. Explicit config (both must be present)
   if (settings.agentName && settings.agentEmoji) {
@@ -1684,12 +1701,53 @@ export function resolveAgentIdentity(
 
   // 2. PI_NICKNAME env var (name fixed, emoji deterministic when seeded)
   if (envNickname) {
-    const generated = generateAgentName(seed);
+    const generated = generateAgentName(seed, role);
     return { name: envNickname, emoji: generated.emoji };
   }
 
   // 3. Fully generated
-  return generateAgentName(seed);
+  return generateAgentName(seed, role);
+}
+
+export function alignAgentIdentityToRole(
+  currentIdentity: { name: string; emoji: string },
+  settings: SlackBridgeSettings,
+  envNickname?: string,
+  seed?: string,
+  role: AgentIdentityRole = "worker",
+): { name: string; emoji: string } {
+  const workerIdentity = resolveAgentIdentity(settings, envNickname, seed, "worker");
+  const brokerIdentity = resolveAgentIdentity(settings, envNickname, seed, "broker");
+  const targetIdentity = role === "broker" ? brokerIdentity : workerIdentity;
+
+  if (
+    (currentIdentity.name === workerIdentity.name &&
+      currentIdentity.emoji === workerIdentity.emoji) ||
+    (currentIdentity.name === brokerIdentity.name && currentIdentity.emoji === brokerIdentity.emoji)
+  ) {
+    return targetIdentity;
+  }
+
+  return currentIdentity;
+}
+
+export function resolveRuntimeAgentIdentity(
+  currentIdentity: { name: string; emoji: string },
+  settings: SlackBridgeSettings,
+  envNickname?: string,
+  seed?: string,
+  role: AgentIdentityRole = "worker",
+): { name: string; emoji: string } {
+  if (settings.agentName && settings.agentEmoji) {
+    return { name: settings.agentName, emoji: settings.agentEmoji };
+  }
+
+  if (envNickname) {
+    const generated = generateAgentName(seed, role);
+    return { name: envNickname, emoji: generated.emoji };
+  }
+
+  return alignAgentIdentityToRole(currentIdentity, settings, undefined, seed, role);
 }
 
 // ─── Confirmation state cleanup ─────────────────────────

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -45,6 +45,8 @@ import {
   partitionFollowerInboxEntries,
   generateAgentName,
   resolveAgentIdentity,
+  resolvePersistedAgentIdentity,
+  resolveRuntimeAgentIdentity,
   shortenPath,
   buildIdentityReplyGuidelines,
   buildBrokerPromptGuidelines,
@@ -181,7 +183,13 @@ export default function (pi: ExtensionAPI) {
     guardrails = settings.security ?? {};
     securityPrompt = buildSecurityPrompt(guardrails);
     const identitySeed = extCtx?.sessionManager.getSessionFile() ?? agentStableId;
-    const refreshedIdentity = resolveAgentIdentity(settings, process.env.PI_NICKNAME, identitySeed);
+    const refreshedIdentity = resolveRuntimeAgentIdentity(
+      { name: agentName, emoji: agentEmoji },
+      settings,
+      process.env.PI_NICKNAME,
+      identitySeed,
+      brokerRole === "broker" ? "broker" : "worker",
+    );
     agentName = refreshedIdentity.name;
     agentEmoji = refreshedIdentity.emoji;
   }
@@ -1898,17 +1906,24 @@ export default function (pi: ExtensionAPI) {
     let selfId: string | null = null;
 
     try {
+      const brokerIdentity = resolveRuntimeAgentIdentity(
+        { name: agentName, emoji: agentEmoji },
+        settings,
+        process.env.PI_NICKNAME,
+        ctx.sessionManager.getSessionFile() ?? agentStableId,
+        "broker",
+      );
+
       const router = new MessageRouter(broker.db);
       const selfAgent = broker.db.registerAgent(
         ctx.sessionManager.getLeafId() ?? `broker-${process.pid}`,
-        agentName,
-        agentEmoji,
+        brokerIdentity.name,
+        brokerIdentity.emoji,
         process.pid,
         await getAgentMetadata("broker"),
         agentStableId,
       );
       selfId = selfAgent.id;
-      applyBrokerIdentity(selfAgent.name, selfAgent.emoji);
 
       resetBrokerDeliveryState(brokerDeliveryState);
       const recoveredBrokerMessages = broker.db.getPendingInboxCount(selfId);
@@ -1993,6 +2008,7 @@ export default function (pi: ExtensionAPI) {
       startBrokerScheduledWakeups(ctx);
       brokerRole = "broker";
       pinetEnabled = true;
+      applyBrokerIdentity(selfAgent.name, selfAgent.emoji);
       setExtStatus(ctx, "ok");
       ctx.ui.notify(`${agentEmoji} ${agentName} — broker started (${botUserId})`, "info");
     } catch (err) {
@@ -2048,13 +2064,21 @@ export default function (pi: ExtensionAPI) {
 
     try {
       await client.connect();
+      const workerIdentity = resolveRuntimeAgentIdentity(
+        { name: agentName, emoji: agentEmoji },
+        settings,
+        process.env.PI_NICKNAME,
+        ctx.sessionManager.getSessionFile() ?? agentStableId,
+        "worker",
+      );
+
       const registration = await client.register(
-        agentName,
-        agentEmoji,
+        workerIdentity.name,
+        workerIdentity.emoji,
         await getAgentMetadata("worker"),
         agentStableId,
       );
-      applyBrokerIdentity(registration.name, registration.emoji);
+      const followerIdentity = { name: registration.name, emoji: registration.emoji };
 
       const brokerClientRef: BrokerClientRef = {
         client,
@@ -2065,8 +2089,8 @@ export default function (pi: ExtensionAPI) {
       let wasDisconnected = false;
       let followerPollRunning = false;
 
-      async function resumeThreadClaims(): Promise<void> {
-        for (const thread of getFollowerOwnedThreadClaims(threads, agentName)) {
+      async function resumeThreadClaims(ownerName = agentName): Promise<void> {
+        for (const thread of getFollowerOwnedThreadClaims(threads, ownerName)) {
           try {
             await client.claimThread(thread.threadTs, thread.channelId);
           } catch {
@@ -2225,11 +2249,12 @@ export default function (pi: ExtensionAPI) {
         })();
       });
 
-      await resumeThreadClaims();
-      startPolling();
+      await resumeThreadClaims(followerIdentity.name);
       brokerClient = brokerClientRef;
       brokerRole = "follower";
       pinetEnabled = true;
+      applyBrokerIdentity(followerIdentity.name, followerIdentity.emoji);
+      startPolling();
       setExtStatus(ctx, "ok");
     } catch (err) {
       await client.unregister().catch(() => {
@@ -2410,7 +2435,7 @@ export default function (pi: ExtensionAPI) {
     handler: async (args, ctx) => {
       const newName = args.trim();
       if (!newName) {
-        const fresh = generateAgentName();
+        const fresh = generateAgentName(undefined, brokerRole === "broker" ? "broker" : "worker");
         agentName = fresh.name;
         agentEmoji = fresh.emoji;
       } else {
@@ -2461,8 +2486,10 @@ export default function (pi: ExtensionAPI) {
         ctx.sessionManager.getLeafId(),
       );
       const identitySeed = ctx.sessionManager.getSessionFile() ?? agentStableId;
-      const restoredIdentity = resolveAgentIdentity(
+      const restoredIdentity = resolvePersistedAgentIdentity(
         settings,
+        savedState?.agentName,
+        savedState?.agentEmoji,
         process.env.PI_NICKNAME,
         identitySeed,
       );


### PR DESCRIPTION
## Summary
- generate broker identities as `The Broker {Animal}` while keeping worker identities as `{Adjective} {Color} {Animal}`
- switch broker registration and broker-side random renames to the broker format without clobbering custom names
- add helper coverage for broker/worker naming and role-alignment behavior

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test