### PR TITLE
test: add e2e coverage for core flows

### DIFF
--- a/nvim-bridge/comments-factory.test.ts
+++ b/nvim-bridge/comments-factory.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+describe("createCommentStore", () => {
+  let repoRoot: string | null = null;
+
+  afterEach(() => {
+    if (repoRoot) {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+      repoRoot = null;
+    }
+    vi.doUnmock("./comments-sqlite.js");
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to the JSON CommentStore when sqlite initialization fails", async () => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nvim-comment-factory-test-"));
+
+    vi.doMock("./comments-sqlite.js", () => ({
+      SqliteCommentStore: class MockSqliteCommentStore {
+        initialize(): void {
+          throw new Error("node:sqlite unavailable");
+        }
+      },
+    }));
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { createCommentStore, CommentStore } = await import("./comments.js");
+
+    const store = await createCommentStore(repoRoot);
+    expect(store).toBeInstanceOf(CommentStore);
+
+    await store.addComment({
+      body: "Fallback note",
+      actorId: "tester",
+      threadId: "fallback-thread",
+    });
+
+    expect(store.listComments({ threadId: "fallback-thread" })).toMatchObject({
+      total: 1,
+      comments: [{ body: "Fallback note" }],
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[picomms] SQLite store init failed, falling back to JSON:",
+      expect.any(Error),
+    );
+  });
+});

--- a/nvim-bridge/comments-sqlite.test.ts
+++ b/nvim-bridge/comments-sqlite.test.ts
@@ -108,6 +108,29 @@ describe("SqliteCommentStore", () => {
     expect(fs.existsSync(path.join(repoRoot, ".pi", "picomms.db"))).toBe(true);
   });
 
+  it("persists comments across reopen and applies listAll pagination", async () => {
+    store = new SqliteCommentStore(repoRoot);
+    store.initialize();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+    await store.addComment({ body: "First", actorId: "reviewer", threadId: "thread-a" });
+
+    vi.setSystemTime(new Date("2024-01-01T00:00:01.000Z"));
+    await store.addComment({ body: "Second", actorId: "reviewer", threadId: "thread-b" });
+
+    vi.setSystemTime(new Date("2024-01-01T00:00:02.000Z"));
+    await store.addComment({ body: "Third", actorId: "reviewer", threadId: "thread-a" });
+
+    store.close();
+    store = new SqliteCommentStore(repoRoot);
+    store.initialize();
+
+    const listed = store.listAllComments({ limit: 2 });
+    expect(listed.total).toBe(3);
+    expect(listed.comments.map((comment) => comment.body)).toEqual(["Second", "Third"]);
+  });
+
   it("wipes all comments from sqlite", async () => {
     store = new SqliteCommentStore(repoRoot);
     store.initialize();

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -10,6 +10,20 @@ import {
 } from "./slack.js";
 import type { OutboundMessage } from "./types.js";
 
+async function waitForAssertion(assertion: () => void, attempts = 50): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 // ─── parseSocketFrame ────────────────────────────────────
 
 describe("parseSocketFrame", () => {
@@ -1246,6 +1260,182 @@ describe("SlackAdapter — disconnect", () => {
     await adapter.disconnect();
 
     await expect(sendPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+});
+
+describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+  const originalWebSocket = globalThis.WebSocket;
+
+  class FakeWebSocket {
+    static readonly OPEN = 1;
+    static readonly CLOSED = 3;
+
+    static instances: FakeWebSocket[] = [];
+
+    readonly url: string;
+    readyState = FakeWebSocket.OPEN;
+    sent: string[] = [];
+    private readonly listeners = new Map<string, Array<(event: { data?: string }) => void>>();
+
+    constructor(url: string) {
+      this.url = url;
+      FakeWebSocket.instances.push(this);
+    }
+
+    addEventListener(type: string, handler: (event: { data?: string }) => void): void {
+      const handlers = this.listeners.get(type) ?? [];
+      handlers.push(handler);
+      this.listeners.set(type, handlers);
+    }
+
+    send(data: string): void {
+      this.sent.push(String(data));
+    }
+
+    close(): void {
+      this.readyState = FakeWebSocket.CLOSED;
+      this.emit("close", {});
+    }
+
+    emit(type: string, event: { data?: string }): void {
+      for (const handler of this.listeners.get(type) ?? []) {
+        handler(event);
+      }
+    }
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn<typeof fetch>();
+    globalThis.fetch = fetchMock;
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
+    if (originalWebSocket) {
+      globalThis.WebSocket = originalWebSocket;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("receives a DM, ACKs the envelope, emits inbound text, then removes 👀 after replying", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      const ok = (data: Record<string, unknown>) =>
+        new Response(JSON.stringify({ ok: true, ...data }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+
+      if (url.endsWith("/auth.test")) {
+        return ok({ user_id: "U_BOT" });
+      }
+      if (url.endsWith("/apps.connections.open")) {
+        return ok({ url: "wss://slack.test/socket" });
+      }
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U123");
+        return ok({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "D123", timestamp: "111.222", name: "eyes" });
+        return ok({});
+      }
+      if (url.endsWith("/chat.postMessage")) {
+        expect(parsedBody).toMatchObject({
+          channel: "D123",
+          thread_ts: "111.222",
+          text: "Roger that",
+        });
+        return ok({ message: { ts: "111.333" } });
+      }
+      if (url.endsWith("/reactions.remove")) {
+        expect(parsedBody).toEqual({ channel: "D123", timestamp: "111.222", name: "eyes" });
+        return ok({});
+      }
+      if (url.endsWith("/assistant.threads.setStatus")) {
+        expect(parsedBody).toEqual({ channel_id: "D123", thread_ts: "111.222", status: "" });
+        return ok({});
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await adapter.connect();
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const ws = FakeWebSocket.instances[0]!;
+    expect(ws.url).toBe("wss://slack.test/socket");
+
+    ws.emit("message", {
+      data: JSON.stringify({
+        envelope_id: "env-1",
+        type: "events_api",
+        payload: {
+          event_id: "Ev-1",
+          event: {
+            type: "message",
+            user: "U123",
+            text: "Hello from Slack",
+            channel: "D123",
+            channel_type: "im",
+            ts: "111.222",
+          },
+        },
+      }),
+    });
+
+    await waitForAssertion(() => {
+      expect(ws.sent).toContain(JSON.stringify({ envelope_id: "env-1" }));
+      expect(handler).toHaveBeenCalledWith({
+        source: "slack",
+        threadId: "111.222",
+        channel: "D123",
+        userId: "U123",
+        userName: "Alice Example",
+        text: "Hello from Slack",
+        timestamp: "111.222",
+      });
+    });
+
+    await adapter.send({
+      threadId: "111.222",
+      channel: "D123",
+      text: "Roger that",
+      agentName: "Silent Crocodile",
+      agentEmoji: "🐊",
+    });
+
+    await waitForAssertion(() => {
+      const endpoints = fetchMock.mock.calls.map(([url]) => String(url));
+      expect(endpoints).toContain("https://slack.com/api/reactions.remove");
+      expect(endpoints).toContain("https://slack.com/api/assistant.threads.setStatus");
+    });
+
+    const endpoints = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(endpoints).toContain("https://slack.com/api/reactions.add");
+    expect(endpoints).toContain("https://slack.com/api/chat.postMessage");
+    expect(endpoints).toContain("https://slack.com/api/reactions.remove");
+    expect(endpoints).toContain("https://slack.com/api/assistant.threads.setStatus");
+
+    await adapter.disconnect();
   });
 });
 


### PR DESCRIPTION
## Summary
- audit Issue #40's current test coverage and add missing high-value end-to-end / lifecycle coverage
- add a true Socket Mode + mocked Slack API lifecycle test for the active Slack broker adapter path
- add PiComms coverage for SQLite persistence/pagination and JSON fallback when SQLite init fails

## Coverage audit
I audited the Issue #40 checklist against current `main` before changing code.

Already substantially covered on `main`:
- PiComms CRUD, JSON→SQLite migration, wipe, concurrent writes
- Slack allowlist checks, settings loading, many mocked Slack API/tool flows
- Slack broker/router/integration coverage

Highest-value gaps I found:
- no true fake Socket Mode lifecycle test covering receive → ACK → inbound emit → reply → 👀 cleanup
- no explicit PiComms factory fallback test for SQLite failure → JSON store
- no explicit SQLite persistence-across-reopen test with paginated `listAllComments`

This PR fills those gaps.

## Changes
### `slack-bridge/broker/adapters/slack.test.ts`
Added an end-to-end lifecycle regression test that:
- mocks `auth.test`, `apps.connections.open`, `users.info`, `reactions.add`, `chat.postMessage`, `reactions.remove`, and `assistant.threads.setStatus`
- uses a fake WebSocket to simulate Socket Mode
- verifies the adapter:
  - ACKs the Slack envelope
  - emits the normalized inbound DM
  - adds 👀 on receipt
  - removes 👀 after replying
  - clears the thread status after replying

### `nvim-bridge/comments-sqlite.test.ts`
Added coverage that:
- persists SQLite comments across close/reopen
- verifies `listAllComments({ limit })` pagination after reload

### `nvim-bridge/comments-factory.test.ts`
Added coverage that:
- simulates SQLite initialization failure
- verifies `createCommentStore()` falls back to the JSON `CommentStore`
- verifies the fallback store remains usable for writes/reads

## Verification
- `cd slack-bridge && pnpm test -- --run broker/adapters/slack.test.ts`
- `cd nvim-bridge && pnpm test -- --run comments-sqlite.test.ts comments-factory.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Refs #40.
