### PR TITLE
feat: add agent-name personalities

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -38,6 +38,8 @@ import {
   buildBrokerPromptGuidelines,
   buildWorkerPromptGuidelines,
   buildIdentityReplyGuidelines,
+  buildAgentPersonalityGuidelines,
+  resolveAgentPersonality,
   resolvePersistedAgentIdentity,
   buildAgentStableId,
   resolveAgentStableId,
@@ -781,6 +783,38 @@ describe("buildIdentityReplyGuidelines", () => {
       "Follow-up messages in the same thread: keep the same full identity prefix — '🦅 `Sonic Eagle` <message>'",
     );
     expect(bareRule).toContain("emoji-only");
+  });
+});
+
+// ─── buildAgentPersonalityGuidelines / resolveAgentPersonality ─────────────
+
+describe("resolveAgentPersonality", () => {
+  it("blends adjective and animal traits for Rocket Dolphin", () => {
+    expect(resolveAgentPersonality("Rocket Dolphin").traits).toEqual(
+      expect.arrayContaining(["fast", "playful", "intelligent"]),
+    );
+  });
+
+  it("handles quiet, patient, precise personalities like Silent Crocodile", () => {
+    expect(resolveAgentPersonality("Silent Crocodile").traits).toEqual(
+      expect.arrayContaining(["quiet", "patient", "precise"]),
+    );
+  });
+
+  it("uses first and last words so generated color names still resolve", () => {
+    expect(resolveAgentPersonality("Cosmic Azure Crane").traits).toEqual(
+      expect.arrayContaining(["far-seeing", "thoughtful", "elegant"]),
+    );
+  });
+});
+
+describe("buildAgentPersonalityGuidelines", () => {
+  it("turns the resolved traits into communication-only prompt guidance", () => {
+    const joined = buildAgentPersonalityGuidelines("Silent Crocodile").join(" ");
+    expect(joined).toContain("quiet");
+    expect(joined).toContain("patient");
+    expect(joined).toContain("precise");
+    expect(joined).toContain("must NOT change task execution quality");
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1136,6 +1136,174 @@ export function buildIdentityReplyGuidelines(
   ];
 }
 
+export interface AgentPersonalityProfile {
+  descriptor?: string;
+  animal?: string;
+  traits: string[];
+}
+
+const DEFAULT_PERSONALITY_TRAITS = ["thoughtful", "steady", "clear"];
+const DESCRIPTOR_PERSONALITY_TRAITS: Record<string, string[]> = {};
+const ANIMAL_PERSONALITY_TRAITS: Record<string, string[]> = {};
+
+function assignPersonalityTraits(
+  target: Record<string, string[]>,
+  names: string[],
+  traits: string[],
+): void {
+  for (const name of names) {
+    target[name] = traits;
+  }
+}
+
+assignPersonalityTraits(
+  DESCRIPTOR_PERSONALITY_TRAITS,
+  ["Rocket", "Turbo", "Hyper", "Ultra", "Mega", "Sonic", "Rapid"],
+  ["fast", "playful", "bold"],
+);
+assignPersonalityTraits(
+  DESCRIPTOR_PERSONALITY_TRAITS,
+  ["Silent", "Shadow", "Velvet", "Frozen", "Glacial"],
+  ["quiet", "patient", "precise"],
+);
+assignPersonalityTraits(
+  DESCRIPTOR_PERSONALITY_TRAITS,
+  ["Cosmic", "Solar", "Stellar", "Galactic", "Lunar", "Nova", "Aurora", "Nimbus", "Orbit", "Comet"],
+  ["far-seeing", "thoughtful", "imaginative"],
+);
+assignPersonalityTraits(
+  DESCRIPTOR_PERSONALITY_TRAITS,
+  ["Quantum", "Pixel", "Cyber", "Atomic", "Binary", "Vector", "Prism", "Ionic", "Laser"],
+  ["analytical", "curious", "precise"],
+);
+assignPersonalityTraits(
+  DESCRIPTOR_PERSONALITY_TRAITS,
+  ["Neon", "Electric", "Radiant", "Blazing", "Thunder", "Ember", "Echo"],
+  ["energetic", "expressive", "confident"],
+);
+assignPersonalityTraits(
+  DESCRIPTOR_PERSONALITY_TRAITS,
+  ["Crystal", "Mystic", "Jade"],
+  ["elegant", "intuitive", "thoughtful"],
+);
+assignPersonalityTraits(
+  DESCRIPTOR_PERSONALITY_TRAITS,
+  ["Golden", "Silver", "Scarlet", "Cobalt", "Iron", "Obsidian", "Slate"],
+  ["steady", "composed", "direct"],
+);
+
+assignPersonalityTraits(
+  ANIMAL_PERSONALITY_TRAITS,
+  ["Dolphin"],
+  ["intelligent", "agile", "friendly"],
+);
+assignPersonalityTraits(
+  ANIMAL_PERSONALITY_TRAITS,
+  ["Crocodile"],
+  ["patient", "precise", "formidable"],
+);
+assignPersonalityTraits(ANIMAL_PERSONALITY_TRAITS, ["Crane"], ["elegant", "observant", "poised"]);
+assignPersonalityTraits(
+  ANIMAL_PERSONALITY_TRAITS,
+  ["Eagle", "Owl", "Raven", "Parrot", "Goose"],
+  ["observant", "articulate", "far-seeing"],
+);
+assignPersonalityTraits(
+  ANIMAL_PERSONALITY_TRAITS,
+  ["Fox", "Wolf", "Lynx", "Jaguar", "Tiger", "Lion", "Cobra", "Shark", "Dragon"],
+  ["sharp", "decisive", "confident"],
+);
+assignPersonalityTraits(
+  ANIMAL_PERSONALITY_TRAITS,
+  [
+    "Badger",
+    "Beaver",
+    "Bison",
+    "Buffalo",
+    "Boar",
+    "Bear",
+    "Rhino",
+    "Elephant",
+    "Moose",
+    "Horse",
+    "Camel",
+    "Goat",
+  ],
+  ["steady", "resilient", "grounded"],
+);
+assignPersonalityTraits(
+  ANIMAL_PERSONALITY_TRAITS,
+  [
+    "Otter",
+    "Rabbit",
+    "Koala",
+    "Panda",
+    "Monkey",
+    "Sloth",
+    "Turtle",
+    "Whale",
+    "Kangaroo",
+    "Llama",
+    "Deer",
+    "Giraffe",
+    "Hippo",
+    "Zebra",
+  ],
+  ["warm", "calm", "approachable"],
+);
+assignPersonalityTraits(
+  ANIMAL_PERSONALITY_TRAITS,
+  ["Raccoon", "Hedgehog", "Gecko", "Mantis"],
+  ["meticulous", "curious", "nimble"],
+);
+
+function mergePersonalityTraits(descriptorTraits: string[], animalTraits: string[]): string[] {
+  const merged: string[] = [];
+  const push = (trait?: string) => {
+    if (!trait || merged.includes(trait)) return;
+    merged.push(trait);
+  };
+
+  const limit = Math.max(descriptorTraits.length, animalTraits.length);
+  for (let index = 0; index < limit; index++) {
+    push(descriptorTraits[index]);
+    push(animalTraits[index]);
+  }
+
+  if (merged.length === 0) {
+    for (const trait of DEFAULT_PERSONALITY_TRAITS) {
+      push(trait);
+    }
+  }
+
+  return merged.slice(0, 4);
+}
+
+export function resolveAgentPersonality(agentName: string): AgentPersonalityProfile {
+  const tokens = agentName.trim().split(/\s+/).filter(Boolean);
+  const descriptor = tokens[0];
+  const animal = tokens.length >= 2 ? tokens.at(-1) : undefined;
+
+  return {
+    descriptor,
+    animal,
+    traits: mergePersonalityTraits(
+      descriptor ? (DESCRIPTOR_PERSONALITY_TRAITS[descriptor] ?? []) : [],
+      animal ? (ANIMAL_PERSONALITY_TRAITS[animal] ?? []) : [],
+    ),
+  };
+}
+
+export function buildAgentPersonalityGuidelines(agentName: string): string[] {
+  const personality = resolveAgentPersonality(agentName);
+  return [
+    "COMMUNICATION STYLE: Let your wording lightly reflect your agent name so your updates feel like the persona behind the name.",
+    `For \`${agentName}\`, aim for a ${personality.traits.join(", ")} tone in Slack and Pinet messages.`,
+    "Keep the style subtle: shape cadence, word choice, and flavor — not the underlying facts or recommendations.",
+    "PERSONALITY SAFETY RAIL: This must NOT change task execution quality, correctness, honesty, safety, technical rigor, or willingness to surface blockers and test results.",
+  ];
+}
+
 export function resolvePersistedAgentIdentity(
   settings: SlackBridgeSettings,
   persistedName?: string,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -47,6 +47,7 @@ import {
   resolveAgentIdentity,
   shortenPath,
   buildIdentityReplyGuidelines,
+  buildAgentPersonalityGuidelines,
   buildBrokerPromptGuidelines,
   buildWorkerPromptGuidelines,
   resolveAgentStableId,
@@ -2638,7 +2639,7 @@ export default function (pi: ExtensionAPI) {
 
   // Inject dynamic identity guidance every turn so reload/session restore keeps prompts in sync.
   pi.on("before_agent_start", async (event) => {
-    const guidelines = [...getIdentityGuidelines()];
+    const guidelines = [...getIdentityGuidelines(), ...buildAgentPersonalityGuidelines(agentName)];
     if (brokerRole === "broker") {
       guidelines.push(...buildBrokerPromptGuidelines(agentEmoji, agentName));
       guidelines.push(buildBrokerToolGuardrailsPrompt());

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -92,7 +92,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     }
 
     const channelId = await resolveChannel(channelInput);
-    const info = await slack("conversations.info", botToken, { channel: channelId });
+    const info = await slack("conversations.info", getBotToken(), { channel: channelId });
     const resolvedCanvasId = extractSlackChannelCanvasId(info);
     if (!resolvedCanvasId) {
       throw new Error(
@@ -452,7 +452,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       ),
     }),
     async execute(_id, params) {
-      requireToolPolicy("slack_canvas_create", undefined);
+      requireToolPolicy(
+        "slack_canvas_create",
+        undefined,
+        `kind=${params.kind ?? "standalone"} | channel=${params.channel ?? ""} | title=${params.title ?? ""}`,
+      );
 
       const channelInput = params.channel?.trim();
       const channelId = channelInput ? await resolveChannel(channelInput) : undefined;
@@ -467,7 +471,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         rememberChannel(channelInput.replace(/^#/, ""), channelId);
       }
 
-      const response = await slack(request.method, botToken, request.body);
+      const response = await slack(request.method, getBotToken(), request.body);
       const canvasId = response.canvas_id as string;
       const channelLabel = channelInput ?? channelId;
       const targetSummary =
@@ -525,7 +529,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       ),
     }),
     async execute(_id, params) {
-      requireToolPolicy("slack_canvas_update", undefined);
+      requireToolPolicy(
+        "slack_canvas_update",
+        undefined,
+        `canvas_id=${params.canvas_id ?? ""} | channel=${params.channel ?? ""} | mode=${params.mode ?? "append"} | section_contains_text=${params.section_contains_text ?? ""}`,
+      );
 
       const mode = normalizeSlackCanvasUpdateMode(params.mode);
       if (params.section_contains_text && mode !== "replace") {
@@ -546,7 +554,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         });
         const response = await slack(
           "canvases.sections.lookup",
-          botToken,
+          getBotToken(),
           lookup as unknown as Record<string, unknown>,
         );
         const sections = response.sections as Array<{ id?: string }> | undefined;
@@ -566,7 +574,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         mode,
         sectionId,
       });
-      await slack("canvases.edit", botToken, request as unknown as Record<string, unknown>);
+      await slack("canvases.edit", getBotToken(), request as unknown as Record<string, unknown>);
 
       const sectionSummary = params.section_contains_text
         ? ` Replaced section matching '${params.section_contains_text}'.`


### PR DESCRIPTION
## Summary
- add a name-based personality generator for Slack/Pinet agents
- inject the resolved personality traits into the dynamic system prompt so each agent's communication style matches its name without affecting task quality
- add helper tests for examples like `Rocket Dolphin`, `Silent Crocodile`, and `Cosmic Azure Crane`

## Details
- `slack-bridge/helpers.ts`
  - added `resolveAgentPersonality(...)`
  - added `buildAgentPersonalityGuidelines(...)`
  - map adjective + animal name components to lightweight communication traits
  - keep a hard safety rail that personality is style-only and must not affect correctness / rigor / blocker reporting
- `slack-bridge/index.ts`
  - inject personality guidance into `before_agent_start` alongside existing identity guidance
- `slack-bridge/helpers.test.ts`
  - cover trait resolution and prompt safety guidance
- `slack-bridge/slack-tools.ts`
  - fixed pre-existing `origin/main` typecheck regressions (`botToken` references / missing `requireToolPolicy` action strings) encountered while running the required checks on this branch

## Verification
- `cd slack-bridge && pnpm test -- --run helpers.test.ts slack-tools.test.ts`
- `cd slack-bridge && pnpm typecheck`
- `cd slack-bridge && pnpm lint`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
