### PR TITLE
feat: structure Pinet control messages

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -11,6 +11,8 @@ import {
   parsePinetControlCommand,
   getPinetControlCommandFromText,
   buildPinetControlMetadata,
+  buildPinetControlMessage,
+  normalizeOutgoingPinetControlMessage,
   buildPinetSkinAssignment,
   buildPinetSkinPromptGuideline,
   buildPinetSkinMetadata,
@@ -401,21 +403,52 @@ describe("Pinet control helpers", () => {
     expect(parsePinetControlCommand("noop")).toBeNull();
   });
 
-  it("detects control commands from exact message text", () => {
+  it("detects control commands from structured JSON and legacy slash text", () => {
+    expect(getPinetControlCommandFromText('{"type":"pinet:control","action":"reload"}')).toBe(
+      "reload",
+    );
     expect(getPinetControlCommandFromText("/reload")).toBe("reload");
     expect(getPinetControlCommandFromText(" /exit ")).toBe("exit");
+    expect(getPinetControlCommandFromText('{"type":"pinet:control","action":"noop"}')).toBe(null);
     expect(getPinetControlCommandFromText("/exit now please")).toBeNull();
     expect(getPinetControlCommandFromText("please /reload")).toBeNull();
   });
 
-  it("builds structured control metadata", () => {
+  it("builds structured control metadata and body", () => {
     expect(buildPinetControlMetadata("reload")).toEqual({
-      kind: "pinet_control",
-      command: "reload",
+      type: "pinet:control",
+      action: "reload",
     });
+    expect(buildPinetControlMessage("reload")).toBe('{"type":"pinet:control","action":"reload"}');
   });
 
-  it("extracts structured control commands from a2a messages", () => {
+  it("normalizes outgoing control messages to the structured envelope", () => {
+    expect(normalizeOutgoingPinetControlMessage("/reload")).toEqual({
+      body: '{"type":"pinet:control","action":"reload"}',
+      metadata: { type: "pinet:control", action: "reload" },
+    });
+    expect(
+      normalizeOutgoingPinetControlMessage('{"type":"pinet:control","action":"exit"}', {
+        custom: true,
+      }),
+    ).toEqual({
+      body: '{"type":"pinet:control","action":"exit"}',
+      metadata: { custom: true, type: "pinet:control", action: "exit" },
+    });
+    expect(normalizeOutgoingPinetControlMessage("hello")).toBeNull();
+  });
+
+  it("extracts structured control commands from a2a metadata", () => {
+    expect(
+      extractPinetControlCommand({
+        threadId: "a2a:sender:target",
+        body: "hello",
+        metadata: { a2a: true, type: "pinet:control", action: "reload" },
+      }),
+    ).toBe("reload");
+  });
+
+  it("keeps backward compatibility for legacy metadata and slash commands", () => {
     expect(
       extractPinetControlCommand({
         threadId: "a2a:sender:target",
@@ -423,9 +456,6 @@ describe("Pinet control helpers", () => {
         metadata: { a2a: true, kind: "pinet_control", command: "reload" },
       }),
     ).toBe("reload");
-  });
-
-  it("falls back to exact slash commands for a2a messages", () => {
     expect(
       extractPinetControlCommand({
         threadId: "a2a:sender:target",
@@ -433,16 +463,33 @@ describe("Pinet control helpers", () => {
         metadata: { a2a: true },
       }),
     ).toBe("exit");
+  });
+
+  it("extracts structured control commands from a2a JSON message bodies", () => {
     expect(
       extractPinetControlCommand({
         threadId: "a2a:sender:target",
-        body: "/exit now please",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { a2a: true },
+      }),
+    ).toBe("reload");
+    expect(
+      extractPinetControlCommand({
+        threadId: "a2a:sender:target",
+        body: '{"type":"pinet:control","action":"noop"}',
         metadata: { a2a: true },
       }),
     ).toBeNull();
   });
 
-  it("ignores slash commands from non-a2a messages", () => {
+  it("ignores control commands from non-a2a messages", () => {
+    expect(
+      extractPinetControlCommand({
+        threadId: "123.456",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { channel: "D123" },
+      }),
+    ).toBeNull();
     expect(
       extractPinetControlCommand({
         threadId: "123.456",

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -269,7 +269,32 @@ export async function reloadPinetRuntimeSafely<State>(
   }
 }
 
-export function getPinetControlCommandFromText(
+export interface PinetControlEnvelope {
+  type: "pinet:control";
+  action: PinetControlCommand;
+}
+
+function parsePinetControlEnvelope(value: unknown): PinetControlCommand | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (record.type !== "pinet:control") return null;
+  return parsePinetControlCommand(record.action);
+}
+
+function parseStructuredPinetControlCommandFromText(
+  text: string | undefined,
+): PinetControlCommand | null {
+  const trimmed = text?.trim();
+  if (!trimmed) return null;
+
+  try {
+    return parsePinetControlEnvelope(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function parseLegacyPinetControlCommandFromText(
   text: string | undefined,
 ): PinetControlCommand | null {
   const trimmed = text?.trim();
@@ -278,8 +303,36 @@ export function getPinetControlCommandFromText(
   return null;
 }
 
-export function buildPinetControlMetadata(command: PinetControlCommand): Record<string, unknown> {
-  return { kind: "pinet_control", command };
+export function getPinetControlCommandFromText(
+  text: string | undefined,
+): PinetControlCommand | null {
+  return (
+    parseStructuredPinetControlCommandFromText(text) ?? parseLegacyPinetControlCommandFromText(text)
+  );
+}
+
+export function buildPinetControlMetadata(command: PinetControlCommand): PinetControlEnvelope {
+  return { type: "pinet:control", action: command };
+}
+
+export function buildPinetControlMessage(command: PinetControlCommand): string {
+  return JSON.stringify(buildPinetControlMetadata(command));
+}
+
+export function normalizeOutgoingPinetControlMessage(
+  body: string,
+  metadata?: Record<string, unknown>,
+): { body: string; metadata: Record<string, unknown> } | null {
+  const command = getPinetControlCommandFromText(body);
+  if (!command) return null;
+
+  return {
+    body: buildPinetControlMessage(command),
+    metadata: {
+      ...(metadata ?? {}),
+      ...buildPinetControlMetadata(command),
+    },
+  };
 }
 
 export interface PinetSkinUpdate {
@@ -331,10 +384,11 @@ export function extractPinetControlCommand(message: {
   if (!isAgentToAgent) return null;
 
   const metadataCommand =
-    metadata.kind === "pinet_control" ? parsePinetControlCommand(metadata.command) : null;
+    parsePinetControlEnvelope(metadata) ??
+    (metadata.kind === "pinet_control" ? parsePinetControlCommand(metadata.command) : null);
   if (metadataCommand) return metadataCommand;
 
-  // Backward-compatible fallback for exact slash commands sent over existing a2a flows.
+  // Backward-compatible fallback for structured JSON or exact slash commands sent over a2a flows.
   return getPinetControlCommandFromText(message.body);
 }
 // ─── Slack API encoding ──────────────────────────────────

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -553,4 +553,93 @@ describe("slack-bridge Pinet reconnect", () => {
       vi.useRealTimers();
     }
   });
+
+  it("sends structured control envelopes for follower pinet_message commands", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const sendCalls: Array<{
+      target: string;
+      body: string;
+      metadata?: Record<string, unknown>;
+    }> = [];
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Test Worker",
+      emoji: "🐘",
+      metadata: { role: "worker" },
+    });
+    vi.spyOn(BrokerClient.prototype, "sendAgentMessage").mockImplementation(
+      async (target: string, body: string, metadata?: Record<string, unknown>) => {
+        sendCalls.push({ target, body, metadata });
+        return 17;
+      },
+    );
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+    const pinetMessage = tools.get("pinet_message");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+    expect(pinetMessage).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await follow?.handler("", ctx);
+    await pinetMessage?.execute("tool-call-1", {
+      to: "receiver-agent",
+      message: "/reload",
+    });
+
+    expect(sendCalls).toEqual([
+      {
+        target: "receiver-agent",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { type: "pinet:control", action: "reload" },
+      },
+    ]);
+
+    await sessionShutdown?.({}, ctx);
+  });
 });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -17,13 +17,12 @@ import {
   isUserAllowed as checkUserAllowed,
   formatInboxMessages,
   formatPinetInboxMessages,
-  buildPinetControlMetadata,
   buildPinetSkinAssignment,
   buildPinetSkinMetadata,
   buildPinetSkinPromptGuideline,
   extractPinetControlCommand,
   extractPinetSkinUpdate,
-  getPinetControlCommandFromText,
+  normalizeOutgoingPinetControlMessage,
   queuePinetRemoteControl,
   finishPinetRemoteControl,
   reloadPinetRuntimeSafely,
@@ -2523,10 +2522,19 @@ export default function (pi: ExtensionAPI) {
     lastBrokerControlPlaneHomeTabSnapshot = null;
   }
 
-  function getOutgoingPinetMessageMetadata(body: string): Record<string, unknown> | undefined {
-    const control = getPinetControlCommandFromText(body);
-    if (!control) return undefined;
-    return buildPinetControlMetadata(control);
+  function prepareOutgoingPinetAgentMessage(
+    body: string,
+    metadata?: Record<string, unknown>,
+  ): { body: string; metadata?: Record<string, unknown> } {
+    const control = normalizeOutgoingPinetControlMessage(body, metadata);
+    if (control) {
+      return {
+        body: control.body,
+        metadata: control.metadata,
+      };
+    }
+
+    return { body, metadata };
   }
 
   async function sendPinetAgentMessage(
@@ -2544,11 +2552,9 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    const effectiveMetadata = {
-      ...(getOutgoingPinetMessageMetadata(body) ?? {}),
-      ...(metadata ?? {}),
-    };
-    const finalMetadata = Object.keys(effectiveMetadata).length > 0 ? effectiveMetadata : undefined;
+    const outgoing = prepareOutgoingPinetAgentMessage(body, metadata);
+    const finalBody = outgoing.body;
+    const finalMetadata = outgoing.metadata;
 
     if (brokerRole === "broker" && activeBroker) {
       const db = activeBroker.db;
@@ -2561,7 +2567,7 @@ export default function (pi: ExtensionAPI) {
         senderAgentId: selfId,
         senderAgentName: agentName,
         target: targetRef,
-        body,
+        body: finalBody,
         metadata: finalMetadata,
       });
 
@@ -2602,7 +2608,7 @@ export default function (pi: ExtensionAPI) {
 
     if (brokerRole === "follower" && brokerClient) {
       const client = brokerClient.client as BrokerClient;
-      const messageId = await client.sendAgentMessage(targetRef, body, finalMetadata);
+      const messageId = await client.sendAgentMessage(targetRef, finalBody, finalMetadata);
       return { messageId, target: targetRef };
     }
 
@@ -2857,11 +2863,13 @@ export default function (pi: ExtensionAPI) {
           throw new Error("Broker agent identity is unavailable.");
         }
 
+        const outgoing = prepareOutgoingPinetAgentMessage(params.message);
         const result = dispatchBroadcastAgentMessage(activeBroker.db, {
           senderAgentId: selfId,
           senderAgentName: agentName,
           channel: params.to,
-          body: params.message,
+          body: outgoing.body,
+          ...(outgoing.metadata ? { metadata: outgoing.metadata } : {}),
         });
         const recipients = result.targets.map((target) => target.name);
         const preview = recipients.slice(0, 5).join(", ");


### PR DESCRIPTION
## Summary
- switch reload/exit control delivery to a structured Pinet control envelope
- keep backward compatibility for legacy `/reload` and `/exit` messages and metadata
- normalize outgoing control messages across direct and broadcast paths, with new tests

Closes #240
