### PR TITLE
feat: add Slack modal workflows

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -34,6 +34,10 @@ If the agent is idle, incoming messages are processed immediately.
 | `slack_read(thread_ts, limit?)`                                                     | Read thread messages                         |
 | `slack_inbox()`                                                                     | Check pending messages manually              |
 | `slack_blocks_build(template, ...)`                                                 | Build common Block Kit payloads              |
+| `slack_modal_build(template, ...)`                                                  | Build common Slack modal payloads            |
+| `slack_modal_open(trigger_id, view, thread_ts?)`                                    | Open a Slack modal                           |
+| `slack_modal_push(trigger_id, view, thread_ts?)`                                    | Push a new modal step onto the stack         |
+| `slack_modal_update(view, view_id?, external_id?, hash?, thread_ts?)`               | Update an existing open modal                |
 | `slack_create_channel(name, topic?, purpose?)`                                      | Create a project channel                     |
 | `slack_post_channel(channel?, text, thread_ts?, blocks?)`                           | Post to a channel                            |
 | `slack_read_channel(channel, thread_ts?, limit?)`                                   | Read channel history or thread               |
@@ -72,7 +76,8 @@ a short cache to avoid hammering Slack.
 - **@mentions** — tag Pinet in any channel and it responds in-thread
 - **Channel & canvas tools** — create/read/post in channels and maintain persistent Slack canvases
 - **Block Kit messages** — send rich Slack layouts via the optional `blocks` parameter
-- **Interactive buttons** — `block_actions` button clicks are routed back into the inbox as structured events
+- **Interactive workflows** — `block_actions` button clicks and `view_submission` modal submits are routed back into the inbox as structured events
+- **Slack modals** — open, push, and update modal views for confirmations, forms, and multi-step workflows
 - **File & snippet uploads** — share diffs, logs, screenshots, exports, and long code snippets without pasting giant messages
 - **Scheduled & delayed messages** — queue reminders, timed announcements, and follow-ups without waiting around
 - **Pins & bookmarks** — highlight key messages and manage durable channel-header links
@@ -166,9 +171,10 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 The `manifest.yaml` includes all required scopes and events, including `files:write`
 for `slack_upload`, `chat:write` for `slack_schedule`, bookmark/pin scopes for
 `slack_bookmark` and `slack_pin`, `users:read` + `users.getPresence` / `dnd.info`
-for presence checks, and `reaction_added` + `reactions:read` plus `presence_change`
-for Slack-side awareness events. Use it when creating the app (**From a manifest**) or
-paste it into **App Manifest** in settings.
+for presence checks, `reaction_added` + `reactions:read` plus `presence_change`
+for Slack-side awareness events, and `interactivity.is_enabled: true` for buttons
+and modals. Use it when creating the app (**From a manifest**) or paste it into
+**App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:
 
