### PR TITLE
feat: add Slack thread export tool (#29)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -28,6 +28,7 @@ If the agent is idle, incoming messages are processed immediately.
 | `slack_schedule(text, channel?, thread_ts?, delay?, at?)`                           | Schedule a Slack message for later           |
 | `slack_pin(action, message_ts, channel?, thread_ts?)`                               | Pin or unpin a Slack message                 |
 | `slack_bookmark(action, channel?, thread_ts?, title?, url?, emoji?, bookmark_id?)`  | Add, list, or remove channel bookmarks       |
+| `slack_export(thread_ts, channel?, format?, include_metadata?, oldest?, latest?)`   | Export a Slack thread for docs or archival   |
 | `slack_read(thread_ts, limit?)`                                                     | Read thread messages                         |
 | `slack_inbox()`                                                                     | Check pending messages manually              |
 | `slack_create_channel(name, topic?, purpose?)`                                      | Create a project channel                     |
@@ -47,6 +48,10 @@ or the system temp directory.
 manages durable channel-header links such as repos, dashboards, docs, and
 runbooks.
 
+`slack_export` turns a thread into markdown, plain text, or JSON with resolved
+authors, timestamps, and attachment links so it can be archived into docs,
+files, canvases, or follow-up summaries.
+
 ## Features
 
 - **Slack Assistant** — appears in Slack's sidebar, native conversation UI
@@ -60,6 +65,7 @@ runbooks.
 - **File & snippet uploads** — share diffs, logs, screenshots, exports, and long code snippets without pasting giant messages
 - **Scheduled & delayed messages** — queue reminders, timed announcements, and follow-ups without waiting around
 - **Pins & bookmarks** — highlight key messages and manage durable channel-header links
+- **Thread export & archival** — convert Slack threads into reusable markdown, plain text, or JSON
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
 - **Remote agent control** — send `/reload` or `/exit` to another Pinet agent

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -99,6 +99,7 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("slack_schedule")).toBe(true);
     expect(WRITE_TOOLS.has("slack_pin")).toBe(true);
     expect(WRITE_TOOLS.has("slack_bookmark")).toBe(true);
