### PR TITLE
feat: add Slack presence awareness

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -25,6 +25,7 @@ If the agent is idle, incoming messages are processed immediately.
 | ----------------------------------------------------------------------------------- | -------------------------------------------- |
 | `slack_send(text, thread_ts?, blocks?)`                                             | Reply in a thread or start new               |
 | `slack_react(emoji, thread_ts?, timestamp?, channel?)`                              | Add an emoji reaction to a Slack message     |
+| `slack_presence(user?, users?)`                                                     | Check active/away/DND status for Slack users |
 | `slack_upload(content?, path?, filename?, filetype?, title?, channel?, thread_ts?)` | Upload a file/snippet into Slack or a thread |
 | `slack_schedule(text, channel?, thread_ts?, delay?, at?)`                           | Schedule a Slack message for later           |
 | `slack_pin(action, message_ts, channel?, thread_ts?)`                               | Pin or unpin a Slack message                 |
@@ -54,6 +55,12 @@ runbooks.
 authors, timestamps, and attachment links so it can be archived into docs,
 files, canvases, or follow-up summaries.
 
+`slack_presence` checks one or more Slack users via `users.getPresence` and
+`dnd.info`, so the agent can see whether people are active, away, or currently
+in Do Not Disturb before sending review requests or other pings. It accepts a
+single `user` or batch `users`, supports user IDs / mentions / names, and uses
+a short cache to avoid hammering Slack.
+
 ## Features
 
 - **Slack Assistant** — appears in Slack's sidebar, native conversation UI
@@ -69,6 +76,7 @@ files, canvases, or follow-up summaries.
 - **File & snippet uploads** — share diffs, logs, screenshots, exports, and long code snippets without pasting giant messages
 - **Scheduled & delayed messages** — queue reminders, timed announcements, and follow-ups without waiting around
 - **Pins & bookmarks** — highlight key messages and manage durable channel-header links
+- **Presence-aware messaging** — check whether teammates are active, away, or in DND before pinging them
 - **Thread export & archival** — convert Slack threads into reusable markdown, plain text, or JSON
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
@@ -157,8 +165,9 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 
 The `manifest.yaml` includes all required scopes and events, including `files:write`
 for `slack_upload`, `chat:write` for `slack_schedule`, bookmark/pin scopes for
-`slack_bookmark` and `slack_pin`, and `reaction_added` + `reactions:read` for
-emoji-triggered actions. Use it when creating the app (**From a manifest**) or
+`slack_bookmark` and `slack_pin`, `users:read` + `users.getPresence` / `dnd.info`
+for presence checks, and `reaction_added` + `reactions:read` plus `presence_change`
+for Slack-side awareness events. Use it when creating the app (**From a manifest**) or
 paste it into **App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -101,6 +101,7 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("slack_bookmark")).toBe(true);
     expect(WRITE_TOOLS.has("slack_react")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_export")).toBe(true);
+    expect(READ_ONLY_TOOLS.has("slack_presence")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_post_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_upload")).toBe(false);
@@ -108,6 +109,7 @@ describe("isToolBlocked", () => {
     expect(READ_ONLY_TOOLS.has("slack_pin")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_bookmark")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_react")).toBe(false);
+    expect(WRITE_TOOLS.has("slack_presence")).toBe(false);
   });
 
   it("combines readOnly and blockedTools", () => {

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -15,6 +15,7 @@ export const READ_ONLY_TOOLS = new Set([
   "slack_read",
   "slack_read_channel",
   "slack_export",
+  "slack_presence",
   "pinet_agents",
   "pinet_message",
   "memory_read",

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -45,6 +45,7 @@ settings:
       - assistant_thread_started
       - assistant_thread_context_changed
       - reaction_added
+      - presence_change
       - message.channels
       - message.groups
       - message.im

--- a/slack-bridge/slack-presence.test.ts
+++ b/slack-bridge/slack-presence.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  findSlackPresenceDirectoryUser,
+  formatSlackPresenceLine,
+  formatSlackPresenceTimestamp,
+  getBestSlackPresenceUserName,
+  isSlackUserId,
+  resolveSlackPresenceDndEndTs,
+  stripSlackUserReference,
+} from "./slack-presence.js";
+
+describe("stripSlackUserReference", () => {
+  it("unwraps Slack mentions and leading @ prefixes", () => {
+    expect(stripSlackUserReference("<@U123ABC>")).toBe("U123ABC");
+    expect(stripSlackUserReference("@alice")).toBe("alice");
+    expect(stripSlackUserReference("  Bob  ")).toBe("Bob");
+  });
+});
+
+describe("isSlackUserId", () => {
+  it("recognizes Slack user IDs and mentions", () => {
+    expect(isSlackUserId("U123ABC")).toBe(true);
+    expect(isSlackUserId("<@W123ABC>")).toBe(true);
+    expect(isSlackUserId("alice")).toBe(false);
+  });
+});
+
+describe("getBestSlackPresenceUserName", () => {
+  it("prefers display name, then real name, then handle", () => {
+    expect(
+      getBestSlackPresenceUserName({
+        id: "U123",
+        name: "alice",
+        real_name: "Alice Example",
+        profile: { display_name: "Alice" },
+      }),
+    ).toBe("Alice");
+
+    expect(
+      getBestSlackPresenceUserName({
+        id: "U124",
+        name: "bob",
+        real_name: "Bob Example",
+        profile: { display_name: "" },
+      }),
+    ).toBe("Bob Example");
+    expect(getBestSlackPresenceUserName({ id: "U125", name: "carol" })).toBe("carol");
+  });
+});
+
+describe("findSlackPresenceDirectoryUser", () => {
+  const users = [
+    {
+      id: "U123",
+      name: "alice",
+      real_name: "Alice Example",
+      profile: { display_name: "Ali" },
+    },
+    {
+      id: "U124",
+      name: "bob",
+      real_name: "Bob Example",
+      profile: { display_name: "Bobby" },
+    },
+  ];
+
+  it("matches by id, handle, real name, and display name", () => {
+    expect(findSlackPresenceDirectoryUser(users, "U123")?.id).toBe("U123");
+    expect(findSlackPresenceDirectoryUser(users, "@alice")?.id).toBe("U123");
+    expect(findSlackPresenceDirectoryUser(users, "Ali")?.id).toBe("U123");
+    expect(findSlackPresenceDirectoryUser(users, "Bob Example")?.id).toBe("U124");
+  });
+
+  it("returns null when no user matches", () => {
+    expect(findSlackPresenceDirectoryUser(users, "nobody")).toBeNull();
+  });
+});
+
+describe("resolveSlackPresenceDndEndTs", () => {
+  it("prefers snooze end when snooze is active", () => {
+    expect(
+      resolveSlackPresenceDndEndTs({
+        snooze_enabled: true,
+        snooze_endtime: 1_800_000_000,
+        dnd_enabled: true,
+        next_dnd_end_ts: 1_700_000_000,
+      }),
+    ).toBe(1_800_000_000);
+  });
+
+  it("falls back to next_dnd_end_ts for regular DND", () => {
+    expect(
+      resolveSlackPresenceDndEndTs({
+        dnd_enabled: true,
+        next_dnd_end_ts: "1700000000",
+      }),
+    ).toBe(1_700_000_000);
+  });
+
+  it("returns undefined when DND is off", () => {
+    expect(resolveSlackPresenceDndEndTs({ dnd_enabled: false, snooze_enabled: false })).toBe(
+      undefined,
+    );
+  });
+});
+
+describe("formatSlackPresenceTimestamp", () => {
+  it("formats positive unix timestamps as ISO strings", () => {
+    expect(formatSlackPresenceTimestamp(1_700_000_000)).toBe("2023-11-14T22:13:20.000Z");
+    expect(formatSlackPresenceTimestamp(undefined)).toBeUndefined();
+  });
+});
+
+describe("formatSlackPresenceLine", () => {
+  it("formats active and DND-off users", () => {
+    expect(
+      formatSlackPresenceLine({
+        userId: "U123",
+        userName: "Alice",
+        presence: "active",
+        dndEnabled: false,
+        online: true,
+      }),
+    ).toContain("Alice (U123) | presence: active | DND: off | online: yes");
+  });
+
+  it("formats DND end times when present", () => {
+    expect(
+      formatSlackPresenceLine({
+        userId: "U124",
+        userName: "Bob",
+        presence: "away",
+        dndEnabled: true,
+        dndEndAt: "2026-04-02T14:30:00.000Z",
+      }),
+    ).toContain("DND: on until 2026-04-02T14:30:00.000Z");
+  });
+});

--- a/slack-bridge/slack-presence.ts
+++ b/slack-bridge/slack-presence.ts
@@ -1,0 +1,142 @@
+export interface SlackPresenceDirectoryUser {
+  id?: string;
+  name?: string;
+  real_name?: string;
+  deleted?: boolean;
+  profile?: {
+    display_name?: string;
+    real_name?: string;
+  };
+}
+
+export interface SlackPresenceSnapshot {
+  userId: string;
+  userName: string;
+  presence: string;
+  dndEnabled: boolean;
+  dndEndTs?: number;
+  dndEndAt?: string;
+  autoAway?: boolean;
+  manualAway?: boolean;
+  connectionCount?: number;
+  lastActivity?: number;
+  online?: boolean;
+}
+
+export interface SlackDndInfoLike {
+  dnd_enabled?: unknown;
+  next_dnd_end_ts?: unknown;
+  snooze_enabled?: unknown;
+  snooze_endtime?: unknown;
+}
+
+export function stripSlackUserReference(value: string): string {
+  const trimmed = value.trim();
+  const mentionMatch = trimmed.match(/^<@([A-Z0-9]+)>$/i);
+  if (mentionMatch?.[1]) {
+    return mentionMatch[1];
+  }
+  return trimmed.replace(/^@/, "").trim();
+}
+
+export function isSlackUserId(value: string): boolean {
+  return /^[UW][A-Z0-9]{2,}$/i.test(stripSlackUserReference(value));
+}
+
+export function getBestSlackPresenceUserName(user: SlackPresenceDirectoryUser): string {
+  const displayName = user.profile?.display_name?.trim();
+  if (displayName) return displayName;
+
+  const realName = user.real_name?.trim() ?? user.profile?.real_name?.trim();
+  if (realName) return realName;
+
+  const handle = user.name?.trim();
+  if (handle) return handle;
+
+  return user.id?.trim() || "unknown-user";
+}
+
+function normalizeLookupValue(value: string): string {
+  return stripSlackUserReference(value).trim().toLowerCase();
+}
+
+export function findSlackPresenceDirectoryUser(
+  users: SlackPresenceDirectoryUser[],
+  identifier: string,
+): SlackPresenceDirectoryUser | null {
+  const normalized = normalizeLookupValue(identifier);
+  if (!normalized) return null;
+
+  for (const user of users) {
+    if (user.deleted) continue;
+
+    const candidates = [
+      user.id,
+      user.name,
+      user.real_name,
+      user.profile?.display_name,
+      user.profile?.real_name,
+    ]
+      .map((value) => value?.trim())
+      .filter((value): value is string => Boolean(value))
+      .map((value) => value.toLowerCase());
+
+    if (candidates.includes(normalized)) {
+      return user;
+    }
+  }
+
+  return null;
+}
+
+function parsePositiveTs(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+export function resolveSlackPresenceDndEndTs(dndInfo: SlackDndInfoLike): number | undefined {
+  if (dndInfo.snooze_enabled === true) {
+    return parsePositiveTs(dndInfo.snooze_endtime);
+  }
+
+  if (dndInfo.dnd_enabled === true) {
+    return parsePositiveTs(dndInfo.next_dnd_end_ts);
+  }
+
+  return undefined;
+}
+
+export function formatSlackPresenceTimestamp(ts: number | undefined): string | undefined {
+  if (ts == null || !Number.isFinite(ts) || ts <= 0) {
+    return undefined;
+  }
+  return new Date(ts * 1000).toISOString();
+}
+
+export function formatSlackPresenceLine(snapshot: SlackPresenceSnapshot): string {
+  const segments = [`${snapshot.userName} (${snapshot.userId})`, `presence: ${snapshot.presence}`];
+
+  if (snapshot.dndEnabled) {
+    segments.push(
+      snapshot.dndEndAt ? `DND: on until ${snapshot.dndEndAt}` : "DND: on (end time unknown)",
+    );
+  } else {
+    segments.push("DND: off");
+  }
+
+  if (snapshot.online != null) {
+    segments.push(`online: ${snapshot.online ? "yes" : "no"}`);
+  }
+
+  return segments.join(" | ");
+}

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -29,6 +29,13 @@ describe("registerSlackTools", () => {
     let securityPrompt = "INITIAL SECURITY PROMPT";
     let resolveUser = async (userId: string) => userId;
     let conversationsRepliesResponses: SlackResult[] = [];
+    let usersListResponse: SlackResult = {
+      ok: true,
+      members: [],
+      response_metadata: { next_cursor: "" },
+    } as SlackResult;
+    const presenceResponses = new Map<string, SlackResult>();
+    const dndResponses = new Map<string, SlackResult>();
 
     const slack = vi.fn<
       (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>
@@ -99,6 +106,26 @@ describe("registerSlackTools", () => {
         } as SlackResult;
       }
 
+      if (method === "users.getPresence") {
+        const user = typeof body?.user === "string" ? body.user : "";
+        return (
+          presenceResponses.get(user) ??
+          ({ ok: true, token, body, presence: "away", online: false } as SlackResult)
+        );
+      }
+
+      if (method === "dnd.info") {
+        const user = typeof body?.user === "string" ? body.user : "";
+        return (
+          dndResponses.get(user) ??
+          ({ ok: true, token, body, dnd_enabled: false, snooze_enabled: false } as SlackResult)
+        );
+      }
+
+      if (method === "users.list") {
+        return usersListResponse;
+      }
+
       if (method === "conversations.replies" && conversationsRepliesResponses.length > 0) {
         return conversationsRepliesResponses.shift() as SlackResult;
       }
@@ -154,6 +181,15 @@ describe("registerSlackTools", () => {
       },
       setConversationsReplies: (responses: SlackResult[]) => {
         conversationsRepliesResponses = [...responses];
+      },
+      setUsersListResponse: (response: SlackResult) => {
+        usersListResponse = response;
+      },
+      setPresenceResponse: (userId: string, response: SlackResult) => {
+        presenceResponses.set(userId, response);
+      },
+      setDndResponse: (userId: string, response: SlackResult) => {
+        dndResponses.set(userId, response);
       },
       setResolveFollowerReplyChannel: (
         fn: (threadTs: string | undefined) => Promise<string | null>,
@@ -213,6 +249,94 @@ describe("registerSlackTools", () => {
       ts: "123.456",
       limit: 20,
     });
+  });
+
+  it("reports presence and dnd status for a single user", async () => {
+    const { tools, setPresenceResponse, setDndResponse, setResolveUser } = setup();
+    setResolveUser(async (userId: string) => (userId === "U123" ? "Alice" : userId));
+    setPresenceResponse("U123", {
+      ok: true,
+      presence: "active",
+      online: true,
+      auto_away: false,
+      manual_away: false,
+      connection_count: 2,
+      last_activity: 1_700_000_000,
+    } as SlackResult);
+    setDndResponse("U123", {
+      ok: true,
+      dnd_enabled: true,
+      next_dnd_end_ts: 1_800_000_000,
+      snooze_enabled: false,
+    } as SlackResult);
+
+    const response = await tools.get("slack_presence")!.execute("tool-4", { user: "U123" });
+
+    expect(response.content?.[0]?.text).toContain("Alice (U123) | presence: active");
+    expect(response.content?.[0]?.text).toContain("DND: on until 2027-01-15T08:00:00.000Z");
+    expect(response.details?.count).toBe(1);
+  });
+
+  it("supports batch presence lookups by name via users.list", async () => {
+    const { slack, tools, setUsersListResponse, setPresenceResponse, setDndResponse } = setup();
+    setUsersListResponse({
+      ok: true,
+      members: [
+        {
+          id: "U123",
+          name: "alice",
+          real_name: "Alice Example",
+          profile: { display_name: "Ali" },
+        },
+        {
+          id: "U456",
+          name: "bob",
+          real_name: "Bob Example",
+          profile: { display_name: "Bobby" },
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    } as SlackResult);
+    setPresenceResponse("U123", { ok: true, presence: "active", online: true } as SlackResult);
+    setPresenceResponse("U456", { ok: true, presence: "away", online: false } as SlackResult);
+    setDndResponse("U123", {
+      ok: true,
+      dnd_enabled: false,
+      snooze_enabled: false,
+    } as SlackResult);
+    setDndResponse("U456", {
+      ok: true,
+      dnd_enabled: false,
+      snooze_enabled: false,
+    } as SlackResult);
+
+    const response = await tools.get("slack_presence")!.execute("tool-5", {
+      users: ["Ali", "@bob"],
+    });
+
+    expect(slack).toHaveBeenCalledWith("users.list", "xoxb-initial", {
+      limit: 1000,
+    });
+    expect(response.content?.[0]?.text).toContain("Ali (U123)");
+    expect(response.content?.[0]?.text).toContain("Bobby (U456)");
+    expect(response.details?.count).toBe(2);
+  });
+
+  it("caches presence lookups briefly to avoid duplicate Slack API calls", async () => {
+    const { slack, tools, setPresenceResponse, setDndResponse, setResolveUser } = setup();
+    setResolveUser(async (userId: string) => userId);
+    setPresenceResponse("U123", { ok: true, presence: "active", online: true } as SlackResult);
+    setDndResponse("U123", {
+      ok: true,
+      dnd_enabled: false,
+      snooze_enabled: false,
+    } as SlackResult);
+
+    await tools.get("slack_presence")!.execute("tool-6", { user: "U123" });
+    await tools.get("slack_presence")!.execute("tool-7", { user: "U123" });
+
+    expect(slack.mock.calls.filter(([method]) => method === "users.getPresence")).toHaveLength(1);
+    expect(slack.mock.calls.filter(([method]) => method === "dnd.info")).toHaveLength(1);
   });
 
   it("adds reactions with normalized emoji names via slack_react", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -19,6 +19,18 @@ import {
   type SlackBlockButtonInput,
 } from "./slack-block-kit.js";
 import {
+  findSlackPresenceDirectoryUser,
+  formatSlackPresenceLine,
+  formatSlackPresenceTimestamp,
+  getBestSlackPresenceUserName,
+  isSlackUserId,
+  resolveSlackPresenceDndEndTs,
+  stripSlackUserReference,
+  type SlackDndInfoLike,
+  type SlackPresenceDirectoryUser,
+  type SlackPresenceSnapshot,
+} from "./slack-presence.js";
+import {
   buildSlackThreadExport,
   filterSlackExportMessagesByRange,
   parseSlackExportBoundaryTs,
@@ -26,6 +38,7 @@ import {
 import { normalizeReactionName } from "./reaction-triggers.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
+import { TtlCache } from "./ttl-cache.js";
 
 export interface RegisterSlackToolsDeps {
   getBotToken: () => string;
@@ -66,6 +79,7 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "Use slack_schedule for reminders, timed announcements, and delayed follow-ups instead of waiting around to send a message later.",
     "Use slack_pin for important Slack messages you want highlighted in the conversation, and use slack_bookmark for durable channel-header links like repos, dashboards, docs, and runbooks.",
     "Use slack_export to archive or document a Slack thread as markdown, plain text, or JSON before writing it into docs, canvases, or files.",
+    "Use slack_presence before pinging reviewers or scheduling follow-ups when timing matters — it tells you whether someone is active, away, or in DND.",
     "When uploading from a local path, only files inside the current working directory or the system temp directory are allowed.",
   ];
 }
@@ -343,6 +357,151 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         : "Provide channel when reacting to a message outside the current tracked thread.",
     );
   }
+
+  const presenceCache = new TtlCache<string, SlackPresenceSnapshot>({
+    maxSize: 512,
+    ttlMs: 30_000,
+  });
+  let presenceDirectoryCache: { fetchedAt: number; users: SlackPresenceDirectoryUser[] } | null =
+    null;
+
+  function normalizeSlackPresenceTargets(
+    user: string | undefined,
+    users: string[] | undefined,
+  ): string[] {
+    const requested = [user, ...(users ?? [])]
+      .map((value) => value?.trim() ?? "")
+      .filter((value) => value.length > 0);
+
+    if (requested.length === 0) {
+      throw new Error("Provide user or users so Slack knows whose presence to check.");
+    }
+
+    const seen = new Set<string>();
+    const deduped: string[] = [];
+    for (const value of requested) {
+      const key = stripSlackUserReference(value).toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        deduped.push(value);
+      }
+    }
+    return deduped;
+  }
+
+  async function listSlackPresenceDirectoryUsers(): Promise<SlackPresenceDirectoryUser[]> {
+    const now = Date.now();
+    if (presenceDirectoryCache && now - presenceDirectoryCache.fetchedAt <= 5 * 60_000) {
+      return presenceDirectoryCache.users;
+    }
+
+    const users: SlackPresenceDirectoryUser[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const response = await slack("users.list", getBotToken(), {
+        limit: 1000,
+        ...(cursor ? { cursor } : {}),
+      });
+      const batch = Array.isArray(response.members)
+        ? (response.members as SlackPresenceDirectoryUser[])
+        : [];
+      users.push(...batch.filter((member) => member.deleted !== true));
+
+      const nextCursor = (response.response_metadata as { next_cursor?: string } | undefined)
+        ?.next_cursor;
+      cursor = typeof nextCursor === "string" && nextCursor.length > 0 ? nextCursor : undefined;
+    } while (cursor);
+
+    presenceDirectoryCache = { fetchedAt: now, users };
+    return users;
+  }
+
+  async function resolveSlackPresenceTarget(
+    identifier: string,
+  ): Promise<{ userId: string; userName?: string }> {
+    const normalized = stripSlackUserReference(identifier);
+    if (!normalized) {
+      throw new Error("Slack user identifier cannot be empty.");
+    }
+
+    if (isSlackUserId(normalized)) {
+      return { userId: normalized.toUpperCase() };
+    }
+
+    const users = await listSlackPresenceDirectoryUsers();
+    const match = findSlackPresenceDirectoryUser(users, normalized);
+    if (!match?.id) {
+      throw new Error(`Slack user '${identifier}' was not found.`);
+    }
+
+    return {
+      userId: match.id,
+      userName: getBestSlackPresenceUserName(match),
+    };
+  }
+
+  function parseSlackPresenceNumber(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    return undefined;
+  }
+
+  async function fetchSlackPresenceSnapshot(
+    userId: string,
+    userNameHint?: string,
+  ): Promise<SlackPresenceSnapshot> {
+    const cached = presenceCache.get(userId);
+    if (cached) {
+      if (userNameHint && cached.userName !== userNameHint) {
+        const hydrated = { ...cached, userName: userNameHint };
+        presenceCache.set(userId, hydrated);
+        return hydrated;
+      }
+      return cached;
+    }
+
+    const [presenceResponse, dndResponse] = await Promise.all([
+      slack("users.getPresence", getBotToken(), { user: userId }),
+      slack("dnd.info", getBotToken(), { user: userId }),
+    ]);
+
+    const dndEndTs = resolveSlackPresenceDndEndTs(dndResponse as SlackDndInfoLike);
+    const presenceValue =
+      typeof presenceResponse.presence === "string" ? presenceResponse.presence : "unknown";
+    const lastActivity = parseSlackPresenceNumber(presenceResponse.last_activity);
+    const snapshot: SlackPresenceSnapshot = {
+      userId,
+      userName: userNameHint ?? (await resolveUser(userId)),
+      presence: presenceValue,
+      dndEnabled: dndResponse.dnd_enabled === true || dndResponse.snooze_enabled === true,
+      dndEndTs,
+      dndEndAt: formatSlackPresenceTimestamp(dndEndTs),
+      autoAway: presenceResponse.auto_away === true,
+      manualAway: presenceResponse.manual_away === true,
+      connectionCount: parseSlackPresenceNumber(presenceResponse.connection_count),
+      lastActivity,
+      online:
+        typeof presenceResponse.online === "boolean"
+          ? presenceResponse.online
+          : presenceValue === "active"
+            ? true
+            : presenceValue === "away"
+              ? false
+              : undefined,
+    };
+
+    presenceCache.set(userId, snapshot);
+    return snapshot;
+  }
+
   pi.registerTool({
     name: "slack_inbox",
     label: "Slack Inbox",
@@ -762,6 +921,67 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       return {
         content: [{ type: "text", text: lines.join("\n") || "(no messages)" }],
         details: { count: messages.length },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_presence",
+    label: "Slack Presence",
+    description:
+      "Check whether one or more Slack users are active, away, or in Do Not Disturb before messaging them.",
+    promptSnippet:
+      "Check whether Slack users are active, away, or in DND before pinging them, routing work, or deciding whether to schedule a follow-up.",
+    parameters: Type.Object({
+      user: Type.Optional(
+        Type.String({
+          description: "Single Slack user ID, mention, @handle, display name, or real name",
+        }),
+      ),
+      users: Type.Optional(
+        Type.Array(
+          Type.String({
+            description: "Multiple Slack user IDs, mentions, @handles, or names to check in batch",
+          }),
+        ),
+      ),
+    }),
+    async execute(_id, params) {
+      const targets = normalizeSlackPresenceTargets(params.user, params.users);
+      requireToolPolicy(
+        "slack_presence",
+        undefined,
+        `user=${params.user ?? ""} | users=${targets.join(",")}`,
+      );
+
+      const resolvedTargets = await Promise.all(
+        targets.map(async (target) => ({
+          target,
+          ...(await resolveSlackPresenceTarget(target)),
+        })),
+      );
+      const snapshots = await Promise.all(
+        resolvedTargets.map(({ userId, userName }) => fetchSlackPresenceSnapshot(userId, userName)),
+      );
+
+      return {
+        content: [{ type: "text", text: snapshots.map(formatSlackPresenceLine).join("\n") }],
+        details: {
+          count: snapshots.length,
+          results: snapshots.map((snapshot) => ({
+            user: snapshot.userId,
+            user_name: snapshot.userName,
+            presence: snapshot.presence,
+            online: snapshot.online,
+            auto_away: snapshot.autoAway,
+            manual_away: snapshot.manualAway,
+            dnd_enabled: snapshot.dndEnabled,
+            dnd_end_ts: snapshot.dndEndTs,
+            dnd_end_at: snapshot.dndEndAt,
+            connection_count: snapshot.connectionCount,
+            last_activity: snapshot.lastActivity,
+          })),
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
- add a new `slack_presence` tool for active/away/DND checks before messaging people
- cache presence lookups briefly and support both single-user and batch presence checks
- subscribe the Slack manifest to `presence_change` alongside the existing presence scopes/docs

## Details
- added `slack-bridge/slack-presence.ts` + `slack-bridge/slack-presence.test.ts` for:
  - Slack user lookup normalization (`<@U...>`, `@handle`, names)
  - directory matching helpers for ID / handle / real name / display name
  - DND end-time extraction and formatting
  - human-readable presence summaries
- added `slack_presence` in `slack-bridge/slack-tools.ts`
  - accepts `user` or batch `users`
  - resolves names via `users.list` when needed
  - calls `users.getPresence` and `dnd.info`
  - returns active/away plus DND status and end time
  - uses a 30s TTL cache to avoid chatty repeat API calls
- updated `slack-bridge/slack-tools.test.ts` coverage for:
  - single-user presence + DND output
  - batch lookup by display name / handle via `users.list`
  - short-term caching avoiding duplicate presence API calls
- marked `slack_presence` as read-only in `slack-bridge/guardrails.ts` / `guardrails.test.ts`
- updated `slack-bridge/manifest.yaml` to subscribe to `presence_change`
- updated `slack-bridge/README.md` with presence tool documentation and manifest notes

## Verification
- `cd slack-bridge && pnpm test -- --run slack-presence.test.ts slack-tools.test.ts guardrails.test.ts`
- `cd slack-bridge && pnpm typecheck`
- `cd slack-bridge && pnpm lint`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
