### PR TITLE
fix: auto-refresh Pinet registration on reconnect

### DIFF
--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { BrokerClient } from "./broker/client.js";
 import slackBridge from "./index.js";
 
 type ToolDefinition = {
@@ -131,5 +132,191 @@ describe("slack-bridge top-level shutdown", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(notify).not.toHaveBeenCalled();
     expect(setStatus).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("slack-bridge Pinet reconnect", () => {
+  const originalBotToken = process.env.SLACK_BOT_TOKEN;
+  const originalAppToken = process.env.SLACK_APP_TOKEN;
+  const originalHome = process.env.HOME;
+
+  beforeEach(() => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    process.env.SLACK_APP_TOKEN = "xapp-test";
+    process.env.HOME = "/tmp/slack-bridge-test-home";
+  });
+
+  afterEach(() => {
+    if (originalBotToken === undefined) {
+      delete process.env.SLACK_BOT_TOKEN;
+    } else {
+      process.env.SLACK_BOT_TOKEN = originalBotToken;
+    }
+
+    if (originalAppToken === undefined) {
+      delete process.env.SLACK_APP_TOKEN;
+    } else {
+      process.env.SLACK_APP_TOKEN = originalAppToken;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes follower registration state after broker reconnect", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let disconnectHandler: (() => void) | null = null;
+    let reconnectHandler: (() => void) | null = null;
+    const registerCalls: Array<{
+      name: string;
+      emoji: string;
+      metadata?: Record<string, unknown>;
+      stableId?: string;
+    }> = [];
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async function (
+      this: BrokerClient,
+      name: string,
+      emoji: string,
+      metadata?: Record<string, unknown>,
+      stableId?: string,
+    ) {
+      const result = {
+        agentId: "worker-1",
+        name,
+        emoji,
+        metadata: metadata ?? null,
+      };
+      (
+        this as unknown as {
+          registeredIdentity: typeof result | null;
+          registrationSnapshot: {
+            name: string;
+            emoji: string;
+            metadata?: Record<string, unknown>;
+            stableId?: string;
+          } | null;
+        }
+      ).registeredIdentity = result;
+      (
+        this as unknown as {
+          registrationSnapshot: {
+            name: string;
+            emoji: string;
+            metadata?: Record<string, unknown>;
+            stableId?: string;
+          } | null;
+        }
+      ).registrationSnapshot = {
+        name,
+        emoji,
+        ...(metadata ? { metadata } : {}),
+        ...(stableId ? { stableId } : {}),
+      };
+      registerCalls.push({ name, emoji, metadata, stableId });
+      return result;
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation((handler) => {
+      disconnectHandler = handler;
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation((handler) => {
+      reconnectHandler = handler;
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await follow?.handler("", ctx);
+
+    expect(registerCalls).toHaveLength(1);
+    expect(disconnectHandler).toBeTypeOf("function");
+    expect(reconnectHandler).toBeTypeOf("function");
+
+    if (!disconnectHandler || !reconnectHandler) {
+      throw new Error("Reconnect handlers were not registered");
+    }
+
+    const runDisconnect: () => void = disconnectHandler;
+    const runReconnect: () => void = reconnectHandler;
+
+    runDisconnect();
+    runReconnect();
+
+    await vi.waitFor(() => {
+      expect(registerCalls).toHaveLength(2);
+    });
+
+    expect(registerCalls[1]?.stableId).toBe(registerCalls[0]?.stableId);
+    expect(registerCalls[1]?.metadata).toMatchObject({
+      role: "worker",
+      capabilities: expect.objectContaining({ role: "worker" }),
+    });
+    expect(notify).toHaveBeenCalledWith("Pinet broker disconnected — reconnecting...", "warning");
+    expect(notify).toHaveBeenCalledWith("Pinet broker reconnected", "info");
+
+    await sessionShutdown?.({}, ctx);
+    expect(setStatus).toHaveBeenCalled();
   });
 });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -3104,6 +3104,7 @@ export default function (pi: ExtensionAPI) {
   // ─── Commands ───────────────────────────────────────
 
   async function connectAsBroker(ctx: ExtensionContext): Promise<void> {
+    refreshSettings();
     const broker = await startBroker();
     const adapter = new SlackAdapter({
       botToken: botToken!,
@@ -3325,10 +3326,11 @@ export default function (pi: ExtensionAPI) {
       throw new Error(getPinetRegistrationBlockReason());
     }
 
+    refreshSettings();
     const client = new BrokerClient();
 
-    try {
-      await client.connect();
+    async function registerFollowerRuntime(): Promise<void> {
+      refreshSettings();
       const workerIdentity = resolveRuntimeAgentIdentity(
         { name: agentName, emoji: agentEmoji },
         settings,
@@ -3344,6 +3346,11 @@ export default function (pi: ExtensionAPI) {
         agentStableId,
       );
       applyRegistrationIdentity(registration);
+    }
+
+    try {
+      await client.connect();
+      await registerFollowerRuntime();
 
       const brokerClientRef: BrokerClientRef = {
         client,
@@ -3533,9 +3540,16 @@ export default function (pi: ExtensionAPI) {
 
       client.onReconnect(() => {
         void (async () => {
-          const registration = client.getRegisteredIdentity();
-          if (registration) {
-            applyRegistrationIdentity(registration);
+          try {
+            await registerFollowerRuntime();
+          } catch (err) {
+            console.error(
+              `[slack-bridge] follower reconnect registration refresh failed: ${msg(err)}`,
+            );
+            const registration = client.getRegisteredIdentity();
+            if (registration) {
+              applyRegistrationIdentity(registration);
+            }
           }
           await resumeThreadClaims();
           const currentlyIdle = ctx.isIdle?.() ?? true;


### PR DESCRIPTION
## Summary
- refresh Slack Bridge settings before starting broker/follower runtimes
- refresh follower registration metadata/identity after broker reconnect instead of relying on manual `/reload` nudges
- add a reconnect test proving runtime registration is refreshed on reconnect

Closes #238
