### PR TITLE
fix: drop stale targeted backlog after purge

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1198,10 +1198,9 @@ describe("BrokerDB", () => {
     expect(db.getThread("t-gone-maint")?.ownerAgent).toBeNull();
   });
 
-  it("maintenance drops stale targeted backlog once the preferred agent is purged", () => {
+  it("maintenance resets orphaned assigned targeted backlog to pending while the preferred agent is still resumable", () => {
     db.registerAgent("sender", "Sender", "📤", 1);
     db.registerAgent("receiver", "Receiver", "📥", 2);
-    db.registerAgent("idle-worker", "Idle Worker", "🫡", 3);
     db.createThread("a2a:sender:receiver", "agent", "", "sender");
     db.insertMessage(
       "a2a:sender:receiver",
@@ -1215,12 +1214,75 @@ describe("BrokerDB", () => {
         a2a: true,
       },
     );
-    db.unregisterAgent("receiver");
+    db.requeueUndeliveredMessages("receiver");
+
+    const backlog = db.getPendingBacklog()[0];
+    expect(backlog.preferredAgentId).toBe("receiver");
+    db.assignBacklogEntry(backlog.id, "receiver");
+    db.disconnectAgent("receiver", 60_000);
 
     const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
     sqlite
-      .prepare("UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?")
-      .run(new Date(Date.now() - 2 * 60 * 60_000).toISOString(), "receiver");
+      .prepare("DELETE FROM inbox WHERE message_id = ? AND agent_id = ?")
+      .run(backlog.messageId, "receiver");
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    const repairedBacklog = sqlite
+      .prepare(
+        "SELECT status, reason, preferred_agent_id, assigned_agent_id FROM unrouted_backlog WHERE id = ?",
+      )
+      .get(backlog.id) as
+      | {
+          status: string;
+          reason: string;
+          preferred_agent_id: string | null;
+          assigned_agent_id: string | null;
+        }
+      | undefined;
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(result.anomalies).toContain("reset 1 orphaned targeted backlog assignment to pending");
+    expect(db.getAgentById("receiver")).not.toBeNull();
+    expect(repairedBacklog).toEqual({
+      status: "pending",
+      reason: "agent_disconnected",
+      preferred_agent_id: "receiver",
+      assigned_agent_id: null,
+    });
+  });
+
+  it("maintenance drops stale targeted backlog once the preferred agent is purged", () => {
+    db.registerAgent("sender", "Sender", "📤", 1);
+    db.registerAgent("receiver", "Receiver", "📥", 2);
+    db.createThread("a2a:sender:receiver", "agent", "", "sender");
+    db.insertMessage(
+      "a2a:sender:receiver",
+      "agent",
+      "inbound",
+      "sender",
+      "please pick this up",
+      ["receiver"],
+      {
+        senderAgent: "Sender",
+        a2a: true,
+      },
+    );
+    db.requeueUndeliveredMessages("receiver");
+
+    const backlog = db.getPendingBacklog()[0];
+    expect(backlog.preferredAgentId).toBe("receiver");
+    db.assignBacklogEntry(backlog.id, "receiver");
+
+    const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
+    sqlite
+      .prepare("DELETE FROM inbox WHERE message_id = ? AND agent_id = ?")
+      .run(backlog.messageId, "receiver");
+    sqlite.prepare("DELETE FROM agents WHERE id = ?").run("receiver");
 
     const result = runBrokerMaintenancePass(db, {
       staleAfterMs: 15_000,
@@ -1229,10 +1291,15 @@ describe("BrokerDB", () => {
 
     const droppedBacklog = sqlite
       .prepare(
-        "SELECT status, reason, preferred_agent_id FROM unrouted_backlog WHERE thread_id = ?",
+        "SELECT status, reason, preferred_agent_id, assigned_agent_id FROM unrouted_backlog WHERE id = ?",
       )
-      .get("a2a:sender:receiver") as
-      | { status: string; reason: string; preferred_agent_id: string | null }
+      .get(backlog.id) as
+      | {
+          status: string;
+          reason: string;
+          preferred_agent_id: string | null;
+          assigned_agent_id: string | null;
+        }
       | undefined;
 
     expect(result.pendingBacklogCount).toBe(0);
@@ -1245,6 +1312,7 @@ describe("BrokerDB", () => {
       status: "dropped",
       reason: "preferred_agent_missing",
       preferred_agent_id: "receiver",
+      assigned_agent_id: null,
     });
   });
 

--- a/slack-bridge/broker/maintenance.test.ts
+++ b/slack-bridge/broker/maintenance.test.ts
@@ -19,6 +19,7 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
   repairedAgentIds: string[] = [];
   requeuedAgents: string[] = [];
   droppedBacklogIds: number[] = [];
+  healthyAssignedBacklogIds = new Set<number>();
   methodCalls: string[] = [];
 
   pruneStaleAgents(_staleAfterMs: number): string[] {
@@ -42,6 +43,37 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
   requeueUndeliveredMessages(agentId: string): number {
     this.requeuedAgents.push(agentId);
     return 0;
+  }
+
+  repairOrphanedAssignedBacklog(): { resetToPendingCount: number; droppedCount: number } {
+    this.methodCalls.push("repair-assigned");
+    let resetToPendingCount = 0;
+    let droppedCount = 0;
+
+    for (const entry of this.backlog) {
+      if (
+        entry.status !== "assigned" ||
+        !entry.preferredAgentId ||
+        this.healthyAssignedBacklogIds.has(entry.id)
+      ) {
+        continue;
+      }
+
+      if (this.getAgentById(entry.preferredAgentId)) {
+        entry.status = "pending";
+        entry.assignedAgentId = null;
+        resetToPendingCount += 1;
+        continue;
+      }
+
+      entry.status = "dropped";
+      entry.reason = "preferred_agent_missing";
+      entry.assignedAgentId = null;
+      this.droppedBacklogIds.push(entry.id);
+      droppedCount += 1;
+    }
+
+    return { resetToPendingCount, droppedCount };
   }
 
   getPendingBacklog(limit = 50): BacklogEntry[] {
@@ -304,6 +336,65 @@ describe("runBrokerMaintenancePass", () => {
     expect(result.anomalies).toContain("dropped 1 undeliverable targeted backlog entry");
   });
 
+  it("repairs orphaned targeted assignments back to pending while the preferred agent is still known", () => {
+    db.agents = [makeAgent({ id: "sender", name: "Sender" })];
+    db.knownAgents = [
+      makeAgent({
+        id: "receiver",
+        name: "Receiver",
+        disconnectedAt: "2026-04-01T00:00:05.000Z",
+        resumableUntil: "2026-04-01T00:01:00.000Z",
+      }),
+    ];
+    db.backlog = [
+      makeBacklog({
+        id: 1,
+        threadId: "a2a:sender:receiver",
+        status: "assigned",
+        preferredAgentId: "receiver",
+        assignedAgentId: "receiver",
+        reason: "agent_disconnected",
+      }),
+    ];
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(db.backlog[0].status).toBe("pending");
+    expect(db.backlog[0].assignedAgentId).toBeNull();
+    expect(result.anomalies).toContain("reset 1 orphaned targeted backlog assignment to pending");
+  });
+
+  it("drops orphaned targeted assignments once the preferred agent is gone", () => {
+    db.agents = [makeAgent({ id: "sender", name: "Sender" })];
+    db.backlog = [
+      makeBacklog({
+        id: 1,
+        threadId: "a2a:sender:receiver",
+        status: "assigned",
+        preferredAgentId: "receiver",
+        assignedAgentId: "receiver",
+        reason: "agent_disconnected",
+      }),
+    ];
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(0);
+    expect(db.backlog[0].status).toBe("dropped");
+    expect(db.backlog[0].reason).toBe("preferred_agent_missing");
+    expect(db.droppedBacklogIds).toEqual([1]);
+    expect(result.anomalies).toContain("dropped 1 undeliverable targeted backlog entry");
+  });
+
   it("leaves backlog pending and reports an anomaly when no workers are available", () => {
     db.backlog = [makeBacklog({ id: 1, threadId: "t-1" })];
 
@@ -336,7 +427,7 @@ describe("runBrokerMaintenancePass", () => {
       now: Date.parse("2026-04-01T00:00:10.000Z"),
     });
 
-    expect(db.methodCalls.slice(0, 3)).toEqual(["prune", "purge", "repair"]);
+    expect(db.methodCalls.slice(0, 4)).toEqual(["prune", "purge", "repair", "repair-assigned"]);
   });
 
   it("surfaces stale-agent and orphaned-thread repair activity", () => {

--- a/slack-bridge/broker/maintenance.ts
+++ b/slack-bridge/broker/maintenance.ts
@@ -9,10 +9,16 @@ export interface ThreadRepairResult {
   releasedAgentIds: string[];
 }
 
+export interface BacklogAssignmentRepairResult {
+  resetToPendingCount: number;
+  droppedCount: number;
+}
+
 export interface BrokerMaintenanceDB {
   pruneStaleAgents(staleAfterMs: number): string[];
   purgeDisconnectedAgents(graceMs?: number): string[];
   repairThreadOwnership(): ThreadRepairResult;
+  repairOrphanedAssignedBacklog(): BacklogAssignmentRepairResult;
   requeueUndeliveredMessages(agentId: string, reason?: string): number;
   getPendingBacklog(limit?: number): BacklogEntry[];
   getBacklogCount(status?: BacklogEntry["status"]): number;
@@ -82,6 +88,7 @@ export function runBrokerMaintenancePass(
   for (const agentId of repaired.releasedAgentIds) {
     db.requeueUndeliveredMessages(agentId, "agent_disconnected");
   }
+  const repairedAssignments = db.repairOrphanedAssignedBacklog();
   const repairedThreadClaims = repaired.releasedClaimCount;
   const brokerAgentId = options.brokerAgentId;
 
@@ -97,7 +104,8 @@ export function runBrokerMaintenancePass(
 
   const nudgedAgentIds = new Set<string>();
   let assignedBacklogCount = 0;
-  let droppedBacklogCount = 0;
+  const resetAssignedBacklogCount = repairedAssignments.resetToPendingCount;
+  let droppedBacklogCount = repairedAssignments.droppedCount;
 
   for (const backlog of db.getPendingBacklog(options.backlogLimit ?? 50)) {
     const preferredAgent = backlog.preferredAgentId
@@ -150,6 +158,11 @@ export function runBrokerMaintenancePass(
   if (repairedThreadClaims > 0) {
     anomalies.push(
       `released ${repairedThreadClaims} orphaned thread claim${repairedThreadClaims === 1 ? "" : "s"}`,
+    );
+  }
+  if (resetAssignedBacklogCount > 0) {
+    anomalies.push(
+      `reset ${resetAssignedBacklogCount} orphaned targeted backlog assignment${resetAssignedBacklogCount === 1 ? "" : "s"} to pending`,
     );
   }
   if (droppedBacklogCount > 0) {

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -1210,6 +1210,82 @@ export class BrokerDB implements BrokerDBInterface {
     return this.getBacklogById(id);
   }
 
+  repairOrphanedAssignedBacklog(): { resetToPendingCount: number; droppedCount: number } {
+    const db = this.getDb();
+
+    return this.withTransaction(() => {
+      const rows = db
+        .prepare(
+          `SELECT id, message_id, preferred_agent_id, assigned_agent_id
+           FROM unrouted_backlog
+           WHERE status = 'assigned'
+             AND preferred_agent_id IS NOT NULL
+             AND (
+               assigned_agent_id IS NULL
+               OR assigned_agent_id NOT IN (SELECT id FROM agents)
+               OR NOT EXISTS (
+                 SELECT 1
+                 FROM inbox
+                 WHERE inbox.message_id = unrouted_backlog.message_id
+                   AND inbox.agent_id = unrouted_backlog.assigned_agent_id
+               )
+             )`,
+        )
+        .all() as Array<{
+        id: number;
+        message_id: number;
+        preferred_agent_id: string;
+        assigned_agent_id: string | null;
+      }>;
+
+      if (rows.length === 0) {
+        return { resetToPendingCount: 0, droppedCount: 0 };
+      }
+
+      const now = new Date().toISOString();
+      const clearStaleInbox = db.prepare(
+        `DELETE FROM inbox
+         WHERE message_id = ?
+           AND agent_id = ?`,
+      );
+      const resetPending = db.prepare(
+        `UPDATE unrouted_backlog
+         SET status = 'pending',
+             assigned_agent_id = NULL,
+             updated_at = ?
+         WHERE id = ?
+           AND status = 'assigned'`,
+      );
+      const dropAssigned = db.prepare(
+        `UPDATE unrouted_backlog
+         SET status = 'dropped',
+             reason = 'preferred_agent_missing',
+             assigned_agent_id = NULL,
+             updated_at = ?
+         WHERE id = ?
+           AND status = 'assigned'`,
+      );
+
+      let resetToPendingCount = 0;
+      let droppedCount = 0;
+
+      for (const row of rows) {
+        if (row.assigned_agent_id) {
+          clearStaleInbox.run(row.message_id, row.assigned_agent_id);
+        }
+
+        if (this.getAgentRowById(row.preferred_agent_id)) {
+          resetToPendingCount += Number(resetPending.run(now, row.id).changes ?? 0);
+          continue;
+        }
+
+        droppedCount += Number(dropAssigned.run(now, row.id).changes ?? 0);
+      }
+
+      return { resetToPendingCount, droppedCount };
+    });
+  }
+
   requeueUndeliveredMessages(agentId: string, reason = "agent_disconnected"): number {
     return this.withTransaction(() => this.requeueUndeliveredMessagesInternal(agentId, reason));
   }


### PR DESCRIPTION
## Summary
- drop pending targeted backlog rows once their preferred agent has been purged and is no longer resolvable
- keep resumable targeted backlog pending while the preferred agent still exists in the broker registry
- add regression coverage for the maintenance sweep and BrokerDB purge path

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #271