### PR TITLE
fix: skip broker in RALPH idle nudges

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1407,6 +1407,48 @@ describe("evaluateRalphLoopCycle", () => {
     expect(result.anomalies.some((item) => item.includes("expected `main`"))).toBe(true);
   });
 
+  it("skips the broker agent id when flagging idle agents with assigned work", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🦙",
+          name: "Broker Llama",
+          id: "broker-self",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:00:00.000Z",
+          lastHeartbeat: "2026-04-01T00:01:55.000Z",
+          pendingInboxCount: 4,
+          ownedThreadCount: 2,
+        },
+        {
+          emoji: "🦊",
+          name: "Busy Fox",
+          id: "worker-1",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:00:00.000Z",
+          lastHeartbeat: "2026-04-01T00:01:55.000Z",
+          pendingInboxCount: 1,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:02:00.000Z"),
+        idleWithWorkThresholdMs: 60_000,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+        brokerAgentId: "broker-self",
+      },
+    );
+
+    expect(result.nudgeAgentIds).toEqual(["worker-1"]);
+    expect(
+      result.anomalies.some((item) => item.includes("Broker Llama idle with assigned work")),
+    ).toBe(false);
+    expect(result.anomalies).toContain("Busy Fox idle with assigned work (1 inbox, 1 threads)");
+  });
+
   it("detects stuck agents: working with no activity for > threshold", () => {
     const now = Date.parse("2026-04-01T00:10:00.000Z");
     const result = evaluateRalphLoopCycle(

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -863,6 +863,7 @@ export interface RalphLoopEvaluationOptions extends AgentVisibilityOptions {
   expectedMainBranch?: string;
   brokerHeartbeatActive?: boolean;
   brokerMaintenanceActive?: boolean;
+  brokerAgentId?: string;
 }
 
 export interface RalphLoopEvaluationResult {
@@ -892,6 +893,7 @@ export function evaluateRalphLoopCycle(
     options.stuckWorkingThresholdMs ?? DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS;
   const pendingBacklogCount = options.pendingBacklogCount ?? 0;
   const expectedMainBranch = options.expectedMainBranch ?? "main";
+  const brokerAgentId = options.brokerAgentId;
   const anomalies: string[] = [];
   const ghostAgentIds: string[] = [];
   const nudgeAgentIds: string[] = [];
@@ -899,6 +901,10 @@ export function evaluateRalphLoopCycle(
   const stuckAgentIds: string[] = [];
 
   for (const workload of workloads) {
+    if (brokerAgentId && workload.id === brokerAgentId) {
+      continue;
+    }
+
     const metadata = asRecord(workload.metadata);
     const capabilities = extractAgentCapabilities(metadata);
     const role = (capabilities.role ?? asString(metadata?.role) ?? "worker").toLowerCase();

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1868,6 +1868,7 @@ export default function (pi: ExtensionAPI) {
       currentBranch,
       brokerHeartbeatActive: brokerHeartbeatTimer != null,
       brokerMaintenanceActive: brokerMaintenanceTimer != null,
+      brokerAgentId: activeSelfId ?? undefined,
     };
     const evaluation = evaluateRalphLoopCycle(workloads, evaluationOptions);
 
@@ -2130,6 +2131,7 @@ export default function (pi: ExtensionAPI) {
         currentBranch,
         brokerHeartbeatActive: brokerHeartbeatTimer != null,
         brokerMaintenanceActive: brokerMaintenanceTimer != null,
+        brokerAgentId: activeSelfId ?? undefined,
       };
       const evaluation = evaluateRalphLoopCycle(workloads, evaluationOptions);
 


### PR DESCRIPTION
## Summary
- exclude the broker's own agent id from the RALPH idle-with-assigned-work evaluation
- thread that broker id through both RALPH evaluation call sites so the live loop and dashboard agree
- add a regression test proving the broker is not nudged even if it would otherwise look idle with assigned work

## Testing
- `cd .worktrees/fix-241 && pnpm lint && pnpm typecheck && pnpm test`

Closes #241.
