### PR TITLE
feat: add Pinet mesh authentication (#235)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -194,9 +194,10 @@ The `manifest.yaml` includes all required scopes and events, including `files:wr
 for `slack_upload`, `chat:write` for `slack_schedule`, bookmark/pin scopes for
 `slack_bookmark` and `slack_pin`, `users:read` + `users.getPresence` / `dnd.info`
 for presence checks, `app_home_opened` for the Home tab dashboard, `reaction_added`
-+ `reactions:read` plus `presence_change` for Slack-side awareness events, and
-`interactivity.is_enabled: true` for buttons and modals. Use it when creating
-the app (**From a manifest**) or paste it into **App Manifest** in settings.
+
+- `reactions:read` plus `presence_change` for Slack-side awareness events, and
+  `interactivity.is_enabled: true` for buttons and modals. Use it when creating
+  the app (**From a manifest**) or paste it into **App Manifest** in settings.
 
 To push the checked-in manifest back to Slack, run:
 
@@ -277,6 +278,10 @@ agent. Only listed users' messages are queued; others receive a polite
 rejection. If not set, all users are allowed.
 
 Find user IDs in Slack: click a user's profile → **More** → **Copy member ID**.
+
+Pinet broker/worker connections on the same machine also use a local shared
+mesh secret. On first broker start, slack-bridge creates `~/.pi/pinet.secret`
+and follower runtimes read that file automatically before joining the mesh.
 
 ## Architecture
 

--- a/slack-bridge/broker/auth.test.ts
+++ b/slack-bridge/broker/auth.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadOrCreateMeshSecret, readMeshSecret, resolveMeshSecret } from "./auth.js";
+
+describe("broker mesh auth helpers", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-auth-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates a secret on first use and reuses it on later reads", () => {
+    const secretPath = path.join(dir, "pinet.secret");
+
+    const first = loadOrCreateMeshSecret(secretPath);
+    const second = loadOrCreateMeshSecret(secretPath);
+
+    expect(first).toHaveLength(64);
+    expect(second).toBe(first);
+    expect(readMeshSecret(secretPath)).toBe(first);
+  });
+
+  it("resolveMeshSecret prefers an explicit secret over the file", () => {
+    const secretPath = path.join(dir, "pinet.secret");
+    fs.writeFileSync(secretPath, "from-file\n", "utf-8");
+
+    expect(resolveMeshSecret({ meshSecret: "  from-option  ", meshSecretPath: secretPath })).toBe(
+      "from-option",
+    );
+  });
+
+  it("resolveMeshSecret reads from a secret file when no explicit secret is provided", () => {
+    const secretPath = path.join(dir, "pinet.secret");
+    fs.writeFileSync(secretPath, "from-file\n", "utf-8");
+
+    expect(resolveMeshSecret({ meshSecretPath: secretPath })).toBe("from-file");
+  });
+
+  it("readMeshSecret rejects empty secret files", () => {
+    const secretPath = path.join(dir, "pinet.secret");
+    fs.writeFileSync(secretPath, "\n", "utf-8");
+
+    expect(() => readMeshSecret(secretPath)).toThrow("empty");
+  });
+});

--- a/slack-bridge/broker/auth.ts
+++ b/slack-bridge/broker/auth.ts
@@ -1,0 +1,71 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getDefaultMeshSecretPath } from "./paths.js";
+
+export interface MeshSecretOptions {
+  meshSecret?: string | null;
+  meshSecretPath?: string | null;
+}
+
+function normalizeMeshSecret(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function getErrorCode(err: unknown): string | null {
+  if (typeof err !== "object" || err == null || !("code" in err)) {
+    return null;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
+
+export function readMeshSecret(secretPath = getDefaultMeshSecretPath()): string {
+  const secret = normalizeMeshSecret(fs.readFileSync(secretPath, "utf-8"));
+  if (!secret) {
+    throw new Error(`Pinet mesh secret file is empty: ${secretPath}`);
+  }
+  return secret;
+}
+
+export function loadOrCreateMeshSecret(secretPath = getDefaultMeshSecretPath()): string {
+  try {
+    return readMeshSecret(secretPath);
+  } catch (err) {
+    if (getErrorCode(err) !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  fs.mkdirSync(path.dirname(secretPath), { recursive: true, mode: 0o700 });
+  const meshSecret = crypto.randomBytes(32).toString("hex");
+
+  try {
+    fs.writeFileSync(secretPath, `${meshSecret}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    return meshSecret;
+  } catch (err) {
+    if (getErrorCode(err) !== "EEXIST") {
+      throw err;
+    }
+    return readMeshSecret(secretPath);
+  }
+}
+
+export function resolveMeshSecret(options: MeshSecretOptions = {}): string | null {
+  const explicitSecret = normalizeMeshSecret(options.meshSecret);
+  if (explicitSecret) {
+    return explicitSecret;
+  }
+
+  const meshSecretPath = options.meshSecretPath?.trim();
+  if (!meshSecretPath) {
+    return null;
+  }
+
+  return readMeshSecret(meshSecretPath);
+}

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -163,6 +163,51 @@ describe("BrokerClient — connect / disconnect", () => {
   });
 });
 
+describe("BrokerClient — mesh auth", () => {
+  let mock: MockServer;
+
+  beforeEach(async () => {
+    mock = await createMockServer();
+  });
+
+  afterEach(async () => {
+    await mock.close();
+  });
+
+  it("sends an auth RPC during connect when a mesh secret is configured", async () => {
+    const client = new BrokerClient({ ...mock.connectOpts, meshSecret: "shared-secret" });
+    const connectPromise = client.connect();
+
+    await waitFor(() => mock.received.length === 1);
+    const authReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { secret: string };
+    };
+
+    expect(authReq.method).toBe("auth");
+    expect(authReq.params.secret).toBe("shared-secret");
+
+    mock.respondTo(mock.connections[0], authReq.id, { ok: true });
+    await connectPromise;
+    expect(client.isConnected()).toBe(true);
+
+    client.disconnect();
+  });
+
+  it("rejects connect when broker auth rejects the mesh secret", async () => {
+    const client = new BrokerClient({ ...mock.connectOpts, meshSecret: "wrong-secret" });
+    const connectPromise = client.connect();
+
+    await waitFor(() => mock.received.length === 1);
+    const authReq = JSON.parse(mock.received[0]) as { id: number };
+    mock.respondError(mock.connections[0], authReq.id, -32001, "Invalid mesh secret.");
+
+    await expect(connectPromise).rejects.toThrow("Invalid mesh secret.");
+    expect(client.isConnected()).toBe(false);
+  });
+});
+
 describe("BrokerClient — register", () => {
   let mock: MockServer;
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -1,4 +1,5 @@
 import * as net from "node:net";
+import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 
 // ─── Types ───────────────────────────────────────────────
@@ -115,10 +116,17 @@ export interface AgentBroadcastResult {
 
 export type BrokerConnectOpts = { path: string } | { host: string; port: number };
 
+export interface BrokerClientAuthOptions {
+  meshSecret?: string;
+  meshSecretPath?: string;
+}
+
 // ─── BrokerClient ────────────────────────────────────────
 
 export class BrokerClient {
   private readonly connectOpts: BrokerConnectOpts;
+  private readonly meshSecret: string | null;
+  private readonly meshSecretPath: string | null;
   private socket: net.Socket | null = null;
   private connected = false;
   private shuttingDown = false;
@@ -134,21 +142,44 @@ export class BrokerClient {
   private readonly pending = new Map<number, PendingRequest>();
   private buffer = "";
 
-  constructor(opts?: string | BrokerConnectOpts) {
+  constructor(opts?: string | (BrokerConnectOpts & BrokerClientAuthOptions)) {
     if (opts === undefined) {
       this.connectOpts = { path: DEFAULT_SOCKET_PATH };
-    } else if (typeof opts === "string") {
-      this.connectOpts = { path: opts };
-    } else {
-      this.connectOpts = opts;
+      this.meshSecret = null;
+      this.meshSecretPath = null;
+      return;
     }
+
+    if (typeof opts === "string") {
+      this.connectOpts = { path: opts };
+      this.meshSecret = null;
+      this.meshSecretPath = null;
+      return;
+    }
+
+    if ("path" in opts) {
+      this.connectOpts = { path: opts.path };
+    } else {
+      this.connectOpts = { host: opts.host, port: opts.port };
+    }
+
+    const meshSecret = opts.meshSecret?.trim();
+    this.meshSecret = meshSecret && meshSecret.length > 0 ? meshSecret : null;
+    const meshSecretPath = opts.meshSecretPath?.trim();
+    this.meshSecretPath = meshSecretPath && meshSecretPath.length > 0 ? meshSecretPath : null;
   }
 
   // ─── Connection ──────────────────────────────────────
 
-  connect(): Promise<void> {
+  async connect(): Promise<void> {
     this.shuttingDown = false;
-    return this.connectSocket();
+    await this.connectSocket();
+    try {
+      await this.authenticateIfNeeded();
+    } catch (err) {
+      this.disconnect();
+      throw err;
+    }
   }
 
   disconnect(): void {
@@ -184,6 +215,24 @@ export class BrokerClient {
 
   isConnected(): boolean {
     return this.connected;
+  }
+
+  private resolveMeshSecret(): string | null {
+    if (this.meshSecret) {
+      return this.meshSecret;
+    }
+    if (this.meshSecretPath) {
+      return readMeshSecret(this.meshSecretPath);
+    }
+    return null;
+  }
+
+  private async authenticateIfNeeded(): Promise<void> {
+    const meshSecret = this.resolveMeshSecret();
+    if (!meshSecret) {
+      return;
+    }
+    await this.request("auth", { secret: meshSecret });
   }
 
   // ─── Registration ────────────────────────────────────
@@ -468,9 +517,7 @@ export class BrokerClient {
     });
   }
 
-  private async performRegister(
-    snapshot: RegistrationSnapshot,
-  ): Promise<{
+  private async performRegister(snapshot: RegistrationSnapshot): Promise<{
     agentId: string;
     name: string;
     emoji: string;
@@ -503,6 +550,7 @@ export class BrokerClient {
     }
 
     try {
+      await this.authenticateIfNeeded();
       if (this.registrationSnapshot) {
         await this.performRegister(this.registrationSnapshot);
       }

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1819,11 +1819,14 @@ describe("startBroker leader lock", () => {
   });
 
   /** Helper: start a broker with TCP + per-test dir, track for cleanup */
-  async function launch(overrides: { lockPath?: string; dbSuffix?: string } = {}): Promise<Broker> {
+  async function launch(
+    overrides: { lockPath?: string; dbSuffix?: string; meshSecretPath?: string } = {},
+  ): Promise<Broker> {
     const b = await startBroker({
       dbPath: path.join(dir, `${overrides.dbSuffix ?? "test"}.db`),
       listenTarget: TCP_TARGET,
       lockPath: overrides.lockPath ?? path.join(dir, "broker.lock"),
+      meshSecretPath: overrides.meshSecretPath ?? path.join(dir, "pinet.secret"),
     });
     brokers.push(b);
     return b;
@@ -1853,6 +1856,7 @@ describe("startBroker leader lock", () => {
         dbPath: path.join(dir, "test2.db"),
         listenTarget: TCP_TARGET,
         lockPath,
+        meshSecretPath: path.join(dir, "pinet.secret"),
       }),
     ).rejects.toThrow("Another pinet broker is already running");
   });
@@ -1877,6 +1881,16 @@ describe("startBroker leader lock", () => {
     expect(broker.lock.isLeader()).toBe(true);
   });
 
+  it("creates and persists a mesh secret on startup", async () => {
+    const meshSecretPath = path.join(dir, "pinet.secret");
+
+    await launch({ meshSecretPath });
+
+    expect(fs.existsSync(meshSecretPath)).toBe(true);
+    const secret = fs.readFileSync(meshSecretPath, "utf-8").trim();
+    expect(secret).toHaveLength(64);
+  });
+
   it("releases lock when db initialization fails", async () => {
     const lockPath = path.join(dir, "broker.lock");
 
@@ -1889,6 +1903,7 @@ describe("startBroker leader lock", () => {
         dbPath: badDbPath,
         listenTarget: TCP_TARGET,
         lockPath,
+        meshSecretPath: path.join(dir, "pinet.secret"),
       }),
     ).rejects.toThrow();
 

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -1,9 +1,10 @@
 import * as fs from "node:fs";
 import { BrokerDB } from "./schema.js";
+import { loadOrCreateMeshSecret } from "./auth.js";
 import { BrokerSocketServer } from "./socket-server.js";
 import type { ListenTarget } from "./socket-server.js";
 import { LeaderLock } from "./leader.js";
-import { getDefaultSocketPath } from "./paths.js";
+import { getDefaultMeshSecretPath, getDefaultSocketPath } from "./paths.js";
 import type { MessageAdapter } from "./types.js";
 
 export { BrokerDB } from "./schema.js";
@@ -36,6 +37,8 @@ export interface BrokerOptions {
   /** Full listen target — overrides socketPath when provided */
   listenTarget?: ListenTarget;
   lockPath?: string;
+  meshSecret?: string;
+  meshSecretPath?: string;
 }
 
 export interface Broker {
@@ -86,7 +89,10 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
     }
   }
 
-  const server = new BrokerSocketServer(db, target);
+  const meshSecretPath = options.meshSecretPath ?? getDefaultMeshSecretPath();
+  const meshSecret = options.meshSecret?.trim() || loadOrCreateMeshSecret(meshSecretPath);
+
+  const server = new BrokerSocketServer(db, target, undefined, { meshSecret });
   try {
     await server.start();
   } catch (err) {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -1135,3 +1135,70 @@ describe("ralph_cycles recording", () => {
     expect(db.getRecentRalphCycles(3)).toHaveLength(3);
   });
 });
+
+describe("broker integration — mesh auth", () => {
+  let dir: string;
+  let db: BrokerDB;
+  let server: BrokerSocketServer;
+
+  beforeEach(async () => {
+    dir = tmpDir();
+    db = new BrokerDB(path.join(dir, "auth.db"));
+    db.initialize();
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, undefined, {
+      meshSecret: "shared-secret",
+      authTimeoutMs: 100,
+    });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    db.close();
+    cleanup(dir);
+  });
+
+  it("accepts clients that present the correct mesh secret", async () => {
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+
+    const client = new BrokerClient({
+      host: info.host,
+      port: info.port,
+      meshSecret: "shared-secret",
+    });
+    await client.connect();
+
+    const reg = await client.register("trusted-agent", "🔐");
+    expect(reg.agentId).toBeDefined();
+
+    client.disconnect();
+  });
+
+  it("rejects clients that do not authenticate before calling broker methods", async () => {
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+
+    const client = new BrokerClient({ host: info.host, port: info.port });
+    await client.connect();
+
+    await expect(client.register("intruder", "🚫")).rejects.toThrow(
+      "Authentication required before calling broker methods.",
+    );
+    await waitFor(() => !client.isConnected());
+  });
+
+  it("rejects clients that present the wrong mesh secret", async () => {
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+
+    const client = new BrokerClient({
+      host: info.host,
+      port: info.port,
+      meshSecret: "wrong-secret",
+    });
+
+    await expect(client.connect()).rejects.toThrow("Invalid mesh secret.");
+    expect(client.isConnected()).toBe(false);
+  });
+});

--- a/slack-bridge/broker/paths.ts
+++ b/slack-bridge/broker/paths.ts
@@ -30,3 +30,10 @@ export const DEFAULT_SOCKET_PATH = getDefaultSocketPath();
 export function getDefaultDbPath(): string {
   return path.join(getPinetConfigDir(), "pinet-broker.db");
 }
+
+// ─── Mesh auth paths ─────────────────────────────────────
+
+/** Shared secret file used to authenticate local Pinet mesh clients: ~/.pi/pinet.secret */
+export function getDefaultMeshSecretPath(): string {
+  return path.join(getPinetConfigDir(), "pinet.secret");
+}

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -14,6 +14,7 @@ import {
   RPC_METHOD_NOT_FOUND,
   RPC_INVALID_PARAMS,
   RPC_INTERNAL_ERROR,
+  RPC_AUTH_REQUIRED,
 } from "./types.js";
 
 export type SlackProxyFn = (
@@ -23,6 +24,7 @@ export type SlackProxyFn = (
 
 export const DEFAULT_HEARTBEAT_TIMEOUT_MS = 15_000;
 export const DEFAULT_PRUNE_INTERVAL_MS = 5_000;
+export const DEFAULT_AUTH_TIMEOUT_MS = 2_000;
 
 // ─── Listen target: Unix socket path or TCP host:port ────
 
@@ -53,6 +55,8 @@ export type AgentRegistrationResolver = (input: {
 export interface BrokerSocketServerOptions {
   heartbeatTimeoutMs?: number;
   pruneIntervalMs?: number;
+  authTimeoutMs?: number;
+  meshSecret?: string;
 }
 
 // ─── Connection state ────────────────────────────────────
@@ -60,6 +64,8 @@ export interface BrokerSocketServerOptions {
 interface ConnectionState {
   agentId: string | null;
   buffer: string;
+  authenticated: boolean;
+  authTimer: ReturnType<typeof setTimeout> | null;
 }
 
 // ─── RPC helpers ─────────────────────────────────────────
@@ -131,6 +137,8 @@ export class BrokerSocketServer {
   private readonly connections = new Map<net.Socket, ConnectionState>();
   private readonly heartbeatTimeoutMs: number;
   private readonly pruneIntervalMs: number;
+  private readonly authTimeoutMs: number;
+  private readonly meshSecret: string | null;
   private pruneTimer: ReturnType<typeof setInterval> | null = null;
   private assignedPort: number | null = null;
   private agentMessageCallback: AgentMessageCallback | null = null;
@@ -148,6 +156,9 @@ export class BrokerSocketServer {
     this.slackProxyFn = slackProxyFn ?? null;
     this.heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS;
     this.pruneIntervalMs = options.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
+    this.authTimeoutMs = options.authTimeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
+    const meshSecret = options.meshSecret?.trim();
+    this.meshSecret = meshSecret && meshSecret.length > 0 ? meshSecret : null;
     if (typeof target === "string") {
       this.target = { type: "unix", path: target };
     } else if (target) {
@@ -264,6 +275,7 @@ export class BrokerSocketServer {
   setAgentRegistrationResolver(resolver: AgentRegistrationResolver | null): void {
     this.agentRegistrationResolver = resolver;
   }
+
   private startPruning(): void {
     this.stopPruning();
     this.pruneTimer = setInterval(() => {
@@ -282,6 +294,25 @@ export class BrokerSocketServer {
     this.pruneTimer = null;
   }
 
+  private clearAuthTimer(state: ConnectionState): void {
+    if (!state.authTimer) return;
+    clearTimeout(state.authTimer);
+    state.authTimer = null;
+  }
+
+  private startAuthTimer(socket: net.Socket, state: ConnectionState): void {
+    this.clearAuthTimer(state);
+    if (state.authenticated || !this.meshSecret) {
+      return;
+    }
+
+    state.authTimer = setTimeout(() => {
+      this.clearAuthTimer(state);
+      socket.destroy();
+    }, this.authTimeoutMs);
+    state.authTimer.unref?.();
+  }
+
   private disconnectDuplicateConnections(agentId: string, currentSocket: net.Socket): void {
     for (const [socket, state] of this.connections) {
       if (socket === currentSocket || state.agentId !== agentId) {
@@ -295,8 +326,14 @@ export class BrokerSocketServer {
   // ─── Connection handling ─────────────────────────────
 
   private onConnection(socket: net.Socket): void {
-    const state: ConnectionState = { agentId: null, buffer: "" };
+    const state: ConnectionState = {
+      agentId: null,
+      buffer: "",
+      authenticated: this.meshSecret == null,
+      authTimer: null,
+    };
     this.connections.set(socket, state);
+    this.startAuthTimer(socket, state);
 
     socket.on("data", (chunk) => {
       state.buffer += chunk.toString("utf-8");
@@ -304,6 +341,7 @@ export class BrokerSocketServer {
     });
 
     socket.on("close", () => {
+      this.clearAuthTimer(state);
       if (state.agentId) {
         this.db.disconnectAgent(state.agentId, this.heartbeatTimeoutMs);
       }
@@ -373,7 +411,18 @@ export class BrokerSocketServer {
     socket: net.Socket,
   ): Promise<JsonRpcResponse> {
     try {
+      if (!state.authenticated && req.method !== "auth") {
+        setImmediate(() => socket.destroy());
+        return rpcError(
+          req.id,
+          RPC_AUTH_REQUIRED,
+          "Authentication required before calling broker methods.",
+        );
+      }
+
       switch (req.method) {
+        case "auth":
+          return this.handleAuth(req, state, socket);
         case "register":
           return this.handleRegister(req, state, socket);
         case "unregister":
@@ -414,6 +463,34 @@ export class BrokerSocketServer {
   }
 
   // ─── Method handlers ─────────────────────────────────
+
+  private handleAuth(
+    req: JsonRpcRequest,
+    state: ConnectionState,
+    socket: net.Socket,
+  ): JsonRpcResponse {
+    if (!this.meshSecret) {
+      state.authenticated = true;
+      this.clearAuthTimer(state);
+      return rpcOk(req.id, { ok: true });
+    }
+
+    const params = req.params ?? {};
+    const providedSecret = typeof params.secret === "string" ? params.secret.trim() : "";
+    if (!providedSecret) {
+      setImmediate(() => socket.destroy());
+      return rpcError(req.id, RPC_AUTH_REQUIRED, "Mesh secret is required.");
+    }
+
+    if (providedSecret !== this.meshSecret) {
+      setImmediate(() => socket.destroy());
+      return rpcError(req.id, RPC_AUTH_REQUIRED, "Invalid mesh secret.");
+    }
+
+    state.authenticated = true;
+    this.clearAuthTimer(state);
+    return rpcOk(req.id, { ok: true });
+  }
 
   private handleRegister(
     req: JsonRpcRequest,

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -135,6 +135,9 @@ export const RPC_METHOD_NOT_FOUND = -32601;
 export const RPC_INVALID_PARAMS = -32602;
 export const RPC_INTERNAL_ERROR = -32603;
 
+// Server-defined broker auth error codes
+export const RPC_AUTH_REQUIRED = -32001;
+
 // ─── Message adapter (canonical types from adapters) ─────
 
 import type {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -106,6 +106,7 @@ import {
   type BrokerMaintenanceResult,
 } from "./broker/maintenance.js";
 import { BrokerClient, DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import { getDefaultMeshSecretPath } from "./broker/paths.js";
 import {
   dispatchBroadcastAgentMessage,
   dispatchDirectAgentMessage,
@@ -3329,7 +3330,10 @@ export default function (pi: ExtensionAPI) {
     }
 
     refreshSettings();
-    const client = new BrokerClient();
+    const client = new BrokerClient({
+      path: DEFAULT_SOCKET_PATH,
+      meshSecretPath: getDefaultMeshSecretPath(),
+    });
 
     async function registerFollowerRuntime(): Promise<void> {
       refreshSettings();


### PR DESCRIPTION
Closes #235

## Summary

Adds a shared-secret mechanism so only authorized agents can join the local Pinet broker mesh. Previously any process on the machine could connect to the broker WebSocket with no authentication.

## What changed

- **New module** `slack-bridge/broker/auth.ts` — helpers for generating, loading, and resolving a local mesh secret stored at `~/.pi/pinet.secret`
- **Broker side** (`socket-server.ts`) — connections must now call an `auth` JSON-RPC method with the correct secret before any other broker method is allowed; unauthenticated connections are rejected and destroyed after a configurable timeout
- **Client side** (`client.ts`) — `BrokerClient` accepts `meshSecret` or `meshSecretPath` options and sends an `auth` RPC automatically during `connect()` and on reconnect
- **Broker startup** (`index.ts`) — `startBroker()` creates/loads the secret on first start and enforces it for all socket connections
- **Follower runtime** (`index.ts`) — followers read `~/.pi/pinet.secret` automatically before joining the mesh
- **New error code** `RPC_AUTH_REQUIRED` (`-32001`) in `types.ts`
- **README** — brief note documenting the local mesh secret behavior

## Tests

- `broker/auth.test.ts` — secret creation, reuse, empty-file rejection, option priority
- `broker/client.test.ts` — client auth RPC flow, rejection on bad secret
- `broker/integration.test.ts` — end-to-end: correct secret accepted, missing auth rejected, wrong secret rejected
- `broker/helpers.test.ts` — `startBroker` creates secret file on startup

All 780 tests pass.