### PR TITLE
feat: add Pinet Home tab dashboard (#21)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -76,6 +76,7 @@ a short cache to avoid hammering Slack.
 - **@mentions** — tag Pinet in any channel and it responds in-thread
 - **Channel & canvas tools** — create/read/post in channels and maintain persistent Slack canvases
 - **Broker control plane canvas** — the broker can maintain a live Slack canvas with agent roster, task/PR state, and RALPH health on every cycle
+- **Home tab dashboard** — opening Pinet from Slack Apps publishes the same control-plane status into the app Home tab with Block Kit
 - **Block Kit messages** — send rich Slack layouts via the optional `blocks` parameter
 - **Interactive workflows** — `block_actions` button clicks and `view_submission` modal submits are routed back into the inbox as structured events
 - **Slack modals** — open, push, and update modal views for confirmations, forms, and multi-step workflows
@@ -194,10 +195,10 @@ Then `/reload` in pi. Pinet appears in Slack's sidebar automatically.
 The `manifest.yaml` includes all required scopes and events, including `files:write`
 for `slack_upload`, `chat:write` for `slack_schedule`, bookmark/pin scopes for
 `slack_bookmark` and `slack_pin`, `users:read` + `users.getPresence` / `dnd.info`
-for presence checks, `reaction_added` + `reactions:read` plus `presence_change`
-for Slack-side awareness events, and `interactivity.is_enabled: true` for buttons
-and modals. Use it when creating the app (**From a manifest**) or paste it into
-**App Manifest** in settings.
+for presence checks, `app_home_opened` for the Home tab dashboard, `reaction_added`
++ `reactions:read` plus `presence_change` for Slack-side awareness events, and
+`interactivity.is_enabled: true` for buttons and modals. Use it when creating
+the app (**From a manifest**) or paste it into **App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseSocketFrame,
   extractThreadStarted,
+  extractAppHomeOpened,
   classifyMessage,
   parseMemberJoinedChannel,
   SlackAdapter,
@@ -161,6 +162,32 @@ describe("extractThreadStarted", () => {
     };
     const result = extractThreadStarted(evt);
     expect(result?.context).toBeUndefined();
+  });
+});
+
+describe("extractAppHomeOpened", () => {
+  it("extracts the user, tab, and event timestamp", () => {
+    expect(
+      extractAppHomeOpened({
+        type: "app_home_opened",
+        user: "U123",
+        tab: "home",
+        event_ts: "123.456",
+      }),
+    ).toEqual({
+      userId: "U123",
+      tab: "home",
+      eventTs: "123.456",
+    });
+  });
+
+  it("defaults the tab to home and rejects missing users", () => {
+    expect(extractAppHomeOpened({ user: "U123" })).toEqual({
+      userId: "U123",
+      tab: "home",
+      eventTs: null,
+    });
+    expect(extractAppHomeOpened({ tab: "home" })).toBeNull();
   });
 });
 
@@ -549,6 +576,79 @@ describe("SlackAdapter", () => {
     adapter.onInbound(handler);
     // handler is registered (can't easily verify without triggering a message)
     expect(adapter.name).toBe("slack");
+  });
+
+  it("forwards app_home_opened events to the configured callback", async () => {
+    const onAppHomeOpened = vi.fn(async () => undefined);
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onAppHomeOpened,
+    });
+
+    await (
+      adapter as unknown as {
+        onAppHomeOpened: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onAppHomeOpened({
+      type: "app_home_opened",
+      user: "U123",
+      tab: "home",
+      event_ts: "123.456",
+    });
+
+    expect(onAppHomeOpened).toHaveBeenCalledWith({
+      userId: "U123",
+      tab: "home",
+      eventTs: "123.456",
+    });
+  });
+
+  it("ignores non-home app_home_opened events", async () => {
+    const onAppHomeOpened = vi.fn(async () => undefined);
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onAppHomeOpened,
+    });
+
+    await (
+      adapter as unknown as {
+        onAppHomeOpened: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onAppHomeOpened({
+      type: "app_home_opened",
+      user: "U123",
+      tab: "messages",
+      event_ts: "123.456",
+    });
+
+    expect(onAppHomeOpened).not.toHaveBeenCalled();
+  });
+
+  it("contains app_home_opened callback failures", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onAppHomeOpened: vi.fn(async () => {
+        throw new Error("views.publish failed");
+      }),
+    });
+
+    await expect(
+      (
+        adapter as unknown as {
+          onAppHomeOpened: (evt: Record<string, unknown>) => Promise<void>;
+        }
+      ).onAppHomeOpened({
+        type: "app_home_opened",
+        user: "U123",
+        tab: "home",
+        event_ts: "123.456",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[slack-adapter] Home tab callback failed: views.publish failed",
+    );
   });
 
   it("ignores duplicate Socket Mode message deliveries with the same Slack event_id", async () => {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -37,6 +37,8 @@ export interface SlackAdapterConfig {
   isKnownThread?: (threadTs: string) => boolean;
   /** Persist thread metadata in the broker DB without claiming ownership. */
   rememberKnownThread?: (threadTs: string, channelId: string) => void;
+  /** Best-effort callback for Home tab opens. */
+  onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
 }
 
 interface SlackThreadInfo {
@@ -98,6 +100,12 @@ export interface ParsedThreadStarted {
   context?: { channelId: string; teamId: string };
 }
 
+export interface ParsedAppHomeOpened {
+  userId: string;
+  tab: string;
+  eventTs: string | null;
+}
+
 /**
  * Extract thread info from an assistant_thread_started event.
  */
@@ -117,6 +125,18 @@ export function extractThreadStarted(evt: Record<string, unknown>): ParsedThread
   }
 
   return result;
+}
+
+export function extractAppHomeOpened(evt: Record<string, unknown>): ParsedAppHomeOpened | null {
+  const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
+  if (!userId) return null;
+
+  const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
+  return {
+    userId,
+    tab,
+    eventTs: typeof evt.event_ts === "string" && evt.event_ts.length > 0 ? evt.event_ts : null,
+  };
 }
 
 /**
@@ -393,6 +413,9 @@ export class SlackAdapter implements MessageAdapter {
         case "member_joined_channel":
           this.onMemberJoined(evt);
           break;
+        case "app_home_opened":
+          await this.onAppHomeOpened(evt);
+          break;
       }
     } catch (err) {
       if (dedupKey) {
@@ -444,6 +467,21 @@ export class SlackAdapter implements MessageAdapter {
         channelId: ctx.channel_id,
         teamId: ctx.team_id ?? "",
       };
+    }
+  }
+
+  private async onAppHomeOpened(evt: Record<string, unknown>): Promise<void> {
+    if (this.shuttingDown) return;
+
+    const parsed = extractAppHomeOpened(evt);
+    if (!parsed || parsed.tab !== "home") {
+      return;
+    }
+
+    try {
+      await this.config.onAppHomeOpened?.(parsed);
+    } catch (err) {
+      console.error(`[slack-adapter] Home tab callback failed: ${errorMsg(err)}`);
     }
   }
 

--- a/slack-bridge/home-tab.test.ts
+++ b/slack-bridge/home-tab.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSlackHomeTabPublishRequest,
+  publishSlackHomeTab,
+  renderBrokerControlPlaneHomeTabView,
+  renderStandalonePinetHomeTabView,
+} from "./home-tab.js";
+
+describe("renderBrokerControlPlaneHomeTabView", () => {
+  it("renders the broker control plane snapshot as a Home tab view", () => {
+    const view = renderBrokerControlPlaneHomeTabView({
+      cycleStartedAt: "2026-04-02T17:00:00.000Z",
+      cycleDurationMs: 2500,
+      currentBranch: "main",
+      totalAgents: 2,
+      liveAgents: 2,
+      brokerCount: 1,
+      workerCount: 1,
+      idleWorkers: 0,
+      workingWorkers: 1,
+      ghostAgents: 1,
+      stuckAgents: 1,
+      pendingBacklogCount: 3,
+      nudgesThisCycle: 1,
+      idleDrainCandidates: 0,
+      assignedBacklogCount: 1,
+      reapedAgents: 1,
+      repairedThreadClaims: 2,
+      maintenanceAnomalies: ["released 2 orphaned thread claims"],
+      anomalies: ["ghost agents detected: ghost-1"],
+      taskCounts: {
+        assigned: 0,
+        branchPushed: 1,
+        openPrs: 1,
+        mergedPrs: 1,
+        closedPrs: 0,
+      },
+      activeTasks: ["#217 PR #225 open"],
+      recentOutcomes: ["#205 PR #205 merged"],
+      roster: [
+        {
+          id: "broker-1",
+          role: "broker",
+          label: "🦦 The Broker Otter",
+          status: "working",
+          health: "healthy",
+          workload: "0 inbox / 0 threads",
+          taskSummary: "—",
+          heartbeat: "2s ago",
+          branch: "main",
+          worktree: "main checkout",
+        },
+      ],
+      recentCycles: [
+        {
+          startedAt: "2026-04-02 17:00Z",
+          duration: "3.0s",
+          agentCount: 2,
+          backlogCount: 3,
+          ghostCount: 1,
+          stuckCount: 1,
+          anomalySummary: "ghost agents detected: ghost-1",
+          followUpDelivered: true,
+        },
+      ],
+    });
+
+    expect(view.type).toBe("home");
+    expect(view.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "header",
+          text: expect.objectContaining({ text: "Pinet Broker Control Plane" }),
+        }),
+        expect.objectContaining({
+          type: "header",
+          text: expect.objectContaining({ text: "Agent roster" }),
+        }),
+        expect.objectContaining({
+          type: "header",
+          text: expect.objectContaining({ text: "Recent RALPH cycles" }),
+        }),
+      ]),
+    );
+
+    expect(JSON.stringify(view)).toContain("ghost agents detected: ghost-1");
+    expect(JSON.stringify(view)).toContain("🦦 The Broker Otter");
+    expect(JSON.stringify(view)).toContain("#217 PR #225 open");
+  });
+});
+
+describe("renderStandalonePinetHomeTabView", () => {
+  it("renders a fallback Home tab for non-broker sessions", () => {
+    const view = renderStandalonePinetHomeTabView({
+      agentName: "Cosmic Crane",
+      agentEmoji: "🦩",
+      connected: true,
+      mode: "standalone",
+      activeThreads: 3,
+      pendingInbox: 1,
+      currentBranch: "feat/home-tab",
+      defaultChannel: "ops-control",
+    });
+
+    expect(view.type).toBe("home");
+    expect(JSON.stringify(view)).toContain("Cosmic Crane");
+    expect(JSON.stringify(view)).toContain("feat/home-tab");
+    expect(JSON.stringify(view)).toContain("full control-plane dashboard");
+  });
+});
+
+describe("buildSlackHomeTabPublishRequest", () => {
+  it("builds a views.publish request body", () => {
+    expect(
+      buildSlackHomeTabPublishRequest("U123", {
+        type: "home",
+        blocks: [],
+      }),
+    ).toEqual({
+      user_id: "U123",
+      view: {
+        type: "home",
+        blocks: [],
+      },
+    });
+  });
+
+  it("rejects missing user ids", () => {
+    expect(() =>
+      buildSlackHomeTabPublishRequest("", {
+        type: "home",
+        blocks: [],
+      }),
+    ).toThrow("Home tab publish requires a user ID.");
+  });
+});
+
+describe("publishSlackHomeTab", () => {
+  it("calls views.publish with the built request", async () => {
+    const slack = vi.fn(async () => ({ ok: true }));
+
+    await publishSlackHomeTab({
+      slack,
+      token: "xoxb-test",
+      userId: "U123",
+      view: {
+        type: "home",
+        blocks: [],
+      },
+    });
+
+    expect(slack).toHaveBeenCalledWith("views.publish", "xoxb-test", {
+      user_id: "U123",
+      view: {
+        type: "home",
+        blocks: [],
+      },
+    });
+  });
+});

--- a/slack-bridge/home-tab.ts
+++ b/slack-bridge/home-tab.ts
@@ -1,0 +1,320 @@
+import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
+
+export type SlackBlock = Record<string, unknown>;
+
+export interface SlackHomeView {
+  type: "home";
+  blocks: SlackBlock[];
+}
+
+export interface PublishSlackHomeTabInput {
+  slack: (
+    method: string,
+    token: string,
+    body?: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>;
+  token: string;
+  userId: string;
+  view: SlackHomeView;
+}
+
+export interface StandalonePinetHomeTabInput {
+  agentName: string;
+  agentEmoji: string;
+  connected: boolean;
+  mode: "broker" | "worker" | "standalone";
+  activeThreads: number;
+  pendingInbox: number;
+  currentBranch?: string | null;
+  defaultChannel?: string | null;
+}
+
+const MAX_SECTION_TEXT_LENGTH = 2800;
+const MAX_ROSTER_ENTRIES = 20;
+
+function asNonEmptyString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function formatTimestamp(value: string): string {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return value;
+  }
+
+  return new Date(parsed)
+    .toISOString()
+    .replace("T", " ")
+    .replace(".000", "")
+    .replace(/:\d\dZ$/, "Z");
+}
+
+function formatDuration(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) return "n/a";
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1_000;
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  const minutes = seconds / 60;
+  return `${minutes.toFixed(minutes < 10 ? 1 : 0)}m`;
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function plainText(text: string): Record<string, unknown> {
+  return {
+    type: "plain_text",
+    text: truncate(text, 150),
+    emoji: true,
+  };
+}
+
+function mrkdwn(text: string): Record<string, unknown> {
+  return {
+    type: "mrkdwn",
+    text,
+  };
+}
+
+function headerBlock(text: string): SlackBlock {
+  return {
+    type: "header",
+    text: plainText(text),
+  };
+}
+
+function contextBlock(lines: string[]): SlackBlock {
+  return {
+    type: "context",
+    elements: lines.map((line) => mrkdwn(line)),
+  };
+}
+
+function dividerBlock(): SlackBlock {
+  return { type: "divider" };
+}
+
+function sectionBlock(options: {
+  text?: string;
+  fields?: string[];
+  accessory?: Record<string, unknown>;
+}): SlackBlock {
+  return {
+    type: "section",
+    ...(options.text ? { text: mrkdwn(options.text) } : {}),
+    ...(options.fields && options.fields.length > 0
+      ? { fields: options.fields.slice(0, 10).map((field) => mrkdwn(field)) }
+      : {}),
+    ...(options.accessory ? { accessory: options.accessory } : {}),
+  };
+}
+
+function buildLineSections(lines: string[], emptyState: string): SlackBlock[] {
+  if (lines.length === 0) {
+    return [sectionBlock({ text: emptyState })];
+  }
+
+  const chunks: string[] = [];
+  let current = "";
+
+  for (const line of lines) {
+    const candidate = current.length > 0 ? `${current}\n${line}` : line;
+    if (candidate.length > MAX_SECTION_TEXT_LENGTH && current.length > 0) {
+      chunks.push(current);
+      current = line;
+      continue;
+    }
+
+    if (line.length > MAX_SECTION_TEXT_LENGTH) {
+      if (current.length > 0) {
+        chunks.push(current);
+        current = "";
+      }
+      chunks.push(truncate(line, MAX_SECTION_TEXT_LENGTH));
+      continue;
+    }
+
+    current = candidate;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return chunks.map((chunk) => sectionBlock({ text: chunk }));
+}
+
+function buildRosterBlocks(snapshot: BrokerControlPlaneDashboardSnapshot): SlackBlock[] {
+  const visibleRoster = snapshot.roster.slice(0, MAX_ROSTER_ENTRIES);
+  const blocks =
+    visibleRoster.length > 0
+      ? visibleRoster.map((row) =>
+          sectionBlock({
+            text: [
+              `*${row.label}* · \`${row.role}\``,
+              `Health: ${row.health} · Status: ${row.status}`,
+              `Workload: ${row.workload}`,
+              `Task: ${truncate(row.taskSummary, 120)}`,
+              `Heartbeat: ${row.heartbeat}`,
+              `Branch: ${row.branch} · Worktree: ${row.worktree}`,
+            ].join("\n"),
+          }),
+        )
+      : [sectionBlock({ text: "No agents are currently registered." })];
+
+  if (snapshot.roster.length > visibleRoster.length) {
+    blocks.push(
+      contextBlock([
+        `_Showing ${visibleRoster.length} of ${snapshot.roster.length} agents on the Home tab._`,
+      ]),
+    );
+  }
+
+  return blocks;
+}
+
+export function renderBrokerControlPlaneHomeTabView(
+  snapshot: BrokerControlPlaneDashboardSnapshot,
+): SlackHomeView {
+  const anomalyLines =
+    snapshot.anomalies.length > 0
+      ? snapshot.anomalies.map((anomaly) => `• ${anomaly}`)
+      : ["• Healthy ✅"];
+  const maintenanceLines = snapshot.maintenanceAnomalies.map((anomaly) => `• ${anomaly}`);
+  const cycleLines = snapshot.recentCycles.map(
+    (cycle) =>
+      `• *${cycle.startedAt}* — ${cycle.duration} · ${cycle.agentCount} agents · backlog ${cycle.backlogCount} · ghosts ${cycle.ghostCount} · stuck ${cycle.stuckCount} · follow-up ${cycle.followUpDelivered ? "yes" : "no"}\n  ${cycle.anomalySummary}`,
+  );
+
+  const blocks: SlackBlock[] = [
+    headerBlock("Pinet Broker Control Plane"),
+    contextBlock([
+      `_Updated ${formatTimestamp(snapshot.cycleStartedAt)} · cycle ${formatDuration(snapshot.cycleDurationMs)}_`,
+    ]),
+    sectionBlock({
+      text: "This Home tab mirrors the broker control-plane dashboard with live mesh, task, and RALPH loop status.",
+    }),
+    dividerBlock(),
+    headerBlock("Mesh summary"),
+    sectionBlock({
+      fields: [
+        `*Main checkout*\n\`${snapshot.currentBranch ?? "unknown"}\``,
+        `*Agents*\n${snapshot.liveAgents} live / ${snapshot.totalAgents} total`,
+        `*Workers*\n${snapshot.workingWorkers} working · ${snapshot.idleWorkers} idle`,
+        `*Backlog*\n${snapshot.pendingBacklogCount} pending · ${snapshot.assignedBacklogCount} assigned`,
+        `*RALPH nudges*\n${snapshot.nudgesThisCycle} nudges · ${snapshot.idleDrainCandidates} idle drains`,
+        `*Maintenance*\n${snapshot.reapedAgents} reaped · ${snapshot.repairedThreadClaims} repaired claims`,
+      ],
+    }),
+    headerBlock("Active anomalies"),
+    ...buildLineSections(anomalyLines, "Healthy ✅"),
+    ...(maintenanceLines.length > 0
+      ? [headerBlock("Maintenance anomalies"), ...buildLineSections(maintenanceLines, "None.")]
+      : []),
+    headerBlock("Agent roster"),
+    ...buildRosterBlocks(snapshot),
+    headerBlock("Task / PR status"),
+    sectionBlock({
+      fields: [
+        `*Assigned*\n${snapshot.taskCounts.assigned}`,
+        `*Branch pushed*\n${snapshot.taskCounts.branchPushed}`,
+        `*Open PRs*\n${snapshot.taskCounts.openPrs}`,
+        `*Merged PRs*\n${snapshot.taskCounts.mergedPrs}`,
+        `*Closed PRs*\n${snapshot.taskCounts.closedPrs}`,
+      ],
+    }),
+    headerBlock("Active tasks"),
+    ...buildLineSections(
+      snapshot.activeTasks.map((task) => `• ${task}`),
+      "No active tracked tasks.",
+    ),
+    headerBlock("Recent outcomes"),
+    ...buildLineSections(
+      snapshot.recentOutcomes.map((task) => `• ${task}`),
+      "No merged or closed PR outcomes tracked yet.",
+    ),
+    headerBlock("Recent RALPH cycles"),
+    ...buildLineSections(cycleLines, "No recorded RALPH cycles yet."),
+    dividerBlock(),
+    headerBlock("Quick actions"),
+    sectionBlock({
+      text: [
+        "• Open a DM with Pinet in the *Messages* tab to assign or follow up on work.",
+        "• Mention Pinet in a channel thread to route a task into the broker mesh.",
+        "• Use the control-plane canvas for a long-form markdown view of the same dashboard.",
+      ].join("\n"),
+    }),
+  ];
+
+  return {
+    type: "home",
+    blocks,
+  };
+}
+
+export function renderStandalonePinetHomeTabView(
+  input: StandalonePinetHomeTabInput,
+): SlackHomeView {
+  const modeLabel = input.mode === "standalone" ? "direct" : input.mode;
+  const branch = asNonEmptyString(input.currentBranch) ?? "unknown";
+  const defaultChannel = asNonEmptyString(input.defaultChannel) ?? "not configured";
+
+  return {
+    type: "home",
+    blocks: [
+      headerBlock("Pinet Home"),
+      contextBlock([
+        `${input.agentEmoji} *${input.agentName}* · ${input.connected ? "connected" : "disconnected"}`,
+      ]),
+      sectionBlock({
+        text: "Pinet is available from Slack’s Home tab. When the broker mesh is running, this surface upgrades into the full control-plane dashboard.",
+      }),
+      dividerBlock(),
+      headerBlock("Current runtime"),
+      sectionBlock({
+        fields: [
+          `*Mode*\n${modeLabel}`,
+          `*Connection*\n${input.connected ? "connected" : "disconnected"}`,
+          `*Branch*\n\`${branch}\``,
+          `*Active threads*\n${input.activeThreads}`,
+          `*Pending inbox*\n${input.pendingInbox}`,
+          `*Default channel*\n${defaultChannel}`,
+        ],
+      }),
+      headerBlock("Getting started"),
+      sectionBlock({
+        text: [
+          "• Open the *Messages* tab and start a conversation with Pinet.",
+          "• Mention Pinet in a channel to continue work in-thread.",
+          "• Start broker mode to expose the full control-plane dashboard here on the Home tab.",
+        ].join("\n"),
+      }),
+    ],
+  };
+}
+
+export function buildSlackHomeTabPublishRequest(
+  userId: string,
+  view: SlackHomeView,
+): Record<string, unknown> {
+  const normalizedUserId = asNonEmptyString(userId);
+  if (!normalizedUserId) {
+    throw new Error("Home tab publish requires a user ID.");
+  }
+
+  return {
+    user_id: normalizedUserId,
+    view,
+  };
+}
+
+export async function publishSlackHomeTab(input: PublishSlackHomeTabInput): Promise<void> {
+  await input.slack(
+    "views.publish",
+    input.token,
+    buildSlackHomeTabPublishRequest(input.userId, input.view),
+  );
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -157,7 +157,13 @@ import {
   buildBrokerControlPlaneDashboardSnapshot,
   refreshBrokerControlPlaneCanvas,
   renderBrokerControlPlaneCanvasMarkdown,
+  type BrokerControlPlaneDashboardSnapshot,
 } from "./broker/control-plane-canvas.js";
+import {
+  publishSlackHomeTab,
+  renderBrokerControlPlaneHomeTabView,
+  renderStandalonePinetHomeTabView,
+} from "./home-tab.js";
 import { getMainCheckoutToolBlockReason } from "./worktree-policy.js";
 
 // Settings and helpers imported from ./helpers.js
@@ -220,6 +226,13 @@ export default function (pi: ExtensionAPI) {
   let brokerControlPlaneCanvasRuntimeChannelId: string | null = null;
   let lastBrokerControlPlaneCanvasRefreshAt: string | null = null;
   let lastBrokerControlPlaneCanvasError: string | null = null;
+  const brokerControlPlaneHomeTabViewers = new TtlCache<string, { openedAt: string }>({
+    maxSize: 100,
+    ttlMs: 12 * 60 * 60 * 1000,
+  });
+  let lastBrokerControlPlaneHomeTabSnapshot: BrokerControlPlaneDashboardSnapshot | null = null;
+  let lastBrokerControlPlaneHomeTabRefreshAt: string | null = null;
+  let lastBrokerControlPlaneHomeTabError: string | null = null;
 
   function isBrokerControlPlaneCanvasEnabled(): boolean {
     return settings.controlPlaneCanvasEnabled ?? true;
@@ -1037,6 +1050,9 @@ export default function (pi: ExtensionAPI) {
         case "assistant_thread_context_changed":
           onContextChanged(evt);
           break;
+        case "app_home_opened":
+          await onAppHomeOpened(evt, ctx);
+          break;
         case "message":
           if (!evt.subtype && !evt.bot_id) await onMessage(evt, ctx);
           break;
@@ -1107,6 +1123,21 @@ export default function (pi: ExtensionAPI) {
       existing.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
       persistState();
     }
+  }
+
+  async function onAppHomeOpened(
+    evt: Record<string, unknown>,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    if (shuttingDown) return;
+
+    const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
+    const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
+    if (!userId || tab !== "home") {
+      return;
+    }
+
+    await publishCurrentPinetHomeTabSafely(userId, ctx);
   }
 
   async function fetchSlackMessageByTs(
@@ -1815,6 +1846,171 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  function getBrokerControlPlaneHomeTabViewerIds(): string[] {
+    return [...brokerControlPlaneHomeTabViewers.entries()].map(([userId]) => userId);
+  }
+
+  async function buildCurrentBrokerControlPlaneDashboardSnapshot(
+    cycleStartedAt: string = new Date().toISOString(),
+  ): Promise<BrokerControlPlaneDashboardSnapshot | null> {
+    if (!activeBroker) {
+      return null;
+    }
+
+    const db = activeBroker.db;
+    const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
+    const workloads = db.getAllAgents().map((agent) => ({
+      ...agent,
+      pendingInboxCount: db.getPendingInboxCount(agent.id),
+      ownedThreadCount: db.getOwnedThreadCount(agent.id),
+    }));
+    const pendingBacklogCount = db.getBacklogCount("pending");
+    const evaluationOptions: RalphLoopEvaluationOptions = {
+      now: Date.now(),
+      heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
+      heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+      stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+      pendingBacklogCount,
+      currentBranch,
+      brokerHeartbeatActive: brokerHeartbeatTimer != null,
+      brokerMaintenanceActive: brokerMaintenanceTimer != null,
+    };
+    const evaluation = evaluateRalphLoopCycle(workloads, evaluationOptions);
+
+    const trackedAssignments = db.listTaskAssignments();
+    let projectedAssignments: ResolvedTaskAssignment[] = [];
+    if (trackedAssignments.length > 0) {
+      const resolvedAssignments = await resolveTaskAssignments(trackedAssignments, process.cwd());
+      projectedAssignments = resolvedAssignments.map((assignment) => ({
+        ...assignment,
+        status: assignment.nextStatus,
+        prNumber: assignment.nextPrNumber,
+      }));
+    }
+
+    const recentRalphCycles = db.getRecentRalphCycles(5).map((cycle) => ({
+      startedAt: cycle.startedAt,
+      completedAt: cycle.completedAt,
+      durationMs: cycle.durationMs,
+      ghostAgentIds: cycle.ghostAgentIds,
+      stuckAgentIds: cycle.stuckAgentIds,
+      anomalies: cycle.anomalies,
+      followUpDelivered: cycle.followUpDelivered,
+      agentCount: cycle.agentCount,
+      backlogCount: cycle.backlogCount,
+    }));
+
+    return buildBrokerControlPlaneDashboardSnapshot({
+      workloads,
+      evaluation,
+      evaluationOptions,
+      maintenance: lastBrokerMaintenance,
+      assignments: projectedAssignments,
+      recentCycles: recentRalphCycles,
+      cycleStartedAt,
+      cycleDurationMs: 0,
+      currentBranch,
+      homedir: os.homedir(),
+    });
+  }
+
+  async function refreshBrokerControlPlaneHomeTabs(
+    ctx: ExtensionContext,
+    snapshot: BrokerControlPlaneDashboardSnapshot,
+    refreshedAt: string,
+    userIds: string[] = getBrokerControlPlaneHomeTabViewerIds(),
+  ): Promise<void> {
+    if (!botToken || userIds.length === 0) {
+      return;
+    }
+
+    lastBrokerControlPlaneHomeTabSnapshot = snapshot;
+    let hadError = false;
+
+    for (const userId of userIds) {
+      try {
+        await publishSlackHomeTab({
+          slack,
+          token: botToken,
+          userId,
+          view: renderBrokerControlPlaneHomeTabView(snapshot),
+        });
+      } catch (err) {
+        hadError = true;
+        const homeTabMessage = `Pinet Home tab publish failed: ${msg(err)}`;
+        if (homeTabMessage !== lastBrokerControlPlaneHomeTabError) {
+          ctx.ui.notify(homeTabMessage, "warning");
+        }
+        lastBrokerControlPlaneHomeTabError = homeTabMessage;
+      }
+    }
+
+    if (!hadError) {
+      lastBrokerControlPlaneHomeTabError = null;
+    }
+    lastBrokerControlPlaneHomeTabRefreshAt = refreshedAt;
+  }
+
+  function reportHomeTabPublishFailure(ctx: ExtensionContext, err: unknown): void {
+    const homeTabMessage = `Pinet Home tab publish failed: ${msg(err)}`;
+    if (homeTabMessage !== lastBrokerControlPlaneHomeTabError) {
+      ctx.ui.notify(homeTabMessage, "warning");
+    }
+    lastBrokerControlPlaneHomeTabError = homeTabMessage;
+  }
+
+  async function publishCurrentPinetHomeTab(
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt: string = new Date().toISOString(),
+  ): Promise<void> {
+    if (!botToken) {
+      return;
+    }
+
+    if (activeBroker && brokerRole === "broker") {
+      brokerControlPlaneHomeTabViewers.set(userId, { openedAt });
+      const snapshot =
+        (await buildCurrentBrokerControlPlaneDashboardSnapshot(openedAt)) ??
+        lastBrokerControlPlaneHomeTabSnapshot;
+      if (snapshot) {
+        await refreshBrokerControlPlaneHomeTabs(ctx, snapshot, openedAt, [userId]);
+        return;
+      }
+    }
+
+    const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
+    await publishSlackHomeTab({
+      slack,
+      token: botToken,
+      userId,
+      view: renderStandalonePinetHomeTabView({
+        agentName,
+        agentEmoji,
+        connected: activeBroker != null || ws?.readyState === WebSocket.OPEN,
+        mode:
+          brokerRole === "broker" ? "broker" : brokerRole === "follower" ? "worker" : "standalone",
+        activeThreads: threads.size,
+        pendingInbox: inbox.length,
+        currentBranch,
+        defaultChannel: settings.defaultChannel ?? null,
+      }),
+    });
+    lastBrokerControlPlaneHomeTabError = null;
+  }
+
+  async function publishCurrentPinetHomeTabSafely(
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt: string = new Date().toISOString(),
+  ): Promise<void> {
+    try {
+      await publishCurrentPinetHomeTab(userId, ctx, openedAt);
+    } catch (err) {
+      reportHomeTabPublishFailure(ctx, err);
+    }
+  }
+
   async function refreshBrokerControlPlaneCanvasDashboard(
     ctx: ExtensionContext,
     input: {
@@ -2220,6 +2416,20 @@ export default function (pi: ExtensionAPI) {
         /* best effort — don't let cycle recording break the loop */
       }
 
+      const controlPlaneSnapshot = buildBrokerControlPlaneDashboardSnapshot({
+        workloads,
+        evaluation: visibleEvaluation,
+        evaluationOptions,
+        maintenance: lastBrokerMaintenance,
+        assignments: projectedAssignments,
+        recentCycles: recentRalphCycles,
+        cycleStartedAt,
+        cycleDurationMs: Date.now() - cycleStartMs,
+        currentBranch,
+        homedir: os.homedir(),
+      });
+      lastBrokerControlPlaneHomeTabSnapshot = controlPlaneSnapshot;
+
       try {
         await refreshBrokerControlPlaneCanvasDashboard(ctx, {
           workloads,
@@ -2238,6 +2448,16 @@ export default function (pi: ExtensionAPI) {
           ctx.ui.notify(canvasMessage, "warning");
         }
         lastBrokerControlPlaneCanvasError = canvasMessage;
+      }
+
+      try {
+        await refreshBrokerControlPlaneHomeTabs(ctx, controlPlaneSnapshot, cycleStartedAt);
+      } catch (homeTabErr) {
+        const homeTabMessage = `Pinet Home tab publish failed: ${msg(homeTabErr)}`;
+        if (homeTabMessage !== lastBrokerControlPlaneHomeTabError) {
+          ctx.ui.notify(homeTabMessage, "warning");
+        }
+        lastBrokerControlPlaneHomeTabError = homeTabMessage;
       }
     } catch (err) {
       ctx.ui.notify(buildRalphLoopStatusMessage(`failed: ${msg(err)}`, cycleStartedAt), "error");
@@ -2276,6 +2496,7 @@ export default function (pi: ExtensionAPI) {
     brokerRalphLoopFollowUpPending = false;
     lastBrokerTaskAssignmentReportSignature = "";
     pendingBrokerTaskAssignmentReport = null;
+    lastBrokerControlPlaneHomeTabSnapshot = null;
   }
 
   function getOutgoingPinetMessageMetadata(body: string): Record<string, unknown> | undefined {
@@ -2458,6 +2679,10 @@ export default function (pi: ExtensionAPI) {
     lastBrokerRalphLoopHadOutstandingAnomalies = false;
     lastBrokerControlPlaneCanvasRefreshAt = null;
     lastBrokerControlPlaneCanvasError = null;
+    lastBrokerControlPlaneHomeTabSnapshot = null;
+    lastBrokerControlPlaneHomeTabRefreshAt = null;
+    lastBrokerControlPlaneHomeTabError = null;
+    brokerControlPlaneHomeTabViewers.clear();
     lastReportedGhostIds.clear();
     resetBrokerDeliveryState(brokerDeliveryState);
 
@@ -2895,6 +3120,9 @@ export default function (pi: ExtensionAPI) {
       isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
       rememberKnownThread: (threadTs: string, channelId: string) => {
         broker.db.updateThread(threadTs, { source: "slack", channel: channelId });
+      },
+      onAppHomeOpened: async ({ userId }) => {
+        await publishCurrentPinetHomeTabSafely(userId, ctx, new Date().toISOString());
       },
     });
     let selfId: string | null = null;
@@ -3561,6 +3789,13 @@ export default function (pi: ExtensionAPI) {
                 : []),
               ...(lastBrokerControlPlaneCanvasError
                 ? [`Canvas status: ${lastBrokerControlPlaneCanvasError}`]
+                : []),
+              `Home tab viewers: ${getBrokerControlPlaneHomeTabViewerIds().length}`,
+              ...(lastBrokerControlPlaneHomeTabRefreshAt
+                ? [`Home tab refreshed: ${lastBrokerControlPlaneHomeTabRefreshAt}`]
+                : []),
+              ...(lastBrokerControlPlaneHomeTabError
+                ? [`Home tab status: ${lastBrokerControlPlaneHomeTabError}`]
                 : []),
             ]
           : [];

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -42,6 +42,7 @@ settings:
   event_subscriptions:
     bot_events:
       - app_mention
+      - app_home_opened
       - assistant_thread_started
       - assistant_thread_context_changed
       - reaction_added


### PR DESCRIPTION
## Summary
- publish a Block Kit Home tab view for Pinet via `views.publish`
- render the broker control-plane snapshot on the Home tab and refresh it for recent viewers on each RALPH cycle
- wire `app_home_opened` through both direct Socket Mode and the broker Slack adapter

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test