### PR TITLE
feat: add Slack pinning and bookmarks tools (#25)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -26,6 +26,8 @@ If the agent is idle, incoming messages are processed immediately.
 | `slack_send(text, thread_ts?)`                                                      | Reply in a thread or start new               |
 | `slack_upload(content?, path?, filename?, filetype?, title?, channel?, thread_ts?)` | Upload a file/snippet into Slack or a thread |
 | `slack_schedule(text, channel?, thread_ts?, delay?, at?)`                           | Schedule a Slack message for later           |
+| `slack_pin(action, message_ts, channel?, thread_ts?)`                               | Pin or unpin a Slack message                 |
+| `slack_bookmark(action, channel?, thread_ts?, title?, url?, emoji?, bookmark_id?)`  | Add, list, or remove channel bookmarks       |
 | `slack_read(thread_ts, limit?)`                                                     | Read thread messages                         |
 | `slack_inbox()`                                                                     | Check pending messages manually              |
 | `slack_create_channel(name, topic?, purpose?)`                                      | Create a project channel                     |
@@ -41,6 +43,10 @@ or the system temp directory.
 `slack_schedule` supports delayed messages via `delay` (for example `30m` or
 `2h`) and absolute scheduling via `at` (ISO-8601 UTC timestamp).
 
+`slack_pin` highlights a specific Slack message by timestamp. `slack_bookmark`
+manages durable channel-header links such as repos, dashboards, docs, and
+runbooks.
+
 ## Features
 
 - **Slack Assistant** — appears in Slack's sidebar, native conversation UI
@@ -53,6 +59,7 @@ or the system temp directory.
 - **Channel & canvas tools** — create/read/post in channels and maintain persistent Slack canvases
 - **File & snippet uploads** — share diffs, logs, screenshots, exports, and long code snippets without pasting giant messages
 - **Scheduled & delayed messages** — queue reminders, timed announcements, and follow-ups without waiting around
+- **Pins & bookmarks** — highlight key messages and manage durable channel-header links
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
 - **Remote agent control** — send `/reload` or `/exit` to another Pinet agent
@@ -126,8 +133,8 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 ## Manifest
 
 The `manifest.yaml` includes all required scopes and events, including `files:write`
-for `slack_upload`. `slack_schedule` uses Slack's existing `chat:write` scope, so
-no extra manifest scope is required. Use it when creating the app (**From a
+for `slack_upload`, `chat:write` for `slack_schedule`, and bookmark/pin scopes
+for `slack_bookmark` and `slack_pin`. Use it when creating the app (**From a
 manifest**) or paste it into **App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -97,10 +97,14 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("slack_post_channel")).toBe(true);
     expect(WRITE_TOOLS.has("slack_upload")).toBe(true);
     expect(WRITE_TOOLS.has("slack_schedule")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_pin")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_bookmark")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_post_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_upload")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_schedule")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_pin")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_bookmark")).toBe(false);
   });
 
   it("combines readOnly and blockedTools", () => {

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -36,6 +36,8 @@ export const WRITE_TOOLS = new Set([
   "slack_post_channel",
   "slack_upload",
   "slack_schedule",
+  "slack_pin",
+  "slack_bookmark",
   "pinet_schedule",
 ]);
 

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -24,6 +24,8 @@ oauth_config:
       - channels:read
       - chat:write
       - files:write
+      - bookmarks:read
+      - bookmarks:write
       - groups:history
       - groups:read
       - im:history
@@ -33,6 +35,8 @@ oauth_config:
       - reactions:read
       - canvases:read
       - canvases:write
+      - pins:read
+      - pins:write
   pkce_enabled: false
 settings:
   event_subscriptions:

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -51,6 +51,52 @@ describe("registerSlackTools", () => {
         } as SlackResult;
       }
 
+      if (method === "pins.add" || method === "pins.remove") {
+        return {
+          ok: true,
+          token,
+          body,
+        } as SlackResult;
+      }
+
+      if (method === "bookmarks.add") {
+        return {
+          ok: true,
+          token,
+          body,
+          bookmark: {
+            id: "Bk123",
+            title: body?.title,
+            link: body?.link,
+            emoji: body?.emoji,
+          },
+        } as SlackResult;
+      }
+
+      if (method === "bookmarks.list") {
+        return {
+          ok: true,
+          token,
+          body,
+          bookmarks: [
+            {
+              id: "Bk123",
+              title: "Repo",
+              link: "https://github.com/gugu91/extensions",
+              emoji: ":rabbit:",
+            },
+          ],
+        } as SlackResult;
+      }
+
+      if (method === "bookmarks.remove") {
+        return {
+          ok: true,
+          token,
+          body,
+        } as SlackResult;
+      }
+
       return {
         ok: true,
         token,
@@ -206,5 +252,109 @@ describe("registerSlackTools", () => {
         post_at: Math.floor(Date.parse("2026-04-02T14:30:00.000Z") / 1000),
       }),
     );
+  });
+
+  it("handles already_pinned gracefully", async () => {
+    const { slack, tools, setResolveFollowerReplyChannel } = setup();
+    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+    slack.mockImplementationOnce(async () => {
+      throw new Error("Slack pins.add: already_pinned");
+    });
+
+    const response = await tools.get("slack_pin")!.execute("tool-6", {
+      action: "pin",
+      message_ts: "123.789",
+      thread_ts: "123.456",
+    });
+
+    expect(slack).toHaveBeenCalledWith("pins.add", "xoxb-initial", {
+      channel: "C-DB",
+      timestamp: "123.789",
+    });
+    expect(response.details?.status).toBe("already_pinned");
+  });
+
+  it("handles no_pin gracefully when unpinning", async () => {
+    const { slack, tools, setDefaultChannel } = setup();
+    setDefaultChannel("ops-alerts");
+    slack.mockImplementationOnce(async () => {
+      throw new Error("Slack pins.remove: no_pin");
+    });
+
+    const response = await tools.get("slack_pin")!.execute("tool-7", {
+      action: "unpin",
+      message_ts: "123.789",
+    });
+
+    expect(slack).toHaveBeenCalledWith("pins.remove", "xoxb-initial", {
+      channel: "resolved:ops-alerts",
+      timestamp: "123.789",
+    });
+    expect(response.details?.status).toBe("not_pinned");
+  });
+
+  it("adds channel bookmarks", async () => {
+    const { slack, tools, setDefaultChannel } = setup();
+    setDefaultChannel("docs");
+
+    const response = await tools.get("slack_bookmark")!.execute("tool-8", {
+      action: "add",
+      title: "Repo",
+      url: "https://github.com/gugu91/extensions",
+      emoji: ":rocket:",
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "bookmarks.add",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel_id: "resolved:docs",
+        title: "Repo",
+        type: "link",
+        link: "https://github.com/gugu91/extensions",
+        emoji: ":rocket:",
+      }),
+    );
+    expect(response.details?.bookmark_id).toBe("Bk123");
+  });
+
+  it("lists bookmarks from the resolved thread channel", async () => {
+    const { slack, tools, setResolveFollowerReplyChannel } = setup();
+    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+
+    const response = await tools.get("slack_bookmark")!.execute("tool-9", {
+      action: "list",
+      thread_ts: "123.456",
+    });
+
+    expect(slack).toHaveBeenCalledWith("bookmarks.list", "xoxb-initial", {
+      channel_id: "C-DB",
+    });
+    expect(response.content?.[0]?.text).toContain("Bk123");
+  });
+
+  it("handles missing bookmarks gracefully when removing", async () => {
+    const { slack, tools, setDefaultChannel } = setup();
+    setDefaultChannel("docs");
+    slack.mockImplementationOnce(async () => {
+      throw new Error("Slack bookmarks.remove: not_found");
+    });
+
+    const response = await tools.get("slack_bookmark")!.execute("tool-10", {
+      action: "remove",
+      bookmark_id: "Bk404",
+    });
+
+    expect(slack).toHaveBeenCalledWith("bookmarks.remove", "xoxb-initial", {
+      channel_id: "resolved:docs",
+      bookmark_id: "Bk404",
+    });
+    expect(response.details?.status).toBe("not_found");
   });
 });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -50,6 +50,7 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "When a tool requires confirmation, call slack_confirm_action first and wait for approval in the same thread.",
     "Use slack_upload instead of giant inline code blocks when sharing diffs, logs, screenshots, generated files, or long snippets.",
     "Use slack_schedule for reminders, timed announcements, and delayed follow-ups instead of waiting around to send a message later.",
+    "Use slack_pin for important Slack messages you want highlighted in the conversation, and use slack_bookmark for durable channel-header links like repos, dashboards, docs, and runbooks.",
     "When uploading from a local path, only files inside the current working directory or the system temp directory are allowed.",
   ];
 }
@@ -59,6 +60,50 @@ function getSlackCanvasSummary(markdown?: string): string {
   const collapsed = markdown.replace(/\s+/g, " ").trim();
   if (collapsed.length <= 80) return collapsed;
   return `${collapsed.slice(0, 77)}...`;
+}
+
+function isSlackMethodError(err: unknown, method: string, ...codes: string[]): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  return codes.some((code) => err.message.includes(`Slack ${method}: ${code}`));
+}
+
+function normalizeSlackPinAction(action: string): "pin" | "unpin" {
+  const normalized = action.trim().toLowerCase();
+  if (normalized === "pin" || normalized === "unpin") {
+    return normalized;
+  }
+  throw new Error("action must be 'pin' or 'unpin'.");
+}
+
+function normalizeSlackBookmarkAction(action: string): "add" | "remove" | "list" {
+  const normalized = action.trim().toLowerCase();
+  if (normalized === "add" || normalized === "remove" || normalized === "list") {
+    return normalized;
+  }
+  throw new Error("action must be 'add', 'remove', or 'list'.");
+}
+
+function normalizeSlackBookmarkUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    throw new Error("url is required when action='add'.");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("url must be an absolute http(s) URL.");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("url must use http or https.");
+  }
+
+  return parsed.toString();
 }
 
 export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDeps): void {
@@ -510,6 +555,248 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           },
         ],
         details: { ts, channel: channelId },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_pin",
+    label: "Slack Pin",
+    description: "Pin or unpin a Slack message by timestamp.",
+    promptSnippet:
+      "Pin important Slack messages like decisions, confirmations, or follow-up items. Unpin stale ones when they are no longer relevant.",
+    parameters: Type.Object({
+      action: Type.String({ description: "'pin' to pin a message or 'unpin' to remove the pin" }),
+      message_ts: Type.String({ description: "Timestamp (ts) of the message to pin or unpin" }),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Channel name or ID. Omit to use the current thread channel, active DM, or defaultChannel.",
+        }),
+      ),
+      thread_ts: Type.Optional(
+        Type.String({
+          description: "Optional thread timestamp used to resolve the current channel",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_pin",
+        params.thread_ts,
+        `action=${params.action} | channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | message_ts=${params.message_ts}`,
+      );
+
+      const action = normalizeSlackPinAction(params.action);
+      const messageTs = params.message_ts.trim();
+      if (!messageTs) {
+        throw new Error("message_ts is required.");
+      }
+
+      const channelId = await resolveSlackTargetChannel(params.thread_ts, params.channel);
+      const method = action === "pin" ? "pins.add" : "pins.remove";
+      const body = { channel: channelId, timestamp: messageTs };
+
+      try {
+        await slack(method, getBotToken(), body);
+      } catch (err) {
+        if (action === "pin" && isSlackMethodError(err, "pins.add", "already_pinned")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Message ${messageTs} is already pinned in channel ${params.channel ?? channelId}.`,
+              },
+            ],
+            details: {
+              channel: channelId,
+              message_ts: messageTs,
+              action,
+              status: "already_pinned",
+            },
+          };
+        }
+
+        if (action === "unpin" && isSlackMethodError(err, "pins.remove", "no_pin", "not_pinned")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Message ${messageTs} is not currently pinned in channel ${params.channel ?? channelId}.`,
+              },
+            ],
+            details: { channel: channelId, message_ts: messageTs, action, status: "not_pinned" },
+          };
+        }
+
+        throw err;
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              action === "pin"
+                ? `Pinned message ${messageTs} in channel ${params.channel ?? channelId}.`
+                : `Unpinned message ${messageTs} in channel ${params.channel ?? channelId}.`,
+          },
+        ],
+        details: {
+          channel: channelId,
+          message_ts: messageTs,
+          action,
+          status: action === "pin" ? "pinned" : "unpinned",
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_bookmark",
+    label: "Slack Bookmark",
+    description:
+      "Add, list, or remove channel bookmarks for durable links like repos, dashboards, docs, and runbooks.",
+    promptSnippet:
+      "Use bookmarks for persistent channel-header links. Add repos, dashboards, docs, and runbooks; list existing bookmarks; remove stale ones by ID.",
+    parameters: Type.Object({
+      action: Type.String({ description: "'add', 'list', or 'remove'" }),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Channel name or ID. Omit to use the current thread channel, active DM, or defaultChannel.",
+        }),
+      ),
+      thread_ts: Type.Optional(
+        Type.String({
+          description: "Optional thread timestamp used to resolve the current channel",
+        }),
+      ),
+      title: Type.Optional(
+        Type.String({ description: "Bookmark title (required when action='add')" }),
+      ),
+      url: Type.Optional(Type.String({ description: "Bookmark URL (required when action='add')" })),
+      emoji: Type.Optional(
+        Type.String({ description: "Optional emoji label for the bookmark, e.g. :rocket:" }),
+      ),
+      bookmark_id: Type.Optional(
+        Type.String({ description: "Bookmark ID (required when action='remove')" }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_bookmark",
+        params.thread_ts,
+        `action=${params.action} | channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | title=${params.title ?? ""} | url=${params.url ?? ""} | bookmark_id=${params.bookmark_id ?? ""}`,
+      );
+
+      const action = normalizeSlackBookmarkAction(params.action);
+      const channelId = await resolveSlackTargetChannel(params.thread_ts, params.channel);
+      const channelLabel = params.channel ?? channelId;
+
+      if (action === "list") {
+        const response = await slack("bookmarks.list", getBotToken(), { channel_id: channelId });
+        const bookmarks = Array.isArray(response.bookmarks)
+          ? (response.bookmarks as Array<Record<string, unknown>>)
+          : [];
+        const lines = bookmarks.map((bookmark) => {
+          const id = typeof bookmark.id === "string" ? bookmark.id : "(unknown-id)";
+          const title = typeof bookmark.title === "string" ? bookmark.title : "(untitled)";
+          const link = typeof bookmark.link === "string" ? bookmark.link : "(no link)";
+          const emoji =
+            typeof bookmark.emoji === "string" && bookmark.emoji.length > 0
+              ? `${bookmark.emoji} `
+              : "";
+          return `- ${id}: ${emoji}${title} -> ${link}`;
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                lines.length > 0
+                  ? `Bookmarks in ${channelLabel}:\n${lines.join("\n")}`
+                  : `No bookmarks found in ${channelLabel}.`,
+            },
+          ],
+          details: { channel: channelId, count: bookmarks.length, bookmarks },
+        };
+      }
+
+      if (action === "add") {
+        const title = params.title?.trim();
+        if (!title) {
+          throw new Error("title is required when action='add'.");
+        }
+
+        const link = normalizeSlackBookmarkUrl(params.url ?? "");
+        const emoji = params.emoji?.trim();
+        const response = await slack("bookmarks.add", getBotToken(), {
+          channel_id: channelId,
+          title,
+          type: "link",
+          link,
+          ...(emoji ? { emoji } : {}),
+        });
+        const bookmark =
+          response.bookmark && typeof response.bookmark === "object"
+            ? (response.bookmark as Record<string, unknown>)
+            : undefined;
+        const bookmarkId = bookmark && typeof bookmark.id === "string" ? bookmark.id : undefined;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Added bookmark '${title}' to ${channelLabel}.`,
+            },
+          ],
+          details: {
+            channel: channelId,
+            action,
+            title,
+            url: link,
+            ...(emoji ? { emoji } : {}),
+            ...(bookmarkId ? { bookmark_id: bookmarkId } : {}),
+          },
+        };
+      }
+
+      const bookmarkId = params.bookmark_id?.trim();
+      if (!bookmarkId) {
+        throw new Error("bookmark_id is required when action='remove'.");
+      }
+
+      try {
+        await slack("bookmarks.remove", getBotToken(), {
+          channel_id: channelId,
+          bookmark_id: bookmarkId,
+        });
+      } catch (err) {
+        if (isSlackMethodError(err, "bookmarks.remove", "not_found")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Bookmark ${bookmarkId} was not found in ${channelLabel}.`,
+              },
+            ],
+            details: { channel: channelId, action, bookmark_id: bookmarkId, status: "not_found" },
+          };
+        }
+
+        throw err;
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Removed bookmark ${bookmarkId} from ${channelLabel}.`,
+          },
+        ],
+        details: { channel: channelId, action, bookmark_id: bookmarkId, status: "removed" },
       };
     },
   });


### PR DESCRIPTION
## Summary
- add `slack_pin` for pinning and unpinning Slack messages by timestamp
- add `slack_bookmark` for adding, listing, and removing channel bookmarks
- add required bookmark and pin scopes to the Slack manifest and document the new tools

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #25