### PR TITLE
fix: refresh reconnecting agent names in broker

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -602,7 +602,7 @@ describe("BrokerDB", () => {
     expect(agents[0].pid).toBe(200);
   });
 
-  it("registerAgent resumes previous identity by stableId", () => {
+  it("registerAgent refreshes identities for reconnecting stable agents", () => {
     const first = db.registerAgent("a1", "Original", "🧠", 100, undefined, "host:session:/tmp/a");
     db.unregisterAgent(first.id);
 
@@ -616,8 +616,8 @@ describe("BrokerDB", () => {
     );
 
     expect(resumed.id).toBe(first.id);
-    expect(resumed.name).toBe("Original");
-    expect(resumed.emoji).toBe("🧠");
+    expect(resumed.name).toBe("Different");
+    expect(resumed.emoji).toBe("🤖");
     expect(db.getAgents()).toHaveLength(1);
   });
 
@@ -817,7 +817,7 @@ describe("BrokerDB", () => {
     );
   });
 
-  it("startup reconciliation marks prior agents disconnected until they reconnect by stableId", () => {
+  it("startup reconciliation preserves ownership until reconnect and refreshes the returning identity", () => {
     const dbPath = path.join(dir, "restart.db");
     const firstDb = new BrokerDB(dbPath);
     firstDb.initialize();
@@ -851,8 +851,8 @@ describe("BrokerDB", () => {
     );
 
     expect(resumed.id).toBe(original.id);
-    expect(resumed.name).toBe("Hyper Owl");
-    expect(resumed.emoji).toBe("🦉");
+    expect(resumed.name).toBe("Different Owl");
+    expect(resumed.emoji).toBe("🦎");
     expect(restartedDb.getThread("t-restart")?.ownerAgent).toBe(original.id);
 
     restartedDb.close();

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -229,7 +229,7 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
-  it("reconnect with same stableId reuses agent identity and thread ownership after a resumable disconnect", async () => {
+  it("reconnect with same stableId refreshes identity while preserving thread ownership", async () => {
     const reg1 = await client.register("resume-agent", "🔁", undefined, "host:session:/tmp/resume");
     await client.claimThread("t-resume");
     client.disconnect();
@@ -250,8 +250,8 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     );
 
     expect(reg2.agentId).toBe(reg1.agentId);
-    expect(reg2.name).toBe("resume-agent");
-    expect(reg2.emoji).toBe("🔁");
+    expect(reg2.name).toBe("different-name");
+    expect(reg2.emoji).toBe("❌");
 
     const threads = await client2.listThreads();
     expect(threads.map((thread) => thread.threadId)).toContain("t-resume");

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -649,15 +649,20 @@ export class BrokerDB implements BrokerDBInterface {
     const now = new Date().toISOString();
     const existing = stableId ? this.getAgentRowByStableId(stableId) : null;
     const existingById = this.getAgentRowById(existing?.id ?? id);
+    const existingRow = existingById ?? existing;
     const agentId = existing?.id ?? id;
-    const hasSkinIdentity =
-      typeof metadata?.skinTheme === "string" && metadata.skinTheme.trim().length > 0;
-    const finalName = hasSkinIdentity
-      ? this.ensureUniqueAgentName(name, agentId)
-      : (existing?.name ?? this.ensureUniqueAgentName(name, agentId));
-    const finalEmoji = hasSkinIdentity ? emoji : (existing?.emoji ?? emoji);
+    const finalName = this.ensureUniqueAgentName(name, agentId);
+    const finalEmoji = emoji.trim() || existingRow?.emoji || "";
     const persistedStableId = stableId ?? existing?.stable_id ?? existingById?.stable_id ?? null;
-    const meta = metadata ? JSON.stringify(metadata) : null;
+    // Reconnecting agents are authoritative for their current runtime identity. If a
+    // stable session comes back with a new name/emoji, refresh the broker roster
+    // instead of replaying stale values from the previous broker DB row.
+    const finalMetadata =
+      metadata ??
+      (existingRow?.metadata
+        ? (JSON.parse(existingRow.metadata) as Record<string, unknown>)
+        : undefined);
+    const meta = finalMetadata ? JSON.stringify(finalMetadata) : null;
 
     db.prepare(
       `INSERT INTO agents (
@@ -691,7 +696,7 @@ export class BrokerDB implements BrokerDBInterface {
       connectedAt: now,
       lastSeen: now,
       lastHeartbeat: now,
-      metadata: metadata ?? null,
+      metadata: finalMetadata ?? null,
       status: "idle" as const,
       idleSince: now,
       lastActivity: null,


### PR DESCRIPTION
## Summary\n- keep follower reconnect registration using the runtime identity, but let the broker roster refresh the stable agent's current name/emoji\n- stop replaying stale DB names for reconnecting stable agents after broker restart\n- update broker helper/integration coverage to assert identity refresh while preserving stable agent ids and thread ownership\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n\nCloses #236