### PR TITLE
fix: stop headless subagents from joining Pinet

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1014,6 +1014,43 @@ describe("isLikelyLocalSubagentContext", () => {
     ).toBe(false);
   });
 
+  it("detects ephemeral leaf sessions that run headless without a session file", () => {
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionFile: undefined,
+        leafId: "leaf-123",
+        argv: ["--mode", "rpc"],
+        hasUI: true,
+        stdinIsTTY: false,
+        stdoutIsTTY: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionFile: undefined,
+        leafId: "leaf-123",
+        argv: [],
+        hasUI: true,
+        stdinIsTTY: false,
+        stdoutIsTTY: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify interactive no-session leaf sessions as subagents", () => {
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionFile: undefined,
+        leafId: "leaf-123",
+        argv: ["--no-session"],
+        hasUI: true,
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+
   it("does not classify plain no-session interactive use as a subagent", () => {
     expect(isLikelyLocalSubagentContext({ argv: ["--no-session"] })).toBe(false);
   });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1383,7 +1383,12 @@ export interface PinetRegistrationContext {
   sessionHeader?: {
     parentSession?: string;
   } | null;
+  sessionFile?: string;
+  leafId?: string;
   argv?: string[];
+  hasUI?: boolean;
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
 }
 
 export function isLikelyLocalSubagentContext(context: PinetRegistrationContext = {}): boolean {
@@ -1399,7 +1404,27 @@ export function isLikelyLocalSubagentContext(context: PinetRegistrationContext =
   const mode = modeIndex >= 0 ? argv[modeIndex + 1] : undefined;
   const hasHeadlessMode = mode === "json" || mode === "rpc";
 
-  return hasNoSession && (hasPrint || hasHeadlessMode);
+  if (hasNoSession && (hasPrint || hasHeadlessMode)) {
+    return true;
+  }
+
+  const sessionFile =
+    typeof context.sessionFile === "string" && context.sessionFile.trim().length > 0
+      ? context.sessionFile.trim()
+      : undefined;
+  const leafId =
+    typeof context.leafId === "string" && context.leafId.trim().length > 0
+      ? context.leafId.trim()
+      : undefined;
+  // Agent-tool subagents commonly show up as ephemeral leaf sessions: no persisted
+  // session file, a generated leaf id, and no attached TTY. Those should never join
+  // the mesh even when auto-follow is enabled.
+  const hasEphemeralLeafSession = !sessionFile && Boolean(leafId);
+  const hasTTY = Boolean(
+    (context.stdinIsTTY ?? process.stdin.isTTY) || (context.stdoutIsTTY ?? process.stdout.isTTY),
+  );
+
+  return hasEphemeralLeafSession && (hasHeadlessMode || context.hasUI === false || !hasTTY);
 }
 
 export interface FollowerThreadState {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1,6 +1,10 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import slackBridge from "./index.js";
+import { BrokerClient } from "./broker/client.js";
 
 type ToolDefinition = {
   name: string;
@@ -14,18 +18,49 @@ type CommandDefinition = {
 
 type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
 
+function stubIsTTY(stream: NodeJS.ReadStream | NodeJS.WriteStream, value: boolean): () => void {
+  const target = stream as unknown as Record<string, unknown>;
+  const hadOwnProperty = Object.prototype.hasOwnProperty.call(target, "isTTY");
+  const previousValue = target.isTTY;
+
+  Object.defineProperty(target, "isTTY", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value,
+  });
+
+  return () => {
+    if (hadOwnProperty) {
+      Object.defineProperty(target, "isTTY", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: previousValue,
+      });
+      return;
+    }
+
+    Reflect.deleteProperty(target, "isTTY");
+  };
+}
+
 describe("slack-bridge top-level shutdown", () => {
   const originalBotToken = process.env.SLACK_BOT_TOKEN;
   const originalAppToken = process.env.SLACK_APP_TOKEN;
   const originalHome = process.env.HOME;
+  let testHome: string;
 
   beforeEach(() => {
     process.env.SLACK_BOT_TOKEN = "xoxb-test";
     process.env.SLACK_APP_TOKEN = "xapp-test";
-    process.env.HOME = "/tmp/slack-bridge-test-home";
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), "slack-bridge-test-home-"));
+    process.env.HOME = testHome;
   });
 
   afterEach(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+
     if (originalBotToken === undefined) {
       delete process.env.SLACK_BOT_TOKEN;
     } else {
@@ -131,5 +166,62 @@ describe("slack-bridge top-level shutdown", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(notify).not.toHaveBeenCalled();
     expect(setStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not auto-follow into the mesh for headless ephemeral subagent sessions", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { autoFollow: true } }));
+
+    const events = new Map<string, EventHandler>();
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "subagent-leaf",
+        getSessionFile: () => undefined,
+      },
+    } as unknown as ExtensionContext;
+
+    const connectSpy = vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    const registerSpy = vi.spyOn(BrokerClient.prototype, "register");
+
+    slackBridge(pi);
+
+    const restoreStdinIsTTY = stubIsTTY(process.stdin, false);
+    const restoreStdoutIsTTY = stubIsTTY(process.stdout, false);
+    try {
+      await events.get("session_start")?.({}, ctx);
+    } finally {
+      restoreStdinIsTTY();
+      restoreStdoutIsTTY();
+    }
+
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect(registerSpy).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+    expect(setStatus).toHaveBeenCalled();
   });
 });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -3863,7 +3863,12 @@ export default function (pi: ExtensionAPI) {
     ).getHeader?.();
     pinetRegistrationBlocked = isLikelyLocalSubagentContext({
       sessionHeader,
+      sessionFile: ctx.sessionManager.getSessionFile(),
+      leafId: ctx.sessionManager.getLeafId(),
       argv: process.argv.slice(2),
+      hasUI: ctx.hasUI,
+      stdinIsTTY: process.stdin.isTTY,
+      stdoutIsTTY: process.stdout.isTTY,
     });
 
     // Restore persisted thread state (always restore, even before /pinet)


### PR DESCRIPTION
## Summary\n- block Pinet registration for ephemeral leaf sessions that look like local Agent-tool subagents\n- pass session file, leaf id, UI, and TTY signals into subagent detection during session startup\n- add helper coverage plus a session_start regression test proving headless subagents do not auto-follow into the mesh\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n\nCloses #237