### PR TITLE
fix: preserve Escape interrupts with Pinet

### DIFF
--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -410,4 +410,147 @@ describe("slack-bridge Pinet reconnect", () => {
     await sessionShutdown?.({}, ctx);
     expect(setStatus).toHaveBeenCalled();
   });
+
+  it("suppresses automatic inbox drain immediately after Escape so interrupts return control", async () => {
+    vi.useFakeTimers();
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const sendUserMessage = vi.fn();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage,
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    let idle = false;
+    let terminalInputHandler:
+      | ((data: string) => { consume?: boolean; data?: string } | undefined)
+      | null = null;
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => idle,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+        onTerminalInput: vi.fn(
+          (handler: (data: string) => { consume?: boolean; data?: string } | undefined) => {
+            terminalInputHandler = handler;
+            return () => {
+              if (terminalInputHandler === handler) {
+                terminalInputHandler = null;
+              }
+            };
+          },
+        ),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let pollCount = 0;
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Agent",
+      emoji: "🦙",
+      metadata: { role: "worker", capabilities: { role: "worker" } },
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockImplementation(async () => {
+      if (pollCount > 0) {
+        pollCount += 1;
+        return [];
+      }
+      pollCount += 1;
+      return [
+        {
+          inboxId: 17,
+          message: {
+            id: 17,
+            threadId: "100.1",
+            source: "slack",
+            direction: "inbound",
+            sender: "U_SENDER",
+            body: "hello from broker",
+            createdAt: "100.1",
+            metadata: { channel: "D123" },
+          },
+        },
+      ];
+    });
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+      /* mocked */
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const agentEnd = events.get("agent_end");
+    const follow = commands.get("pinet-follow");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(agentEnd).toBeDefined();
+    expect(follow).toBeDefined();
+
+    try {
+      await sessionStart?.({}, ctx);
+      await follow?.handler("", ctx);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(sendUserMessage).not.toHaveBeenCalled();
+      const inputHandler = terminalInputHandler as unknown as
+        | ((data: string) => { consume?: boolean; data?: string } | undefined)
+        | undefined;
+      expect(inputHandler).toBeTypeOf("function");
+      expect(inputHandler?.("\u001b")).toBeUndefined();
+
+      idle = true;
+      await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
+      expect(sendUserMessage).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_501);
+      await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
+
+      expect(sendUserMessage).toHaveBeenCalledTimes(1);
+      expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"), {
+        deliverAs: "followUp",
+      });
+
+      await sessionShutdown?.({}, ctx);
+      expect(setStatus).toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("following broker"), "info");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -602,6 +602,9 @@ export default function (pi: ExtensionAPI) {
 
   const inbox: InboxMessage[] = [];
   const brokerDeliveryState = createBrokerDeliveryState();
+  const AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS = 1_500;
+  let suppressAutoDrainUntil = 0;
+  let terminalInputUnsubscribe: (() => void) | null = null;
   let extCtx: ExtensionContext | null = null; // cached for badge updates
   let lastActivityLogFailureAt = 0;
 
@@ -614,6 +617,39 @@ export default function (pi: ExtensionAPI) {
         ? t.fg("accent", `${agentEmoji} ${agentName} ✦ ${n}`)
         : t.fg("accent", `${agentEmoji} ${agentName} ✦`);
     extCtx.ui.setStatus("slack-bridge", label);
+  }
+
+  function notePotentialInterruptInput(data: string): void {
+    if (data !== "\u001b") {
+      return;
+    }
+
+    suppressAutoDrainUntil = Math.max(
+      suppressAutoDrainUntil,
+      Date.now() + AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS,
+    );
+  }
+
+  function shouldSuppressAutomaticInboxDrain(now = Date.now()): boolean {
+    if (suppressAutoDrainUntil === 0) {
+      return false;
+    }
+    if (now >= suppressAutoDrainUntil) {
+      suppressAutoDrainUntil = 0;
+      return false;
+    }
+    return true;
+  }
+
+  function maybeDrainInboxIfIdle(ctx?: ExtensionContext): boolean {
+    if (!(ctx?.isIdle?.() ?? false)) {
+      return false;
+    }
+    if (shouldSuppressAutomaticInboxDrain()) {
+      return false;
+    }
+    drainInbox();
+    return true;
   }
 
   // ─── Helpers ─────────────────────────────────────────
@@ -1065,7 +1101,7 @@ export default function (pi: ExtensionAPI) {
               timestamp: String(Date.now() / 1000),
             });
             updateBadge();
-            if (ctx.isIdle?.()) drainInbox();
+            maybeDrainInboxIfIdle(ctx);
           }
           break;
       }
@@ -1266,9 +1302,7 @@ export default function (pi: ExtensionAPI) {
       updateBadge();
       await addReaction(item.channel, item.ts, "white_check_mark");
 
-      if (ctx.isIdle?.()) {
-        drainInbox();
-      }
+      maybeDrainInboxIfIdle(ctx);
     } catch (err) {
       console.error(`[slack-bridge] reaction trigger failed: ${msg(err)}`);
       await addReaction(item.channel, item.ts, "x");
@@ -1375,9 +1409,7 @@ export default function (pi: ExtensionAPI) {
     updateBadge();
 
     // If agent is idle, trigger immediately — otherwise agent_end drains it
-    if (ctx.isIdle?.()) {
-      drainInbox();
-    }
+    maybeDrainInboxIfIdle(ctx);
   }
 
   async function queueInteractiveInboxEvent(
@@ -1447,9 +1479,7 @@ export default function (pi: ExtensionAPI) {
     });
     updateBadge();
 
-    if (ctx.isIdle?.()) {
-      drainInbox();
-    }
+    maybeDrainInboxIfIdle(ctx);
   }
 
   async function onBlockActions(
@@ -1646,9 +1676,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     updateBadge();
-    if (extCtx?.isIdle?.()) {
-      drainInbox();
-    }
+    maybeDrainInboxIfIdle(extCtx ?? undefined);
   }
 
   function startBrokerHeartbeat(): void {
@@ -3199,7 +3227,7 @@ export default function (pi: ExtensionAPI) {
             metadata: inMsg.metadata ?? null,
           });
           updateBadge();
-          if (extCtx?.isIdle?.()) drainInbox();
+          maybeDrainInboxIfIdle(extCtx ?? undefined);
         }
       });
 
@@ -3512,7 +3540,7 @@ export default function (pi: ExtensionAPI) {
               );
               if (synced.changed) persistState();
               updateBadge();
-              if (ctx.isIdle?.()) drainInbox();
+              maybeDrainInboxIfIdle(ctx);
             }
           } catch {
             /* broker may be restarting */
@@ -3873,6 +3901,9 @@ export default function (pi: ExtensionAPI) {
     shuttingDown = false;
     slackRequests = createAbortableOperationTracker();
     remoteControlState = { currentCommand: null, queuedCommand: null };
+    suppressAutoDrainUntil = 0;
+    terminalInputUnsubscribe?.();
+    terminalInputUnsubscribe = null;
     extCtx = ctx;
     const sessionHeader = (
       ctx.sessionManager as { getHeader?: () => { parentSession?: string } | null }
@@ -3886,6 +3917,17 @@ export default function (pi: ExtensionAPI) {
       stdinIsTTY: process.stdin.isTTY,
       stdoutIsTTY: process.stdout.isTTY,
     });
+    const uiWithTerminalInput = ctx.ui as ExtensionContext["ui"] & {
+      onTerminalInput?: (
+        handler: (data: string) => { consume?: boolean; data?: string } | undefined,
+      ) => () => void;
+    };
+    if (ctx.hasUI && typeof uiWithTerminalInput.onTerminalInput === "function") {
+      terminalInputUnsubscribe = uiWithTerminalInput.onTerminalInput((data: string) => {
+        notePotentialInterruptInput(data);
+        return undefined;
+      });
+    }
 
     // Restore persisted thread state (always restore, even before /pinet)
     interface PersistedState {
@@ -4019,10 +4061,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     const queuedInboxCount = inbox.length;
-    const drainedQueuedInbox = queuedInboxCount > 0 && (ctx ? (ctx.isIdle?.() ?? true) : false);
-    if (drainedQueuedInbox) {
-      drainInbox();
-    }
+    const drainedQueuedInbox = queuedInboxCount > 0 && (ctx ? maybeDrainInboxIfIdle(ctx) : false);
 
     return { queuedInboxCount, drainedQueuedInbox };
   }
@@ -4144,6 +4183,9 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_shutdown", async (_event, ctx) => {
     remoteControlState = { currentCommand: null, queuedCommand: null };
+    terminalInputUnsubscribe?.();
+    terminalInputUnsubscribe = null;
+    suppressAutoDrainUntil = 0;
     await stopPinetRuntime(ctx, { releaseIdentity: true });
     pinetRegistrationBlocked = false;
   });


### PR DESCRIPTION
## Summary
- investigate #245 and confirm slack-bridge is not swallowing raw stdin or overriding pi's Escape handler
- fix the user-visible interruption failure by suppressing automatic inbox auto-drain briefly after a raw Escape press
- add a regression test proving queued Pinet inbox work does not immediately restart a turn right after Escape, but still drains normally once the suppression window expires

## Root cause
The extension was **not** consuming raw keyboard input:
- no `process.stdin` listeners
- no `setRawMode(...)`
- no `readline`/keypress hooks
- Socket Mode listeners are attached only to WebSocket/network sockets

The user-facing bug came from auto-drain behavior instead:
- Pinet queues inbox work in the background
- on `agent_end`, slack-bridge immediately calls `signalAgentFree()` and auto-drains queued inbox work
- after pressing Escape to interrupt, that queued follow-up could start immediately, making it look like Escape did nothing

## Fix
- record a recent raw Escape press via `ctx.ui.onTerminalInput(...)` without consuming the key
- suppress automatic inbox draining for a short window after that interrupt
- apply the suppression to all automatic drain sites and the `agent_end` free/drain path
- keep manual key handling in pi untouched; Escape still reaches the TUI normally

## Testing
- `cd .worktrees/fix-245 && pnpm lint && pnpm typecheck && pnpm test`

Closes #245.
