### PR TITLE
feat: add broker activity log channel (#30)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -84,6 +84,7 @@ a short cache to avoid hammering Slack.
 - **Pins & bookmarks** — highlight key messages and manage durable channel-header links
 - **Presence-aware messaging** — check whether teammates are active, away, or in DND before pinging them
 - **Thread export & archival** — convert Slack threads into reusable markdown, plain text, or JSON
+- **Activity log channel** — broker-side assignments, completions, merges, stalls, and RALPH events can be mirrored into a dedicated Slack log thread
 - **Agent identity** — agents pick a fun name + emoji per task
 - **Thread persistence** — thread state survives `/reload`
 - **Remote agent control** — send `/reload` or `/exit` to another Pinet agent
@@ -121,6 +122,8 @@ Add to `~/.pi/agent/settings.json`:
     "appConfigToken": "xoxe.xoxp-...",
     "allowedUsers": ["U09GWL270LA"],
     "defaultChannel": "C0APL58LB1R",
+    "logChannel": "#pinet-logs",
+    "logLevel": "actions",
     "controlPlaneCanvasEnabled": true,
     "controlPlaneCanvasChannel": "C0APL58LB1R",
     "controlPlaneCanvasTitle": "Pinet Broker Control Plane",
@@ -147,6 +150,8 @@ Add to `~/.pi/agent/settings.json`:
 | `appConfigToken`            | deploy   | App configuration token (`xoxe.xoxp-...`)                                  |
 | `allowedUsers`              | no       | Slack user IDs allowed to interact                                         |
 | `defaultChannel`            | no       | Default channel for `slack_post_channel` and control-plane canvas fallback |
+| `logChannel`                | no       | Broker activity log channel name or ID                                     |
+| `logLevel`                  | no       | `errors`, `actions` (default), or `verbose`                                |
 | `controlPlaneCanvasEnabled` | no       | Enable the broker-maintained control plane canvas (defaults to true)       |
 | `controlPlaneCanvasId`      | no       | Existing canvas ID to update instead of creating/finding a channel canvas  |
 | `controlPlaneCanvasChannel` | no       | Channel ID/name used to create or recover the broker control plane canvas  |
@@ -168,6 +173,13 @@ Add to `~/.pi/agent/settings.json`:
 emoji characters themselves (`👀`, `🔄`). The default mappings include `📝`
 → summarize and `🐛` → file-issue, and you can extend them with review /
 approve / retry style actions as needed.
+
+`logChannel` enables a broker-only observability feed. When configured, the
+broker posts structured activity updates into a daily thread in that channel.
+Default `logLevel` is `actions`, which captures worker task assignments,
+completion/PR-open transitions, merges, stalls, maintenance anomalies, and
+RALPH events. Use `errors` for failures only or `verbose` to also include
+routine broker/worker status chatter.
 
 ### 4. Install extension
 
@@ -282,6 +294,7 @@ Use these local commands to control another connected Pinet agent by name or ID:
 - `/pinet-reload <agent>` — ask the target agent to reload cleanly
 - `/pinet-exit <agent>` — ask the target agent to disconnect cleanly and exit
 - `/pinet-free` — mark this agent idle/free and available for new work
+- `/pinet-logs` / `/slack-logs` — show the most recent broker activity log entries captured this session
 
 Agents can also send the exact A2A message `/reload` or `/exit` via `pinet_message`; the
 receiver handles it automatically instead of surfacing it to the LLM as normal work.

--- a/slack-bridge/activity-log.test.ts
+++ b/slack-bridge/activity-log.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildActivityLogBlocks,
+  buildActivityLogText,
+  formatRecentActivityLogEntries,
+  normalizeActivityLogLevel,
+  redactSensitiveText,
+  shouldLogActivity,
+  SlackActivityLogger,
+} from "./activity-log.js";
+import type { LoggedActivityLogEntry } from "./activity-log.js";
+import type { SlackResult } from "./slack-api.js";
+
+describe("normalizeActivityLogLevel", () => {
+  it("defaults invalid values to actions", () => {
+    expect(normalizeActivityLogLevel(undefined)).toBe("actions");
+    expect(normalizeActivityLogLevel("wat")).toBe("actions");
+  });
+
+  it("accepts supported values", () => {
+    expect(normalizeActivityLogLevel("errors")).toBe("errors");
+    expect(normalizeActivityLogLevel("actions")).toBe("actions");
+    expect(normalizeActivityLogLevel("verbose")).toBe("verbose");
+  });
+});
+
+describe("shouldLogActivity", () => {
+  it("filters by configured level", () => {
+    expect(shouldLogActivity("errors", "errors")).toBe(true);
+    expect(shouldLogActivity("errors", "actions")).toBe(false);
+    expect(shouldLogActivity("actions", "errors")).toBe(true);
+    expect(shouldLogActivity("actions", "verbose")).toBe(false);
+    expect(shouldLogActivity("verbose", "verbose")).toBe(true);
+  });
+});
+
+describe("redactSensitiveText", () => {
+  it("redacts common token and secret patterns", () => {
+    const input =
+      "token=xoxb-secret-value Bearer abc123 password: hunter2 SLACK_BOT_TOKEN=xoxp-foo";
+    const output = redactSensitiveText(input);
+    expect(output).not.toContain("xoxb-secret-value");
+    expect(output).not.toContain("hunter2");
+    expect(output).not.toContain("abc123");
+    expect(output).toContain("[REDACTED]");
+  });
+});
+
+describe("activity log rendering", () => {
+  const entry: LoggedActivityLogEntry = {
+    kind: "task_assignment",
+    level: "actions",
+    title: "Task assigned",
+    summary: "Assigned #30 to Ultra Rabbit.",
+    fields: [
+      { label: "Issue", value: "#30" },
+      { label: "Branch", value: "feat/activity-log-channel" },
+    ],
+    details: ["Created worktree .worktrees/feat-30"],
+    tone: "info",
+    timestamp: "2026-04-02T20:00:00.000Z",
+  };
+
+  it("builds fallback text", () => {
+    const text = buildActivityLogText("Solar Mantis", "🦗", entry);
+    expect(text).toContain("Task assigned");
+    expect(text).toContain("Assigned #30 to Ultra Rabbit.");
+    expect(text).toContain("🦗 Solar Mantis");
+  });
+
+  it("builds block kit payload", () => {
+    const blocks = buildActivityLogBlocks("Solar Mantis", "🦗", entry);
+    expect(blocks).toHaveLength(4);
+    expect(JSON.stringify(blocks)).toContain("Task assigned");
+    expect(JSON.stringify(blocks)).toContain("feat/activity-log-channel");
+  });
+
+  it("formats recent entries for TUI", () => {
+    const text = formatRecentActivityLogEntries([entry]);
+    expect(text).toContain("Task assigned");
+    expect(text).toContain("Assigned #30 to Ultra Rabbit.");
+  });
+});
+
+describe("SlackActivityLogger", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("posts entries into a daily thread and rate-limits sends", async () => {
+    vi.useFakeTimers();
+
+    const slack = vi.fn<
+      (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>
+    >(async (_method, _token, body) => {
+      if (!body?.thread_ts) {
+        return { ok: true, ts: "100.200" } as SlackResult;
+      }
+      return { ok: true, ts: `${body.thread_ts}.reply` } as SlackResult;
+    });
+    const resolveChannel = vi.fn(async () => "CLOGS");
+
+    const logger = new SlackActivityLogger({
+      getBotToken: () => "xoxb-test",
+      getLogChannel: () => "#pinet-logs",
+      getLogLevel: () => "actions",
+      getAgentName: () => "Solar Mantis",
+      getAgentEmoji: () => "🦗",
+      resolveChannel,
+      slack,
+      now: () => new Date("2026-04-02T20:00:00.000Z"),
+    });
+
+    logger.log({
+      kind: "task_assignment",
+      level: "actions",
+      title: "Task assigned",
+      summary: "Assigned #30 to Ultra Rabbit.",
+    });
+    logger.log({
+      kind: "task_progress",
+      level: "actions",
+      title: "PR opened",
+      summary: "Issue #30 is now in review.",
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolveChannel).toHaveBeenCalledTimes(1);
+    expect(slack).toHaveBeenCalledTimes(2);
+    expect(slack).toHaveBeenNthCalledWith(
+      1,
+      "chat.postMessage",
+      "xoxb-test",
+      expect.objectContaining({ channel: "CLOGS" }),
+    );
+    expect(slack).toHaveBeenNthCalledWith(
+      2,
+      "chat.postMessage",
+      "xoxb-test",
+      expect.objectContaining({ channel: "CLOGS", thread_ts: "100.200" }),
+    );
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(slack).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(slack).toHaveBeenCalledTimes(3);
+    expect(slack).toHaveBeenNthCalledWith(
+      3,
+      "chat.postMessage",
+      "xoxb-test",
+      expect.objectContaining({ channel: "CLOGS", thread_ts: "100.200" }),
+    );
+  });
+
+  it("filters entries below the configured level", async () => {
+    vi.useFakeTimers();
+    const slack = vi.fn(async () => ({ ok: true, ts: "100.200" }) as SlackResult);
+
+    const logger = new SlackActivityLogger({
+      getBotToken: () => "xoxb-test",
+      getLogChannel: () => "CLOGS",
+      getLogLevel: () => "errors",
+      getAgentName: () => "Solar Mantis",
+      getAgentEmoji: () => "🦗",
+      resolveChannel: async (channel) => channel,
+      slack,
+      now: () => new Date("2026-04-02T20:00:00.000Z"),
+    });
+
+    logger.log({
+      kind: "task_assignment",
+      level: "actions",
+      title: "Task assigned",
+      summary: "Assigned #30 to Ultra Rabbit.",
+    });
+    logger.log({
+      kind: "activity_error",
+      level: "errors",
+      title: "Log failure",
+      summary: "Slack chat.postMessage failed.",
+      tone: "error",
+    });
+
+    await vi.runAllTimersAsync();
+    expect(slack).toHaveBeenCalledTimes(2);
+    expect(logger.getRecentEntries()).toHaveLength(1);
+    expect(logger.getRecentEntries()[0]?.title).toBe("Log failure");
+  });
+});

--- a/slack-bridge/activity-log.ts
+++ b/slack-bridge/activity-log.ts
@@ -1,0 +1,399 @@
+import type { SlackResult } from "./slack-api.js";
+
+export type ActivityLogLevel = "errors" | "actions" | "verbose";
+export type ActivityLogTone = "info" | "success" | "warning" | "error";
+
+export interface ActivityLogField {
+  label: string;
+  value: string | number | boolean | null | undefined;
+}
+
+export interface ActivityLogEntry {
+  kind: string;
+  level: ActivityLogLevel;
+  title: string;
+  summary: string;
+  details?: string[];
+  fields?: ActivityLogField[];
+  tone?: ActivityLogTone;
+  timestamp?: string;
+}
+
+export interface LoggedActivityLogEntry extends ActivityLogEntry {
+  timestamp: string;
+}
+
+interface QueuedActivityLogEntry {
+  entry: LoggedActivityLogEntry;
+  attempts: number;
+}
+
+export interface SlackActivityLoggerDeps {
+  getBotToken: () => string | undefined;
+  getLogChannel: () => string | undefined;
+  getLogLevel: () => string | undefined;
+  getAgentName: () => string;
+  getAgentEmoji: () => string;
+  resolveChannel: (nameOrId: string) => Promise<string>;
+  slack: (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>;
+  onError?: (error: unknown) => void;
+  now?: () => Date;
+  maxRecentEntries?: number;
+}
+
+const LEVEL_RANK: Record<ActivityLogLevel, number> = {
+  errors: 0,
+  actions: 1,
+  verbose: 2,
+};
+
+const DEFAULT_MAX_RECENT_ENTRIES = 100;
+const MAX_TEXT_LENGTH = 2800;
+const REDACTED = "[REDACTED]";
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\r\n/g, "\n").replaceAll("\u0000", "").trim();
+}
+
+function truncate(value: string, maxLength = MAX_TEXT_LENGTH): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+export function normalizeActivityLogLevel(value: string | undefined): ActivityLogLevel {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "errors" || normalized === "actions" || normalized === "verbose") {
+    return normalized;
+  }
+  return "actions";
+}
+
+export function shouldLogActivity(
+  configuredLevel: ActivityLogLevel,
+  eventLevel: ActivityLogLevel,
+): boolean {
+  return LEVEL_RANK[eventLevel] <= LEVEL_RANK[configuredLevel];
+}
+
+export function redactSensitiveText(value: string): string {
+  let redacted = normalizeWhitespace(value);
+
+  const replacements: Array<[RegExp, string]> = [
+    [/xox[baprs]-[A-Za-z0-9-]+/g, REDACTED],
+    [/xoxe\.[A-Za-z0-9.-]+/g, REDACTED],
+    [/(Bearer\s+)[^\s]+/gi, `$1${REDACTED}`],
+    [
+      /\b(token|password|secret|api[_-]?key|authorization)\b\s*([:=])\s*([^\s,;]+)/gi,
+      `$1$2 ${REDACTED}`,
+    ],
+    [
+      /("(?:token|password|secret|api[_-]?key|authorization)"\s*:\s*")([^"]+)(")/gi,
+      `$1${REDACTED}$3`,
+    ],
+    [/(SLACK_[A-Z_]+)=([^\s]+)/g, `$1=${REDACTED}`],
+  ];
+
+  for (const [pattern, replacement] of replacements) {
+    redacted = redacted.replace(pattern, replacement);
+  }
+
+  return truncate(redacted);
+}
+
+function sanitizeFieldValue(value: ActivityLogField["value"]): string {
+  if (value == null) {
+    return "—";
+  }
+  if (typeof value === "boolean") {
+    return value ? "yes" : "no";
+  }
+  return redactSensitiveText(String(value));
+}
+
+function sanitizeEntry(entry: ActivityLogEntry, now: Date): LoggedActivityLogEntry {
+  return {
+    ...entry,
+    title: redactSensitiveText(entry.title),
+    summary: redactSensitiveText(entry.summary),
+    details: entry.details?.map((detail) => redactSensitiveText(detail)).filter(Boolean),
+    fields: entry.fields
+      ?.map((field) => ({
+        label: redactSensitiveText(field.label),
+        value: sanitizeFieldValue(field.value),
+      }))
+      .filter((field) => field.label.length > 0),
+    timestamp: entry.timestamp ?? now.toISOString(),
+  };
+}
+
+function getToneEmoji(tone: ActivityLogTone | undefined): string {
+  switch (tone) {
+    case "success":
+      return "✅";
+    case "warning":
+      return "⚠️";
+    case "error":
+      return "🚨";
+    case "info":
+    default:
+      return "📡";
+  }
+}
+
+function formatSlackTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+  return date.toISOString().replace(".000Z", "Z");
+}
+
+export function buildActivityLogText(
+  agentName: string,
+  agentEmoji: string,
+  entry: LoggedActivityLogEntry,
+): string {
+  return `${getToneEmoji(entry.tone)} ${entry.title} — ${entry.summary} (${agentEmoji} ${agentName} · ${formatSlackTimestamp(entry.timestamp)})`;
+}
+
+export function buildActivityLogBlocks(
+  agentName: string,
+  agentEmoji: string,
+  entry: LoggedActivityLogEntry,
+): Record<string, unknown>[] {
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${getToneEmoji(entry.tone)} ${entry.title}*\n${entry.summary}`,
+      },
+    },
+  ];
+
+  const fields = (entry.fields ?? [])
+    .filter((field) => field.value !== "—")
+    .slice(0, 10)
+    .map((field) => ({
+      type: "mrkdwn",
+      text: `*${field.label}*\n${field.value}`,
+    }));
+  if (fields.length > 0) {
+    blocks.push({ type: "section", fields });
+  }
+
+  if (entry.details && entry.details.length > 0) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: entry.details.map((detail) => `• ${detail}`).join("\n"),
+      },
+    });
+  }
+
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: `${agentEmoji} ${agentName} · ${entry.kind} · ${formatSlackTimestamp(entry.timestamp)}`,
+      },
+    ],
+  });
+
+  return blocks;
+}
+
+export function buildActivityLogThreadHeader(
+  agentName: string,
+  agentEmoji: string,
+  dateKey: string,
+): { text: string; blocks: Record<string, unknown>[] } {
+  return {
+    text: `Pinet activity log — ${dateKey}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*📚 Pinet activity log — ${dateKey}*\nBroker-side coordination updates: assignments, completions, merges, stalls, and RALPH maintenance events.`,
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `${agentEmoji} ${agentName} · daily thread`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function formatRecentActivityLogEntries(
+  entries: ReadonlyArray<LoggedActivityLogEntry>,
+): string {
+  if (entries.length === 0) {
+    return "No activity log entries recorded in this session.";
+  }
+
+  return entries
+    .map((entry) => `[${formatSlackTimestamp(entry.timestamp)}] ${entry.title} — ${entry.summary}`)
+    .join("\n");
+}
+
+export class SlackActivityLogger {
+  private readonly queue: QueuedActivityLogEntry[] = [];
+  private readonly recent: LoggedActivityLogEntry[] = [];
+  private readonly maxRecentEntries: number;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private flushRunning = false;
+  private resolvedChannelCache: { raw: string; id: string } | null = null;
+  private dailyThreadCache: { rawChannel: string; dateKey: string; threadTs: string } | null = null;
+
+  constructor(private readonly deps: SlackActivityLoggerDeps) {
+    this.maxRecentEntries = deps.maxRecentEntries ?? DEFAULT_MAX_RECENT_ENTRIES;
+  }
+
+  log(entry: ActivityLogEntry): void {
+    const rawChannel = this.deps.getLogChannel()?.trim();
+    if (!rawChannel) {
+      return;
+    }
+
+    const configuredLevel = normalizeActivityLogLevel(this.deps.getLogLevel());
+    if (!shouldLogActivity(configuredLevel, entry.level)) {
+      return;
+    }
+
+    const sanitized = sanitizeEntry(entry, this.getNow());
+    this.recent.unshift(sanitized);
+    this.recent.splice(this.maxRecentEntries);
+    this.queue.push({ entry: sanitized, attempts: 0 });
+    this.scheduleFlush(0);
+  }
+
+  getRecentEntries(limit = 20): LoggedActivityLogEntry[] {
+    return this.recent.slice(0, Math.max(0, limit));
+  }
+
+  clearPending(): void {
+    this.queue.splice(0, this.queue.length);
+    this.resolvedChannelCache = null;
+    this.dailyThreadCache = null;
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  private getNow(): Date {
+    return this.deps.now ? this.deps.now() : new Date();
+  }
+
+  private scheduleFlush(delayMs: number): void {
+    if (this.flushTimer || this.flushRunning || this.queue.length === 0) {
+      return;
+    }
+
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      void this.flushNext();
+    }, delayMs);
+    this.flushTimer.unref?.();
+  }
+
+  private async flushNext(): Promise<void> {
+    if (this.flushRunning) {
+      return;
+    }
+
+    const next = this.queue.shift();
+    if (!next) {
+      return;
+    }
+
+    this.flushRunning = true;
+    try {
+      await this.postEntry(next.entry);
+    } catch (error) {
+      if (next.attempts < 2) {
+        this.queue.unshift({ entry: next.entry, attempts: next.attempts + 1 });
+      } else {
+        this.deps.onError?.(error);
+      }
+    } finally {
+      this.flushRunning = false;
+      if (this.queue.length > 0) {
+        this.scheduleFlush(1000);
+      }
+    }
+  }
+
+  private async resolveLogChannel(rawChannel: string): Promise<string> {
+    if (this.resolvedChannelCache?.raw === rawChannel) {
+      return this.resolvedChannelCache.id;
+    }
+
+    const channelId = await this.deps.resolveChannel(rawChannel);
+    this.resolvedChannelCache = { raw: rawChannel, id: channelId };
+    return channelId;
+  }
+
+  private async ensureDailyThread(rawChannel: string, channelId: string): Promise<string> {
+    const dateKey = this.getNow().toISOString().slice(0, 10);
+    if (
+      this.dailyThreadCache?.rawChannel === rawChannel &&
+      this.dailyThreadCache.dateKey === dateKey
+    ) {
+      return this.dailyThreadCache.threadTs;
+    }
+
+    const token = this.deps.getBotToken();
+    if (!token) {
+      throw new Error("Slack bot token unavailable for activity logging.");
+    }
+
+    const heading = buildActivityLogThreadHeader(
+      this.deps.getAgentName(),
+      this.deps.getAgentEmoji(),
+      dateKey,
+    );
+    const response = await this.deps.slack("chat.postMessage", token, {
+      channel: channelId,
+      text: heading.text,
+      blocks: heading.blocks,
+    });
+
+    const threadTs = typeof response.ts === "string" ? response.ts : null;
+    if (!threadTs) {
+      throw new Error("Slack activity log thread creation did not return a ts.");
+    }
+
+    this.dailyThreadCache = { rawChannel, dateKey, threadTs };
+    return threadTs;
+  }
+
+  private async postEntry(entry: LoggedActivityLogEntry): Promise<void> {
+    const rawChannel = this.deps.getLogChannel()?.trim();
+    const token = this.deps.getBotToken();
+    if (!rawChannel || !token) {
+      return;
+    }
+
+    const channelId = await this.resolveLogChannel(rawChannel);
+    const threadTs = await this.ensureDailyThread(rawChannel, channelId);
+
+    await this.deps.slack("chat.postMessage", token, {
+      channel: channelId,
+      thread_ts: threadTs,
+      text: buildActivityLogText(this.deps.getAgentName(), this.deps.getAgentEmoji(), entry),
+      blocks: buildActivityLogBlocks(this.deps.getAgentName(), this.deps.getAgentEmoji(), entry),
+    });
+  }
+}

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -121,6 +121,8 @@ describe("loadSettings", () => {
         autoConnect: true,
         allowedUsers: ["U123"],
         defaultChannel: "C456",
+        logChannel: "#pinet-logs",
+        logLevel: "verbose",
       },
     };
     fs.writeFileSync(p, JSON.stringify(settings));
@@ -130,6 +132,8 @@ describe("loadSettings", () => {
     expect(result.autoConnect).toBe(true);
     expect(result.allowedUsers).toEqual(["U123"]);
     expect(result.defaultChannel).toBe("C456");
+    expect(result.logChannel).toBe("#pinet-logs");
+    expect(result.logLevel).toBe("verbose");
   });
 
   it("returns autoFollow setting", () => {
@@ -183,6 +187,22 @@ describe("loadSettings", () => {
     fs.writeFileSync(p, JSON.stringify(settings));
     const result = loadSettings(p);
     expect(result.suggestedPrompts).toEqual([{ title: "Hi", message: "Hello!" }]);
+  });
+
+  it("returns activity log settings", () => {
+    const p = path.join(tmpDir, "settings.json");
+    fs.writeFileSync(
+      p,
+      JSON.stringify({
+        "slack-bridge": {
+          logChannel: "CLOGS",
+          logLevel: "errors",
+        },
+      }),
+    );
+    const result = loadSettings(p);
+    expect(result.logChannel).toBe("CLOGS");
+    expect(result.logLevel).toBe("errors");
   });
 
   it("returns control plane canvas settings", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -13,6 +13,8 @@ export interface SlackBridgeSettings {
   appConfigToken?: string;
   allowedUsers?: string[];
   defaultChannel?: string;
+  logChannel?: string;
+  logLevel?: "errors" | "actions" | "verbose";
   suggestedPrompts?: { title: string; message: string }[];
   reactionCommands?: ReactionCommandSettings;
   autoConnect?: boolean;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -129,6 +129,12 @@ import {
   resolveTaskAssignments,
   type ResolvedTaskAssignment,
 } from "./task-assignments.js";
+import {
+  formatRecentActivityLogEntries,
+  SlackActivityLogger,
+  type ActivityLogEntry,
+  type ActivityLogTone,
+} from "./activity-log.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import {
   createBrokerDeliveryState,
@@ -475,6 +481,7 @@ export default function (pi: ExtensionAPI) {
   const inbox: InboxMessage[] = [];
   const brokerDeliveryState = createBrokerDeliveryState();
   let extCtx: ExtensionContext | null = null; // cached for badge updates
+  let lastActivityLogFailureAt = 0;
 
   function updateBadge(): void {
     if (!extCtx?.hasUI) return;
@@ -544,6 +551,78 @@ export default function (pi: ExtensionAPI) {
     } while (cursor);
 
     throw new Error(`Channel "${name}" not found.`);
+  }
+
+  const activityLogger = new SlackActivityLogger({
+    getBotToken: () => botToken,
+    getLogChannel: () => settings.logChannel,
+    getLogLevel: () => settings.logLevel,
+    getAgentName: () => agentName,
+    getAgentEmoji: () => agentEmoji,
+    resolveChannel,
+    slack,
+    onError: (error) => {
+      console.error(`[slack-bridge] activity log failed: ${msg(error)}`);
+      const now = Date.now();
+      if (!extCtx?.hasUI || now - lastActivityLogFailureAt < 60_000) {
+        return;
+      }
+      lastActivityLogFailureAt = now;
+      extCtx.ui.notify(`Pinet activity log failed: ${msg(error)}`, "warning");
+    },
+  });
+
+  function logBrokerActivity(entry: ActivityLogEntry): void {
+    if (!settings.logChannel) {
+      return;
+    }
+    if (brokerRole !== "broker" && activeBroker == null) {
+      return;
+    }
+    activityLogger.log(entry);
+  }
+
+  function formatTrackedAgent(agentId: string): string {
+    const agent = activeBroker?.db.getAgentById(agentId);
+    if (!agent) {
+      return agentId;
+    }
+    return `${agent.emoji} ${agent.name}`.trim();
+  }
+
+  function summarizeTrackedAssignmentStatus(
+    status: "assigned" | "branch_pushed" | "pr_open" | "pr_merged" | "pr_closed",
+    prNumber: number | null,
+    branch: string | null,
+  ): { summary: string; tone: ActivityLogTone } {
+    switch (status) {
+      case "pr_merged":
+        return {
+          summary: `PR #${prNumber ?? "?"} merged`,
+          tone: "success",
+        };
+      case "pr_open":
+        return {
+          summary: `PR #${prNumber ?? "?"} opened for review`,
+          tone: "success",
+        };
+      case "pr_closed":
+        return {
+          summary: `PR #${prNumber ?? "?"} closed without merge`,
+          tone: "warning",
+        };
+      case "branch_pushed":
+        return {
+          summary: `commits pushed on ${branch ?? "tracked branch"}`,
+          tone: "info",
+        };
+      case "assigned":
+      default:
+        return {
+          summary: "assigned",
+          tone: "info",
+        };
+    }
   }
 
   async function resolveFollowerReplyChannel(threadTs: string | undefined): Promise<string | null> {
@@ -1450,14 +1529,70 @@ export default function (pi: ExtensionAPI) {
       lastBrokerMaintenance = result;
 
       const signature = result.anomalies.join("|");
-      if (signature && signature !== lastBrokerMaintenanceSignature) {
+      const previousSignature = lastBrokerMaintenanceSignature;
+      if (signature && signature !== previousSignature) {
         ctx.ui.notify(`Pinet broker: ${result.anomalies.join("; ")}`, "warning");
-      } else if (!signature && lastBrokerMaintenanceSignature) {
+      } else if (!signature && previousSignature) {
         ctx.ui.notify("Pinet broker health recovered", "info");
       }
+
+      const maintenanceDetails: string[] = [];
+      if (result.assignedBacklogCount > 0) {
+        maintenanceDetails.push(
+          `assigned ${result.assignedBacklogCount} backlog item${result.assignedBacklogCount === 1 ? "" : "s"}`,
+        );
+      }
+      if (result.reapedAgentIds.length > 0) {
+        maintenanceDetails.push(
+          `reaped stale agents: ${result.reapedAgentIds.map((agentId) => formatTrackedAgent(agentId)).join(", ")}`,
+        );
+      }
+      if (result.repairedThreadClaims > 0) {
+        maintenanceDetails.push(
+          `released ${result.repairedThreadClaims} orphaned thread claim${result.repairedThreadClaims === 1 ? "" : "s"}`,
+        );
+      }
+      maintenanceDetails.push(...result.anomalies);
+
+      const hasMaintenanceActions =
+        result.assignedBacklogCount > 0 ||
+        result.reapedAgentIds.length > 0 ||
+        result.repairedThreadClaims > 0;
+      const shouldLogMaintenance = hasMaintenanceActions || previousSignature !== signature;
+      if (shouldLogMaintenance) {
+        logBrokerActivity({
+          kind: "broker_maintenance",
+          level: hasMaintenanceActions ? "actions" : "verbose",
+          title: signature ? "Broker maintenance anomaly" : "Broker maintenance recovery",
+          summary: signature
+            ? `Broker maintenance recorded ${maintenanceDetails.length} noteworthy event${maintenanceDetails.length === 1 ? "" : "s"}.`
+            : "Broker maintenance is healthy again.",
+          details:
+            signature && maintenanceDetails.length > 0
+              ? maintenanceDetails
+              : previousSignature
+                ? ["Previous anomalies cleared."]
+                : undefined,
+          fields: [
+            { label: "Backlog", value: result.pendingBacklogCount },
+            { label: "Assigned", value: result.assignedBacklogCount },
+            { label: "Reaped", value: result.reapedAgentIds.length },
+            { label: "Repaired", value: result.repairedThreadClaims },
+          ],
+          tone: signature ? "warning" : "success",
+        });
+      }
+
       lastBrokerMaintenanceSignature = signature;
     } catch (err) {
       ctx.ui.notify(`Pinet maintenance failed: ${msg(err)}`, "error");
+      logBrokerActivity({
+        kind: "broker_maintenance_error",
+        level: "errors",
+        title: "Broker maintenance failed",
+        summary: msg(err),
+        tone: "error",
+      });
     } finally {
       brokerMaintenanceRunning = false;
     }
@@ -1489,6 +1624,13 @@ export default function (pi: ExtensionAPI) {
       }
     } catch (err) {
       ctx.ui.notify(`Pinet scheduled wake-ups failed: ${msg(err)}`, "error");
+      logBrokerActivity({
+        kind: "scheduled_wakeup_error",
+        level: "errors",
+        title: "Scheduled wake-up delivery failed",
+        summary: msg(err),
+        tone: "error",
+      });
     } finally {
       brokerScheduledWakeupRunning = false;
     }
@@ -1725,6 +1867,7 @@ export default function (pi: ExtensionAPI) {
         lastBrokerTaskAssignmentReportSignature = "";
       } else {
         const resolvedAssignments = await resolveTaskAssignments(trackedAssignments, process.cwd());
+        const changedAssignments = resolvedAssignments.filter(hasTaskAssignmentStatusChange);
         projectedAssignments = resolvedAssignments.map((assignment) => {
           if (hasTaskAssignmentStatusChange(assignment)) {
             db.updateTaskAssignmentProgress(
@@ -1740,6 +1883,68 @@ export default function (pi: ExtensionAPI) {
             prNumber: assignment.nextPrNumber,
           };
         });
+
+        if (changedAssignments.length > 0) {
+          const openedCount = changedAssignments.filter(
+            (assignment) => assignment.nextStatus === "pr_open",
+          ).length;
+          const mergedCount = changedAssignments.filter(
+            (assignment) => assignment.nextStatus === "pr_merged",
+          ).length;
+          const closedCount = changedAssignments.filter(
+            (assignment) => assignment.nextStatus === "pr_closed",
+          ).length;
+          const tone: ActivityLogTone =
+            closedCount > 0 ? "warning" : mergedCount > 0 || openedCount > 0 ? "success" : "info";
+          const title =
+            mergedCount > 0
+              ? mergedCount === 1
+                ? "Task merged"
+                : "Tasks merged"
+              : openedCount > 0
+                ? openedCount === 1
+                  ? "Worker completion recorded"
+                  : "Worker completions recorded"
+                : "Task progress updated";
+          const summaryParts = [];
+          if (openedCount > 0) {
+            summaryParts.push(
+              `${openedCount} worker completion${openedCount === 1 ? "" : "s"} moved to PR open`,
+            );
+          }
+          if (mergedCount > 0) {
+            summaryParts.push(`${mergedCount} PR${mergedCount === 1 ? "" : "s"} merged`);
+          }
+          if (closedCount > 0) {
+            summaryParts.push(`${closedCount} PR${closedCount === 1 ? "" : "s"} closed`);
+          }
+          if (summaryParts.length === 0) {
+            summaryParts.push(
+              `${changedAssignments.length} tracked assignment${changedAssignments.length === 1 ? " changed" : "s changed"}`,
+            );
+          }
+          logBrokerActivity({
+            kind: "task_progress",
+            level: "actions",
+            title,
+            summary: summaryParts.join("; "),
+            details: changedAssignments.map((assignment) => {
+              const next = summarizeTrackedAssignmentStatus(
+                assignment.nextStatus,
+                assignment.nextPrNumber,
+                assignment.branch,
+              );
+              return `${formatTrackedAgent(assignment.agentId)} — #${assignment.issueNumber}: ${next.summary}`;
+            }),
+            fields: [
+              { label: "Updated", value: changedAssignments.length },
+              { label: "Merged", value: mergedCount },
+              { label: "PR open", value: openedCount },
+              { label: "Cycle", value: cycleStartedAt },
+            ],
+            tone,
+          });
+        }
 
         pendingBrokerTaskAssignmentReport = getPendingTaskAssignmentReport(
           projectedAssignments,
@@ -1786,6 +1991,56 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.notify(ralphNotifications.anomalyStatus ?? "RALPH loop anomaly detected", "info");
       } else if (!hasOutstandingAnomalies && lastBrokerRalphLoopHadOutstandingAnomalies) {
         ctx.ui.notify(ralphNotifications.recoveryStatus, "info");
+      }
+
+      if (shouldWarn || shouldInform) {
+        logBrokerActivity({
+          kind: "ralph_event",
+          level: "actions",
+          title: shouldWarn ? "RALPH anomaly detected" : "RALPH status updated",
+          summary: ralphNotifications.anomalyStatus ?? "RALPH loop anomaly detected",
+          details: visibleEvaluation.anomalies,
+          fields: [
+            { label: "Ghosts", value: visibleEvaluation.ghostAgentIds.length },
+            { label: "Stuck", value: visibleEvaluation.stuckAgentIds.length },
+            { label: "Nudged", value: visibleEvaluation.nudgeAgentIds.length },
+            { label: "Backlog", value: pendingBacklogCount },
+            { label: "Follow-up", value: shouldDeliverFollowUp },
+          ],
+          tone: shouldWarn ? "warning" : "info",
+        });
+      } else if (!hasOutstandingAnomalies && lastBrokerRalphLoopHadOutstandingAnomalies) {
+        logBrokerActivity({
+          kind: "ralph_event",
+          level: "actions",
+          title: "RALPH recovered",
+          summary: ralphNotifications.recoveryStatus,
+          details: ["Previous ghost/stall/backlog anomalies cleared."],
+          fields: [
+            { label: "Backlog", value: pendingBacklogCount },
+            { label: "Idle workers", value: visibleEvaluation.idleDrainAgentIds.length },
+          ],
+          tone: "success",
+        });
+      } else {
+        logBrokerActivity({
+          kind: "ralph_cycle",
+          level: "verbose",
+          title: "RALPH cycle",
+          summary:
+            visibleEvaluation.anomalies.length > 0
+              ? `${visibleEvaluation.anomalies.length} anomaly entries observed this cycle.`
+              : "Broker health steady this cycle.",
+          details: visibleEvaluation.anomalies.length > 0 ? visibleEvaluation.anomalies : undefined,
+          fields: [
+            { label: "Ghosts", value: visibleEvaluation.ghostAgentIds.length },
+            { label: "Stuck", value: visibleEvaluation.stuckAgentIds.length },
+            { label: "Nudged", value: visibleEvaluation.nudgeAgentIds.length },
+            { label: "Idle", value: visibleEvaluation.idleDrainAgentIds.length },
+            { label: "Backlog", value: pendingBacklogCount },
+          ],
+          tone: visibleEvaluation.anomalies.length > 0 ? "warning" : "info",
+        });
       }
       lastBrokerRalphLoopNonGhostSignature = nonGhostSignature;
       lastBrokerRalphLoopHadOutstandingAnomalies = hasOutstandingAnomalies;
@@ -1855,6 +2110,14 @@ export default function (pi: ExtensionAPI) {
       }
     } catch (err) {
       ctx.ui.notify(buildRalphLoopStatusMessage(`failed: ${msg(err)}`, cycleStartedAt), "error");
+      logBrokerActivity({
+        kind: "ralph_error",
+        level: "errors",
+        title: "RALPH loop failed",
+        summary: msg(err),
+        fields: [{ label: "Cycle", value: cycleStartedAt }],
+        tone: "error",
+      });
     } finally {
       brokerRalphLoopRunning = false;
     }
@@ -1926,14 +2189,36 @@ export default function (pi: ExtensionAPI) {
         metadata: finalMetadata,
       });
 
+      const recordedAssignments = [] as Array<{ issueNumber: number; branch: string | null }>;
       for (const assignment of extractTaskAssignmentsFromMessage(body)) {
-        db.recordTaskAssignment(
+        const tracked = db.recordTaskAssignment(
           result.target.id,
           assignment.issueNumber,
           assignment.branch,
           result.threadId,
           result.messageId,
         );
+        recordedAssignments.push({ issueNumber: tracked.issueNumber, branch: tracked.branch });
+      }
+
+      if (recordedAssignments.length > 0) {
+        logBrokerActivity({
+          kind: "task_assignment",
+          level: "actions",
+          title: recordedAssignments.length === 1 ? "Task assigned" : "Tasks assigned",
+          summary: `Assigned ${recordedAssignments.map((assignment) => `#${assignment.issueNumber}`).join(", ")} to ${formatTrackedAgent(result.target.id)}.`,
+          details: recordedAssignments.map((assignment) =>
+            assignment.branch
+              ? `#${assignment.issueNumber} on \`${assignment.branch}\``
+              : `#${assignment.issueNumber}`,
+          ),
+          fields: [
+            { label: "Worker", value: formatTrackedAgent(result.target.id) },
+            { label: "Thread", value: result.threadId },
+            { label: "Message", value: result.messageId },
+          ],
+          tone: "info",
+        });
       }
 
       return { messageId: result.messageId, target: result.target.name };
@@ -2011,6 +2296,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     await disconnect();
+    activityLogger.clearPending();
     brokerRole = null;
     pinetEnabled = false;
     setExtStatus(ctx, "off");
@@ -2519,20 +2805,48 @@ export default function (pi: ExtensionAPI) {
 
         syncBrokerDbInbox(selfId, broker.db);
       });
-      broker.server.onAgentStatusChange((_agentId, status) => {
+      broker.server.onAgentStatusChange((changedAgentId, status) => {
         if (status === "idle") {
           runBrokerMaintenance(ctx);
         }
+
+        logBrokerActivity({
+          kind: "agent_status",
+          level: "verbose",
+          title: status === "idle" ? "Worker available" : "Worker busy",
+          summary: `${formatTrackedAgent(changedAgentId)} marked itself ${status}.`,
+          fields: [{ label: "Agent", value: formatTrackedAgent(changedAgentId) }],
+          tone: status === "idle" ? "success" : "info",
+        });
       });
 
+      brokerRole = "broker";
+      pinetEnabled = true;
+      applyBrokerIdentity(selfAgent.name, selfAgent.emoji);
       startBrokerHeartbeat();
       startBrokerMaintenance(ctx);
       startBrokerRalphLoop(ctx);
       startBrokerScheduledWakeups(ctx);
-      brokerRole = "broker";
-      pinetEnabled = true;
-      applyBrokerIdentity(selfAgent.name, selfAgent.emoji);
       setExtStatus(ctx, "ok");
+      logBrokerActivity({
+        kind: "broker_started",
+        level: "actions",
+        title: "Broker started",
+        summary: `${agentEmoji} ${agentName} is online and coordinating the mesh.`,
+        details:
+          recoveredBrokerMessages > 0 || releasedBrokerClaims > 0
+            ? [
+                `Recovered ${recoveredBrokerMessages} pending broker inbox item${recoveredBrokerMessages === 1 ? "" : "s"}.`,
+                `Released ${releasedBrokerClaims} stale broker-owned thread claim${releasedBrokerClaims === 1 ? "" : "s"}.`,
+              ]
+            : undefined,
+        fields: [
+          { label: "Bot", value: botUserId ?? "unknown" },
+          { label: "Log channel", value: settings.logChannel ?? "disabled" },
+          { label: "Log level", value: settings.logLevel ?? "actions" },
+        ],
+        tone: "success",
+      });
       ctx.ui.notify(`${agentEmoji} ${agentName} — broker started (${botUserId})`, "info");
     } catch (err) {
       try {
@@ -2947,6 +3261,9 @@ export default function (pi: ExtensionAPI) {
       const defaultChInfo = settings.defaultChannel
         ? `Default channel: ${settings.defaultChannel}`
         : "Default channel: none";
+      const activityLogInfo = settings.logChannel
+        ? `Activity log: ${settings.logChannel} (${settings.logLevel ?? "actions"})`
+        : "Activity log: disabled";
       const brokerHealthInfo =
         mode === "broker" && lastBrokerMaintenance
           ? [
@@ -2984,12 +3301,36 @@ export default function (pi: ExtensionAPI) {
           `DM channel: ${lastDmChannel ?? "none yet"}`,
           allowlistInfo,
           defaultChInfo,
+          activityLogInfo,
           ...brokerHealthInfo,
           ...brokerCanvasInfo,
         ].join("\n"),
         "info",
       );
     },
+  });
+
+  const showActivityLogs = async (_args: string, ctx: ExtensionContext) => {
+    const channelInfo = settings.logChannel
+      ? `${settings.logChannel} (${settings.logLevel ?? "actions"})`
+      : "disabled";
+    ctx.ui.notify(
+      [
+        `Activity log channel: ${channelInfo}`,
+        formatRecentActivityLogEntries(activityLogger.getRecentEntries(10)),
+      ].join("\n\n"),
+      settings.logChannel ? "info" : "warning",
+    );
+  };
+
+  pi.registerCommand("pinet-logs", {
+    description: "Show recent broker activity log entries",
+    handler: showActivityLogs,
+  });
+
+  pi.registerCommand("slack-logs", {
+    description: "Show recent broker activity log entries",
+    handler: showActivityLogs,
   });
 
   pi.registerCommand("pinet-rename", {


### PR DESCRIPTION
## Summary
- add a broker-only Slack activity log channel with `logChannel` / `logLevel` settings and a daily-thread logger
- mirror task assignments, PR-open completions, merges, stalls, maintenance anomalies, and RALPH events into structured Block Kit log entries
- add `pinet-logs` / `slack-logs` plus README/settings/test coverage for the observability workflow

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #30