### PR TITLE
chore: rename npm scope from @gugu91 to @gugu910

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ First public release prep for the Pi extensions monorepo. This cut rolls up 66 p
 ### Version verification
 
 - `pi-extensions` — `0.1.0`
-- `@gugu91/pi-slack-bridge` — `0.1.0`
-- `@gugu91/pi-nvim-bridge` — `0.1.0`
-- `@gugu91/pi-neon-psql` — `0.1.0`
-- `@gugu91/pi-slack-api` — `0.1.0`
-- `@gugu91/pi-ext-types` — `0.1.0`
+- `@gugu910/pi-slack-bridge` — `0.1.0`
+- `@gugu910/pi-nvim-bridge` — `0.1.0`
+- `@gugu910/pi-neon-psql` — `0.1.0`
+- `@gugu910/pi-slack-api` — `0.1.0`
+- `@gugu910/pi-ext-types` — `0.1.0`
 
 ### Release highlights
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ export default function (pi: ExtensionAPI) {
 ```json
 // package.json
 {
-  "name": "@gugu91/pi-slack-bridge",
+  "name": "@gugu910/pi-slack-bridge",
   "keywords": ["pi-package"],
   "pi": { "extensions": ["./index.ts"] }
 }

--- a/README.md
+++ b/README.md
@@ -120,22 +120,22 @@ caching.
 
 ```
 extensions/
-├── slack-bridge/       # @gugu91/pi-slack-bridge
+├── slack-bridge/       # @gugu910/pi-slack-bridge
 │   ├── broker/         #   message routing, socket server, adapters
 │   ├── index.ts        #   extension entry point
 │   └── package.json    #   workspace package + pi manifest
-├── slack-api/          # @gugu91/pi-slack-api
+├── slack-api/          # @gugu910/pi-slack-api
 │   ├── generated/      #   generated typed Slack Web API client
 │   ├── cli.ts          #   CLI wrapper around generated methods
 │   └── package.json    #   workspace package + pi manifest
-├── nvim-bridge/        # @gugu91/pi-nvim-bridge
+├── nvim-bridge/        # @gugu910/pi-nvim-bridge
 │   ├── nvim/           #   Neovim Lua plugin
 │   ├── index.ts        #   extension entry point
 │   └── package.json
-├── neon-psql/          # @gugu91/pi-neon-psql
+├── neon-psql/          # @gugu910/pi-neon-psql
 │   ├── index.ts        #   extension entry point
 │   └── package.json
-├── types/              # @gugu91/pi-ext-types (shared .d.ts)
+├── types/              # @gugu910/pi-ext-types (shared .d.ts)
 ├── plans/              # Architecture docs
 ├── .pi/                # Pi config (skills, agents)
 ├── turbo.json          # Turborepo task config

--- a/neon-psql/index.ts
+++ b/neon-psql/index.ts
@@ -14,7 +14,7 @@ import {
   truncateHead,
 } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
-import { Type } from "@gugu91/pi-ext-types/typebox";
+import { Type } from "@gugu910/pi-ext-types/typebox";
 
 import {
   buildInjectedValues as computeInjectedValues,

--- a/neon-psql/package.json
+++ b/neon-psql/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu91/pi-neon-psql",
+  "name": "@gugu910/pi-neon-psql",
   "version": "0.1.0",
   "type": "module",
   "description": "Neon Postgres tunnel + psql tool for pi",
@@ -41,6 +41,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gugu91/pi-ext-types": "workspace:*"
+    "@gugu910/pi-ext-types": "workspace:*"
   }
 }

--- a/nvim-bridge/index.ts
+++ b/nvim-bridge/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Type } from "@gugu91/pi-ext-types/typebox";
+import { Type } from "@gugu910/pi-ext-types/typebox";
 import * as crypto from "node:crypto";
 import { execSync } from "node:child_process";
 import * as fs from "node:fs";

--- a/nvim-bridge/package.json
+++ b/nvim-bridge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu91/pi-nvim-bridge",
+  "name": "@gugu910/pi-nvim-bridge",
   "version": "0.1.0",
   "type": "module",
   "description": "Neovim bridge for pi — editor context sync and PiComms persistent comments",
@@ -39,6 +39,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gugu91/pi-ext-types": "workspace:*"
+    "@gugu910/pi-ext-types": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,13 +43,13 @@ importers:
 
   neon-psql:
     dependencies:
-      "@gugu91/pi-ext-types":
+      "@gugu910/pi-ext-types":
         specifier: workspace:*
         version: link:../types
 
   nvim-bridge:
     dependencies:
-      "@gugu91/pi-ext-types":
+      "@gugu910/pi-ext-types":
         specifier: workspace:*
         version: link:../types
 
@@ -64,7 +64,7 @@ importers:
 
   slack-bridge:
     dependencies:
-      "@gugu91/pi-ext-types":
+      "@gugu910/pi-ext-types":
         specifier: workspace:*
         version: link:../types
 

--- a/slack-api/README.md
+++ b/slack-api/README.md
@@ -12,7 +12,7 @@ Typed Slack Web API client + CLI generated from Slack's OpenAPI spec with
 ## Regenerate the client
 
 ```bash
-pnpm --filter @gugu91/pi-slack-api run generate
+pnpm --filter @gugu910/pi-slack-api run generate
 ```
 
 The generator currently tries these sources in order:
@@ -27,13 +27,13 @@ The generator currently tries these sources in order:
 List all generated Slack methods:
 
 ```bash
-pnpm --filter @gugu91/pi-slack-api exec node --experimental-strip-types cli.ts list
+pnpm --filter @gugu910/pi-slack-api exec node --experimental-strip-types cli.ts list
 ```
 
 Call a method with repeated key/value params:
 
 ```bash
-pnpm --filter @gugu91/pi-slack-api exec node --experimental-strip-types cli.ts conversations.list \
+pnpm --filter @gugu910/pi-slack-api exec node --experimental-strip-types cli.ts conversations.list \
   --token "$SLACK_TOKEN" \
   --param limit=50
 ```
@@ -41,7 +41,7 @@ pnpm --filter @gugu91/pi-slack-api exec node --experimental-strip-types cli.ts c
 Call a method with JSON input:
 
 ```bash
-pnpm --filter @gugu91/pi-slack-api exec node --experimental-strip-types cli.ts chat.postMessage \
+pnpm --filter @gugu910/pi-slack-api exec node --experimental-strip-types cli.ts chat.postMessage \
   --token "$SLACK_TOKEN" \
   --input '{"channel":"C123","text":"hello from slack-api"}'
 ```

--- a/slack-api/package.json
+++ b/slack-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu91/pi-slack-api",
+  "name": "@gugu910/pi-slack-api",
   "version": "0.1.0",
   "type": "module",
   "description": "Typed Slack Web API client and CLI generated from Slack's OpenAPI spec",

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Type } from "@gugu91/pi-ext-types/typebox";
+import { Type } from "@gugu910/pi-ext-types/typebox";
 import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-metadata.js";
 import {
   type InboxMessage,

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu91/pi-slack-bridge",
+  "name": "@gugu910/pi-slack-bridge",
   "version": "0.1.0",
   "type": "module",
   "description": "Slack assistant integration for pi (Pinet) — multi-agent broker, thread routing, and inbox tools",
@@ -39,6 +39,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gugu91/pi-ext-types": "workspace:*"
+    "@gugu910/pi-ext-types": "workspace:*"
   }
 }

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Type } from "@gugu91/pi-ext-types/typebox";
+import { Type } from "@gugu910/pi-ext-types/typebox";
 import type { InboxMessage } from "./helpers.js";
 import type { SlackResult } from "./slack-api.js";
 import {

--- a/types/package.json
+++ b/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu91/pi-ext-types",
+  "name": "@gugu910/pi-ext-types",
   "version": "0.1.0",
   "type": "module",
   "description": "Shared ambient type declarations and workspace helpers for pi extensions",


### PR DESCRIPTION
Renames all package scopes from `@gugu91/` to `@gugu910/` to match the npm username for publishing.

All 5 packages updated:
- `@gugu910/pi-ext-types`
- `@gugu910/pi-slack-bridge`
- `@gugu910/pi-slack-api`
- `@gugu910/pi-neon-psql`
- `@gugu910/pi-nvim-bridge`

Also updates references in source files, docs, and config.