### PR TITLE
feat: add Slack scheduled message tool (#33)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -25,6 +25,7 @@ If the agent is idle, incoming messages are processed immediately.
 | ----------------------------------------------------------------------------------- | -------------------------------------------- |
 | `slack_send(text, thread_ts?)`                                                      | Reply in a thread or start new               |
 | `slack_upload(content?, path?, filename?, filetype?, title?, channel?, thread_ts?)` | Upload a file/snippet into Slack or a thread |
+| `slack_schedule(text, channel?, thread_ts?, delay?, at?)`                           | Schedule a Slack message for later           |
 | `slack_read(thread_ts, limit?)`                                                     | Read thread messages                         |
 | `slack_inbox()`                                                                     | Check pending messages manually              |
 | `slack_create_channel(name, topic?, purpose?)`                                      | Create a project channel                     |
@@ -37,6 +38,9 @@ If the agent is idle, incoming messages are processed immediately.
 safety, local uploads are limited to files inside the current working directory
 or the system temp directory.
 
+`slack_schedule` supports delayed messages via `delay` (for example `30m` or
+`2h`) and absolute scheduling via `at` (ISO-8601 UTC timestamp).
+
 ## Features
 
 - **Slack Assistant** — appears in Slack's sidebar, native conversation UI
@@ -48,6 +52,7 @@ or the system temp directory.
 - **@mentions** — tag Pinet in any channel and it responds in-thread
 - **Channel & canvas tools** — create/read/post in channels and maintain persistent Slack canvases
 - **File & snippet uploads** — share diffs, logs, screenshots, exports, and long code snippets without pasting giant messages
+- **Scheduled & delayed messages** — queue reminders, timed announcements, and follow-ups without waiting around
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
 - **Remote agent control** — send `/reload` or `/exit` to another Pinet agent
@@ -121,8 +126,9 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 ## Manifest
 
 The `manifest.yaml` includes all required scopes and events, including `files:write`
-for `slack_upload`. Use it when creating the app (**From a manifest**) or paste
-it into **App Manifest** in settings.
+for `slack_upload`. `slack_schedule` uses Slack's existing `chat:write` scope, so
+no extra manifest scope is required. Use it when creating the app (**From a
+manifest**) or paste it into **App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:
 

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -96,9 +96,11 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("slack_create_channel")).toBe(true);
     expect(WRITE_TOOLS.has("slack_post_channel")).toBe(true);
     expect(WRITE_TOOLS.has("slack_upload")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_schedule")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_post_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_upload")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_schedule")).toBe(false);
   });
 
   it("combines readOnly and blockedTools", () => {

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -35,6 +35,7 @@ export const WRITE_TOOLS = new Set([
   "slack_create_channel",
   "slack_post_channel",
   "slack_upload",
+  "slack_schedule",
   "pinet_schedule",
 ]);
 

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -40,6 +40,17 @@ describe("registerSlackTools", () => {
         } as SlackResult;
       }
 
+      if (method === "chat.scheduleMessage") {
+        return {
+          ok: true,
+          token,
+          body,
+          channel: typeof body?.channel === "string" ? body.channel : "C123",
+          post_at: typeof body?.post_at === "number" ? body.post_at : 1_800_000_000,
+          scheduled_message_id: "Q12345",
+        } as SlackResult;
+      }
+
       return {
         ok: true,
         token,
@@ -144,5 +155,56 @@ describe("registerSlackTools", () => {
       ts: "123.456",
       limit: 20,
     });
+  });
+
+  it("reads the latest bot token and default channel when slack_schedule executes", async () => {
+    const { slack, tools, setBotToken, setDefaultChannel } = setup();
+    setBotToken("xoxb-reloaded");
+    setDefaultChannel("ops-alerts");
+
+    await tools.get("slack_schedule")!.execute("tool-4", {
+      text: "hello from the future",
+      at: "2030-01-02T03:04:05Z",
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "chat.scheduleMessage",
+      "xoxb-reloaded",
+      expect.objectContaining({
+        channel: "resolved:ops-alerts",
+        text: "hello from the future",
+        post_at: Math.floor(Date.parse("2030-01-02T03:04:05Z") / 1000),
+      }),
+    );
+  });
+
+  it("uses thread channel resolution for slack_schedule delays", async () => {
+    const { slack, tools, setResolveFollowerReplyChannel } = setup();
+    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-02T14:00:00Z"));
+    try {
+      await tools.get("slack_schedule")!.execute("tool-5", {
+        text: "follow up later",
+        thread_ts: "123.456",
+        delay: "30m",
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(slack).toHaveBeenCalledWith(
+      "chat.scheduleMessage",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel: "C-DB",
+        thread_ts: "123.456",
+        text: "follow up later",
+        post_at: Math.floor(Date.parse("2026-04-02T14:30:00.000Z") / 1000),
+      }),
+    );
   });
 });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -11,6 +11,7 @@ import {
   normalizeSlackCanvasUpdateMode,
   pickSlackCanvasSectionId,
 } from "./canvases.js";
+import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
 
 export interface RegisterSlackToolsDeps {
@@ -48,6 +49,7 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "Security guardrails may be active for Slack-triggered actions. Check the current security prompt in each message for restrictions.",
     "When a tool requires confirmation, call slack_confirm_action first and wait for approval in the same thread.",
     "Use slack_upload instead of giant inline code blocks when sharing diffs, logs, screenshots, generated files, or long snippets.",
+    "Use slack_schedule for reminders, timed announcements, and delayed follow-ups instead of waiting around to send a message later.",
     "When uploading from a local path, only files inside the current working directory or the system temp directory are allowed.",
   ];
 }
@@ -111,7 +113,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     };
   }
 
-  async function resolveUploadChannel(
+  async function resolveSlackTargetChannel(
     threadTs: string | undefined,
     channel: string | undefined,
   ): Promise<string> {
@@ -309,7 +311,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       );
 
       const upload = await prepareSlackUpload(params, process.cwd(), os.tmpdir());
-      const channelId = await resolveUploadChannel(params.thread_ts, params.channel);
+      const channelId = await resolveSlackTargetChannel(params.thread_ts, params.channel);
       const { fileId, response } = await performSlackUpload({
         upload,
         channelId,
@@ -508,6 +510,82 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           },
         ],
         details: { ts, channel: channelId },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_schedule",
+    label: "Slack Schedule",
+    description:
+      "Schedule a Slack message for later using chat.scheduleMessage. Supports relative delays and absolute times.",
+    promptSnippet:
+      "Schedule a Slack message for later instead of waiting around. Use it for reminders, timed announcements, and delayed follow-ups.",
+    parameters: Type.Object({
+      text: Type.String({ description: "Message text (Slack markdown)" }),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Channel name or ID. Omit to use the current thread channel, active DM, or defaultChannel.",
+        }),
+      ),
+      thread_ts: Type.Optional(
+        Type.String({ description: "Optional thread timestamp to reply in later" }),
+      ),
+      delay: Type.Optional(
+        Type.String({ description: "Relative delay like 5m, 30s, 1h30m, or 1d" }),
+      ),
+      at: Type.Optional(
+        Type.String({ description: "Absolute ISO-8601 UTC time, e.g. 2026-04-02T14:30:00Z" }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_schedule",
+        params.thread_ts,
+        `channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | delay=${params.delay ?? ""} | at=${params.at ?? ""} | text=${params.text}`,
+      );
+
+      const text = params.text.trim();
+      if (!text) {
+        throw new Error("text is required");
+      }
+
+      const channelId = await resolveSlackTargetChannel(params.thread_ts, params.channel);
+      const fireAt = resolveScheduledWakeupFireAt({ delay: params.delay, at: params.at });
+      const postAt = Math.floor(Date.parse(fireAt) / 1000);
+
+      const body: Record<string, unknown> = {
+        channel: channelId,
+        text,
+        post_at: postAt,
+      };
+      if (params.thread_ts) {
+        body.thread_ts = params.thread_ts;
+      }
+
+      const response = await slack("chat.scheduleMessage", getBotToken(), body);
+      const scheduledMessageId =
+        typeof response.scheduled_message_id === "string"
+          ? response.scheduled_message_id
+          : undefined;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: params.thread_ts
+              ? `Scheduled message for ${fireAt} in thread ${params.thread_ts}.`
+              : `Scheduled message for ${fireAt} in channel ${params.channel ?? channelId}.`,
+          },
+        ],
+        details: {
+          channel: channelId,
+          post_at: postAt,
+          fire_at: fireAt,
+          ...(scheduledMessageId ? { scheduled_message_id: scheduledMessageId } : {}),
+          ...(params.thread_ts ? { thread_ts: params.thread_ts } : {}),
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
- add a `slack_schedule` tool backed by `chat.scheduleMessage`
- support delayed scheduling with `delay` and absolute scheduling with `at`
- document the new tool and mark it as a Slack write tool for guardrails

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #33