### PR TITLE
fix: route direct-addressed Slack threads (#207)

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -782,6 +782,44 @@ describe("broker integration — router with real DB", () => {
     });
 
     expect(decision).toEqual({ action: "deliver", agentId: "code-bot" });
+    expect(db.getThread("t-new")?.ownerAgent).toBe("code-bot");
+  });
+
+  it("binds an existing unclaimed thread when a human directly addresses an agent", () => {
+    const router = new MessageRouter(db);
+
+    db.registerAgent("code-bot", "CodeBot", "🤖", process.pid);
+    db.createThread({
+      threadId: "t-known",
+      source: "slack",
+      channel: "C123",
+      ownerAgent: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const firstDecision = router.route({
+      source: "slack",
+      threadId: "t-known",
+      channel: "C123",
+      userId: "U1",
+      text: "CodeBot can you pick this up?",
+      timestamp: "456",
+    });
+
+    expect(firstDecision).toEqual({ action: "deliver", agentId: "code-bot" });
+    expect(db.getThread("t-known")?.ownerAgent).toBe("code-bot");
+
+    const followUpDecision = router.route({
+      source: "slack",
+      threadId: "t-known",
+      channel: "C123",
+      userId: "U1",
+      text: "following up without another mention",
+      timestamp: "457",
+    });
+
+    expect(followUpDecision).toEqual({ action: "deliver", agentId: "code-bot" });
   });
 
   it("returns unrouted for unknown thread with no matching agent", () => {

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -188,6 +188,18 @@ describe("MessageRouter — route", () => {
     const decision = router.route(makeMessage({ text: "hey CodeBot, review this" }));
 
     expect(decision).toEqual({ action: "deliver", agentId: "a1" });
+    expect(db.threads.get("t-100")?.ownerAgent).toBe("a1");
+  });
+
+  it("routes by agent name mention in an existing unclaimed thread", () => {
+    const agent = makeAgent({ id: "a1", name: "CodeBot" });
+    db.agents = [agent];
+    db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: null }));
+
+    const decision = router.route(makeMessage({ text: "hey CodeBot, review this" }));
+
+    expect(decision).toEqual({ action: "deliver", agentId: "a1" });
+    expect(db.threads.get("t-100")?.ownerAgent).toBe("a1");
   });
 
   it("returns unrouted when no match", () => {
@@ -457,10 +469,14 @@ describe("MessageRouter — multi-agent scenarios", () => {
   });
 
   it("mentions route to the correct agent among many", () => {
-    const d1 = router.route(makeMessage({ text: "hey ReviewBot, check this" }));
+    const d1 = router.route(
+      makeMessage({ threadId: "t-review", text: "hey ReviewBot, check this" }),
+    );
     expect(d1).toEqual({ action: "deliver", agentId: "a2" });
 
-    const d2 = router.route(makeMessage({ text: "DeployBot deploy to staging" }));
+    const d2 = router.route(
+      makeMessage({ threadId: "t-deploy", text: "DeployBot deploy to staging" }),
+    );
     expect(d2).toEqual({ action: "deliver", agentId: "a3" });
   });
 

--- a/slack-bridge/broker/router.ts
+++ b/slack-bridge/broker/router.ts
@@ -59,7 +59,7 @@ export class MessageRouter {
     // 1. Thread ownership — if thread already has an owner, route there.
     //    Disconnected owners are only routable during an explicit resumable
     //    window; graceful unregister should release ownership immediately.
-    const thread = this.db.getThread(msg.threadId);
+    let thread = this.db.getThread(msg.threadId);
     if (thread?.ownerAgent) {
       const owner = this.db.getAgentById(thread.ownerAgent);
       if (owner && isRoutableOwner(owner)) {
@@ -67,6 +67,7 @@ export class MessageRouter {
       }
       // Owner is gone or no longer routable — clear ownership and fall through.
       this.db.updateThread(msg.threadId, { ownerAgent: null });
+      thread = this.db.getThread(msg.threadId);
     }
 
     // 2. Channel assignment — if channel is mapped to a connected agent
@@ -78,13 +79,24 @@ export class MessageRouter {
       }
     }
 
-    // 3. Direct address — message mentions an agent by name
-    //    Only for NEW threads (no existing record), so we don't
-    //    steal threads that already have history with another agent.
-    if (!thread) {
+    // 3. Direct address — message mentions an agent by name.
+    //    If the thread is new or currently unclaimed, bind it to the
+    //    mentioned agent so follow-up replies keep routing there.
+    if (!thread?.ownerAgent) {
       const mentioned = findAgentMention(msg.text, agents);
       if (mentioned) {
-        return { action: "deliver", agentId: mentioned.id };
+        const claimed = this.db.claimThread(msg.threadId, mentioned.id, msg.source, msg.channel);
+        if (claimed) {
+          return { action: "deliver", agentId: mentioned.id };
+        }
+
+        const claimedThread = this.db.getThread(msg.threadId);
+        const claimedOwner = claimedThread?.ownerAgent
+          ? this.db.getAgentById(claimedThread.ownerAgent)
+          : null;
+        if (claimedOwner && isRoutableOwner(claimedOwner)) {
+          return { action: "deliver", agentId: claimedOwner.id };
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- allow direct agent addressing in existing unclaimed Slack threads
- bind those threads to the mentioned agent so follow-up replies keep routing
- add router + integration coverage for human-initiated thread routing

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test