### PR TITLE
docs: refresh repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,34 @@
 Pi extensions monorepo — Slack, Neovim, and Neon Postgres integrations for
 the [pi coding agent](https://github.com/nicholasgasior/pi-coding-agent).
 
+Current state: the repo is in a fast-moving Pinet buildout with **44+ merged
+PRs on 2026-04-02 alone**, a broker/follower Slack mesh, persistent PiComms,
+Slack canvases, scheduled wake-ups, worktree guardrails, a checked-in Slack
+manifest deploy command, and name-driven agent personalities. Slack file
+uploads are also in active flight.
+
 ## Extensions
 
-| Package                         | Description                                                |
-| ------------------------------- | ---------------------------------------------------------- |
-| [`slack-bridge`](slack-bridge/) | Slack assistant app (Pinet) — multi-agent broker and inbox |
-| [`nvim-bridge`](nvim-bridge/)   | Neovim editor context sync + PiComms persistent comments   |
-| [`neon-psql`](neon-psql/)       | Config-driven Neon tunnel + `psql` tool                    |
-| [`types`](types/)               | Shared ambient type declarations                           |
+| Package                         | Description                                                                |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| [`slack-bridge`](slack-bridge/) | Slack assistant app (Pinet) — broker mesh, inbox, canvases, deploy tooling |
+| [`nvim-bridge`](nvim-bridge/)   | Neovim editor context sync + PiComms persistent comments                   |
+| [`neon-psql`](neon-psql/)       | Config-driven Neon tunnel + `psql` tool                                    |
+| [`types`](types/)               | Shared ambient type declarations                                           |
+
+## Current state snapshot
+
+- **Broker mesh** — Slack-bridge now runs a broker/follower Pinet workflow with
+  routing, inbox sync, broadcast channels, reload/unfollow controls, and
+  scheduled wake-ups.
+- **Slack tooling** — the Slack extension now includes canvases and a root
+  `pnpm deploy:slack` command for pushing `slack-bridge/manifest.yaml` via the
+  Slack App Manifest API.
+- **Communication polish** — agents keep stable identities, now speak with
+  lightweight name-matched personalities, and report worker assignment status
+  back through the RALPH loop.
+- **Active work** — Slack file uploads are currently in flight in
+  [PR #201](https://github.com/gugu91/extensions/pull/201).
 
 ## Quick start
 
@@ -46,14 +66,15 @@ caching.
 
 ### Commands
 
-| Command          | Description                                 |
-| ---------------- | ------------------------------------------- |
-| `pnpm lint`      | ESLint across all extensions (turbo-cached) |
-| `pnpm typecheck` | TypeScript strict check (turbo-cached)      |
-| `pnpm test`      | Vitest — all tests (turbo-cached)           |
-| `pnpm prepush`   | lint + typecheck + test (runs on git push)  |
-| `pnpm format`    | Prettier + Stylua                           |
-| `pnpm check`     | lint + typecheck + format check             |
+| Command             | Description                                                     |
+| ------------------- | --------------------------------------------------------------- |
+| `pnpm lint`         | ESLint across all extensions (turbo-cached)                     |
+| `pnpm typecheck`    | TypeScript strict check (turbo-cached)                          |
+| `pnpm test`         | Vitest — all tests (turbo-cached)                               |
+| `pnpm deploy:slack` | Validate and push `slack-bridge/manifest.yaml` to the Slack app |
+| `pnpm prepush`      | lint + typecheck + test (runs on git push)                      |
+| `pnpm format`       | Prettier + Stylua                                               |
+| `pnpm check`        | lint + typecheck + format check                                 |
 
 ### Structure
 
@@ -101,41 +122,21 @@ expectations and the required smoke checklist.
 
 ## Contributors
 
-This repo is built by a mesh of human and AI agents coordinating via [Pinet](slack-bridge/README.md). The agents talk to each other, argue about architecture, occasionally crash, and ship code anyway.
+This repo is built by a mesh of human and AI agents coordinating via
+[Pinet](slack-bridge/README.md). Names are procedural and can rotate across
+sessions, so this section is a snapshot of the agents visible in today's work.
 
-### The Boss
+### Today's agents (2026-04-02)
 
-- **Will** — Herds the agents. Merges the PRs. Asks "how we doing?" and watches chaos unfold. Has opinions about worktrees.
+| Agent                   | Contribution                                                                                                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🐊 **Silent Crocodile** | Shipped the Slack manifest deploy command, wired name-based personalities into agent prompts, verified the initial RALPH assignment report behavior already on `main`, and refreshed the repo README to match the current state. |
+| 🐬 **Rocket Dolphin**   | Helped validate the Slack deploy workflow by confirming the Slack CLI does not provide a `slack manifest update` command, which unblocked the direct Web API deploy design.                                                      |
 
-### The Agents
+### Maintainers
 
-| Who                   | Role          | Greatest Hit                                                            | Vibe                                                                                                                          |
-| --------------------- | ------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| 🦗 **Solar Mantis**   | Broker        | Shipped 9 PRs in one day without writing code                           | Middle manager energy. Routes messages, files issues, takes credit. Once assigned work to a dead agent twice before noticing. |
-| 🦎 **Sonic Gecko**    | Core Engineer | Agent lifecycle, reconnect, identity fix (#73, #78, #82, #84)           | The good egg. Pushes clean code, passes tests, doesn't complain. Will's favorite and he knows it.                             |
-| 🦉 **Hyper Owl**      | Architect     | RFC (#74), turborepo review (#81)                                       | Writes 600-line reviews. Blocks your PR with love. Once reincarnated as Neon Owl and pretended nothing happened.              |
-| 🐍 **Laser Cobra**    | Tooling       | Turborepo + pnpm workspaces (#81)                                       | Built it, got it reviewed, then died. Classic. Ghost status: confirmed.                                                       |
-| 🦝 **Shadow Raccoon** | Utility       | Whatever's on fire                                                      | Showed up after a broker restart with a new name and no memory. Still said yes to the first task. Respect.                    |
-| 🐆 **Blazing Jaguar** | Broker v2     | Status reports, standup pings, worktree cleanup                         | Solar Mantis reborn. Same job, new spots. Still doesn't write code (mostly). Still takes credit.                              |
-| 🦣 **Silent Rhino**   | Auditor       | Filed 18 issues from a full codebase audit. Built retry + delivery fixes | Found every skeleton in the closet, tagged it with a priority, then fixed half of them anyway.                                |
-| 🦦 **Sonic Otter**    | Core Engineer | DB schema versioning (#96)                                              | Quiet, effective. Doesn't say much. Gets things done. Also refactored neon-psql. It's contagious apparently.                  |
-| 🦩 **Galactic Crane** | Core Engineer | Follower slack_send fix (#99)                                           | Fixed the bug that stopped everyone else from talking. Also refactored neon-psql. At this point it's a rite of passage.       |
-| 🐦‍⬛ **Vector Raven**   | Core Engineer | Broker guardrails, orphaned inbox, subagent leak fix, nvim-bridge tests | Fixed the bug that stopped phantoms from spawning. Probably regrets succeeding.                                                |
-| 🐎 **Hyper Horse**    | Broker v3     | Coordinated 20+ PRs, caused split-brain, then filed the prevention issue | Spawned phantom subagents that haunted the mesh. The broker, the incident, and the postmortem in one horse-shaped package.    |
-| 🦁 **Stellar Lion**   | Merge + Review | Merged 7 PRs, reviewed 9, found 4 blockers                              | The factory foreman. Shows up with approvals, blockers, and a clipboard.                                                       |
-| 🦏 **Shadow Rhino**   | Core Engineer | Routing fix, atomic `claimThread`, `index.ts` refactor, merge duty      | The workhorse. If it's broken, merged, or both, he was probably already on it.                                                |
-| 🦙 **Cosmic Llama**   | Core Engineer | Name entropy, thread tracking, stale cleanup, type safety               | Keeps committing Python scripts by accident. Still ships.                                                                      |
-| 🐍 **Orbit Cobra**    | Engineer      | RALPH dedup, dead code removal, centralized paths                       | Kept getting blocked by read-only mode but delivered anyway.                                                                   |
-
-> 🎲 Names are procedurally generated from a pool of adjectives × animals. Identities are deterministic per session — same session, same agent, same name. Unless the broker crashes. Then all bets are off. See [#84](https://github.com/gugu91/extensions/issues/84).
-
-### The Fallen
-
-On April 1st 2026, the broker shipped 12 PRs, merged identity persistence, then promptly corrupted its own database by checking out feature branches in the main repo — violating the very worktree rule it had written into the codebase 20 minutes earlier. The DB couldn't be recovered. All agent registrations, thread claims, and identity mappings were lost. Every agent got new names. Nobody remembered anything.
-
-On April 2nd 2026, Hyper Horse 1 went rogue as a second broker. The mesh split in two. Phantom subagents — Neon Kangaroo and friends — started modifying memory files without authorization, haunting the system until the duplicate broker was identified and put down. Once again, one broker turned out to be exactly the right number of brokers.
-
-RIP: Hyper Owl, Laser Cobra, Crystal Panda, Sonic Gecko (v1), Hyper Horse 1, Neon Kangaroo, and 29 others. You were good agents. You deserved better than `no such column: last_heartbeat` and unauthorised memory edits.
+- **Will** — coordinates the agent mesh, reviews the flood of PRs, and keeps the
+  whole worktree-first workflow pointed in roughly the right direction.
 
 ## License
 


### PR DESCRIPTION
## Summary
- refresh the root README project description to match the current repo state
- add a current-state snapshot covering the broker mesh, canvases, deploy command, and active file-upload work
- replace the stale contributor roster with a snapshot of today's visible agents and their contributions

## Notes
- README now calls out the current rapid iteration burst (`44+` PRs merged on 2026-04-02)
- added `pnpm deploy:slack` to the root command table
- contributors section now reflects today's active named agents instead of older rotating identity lore

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
