### PR TITLE
feat: add reaction-triggered Slack actions

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -24,6 +24,7 @@ If the agent is idle, incoming messages are processed immediately.
 | Tool                                                                                | Description                                  |
 | ----------------------------------------------------------------------------------- | -------------------------------------------- |
 | `slack_send(text, thread_ts?)`                                                      | Reply in a thread or start new               |
+| `slack_react(emoji, thread_ts?, timestamp?, channel?)`                              | Add an emoji reaction to a Slack message     |
 | `slack_upload(content?, path?, filename?, filetype?, title?, channel?, thread_ts?)` | Upload a file/snippet into Slack or a thread |
 | `slack_schedule(text, channel?, thread_ts?, delay?, at?)`                           | Schedule a Slack message for later           |
 | `slack_pin(action, message_ts, channel?, thread_ts?)`                               | Pin or unpin a Slack message                 |
@@ -57,7 +58,7 @@ files, canvases, or follow-up summaries.
 - **Slack Assistant** — appears in Slack's sidebar, native conversation UI
 - **Queued inbox** — messages don't interrupt the agent mid-task
 - **Auto-drain** — inbox processed when agent is idle or finishes a task
-- **Reactions** — 👀 on receive, removed on reply
+- **Reactions** — 👀 on receive, removed on reply; reaction-triggered commands can queue work from emoji alone
 - **Suggested prompts** — shown when a user opens a new conversation
 - **Multi-user** — handles concurrent conversations from different users
 - **@mentions** — tag Pinet in any channel and it responds in-thread
@@ -103,6 +104,13 @@ Add to `~/.pi/agent/settings.json`:
     "appConfigToken": "xoxe.xoxp-...",
     "allowedUsers": ["U09GWL270LA"],
     "defaultChannel": "C0APL58LB1R",
+    "reactionCommands": {
+      "📝": "summarize",
+      "🐛": "file-issue",
+      "👀": "review",
+      "✅": "approve",
+      "🔄": "retry"
+    },
     "suggestedPrompts": [
       { "title": "Status", "message": "What are you working on?" },
       { "title": "Help", "message": "I need help with something" }
@@ -119,6 +127,7 @@ Add to `~/.pi/agent/settings.json`:
 | `appConfigToken`   | deploy   | App configuration token (`xoxe.xoxp-...`)        |
 | `allowedUsers`     | no       | Slack user IDs allowed to interact               |
 | `defaultChannel`   | no       | Default channel for `slack_post_channel`         |
+| `reactionCommands` | no       | Emoji/name → action mapping for `reaction_added` |
 | `suggestedPrompts` | no       | Prompts shown on new assistant thread            |
 
 > Runtime tokens can also be set via `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`
@@ -127,6 +136,11 @@ Add to `~/.pi/agent/settings.json`:
 > Manifest deploy also reads `SLACK_APP_ID` and `SLACK_APP_CONFIG_TOKEN`
 > (or `SLACK_CONFIG_TOKEN`). The Socket Mode `xapp-...` token cannot be used
 > with `apps.manifest.update`.
+
+`reactionCommands` accepts either Slack reaction names (`eyes`, `repeat`) or the
+emoji characters themselves (`👀`, `🔄`). The default mappings include `📝`
+→ summarize and `🐛` → file-issue, and you can extend them with review /
+approve / retry style actions as needed.
 
 ### 4. Install extension
 
@@ -139,9 +153,10 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 ## Manifest
 
 The `manifest.yaml` includes all required scopes and events, including `files:write`
-for `slack_upload`, `chat:write` for `slack_schedule`, and bookmark/pin scopes
-for `slack_bookmark` and `slack_pin`. Use it when creating the app (**From a
-manifest**) or paste it into **App Manifest** in settings.
+for `slack_upload`, `chat:write` for `slack_schedule`, bookmark/pin scopes for
+`slack_bookmark` and `slack_pin`, and `reaction_added` + `reactions:read` for
+emoji-triggered actions. Use it when creating the app (**From a manifest**) or
+paste it into **App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -484,6 +484,14 @@ describe("SlackAdapter", () => {
     expect(adapter.name).toBe("slack");
   });
 
+  it("can be constructed with reactionCommands", () => {
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      reactionCommands: { "👀": "review" },
+    });
+    expect(adapter.name).toBe("slack");
+  });
+
   it("can be constructed with isKnownThread callback", () => {
     const adapter = new SlackAdapter({
       ...baseConfig,
@@ -563,6 +571,119 @@ describe("SlackAdapter — allowlist filtering", () => {
 });
 
 // ─── SlackAdapter — send (mocked fetch) ─────────────────
+
+describe("SlackAdapter — reaction triggers", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn<typeof fetch>();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockSlackResponse(data: Record<string, unknown> = {}) {
+    return new Response(JSON.stringify({ ok: true, ...data }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("queues mapped reaction_added events with structured context and acknowledges with ✅", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.history")) {
+        return mockSlackResponse({
+          messages: [
+            {
+              ts: "111.333",
+              thread_ts: "111.222",
+              text: "Please review PR #210",
+              user: "U_TARGET",
+            },
+          ],
+        });
+      }
+
+      if (url.endsWith("/users.info")) {
+        if (parsedBody.user === "U_REACTOR") {
+          return mockSlackResponse({ user: { real_name: "Alice" } });
+        }
+        if (parsedBody.user === "U_TARGET") {
+          return mockSlackResponse({ user: { real_name: "Bob" } });
+        }
+      }
+
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const rememberKnownThread = vi.fn();
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      reactionCommands: { "👀": "review" },
+      rememberKnownThread,
+    });
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as { onReactionAdded: (evt: Record<string, unknown>) => Promise<void> }
+    ).onReactionAdded({
+      type: "reaction_added",
+      user: "U_REACTOR",
+      reaction: "eyes",
+      item_user: "U_TARGET",
+      item: {
+        type: "message",
+        channel: "C123",
+        ts: "111.333",
+      },
+      event_ts: "999.000",
+    });
+
+    expect(rememberKnownThread).toHaveBeenCalledWith("111.222", "C123");
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        threadId: "111.222",
+        channel: "C123",
+        userId: "U_REACTOR",
+        userName: "Alice",
+        timestamp: "999.000",
+      }),
+    );
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("Reaction trigger from Slack:");
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("- action: review");
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("Please review PR #210");
+
+    const reactionCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/reactions.add"),
+    );
+    expect(reactionCall).toBeDefined();
+    const reactionBody = JSON.parse(reactionCall?.[1]?.body as string) as Record<string, unknown>;
+    expect(reactionBody).toEqual({
+      channel: "C123",
+      timestamp: "111.333",
+      name: "white_check_mark",
+    });
+  });
+});
 
 describe("SlackAdapter — send", () => {
   let originalFetch: typeof globalThis.fetch;

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -6,6 +6,12 @@ import {
   isUserAllowed,
   stripBotMention,
 } from "../../helpers.js";
+import {
+  buildReactionTriggerMessage,
+  normalizeReactionName,
+  resolveReactionCommands,
+  type ReactionCommandSettings,
+} from "../../reaction-triggers.js";
 import { TtlCache } from "../../ttl-cache.js";
 import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
 
@@ -16,6 +22,7 @@ export interface SlackAdapterConfig {
   appToken: string;
   allowedUsers?: string[];
   suggestedPrompts?: { title: string; message: string }[];
+  reactionCommands?: ReactionCommandSettings;
   /** Check whether a thread_ts belongs to a known thread in the broker DB. */
   isKnownThread?: (threadTs: string) => boolean;
   /** Persist thread metadata in the broker DB without claiming ownership. */
@@ -182,6 +189,7 @@ export class SlackAdapter implements MessageAdapter {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private shuttingDown = false;
   private inboundHandler: ((msg: InboundMessage) => void) | null = null;
+  private readonly reactionCommands: Map<string, { action: string; prompt: string }>;
 
   private readonly threads = new Map<string, SlackThreadInfo>();
   private readonly userNames = new TtlCache<string, string>({
@@ -193,6 +201,7 @@ export class SlackAdapter implements MessageAdapter {
   constructor(config: SlackAdapterConfig) {
     this.config = config;
     this.allowlist = buildAllowlist({ allowedUsers: config.allowedUsers }, undefined);
+    this.reactionCommands = resolveReactionCommands(config.reactionCommands);
   }
 
   private async callSlack(method: string, token: string, body?: Record<string, unknown>) {
@@ -334,6 +343,9 @@ export class SlackAdapter implements MessageAdapter {
       case "message":
         await this.onMessage(evt);
         break;
+      case "reaction_added":
+        await this.onReactionAdded(evt);
+        break;
       case "member_joined_channel":
         this.onMemberJoined(evt);
         break;
@@ -382,6 +394,116 @@ export class SlackAdapter implements MessageAdapter {
         channelId: ctx.channel_id,
         teamId: ctx.team_id ?? "",
       };
+    }
+  }
+
+  private async fetchMessageByTs(
+    channel: string,
+    messageTs: string,
+  ): Promise<Record<string, unknown> | null> {
+    try {
+      const response = await this.callSlack("conversations.history", this.config.botToken, {
+        channel,
+        oldest: messageTs,
+        latest: messageTs,
+        inclusive: true,
+        limit: 1,
+      });
+      const messages = (response.messages as Record<string, unknown>[]) ?? [];
+      return messages.find((message) => message.ts === messageTs) ?? messages[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async onReactionAdded(evt: Record<string, unknown>): Promise<void> {
+    if (this.shuttingDown) return;
+
+    const item = evt.item as { type?: string; channel?: string; ts?: string } | undefined;
+    const userId = evt.user as string | undefined;
+    const rawReaction = evt.reaction as string | undefined;
+    if (!item || item.type !== "message" || !item.channel || !item.ts || !userId || !rawReaction) {
+      return;
+    }
+
+    if (userId === this.botUserId) return;
+
+    let reactionName: string;
+    try {
+      reactionName = normalizeReactionName(rawReaction);
+    } catch {
+      return;
+    }
+
+    const command = this.reactionCommands.get(reactionName);
+    if (!command || !isUserAllowed(this.allowlist, userId)) {
+      return;
+    }
+
+    try {
+      const reactedMessage = await this.fetchMessageByTs(item.channel, item.ts);
+      if (!reactedMessage) {
+        throw new Error(`Unable to fetch reacted message ${item.ts} in channel ${item.channel}`);
+      }
+
+      const threadTs =
+        (reactedMessage.thread_ts as string | undefined) ??
+        (reactedMessage.ts as string | undefined) ??
+        item.ts;
+
+      if (!this.threads.has(threadTs)) {
+        this.threads.set(threadTs, {
+          channelId: item.channel,
+          threadTs,
+          userId: (reactedMessage.user as string | undefined) ?? userId,
+        });
+        try {
+          this.config.rememberKnownThread?.(threadTs, item.channel);
+        } catch {
+          /* best effort — DB cache sync must not break reaction handling */
+        }
+      }
+
+      const reactorName = await this.resolveUser(userId);
+      if (this.shuttingDown) return;
+      const reactedMessageAuthorId =
+        (reactedMessage.user as string | undefined) ?? (evt.item_user as string | undefined);
+      const reactedMessageAuthor = reactedMessageAuthorId
+        ? await this.resolveUser(reactedMessageAuthorId)
+        : (reactedMessage.bot_id as string | undefined)
+          ? "bot"
+          : "unknown";
+      if (this.shuttingDown) return;
+
+      const reactedMessageText =
+        typeof reactedMessage.text === "string" && reactedMessage.text.trim().length > 0
+          ? reactedMessage.text
+          : "(no text)";
+
+      this.inboundHandler?.({
+        source: "slack",
+        threadId: threadTs,
+        channel: item.channel,
+        userId,
+        userName: reactorName,
+        text: buildReactionTriggerMessage({
+          reactionName,
+          command,
+          reactorName,
+          channel: item.channel,
+          threadTs,
+          messageTs: item.ts,
+          reactedMessageText,
+          reactedMessageAuthor,
+        }),
+        timestamp: (evt.event_ts as string) ?? item.ts,
+      });
+
+      await this.addReaction(item.channel, item.ts, "white_check_mark");
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      console.error(`[slack-adapter] reaction trigger failed: ${errorMsg}`);
+      await this.addReaction(item.channel, item.ts, "x");
     }
   }
 

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -99,6 +99,7 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("slack_schedule")).toBe(true);
     expect(WRITE_TOOLS.has("slack_pin")).toBe(true);
     expect(WRITE_TOOLS.has("slack_bookmark")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_react")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_export")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_post_channel")).toBe(false);
@@ -106,6 +107,7 @@ describe("isToolBlocked", () => {
     expect(READ_ONLY_TOOLS.has("slack_schedule")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_pin")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_bookmark")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_react")).toBe(false);
   });
 
   it("combines readOnly and blockedTools", () => {

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -39,6 +39,7 @@ export const WRITE_TOOLS = new Set([
   "slack_schedule",
   "slack_pin",
   "slack_bookmark",
+  "slack_react",
   "pinet_schedule",
 ]);
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { ReactionCommandSettings } from "./reaction-triggers.js";
 import { matchesToolPattern } from "./guardrails.js";
 
 // ─── Settings ────────────────────────────────────────────
@@ -13,6 +14,7 @@ export interface SlackBridgeSettings {
   allowedUsers?: string[];
   defaultChannel?: string;
   suggestedPrompts?: { title: string; message: string }[];
+  reactionCommands?: ReactionCommandSettings;
   autoConnect?: boolean;
   autoFollow?: boolean;
   agentName?: string;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -76,6 +76,12 @@ import {
   type SecurityGuardrails,
 } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
+import {
+  buildReactionPromptGuidelines,
+  buildReactionTriggerMessage,
+  normalizeReactionName,
+  resolveReactionCommands,
+} from "./reaction-triggers.js";
 import { startBroker, type Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
@@ -151,6 +157,7 @@ export default function (pi: ExtensionAPI) {
 
   // allowedUsers: settings.json takes priority, env var as fallback
   let allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
+  let reactionCommands = resolveReactionCommands(settings.reactionCommands);
 
   function isUserAllowed(userId: string): boolean {
     return checkUserAllowed(allowedUsers, userId);
@@ -171,6 +178,7 @@ export default function (pi: ExtensionAPI) {
     appToken: string | undefined;
     allowedUsers: Set<string> | null;
     guardrails: SecurityGuardrails;
+    reactionCommands: Map<string, { action: string; prompt: string }>;
     securityPrompt: string;
     agentName: string;
     agentEmoji: string;
@@ -182,6 +190,7 @@ export default function (pi: ExtensionAPI) {
     appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
     allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
     guardrails = settings.security ?? {};
+    reactionCommands = resolveReactionCommands(settings.reactionCommands);
     securityPrompt = buildSecurityPrompt(guardrails);
     const identitySeed = extCtx?.sessionManager.getSessionFile() ?? agentStableId;
     const refreshedIdentity = resolveRuntimeAgentIdentity(
@@ -202,6 +211,7 @@ export default function (pi: ExtensionAPI) {
       appToken,
       allowedUsers: allowedUsers ? new Set(allowedUsers) : null,
       guardrails: structuredClone(guardrails),
+      reactionCommands: new Map(reactionCommands),
       securityPrompt,
       agentName,
       agentEmoji,
@@ -214,6 +224,7 @@ export default function (pi: ExtensionAPI) {
     appToken = snapshot.appToken;
     allowedUsers = snapshot.allowedUsers ? new Set(snapshot.allowedUsers) : null;
     guardrails = structuredClone(snapshot.guardrails);
+    reactionCommands = new Map(snapshot.reactionCommands);
     securityPrompt = snapshot.securityPrompt;
     agentName = snapshot.agentName;
     agentEmoji = snapshot.agentEmoji;
@@ -748,6 +759,9 @@ export default function (pi: ExtensionAPI) {
         case "message":
           if (!evt.subtype && !evt.bot_id) await onMessage(evt, ctx);
           break;
+        case "reaction_added":
+          await onReactionAdded(evt, ctx);
+          break;
         case "member_joined_channel":
           if ((evt.user as string) === botUserId) {
             const ch = evt.channel as string;
@@ -808,6 +822,147 @@ export default function (pi: ExtensionAPI) {
     if (ctx?.channel_id) {
       existing.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
       persistState();
+    }
+  }
+
+  async function fetchSlackMessageByTs(
+    channel: string,
+    messageTs: string,
+  ): Promise<Record<string, unknown> | null> {
+    try {
+      const response = await slack("conversations.history", botToken!, {
+        channel,
+        oldest: messageTs,
+        latest: messageTs,
+        inclusive: true,
+        limit: 1,
+      });
+      const messages = (response.messages as Record<string, unknown>[]) ?? [];
+      return messages.find((message) => message.ts === messageTs) ?? messages[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function onReactionAdded(
+    evt: Record<string, unknown>,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    if (shuttingDown) return;
+
+    const item = evt.item as { type?: string; channel?: string; ts?: string } | undefined;
+    const user = evt.user as string | undefined;
+    const rawReactionName = evt.reaction as string | undefined;
+    if (
+      !item ||
+      item.type !== "message" ||
+      !item.channel ||
+      !item.ts ||
+      !user ||
+      !rawReactionName
+    ) {
+      return;
+    }
+
+    if (user === botUserId) {
+      return;
+    }
+
+    let reactionName: string;
+    try {
+      reactionName = normalizeReactionName(rawReactionName);
+    } catch {
+      return;
+    }
+
+    const command = reactionCommands.get(reactionName);
+    if (!command || !isUserAllowed(user)) {
+      return;
+    }
+
+    try {
+      const reactedMessage = await fetchSlackMessageByTs(item.channel, item.ts);
+      if (!reactedMessage) {
+        throw new Error(`Unable to fetch reacted message ${item.ts} in channel ${item.channel}`);
+      }
+
+      const threadTs =
+        (reactedMessage.thread_ts as string | undefined) ??
+        (reactedMessage.ts as string | undefined) ??
+        item.ts;
+
+      if (!threads.has(threadTs)) {
+        threads.set(threadTs, {
+          channelId: item.channel,
+          threadTs,
+          userId: (reactedMessage.user as string | undefined) ?? user,
+        });
+      }
+
+      const localOwner = threads.get(threadTs)?.owner;
+      if (localOwner && localOwner !== agentName) return;
+
+      if (!localOwner && !unclaimedThreads.has(threadTs)) {
+        const remoteOwner = await resolveThreadOwner(item.channel, threadTs);
+        if (shuttingDown) return;
+        if (remoteOwner && remoteOwner !== agentName) {
+          const thread = threads.get(threadTs);
+          if (thread) thread.owner = remoteOwner;
+          return;
+        }
+        if (remoteOwner === agentName) {
+          const thread = threads.get(threadTs);
+          if (thread) thread.owner = agentName;
+        }
+        if (!remoteOwner) {
+          unclaimedThreads.add(threadTs);
+        }
+      }
+
+      const reactorName = await resolveUser(user);
+      if (shuttingDown) return;
+      const reactedMessageAuthorId =
+        (reactedMessage.user as string | undefined) ?? (evt.item_user as string | undefined);
+      const reactedMessageAuthor = reactedMessageAuthorId
+        ? await resolveUser(reactedMessageAuthorId)
+        : (reactedMessage.bot_id as string | undefined)
+          ? "bot"
+          : "unknown";
+      if (shuttingDown) return;
+
+      const reactedMessageText =
+        typeof reactedMessage.text === "string" && reactedMessage.text.trim().length > 0
+          ? reactedMessage.text
+          : "(no text)";
+      const reactionMessage = buildReactionTriggerMessage({
+        reactionName,
+        command,
+        reactorName,
+        channel: item.channel,
+        threadTs,
+        messageTs: item.ts,
+        reactedMessageText,
+        reactedMessageAuthor,
+      });
+
+      ctx.ui.notify(`${reactorName} reacted with :${reactionName}:`, "info");
+      inbox.push({
+        channel: item.channel,
+        threadTs,
+        userId: user,
+        text: reactionMessage,
+        timestamp: (evt.event_ts as string) ?? item.ts,
+      });
+      persistState();
+      updateBadge();
+      await addReaction(item.channel, item.ts, "white_check_mark");
+
+      if (ctx.isIdle?.()) {
+        drainInbox();
+      }
+    } catch (err) {
+      console.error(`[slack-bridge] reaction trigger failed: ${msg(err)}`);
+      await addReaction(item.channel, item.ts, "x");
     }
   }
 
@@ -1936,6 +2091,7 @@ export default function (pi: ExtensionAPI) {
       appToken: appToken!,
       allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
       suggestedPrompts: settings.suggestedPrompts,
+      reactionCommands: settings.reactionCommands,
       isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
       rememberKnownThread: (threadTs: string, channelId: string) => {
         broker.db.updateThread(threadTs, { source: "slack", channel: channelId });
@@ -2755,7 +2911,11 @@ export default function (pi: ExtensionAPI) {
 
   // Inject dynamic identity guidance every turn so reload/session restore keeps prompts in sync.
   pi.on("before_agent_start", async (event) => {
-    const guidelines = [...getIdentityGuidelines(), ...buildAgentPersonalityGuidelines(agentName)];
+    const guidelines = [
+      ...getIdentityGuidelines(),
+      ...buildAgentPersonalityGuidelines(agentName),
+      ...buildReactionPromptGuidelines(),
+    ];
     if (brokerRole === "broker") {
       guidelines.push(...buildBrokerPromptGuidelines(agentEmoji, agentName));
       guidelines.push(buildBrokerToolGuardrailsPrompt());

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -44,6 +44,7 @@ settings:
       - app_mention
       - assistant_thread_started
       - assistant_thread_context_changed
+      - reaction_added
       - message.channels
       - message.groups
       - message.im

--- a/slack-bridge/reaction-triggers.test.ts
+++ b/slack-bridge/reaction-triggers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReactionPromptGuidelines,
+  buildReactionTriggerMessage,
+  formatReactionDisplay,
+  normalizeReactionName,
+  resolveReactionCommands,
+} from "./reaction-triggers.js";
+
+describe("normalizeReactionName", () => {
+  it("normalizes supported emoji characters and Slack aliases", () => {
+    expect(normalizeReactionName("👀")).toBe("eyes");
+    expect(normalizeReactionName(":white_check_mark:")).toBe("white_check_mark");
+    expect(normalizeReactionName("memo")).toBe("memo");
+  });
+
+  it("throws for unsupported raw emoji input", () => {
+    expect(() => normalizeReactionName("💥")).toThrow("Unsupported reaction");
+  });
+});
+
+describe("resolveReactionCommands", () => {
+  it("provides default mappings for summary and file-issue triggers", () => {
+    const commands = resolveReactionCommands(undefined);
+    expect(commands.get("memo")?.action).toBe("summarize");
+    expect(commands.get("bug")?.action).toBe("file-issue");
+  });
+
+  it("merges custom settings keyed by emoji or alias", () => {
+    const commands = resolveReactionCommands({
+      "👀": "review",
+      ":repeat:": { action: "retry", prompt: "Retry the prior response right now." },
+    });
+
+    expect(commands.get("eyes")?.action).toBe("review");
+    expect(commands.get("repeat")?.prompt).toBe("Retry the prior response right now.");
+  });
+});
+
+describe("formatReactionDisplay", () => {
+  it("includes both the emoji and Slack reaction name when known", () => {
+    expect(formatReactionDisplay("eyes")).toBe("👀 (:eyes:)");
+  });
+});
+
+describe("buildReactionTriggerMessage", () => {
+  it("formats a structured inbox message with context", () => {
+    const message = buildReactionTriggerMessage({
+      reactionName: "eyes",
+      command: {
+        action: "review",
+        prompt: "Review the referenced message or work item.",
+      },
+      reactorName: "Alice",
+      channel: "C123",
+      threadTs: "111.222",
+      messageTs: "111.333",
+      reactedMessageText: "Please review PR #210",
+      reactedMessageAuthor: "Bob",
+    });
+
+    expect(message).toContain("Reaction trigger from Slack:");
+    expect(message).toContain("- reaction: 👀 (:eyes:)");
+    expect(message).toContain("- action: review");
+    expect(message).toContain("- reacted_message_text: Please review PR #210");
+    expect(message).toContain("Requested action: Review the referenced message or work item.");
+  });
+});
+
+describe("buildReactionPromptGuidelines", () => {
+  it("explains that reaction-triggered requests are structured inbox messages", () => {
+    const joined = buildReactionPromptGuidelines().join(" ");
+    expect(joined).toContain("Reaction trigger from Slack");
+    expect(joined).toContain("emoji reactions");
+  });
+});

--- a/slack-bridge/reaction-triggers.ts
+++ b/slack-bridge/reaction-triggers.ts
@@ -1,0 +1,207 @@
+export interface ReactionCommandTemplate {
+  action: string;
+  prompt: string;
+}
+
+export type ReactionCommandSetting =
+  | string
+  | {
+      action?: string;
+      prompt?: string;
+    };
+
+export type ReactionCommandSettings = Record<string, ReactionCommandSetting>;
+
+const REACTION_ALIASES: Record<string, string> = {
+  "📝": "memo",
+  memo: "memo",
+  "🐛": "bug",
+  bug: "bug",
+  "🔍": "mag",
+  mag: "mag",
+  mag_right: "mag_right",
+  "📌": "pushpin",
+  pushpin: "pushpin",
+  "🌐": "globe_with_meridians",
+  globe_with_meridians: "globe_with_meridians",
+  "🔄": "repeat",
+  repeat: "repeat",
+  "👀": "eyes",
+  eyes: "eyes",
+  "✅": "white_check_mark",
+  white_check_mark: "white_check_mark",
+};
+
+const REACTION_DISPLAY: Record<string, string> = {
+  memo: "📝",
+  bug: "🐛",
+  mag: "🔍",
+  mag_right: "🔎",
+  pushpin: "📌",
+  globe_with_meridians: "🌐",
+  repeat: "🔄",
+  eyes: "👀",
+  white_check_mark: "✅",
+};
+
+export const DEFAULT_REACTION_COMMANDS: Record<string, ReactionCommandTemplate> = {
+  memo: {
+    action: "summarize",
+    prompt:
+      "Summarize the reacted-to message and the surrounding thread. Focus on key decisions, action items, and open questions.",
+  },
+  bug: {
+    action: "file-issue",
+    prompt:
+      "Turn the reacted-to message or thread into a GitHub issue. Capture the problem, context, reproduction clues, and a sensible next step.",
+  },
+  eyes: {
+    action: "review",
+    prompt:
+      "Review the referenced message, code, or work item and report what needs attention. If the context points to a PR or diff, review that artifact.",
+  },
+  white_check_mark: {
+    action: "approve",
+    prompt:
+      "Evaluate whether the referenced work should be approved. If it looks good, say so clearly and note any final caveats.",
+  },
+  repeat: {
+    action: "retry",
+    prompt:
+      "Retry or regenerate the requested work using the reacted message and surrounding thread as the source of truth.",
+  },
+  mag: {
+    action: "search",
+    prompt:
+      "Search the codebase for code related to the reacted message and report the most relevant files or findings.",
+  },
+  pushpin: {
+    action: "track",
+    prompt:
+      "Treat the reacted message as something to preserve and track. Pin or record it in the most appropriate project artifact, such as a Slack canvas.",
+  },
+  globe_with_meridians: {
+    action: "fetch-url",
+    prompt:
+      "If the reacted message contains a URL, fetch the linked page and summarize the important information for the user.",
+  },
+};
+
+function normalizeReactionNameOrNull(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const withoutColons = trimmed.replace(/^:+|:+$/g, "").toLowerCase();
+  return (
+    REACTION_ALIASES[trimmed] ??
+    REACTION_ALIASES[withoutColons] ??
+    (/^[a-z0-9_+-]+$/.test(withoutColons) ? withoutColons : null)
+  );
+}
+
+export function normalizeReactionName(input: string): string {
+  const normalized = normalizeReactionNameOrNull(input);
+  if (!normalized) {
+    throw new Error(
+      `Unsupported reaction ${JSON.stringify(input)}. Use a Slack reaction name like "eyes" or a supported emoji such as 👀, ✅, 🔄, 📝, or 🐛.`,
+    );
+  }
+  return normalized;
+}
+
+function buildDefaultPromptForAction(action: string): string {
+  switch (action) {
+    case "summarize":
+      return DEFAULT_REACTION_COMMANDS.memo.prompt;
+    case "file-issue":
+      return DEFAULT_REACTION_COMMANDS.bug.prompt;
+    case "review":
+      return DEFAULT_REACTION_COMMANDS.eyes.prompt;
+    case "approve":
+      return DEFAULT_REACTION_COMMANDS.white_check_mark.prompt;
+    case "retry":
+      return DEFAULT_REACTION_COMMANDS.repeat.prompt;
+    case "search":
+      return DEFAULT_REACTION_COMMANDS.mag.prompt;
+    case "track":
+      return DEFAULT_REACTION_COMMANDS.pushpin.prompt;
+    case "fetch-url":
+      return DEFAULT_REACTION_COMMANDS.globe_with_meridians.prompt;
+    default:
+      return `Carry out the "${action}" action for the reacted Slack message or thread, using the included context before you decide what to do.`;
+  }
+}
+
+export function resolveReactionCommands(
+  settings: ReactionCommandSettings | undefined,
+): Map<string, ReactionCommandTemplate> {
+  const resolved = new Map<string, ReactionCommandTemplate>(
+    Object.entries(DEFAULT_REACTION_COMMANDS),
+  );
+
+  if (!settings) {
+    return resolved;
+  }
+
+  for (const [rawReaction, config] of Object.entries(settings)) {
+    const normalizedReaction = normalizeReactionNameOrNull(rawReaction);
+    if (!normalizedReaction) continue;
+
+    if (typeof config === "string") {
+      resolved.set(normalizedReaction, {
+        action: config,
+        prompt: buildDefaultPromptForAction(config),
+      });
+      continue;
+    }
+
+    if (!config || typeof config !== "object") continue;
+
+    const action =
+      config.action?.trim() || resolved.get(normalizedReaction)?.action || normalizedReaction;
+    const prompt = config.prompt?.trim() || buildDefaultPromptForAction(action);
+    resolved.set(normalizedReaction, { action, prompt });
+  }
+
+  return resolved;
+}
+
+export function formatReactionDisplay(reactionName: string): string {
+  return `${REACTION_DISPLAY[reactionName] ?? `:${reactionName}:`} (:${reactionName}:)`;
+}
+
+export interface ReactionTriggerMessageInput {
+  reactionName: string;
+  command: ReactionCommandTemplate;
+  reactorName: string;
+  channel: string;
+  threadTs: string;
+  messageTs: string;
+  reactedMessageText: string;
+  reactedMessageAuthor: string;
+}
+
+export function buildReactionTriggerMessage(input: ReactionTriggerMessageInput): string {
+  const reactedMessageText = input.reactedMessageText.trim() || "(no text)";
+  return [
+    "Reaction trigger from Slack:",
+    `- reaction: ${formatReactionDisplay(input.reactionName)}`,
+    `- action: ${input.command.action}`,
+    `- reactor: ${input.reactorName}`,
+    `- channel: <#${input.channel}>`,
+    `- thread_ts: ${input.threadTs}`,
+    `- message_ts: ${input.messageTs}`,
+    `- reacted_message_author: ${input.reactedMessageAuthor}`,
+    `- reacted_message_text: ${reactedMessageText}`,
+    "",
+    `Requested action: ${input.command.prompt}`,
+    "Treat this reaction as an explicit user request, but still verify context before acting.",
+  ].join("\n");
+}
+
+export function buildReactionPromptGuidelines(): string[] {
+  return [
+    "Reaction-triggered requests may appear in your Slack inbox as structured 'Reaction trigger from Slack:' messages.",
+    "Treat them as explicit user requests keyed off emoji reactions. Use the included action, reacted message text, and thread context to decide what to do.",
+  ];
+}

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -215,12 +215,32 @@ describe("registerSlackTools", () => {
     });
   });
 
+  it("adds reactions with normalized emoji names via slack_react", async () => {
+    const { slack, tools, setResolveFollowerReplyChannel } = setup();
+    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+
+    const response = await tools.get("slack_react")!.execute("tool-4", {
+      emoji: "✅",
+      thread_ts: "123.456",
+    });
+
+    expect(slack).toHaveBeenCalledWith("reactions.add", "xoxb-initial", {
+      channel: "C-DB",
+      timestamp: "123.456",
+      name: "white_check_mark",
+    });
+    expect(response.content?.[0]?.text).toContain("Added :white_check_mark:");
+  });
+
   it("reads the latest bot token and default channel when slack_schedule executes", async () => {
     const { slack, tools, setBotToken, setDefaultChannel } = setup();
     setBotToken("xoxb-reloaded");
     setDefaultChannel("ops-alerts");
 
-    await tools.get("slack_schedule")!.execute("tool-4", {
+    await tools.get("slack_schedule")!.execute("tool-5", {
       text: "hello from the future",
       at: "2030-01-02T03:04:05Z",
     });
@@ -245,7 +265,7 @@ describe("registerSlackTools", () => {
 
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-02T14:00:00Z"));
     try {
-      await tools.get("slack_schedule")!.execute("tool-5", {
+      await tools.get("slack_schedule")!.execute("tool-6", {
         text: "follow up later",
         thread_ts: "123.456",
         delay: "30m",
@@ -276,7 +296,7 @@ describe("registerSlackTools", () => {
       throw new Error("Slack pins.add: already_pinned");
     });
 
-    const response = await tools.get("slack_pin")!.execute("tool-6", {
+    const response = await tools.get("slack_pin")!.execute("tool-7", {
       action: "pin",
       message_ts: "123.789",
       thread_ts: "123.456",
@@ -296,7 +316,7 @@ describe("registerSlackTools", () => {
       throw new Error("Slack pins.remove: no_pin");
     });
 
-    const response = await tools.get("slack_pin")!.execute("tool-7", {
+    const response = await tools.get("slack_pin")!.execute("tool-8", {
       action: "unpin",
       message_ts: "123.789",
     });
@@ -312,7 +332,7 @@ describe("registerSlackTools", () => {
     const { slack, tools, setDefaultChannel } = setup();
     setDefaultChannel("docs");
 
-    const response = await tools.get("slack_bookmark")!.execute("tool-8", {
+    const response = await tools.get("slack_bookmark")!.execute("tool-9", {
       action: "add",
       title: "Repo",
       url: "https://github.com/gugu91/extensions",
@@ -340,7 +360,7 @@ describe("registerSlackTools", () => {
       return "C-DB";
     });
 
-    const response = await tools.get("slack_bookmark")!.execute("tool-9", {
+    const response = await tools.get("slack_bookmark")!.execute("tool-10", {
       action: "list",
       thread_ts: "123.456",
     });
@@ -358,7 +378,7 @@ describe("registerSlackTools", () => {
       throw new Error("Slack bookmarks.remove: not_found");
     });
 
-    const response = await tools.get("slack_bookmark")!.execute("tool-10", {
+    const response = await tools.get("slack_bookmark")!.execute("tool-11", {
       action: "remove",
       bookmark_id: "Bk404",
     });
@@ -415,7 +435,7 @@ describe("registerSlackTools", () => {
       } as SlackResult,
     ]);
 
-    const response = await tools.get("slack_export")!.execute("tool-11", {
+    const response = await tools.get("slack_export")!.execute("tool-12", {
       thread_ts: "123.456",
       format: "markdown",
     });
@@ -455,7 +475,7 @@ describe("registerSlackTools", () => {
       } as SlackResult,
     ]);
 
-    const response = await tools.get("slack_export")!.execute("tool-12", {
+    const response = await tools.get("slack_export")!.execute("tool-13", {
       thread_ts: "100.000001",
       format: "plain",
       oldest: "150",

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -16,6 +16,7 @@ import {
   filterSlackExportMessagesByRange,
   parseSlackExportBoundaryTs,
 } from "./slack-export.js";
+import { normalizeReactionName } from "./reaction-triggers.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
 
@@ -53,6 +54,7 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "When you receive messages: ACK briefly, do the work, report blockers immediately, report the outcome when done.",
     "Security guardrails may be active for Slack-triggered actions. Check the current security prompt in each message for restrictions.",
     "When a tool requires confirmation, call slack_confirm_action first and wait for approval in the same thread.",
+    "Reaction-triggered requests may arrive as structured 'Reaction trigger from Slack:' messages — treat them as explicit user instructions attached to the referenced Slack message or thread.",
     "Use slack_upload instead of giant inline code blocks when sharing diffs, logs, screenshots, generated files, or long snippets.",
     "Use slack_schedule for reminders, timed announcements, and delayed follow-ups instead of waiting around to send a message later.",
     "Use slack_pin for important Slack messages you want highlighted in the conversation, and use slack_bookmark for durable channel-header links like repos, dashboards, docs, and runbooks.",
@@ -310,6 +312,26 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     };
   }
 
+  async function resolveReactionChannel(
+    threadTs: string | undefined,
+    channel: string | undefined,
+  ): Promise<string> {
+    const trackedThreadChannel = threadTs ? await resolveFollowerReplyChannel(threadTs) : null;
+    if (trackedThreadChannel) {
+      return trackedThreadChannel;
+    }
+
+    const channelInput = channel?.trim();
+    if (channelInput) {
+      return resolveChannel(channelInput);
+    }
+
+    throw new Error(
+      threadTs
+        ? "Unknown Slack thread. If you know the destination channel, pass channel explicitly."
+        : "Provide channel when reacting to a message outside the current tracked thread.",
+    );
+  }
   pi.registerTool({
     name: "slack_inbox",
     label: "Slack Inbox",
@@ -419,6 +441,73 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           },
         ],
         details: { ts, channel },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_react",
+    label: "Slack React",
+    description: "Add an emoji reaction to a Slack message or thread root.",
+    promptSnippet:
+      "Add a reaction to a Slack thread root or message. Use this for lightweight acknowledgements like 👀, ✅, or 🔄.",
+    parameters: Type.Object({
+      emoji: Type.String({
+        description:
+          "Reaction emoji or Slack reaction name, e.g. 👀, ✅, :eyes:, or white_check_mark",
+      }),
+      thread_ts: Type.Optional(
+        Type.String({
+          description: "Tracked Slack thread. If timestamp is omitted, reacts to the thread root.",
+        }),
+      ),
+      timestamp: Type.Optional(
+        Type.String({
+          description:
+            "Specific message timestamp to react to. Defaults to thread_ts when omitted.",
+        }),
+      ),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Optional channel name or ID. Required when reacting to a standalone message outside the current tracked thread.",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      const targetTimestamp = params.timestamp ?? params.thread_ts;
+      if (!targetTimestamp) {
+        throw new Error("Provide thread_ts or timestamp so Slack knows which message to react to.");
+      }
+
+      requireToolPolicy(
+        "slack_react",
+        params.thread_ts,
+        `emoji=${params.emoji} | thread_ts=${params.thread_ts ?? ""} | timestamp=${targetTimestamp} | channel=${params.channel ?? ""}`,
+      );
+
+      const reactionName = normalizeReactionName(params.emoji);
+      const channelId = await resolveReactionChannel(params.thread_ts, params.channel);
+
+      await slack("reactions.add", getBotToken(), {
+        channel: channelId,
+        timestamp: targetTimestamp,
+        name: reactionName,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Added :${reactionName}: to message ${targetTimestamp}.`,
+          },
+        ],
+        details: {
+          channel: channelId,
+          timestamp: targetTimestamp,
+          emoji: reactionName,
+          ...(params.thread_ts ? { thread_ts: params.thread_ts } : {}),
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
- subscribe Slack Bridge to `reaction_added` and turn mapped emoji reactions into structured inbound action requests
- add configurable `reactionCommands` plus a new `slack_react` tool for adding reactions from the agent
- document the new reaction-trigger workflow in the Slack Bridge README and ensure the manifest includes the event subscription

## Details
- added `slack-bridge/reaction-triggers.ts` + tests for:
  - reaction name normalization (`👀`, `✅`, `🔄`, `📝`, `🐛`, etc.)
  - default + custom reaction command resolution
  - structured inbox message formatting for reaction-triggered requests
- wired `reaction_added` handling into the broker Slack adapter (the active Socket Mode path)
  - respects allowlist
  - fetches the reacted-to message text via `conversations.history`
  - emits structured inbound messages keyed to the correct thread
  - adds `✅` on success or `❌` on handler failure
- also wired the local slack-bridge event path for parity
- added `slack_react` tool and marked it as a Slack write tool in guardrails
- updated `manifest.yaml` to subscribe to `reaction_added` (scope `reactions:read` was already present)
- updated `slack-bridge/README.md` with tool/config/docs for reaction commands

## Verification
- `cd slack-bridge && pnpm test -- --run reaction-triggers.test.ts slack-tools.test.ts guardrails.test.ts broker/adapters/slack.test.ts`
- `cd slack-bridge && pnpm typecheck`
- `cd slack-bridge && pnpm lint`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
