### PR TITLE
fix: add momentum to RALPH follow-up prompt

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1768,7 +1768,7 @@ describe("buildRalphLoopCycleNotifications", () => {
         "- ghost agents detected: ghost-1",
         "- Idle Gecko idle with assigned work (2 inbox, 1 threads)",
         "",
-        "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
+        "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, maintain momentum, and repair broker anomalies.",
       ].join("\n"),
       anomalyStatus:
         "RALPH loop (2026-04-02T14:10:00.000Z): ghost agents detected: ghost-1; Idle Gecko idle with assigned work (2 inbox, 1 threads)",
@@ -1802,7 +1802,7 @@ describe("buildRalphLoopFollowUpMessage", () => {
         "- Idle Gecko idle with assigned work (2 inbox, 1 threads)",
         "- main checkout is on `feat/not-main`, expected `main`",
         "",
-        "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
+        "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, maintain momentum, and repair broker anomalies.",
       ].join("\n"),
     );
   });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1088,7 +1088,7 @@ export function buildRalphLoopFollowUpMessage(
     `Timestamp: ${cycleStartedAt}`,
     ...evaluation.anomalies.map((anomaly) => `- ${anomaly}`),
     "",
-    "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, and repair broker anomalies.",
+    "Take action: reap ghosts, nudge idle workers, reassign stalled work, drain backlog, maintain momentum, and repair broker anomalies.",
   ].join("\n");
 }
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { BrokerClient } from "./broker/client.js";
 import slackBridge from "./index.js";
-import { BrokerClient } from "./broker/client.js";
 
 type ToolDefinition = {
   name: string;


### PR DESCRIPTION
## Summary
- add "maintain momentum" to the broker-facing RALPH follow-up action list
- update the helper expectations that assert the generated RALPH cycle prompt text
- clean up a duplicate `BrokerClient` import in `slack-bridge/index.test.ts` that was already breaking fresh `origin/main` typecheck/test runs in this worktree

## Testing
- `cd .worktrees/fix-ralph-msg && pnpm lint && pnpm typecheck && pnpm test`
