### PR TITLE
fix: dedup retried Slack Socket Mode events

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -551,6 +551,74 @@ describe("SlackAdapter", () => {
     expect(adapter.name).toBe("slack");
   });
 
+  it("ignores duplicate Socket Mode message deliveries with the same Slack event_id", async () => {
+    const adapter = new SlackAdapter(baseConfig);
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    const resolveUserSpy = vi
+      .spyOn(
+        adapter as unknown as { resolveUser: (userId: string) => Promise<string> },
+        "resolveUser",
+      )
+      .mockResolvedValue("Alice");
+    const addReactionSpy = vi
+      .spyOn(
+        adapter as unknown as {
+          addReaction: (channel: string, ts: string, emoji: string) => Promise<void>;
+        },
+        "addReaction",
+      )
+      .mockResolvedValue(undefined);
+
+    const firstFrame = JSON.stringify({
+      envelope_id: "env-1",
+      type: "events_api",
+      payload: {
+        event_id: "Ev-duplicate",
+        event: {
+          type: "message",
+          user: "U1",
+          text: "hello",
+          channel: "D1",
+          channel_type: "im",
+          ts: "1.1",
+        },
+      },
+    });
+    const secondFrame = JSON.stringify({
+      envelope_id: "env-2",
+      type: "events_api",
+      payload: {
+        event_id: "Ev-duplicate",
+        event: {
+          type: "message",
+          user: "U1",
+          text: "hello",
+          channel: "D1",
+          channel_type: "im",
+          ts: "1.1",
+        },
+      },
+    });
+
+    await (
+      adapter as unknown as {
+        handleFrame: (raw: string) => Promise<void>;
+      }
+    ).handleFrame(firstFrame);
+    await (
+      adapter as unknown as {
+        handleFrame: (raw: string) => Promise<void>;
+      }
+    ).handleFrame(secondFrame);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(resolveUserSpy).toHaveBeenCalledTimes(1);
+    expect(addReactionSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("emits normalized block action payloads with structured metadata", async () => {
     const rememberKnownThread = vi.fn();
     const adapter = new SlackAdapter({

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -12,7 +12,12 @@ import {
   resolveReactionCommands,
   type ReactionCommandSettings,
 } from "../../reaction-triggers.js";
-import { TtlCache } from "../../ttl-cache.js";
+import { TtlCache, TtlSet } from "../../ttl-cache.js";
+import {
+  extractSlackSocketDedupKey,
+  SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
+  SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
+} from "../../slack-socket-dedup.js";
 import {
   extractSlackBlockActionsPayloadFromEnvelope,
   normalizeSlackBlockActionPayload,
@@ -47,6 +52,7 @@ interface SlackThreadInfo {
 export interface ParsedEnvelope {
   envelopeId?: string;
   type: string;
+  dedupKey?: string;
   event?: Record<string, unknown>;
   interactivePayload?: Record<string, unknown>;
 }
@@ -63,6 +69,10 @@ export function parseSocketFrame(raw: string): ParsedEnvelope | null {
     };
     if (data.envelope_id) {
       result.envelopeId = data.envelope_id as string;
+    }
+    const dedupKey = extractSlackSocketDedupKey(data);
+    if (dedupKey) {
+      result.dedupKey = dedupKey;
     }
     if (data.type === "events_api") {
       const payload = data.payload as { event?: Record<string, unknown> } | undefined;
@@ -206,6 +216,10 @@ export class SlackAdapter implements MessageAdapter {
     maxSize: 2000,
     ttlMs: 60 * 60 * 1000,
   });
+  private readonly processedSocketDeliveries = new TtlSet<string>({
+    maxSize: SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
+    ttlMs: SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
+  });
   private readonly pendingEyes = new Map<string, { channel: string; messageTs: string }[]>();
 
   constructor(config: SlackAdapterConfig) {
@@ -334,36 +348,52 @@ export class SlackAdapter implements MessageAdapter {
       this.ws?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
     }
 
-    if (envelope.type === "disconnect") {
-      this.scheduleReconnect();
-      return;
-    }
+    const dedupKey: string | null = envelope.dedupKey ?? null;
 
-    if (envelope.interactivePayload) {
-      await this.onBlockActions(envelope.interactivePayload);
-      return;
-    }
+    try {
+      if (dedupKey) {
+        if (this.processedSocketDeliveries.has(dedupKey)) {
+          return;
+        }
+        this.processedSocketDeliveries.add(dedupKey);
+      }
 
-    if (!envelope.event) return;
+      if (envelope.type === "disconnect") {
+        this.scheduleReconnect();
+        return;
+      }
 
-    const evt = envelope.event;
+      if (envelope.interactivePayload) {
+        await this.onBlockActions(envelope.interactivePayload);
+        return;
+      }
 
-    switch (evt.type) {
-      case "assistant_thread_started":
-        await this.onThreadStarted(evt);
-        break;
-      case "assistant_thread_context_changed":
-        this.onContextChanged(evt);
-        break;
-      case "message":
-        await this.onMessage(evt);
-        break;
-      case "reaction_added":
-        await this.onReactionAdded(evt);
-        break;
-      case "member_joined_channel":
-        this.onMemberJoined(evt);
-        break;
+      if (!envelope.event) return;
+
+      const evt = envelope.event;
+
+      switch (evt.type) {
+        case "assistant_thread_started":
+          await this.onThreadStarted(evt);
+          break;
+        case "assistant_thread_context_changed":
+          this.onContextChanged(evt);
+          break;
+        case "message":
+          await this.onMessage(evt);
+          break;
+        case "reaction_added":
+          await this.onReactionAdded(evt);
+          break;
+        case "member_joined_channel":
+          this.onMemberJoined(evt);
+          break;
+      }
+    } catch (err) {
+      if (dedupKey) {
+        this.processedSocketDeliveries.delete(dedupKey);
+      }
+      throw err;
     }
   }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -105,6 +105,11 @@ import {
   normalizeSlackBlockActionPayload,
 } from "./slack-block-kit.js";
 import {
+  extractSlackSocketDedupKey,
+  SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
+  SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
+} from "./slack-socket-dedup.js";
+import {
   createFollowerDeliveryState,
   drainFollowerAckBatches,
   hasDeliveredFollowerInboxIds,
@@ -336,6 +341,10 @@ export default function (pi: ExtensionAPI) {
   let lastDmChannel: string | null = null;
   const channelCache = new TtlCache<string, string>({ maxSize: 500, ttlMs: 30 * 60 * 1000 });
   const unclaimedThreads = new TtlSet<string>({ maxSize: 5000, ttlMs: 5 * 60 * 1000 });
+  const processedSlackSocketDeliveries = new TtlSet<string>({
+    maxSize: SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
+    ttlMs: SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
+  });
 
   const threadConfirmationStates = new Map<string, ThreadConfirmationState>();
 
@@ -736,12 +745,22 @@ export default function (pi: ExtensionAPI) {
   async function handleFrame(raw: string, ctx: ExtensionContext): Promise<void> {
     if (shuttingDown) return;
 
+    let dedupKey: string | null = null;
+
     try {
       const data = JSON.parse(raw) as Record<string, unknown>;
 
       // ack every envelope
       if (data.envelope_id) {
         ws?.send(JSON.stringify({ envelope_id: data.envelope_id }));
+      }
+
+      dedupKey = extractSlackSocketDedupKey(data);
+      if (dedupKey) {
+        if (processedSlackSocketDeliveries.has(dedupKey)) {
+          return;
+        }
+        processedSlackSocketDeliveries.add(dedupKey);
       }
 
       if (data.type === "disconnect") {
@@ -789,6 +808,9 @@ export default function (pi: ExtensionAPI) {
           break;
       }
     } catch {
+      if (dedupKey) {
+        processedSlackSocketDeliveries.delete(dedupKey);
+      }
       /* malformed frame */
     }
   }

--- a/slack-bridge/slack-socket-dedup.test.ts
+++ b/slack-bridge/slack-socket-dedup.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractSlackBlockActionDedupKey,
+  extractSlackEventDedupKey,
+  extractSlackSocketDedupKey,
+} from "./slack-socket-dedup.js";
+
+describe("extractSlackSocketDedupKey", () => {
+  it("prefers Slack event_id for events_api frames", () => {
+    expect(
+      extractSlackSocketDedupKey({
+        type: "events_api",
+        payload: {
+          event_id: "Ev123",
+          event: {
+            type: "message",
+            channel: "D1",
+            ts: "111.222",
+            user: "U1",
+          },
+        },
+      }),
+    ).toBe("event:Ev123");
+  });
+
+  it("falls back to a stable message signature when event_id is missing", () => {
+    expect(
+      extractSlackSocketDedupKey({
+        type: "events_api",
+        payload: {
+          event: {
+            type: "message",
+            channel: "D1",
+            thread_ts: "111.000",
+            ts: "111.222",
+            user: "U1",
+          },
+        },
+      }),
+    ).toBe("message:D1:111.000:111.222:U1:");
+  });
+
+  it("extracts block action dedup keys from interactive frames", () => {
+    expect(
+      extractSlackSocketDedupKey({
+        type: "interactive",
+        payload: {
+          type: "block_actions",
+          user: { id: "U1" },
+          channel: { id: "C1" },
+          container: {
+            channel_id: "C1",
+            thread_ts: "111.000",
+            message_ts: "111.222",
+          },
+          actions: [
+            {
+              action_id: "review.approve",
+              action_ts: "111.333",
+            },
+          ],
+        },
+      }),
+    ).toBe("block_actions:U1:C1:111.000:111.222:review.approve@111.333");
+  });
+});
+
+describe("extractSlackEventDedupKey", () => {
+  it("builds stable keys for reaction_added events", () => {
+    expect(
+      extractSlackEventDedupKey({
+        type: "reaction_added",
+        user: "U_REACTOR",
+        reaction: "eyes",
+        event_ts: "999.000",
+        item: {
+          type: "message",
+          channel: "C123",
+          ts: "111.333",
+        },
+      }),
+    ).toBe("reaction_added:C123:111.333:U_REACTOR:eyes:999.000");
+  });
+});
+
+describe("extractSlackBlockActionDedupKey", () => {
+  it("still derives a stable key when block actions omit action_ts", () => {
+    expect(
+      extractSlackBlockActionDedupKey({
+        type: "block_actions",
+        user: { id: "U1" },
+        channel: { id: "C1" },
+        container: {
+          channel_id: "C1",
+          thread_ts: "111.000",
+          message_ts: "111.222",
+        },
+        actions: [{ action_id: "review.approve" }],
+      }),
+    ).toBe("block_actions:U1:C1:111.000:111.222:review.approve@");
+  });
+});

--- a/slack-bridge/slack-socket-dedup.ts
+++ b/slack-bridge/slack-socket-dedup.ts
@@ -1,0 +1,141 @@
+import { extractSlackBlockActionsPayloadFromEnvelope } from "./slack-block-kit.js";
+
+export const SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS = 10 * 60 * 1000;
+export const SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE = 10_000;
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function buildSlackMessageDedupKey(evt: Record<string, unknown>): string | null {
+  const channel = asNonEmptyString(evt.channel);
+  const ts = asNonEmptyString(evt.ts);
+  if (!channel || !ts) {
+    return null;
+  }
+
+  return [
+    "message",
+    channel,
+    asNonEmptyString(evt.thread_ts) ?? "",
+    ts,
+    asNonEmptyString(evt.user) ?? asNonEmptyString(evt.bot_id) ?? "",
+    asNonEmptyString(evt.subtype) ?? "",
+  ].join(":");
+}
+
+function buildSlackReactionDedupKey(evt: Record<string, unknown>): string | null {
+  const item = evt.item as { type?: string; channel?: string; ts?: string } | undefined;
+  if (!item || item.type !== "message" || !item.channel || !item.ts) {
+    return null;
+  }
+
+  return [
+    "reaction_added",
+    item.channel,
+    item.ts,
+    asNonEmptyString(evt.user) ?? "",
+    asNonEmptyString(evt.reaction) ?? "",
+    asNonEmptyString(evt.event_ts) ?? "",
+  ].join(":");
+}
+
+function buildSlackAssistantThreadDedupKey(
+  kind: "assistant_thread_started" | "assistant_thread_context_changed",
+  evt: Record<string, unknown>,
+): string | null {
+  const thread = evt.assistant_thread as
+    | { channel_id?: string; thread_ts?: string; user_id?: string }
+    | undefined;
+  if (!thread?.channel_id || !thread.thread_ts) {
+    return null;
+  }
+
+  return [kind, thread.channel_id, thread.thread_ts, thread.user_id ?? ""].join(":");
+}
+
+function buildMemberJoinedDedupKey(evt: Record<string, unknown>): string | null {
+  const channel = asNonEmptyString(evt.channel);
+  const user = asNonEmptyString(evt.user);
+  if (!channel || !user) {
+    return null;
+  }
+
+  return ["member_joined_channel", channel, user, asNonEmptyString(evt.event_ts) ?? ""].join(":");
+}
+
+export function extractSlackEventDedupKey(evt: Record<string, unknown>): string | null {
+  const type = asNonEmptyString(evt.type);
+  if (!type) {
+    return null;
+  }
+
+  switch (type) {
+    case "message":
+      return buildSlackMessageDedupKey(evt);
+    case "reaction_added":
+      return buildSlackReactionDedupKey(evt);
+    case "assistant_thread_started":
+      return buildSlackAssistantThreadDedupKey("assistant_thread_started", evt);
+    case "assistant_thread_context_changed":
+      return buildSlackAssistantThreadDedupKey("assistant_thread_context_changed", evt);
+    case "member_joined_channel":
+      return buildMemberJoinedDedupKey(evt);
+    default: {
+      const eventTs = asNonEmptyString(evt.event_ts);
+      return eventTs ? [type, eventTs].join(":") : null;
+    }
+  }
+}
+
+export function extractSlackBlockActionDedupKey(payload: Record<string, unknown>): string | null {
+  if (payload.type !== "block_actions") {
+    return null;
+  }
+
+  const user = payload.user as { id?: string } | undefined;
+  const channel = payload.channel as { id?: string } | undefined;
+  const container = payload.container as
+    | { channel_id?: string; message_ts?: string; thread_ts?: string }
+    | undefined;
+  const actions = Array.isArray(payload.actions)
+    ? payload.actions.filter(
+        (action): action is { action_id?: string; action_ts?: string } =>
+          typeof action === "object" && action !== null,
+      )
+    : [];
+
+  const actionSignature = actions
+    .map((action) => `${action.action_id ?? ""}@${action.action_ts ?? ""}`)
+    .sort()
+    .join(",");
+  if (!actionSignature) {
+    return null;
+  }
+
+  return [
+    "block_actions",
+    user?.id ?? "",
+    channel?.id ?? container?.channel_id ?? "",
+    container?.thread_ts ?? "",
+    container?.message_ts ?? "",
+    actionSignature,
+  ].join(":");
+}
+
+export function extractSlackSocketDedupKey(frame: Record<string, unknown>): string | null {
+  if (frame.type === "events_api") {
+    const payload = frame.payload as
+      | { event_id?: string; event?: Record<string, unknown> }
+      | undefined;
+    const eventId = asNonEmptyString(payload?.event_id);
+    if (eventId) {
+      return `event:${eventId}`;
+    }
+
+    return payload?.event ? extractSlackEventDedupKey(payload.event) : null;
+  }
+
+  const interactivePayload = extractSlackBlockActionsPayloadFromEnvelope(frame);
+  return interactivePayload ? extractSlackBlockActionDedupKey(interactivePayload) : null;
+}


### PR DESCRIPTION
## Summary
- dedup retried Slack Socket Mode deliveries before they can re-enter the broker or local inbox
- share stable Slack delivery key extraction for events_api and interactive block actions
- cover the regression with adapter + helper tests

## Root cause
PR #186 deduplicates follower delivery by broker inbox row id. That protects against ACK/reconnect races, but it does **not** stop the same Slack event from creating multiple broker inbox rows when Socket Mode redelivers it. A retried Slack event gets a new envelope and new broker row ids, so the follower-side dedup never matches it.

The missing stable key was the Slack delivery itself (`event_id`, with a fallback signature when needed).

## Details
- added `slack-bridge/slack-socket-dedup.ts`
  - extracts a stable dedup key from Socket Mode frames
  - prefers Slack `event_id`
  - falls back to stable signatures for message / reaction / assistant-thread / member-joined events
  - derives interactive `block_actions` dedup keys too
- updated `slack-bridge/broker/adapters/slack.ts`
  - parse + retain Socket Mode dedup keys
  - keep a TTL dedup set across reconnects
  - drop duplicate Slack deliveries before broker routing / inbox fanout
  - release the key again if processing throws so a later retry is not permanently suppressed
- updated `slack-bridge/index.ts`
  - apply the same dedup protection to the non-broker/local Socket Mode path
- added tests:
  - `slack-bridge/slack-socket-dedup.test.ts`
  - `slack-bridge/broker/adapters/slack.test.ts` regression for duplicate `event_id`

## Verification
- `cd slack-bridge && pnpm test -- --run slack-socket-dedup.test.ts broker/adapters/slack.test.ts`
- `cd slack-bridge && pnpm typecheck`
- `cd slack-bridge && pnpm lint`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #223.