+    expect(READ_ONLY_TOOLS.has("slack_export")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_post_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_upload")).toBe(false);

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -14,6 +14,7 @@ export const READ_ONLY_TOOLS = new Set([
   "slack_send",
   "slack_read",
   "slack_read_channel",
+  "slack_export",
   "pinet_agents",
   "pinet_message",
   "memory_read",

--- a/slack-bridge/slack-export.test.ts
+++ b/slack-bridge/slack-export.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackThreadExport,
+  convertSlackMrkdwnToMarkdown,
+  filterSlackExportMessagesByRange,
+  normalizeSlackExportFormat,
+  parseSlackExportBoundaryTs,
+} from "./slack-export.js";
+
+describe("normalizeSlackExportFormat", () => {
+  it("defaults to markdown", () => {
+    expect(normalizeSlackExportFormat()).toBe("markdown");
+  });
+
+  it("accepts markdown, plain, and json", () => {
+    expect(normalizeSlackExportFormat("markdown")).toBe("markdown");
+    expect(normalizeSlackExportFormat("plain")).toBe("plain");
+    expect(normalizeSlackExportFormat("json")).toBe("json");
+  });
+
+  it("rejects unsupported formats", () => {
+    expect(() => normalizeSlackExportFormat("html")).toThrow(
+      "format must be 'markdown', 'json', or 'plain'.",
+    );
+  });
+});
+
+describe("parseSlackExportBoundaryTs", () => {
+  it("parses Slack ts values", () => {
+    expect(parseSlackExportBoundaryTs("1712345678.123456")).toBe(1712345678.123456);
+  });
+
+  it("parses ISO timestamps", () => {
+    expect(parseSlackExportBoundaryTs("2026-04-02T14:30:00Z")).toBe(1775140200);
+  });
+});
+
+describe("filterSlackExportMessagesByRange", () => {
+  it("keeps only messages inside the requested range", () => {
+    const messages = [
+      { ts: "100.000001", text: "too early" },
+      { ts: "200.000002", text: "keep me" },
+      { ts: "300.000003", text: "too late" },
+    ];
+
+    expect(filterSlackExportMessagesByRange(messages, 150, 250)).toEqual([
+      { ts: "200.000002", text: "keep me" },
+    ]);
+  });
+});
+
+describe("convertSlackMrkdwnToMarkdown", () => {
+  it("converts Slack links, mentions, and formatting", () => {
+    const result = convertSlackMrkdwnToMarkdown(
+      "Hello <@U123> see <https://example.com|the docs> and *important* ~old~ <!here>",
+      { U123: "alice" },
+    );
+
+    expect(result).toBe(
+      "Hello @alice see [the docs](https://example.com) and **important** ~~old~~ @here",
+    );
+  });
+});
+
+describe("buildSlackThreadExport", () => {
+  const messages = [
+    {
+      ts: "1712345678.000001",
+      authorName: "alice",
+      text: "Hello <@U456>\n\nSee <https://example.com|design doc>",
+      files: [
+        {
+          title: "incident.md",
+          filetype: "markdown",
+          permalink: "https://files.example/incident.md",
+          preview: "Root cause analysis",
+        },
+      ],
+    },
+    {
+      ts: "1712345688.000002",
+      authorName: "bob",
+      text: "*Ship it*",
+    },
+  ];
+
+  it("renders markdown exports with metadata and attachments", () => {
+    const result = buildSlackThreadExport({
+      format: "markdown",
+      includeMetadata: true,
+      threadTs: "1712345678.000001",
+      channelId: "C123",
+      channelLabel: "#eng",
+      messages,
+      mentionNames: { U456: "bob" },
+    });
+
+    expect(result).toContain("# Slack Thread Export");
+    expect(result).toContain("- Thread: `1712345678.000001`");
+    expect(result).toContain("- Participants: alice, bob");
+    expect(result).toContain("## 2024-04-05T19:34:38.000Z — alice");
+    expect(result).toContain("Hello @bob");
+    expect(result).toContain("[design doc](https://example.com)");
+    expect(result).toContain("Attachments:");
+    expect(result).toContain("incident.md (markdown) — https://files.example/incident.md");
+    expect(result).toContain("Preview: Root cause analysis");
+    expect(result).toContain("**Ship it**");
+  });
+
+  it("renders plain exports without message metadata when disabled", () => {
+    const result = buildSlackThreadExport({
+      format: "plain",
+      includeMetadata: false,
+      threadTs: "1712345678.000001",
+      channelId: "C123",
+      messages,
+      mentionNames: { U456: "bob" },
+    });
+
+    expect(result).not.toContain("[2024-");
+    expect(result).toContain("Hello @bob");
+    expect(result).toContain("Attachments:");
+  });
+
+  it("renders JSON exports", () => {
+    const result = buildSlackThreadExport({
+      format: "json",
+      includeMetadata: true,
+      threadTs: "1712345678.000001",
+      channelId: "C123",
+      messages,
+      mentionNames: { U456: "bob" },
+    });
+
+    const parsed = JSON.parse(result) as {
+      format: string;
+      messages: Array<{ author: string; text: string }>;
+    };
+
+    expect(parsed.format).toBe("json");
+    expect(parsed.messages[0]?.author).toBe("alice");
+    expect(parsed.messages[0]?.text).toContain("Hello @bob");
+  });
+});

--- a/slack-bridge/slack-export.ts
+++ b/slack-bridge/slack-export.ts
@@ -1,0 +1,292 @@
+export type SlackExportFormat = "markdown" | "json" | "plain";
+
+export interface SlackExportFileInput {
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  filetype?: string;
+  permalink?: string;
+  urlPrivate?: string;
+  preview?: string;
+}
+
+export interface SlackExportMessageInput {
+  ts?: string;
+  authorName?: string;
+  text?: string;
+  files?: SlackExportFileInput[];
+}
+
+export interface BuildSlackThreadExportOptions {
+  format?: string;
+  includeMetadata?: boolean;
+  threadTs: string;
+  channelId: string;
+  channelLabel?: string;
+  messages: SlackExportMessageInput[];
+  mentionNames?: Record<string, string>;
+}
+
+function decodeSlackEntities(text: string): string {
+  return text.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+}
+
+function formatSlackToken(token: string, mentionNames: Record<string, string>): string {
+  if (token.startsWith("@")) {
+    const userId = token.slice(1);
+    return `@${mentionNames[userId] ?? userId}`;
+  }
+
+  if (token.startsWith("#")) {
+    const [, fallback] = token.split("|");
+    return `#${fallback ?? token.slice(1)}`;
+  }
+
+  if (token.startsWith("!")) {
+    if (token === "!here" || token === "!channel" || token === "!everyone") {
+      return `@${token.slice(1)}`;
+    }
+
+    if (token.startsWith("!subteam^")) {
+      const [, handle] = token.split("|");
+      return `@${handle ?? "group"}`;
+    }
+
+    if (token.startsWith("!date^")) {
+      const [, fallback] = token.split("|");
+      return fallback ?? token;
+    }
+
+    return token.slice(1);
+  }
+
+  const [target, label] = token.split("|");
+  if (!target) {
+    return token;
+  }
+
+  if (target.startsWith("mailto:")) {
+    const visible = label ?? target.slice("mailto:".length);
+    return `[${visible}](${target})`;
+  }
+
+  if (target.startsWith("http://") || target.startsWith("https://")) {
+    const visible = label ?? target;
+    return `[${visible}](${target})`;
+  }
+
+  return label ?? target;
+}
+
+export function convertSlackMrkdwnToMarkdown(
+  text: string,
+  mentionNames: Record<string, string> = {},
+): string {
+  const decoded = decodeSlackEntities(text);
+  const withTokens = decoded.replace(/<([^>]+)>/g, (_match, token: string) =>
+    formatSlackToken(token, mentionNames),
+  );
+
+  return withTokens
+    .replace(/(^|[\s(])\*(\S(?:[\s\S]*?\S)?)\*(?=$|[\s).,!?:;])/g, "$1**$2**")
+    .replace(/(^|[\s(])~(\S(?:[\s\S]*?\S)?)~(?=$|[\s).,!?:;])/g, "$1~~$2~~");
+}
+
+export function normalizeSlackExportFormat(format?: string): SlackExportFormat {
+  const normalized = format?.trim().toLowerCase() ?? "markdown";
+  if (normalized === "markdown" || normalized === "json" || normalized === "plain") {
+    return normalized;
+  }
+  throw new Error("format must be 'markdown', 'json', or 'plain'.");
+}
+
+export function parseSlackExportBoundaryTs(value: string): number {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("Timestamp boundary cannot be empty.");
+  }
+
+  if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    return Number.parseFloat(trimmed);
+  }
+
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid timestamp boundary: ${value}`);
+  }
+
+  return parsed / 1000;
+}
+
+export function filterSlackExportMessagesByRange(
+  messages: SlackExportMessageInput[],
+  oldestTs?: number,
+  latestTs?: number,
+): SlackExportMessageInput[] {
+  return messages.filter((message) => {
+    const ts = message.ts ? Number.parseFloat(message.ts) : Number.NaN;
+    if (!Number.isFinite(ts)) {
+      return true;
+    }
+    if (oldestTs != null && ts < oldestTs) {
+      return false;
+    }
+    if (latestTs != null && ts > latestTs) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function formatSlackExportTimestamp(ts?: string): string {
+  if (!ts) {
+    return "unknown time";
+  }
+
+  const numeric = Number.parseFloat(ts);
+  if (!Number.isFinite(numeric)) {
+    return ts;
+  }
+
+  return new Date(numeric * 1000).toISOString();
+}
+
+function buildSlackFileSummary(file: SlackExportFileInput): string {
+  const label = file.title ?? file.name ?? "attachment";
+  const url = file.permalink ?? file.urlPrivate;
+  const type = file.filetype ?? file.mimetype;
+  const parts = [`- ${label}`];
+
+  if (type) {
+    parts.push(`(${type})`);
+  }
+  if (url) {
+    parts.push(`— ${url}`);
+  }
+
+  let line = parts.join(" ");
+  const preview = file.preview?.trim();
+  if (preview) {
+    line += `\n  Preview: ${preview}`;
+  }
+
+  return line;
+}
+
+function buildSlackExportHeader(
+  options: BuildSlackThreadExportOptions,
+  participants: string[],
+): string[] {
+  const header = ["# Slack Thread Export", ""];
+  header.push(`- Thread: \`${options.threadTs}\``);
+  header.push(
+    options.channelLabel
+      ? `- Channel: ${options.channelLabel} (\`${options.channelId}\`)`
+      : `- Channel: \`${options.channelId}\``,
+  );
+  header.push(`- Messages: ${options.messages.length}`);
+  if (participants.length > 0) {
+    header.push(`- Participants: ${participants.join(", ")}`);
+  }
+  header.push("");
+  return header;
+}
+
+function buildMarkdownExport(options: BuildSlackThreadExportOptions): string {
+  const mentionNames = options.mentionNames ?? {};
+  const participants = [
+    ...new Set(options.messages.map((message) => message.authorName).filter(Boolean)),
+  ];
+  const lines = buildSlackExportHeader(options, participants as string[]);
+
+  options.messages.forEach((message, index) => {
+    const heading =
+      options.includeMetadata !== false
+        ? `## ${formatSlackExportTimestamp(message.ts)} — ${message.authorName ?? "unknown"}`
+        : `## Message ${index + 1}`;
+    lines.push(heading, "");
+
+    const body = convertSlackMrkdwnToMarkdown(message.text ?? "", mentionNames).trim();
+    lines.push(body || "(no text)");
+
+    if ((message.files?.length ?? 0) > 0) {
+      lines.push("", "Attachments:");
+      for (const file of message.files ?? []) {
+        lines.push(buildSlackFileSummary(file));
+      }
+    }
+
+    lines.push("", "---", "");
+  });
+
+  return lines.join("\n").trim();
+}
+
+function buildPlainExport(options: BuildSlackThreadExportOptions): string {
+  const mentionNames = options.mentionNames ?? {};
+  const lines: string[] = [];
+
+  for (const message of options.messages) {
+    if (options.includeMetadata !== false) {
+      lines.push(`[${formatSlackExportTimestamp(message.ts)}] ${message.authorName ?? "unknown"}`);
+    }
+    lines.push(
+      convertSlackMrkdwnToMarkdown(message.text ?? "", mentionNames).trim() || "(no text)",
+    );
+
+    if ((message.files?.length ?? 0) > 0) {
+      lines.push("Attachments:");
+      for (const file of message.files ?? []) {
+        lines.push(buildSlackFileSummary(file));
+      }
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+function buildJsonExport(options: BuildSlackThreadExportOptions): string {
+  const mentionNames = options.mentionNames ?? {};
+  const payload = {
+    format: "json",
+    thread_ts: options.threadTs,
+    channel: options.channelId,
+    channel_label: options.channelLabel,
+    include_metadata: options.includeMetadata !== false,
+    message_count: options.messages.length,
+    messages: options.messages.map((message, index) => ({
+      index: index + 1,
+      ...(options.includeMetadata !== false
+        ? {
+            ts: message.ts,
+            timestamp: formatSlackExportTimestamp(message.ts),
+            author: message.authorName ?? "unknown",
+          }
+        : {}),
+      text: convertSlackMrkdwnToMarkdown(message.text ?? "", mentionNames),
+      files: (message.files ?? []).map((file) => ({
+        title: file.title,
+        name: file.name,
+        type: file.filetype ?? file.mimetype,
+        permalink: file.permalink,
+        url_private: file.urlPrivate,
+        preview: file.preview,
+      })),
+    })),
+  };
+
+  return JSON.stringify(payload, null, 2);
+}
+
+export function buildSlackThreadExport(options: BuildSlackThreadExportOptions): string {
+  const format = normalizeSlackExportFormat(options.format);
+  if (format === "json") {
+    return buildJsonExport(options);
+  }
+  if (format === "plain") {
+    return buildPlainExport(options);
+  }
+  return buildMarkdownExport(options);
+}

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -27,6 +27,8 @@ describe("registerSlackTools", () => {
     let botToken = "xoxb-initial";
     let defaultChannel = "general";
     let securityPrompt = "INITIAL SECURITY PROMPT";
+    let resolveUser = async (userId: string) => userId;
+    let conversationsRepliesResponses: SlackResult[] = [];
 
     const slack = vi.fn<
       (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>
@@ -97,6 +99,10 @@ describe("registerSlackTools", () => {
         } as SlackResult;
       }
 
+      if (method === "conversations.replies" && conversationsRepliesResponses.length > 0) {
+        return conversationsRepliesResponses.shift() as SlackResult;
+      }
+
       return {
         ok: true,
         token,
@@ -119,7 +125,7 @@ describe("registerSlackTools", () => {
       getAgentEmoji: () => "🐨",
       getLastDmChannel: () => null,
       updateBadge: () => {},
-      resolveUser: async (userId) => userId,
+      resolveUser: async (userId) => resolveUser(userId),
       resolveFollowerReplyChannel: (threadTs) => resolveFollowerReplyChannel(threadTs),
       resolveChannel: async (nameOrId) => `resolved:${nameOrId}`,
       rememberChannel: () => {},
@@ -142,6 +148,12 @@ describe("registerSlackTools", () => {
       },
       setSecurityPrompt: (value: string) => {
         securityPrompt = value;
+      },
+      setResolveUser: (fn: (userId: string) => Promise<string>) => {
+        resolveUser = fn;
+      },
+      setConversationsReplies: (responses: SlackResult[]) => {
+        conversationsRepliesResponses = [...responses];
       },
       setResolveFollowerReplyChannel: (
         fn: (threadTs: string | undefined) => Promise<string | null>,
@@ -356,5 +368,104 @@ describe("registerSlackTools", () => {
       bookmark_id: "Bk404",
     });
     expect(response.details?.status).toBe("not_found");
+  });
+
+  it("exports paginated thread content as markdown", async () => {
+    const {
+      slack,
+      tools,
+      setConversationsReplies,
+      setResolveFollowerReplyChannel,
+      setResolveUser,
+    } = setup();
+    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+    setResolveUser(async (userId: string) => ({ U123: "alice", U456: "bob" })[userId] ?? userId);
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [
+          {
+            ts: "123.456",
+            user: "U123",
+            text: "Hello <@U456>",
+          },
+        ],
+        response_metadata: { next_cursor: "cursor-1" },
+      } as SlackResult,
+      {
+        ok: true,
+        messages: [
+          {
+            ts: "123.789",
+            user: "U456",
+            text: "See <https://example.com|the doc>",
+            files: [
+              {
+                title: "incident.md",
+                filetype: "markdown",
+                permalink: "https://files.example/incident.md",
+              },
+            ],
+          },
+        ],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+
+    const response = await tools.get("slack_export")!.execute("tool-11", {
+      thread_ts: "123.456",
+      format: "markdown",
+    });
+
+    expect(slack).toHaveBeenNthCalledWith(1, "conversations.replies", "xoxb-initial", {
+      channel: "C-DB",
+      ts: "123.456",
+      limit: 1000,
+    });
+    expect(slack).toHaveBeenNthCalledWith(2, "conversations.replies", "xoxb-initial", {
+      channel: "C-DB",
+      ts: "123.456",
+      limit: 1000,
+      cursor: "cursor-1",
+    });
+    expect(response.content?.[0]?.text).toContain("# Slack Thread Export");
+    expect(response.content?.[0]?.text).toContain("Hello @bob");
+    expect(response.content?.[0]?.text).toContain("[the doc](https://example.com)");
+    expect(response.content?.[0]?.text).toContain(
+      "incident.md (markdown) — https://files.example/incident.md",
+    );
+    expect(response.details?.count).toBe(2);
+  });
+
+  it("filters exported threads by oldest/latest boundaries", async () => {
+    const { tools, setConversationsReplies, setDefaultChannel } = setup();
+    setDefaultChannel("docs");
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [
+          { ts: "100.000001", user: "U100", text: "too early" },
+          { ts: "200.000002", user: "U200", text: "keep me" },
+          { ts: "300.000003", user: "U300", text: "too late" },
+        ],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+
+    const response = await tools.get("slack_export")!.execute("tool-12", {
+      thread_ts: "100.000001",
+      format: "plain",
+      oldest: "150",
+      latest: "250",
+      channel: "docs",
+    });
+
+    expect(response.content?.[0]?.text).toContain("keep me");
+    expect(response.content?.[0]?.text).not.toContain("too early");
+    expect(response.content?.[0]?.text).not.toContain("too late");
+    expect(response.details?.count).toBe(1);
   });
 });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -11,6 +11,11 @@ import {
   normalizeSlackCanvasUpdateMode,
   pickSlackCanvasSectionId,
 } from "./canvases.js";
+import {
+  buildSlackThreadExport,
+  filterSlackExportMessagesByRange,
+  parseSlackExportBoundaryTs,
+} from "./slack-export.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
 
@@ -51,6 +56,7 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "Use slack_upload instead of giant inline code blocks when sharing diffs, logs, screenshots, generated files, or long snippets.",
     "Use slack_schedule for reminders, timed announcements, and delayed follow-ups instead of waiting around to send a message later.",
     "Use slack_pin for important Slack messages you want highlighted in the conversation, and use slack_bookmark for durable channel-header links like repos, dashboards, docs, and runbooks.",
+    "Use slack_export to archive or document a Slack thread as markdown, plain text, or JSON before writing it into docs, canvases, or files.",
     "When uploading from a local path, only files inside the current working directory or the system temp directory are allowed.",
   ];
 }
@@ -189,6 +195,119 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         ? "Unknown Slack thread. If you know the destination channel, pass channel explicitly."
         : "No active Slack thread. Provide channel or configure defaultChannel in settings.json.",
     );
+  }
+
+  async function fetchSlackThreadMessages(
+    channelId: string,
+    threadTs: string,
+    oldest?: string,
+    latest?: string,
+  ): Promise<Record<string, unknown>[]> {
+    const messages: Record<string, unknown>[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const response = await slack("conversations.replies", getBotToken(), {
+        channel: channelId,
+        ts: threadTs,
+        limit: 1000,
+        ...(cursor ? { cursor } : {}),
+        ...(oldest ? { oldest } : {}),
+        ...(latest ? { latest } : {}),
+      });
+
+      const batch = Array.isArray(response.messages)
+        ? (response.messages as Record<string, unknown>[])
+        : [];
+      messages.push(...batch);
+
+      const nextCursor = (response.response_metadata as { next_cursor?: string } | undefined)
+        ?.next_cursor;
+      cursor = typeof nextCursor === "string" && nextCursor.length > 0 ? nextCursor : undefined;
+    } while (cursor);
+
+    return messages;
+  }
+
+  async function buildSlackExportPayload(messages: Record<string, unknown>[]): Promise<{
+    mentionNames: Record<string, string>;
+    authors: string[];
+    messages: Array<{
+      ts?: string;
+      authorName?: string;
+      text?: string;
+      files?: Array<{
+        name?: string;
+        title?: string;
+        mimetype?: string;
+        filetype?: string;
+        permalink?: string;
+        urlPrivate?: string;
+        preview?: string;
+      }>;
+    }>;
+  }> {
+    const userIds = new Set<string>();
+
+    for (const message of messages) {
+      const userId = typeof message.user === "string" ? message.user : undefined;
+      if (userId) {
+        userIds.add(userId);
+      }
+
+      const text = typeof message.text === "string" ? message.text : "";
+      for (const match of text.matchAll(/<@([A-Z0-9]+)>/g)) {
+        if (match[1]) {
+          userIds.add(match[1]);
+        }
+      }
+    }
+
+    const mentionNames = Object.fromEntries(
+      await Promise.all(
+        [...userIds].map(async (userId) => [userId, await resolveUser(userId)] as const),
+      ),
+    );
+
+    const exportedMessages = messages.map((message) => {
+      const userId = typeof message.user === "string" ? message.user : undefined;
+      const authorName = userId
+        ? mentionNames[userId]
+        : typeof message.username === "string"
+          ? message.username
+          : typeof message.bot_id === "string"
+            ? `bot:${message.bot_id}`
+            : "bot";
+      const rawFiles = Array.isArray(message.files)
+        ? (message.files as Array<Record<string, unknown>>)
+        : [];
+
+      return {
+        ts: typeof message.ts === "string" ? message.ts : undefined,
+        authorName,
+        text: typeof message.text === "string" ? message.text : "",
+        files: rawFiles.map((file) => ({
+          name: typeof file.name === "string" ? file.name : undefined,
+          title: typeof file.title === "string" ? file.title : undefined,
+          mimetype: typeof file.mimetype === "string" ? file.mimetype : undefined,
+          filetype: typeof file.filetype === "string" ? file.filetype : undefined,
+          permalink: typeof file.permalink === "string" ? file.permalink : undefined,
+          urlPrivate:
+            typeof file.url_private_download === "string"
+              ? file.url_private_download
+              : typeof file.url_private === "string"
+                ? file.url_private
+                : undefined,
+          preview: typeof file.preview === "string" ? file.preview : undefined,
+        })),
+      };
+    });
+
+    return {
+      mentionNames,
+      authors: [...new Set(exportedMessages.map((message) => message.authorName).filter(Boolean))],
+      messages: exportedMessages,
+    };
   }
 
   pi.registerTool({
@@ -443,6 +562,103 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       return {
         content: [{ type: "text", text: lines.join("\n") || "(no messages)" }],
         details: { count: messages.length },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_export",
+    label: "Slack Export",
+    description:
+      "Export a Slack thread as markdown, plain text, or JSON for documentation and archival.",
+    promptSnippet:
+      "Export a Slack thread before turning it into docs, ADRs, canvases, archives, or follow-up summaries.",
+    parameters: Type.Object({
+      thread_ts: Type.String({ description: "Thread timestamp to export" }),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Channel name or ID. Omit to use the current thread channel, active DM, or defaultChannel.",
+        }),
+      ),
+      format: Type.Optional(
+        Type.String({ description: "Export format: 'markdown' (default), 'plain', or 'json'" }),
+      ),
+      include_metadata: Type.Optional(
+        Type.Boolean({ description: "Include timestamps and author names (default true)" }),
+      ),
+      oldest: Type.Optional(
+        Type.String({
+          description: "Optional oldest boundary as a Slack ts or ISO-8601 UTC timestamp",
+        }),
+      ),
+      latest: Type.Optional(
+        Type.String({
+          description: "Optional latest boundary as a Slack ts or ISO-8601 UTC timestamp",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_export",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts} | channel=${params.channel ?? ""} | format=${params.format ?? "markdown"} | include_metadata=${params.include_metadata ?? true} | oldest=${params.oldest ?? ""} | latest=${params.latest ?? ""}`,
+      );
+
+      const channelId = await resolveSlackTargetChannel(params.thread_ts, params.channel);
+      const oldestTs = params.oldest?.trim()
+        ? parseSlackExportBoundaryTs(params.oldest)
+        : undefined;
+      const latestTs = params.latest?.trim()
+        ? parseSlackExportBoundaryTs(params.latest)
+        : undefined;
+
+      if (oldestTs != null && latestTs != null && oldestTs > latestTs) {
+        throw new Error("oldest must be earlier than or equal to latest.");
+      }
+
+      const rawMessages = await fetchSlackThreadMessages(
+        channelId,
+        params.thread_ts,
+        oldestTs != null ? String(oldestTs) : undefined,
+        latestTs != null ? String(latestTs) : undefined,
+      );
+      const exportPayload = await buildSlackExportPayload(rawMessages);
+      const filteredMessages = filterSlackExportMessagesByRange(
+        exportPayload.messages,
+        oldestTs,
+        latestTs,
+      );
+      const participants = [
+        ...new Set(filteredMessages.map((message) => message.authorName).filter(Boolean)),
+      ];
+      const exportText = buildSlackThreadExport({
+        format: params.format,
+        includeMetadata: params.include_metadata,
+        threadTs: params.thread_ts,
+        channelId,
+        channelLabel: params.channel,
+        messages: filteredMessages,
+        mentionNames: exportPayload.mentionNames,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: exportText || "(no messages)",
+          },
+        ],
+        details: {
+          thread_ts: params.thread_ts,
+          channel: channelId,
+          format: params.format?.trim().toLowerCase() ?? "markdown",
+          include_metadata: params.include_metadata ?? true,
+          count: filteredMessages.length,
+          participants,
+          ...(oldestTs != null ? { oldest: oldestTs } : {}),
+          ...(latestTs != null ? { latest: latestTs } : {}),
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
- add a read-only `slack_export` tool for exporting Slack threads as markdown, plain text, or JSON
- paginate full thread reads, resolve authors and mentions, and include attachment links in the export
- add pure export helpers/tests and document the new archival workflow

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #29