### PR TITLE
feat: add slack_project_create tool for project channels (#252)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1588,6 +1588,7 @@ export default function (pi: ExtensionAPI) {
       unclaimedThreads.delete(threadTs);
       persistState();
     },
+    getBotUserId: () => botUserId,
     claimThreadOwnership: (threadTs, channelId) => {
       if (brokerRole === "broker" && activeRouter && activeSelfId) {
         activeRouter.claimThread(threadTs, activeSelfId);

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -144,6 +144,25 @@ describe("registerSlackTools", () => {
         return conversationsRepliesResponses.shift() as SlackResult;
       }
 
+      if (method === "conversations.create") {
+        const name = typeof body?.name === "string" ? body.name : "test-channel";
+        return {
+          ok: true,
+          channel: { id: "C_PROJ", name },
+        } as unknown as SlackResult;
+      }
+
+      if (method === "conversations.canvases.create") {
+        return { ok: true, canvas_id: "CANVAS_1" } as unknown as SlackResult;
+      }
+
+      if (method === "conversations.info") {
+        return {
+          ok: true,
+          channel: { id: body?.channel ?? "C_PROJ", properties: {} },
+        } as unknown as SlackResult;
+      }
+
       return {
         ok: true,
         token,
@@ -176,6 +195,7 @@ describe("registerSlackTools", () => {
       claimThreadOwnership: () => {},
       clearPendingEyes: () => {},
       registerConfirmationRequest: () => ({ status: "created" }),
+      getBotUserId: () => "U_BOT",
     });
 
     return {
@@ -869,5 +889,65 @@ describe("registerSlackTools", () => {
         },
       ],
     });
+  });
+
+  // ─── slack_project_create ─────────────────────────────
+
+  it("creates a project channel with canvas and bot invite in one call", async () => {
+    const { slack, tools } = setup();
+
+    const result = await tools.get("slack_project_create")!.execute("tool-proj-1", {
+      name: "proj-alpha",
+      topic: "Alpha project",
+      canvas_title: "Alpha RFC",
+      canvas_markdown: "# Overview\nProject goals.",
+    });
+
+    expect(slack).toHaveBeenCalledWith("conversations.create", "xoxb-initial", {
+      name: "proj-alpha",
+    });
+    expect(slack).toHaveBeenCalledWith("conversations.setTopic", "xoxb-initial", {
+      channel: "C_PROJ",
+      topic: "Alpha project",
+    });
+    expect(slack).toHaveBeenCalledWith(
+      "conversations.invite",
+      "xoxb-initial",
+      expect.objectContaining({ channel: "C_PROJ", users: "U_BOT" }),
+    );
+    expect(slack).toHaveBeenCalledWith(
+      "conversations.canvases.create",
+      "xoxb-initial",
+      expect.objectContaining({ channel_id: "C_PROJ", title: "Alpha RFC" }),
+    );
+
+    const details = (result as { details: Record<string, unknown> }).details;
+    expect(details.channel_id).toBe("C_PROJ");
+    expect(details.channel_name).toBe("proj-alpha");
+    expect(details.canvas_id).toBe("CANVAS_1");
+    expect(details.bot_invited).toBe(true);
+  });
+
+  it("creates project channel even when canvas creation fails", async () => {
+    const { slack, tools } = setup();
+
+    // Override slack to fail on canvas creation
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "conversations.canvases.create") {
+          throw new Error("canvas_error");
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    const result = await tools.get("slack_project_create")!.execute("tool-proj-2", {
+      name: "proj-beta",
+    });
+
+    const details = (result as { details: Record<string, unknown> }).details;
+    expect(details.channel_id).toBe("C_PROJ");
+    expect(details.canvas_id).toBeNull();
   });
 });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -76,6 +76,7 @@ export interface RegisterSlackToolsDeps {
     status: "created" | "refreshed" | "conflict";
     conflict?: { toolPattern: string; action: string };
   };
+  getBotUserId: () => string | null;
 }
 
 function buildSlackInboxPromptGuidelines(): string[] {
@@ -175,6 +176,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     claimThreadOwnership,
     clearPendingEyes,
     registerConfirmationRequest,
+    getBotUserId,
   } = deps;
 
   async function resolveCanvasTarget(
@@ -1485,6 +1487,114 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       return {
         content: [{ type: "text", text: `Created channel #${channel.name} (${channel.id})` }],
         details: { id: channel.id, name: channel.name },
+      };
+    },
+  });
+
+  // ─── Project channel creation ──────────────────────────
+
+  pi.registerTool({
+    name: "slack_project_create",
+    label: "Slack Project Create",
+    description:
+      "Create a Slack project channel with an attached RFC canvas and bot membership in one step.",
+    promptSnippet:
+      "Create a project channel, attach an RFC/spec canvas, and invite the Pinet bot — all in one call.",
+    parameters: Type.Object({
+      name: Type.String({
+        description: "Channel name (lowercase, no spaces, max 80 chars)",
+      }),
+      topic: Type.Optional(Type.String({ description: "Channel topic" })),
+      purpose: Type.Optional(Type.String({ description: "Channel purpose" })),
+      canvas_title: Type.Optional(
+        Type.String({ description: "Title for the RFC/spec canvas (defaults to channel name)" }),
+      ),
+      canvas_markdown: Type.Optional(
+        Type.String({ description: "Markdown content for the RFC/spec canvas" }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_project_create",
+        undefined,
+        `name=${params.name} | topic=${params.topic ?? ""} | canvas=${params.canvas_title ?? params.name}`,
+      );
+
+      // 1. Create the channel
+      const createResponse = await slack("conversations.create", getBotToken(), {
+        name: params.name,
+      });
+      const channel = createResponse.channel as { id: string; name: string };
+      rememberChannel(channel.name, channel.id);
+
+      // 2. Set topic and purpose if provided
+      if (params.topic) {
+        await slack("conversations.setTopic", getBotToken(), {
+          channel: channel.id,
+          topic: params.topic,
+        });
+      }
+      if (params.purpose) {
+        await slack("conversations.setPurpose", getBotToken(), {
+          channel: channel.id,
+          purpose: params.purpose,
+        });
+      }
+
+      // 3. Invite the bot to the channel (if we know the bot user id)
+      const botId = getBotUserId();
+      let botInvited = false;
+      if (botId) {
+        try {
+          await slack("conversations.invite", getBotToken(), {
+            channel: channel.id,
+            users: botId,
+          });
+          botInvited = true;
+        } catch (err) {
+          // already_in_channel is fine — the bot created the channel so it's already a member
+          if (isSlackMethodError(err, "conversations.invite", "already_in_channel")) {
+            botInvited = true;
+          }
+          // Other errors are non-fatal — the channel still works, just without explicit bot membership
+        }
+      }
+
+      // 4. Create the channel canvas with the RFC/spec
+      const canvasTitle = params.canvas_title?.trim() || `${channel.name} RFC`;
+      let canvasId: string | null = null;
+      try {
+        const canvasRequest = buildSlackCanvasCreateRequest({
+          kind: "channel",
+          title: canvasTitle,
+          markdown: params.canvas_markdown,
+          channelId: channel.id,
+        });
+        const canvasResponse = await slack(canvasRequest.method, getBotToken(), canvasRequest.body);
+        canvasId = canvasResponse.canvas_id as string;
+      } catch {
+        // Canvas creation failure is non-fatal — the channel is still usable
+      }
+
+      const parts = [`Created project channel #${channel.name} (${channel.id})`];
+      if (canvasId) {
+        parts.push(`RFC canvas: ${canvasId} — "${canvasTitle}"`);
+      } else {
+        parts.push("Canvas creation failed — create it manually with slack_canvas_create.");
+      }
+      if (botInvited) {
+        parts.push("Bot joined the channel.");
+      }
+
+      return {
+        content: [{ type: "text", text: parts.join("\n") }],
+        details: {
+          channel_id: channel.id,
+          channel_name: channel.name,
+          canvas_id: canvasId,
+          canvas_title: canvasTitle,
+          bot_invited: botInvited,
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
Adds a new `slack_project_create` tool that creates a Slack project channel with an attached RFC canvas and bot membership in one atomic call.

### What it does
1. **Creates the channel** via `conversations.create`
2. **Sets topic/purpose** if provided
3. **Invites the Pinet bot** via `conversations.invite` (gracefully handles `already_in_channel`)
4. **Creates a channel canvas** with the RFC/spec content via `conversations.canvases.create`

### Resilience
- Canvas creation failure is non-fatal — the channel is still returned
- Bot invite failure is non-fatal — `already_in_channel` is treated as success
- Returns structured details with `channel_id`, `channel_name`, `canvas_id`, `canvas_title`, `bot_invited`

### Files changed
- `slack-bridge/slack-tools.ts` — new `slack_project_create` tool + `getBotUserId` dep
- `slack-bridge/slack-tools.test.ts` — 2 new tests (happy path + canvas failure resilience) + mock improvements
- `slack-bridge/index.ts` — wire `getBotUserId` into tool deps

### Testing
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (849 tests across all packages)

Closes #252 (Phase 1)