@@ -214,7 +220,33 @@ Example `slack_send` payload:
 }
 ```
 
-Button clicks arrive back through the inbox as structured events with metadata like `kind=slack_block_action`, `actionId`, `value`, and best-effort `parsedValue` when the button value is JSON.
+Button clicks arrive back through the inbox as structured events with metadata like `kind=slack_block_action`, `triggerId`, `actionId`, `value`, and best-effort `parsedValue` when the button value is JSON.
+
+## Modal workflows
+
+Use `slack_modal_build` to generate common modal payloads, then pass the returned `view`
+into `slack_modal_open`, `slack_modal_push`, or `slack_modal_update`.
+
+- `slack_modal_open` / `slack_modal_push` need a fresh `trigger_id` from a recent
+  Slack interaction (button click or modal submit). Trigger IDs expire after roughly
+  3 seconds, so if Slack returns `invalid_trigger`, ask the user to click again and
+  reopen the modal immediately.
+- Pass `thread_ts` when opening or pushing a modal if you want later `view_submission`
+  payloads routed back into the original Slack thread.
+- Modal submissions arrive through the inbox as `kind=slack_view_submission` with
+  `callbackId`, `viewId`, and parsed `stateValues`.
+
+Example `slack_modal_build` confirmation request:
+
+```json
+{
+  "template": "confirmation",
+  "title": "Deploy approval",
+  "text": "Ready to deploy to production.",
+  "confirm_phrase": "CONFIRM",
+  "callback_id": "deploy.confirm"
+}
+```
 
 ## Security
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -669,6 +669,10 @@ describe("SlackAdapter", () => {
       timestamp: "123.789",
       metadata: {
         kind: "slack_block_action",
+        triggerId: "trigger-1",
+        viewId: null,
+        callbackId: null,
+        viewHash: null,
         actionId: "review.approve",
         blockId: "review-actions",
         value: '{"decision":"approve"}',
@@ -677,6 +681,7 @@ describe("SlackAdapter", () => {
         channel: "C123",
         threadTs: "123.000",
         messageTs: "123.456",
+        modalPrivateMetadata: null,
         actions: [
           {
             actionId: "review.approve",
@@ -689,6 +694,77 @@ describe("SlackAdapter", () => {
             actionTs: "123.789",
           },
         ],
+      },
+    });
+  });
+
+  it("emits view submission payloads with parsed modal state", async () => {
+    const rememberKnownThread = vi.fn();
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      rememberKnownThread,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    vi.spyOn(
+      adapter as unknown as { resolveUser: (userId: string) => Promise<string> },
+      "resolveUser",
+    ).mockResolvedValue("Will");
+
+    await (
+      adapter as unknown as {
+        onViewSubmission: (payload: Record<string, unknown>) => Promise<void>;
+      }
+    ).onViewSubmission({
+      type: "view_submission",
+      trigger_id: "trigger-1",
+      user: { id: "U123" },
+      view: {
+        id: "V123",
+        callback_id: "deploy.confirm",
+        title: { type: "plain_text", text: "Deploy approval" },
+        private_metadata:
+          '{"workflow":"deploy","__piSlackModalContext":{"threadTs":"123.000","channel":"C123"}}',
+        state: {
+          values: {
+            confirm_phrase: {
+              confirm_phrase: {
+                type: "plain_text_input",
+                value: "CONFIRM",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123");
+    expect(handler).toHaveBeenCalledWith({
+      source: "slack",
+      threadId: "123.000",
+      channel: "C123",
+      userId: "U123",
+      userName: "Will",
+      text: 'Submitted Slack modal (deploy.confirm) "Deploy approval".',
+      timestamp: "V123",
+      metadata: {
+        kind: "slack_view_submission",
+        triggerId: "trigger-1",
+        callbackId: "deploy.confirm",
+        viewId: "V123",
+        externalId: null,
+        viewHash: null,
+        channel: "C123",
+        threadTs: "123.000",
+        privateMetadata: { workflow: "deploy" },
+        stateValues: {
+          confirm_phrase: {
+            confirm_phrase: {
+              type: "plain_text_input",
+              value: "CONFIRM",
+            },
+          },
+        },
       },
     });
   });

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -19,8 +19,9 @@ import {
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
 } from "../../slack-socket-dedup.js";
 import {
-  extractSlackBlockActionsPayloadFromEnvelope,
+  extractSlackInteractivePayloadFromEnvelope,
   normalizeSlackBlockActionPayload,
+  normalizeSlackViewSubmissionPayload,
 } from "../../slack-block-kit.js";
 import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
 
@@ -79,7 +80,7 @@ export function parseSocketFrame(raw: string): ParsedEnvelope | null {
       result.event = payload?.event;
     }
 
-    const interactivePayload = extractSlackBlockActionsPayloadFromEnvelope(data);
+    const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
     if (interactivePayload) {
       result.interactivePayload = interactivePayload;
     }
@@ -364,7 +365,11 @@ export class SlackAdapter implements MessageAdapter {
       }
 
       if (envelope.interactivePayload) {
-        await this.onBlockActions(envelope.interactivePayload);
+        if (envelope.interactivePayload.type === "block_actions") {
+          await this.onBlockActions(envelope.interactivePayload);
+        } else if (envelope.interactivePayload.type === "view_submission") {
+          await this.onViewSubmission(envelope.interactivePayload);
+        }
         return;
       }
 
@@ -600,12 +605,14 @@ export class SlackAdapter implements MessageAdapter {
     });
   }
 
-  private async onBlockActions(payload: Record<string, unknown>): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const normalized = normalizeSlackBlockActionPayload(payload);
-    if (!normalized) return;
-
+  private async emitInteractiveInbound(normalized: {
+    channel: string;
+    threadTs: string;
+    userId: string;
+    text: string;
+    timestamp: string;
+    metadata: Record<string, unknown>;
+  }): Promise<void> {
     if (!this.threads.has(normalized.threadTs)) {
       this.threads.set(normalized.threadTs, {
         channelId: normalized.channel,
@@ -635,6 +642,22 @@ export class SlackAdapter implements MessageAdapter {
       timestamp: normalized.timestamp,
       metadata: normalized.metadata,
     });
+  }
+
+  private async onBlockActions(payload: Record<string, unknown>): Promise<void> {
+    if (this.shuttingDown) return;
+
+    const normalized = normalizeSlackBlockActionPayload(payload);
+    if (!normalized) return;
+    await this.emitInteractiveInbound(normalized);
+  }
+
+  private async onViewSubmission(payload: Record<string, unknown>): Promise<void> {
+    if (this.shuttingDown) return;
+
+    const normalized = normalizeSlackViewSubmissionPayload(payload);
+    if (!normalized) return;
+    await this.emitInteractiveInbound(normalized);
   }
 
   private onMemberJoined(evt: Record<string, unknown>): void {

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -100,6 +100,9 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("slack_pin")).toBe(true);
     expect(WRITE_TOOLS.has("slack_bookmark")).toBe(true);
     expect(WRITE_TOOLS.has("slack_react")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_modal_open")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_modal_push")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_modal_update")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_export")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_presence")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
@@ -109,6 +112,9 @@ describe("isToolBlocked", () => {
     expect(READ_ONLY_TOOLS.has("slack_pin")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_bookmark")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_react")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_modal_open")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_modal_push")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_modal_update")).toBe(false);
     expect(WRITE_TOOLS.has("slack_presence")).toBe(false);
   });
 

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -41,6 +41,9 @@ export const WRITE_TOOLS = new Set([
   "slack_pin",
   "slack_bookmark",
   "slack_react",
+  "slack_modal_open",
+  "slack_modal_push",
+  "slack_modal_update",
   "pinet_schedule",
 ]);
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -101,8 +101,9 @@ import {
 } from "./broker/agent-messaging.js";
 import { registerSlackTools } from "./slack-tools.js";
 import {
-  extractSlackBlockActionsPayloadFromEnvelope,
+  extractSlackInteractivePayloadFromEnvelope,
   normalizeSlackBlockActionPayload,
+  normalizeSlackViewSubmissionPayload,
 } from "./slack-block-kit.js";
 import {
   extractSlackSocketDedupKey,
@@ -768,9 +769,13 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      const interactivePayload = extractSlackBlockActionsPayloadFromEnvelope(data);
+      const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
       if (interactivePayload) {
-        await onBlockActions(interactivePayload, ctx);
+        if (interactivePayload.type === "block_actions") {
+          await onBlockActions(interactivePayload, ctx);
+        } else if (interactivePayload.type === "view_submission") {
+          await onViewSubmission(interactivePayload, ctx);
+        }
         return;
       }
 
@@ -1095,15 +1100,17 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
-  async function onBlockActions(
-    payload: Record<string, unknown>,
+  async function queueInteractiveInboxEvent(
+    normalized: {
+      channel: string;
+      threadTs: string;
+      userId: string;
+      text: string;
+      timestamp: string;
+      metadata: Record<string, unknown>;
+    },
     ctx: ExtensionContext,
   ): Promise<void> {
-    if (shuttingDown) return;
-
-    const normalized = normalizeSlackBlockActionPayload(payload);
-    if (!normalized) return;
-
     if (!threads.has(normalized.threadTs)) {
       threads.set(normalized.threadTs, {
         channelId: normalized.channel,
@@ -1163,6 +1170,28 @@ export default function (pi: ExtensionAPI) {
     if (ctx.isIdle?.()) {
       drainInbox();
     }
+  }
+
+  async function onBlockActions(
+    payload: Record<string, unknown>,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    if (shuttingDown) return;
+
+    const normalized = normalizeSlackBlockActionPayload(payload);
+    if (!normalized) return;
+    await queueInteractiveInboxEvent(normalized, ctx);
+  }
+
+  async function onViewSubmission(
+    payload: Record<string, unknown>,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    if (shuttingDown) return;
+
+    const normalized = normalizeSlackViewSubmissionPayload(payload);
+    if (!normalized) return;
+    await queueInteractiveInboxEvent(normalized, ctx);
   }
 
   // ─── Reconnect / status ─────────────────────────────

--- a/slack-bridge/slack-block-kit.test.ts
+++ b/slack-bridge/slack-block-kit.test.ts
@@ -4,8 +4,10 @@ import {
   buildSlackBlocksTemplate,
   encodeSlackBlockActionValue,
   extractSlackBlockActionsPayloadFromEnvelope,
+  extractSlackInteractivePayloadFromEnvelope,
   normalizeSlackBlockActionPayload,
   normalizeSlackBlocksInput,
+  normalizeSlackViewSubmissionPayload,
 } from "./slack-block-kit.js";
 
 describe("normalizeSlackBlocksInput", () => {
@@ -116,6 +118,15 @@ describe("extractSlackBlockActionsPayloadFromEnvelope", () => {
     ).toEqual({ type: "block_actions", actions: [] });
   });
 
+  it("extracts generic interactive payloads such as view submissions", () => {
+    expect(
+      extractSlackInteractivePayloadFromEnvelope({
+        type: "interactive",
+        payload: JSON.stringify({ type: "view_submission", view: { id: "V1" } }),
+      }),
+    ).toEqual({ type: "view_submission", view: { id: "V1" } });
+  });
+
   it("ignores non-interactive envelopes", () => {
     expect(
       extractSlackBlockActionsPayloadFromEnvelope({
@@ -159,6 +170,10 @@ describe("normalizeSlackBlockActionPayload", () => {
       timestamp: "123.789",
       metadata: {
         kind: "slack_block_action",
+        triggerId: "trigger-1",
+        viewId: null,
+        callbackId: null,
+        viewHash: null,
         actionId: "review.approve",
         blockId: "review-actions",
         value: '{"decision":"approve","pr":212}',
@@ -167,6 +182,7 @@ describe("normalizeSlackBlockActionPayload", () => {
         channel: "C123",
         threadTs: "123.000",
         messageTs: "123.456",
+        modalPrivateMetadata: null,
         actions: [
           {
             actionId: "review.approve",
@@ -203,5 +219,93 @@ describe("normalizeSlackBlockActionPayload", () => {
 
     expect(event?.threadTs).toBe("222.333");
     expect(event?.timestamp).toBe("222.333");
+  });
+
+  it("routes modal block actions using private_metadata thread context", () => {
+    const event = normalizeSlackBlockActionPayload({
+      type: "block_actions",
+      trigger_id: "trigger-2",
+      user: { id: "U123" },
+      view: {
+        id: "V123",
+        callback_id: "deploy.confirm",
+        hash: "hash-1",
+        private_metadata:
+          '{"workflow":"deploy","__piSlackModalContext":{"threadTs":"123.456","channel":"C123"}}',
+      },
+      actions: [
+        {
+          action_id: "deploy.confirm.toggle",
+          type: "radio_buttons",
+          action_ts: "333.444",
+        },
+      ],
+    });
+
+    expect(event).toMatchObject({
+      channel: "C123",
+      threadTs: "123.456",
+      metadata: {
+        kind: "slack_block_action",
+        triggerId: "trigger-2",
+        viewId: "V123",
+        callbackId: "deploy.confirm",
+        modalPrivateMetadata: { workflow: "deploy" },
+      },
+    });
+  });
+});
+
+describe("normalizeSlackViewSubmissionPayload", () => {
+  it("normalizes modal submissions into inbox events with parsed state", () => {
+    const event = normalizeSlackViewSubmissionPayload({
+      type: "view_submission",
+      trigger_id: "trigger-1",
+      user: { id: "U123" },
+      view: {
+        id: "V123",
+        callback_id: "deploy.confirm",
+        title: { type: "plain_text", text: "Deploy approval" },
+        private_metadata:
+          '{"workflow":"deploy","__piSlackModalContext":{"threadTs":"123.456","channel":"C123"}}',
+        state: {
+          values: {
+            confirm_phrase: {
+              confirm_phrase: {
+                type: "plain_text_input",
+                value: "CONFIRM",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(event).toEqual({
+      channel: "C123",
+      threadTs: "123.456",
+      userId: "U123",
+      text: 'Submitted Slack modal (deploy.confirm) "Deploy approval".',
+      timestamp: "V123",
+      metadata: {
+        kind: "slack_view_submission",
+        triggerId: "trigger-1",
+        callbackId: "deploy.confirm",
+        viewId: "V123",
+        externalId: null,
+        viewHash: null,
+        channel: "C123",
+        threadTs: "123.456",
+        privateMetadata: { workflow: "deploy" },
+        stateValues: {
+          confirm_phrase: {
+            confirm_phrase: {
+              type: "plain_text_input",
+              value: "CONFIRM",
+            },
+          },
+        },
+      },
+    });
   });
 });

--- a/slack-bridge/slack-block-kit.ts
+++ b/slack-bridge/slack-block-kit.ts
@@ -1,3 +1,5 @@
+import { decodeSlackModalPrivateMetadata } from "./slack-modals.js";
+
 export type SlackBlock = Record<string, unknown>;
 
 export interface SlackBlockFieldInput {
@@ -52,6 +54,17 @@ export interface SlackBlockActionInboxEvent {
   metadata: Record<string, unknown>;
 }
 
+export interface SlackViewSubmissionInboxEvent {
+  channel: string;
+  threadTs: string;
+  userId: string;
+  text: string;
+  timestamp: string;
+  metadata: Record<string, unknown>;
+}
+
+export type SlackInteractiveInboxEvent = SlackBlockActionInboxEvent | SlackViewSubmissionInboxEvent;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -78,6 +91,49 @@ function tryParseJson(value: string | undefined): unknown {
   } catch {
     return undefined;
   }
+}
+
+function normalizeViewStateValue(value: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  if (typeof value.type === "string") {
+    result.type = value.type;
+  }
+  if (typeof value.value === "string") {
+    result.value = value.value;
+  }
+  if (typeof value.selected_date === "string") {
+    result.selectedDate = value.selected_date;
+  }
+  if (typeof value.selected_time === "string") {
+    result.selectedTime = value.selected_time;
+  }
+  if (typeof value.selected_conversation === "string") {
+    result.selectedConversation = value.selected_conversation;
+  }
+  if (typeof value.selected_channel === "string") {
+    result.selectedChannel = value.selected_channel;
+  }
+  if (typeof value.selected_user === "string") {
+    result.selectedUser = value.selected_user;
+  }
+  if (typeof value.selected_option === "object" && value.selected_option !== null) {
+    result.selectedOption = value.selected_option;
+  }
+  if (Array.isArray(value.selected_options)) {
+    result.selectedOptions = value.selected_options;
+  }
+  if (Array.isArray(value.selected_conversations)) {
+    result.selectedConversations = value.selected_conversations;
+  }
+  if (Array.isArray(value.selected_channels)) {
+    result.selectedChannels = value.selected_channels;
+  }
+  if (Array.isArray(value.selected_users)) {
+    result.selectedUsers = value.selected_users;
+  }
+
+  return result;
 }
 
 function joinNonEmpty(parts: Array<string | undefined>): string {
@@ -298,7 +354,7 @@ export function buildSlackBlocksTemplate(
   }
 }
 
-export function extractSlackBlockActionsPayloadFromEnvelope(
+export function extractSlackInteractivePayloadFromEnvelope(
   envelope: Record<string, unknown>,
 ): Record<string, unknown> | null {
   if (envelope.type !== "interactive") return null;
@@ -314,7 +370,14 @@ export function extractSlackBlockActionsPayloadFromEnvelope(
   }
 
   if (!isRecord(payload)) return null;
-  return payload.type === "block_actions" ? payload : null;
+  return payload;
+}
+
+export function extractSlackBlockActionsPayloadFromEnvelope(
+  envelope: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const payload = extractSlackInteractivePayloadFromEnvelope(envelope);
+  return payload?.type === "block_actions" ? payload : null;
 }
 
 export function normalizeSlackBlockActionPayload(
@@ -324,6 +387,7 @@ export function normalizeSlackBlockActionPayload(
   const container = asRecord(payload.container);
   const channel = asRecord(payload.channel);
   const message = asRecord(payload.message);
+  const view = asRecord(payload.view);
   const actions = Array.isArray(payload.actions)
     ? payload.actions
         .map((entry) => asRecord(entry))
@@ -335,19 +399,30 @@ export function normalizeSlackBlockActionPayload(
     .filter((action): action is SlackNormalizedBlockAction => Boolean(action));
   if (normalizedActions.length === 0) return null;
 
+  const modalMetadata = decodeSlackModalPrivateMetadata(asString(view?.private_metadata));
   const channelId =
     asString(container?.channel_id) ??
     asString(channel?.id) ??
-    asString((message?.channel as Record<string, unknown> | undefined)?.id);
+    asString((message?.channel as Record<string, unknown> | undefined)?.id) ??
+    modalMetadata.threadContext?.channel;
   const messageTs = asString(container?.message_ts) ?? asString(message?.ts);
-  const threadTs = asString(container?.thread_ts) ?? asString(message?.thread_ts) ?? messageTs;
+  const threadTs =
+    asString(container?.thread_ts) ??
+    asString(message?.thread_ts) ??
+    messageTs ??
+    modalMetadata.threadContext?.threadTs;
   const userId = asString(user?.id);
 
-  if (!channelId || !threadTs || !userId || !messageTs) return null;
+  if (!channelId || !threadTs || !userId) return null;
 
   const primaryAction = normalizedActions[0];
   const label = primaryAction.text?.trim() ? `"${primaryAction.text.trim()}"` : "button";
-  const timestamp = primaryAction.actionTs ?? messageTs;
+  const timestamp =
+    primaryAction.actionTs ??
+    asString(payload.action_ts) ??
+    asString(view?.hash) ??
+    messageTs ??
+    threadTs;
 
   return {
     channel: channelId,
@@ -357,15 +432,90 @@ export function normalizeSlackBlockActionPayload(
     timestamp,
     metadata: {
       kind: "slack_block_action",
-      actionId: primaryAction.actionId,
+      triggerId: asString(payload.trigger_id) ?? null,
+      viewId: asString(view?.id) ?? null,
+      callbackId: asString(view?.callback_id) ?? null,
+      viewHash: asString(view?.hash) ?? null,
       blockId: primaryAction.blockId ?? null,
+      actionId: primaryAction.actionId,
       value: primaryAction.value ?? null,
       parsedValue: primaryAction.parsedValue ?? null,
       actionText: primaryAction.text ?? null,
       channel: channelId,
       threadTs,
-      messageTs,
+      messageTs: messageTs ?? null,
+      modalPrivateMetadata: modalMetadata.value ?? null,
       actions: sanitizeNormalizedActions(normalizedActions),
     },
   };
+}
+
+export function normalizeSlackViewSubmissionPayload(
+  payload: Record<string, unknown>,
+): SlackViewSubmissionInboxEvent | null {
+  if (payload.type !== "view_submission") {
+    return null;
+  }
+
+  const user = asRecord(payload.user);
+  const view = asRecord(payload.view);
+  const state = asRecord(view?.state);
+  const stateValues = asRecord(state?.values);
+  const userId = asString(user?.id);
+  const viewId = asString(view?.id);
+  const modalMetadata = decodeSlackModalPrivateMetadata(asString(view?.private_metadata));
+  const threadTs = modalMetadata.threadContext?.threadTs;
+  const channel = modalMetadata.threadContext?.channel;
+
+  if (!userId || !threadTs || !channel || !viewId || !stateValues) {
+    return null;
+  }
+
+  const normalizedValues: Record<string, Record<string, unknown>> = {};
+  for (const [blockId, rawActions] of Object.entries(stateValues)) {
+    const actionMap = asRecord(rawActions);
+    if (!actionMap) continue;
+    normalizedValues[blockId] = Object.fromEntries(
+      Object.entries(actionMap).map(([actionId, rawValue]) => [
+        actionId,
+        normalizeViewStateValue(asRecord(rawValue) ?? {}),
+      ]),
+    );
+  }
+
+  const callbackId = asString(view?.callback_id);
+  const titleText = asString((asRecord(view?.title) ?? {}).text);
+  const timestamp = asString(payload.hash) ?? viewId;
+
+  return {
+    channel,
+    threadTs,
+    userId,
+    text: `Submitted Slack modal ${callbackId ? `(${callbackId}) ` : ""}${titleText ? `"${titleText}"` : `view ${viewId}`}.`,
+    timestamp,
+    metadata: {
+      kind: "slack_view_submission",
+      triggerId: asString(payload.trigger_id) ?? null,
+      callbackId: callbackId ?? null,
+      viewId,
+      externalId: asString(view?.external_id) ?? null,
+      viewHash: asString(view?.hash) ?? null,
+      channel,
+      threadTs,
+      privateMetadata: modalMetadata.value ?? null,
+      stateValues: normalizedValues,
+    },
+  };
+}
+
+export function normalizeSlackInteractivePayload(
+  payload: Record<string, unknown>,
+): SlackInteractiveInboxEvent | null {
+  if (payload.type === "block_actions") {
+    return normalizeSlackBlockActionPayload(payload);
+  }
+  if (payload.type === "view_submission") {
+    return normalizeSlackViewSubmissionPayload(payload);
+  }
+  return null;
 }

--- a/slack-bridge/slack-modals.test.ts
+++ b/slack-bridge/slack-modals.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackModalTemplate,
+  decodeSlackModalPrivateMetadata,
+  encodeSlackModalPrivateMetadata,
+  normalizeSlackModalViewInput,
+} from "./slack-modals.js";
+
+describe("buildSlackModalTemplate", () => {
+  it("builds a confirmation modal", () => {
+    const result = buildSlackModalTemplate({
+      template: "confirmation",
+      title: "Deploy approval",
+      text: "Ready to deploy to production.",
+      confirm_phrase: "CONFIRM",
+      callback_id: "deploy.confirm",
+    });
+
+    expect(result.view).toMatchObject({
+      type: "modal",
+      callback_id: "deploy.confirm",
+      blocks: [{ type: "section" }, { type: "input", block_id: "confirm_phrase" }],
+    });
+  });
+
+  it("builds a form modal", () => {
+    const result = buildSlackModalTemplate({
+      template: "form",
+      title: "PR review",
+      fields: [
+        { label: "Status", action_id: "status" },
+        { label: "Comments", action_id: "comments", multiline: true },
+      ],
+    });
+
+    expect(result.view.blocks).toHaveLength(2);
+  });
+
+  it("builds a multi-select modal", () => {
+    const result = buildSlackModalTemplate({
+      template: "multi_select",
+      title: "Pick services",
+      label: "Services",
+      action_id: "services",
+      options: [
+        { text: "API", value: "api" },
+        { text: "Worker", value: "worker" },
+      ],
+      initial_values: ["worker"],
+    });
+
+    expect(result.view).toMatchObject({
+      type: "modal",
+      blocks: [
+        {
+          type: "input",
+          element: {
+            type: "multi_static_select",
+            initial_options: [{ value: "worker" }],
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe("normalizeSlackModalViewInput", () => {
+  it("requires a modal view object", () => {
+    expect(() => normalizeSlackModalViewInput({ type: "home" })).toThrow(
+      'Slack modal view.type must be "modal".',
+    );
+  });
+});
+
+describe("modal private metadata helpers", () => {
+  it("embeds and restores thread context alongside custom metadata", () => {
+    const encoded = encodeSlackModalPrivateMetadata(JSON.stringify({ workflow: "deploy" }), {
+      threadTs: "123.456",
+      channel: "C123",
+    });
+    const decoded = decodeSlackModalPrivateMetadata(encoded);
+
+    expect(decoded.threadContext).toEqual({ threadTs: "123.456", channel: "C123" });
+    expect(decoded.value).toEqual({ workflow: "deploy" });
+  });
+
+  it("preserves plain-string metadata when encoding thread context", () => {
+    const encoded = encodeSlackModalPrivateMetadata("deploy", {
+      threadTs: "123.456",
+      channel: "C123",
+    });
+    const decoded = decodeSlackModalPrivateMetadata(encoded);
+
+    expect(decoded.threadContext).toEqual({ threadTs: "123.456", channel: "C123" });
+    expect(decoded.value).toBe("deploy");
+  });
+});

--- a/slack-bridge/slack-modals.ts
+++ b/slack-bridge/slack-modals.ts
@@ -1,0 +1,362 @@
+export type SlackModalView = Record<string, unknown>;
+
+export interface SlackModalOptionInput {
+  text: string;
+  value: string;
+}
+
+export interface SlackModalFieldInput {
+  label: string;
+  action_id: string;
+  block_id?: string;
+  placeholder?: string;
+  hint?: string;
+  initial_value?: string;
+  multiline?: boolean;
+  optional?: boolean;
+}
+
+export interface SlackModalTemplateInput {
+  template: string;
+  title?: string;
+  submit_label?: string;
+  close_label?: string;
+  callback_id?: string;
+  external_id?: string;
+  private_metadata?: string;
+  text?: string;
+  confirm_phrase?: string;
+  confirm_label?: string;
+  confirm_action_id?: string;
+  confirm_placeholder?: string;
+  fields?: SlackModalFieldInput[];
+  label?: string;
+  action_id?: string;
+  placeholder?: string;
+  options?: SlackModalOptionInput[];
+  initial_values?: string[];
+  max_selected_items?: number;
+  optional?: boolean;
+}
+
+export interface SlackModalTemplateResult {
+  view: SlackModalView;
+  summary: string;
+}
+
+const PI_SLACK_MODAL_CONTEXT_KEY = "__piSlackModalContext";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asOptionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function normalizePlainText(text: string | undefined, fallback: string, maxLength: number): string {
+  const value = (text?.trim() || fallback).slice(0, maxLength);
+  if (!value) {
+    throw new Error("Slack modal text values must not be empty.");
+  }
+  return value;
+}
+
+function plainText(text: string, maxLength = 75): Record<string, unknown> {
+  return {
+    type: "plain_text",
+    text: normalizePlainText(text, text, maxLength),
+  };
+}
+
+function buildBaseModalView(input: SlackModalTemplateInput): SlackModalView {
+  const view: SlackModalView = {
+    type: "modal",
+    title: plainText(input.title ?? "Modal", 24),
+    close: plainText(input.close_label ?? "Cancel", 24),
+    blocks: [],
+  };
+
+  const submitLabel = input.submit_label?.trim();
+  if (submitLabel) {
+    view.submit = plainText(submitLabel, 24);
+  }
+  if (input.callback_id?.trim()) {
+    view.callback_id = input.callback_id.trim();
+  }
+  if (input.external_id?.trim()) {
+    view.external_id = input.external_id.trim();
+  }
+  if (input.private_metadata != null) {
+    view.private_metadata = String(input.private_metadata);
+  }
+  return view;
+}
+
+function buildConfirmationModal(input: SlackModalTemplateInput): SlackModalTemplateResult {
+  if (!input.text?.trim()) {
+    throw new Error('Template "confirmation" requires text.');
+  }
+
+  const view = buildBaseModalView({
+    ...input,
+    title: input.title ?? "Confirm action",
+    submit_label: input.submit_label ?? "Confirm",
+    close_label: input.close_label ?? "Cancel",
+  });
+
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: input.text.trim(),
+      },
+    },
+  ];
+
+  if (input.confirm_phrase?.trim()) {
+    blocks.push({
+      type: "input",
+      block_id: "confirm_phrase",
+      label: plainText(
+        input.confirm_label ?? `Type ${input.confirm_phrase.trim()} to continue`,
+        2000,
+      ),
+      element: {
+        type: "plain_text_input",
+        action_id: input.confirm_action_id?.trim() || "confirm_phrase",
+        placeholder: plainText(input.confirm_placeholder ?? input.confirm_phrase.trim(), 150),
+      },
+    });
+  }
+
+  view.blocks = blocks;
+  return {
+    view,
+    summary: `Built confirmation modal ${JSON.stringify(asString(view.callback_id) ?? asString(view.external_id) ?? "modal")}.`,
+  };
+}
+
+function buildFormModal(input: SlackModalTemplateInput): SlackModalTemplateResult {
+  const fields = input.fields ?? [];
+  if (fields.length === 0) {
+    throw new Error('Template "form" requires at least one field.');
+  }
+
+  const view = buildBaseModalView({
+    ...input,
+    title: input.title ?? "Form",
+    submit_label: input.submit_label ?? "Submit",
+    close_label: input.close_label ?? "Cancel",
+  });
+
+  view.blocks = fields.map((field, index) => {
+    const element: Record<string, unknown> = {
+      type: "plain_text_input",
+      action_id: field.action_id.trim(),
+      ...(field.placeholder?.trim() ? { placeholder: plainText(field.placeholder, 150) } : {}),
+      ...(field.initial_value?.trim() ? { initial_value: field.initial_value } : {}),
+      ...(field.multiline ? { multiline: true } : {}),
+    };
+
+    const block: Record<string, unknown> = {
+      type: "input",
+      block_id: field.block_id?.trim() || field.action_id.trim() || `field_${index + 1}`,
+      label: plainText(field.label, 2000),
+      element,
+    };
+    if (field.hint?.trim()) {
+      block.hint = plainText(field.hint, 2000);
+    }
+    if (field.optional) {
+      block.optional = true;
+    }
+    return block;
+  });
+
+  return {
+    view,
+    summary: `Built form modal with ${fields.length} field${fields.length === 1 ? "" : "s"}.`,
+  };
+}
+
+function buildMultiSelectModal(input: SlackModalTemplateInput): SlackModalTemplateResult {
+  const label = input.label?.trim();
+  const actionId = input.action_id?.trim();
+  const options = input.options ?? [];
+  if (!label) {
+    throw new Error('Template "multi_select" requires label.');
+  }
+  if (!actionId) {
+    throw new Error('Template "multi_select" requires action_id.');
+  }
+  if (options.length === 0) {
+    throw new Error('Template "multi_select" requires at least one option.');
+  }
+
+  const optionLookup = new Map(options.map((option) => [option.value, option] as const));
+  const initialOptions = (input.initial_values ?? [])
+    .map((value) => optionLookup.get(value))
+    .filter((option): option is SlackModalOptionInput => Boolean(option))
+    .map((option) => ({
+      text: plainText(option.text, 75),
+      value: option.value,
+    }));
+
+  const view = buildBaseModalView({
+    ...input,
+    title: input.title ?? "Choose options",
+    submit_label: input.submit_label ?? "Submit",
+    close_label: input.close_label ?? "Cancel",
+  });
+
+  view.blocks = [
+    {
+      type: "input",
+      block_id: actionId,
+      label: plainText(label, 2000),
+      optional: input.optional === true,
+      element: {
+        type: "multi_static_select",
+        action_id: actionId,
+        placeholder: plainText(input.placeholder ?? "Select one or more options", 150),
+        options: options.map((option) => ({
+          text: plainText(option.text, 75),
+          value: option.value,
+        })),
+        ...(initialOptions.length > 0 ? { initial_options: initialOptions } : {}),
+        ...(input.max_selected_items != null
+          ? { max_selected_items: input.max_selected_items }
+          : {}),
+      },
+    },
+  ];
+
+  return {
+    view,
+    summary: `Built multi-select modal with ${options.length} option${options.length === 1 ? "" : "s"}.`,
+  };
+}
+
+export function buildSlackModalTemplate(input: SlackModalTemplateInput): SlackModalTemplateResult {
+  switch (input.template) {
+    case "confirmation":
+      return buildConfirmationModal(input);
+    case "form":
+      return buildFormModal(input);
+    case "multi_select":
+      return buildMultiSelectModal(input);
+    default:
+      throw new Error(
+        `Unknown modal template ${JSON.stringify(input.template)}. Use one of: confirmation, form, multi_select.`,
+      );
+  }
+}
+
+export function normalizeSlackModalViewInput(view: unknown): SlackModalView {
+  if (!isRecord(view)) {
+    throw new Error("Slack modal view must be a JSON object.");
+  }
+  const cloned = structuredClone(view) as SlackModalView;
+  if ((cloned.type as string | undefined) !== "modal") {
+    throw new Error('Slack modal view.type must be "modal".');
+  }
+  return cloned;
+}
+
+export function buildSlackModalPromptGuidelines(): string[] {
+  return [
+    "Use Slack modals when you need structured input, explicit approvals, or multi-step workflows instead of free-form thread replies.",
+    "slack_modal_open and slack_modal_push require a fresh trigger_id from a recent Slack interaction; trigger IDs expire after about 3 seconds.",
+    "If you want a modal submission routed back into the original Slack thread, pass thread_ts when opening/pushing the modal so the bridge can store thread context in private_metadata.",
+    "Use slack_modal_build for common confirmation dialogs, forms, and multi-select workflows before opening or updating a modal.",
+  ];
+}
+
+export interface SlackModalThreadContext {
+  threadTs: string;
+  channel: string;
+}
+
+export interface DecodedSlackModalPrivateMetadata {
+  raw: string | null;
+  value: unknown;
+  threadContext: SlackModalThreadContext | null;
+}
+
+export function encodeSlackModalPrivateMetadata(
+  privateMetadata: string | undefined,
+  threadContext: SlackModalThreadContext | null,
+): string | undefined {
+  if (!threadContext) {
+    return privateMetadata;
+  }
+
+  const raw = privateMetadata?.trim();
+  let value: unknown = raw ?? null;
+  if (raw) {
+    try {
+      value = JSON.parse(raw) as unknown;
+    } catch {
+      value = raw;
+    }
+  }
+
+  if (isRecord(value)) {
+    return JSON.stringify({
+      ...value,
+      [PI_SLACK_MODAL_CONTEXT_KEY]: threadContext,
+    });
+  }
+
+  return JSON.stringify({
+    [PI_SLACK_MODAL_CONTEXT_KEY]: threadContext,
+    value,
+  });
+}
+
+export function decodeSlackModalPrivateMetadata(
+  privateMetadata: string | undefined,
+): DecodedSlackModalPrivateMetadata {
+  const raw = asOptionalString(privateMetadata);
+  if (!raw) {
+    return { raw, value: null, threadContext: null };
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (isRecord(parsed)) {
+      const context = parsed[PI_SLACK_MODAL_CONTEXT_KEY];
+      const threadContext = isRecord(context)
+        ? {
+            threadTs: asString(context.threadTs) ?? "",
+            channel: asString(context.channel) ?? "",
+          }
+        : null;
+      const normalizedContext =
+        threadContext && threadContext.threadTs && threadContext.channel ? threadContext : null;
+
+      if (PI_SLACK_MODAL_CONTEXT_KEY in parsed) {
+        const clone = { ...parsed };
+        delete clone[PI_SLACK_MODAL_CONTEXT_KEY];
+        const userValue = Object.keys(clone).length === 1 && "value" in clone ? clone.value : clone;
+        return {
+          raw,
+          value: userValue,
+          threadContext: normalizedContext,
+        };
+      }
+
+      return { raw, value: parsed, threadContext: normalizedContext };
+    }
+
+    return { raw, value: parsed, threadContext: null };
+  } catch {
+    return { raw, value: raw, threadContext: null };
+  }
+}

--- a/slack-bridge/slack-socket-dedup.test.ts
+++ b/slack-bridge/slack-socket-dedup.test.ts
@@ -3,6 +3,7 @@ import {
   extractSlackBlockActionDedupKey,
   extractSlackEventDedupKey,
   extractSlackSocketDedupKey,
+  extractSlackViewSubmissionDedupKey,
 } from "./slack-socket-dedup.js";
 
 describe("extractSlackSocketDedupKey", () => {
@@ -80,6 +81,22 @@ describe("extractSlackEventDedupKey", () => {
         },
       }),
     ).toBe("reaction_added:C123:111.333:U_REACTOR:eyes:999.000");
+  });
+});
+
+describe("extractSlackViewSubmissionDedupKey", () => {
+  it("derives a stable key for modal submissions", () => {
+    expect(
+      extractSlackViewSubmissionDedupKey({
+        type: "view_submission",
+        user: { id: "U1" },
+        view: {
+          id: "V123",
+          hash: "hash-1",
+          callback_id: "deploy.confirm",
+        },
+      }),
+    ).toBe("view_submission:U1:V123:hash-1:deploy.confirm");
   });
 });
 

--- a/slack-bridge/slack-socket-dedup.ts
+++ b/slack-bridge/slack-socket-dedup.ts
@@ -1,4 +1,4 @@
-import { extractSlackBlockActionsPayloadFromEnvelope } from "./slack-block-kit.js";
+import { extractSlackInteractivePayloadFromEnvelope } from "./slack-block-kit.js";
 
 export const SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS = 10 * 60 * 1000;
 export const SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE = 10_000;
@@ -98,6 +98,7 @@ export function extractSlackBlockActionDedupKey(payload: Record<string, unknown>
   const container = payload.container as
     | { channel_id?: string; message_ts?: string; thread_ts?: string }
     | undefined;
+  const view = payload.view as { id?: string; hash?: string } | undefined;
   const actions = Array.isArray(payload.actions)
     ? payload.actions.filter(
         (action): action is { action_id?: string; action_ts?: string } =>
@@ -113,14 +114,46 @@ export function extractSlackBlockActionDedupKey(payload: Record<string, unknown>
     return null;
   }
 
-  return [
+  const parts = [
     "block_actions",
     user?.id ?? "",
     channel?.id ?? container?.channel_id ?? "",
     container?.thread_ts ?? "",
     container?.message_ts ?? "",
-    actionSignature,
-  ].join(":");
+  ];
+  if (view?.id || view?.hash) {
+    parts.push(view?.id ?? "", view?.hash ?? "");
+  }
+  parts.push(actionSignature);
+  return parts.join(":");
+}
+
+export function extractSlackViewSubmissionDedupKey(
+  payload: Record<string, unknown>,
+): string | null {
+  if (payload.type !== "view_submission") {
+    return null;
+  }
+
+  const user = payload.user as { id?: string } | undefined;
+  const view = payload.view as { id?: string; hash?: string; callback_id?: string } | undefined;
+  if (!view?.id) {
+    return null;
+  }
+
+  return ["view_submission", user?.id ?? "", view.id, view.hash ?? "", view.callback_id ?? ""].join(
+    ":",
+  );
+}
+
+export function extractSlackInteractiveDedupKey(payload: Record<string, unknown>): string | null {
+  if (payload.type === "block_actions") {
+    return extractSlackBlockActionDedupKey(payload);
+  }
+  if (payload.type === "view_submission") {
+    return extractSlackViewSubmissionDedupKey(payload);
+  }
+  return null;
 }
 
 export function extractSlackSocketDedupKey(frame: Record<string, unknown>): string | null {
@@ -136,6 +169,6 @@ export function extractSlackSocketDedupKey(frame: Record<string, unknown>): stri
     return payload?.event ? extractSlackEventDedupKey(payload.event) : null;
   }
 
-  const interactivePayload = extractSlackBlockActionsPayloadFromEnvelope(frame);
-  return interactivePayload ? extractSlackBlockActionDedupKey(interactivePayload) : null;
+  const interactivePayload = extractSlackInteractivePayloadFromEnvelope(frame);
+  return interactivePayload ? extractSlackInteractiveDedupKey(interactivePayload) : null;
 }

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -60,6 +60,20 @@ describe("registerSlackTools", () => {
         } as SlackResult;
       }
 
+      if (method === "views.open" || method === "views.push" || method === "views.update") {
+        return {
+          ok: true,
+          token,
+          body,
+          view: {
+            id: "V123",
+            external_id: typeof body?.external_id === "string" ? body.external_id : undefined,
+            hash: "hash-123",
+            ...(body?.view as Record<string, unknown> | undefined),
+          },
+        } as SlackResult;
+      }
+
       if (method === "pins.add" || method === "pins.remove") {
         return {
           ok: true,
@@ -678,9 +692,8 @@ describe("registerSlackTools", () => {
 
     const response = await tools.get("slack_inbox")!.execute("tool-16", {});
 
-    expect(response.content?.[0]?.text).toContain(
-      'metadata={"kind":"slack_block_action","actionId":"review.approve"',
-    );
+    expect(response.content?.[0]?.text).toContain('metadata={"kind":"slack_block_action"');
+    expect(response.content?.[0]?.text).toContain('"actionId":"review.approve"');
     expect(response.details).toEqual({
       count: 1,
       messages: [
@@ -721,6 +734,138 @@ describe("registerSlackTools", () => {
         { type: "header" },
         { type: "section" },
         { type: "actions", elements: expect.any(Array) },
+      ],
+    });
+  });
+
+  it("builds modal templates via slack_modal_build", async () => {
+    const { tools } = setup();
+
+    const response = await tools.get("slack_modal_build")!.execute("tool-18", {
+      template: "confirmation",
+      title: "Deploy approval",
+      text: "Ready to deploy to production.",
+      confirm_phrase: "CONFIRM",
+      callback_id: "deploy.confirm",
+    });
+
+    expect(response.content?.[0]?.text).toContain("Use this JSON as the view parameter");
+    expect(response.details).toMatchObject({
+      template: "confirmation",
+      view: {
+        type: "modal",
+        callback_id: "deploy.confirm",
+        blocks: expect.any(Array),
+      },
+    });
+  });
+
+  it("opens a modal and embeds thread context in private_metadata", async () => {
+    const { slack, tools, setResolveFollowerReplyChannel } = setup();
+    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+
+    const response = await tools.get("slack_modal_open")!.execute("tool-19", {
+      trigger_id: "trigger-1",
+      thread_ts: "123.456",
+      view: {
+        type: "modal",
+        title: { type: "plain_text", text: "Deploy" },
+        submit: { type: "plain_text", text: "Approve" },
+        close: { type: "plain_text", text: "Cancel" },
+        private_metadata: JSON.stringify({ workflow: "deploy" }),
+        blocks: [],
+      },
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "views.open",
+      "xoxb-initial",
+      expect.objectContaining({
+        trigger_id: "trigger-1",
+        view: expect.objectContaining({
+          private_metadata: expect.stringContaining("123.456"),
+        }),
+      }),
+    );
+    expect(response.details).toMatchObject({
+      thread_ts: "123.456",
+      view_id: "V123",
+    });
+  });
+
+  it("updates a modal by view_id", async () => {
+    const { slack, tools } = setup();
+
+    await tools.get("slack_modal_update")!.execute("tool-20", {
+      view_id: "V555",
+      view: {
+        type: "modal",
+        title: { type: "plain_text", text: "Step 2" },
+        submit: { type: "plain_text", text: "Continue" },
+        close: { type: "plain_text", text: "Cancel" },
+        blocks: [],
+      },
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "views.update",
+      "xoxb-initial",
+      expect.objectContaining({
+        view_id: "V555",
+        view: expect.objectContaining({ type: "modal" }),
+      }),
+    );
+  });
+
+  it("returns structured inbox messages including modal submission metadata", async () => {
+    const { inbox, tools } = setup();
+    inbox.push({
+      channel: "C123",
+      threadTs: "123.456",
+      userId: "U123",
+      text: 'Submitted Slack modal (deploy.confirm) "Deploy approval".',
+      timestamp: "hash-123",
+      metadata: {
+        kind: "slack_view_submission",
+        triggerId: "trigger-1",
+        callbackId: "deploy.confirm",
+        viewId: "V123",
+        stateValues: {
+          confirm_phrase: {
+            confirm_phrase: { type: "plain_text_input", value: "CONFIRM" },
+          },
+        },
+      },
+    });
+
+    const response = await tools.get("slack_inbox")!.execute("tool-21", {});
+
+    expect(response.content?.[0]?.text).toContain('metadata={"kind":"slack_view_submission"');
+    expect(response.content?.[0]?.text).toContain('"triggerId":"trigger-1"');
+    expect(response.details).toEqual({
+      count: 1,
+      messages: [
+        {
+          channel: "C123",
+          threadTs: "123.456",
+          userId: "U123",
+          text: 'Submitted Slack modal (deploy.confirm) "Deploy approval".',
+          timestamp: "hash-123",
+          metadata: {
+            kind: "slack_view_submission",
+            triggerId: "trigger-1",
+            callbackId: "deploy.confirm",
+            viewId: "V123",
+            stateValues: {
+              confirm_phrase: {
+                confirm_phrase: { type: "plain_text_input", value: "CONFIRM" },
+              },
+            },
+          },
+        },
       ],
     });
   });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -19,6 +19,14 @@ import {
   type SlackBlockButtonInput,
 } from "./slack-block-kit.js";
 import {
+  buildSlackModalPromptGuidelines,
+  buildSlackModalTemplate,
+  encodeSlackModalPrivateMetadata,
+  normalizeSlackModalViewInput,
+  type SlackModalFieldInput,
+  type SlackModalOptionInput,
+} from "./slack-modals.js";
+import {
   findSlackPresenceDirectoryUser,
   formatSlackPresenceLine,
   formatSlackPresenceTimestamp,
@@ -79,13 +87,18 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "Use slack_schedule for reminders, timed announcements, and delayed follow-ups instead of waiting around to send a message later.",
     "Use slack_pin for important Slack messages you want highlighted in the conversation, and use slack_bookmark for durable channel-header links like repos, dashboards, docs, and runbooks.",
     "Use slack_export to archive or document a Slack thread as markdown, plain text, or JSON before writing it into docs, canvases, or files.",
+    "Use Slack modals when you need structured input, explicit approvals, or multi-step workflows instead of free-form thread replies.",
     "Use slack_presence before pinging reviewers or scheduling follow-ups when timing matters — it tells you whether someone is active, away, or in DND.",
     "When uploading from a local path, only files inside the current working directory or the system temp directory are allowed.",
   ];
 }
 
 function buildSlackRichMessagePromptGuidelines(): string[] {
-  return [...buildSlackInboxPromptGuidelines(), ...buildSlackBlockKitPromptGuidelines()];
+  return [
+    ...buildSlackInboxPromptGuidelines(),
+    ...buildSlackBlockKitPromptGuidelines(),
+    ...buildSlackModalPromptGuidelines(),
+  ];
 }
 
 function getSlackCanvasSummary(markdown?: string): string {
@@ -358,6 +371,53 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     );
   }
 
+  async function resolveSlackModalThreadContext(
+    threadTs: string | undefined,
+  ): Promise<{ threadTs: string; channel: string } | null> {
+    const normalizedThreadTs = threadTs?.trim();
+    if (!normalizedThreadTs) {
+      return null;
+    }
+
+    const channel = await resolveFollowerReplyChannel(normalizedThreadTs);
+    if (!channel) {
+      throw new Error(
+        `No active Slack thread for thread_ts ${normalizedThreadTs}. Pass a live Slack thread so modal submissions can route back correctly.`,
+      );
+    }
+
+    return {
+      threadTs: normalizedThreadTs,
+      channel,
+    };
+  }
+
+  async function buildSlackModalView(
+    view: unknown,
+    threadTs: string | undefined,
+  ): Promise<Record<string, unknown>> {
+    const normalizedView = normalizeSlackModalViewInput(view);
+    const threadContext = await resolveSlackModalThreadContext(threadTs);
+    const privateMetadata =
+      typeof normalizedView.private_metadata === "string"
+        ? normalizedView.private_metadata
+        : undefined;
+    const encodedPrivateMetadata = encodeSlackModalPrivateMetadata(privateMetadata, threadContext);
+    if (encodedPrivateMetadata !== undefined) {
+      normalizedView.private_metadata = encodedPrivateMetadata;
+    }
+    return normalizedView;
+  }
+
+  function rethrowSlackModalError(err: unknown, action: "open" | "push" | "update"): never {
+    if (isSlackMethodError(err, `views.${action}`, "invalid_trigger")) {
+      throw new Error(
+        `Slack trigger_id expired before views.${action} could run. Ask the user to click the button or retry the interaction again, then immediately reopen the modal.`,
+      );
+    }
+    throw err;
+  }
+
   const presenceCache = new TtlCache<string, SlackPresenceSnapshot>({
     maxSize: 512,
     ttlMs: 30_000,
@@ -541,13 +601,23 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           message.metadata?.kind === "slack_block_action"
             ? ` | metadata=${JSON.stringify({
                 kind: message.metadata.kind,
+                triggerId: message.metadata.triggerId ?? null,
                 actionId: message.metadata.actionId ?? null,
                 value: message.metadata.value ?? null,
                 parsedValue: message.metadata.parsedValue ?? null,
+                viewId: message.metadata.viewId ?? null,
               })}`
-            : message.metadata?.kind
-              ? ` | metadata.kind=${String(message.metadata.kind)}`
-              : "";
+            : message.metadata?.kind === "slack_view_submission"
+              ? ` | metadata=${JSON.stringify({
+                  kind: message.metadata.kind,
+                  triggerId: message.metadata.triggerId ?? null,
+                  callbackId: message.metadata.callbackId ?? null,
+                  viewId: message.metadata.viewId ?? null,
+                  stateValues: message.metadata.stateValues ?? null,
+                })}`
+              : message.metadata?.kind
+                ? ` | metadata.kind=${String(message.metadata.kind)}`
+                : "";
         lines.push(`${prefix} (${message.timestamp}): ${message.text}${metadataSuffix}`);
       }
 
@@ -640,6 +710,293 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           blocks: result.blocks,
         },
       };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_modal_build",
+    label: "Slack Modal Build",
+    description:
+      "Build Slack modal JSON for common templates like confirmation dialogs, forms, and multi-select workflows.",
+    promptSnippet: "Build Slack modal JSON for a structured Slack workflow.",
+    promptGuidelines: buildSlackRichMessagePromptGuidelines(),
+    parameters: Type.Object({
+      template: Type.String({
+        description: "Template name: confirmation | form | multi_select",
+      }),
+      title: Type.Optional(Type.String({ description: "Modal title" })),
+      submit_label: Type.Optional(Type.String({ description: "Submit button label" })),
+      close_label: Type.Optional(Type.String({ description: "Close button label" })),
+      callback_id: Type.Optional(Type.String({ description: "Optional Slack callback_id" })),
+      external_id: Type.Optional(Type.String({ description: "Optional Slack external_id" })),
+      private_metadata: Type.Optional(
+        Type.String({ description: "Optional custom private_metadata string" }),
+      ),
+      text: Type.Optional(
+        Type.String({ description: "Primary explanatory text for confirmation modals" }),
+      ),
+      confirm_phrase: Type.Optional(
+        Type.String({ description: "Optional phrase the user must type before submitting" }),
+      ),
+      confirm_label: Type.Optional(
+        Type.String({ description: "Optional label for the confirmation input" }),
+      ),
+      confirm_action_id: Type.Optional(
+        Type.String({ description: "Optional action_id for the confirmation input" }),
+      ),
+      confirm_placeholder: Type.Optional(
+        Type.String({ description: "Optional placeholder for the confirmation input" }),
+      ),
+      fields: Type.Optional(
+        Type.Array(
+          Type.Object({
+            label: Type.String({ description: "Visible field label" }),
+            action_id: Type.String({ description: "Stable Slack action_id for the input" }),
+            block_id: Type.Optional(Type.String({ description: "Optional block_id override" })),
+            placeholder: Type.Optional(Type.String({ description: "Optional placeholder text" })),
+            hint: Type.Optional(Type.String({ description: "Optional hint text" })),
+            initial_value: Type.Optional(Type.String({ description: "Optional initial value" })),
+            multiline: Type.Optional(
+              Type.Boolean({ description: "Whether the input is multiline" }),
+            ),
+            optional: Type.Optional(Type.Boolean({ description: "Whether the field is optional" })),
+          }),
+        ),
+      ),
+      label: Type.Optional(Type.String({ description: "Input label for multi_select" })),
+      action_id: Type.Optional(Type.String({ description: "action_id for multi_select" })),
+      placeholder: Type.Optional(
+        Type.String({ description: "Optional placeholder for multi_select" }),
+      ),
+      options: Type.Optional(
+        Type.Array(
+          Type.Object({
+            text: Type.String({ description: "Visible option label" }),
+            value: Type.String({ description: "Stable option value" }),
+          }),
+        ),
+      ),
+      initial_values: Type.Optional(
+        Type.Array(Type.String({ description: "Initially selected multi_select values" })),
+      ),
+      max_selected_items: Type.Optional(
+        Type.Number({ description: "Optional max_selected_items for multi_select" }),
+      ),
+      optional: Type.Optional(Type.Boolean({ description: "Whether multi_select is optional" })),
+    }),
+    async execute(_id, params) {
+      const result = buildSlackModalTemplate({
+        template: params.template,
+        title: params.title,
+        submit_label: params.submit_label,
+        close_label: params.close_label,
+        callback_id: params.callback_id,
+        external_id: params.external_id,
+        private_metadata: params.private_metadata,
+        text: params.text,
+        confirm_phrase: params.confirm_phrase,
+        confirm_label: params.confirm_label,
+        confirm_action_id: params.confirm_action_id,
+        confirm_placeholder: params.confirm_placeholder,
+        fields: params.fields as SlackModalFieldInput[] | undefined,
+        label: params.label,
+        action_id: params.action_id,
+        placeholder: params.placeholder,
+        options: params.options as SlackModalOptionInput[] | undefined,
+        initial_values: params.initial_values,
+        max_selected_items: params.max_selected_items,
+        optional: params.optional,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Built Slack modal template ${JSON.stringify(params.template)}. ` +
+              `Use this JSON as the view parameter:\n\n${JSON.stringify(result.view, null, 2)}`,
+          },
+        ],
+        details: {
+          template: params.template,
+          summary: result.summary,
+          view: result.view,
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_modal_open",
+    label: "Slack Modal Open",
+    description: "Open a Slack modal with views.open using a fresh trigger_id.",
+    promptSnippet: "Open a Slack modal to collect structured input or approvals.",
+    promptGuidelines: buildSlackRichMessagePromptGuidelines(),
+    parameters: Type.Object({
+      trigger_id: Type.String({ description: "Fresh Slack trigger_id from a recent interaction" }),
+      view: Type.Record(Type.String(), Type.Unknown(), {
+        description: "Slack modal view JSON object (type='modal')",
+      }),
+      thread_ts: Type.Optional(
+        Type.String({
+          description:
+            "Optional Slack thread to bind into private_metadata so view submissions route back into the thread",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_modal_open",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts ?? ""} | trigger_id=${params.trigger_id} | view=modal`,
+      );
+
+      try {
+        const view = await buildSlackModalView(params.view, params.thread_ts);
+        const response = await slack("views.open", getBotToken(), {
+          trigger_id: params.trigger_id,
+          view,
+        });
+        const modalView = response.view as Record<string, unknown> | undefined;
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Opened Slack modal${params.thread_ts ? ` for thread ${params.thread_ts}` : ""}.`,
+            },
+          ],
+          details: {
+            thread_ts: params.thread_ts ?? null,
+            view_id: typeof modalView?.id === "string" ? modalView.id : null,
+            external_id: typeof modalView?.external_id === "string" ? modalView.external_id : null,
+            hash: typeof modalView?.hash === "string" ? modalView.hash : null,
+            view,
+          },
+        };
+      } catch (err) {
+        rethrowSlackModalError(err, "open");
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_modal_push",
+    label: "Slack Modal Push",
+    description: "Push a new view onto an open Slack modal stack using views.push.",
+    promptSnippet: "Push another Slack modal view for a multi-step workflow.",
+    promptGuidelines: buildSlackRichMessagePromptGuidelines(),
+    parameters: Type.Object({
+      trigger_id: Type.String({ description: "Fresh Slack trigger_id from a recent interaction" }),
+      view: Type.Record(Type.String(), Type.Unknown(), {
+        description: "Slack modal view JSON object (type='modal')",
+      }),
+      thread_ts: Type.Optional(
+        Type.String({
+          description:
+            "Optional Slack thread to bind into private_metadata so later submissions route back into the thread",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_modal_push",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts ?? ""} | trigger_id=${params.trigger_id} | view=modal`,
+      );
+
+      try {
+        const view = await buildSlackModalView(params.view, params.thread_ts);
+        const response = await slack("views.push", getBotToken(), {
+          trigger_id: params.trigger_id,
+          view,
+        });
+        const modalView = response.view as Record<string, unknown> | undefined;
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Pushed a new Slack modal view${params.thread_ts ? ` for thread ${params.thread_ts}` : ""}.`,
+            },
+          ],
+          details: {
+            thread_ts: params.thread_ts ?? null,
+            view_id: typeof modalView?.id === "string" ? modalView.id : null,
+            external_id: typeof modalView?.external_id === "string" ? modalView.external_id : null,
+            hash: typeof modalView?.hash === "string" ? modalView.hash : null,
+            view,
+          },
+        };
+      } catch (err) {
+        rethrowSlackModalError(err, "push");
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_modal_update",
+    label: "Slack Modal Update",
+    description: "Update an open Slack modal using views.update.",
+    promptSnippet: "Update an existing Slack modal with a new view.",
+    promptGuidelines: buildSlackRichMessagePromptGuidelines(),
+    parameters: Type.Object({
+      view: Type.Record(Type.String(), Type.Unknown(), {
+        description: "Slack modal view JSON object (type='modal')",
+      }),
+      view_id: Type.Optional(
+        Type.String({ description: "Slack view_id from a modal interaction" }),
+      ),
+      external_id: Type.Optional(Type.String({ description: "Slack external_id for the modal" })),
+      hash: Type.Optional(
+        Type.String({ description: "Optional modal hash for optimistic locking" }),
+      ),
+      thread_ts: Type.Optional(
+        Type.String({
+          description:
+            "Optional Slack thread to bind into private_metadata so later submissions route back into the thread",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_modal_update",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts ?? ""} | view_id=${params.view_id ?? ""} | external_id=${params.external_id ?? ""} | view=modal`,
+      );
+
+      if (!params.view_id && !params.external_id) {
+        throw new Error("Provide either view_id or external_id when updating a Slack modal.");
+      }
+
+      try {
+        const view = await buildSlackModalView(params.view, params.thread_ts);
+        const response = await slack("views.update", getBotToken(), {
+          ...(params.view_id ? { view_id: params.view_id } : {}),
+          ...(params.external_id ? { external_id: params.external_id } : {}),
+          ...(params.hash ? { hash: params.hash } : {}),
+          view,
+        });
+        const modalView = response.view as Record<string, unknown> | undefined;
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Updated Slack modal${params.view_id ? ` ${params.view_id}` : ""}.`,
+            },
+          ],
+          details: {
+            thread_ts: params.thread_ts ?? null,
+            view_id: typeof modalView?.id === "string" ? modalView.id : (params.view_id ?? null),
+            external_id:
+              typeof modalView?.external_id === "string"
+                ? modalView.external_id
+                : (params.external_id ?? null),
+            hash: typeof modalView?.hash === "string" ? modalView.hash : (params.hash ?? null),
+            view,
+          },
+        };
+      } catch (err) {
+        rethrowSlackModalError(err, "update");
+      }
     },
   });
 


### PR DESCRIPTION
## Summary
- add Slack modal tools for `views.open`, `views.push`, and `views.update`
- route interactive modal submissions and button clicks back into the inbox with structured metadata
- add helper modal templates plus docs/guidance for approval workflows and structured input

## Details
- added `slack-bridge/slack-modals.ts` + `slack-bridge/slack-modals.test.ts`
  - modal template builders for `confirmation`, `form`, and `multi_select`
  - modal prompt guidance
  - private metadata helpers that preserve user metadata while embedding thread/channel context so modal submissions can route back into Slack threads
- updated `slack-bridge/slack-tools.ts`
  - new tools:
    - `slack_modal_build`
    - `slack_modal_open`
    - `slack_modal_push`
    - `slack_modal_update`
  - modal tools catch `views.open` / `views.push` invalid trigger failures and return a clear “ask the user to click again” error
  - `slack_inbox` now surfaces modal/block-action metadata including `triggerId`, `viewId`, and parsed modal state
  - prompt guidelines now tell agents when to prefer modals over plain messages
- updated `slack-bridge/slack-block-kit.ts`
  - general interactive payload extraction for Socket Mode `interactive` frames
  - `view_submission` normalization with parsed `state.values`
  - block-action normalization now carries `triggerId` and supports modal-originated actions via embedded private metadata context
- updated both Slack ingestion paths:
  - `slack-bridge/index.ts`
  - `slack-bridge/broker/adapters/slack.ts`
  so `block_actions` and `view_submission` both route back through the inbox as structured events
- updated `slack-bridge/slack-socket-dedup.ts`
  - interactive dedup now covers modal submissions too, not only block actions
- updated `slack-bridge/guardrails.ts` / `guardrails.test.ts`
  - modal open/push/update are treated as Slack write tools
- updated `slack-bridge/README.md`
  - modal tools table/docs
  - interactivity workflow guidance
  - trigger expiry note and routing requirements for `thread_ts`

## Verification
- `cd slack-bridge && pnpm test -- --run slack-modals.test.ts slack-block-kit.test.ts slack-tools.test.ts broker/adapters/slack.test.ts slack-socket-dedup.test.ts`
- `cd slack-bridge && pnpm typecheck`
- `cd slack-bridge && pnpm lint`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #32.
