### PR TITLE
test: cover neon-psql query execution path (#149)

### DIFF
--- a/neon-psql/index.ts
+++ b/neon-psql/index.ts
@@ -1,7 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -13,7 +12,6 @@ import {
   formatSize,
   getAgentDir,
   truncateHead,
-  type TruncationResult,
 } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@gugu91/pi-ext-types/typebox";
@@ -21,10 +19,11 @@ import { Type } from "@gugu91/pi-ext-types/typebox";
 import {
   buildInjectedValues as computeInjectedValues,
   deriveEndpoint,
-  isReadOnlyQuery,
   needsSsl,
   type SourceValues,
 } from "./helpers.js";
+import { executePsqlQuery, type OutputFormat, type PsqlDetails } from "./query-execution.js";
+import { runPsqlQueryWithTunnel } from "./query-runner.js";
 import { resolvePsqlBin } from "./psql-bin.js";
 import { loadConfig, type ResolvedConfig } from "./settings.js";
 
@@ -52,21 +51,6 @@ interface TunnelState {
   source: SourceValues;
   requiresSsl: boolean;
 }
-
-interface PsqlDetails {
-  query: string;
-  format: OutputFormat;
-  tunnelPort: number;
-  endpoint: string;
-  logPath: string;
-  configPath: string;
-  streaming?: boolean;
-  truncation?: TruncationResult;
-  fullOutputPath?: string;
-  outputPreview?: string;
-}
-
-type OutputFormat = "table" | "csv" | "tsv";
 
 const PsqlParams = Type.Object({
   query: Type.String({
@@ -330,12 +314,6 @@ async function prepareBashTunnel(config: ResolvedConfig, ctx: ExtensionContext):
   }
 }
 
-async function writeFullOutput(output: string): Promise<string> {
-  const path = join(tmpdir(), `pi-psql-${Date.now()}.txt`);
-  await writeFile(path, output, "utf8");
-  return path;
-}
-
 function renderPreview(
   text: string,
   expanded: boolean,
@@ -361,97 +339,16 @@ async function runPsqlQuery(
     details?: PsqlDetails;
   }) => void,
 ): Promise<{ text: string; details: PsqlDetails }> {
-  if (!isReadOnlyQuery(query)) {
-    throw new Error(
-      "The psql extension only allows read-only queries and psql inspection meta-commands (e.g. SELECT, WITH, SHOW, EXPLAIN, VALUES, TABLE, \\d, \\dt).",
-    );
-  }
-
-  const state = await ensureTunnel(config, ctx);
-  const injected = buildInjectedValues(config, state);
-  const connection = injected.NEON_TUNNEL_DATABASE_URL;
-  const args = [connection, "-v", "ON_ERROR_STOP=1", "-P", "pager=off"];
-  if (format === "csv") args.push("--csv");
-  if (format === "tsv") args.push("-A", "-F", "\t");
-  args.push("-c", query);
-
-  const details: PsqlDetails = {
-    query,
-    format,
-    tunnelPort: state.port,
-    endpoint: state.endpoint,
-    logPath: state.logPath,
-    configPath: config.path,
-    streaming: true,
-  };
-
-  let stdout = "";
-  let stderr = "";
-
-  const pushPartial = (stage: string) => {
-    if (!onUpdate) return;
-    const combined = [stdout, stderr].filter(Boolean).join("\n").trim();
-    const preview = combined
-      ? truncateHead(combined, { maxLines: 60, maxBytes: 6 * 1024 }).content
-      : `${stage}...`;
-    onUpdate({
-      content: [{ type: "text", text: preview }],
-      details: { ...details, outputPreview: preview, streaming: true },
-    });
-  };
-
-  const child = spawn(resolvePsqlBin({ configuredPath: config.psqlBin }), args, {
-    env: {
-      ...process.env,
-      ...injected,
-      PGPASSWORD: state.source.password,
-      PGAPPNAME: "pi-extension-psql",
-    },
-    stdio: ["ignore", "pipe", "pipe"],
+  return runPsqlQueryWithTunnel(config, query, format, ctx, signal, onUpdate, {
+    ensureTunnel,
+    buildInjectedValues,
+    resolvePsqlBin,
+    executePsqlQuery,
+    truncateOutput: truncateHead,
+    formatBytes: formatSize,
+    maxOutputLines: DEFAULT_MAX_LINES,
+    maxOutputBytes: DEFAULT_MAX_BYTES,
   });
-
-  const abort = () => child.kill("SIGTERM");
-  signal?.addEventListener("abort", abort, { once: true });
-
-  child.stdout.on("data", (chunk: Buffer) => {
-    stdout += chunk.toString("utf8");
-    pushPartial("Running query");
-  });
-  child.stderr.on("data", (chunk: Buffer) => {
-    stderr += chunk.toString("utf8");
-    pushPartial("Running query");
-  });
-
-  const exitCode = await new Promise<number>((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (code) => resolve(code ?? 1));
-  });
-
-  signal?.removeEventListener("abort", abort);
-
-  if (signal?.aborted) throw new Error("psql query aborted");
-
-  const combined = [stdout, stderr].filter(Boolean).join("\n").trim() || "(no output)";
-  if (exitCode !== 0) {
-    throw new Error(combined);
-  }
-
-  const truncation = truncateHead(combined, {
-    maxLines: DEFAULT_MAX_LINES,
-    maxBytes: DEFAULT_MAX_BYTES,
-  });
-
-  let text = truncation.content;
-  if (truncation.truncated) {
-    const fullOutputPath = await writeFullOutput(combined);
-    details.truncation = truncation;
-    details.fullOutputPath = fullOutputPath;
-    text += `\n\n[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). Full output saved to: ${fullOutputPath}]`;
-  }
-
-  details.streaming = false;
-  details.outputPreview = text;
-  return { text, details };
 }
 
 function redactValue(key: string, value: string): string {

--- a/neon-psql/query-execution.test.ts
+++ b/neon-psql/query-execution.test.ts
@@ -1,0 +1,264 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executePsqlQuery,
+  type ExecutePsqlQueryOptions,
+  type PsqlExecutionState,
+  type SpawnedPsqlProcess,
+} from "./query-execution.js";
+import type { ResolvedConfig } from "./settings.js";
+
+class FakePsqlProcess extends EventEmitter implements SpawnedPsqlProcess {
+  readonly stdout = new EventEmitter();
+  readonly stderr = new EventEmitter();
+  readonly killSignals: Array<NodeJS.Signals | undefined> = [];
+
+  emitStdout(text: string): void {
+    this.stdout.emit("data", Buffer.from(text, "utf8"));
+  }
+
+  emitStderr(text: string): void {
+    this.stderr.emit("data", Buffer.from(text, "utf8"));
+  }
+
+  close(code: number | null = 0): void {
+    this.emit("close", code);
+  }
+
+  fail(error: Error): void {
+    this.emit("error", error);
+  }
+
+  kill(signal?: NodeJS.Signals): void {
+    this.killSignals.push(signal);
+    queueMicrotask(() => this.emit("close", null));
+  }
+}
+
+const source = {
+  host: "ep-cool-river.us-east-1.aws.neon.tech",
+  port: "5432",
+  user: "user@example.com",
+  password: "super-secret",
+  database: "app",
+};
+
+const state: PsqlExecutionState = {
+  port: 6543,
+  endpoint: "ep-cool-river",
+  logPath: "/tmp/neon-psql.log",
+  source,
+};
+
+const config: ResolvedConfig = {
+  path: "/tmp/neon-psql.json",
+  injectIntoBash: true,
+  injectPythonShim: true,
+  logPath: "/tmp/neon-psql.log",
+  psqlBin: "/custom/bin/psql",
+  sourceEnv: {
+    host: "DB_HOST",
+    port: "DB_PORT",
+    user: "DB_USER",
+    password: "DB_PASSWORD",
+    database: "DB_NAME",
+  },
+  injectEnv: {
+    NEON_TUNNEL_DATABASE_URL:
+      "postgresql://user%40example.com:super-secret@127.0.0.1:6543/app?sslmode=require",
+  },
+};
+
+function makeOptions(overrides: Partial<ExecutePsqlQueryOptions> = {}): ExecutePsqlQueryOptions {
+  return {
+    psqlBin: config.psqlBin ?? "/usr/bin/psql",
+    configPath: config.path,
+    query: "SELECT 1",
+    format: "table",
+    state,
+    injectedEnv: config.injectEnv,
+    spawnProcess: vi.fn(() => new FakePsqlProcess()),
+    truncateOutput: (text) => ({
+      content: text,
+      truncated: false,
+      outputLines: text === "" ? 0 : text.split("\n").length,
+      totalLines: text === "" ? 0 : text.split("\n").length,
+      outputBytes: Buffer.byteLength(text, "utf8"),
+      totalBytes: Buffer.byteLength(text, "utf8"),
+    }),
+    formatBytes: (bytes) => `${bytes}B`,
+    ...overrides,
+  };
+}
+
+describe("executePsqlQuery", () => {
+  it("rejects non-read-only queries before spawning psql", async () => {
+    const spawnProcess = vi.fn();
+
+    await expect(
+      executePsqlQuery(
+        makeOptions({ query: "DELETE FROM users", spawnProcess: spawnProcess as never }),
+      ),
+    ).rejects.toThrow(
+      "The psql extension only allows read-only queries and psql inspection meta-commands",
+    );
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it("spawns psql with the injected connection env and streams partial updates", async () => {
+    const child = new FakePsqlProcess();
+    const spawnProcess = vi.fn(() => child);
+    const updates: string[] = [];
+
+    const promise = executePsqlQuery(
+      makeOptions({
+        format: "csv",
+        spawnProcess: spawnProcess as never,
+        onUpdate: (update) => {
+          updates.push(update.content?.[0]?.text ?? "");
+        },
+      }),
+    );
+
+    child.emitStdout("id,name");
+    child.emitStderr("NOTICE: streamed");
+    child.close(0);
+
+    const result = await promise;
+
+    expect(spawnProcess).toHaveBeenCalledTimes(1);
+    expect(spawnProcess).toHaveBeenCalledWith(
+      "/custom/bin/psql",
+      [
+        config.injectEnv.NEON_TUNNEL_DATABASE_URL,
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-P",
+        "pager=off",
+        "--csv",
+        "-c",
+        "SELECT 1",
+      ],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          NEON_TUNNEL_DATABASE_URL: config.injectEnv.NEON_TUNNEL_DATABASE_URL,
+          PGPASSWORD: source.password,
+          PGAPPNAME: "pi-extension-psql",
+        }),
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+    expect(updates).toEqual(["id,name", "id,name\nNOTICE: streamed"]);
+    expect(result.text).toBe("id,name\nNOTICE: streamed");
+    expect(result.details.streaming).toBe(false);
+    expect(result.details.outputPreview).toBe("id,name\nNOTICE: streamed");
+    expect(result.details.tunnelPort).toBe(state.port);
+  });
+
+  it("uses tsv flags when requested", async () => {
+    const child = new FakePsqlProcess();
+    const spawnProcess = vi.fn(() => child);
+
+    const promise = executePsqlQuery(
+      makeOptions({ format: "tsv", spawnProcess: spawnProcess as never }),
+    );
+
+    child.emitStdout("1\tAlice");
+    child.close(0);
+    await promise;
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      "/custom/bin/psql",
+      [
+        config.injectEnv.NEON_TUNNEL_DATABASE_URL,
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-P",
+        "pager=off",
+        "-A",
+        "-F",
+        "\t",
+        "-c",
+        "SELECT 1",
+      ],
+      expect.any(Object),
+    );
+  });
+
+  it("throws combined output when psql exits non-zero", async () => {
+    const child = new FakePsqlProcess();
+
+    const promise = executePsqlQuery(makeOptions({ spawnProcess: vi.fn(() => child) as never }));
+
+    child.emitStdout("partial rows");
+    child.emitStderr("ERROR: syntax error at or near FROM");
+    child.close(1);
+
+    await expect(promise).rejects.toThrow("partial rows\nERROR: syntax error at or near FROM");
+  });
+
+  it("writes the full output to disk when the rendered output is truncated", async () => {
+    const child = new FakePsqlProcess();
+    const truncateOutput = vi.fn(() => ({
+      content: "row 1\nrow 2",
+      truncated: true,
+      outputLines: 2,
+      totalLines: 10,
+      outputBytes: 20,
+      totalBytes: 100,
+    }));
+    const writeFullOutput = vi.fn(async () => "/tmp/pi-psql-full.txt");
+    const formatBytes = vi.fn((bytes: number) => `${bytes}B`);
+
+    const promise = executePsqlQuery(
+      makeOptions({
+        spawnProcess: vi.fn(() => child) as never,
+        truncateOutput,
+        writeFullOutput,
+        formatBytes,
+      }),
+    );
+
+    child.emitStdout("lots of rows...");
+    child.close(0);
+
+    const result = await promise;
+
+    expect(truncateOutput).toHaveBeenCalledWith("lots of rows...", {
+      maxLines: expect.any(Number),
+      maxBytes: expect.any(Number),
+    });
+    expect(writeFullOutput).toHaveBeenCalledWith("lots of rows...");
+    expect(result.details.fullOutputPath).toBe("/tmp/pi-psql-full.txt");
+    expect(result.text).toContain(
+      "[Output truncated: showing 2 of 10 lines (20B of 100B). Full output saved to: /tmp/pi-psql-full.txt]",
+    );
+  });
+
+  it("kills the child process and surfaces an abort error", async () => {
+    const child = new FakePsqlProcess();
+    const controller = new AbortController();
+
+    const promise = executePsqlQuery(
+      makeOptions({ signal: controller.signal, spawnProcess: vi.fn(() => child) as never }),
+    );
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow("psql query aborted");
+    expect(child.killSignals).toEqual(["SIGTERM"]);
+  });
+
+  it("surfaces spawn errors directly", async () => {
+    const child = new FakePsqlProcess();
+
+    const promise = executePsqlQuery(makeOptions({ spawnProcess: vi.fn(() => child) as never }));
+
+    child.fail(new Error("spawn failed"));
+
+    await expect(promise).rejects.toThrow("spawn failed");
+  });
+});

--- a/neon-psql/query-execution.ts
+++ b/neon-psql/query-execution.ts
@@ -1,0 +1,207 @@
+import { spawn } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { TruncationResult } from "@mariozechner/pi-coding-agent";
+
+import { isReadOnlyQuery, type SourceValues } from "./helpers.js";
+
+export interface PsqlExecutionState {
+  port: number;
+  endpoint: string;
+  logPath: string;
+  source: SourceValues;
+}
+
+export type OutputFormat = "table" | "csv" | "tsv";
+
+export interface PsqlDetails {
+  query: string;
+  format: OutputFormat;
+  tunnelPort: number;
+  endpoint: string;
+  logPath: string;
+  configPath: string;
+  streaming?: boolean;
+  truncation?: TruncationResult;
+  fullOutputPath?: string;
+  outputPreview?: string;
+}
+
+export interface PsqlPartialUpdate {
+  content?: { type: "text"; text: string }[];
+  details?: PsqlDetails;
+}
+
+interface SpawnedPsqlStream {
+  on(event: "data", listener: (chunk: Buffer) => void): void;
+}
+
+export interface SpawnedPsqlProcess {
+  stdout: SpawnedPsqlStream;
+  stderr: SpawnedPsqlStream;
+  once(event: "error", listener: (error: Error) => void): void;
+  once(event: "close", listener: (code: number | null) => void): void;
+  kill(signal?: NodeJS.Signals): void;
+}
+
+export interface ExecutePsqlQueryOptions {
+  psqlBin: string;
+  configPath: string;
+  query: string;
+  format: OutputFormat;
+  state: PsqlExecutionState;
+  injectedEnv: Record<string, string>;
+  signal?: AbortSignal;
+  onUpdate?: (update: PsqlPartialUpdate) => void;
+  processEnv?: NodeJS.ProcessEnv;
+  spawnProcess?: (
+    bin: string,
+    args: string[],
+    options: {
+      env: NodeJS.ProcessEnv;
+      stdio: ["ignore", "pipe", "pipe"];
+    },
+  ) => SpawnedPsqlProcess;
+  truncateOutput: (
+    text: string,
+    options: { maxLines: number; maxBytes: number },
+  ) => TruncationResult;
+  writeFullOutput?: (output: string) => Promise<string>;
+  formatBytes: (bytes: number) => string;
+  maxOutputLines?: number;
+  maxOutputBytes?: number;
+}
+
+export async function writePsqlFullOutput(output: string): Promise<string> {
+  const path = join(tmpdir(), `pi-psql-${Date.now()}.txt`);
+  await writeFile(path, output, "utf8");
+  return path;
+}
+
+export async function executePsqlQuery(
+  options: ExecutePsqlQueryOptions,
+): Promise<{ text: string; details: PsqlDetails }> {
+  const {
+    psqlBin,
+    configPath,
+    query,
+    format,
+    state,
+    injectedEnv,
+    signal,
+    onUpdate,
+    processEnv = process.env,
+    spawnProcess,
+    truncateOutput,
+    writeFullOutput = writePsqlFullOutput,
+    formatBytes,
+    maxOutputLines = 2000,
+    maxOutputBytes = 50 * 1024,
+  } = options;
+
+  const spawnPsqlProcess =
+    spawnProcess ??
+    (spawn as (
+      bin: string,
+      args: string[],
+      options: {
+        env: NodeJS.ProcessEnv;
+        stdio: ["ignore", "pipe", "pipe"];
+      },
+    ) => SpawnedPsqlProcess);
+
+  if (!isReadOnlyQuery(query)) {
+    throw new Error(
+      "The psql extension only allows read-only queries and psql inspection meta-commands (e.g. SELECT, WITH, SHOW, EXPLAIN, VALUES, TABLE, \\d, \\dt).",
+    );
+  }
+
+  const connection = injectedEnv.NEON_TUNNEL_DATABASE_URL;
+  const args = [connection, "-v", "ON_ERROR_STOP=1", "-P", "pager=off"];
+  if (format === "csv") args.push("--csv");
+  if (format === "tsv") args.push("-A", "-F", "\t");
+  args.push("-c", query);
+
+  const details: PsqlDetails = {
+    query,
+    format,
+    tunnelPort: state.port,
+    endpoint: state.endpoint,
+    logPath: state.logPath,
+    configPath,
+    streaming: true,
+  };
+
+  let stdout = "";
+  let stderr = "";
+
+  const pushPartial = (stage: string) => {
+    if (!onUpdate) return;
+    const combined = [stdout, stderr].filter(Boolean).join("\n").trim();
+    const preview = combined
+      ? truncateOutput(combined, { maxLines: 60, maxBytes: 6 * 1024 }).content
+      : `${stage}...`;
+    onUpdate({
+      content: [{ type: "text", text: preview }],
+      details: { ...details, outputPreview: preview, streaming: true },
+    });
+  };
+
+  const child = spawnPsqlProcess(psqlBin, args, {
+    env: {
+      ...processEnv,
+      ...injectedEnv,
+      PGPASSWORD: state.source.password,
+      PGAPPNAME: "pi-extension-psql",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const abort = () => child.kill("SIGTERM");
+  signal?.addEventListener("abort", abort, { once: true });
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+    pushPartial("Running query");
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+    pushPartial("Running query");
+  });
+
+  let exitCode: number;
+  try {
+    exitCode = await new Promise<number>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code) => resolve(code ?? 1));
+    });
+  } finally {
+    signal?.removeEventListener("abort", abort);
+  }
+
+  if (signal?.aborted) throw new Error("psql query aborted");
+
+  const combined = [stdout, stderr].filter(Boolean).join("\n").trim() || "(no output)";
+  if (exitCode !== 0) {
+    throw new Error(combined);
+  }
+
+  const truncation = truncateOutput(combined, {
+    maxLines: maxOutputLines,
+    maxBytes: maxOutputBytes,
+  });
+
+  let text = truncation.content;
+  if (truncation.truncated) {
+    const fullOutputPath = await writeFullOutput(combined);
+    details.truncation = truncation;
+    details.fullOutputPath = fullOutputPath;
+    text += `\n\n[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${formatBytes(truncation.outputBytes)} of ${formatBytes(truncation.totalBytes)}). Full output saved to: ${fullOutputPath}]`;
+  }
+
+  details.streaming = false;
+  details.outputPreview = text;
+  return { text, details };
+}

--- a/neon-psql/query-runner.test.ts
+++ b/neon-psql/query-runner.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runPsqlQueryWithTunnel, type PsqlTunnelState } from "./query-runner.js";
+import type { ResolvedConfig } from "./settings.js";
+
+const config: ResolvedConfig = {
+  path: "/tmp/neon-psql.json",
+  injectIntoBash: true,
+  injectPythonShim: true,
+  logPath: "/tmp/neon-psql.log",
+  psqlBin: "/custom/bin/psql",
+  sourceEnv: {
+    host: "DB_HOST",
+    port: "DB_PORT",
+    user: "DB_USER",
+    password: "DB_PASSWORD",
+    database: "DB_NAME",
+  },
+  injectEnv: {
+    NEON_TUNNEL_DATABASE_URL: "postgresql://user:pass@127.0.0.1:6543/app",
+  },
+};
+
+const state: PsqlTunnelState = {
+  port: 6543,
+  endpoint: "ep-cool-river",
+  logPath: "/tmp/neon-psql.log",
+  source: {
+    host: "ep-cool-river.us-east-1.aws.neon.tech",
+    port: "5432",
+    user: "user@example.com",
+    password: "super-secret",
+    database: "app",
+  },
+};
+
+describe("runPsqlQueryWithTunnel", () => {
+  it("rejects mutating queries before trying to start the tunnel", async () => {
+    const ensureTunnel = vi.fn();
+    const buildInjectedValues = vi.fn();
+    const resolvePsqlBin = vi.fn();
+    const executePsqlQuery = vi.fn();
+
+    await expect(
+      runPsqlQueryWithTunnel(config, "DELETE FROM users", "table", {}, undefined, undefined, {
+        ensureTunnel,
+        buildInjectedValues,
+        resolvePsqlBin,
+        executePsqlQuery,
+        truncateOutput: vi.fn(),
+        formatBytes: vi.fn((bytes: number) => `${bytes}B`),
+        maxOutputLines: 2000,
+        maxOutputBytes: 50 * 1024,
+      }),
+    ).rejects.toThrow(
+      "The psql extension only allows read-only queries and psql inspection meta-commands",
+    );
+
+    expect(ensureTunnel).not.toHaveBeenCalled();
+    expect(buildInjectedValues).not.toHaveBeenCalled();
+    expect(resolvePsqlBin).not.toHaveBeenCalled();
+    expect(executePsqlQuery).not.toHaveBeenCalled();
+  });
+
+  it("starts the tunnel and delegates to executePsqlQuery for read-only queries", async () => {
+    const ensureTunnel = vi.fn(async () => state);
+    const buildInjectedValues = vi.fn(() => config.injectEnv);
+    const resolvePsqlBin = vi.fn(() => "/custom/bin/psql");
+    const executePsqlQuery = vi.fn(async () => ({
+      text: "id,name\n1,Alice",
+      details: {
+        query: "SELECT 1",
+        format: "table" as const,
+        tunnelPort: state.port,
+        endpoint: state.endpoint,
+        logPath: state.logPath,
+        configPath: config.path,
+        streaming: false,
+        outputPreview: "id,name\n1,Alice",
+      },
+    }));
+    const truncateOutput = vi.fn((text: string) => ({
+      content: text,
+      truncated: false,
+      outputLines: text.split("\n").length,
+      totalLines: text.split("\n").length,
+      outputBytes: Buffer.byteLength(text, "utf8"),
+      totalBytes: Buffer.byteLength(text, "utf8"),
+    }));
+    const formatBytes = vi.fn((bytes: number) => `${bytes}B`);
+    const onUpdate = vi.fn();
+    const signal = new AbortController().signal;
+
+    const result = await runPsqlQueryWithTunnel(
+      config,
+      "SELECT 1",
+      "table",
+      { hasUI: false },
+      signal,
+      onUpdate,
+      {
+        ensureTunnel,
+        buildInjectedValues,
+        resolvePsqlBin,
+        executePsqlQuery,
+        truncateOutput,
+        formatBytes,
+        maxOutputLines: 2000,
+        maxOutputBytes: 50 * 1024,
+      },
+    );
+
+    expect(ensureTunnel).toHaveBeenCalledWith(config, { hasUI: false });
+    expect(buildInjectedValues).toHaveBeenCalledWith(config, state);
+    expect(resolvePsqlBin).toHaveBeenCalledWith({ configuredPath: config.psqlBin });
+    expect(executePsqlQuery).toHaveBeenCalledWith({
+      psqlBin: "/custom/bin/psql",
+      configPath: config.path,
+      query: "SELECT 1",
+      format: "table",
+      state,
+      injectedEnv: config.injectEnv,
+      signal,
+      onUpdate,
+      truncateOutput,
+      formatBytes,
+      maxOutputLines: 2000,
+      maxOutputBytes: 50 * 1024,
+    });
+    expect(result.text).toBe("id,name\n1,Alice");
+  });
+});

--- a/neon-psql/query-runner.ts
+++ b/neon-psql/query-runner.ts
@@ -1,0 +1,68 @@
+import { isReadOnlyQuery, type SourceValues } from "./helpers.js";
+import {
+  type ExecutePsqlQueryOptions,
+  type OutputFormat,
+  type PsqlDetails,
+  type PsqlPartialUpdate,
+} from "./query-execution.js";
+import type { ResolvedConfig } from "./settings.js";
+
+export interface PsqlTunnelState {
+  port: number;
+  endpoint: string;
+  logPath: string;
+  source: SourceValues;
+}
+
+export interface RunPsqlQueryWithTunnelDependencies<
+  TContext,
+  TState extends PsqlTunnelState = PsqlTunnelState,
+> {
+  ensureTunnel: (config: ResolvedConfig, ctx: TContext) => Promise<TState>;
+  buildInjectedValues: (config: ResolvedConfig, state: TState) => Record<string, string>;
+  resolvePsqlBin: (options: { configuredPath?: string }) => string;
+  executePsqlQuery: (
+    options: ExecutePsqlQueryOptions,
+  ) => Promise<{ text: string; details: PsqlDetails }>;
+  truncateOutput: ExecutePsqlQueryOptions["truncateOutput"];
+  formatBytes: ExecutePsqlQueryOptions["formatBytes"];
+  maxOutputLines: number;
+  maxOutputBytes: number;
+}
+
+export async function runPsqlQueryWithTunnel<
+  TContext,
+  TState extends PsqlTunnelState = PsqlTunnelState,
+>(
+  config: ResolvedConfig,
+  query: string,
+  format: OutputFormat,
+  ctx: TContext,
+  signal: AbortSignal | undefined,
+  onUpdate: ((update: PsqlPartialUpdate) => void) | undefined,
+  dependencies: RunPsqlQueryWithTunnelDependencies<TContext, TState>,
+): Promise<{ text: string; details: PsqlDetails }> {
+  if (!isReadOnlyQuery(query)) {
+    throw new Error(
+      "The psql extension only allows read-only queries and psql inspection meta-commands (e.g. SELECT, WITH, SHOW, EXPLAIN, VALUES, TABLE, \\d, \\dt).",
+    );
+  }
+
+  const state = await dependencies.ensureTunnel(config, ctx);
+  const injected = dependencies.buildInjectedValues(config, state);
+
+  return dependencies.executePsqlQuery({
+    psqlBin: dependencies.resolvePsqlBin({ configuredPath: config.psqlBin }),
+    configPath: config.path,
+    query,
+    format,
+    state,
+    injectedEnv: injected,
+    signal,
+    onUpdate,
+    truncateOutput: dependencies.truncateOutput,
+    formatBytes: dependencies.formatBytes,
+    maxOutputLines: dependencies.maxOutputLines,
+    maxOutputBytes: dependencies.maxOutputBytes,
+  });
+}


### PR DESCRIPTION
## Summary
- extract the psql process execution path into a focused helper module
- add unit coverage for read-only rejection, spawn args/env, streaming updates, truncation, spawn failures, and abort handling
- keep the extension entrypoint as a thin wrapper around tunnel setup plus the tested execution helper

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test