### PR TITLE
fix: timestamp all RALPH loop messages (#191)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1488,6 +1488,12 @@ describe("buildRalphLoopNudgeMessage", () => {
   it("formats pending inbox and claimed thread counts", () => {
     expect(buildRalphLoopNudgeMessage(2, 1)).toContain("2 inbox items and 1 claimed thread");
   });
+
+  it("includes the cycle timestamp when provided", () => {
+    expect(buildRalphLoopNudgeMessage(2, 1, "2026-04-02T14:10:00.000Z")).toContain(
+      "RALPH LOOP nudge (2026-04-02T14:10:00.000Z):",
+    );
+  });
 });
 
 describe("buildRalphLoopAnomalySignature", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -993,6 +993,7 @@ export function rewriteRalphLoopGhostAnomalies(
 export function buildRalphLoopNudgeMessage(
   pendingInboxCount: number,
   ownedThreadCount: number,
+  cycleStartedAt?: string,
 ): string {
   const parts = [];
   if (pendingInboxCount > 0) {
@@ -1002,7 +1003,8 @@ export function buildRalphLoopNudgeMessage(
     parts.push(`${ownedThreadCount} claimed thread${ownedThreadCount === 1 ? "" : "s"}`);
   }
   const workload = parts.length > 0 ? parts.join(" and ") : "assigned work";
-  return `RALPH LOOP nudge: you appear idle but still have ${workload}. Please pick it up, post a status update, or release ownership so the broker can reassign it.`;
+  const prefix = cycleStartedAt ? `RALPH LOOP nudge (${cycleStartedAt})` : "RALPH LOOP nudge";
+  return `${prefix}: you appear idle but still have ${workload}. Please pick it up, post a status update, or release ownership so the broker can reassign it.`;
 }
 
 export function buildRalphLoopAnomalySignature(evaluation: RalphLoopEvaluationResult): string {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1033,8 +1033,8 @@ export default function (pi: ExtensionAPI) {
   let lastBrokerRalphLoopFollowUpAt = 0;
   let brokerRalphLoopFollowUpPending = false;
   const lastReportedGhostIds = new Set<string>();
-  let lastBrokerTaskAssignmentReport = "";
-  let pendingBrokerTaskAssignmentReport: string | null = null;
+  let lastBrokerTaskAssignmentReportSignature = "";
+  let pendingBrokerTaskAssignmentReport: { message: string; signature: string } | null = null;
   const lastBrokerNudges = new Map<string, number>();
 
   function getPinetRegistrationBlockReason(): string {
@@ -1244,7 +1244,11 @@ export default function (pi: ExtensionAPI) {
 
         sendBrokerMaintenanceMessage(
           workload.id,
-          buildRalphLoopNudgeMessage(workload.pendingInboxCount, workload.ownedThreadCount),
+          buildRalphLoopNudgeMessage(
+            workload.pendingInboxCount,
+            workload.ownedThreadCount,
+            cycleStartedAt,
+          ),
         );
         lastBrokerNudges.set(workload.id, now);
       }
@@ -1276,7 +1280,7 @@ export default function (pi: ExtensionAPI) {
       const trackedAssignments = db.listTaskAssignments();
       if (trackedAssignments.length === 0) {
         pendingBrokerTaskAssignmentReport = null;
-        lastBrokerTaskAssignmentReport = "";
+        lastBrokerTaskAssignmentReportSignature = "";
       } else {
         const resolvedAssignments = await resolveTaskAssignments(trackedAssignments, process.cwd());
         const projectedAssignments = resolvedAssignments.map((assignment) => {
@@ -1298,7 +1302,8 @@ export default function (pi: ExtensionAPI) {
         pendingBrokerTaskAssignmentReport = getPendingTaskAssignmentReport(
           projectedAssignments,
           agentsById,
-          lastBrokerTaskAssignmentReport,
+          lastBrokerTaskAssignmentReportSignature,
+          cycleStartedAt,
         );
       }
       // Keep cooldown state across transient clean cycles so flapping anomalies
@@ -1319,18 +1324,12 @@ export default function (pi: ExtensionAPI) {
           lastBrokerRalphLoopFollowUpAt = now;
         });
       }
-      if (
-        pendingBrokerTaskAssignmentReport &&
-        (ctx.isIdle?.() ?? true) &&
-        pendingBrokerTaskAssignmentReport !== lastBrokerTaskAssignmentReport
-      ) {
+      if (pendingBrokerTaskAssignmentReport && (ctx.isIdle?.() ?? true)) {
         const reportToDeliver = pendingBrokerTaskAssignmentReport;
-        trySendBrokerFollowUp(reportToDeliver, () => {
-          lastBrokerTaskAssignmentReport = reportToDeliver;
+        trySendBrokerFollowUp(reportToDeliver.message, () => {
+          lastBrokerTaskAssignmentReportSignature = reportToDeliver.signature;
           pendingBrokerTaskAssignmentReport = null;
         });
-      } else if (pendingBrokerTaskAssignmentReport === lastBrokerTaskAssignmentReport) {
-        pendingBrokerTaskAssignmentReport = null;
       }
 
       const shouldWarn =
@@ -1396,7 +1395,7 @@ export default function (pi: ExtensionAPI) {
     lastBrokerRalphLoopHadOutstandingAnomalies = false;
     lastBrokerRalphLoopFollowUpAt = 0;
     brokerRalphLoopFollowUpPending = false;
-    lastBrokerTaskAssignmentReport = "";
+    lastBrokerTaskAssignmentReportSignature = "";
     pendingBrokerTaskAssignmentReport = null;
   }
 

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -246,6 +246,29 @@ describe("buildTaskAssignmentReport", () => {
       ].join("\n"),
     );
   });
+
+  it("includes a timestamp when one is provided", () => {
+    const report = buildTaskAssignmentReport(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-2",
+          issueNumber: 103,
+          status: "assigned",
+        }),
+      ],
+      new Map([["worker-2", makeAgent("worker-2", "Frozen Raven", "🐦‍⬛")]]),
+      "2026-04-02T14:10:00.000Z",
+    );
+
+    expect(report).toBe(
+      [
+        "RALPH LOOP — WORKER STATUS:",
+        "Timestamp: 2026-04-02T14:10:00.000Z",
+        "- 🐦‍⬛ Frozen Raven: #103 → no commits, no PR ⚠️",
+      ].join("\n"),
+    );
+  });
 });
 
 describe("getPendingTaskAssignmentReport", () => {
@@ -266,14 +289,23 @@ describe("getPendingTaskAssignmentReport", () => {
       ],
       agentsById,
       "",
+      "2026-04-02T14:10:00.000Z",
     );
 
-    expect(report).toBe(
-      ["RALPH LOOP — WORKER STATUS:", "- 🐦‍⬛ Frozen Raven: #103 → no commits, no PR ⚠️"].join("\n"),
-    );
+    expect(report).toEqual({
+      signature: [
+        "RALPH LOOP — WORKER STATUS:",
+        "- 🐦‍⬛ Frozen Raven: #103 → no commits, no PR ⚠️",
+      ].join("\n"),
+      message: [
+        "RALPH LOOP — WORKER STATUS:",
+        "Timestamp: 2026-04-02T14:10:00.000Z",
+        "- 🐦‍⬛ Frozen Raven: #103 → no commits, no PR ⚠️",
+      ].join("\n"),
+    });
   });
 
-  it("does not queue a report when it matches the last delivered summary", () => {
+  it("does not queue a report when it matches the last delivered summary signature", () => {
     const lastDeliveredReport = [
       "RALPH LOOP — WORKER STATUS:",
       "- 🐎 Hyper Horse: #106 → PR #109 MERGED ✅",
@@ -291,6 +323,7 @@ describe("getPendingTaskAssignmentReport", () => {
       ],
       agentsById,
       lastDeliveredReport,
+      "2026-04-02T14:10:00.000Z",
     );
 
     expect(report).toBeNull();

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -392,6 +392,7 @@ export function buildTaskAssignmentReport(
     Pick<TaskAssignmentInfo, "agentId" | "issueNumber" | "branch" | "status" | "prNumber">
   >,
   agentsById: ReadonlyMap<string, Pick<AgentInfo, "emoji" | "name">>,
+  cycleStartedAt?: string,
 ): string | null {
   if (assignments.length === 0) {
     return null;
@@ -424,7 +425,15 @@ export function buildTaskAssignmentReport(
       return `- ${formatAgentLabel(agentId, agentsById)}: ${summary}`;
     });
 
-  return `RALPH LOOP — WORKER STATUS:\n${lines.join("\n")}`;
+  const header = cycleStartedAt
+    ? ["RALPH LOOP — WORKER STATUS:", `Timestamp: ${cycleStartedAt}`]
+    : ["RALPH LOOP — WORKER STATUS:"];
+  return [...header, ...lines].join("\n");
+}
+
+export interface PendingTaskAssignmentReport {
+  message: string;
+  signature: string;
 }
 
 export function getPendingTaskAssignmentReport(
@@ -432,11 +441,18 @@ export function getPendingTaskAssignmentReport(
     Pick<TaskAssignmentInfo, "agentId" | "issueNumber" | "branch" | "status" | "prNumber">
   >,
   agentsById: ReadonlyMap<string, Pick<AgentInfo, "emoji" | "name">>,
-  lastDeliveredReport: string,
-): string | null {
-  const report = buildTaskAssignmentReport(assignments, agentsById);
-  if (!report || report === lastDeliveredReport) {
+  lastDeliveredSignature: string,
+  cycleStartedAt?: string,
+): PendingTaskAssignmentReport | null {
+  const signature = buildTaskAssignmentReport(assignments, agentsById);
+  if (!signature || signature === lastDeliveredSignature) {
     return null;
   }
-  return report;
+
+  const message = buildTaskAssignmentReport(assignments, agentsById, cycleStartedAt);
+  if (!message) {
+    return null;
+  }
+
+  return { message, signature };
 }


### PR DESCRIPTION
## Summary
- add cycle timestamps to RALPH nudge messages sent to workers
- add cycle timestamps to the RALPH worker-status follow-up report
- keep worker-status dedupe stable by comparing a timestamp-free signature while sending the timestamped message

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test