### PR TITLE
fix: expire stale targeted broker backlog

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -4,7 +4,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import * as net from "node:net";
-import { BrokerDB, CURRENT_BROKER_SCHEMA_VERSION } from "./schema.js";
+import {
+  BrokerDB,
+  CURRENT_BROKER_SCHEMA_VERSION,
+  DEFAULT_DISCONNECTED_PURGE_GRACE_MS,
+} from "./schema.js";
 import { LeaderLock } from "./leader.js";
 import { startBroker, type Broker } from "./index.js";
 import { runBrokerMaintenancePass } from "./maintenance.js";
@@ -1077,6 +1081,22 @@ describe("BrokerDB", () => {
     expect(db.getThread("t-gone")?.ownerAgent).toBeNull();
     // Messages should be moved to backlog for reassignment
     expect(db.getPendingBacklog().map((entry) => entry.threadId)).toContain("t-gone");
+  });
+
+  it("purgeDisconnectedAgents uses the default grace window for stale ghosts", () => {
+    db.registerAgent("ghost", "Ghost", "⚫️", 3);
+    db.disconnectAgent("ghost", 0);
+
+    const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
+    sqlite
+      .prepare("UPDATE agents SET disconnected_at = ?, resumable_until = NULL WHERE id = ?")
+      .run(
+        new Date(Date.now() - DEFAULT_DISCONNECTED_PURGE_GRACE_MS - 1_000).toISOString(),
+        "ghost",
+      );
+
+    expect(db.purgeDisconnectedAgents()).toEqual(["ghost"]);
+    expect(db.getAgentById("ghost")).toBeNull();
   });
 
   it("queueUnroutedMessage persists pending backlog without assigning an owner", () => {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -469,6 +469,49 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("expires requeued a2a work once the intended recipient is purged", async () => {
+    await client.register("sender-agent", "📤", undefined, "host:session:/tmp/sender-expire");
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    const reg2 = await client2.register(
+      "receiver-agent",
+      "📥",
+      undefined,
+      "host:session:/tmp/receiver-expire",
+    );
+
+    await client.sendAgentMessage("receiver-agent", "Expire if receiver is gone");
+    await waitFor(() => db.getInbox(reg2.agentId).length === 1);
+
+    await client2.unregister();
+
+    let result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(db.getPendingBacklog()).toHaveLength(1);
+
+    expect(db.purgeDisconnectedAgents(0)).toEqual([reg2.agentId]);
+
+    result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:20.000Z"),
+    });
+
+    expect(result.pendingBacklogCount).toBe(0);
+    expect(result.anomalies).toContain("expired 1 stale targeted backlog item");
+    expect(db.getPendingBacklog()).toHaveLength(0);
+    expect(db.getBacklogCount("dropped")).toBe(1);
+    expect(await client.pollInbox()).toHaveLength(0);
+
+    client2.disconnect();
+  });
+
   it("agent.message returns error for unknown target", async () => {
     await client.register("lonely-agent", "😢");
     await expect(client.sendAgentMessage("ghost-agent", "Hello?")).rejects.toThrow(

--- a/slack-bridge/broker/maintenance.test.ts
+++ b/slack-bridge/broker/maintenance.test.ts
@@ -10,6 +10,7 @@ import {
 
 class StubMaintenanceDB implements BrokerMaintenanceDB {
   agents: AgentInfo[] = [];
+  knownAgents = new Map<string, AgentInfo>();
   backlog: BacklogEntry[] = [];
   threads = new Map<string, ThreadInfo>();
   pendingInboxCounts = new Map<string, number>();
@@ -54,6 +55,12 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
     return this.agents;
   }
 
+  getAgentById(agentId: string): AgentInfo | null {
+    return (
+      this.agents.find((agent) => agent.id === agentId) ?? this.knownAgents.get(agentId) ?? null
+    );
+  }
+
   getPendingInboxCount(agentId: string): number {
     return this.pendingInboxCounts.get(agentId) ?? 0;
   }
@@ -69,6 +76,15 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
     entry.assignedAgentId = agentId;
     entry.attemptCount += 1;
     this.pendingInboxCounts.set(agentId, (this.pendingInboxCounts.get(agentId) ?? 0) + 1);
+    return entry;
+  }
+
+  dropBacklogEntry(id: number, reason: string): BacklogEntry | null {
+    const entry = this.backlog.find((backlog) => backlog.id === id) ?? null;
+    if (!entry) return null;
+    entry.status = "dropped";
+    entry.reason = reason;
+    entry.assignedAgentId = null;
     return entry;
   }
 }
@@ -197,6 +213,7 @@ describe("runBrokerMaintenancePass", () => {
 
   it("holds targeted backlog until the intended agent is live", () => {
     db.agents = [makeAgent({ id: "sender", name: "Sender" })];
+    db.knownAgents.set("receiver", makeAgent({ id: "receiver", name: "Receiver" }));
     db.backlog = [
       makeBacklog({ id: 1, threadId: "a2a:sender:receiver", preferredAgentId: "receiver" }),
     ];
@@ -244,6 +261,24 @@ describe("runBrokerMaintenancePass", () => {
 
     expect(result.assignedBacklogCount).toBe(1);
     expect(db.backlog[0].assignedAgentId).toBe("receiver");
+  });
+
+  it("expires targeted backlog once the intended agent no longer exists", () => {
+    db.agents = [makeAgent({ id: "sender", name: "Sender" })];
+    db.backlog = [
+      makeBacklog({ id: 1, threadId: "a2a:sender:receiver", preferredAgentId: "receiver" }),
+    ];
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(0);
+    expect(db.backlog[0].status).toBe("dropped");
+    expect(db.backlog[0].reason).toBe("preferred_agent_missing");
+    expect(result.anomalies).toContain("expired 1 stale targeted backlog item");
   });
 
   it("leaves backlog pending and reports an anomaly when no workers are available", () => {

--- a/slack-bridge/broker/maintenance.ts
+++ b/slack-bridge/broker/maintenance.ts
@@ -17,9 +17,11 @@ export interface BrokerMaintenanceDB {
   getPendingBacklog(limit?: number): BacklogEntry[];
   getBacklogCount(status?: BacklogEntry["status"]): number;
   getAgents(): AgentInfo[];
+  getAgentById(agentId: string): AgentInfo | null;
   getPendingInboxCount(agentId: string): number;
   getThread(threadId: string): ThreadInfo | null;
   assignBacklogEntry(id: number, agentId: string): BacklogEntry | null;
+  dropBacklogEntry(id: number, reason: string): BacklogEntry | null;
 }
 
 export interface BrokerMaintenanceOptions {
@@ -95,12 +97,21 @@ export function runBrokerMaintenancePass(
 
   const nudgedAgentIds = new Set<string>();
   let assignedBacklogCount = 0;
+  let expiredTargetedBacklogCount = 0;
 
   for (const backlog of db.getPendingBacklog(options.backlogLimit ?? 50)) {
     const preferredAgent = backlog.preferredAgentId
       ? (agents.find((agent) => agent.id === backlog.preferredAgentId) ?? null)
       : null;
     if (backlog.preferredAgentId && !preferredAgent) {
+      if (db.getAgentById(backlog.preferredAgentId)) {
+        continue;
+      }
+
+      const dropped = db.dropBacklogEntry(backlog.id, "preferred_agent_missing");
+      if (dropped) {
+        expiredTargetedBacklogCount += 1;
+      }
       continue;
     }
 
@@ -140,6 +151,11 @@ export function runBrokerMaintenancePass(
   if (repairedThreadClaims > 0) {
     anomalies.push(
       `released ${repairedThreadClaims} orphaned thread claim${repairedThreadClaims === 1 ? "" : "s"}`,
+    );
+  }
+  if (expiredTargetedBacklogCount > 0) {
+    anomalies.push(
+      `expired ${expiredTargetedBacklogCount} stale targeted backlog item${expiredTargetedBacklogCount === 1 ? "" : "s"}`,
     );
   }
   if (pendingBacklogCount > 0 && agentLoads.length === 0) {

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -187,7 +187,7 @@ export function defaultDbPath(): string {
 }
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
-export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
+export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 15 * 60_000;
 export const CURRENT_BROKER_SCHEMA_VERSION = 10;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
@@ -1183,6 +1183,28 @@ export class BrokerDB implements BrokerDBInterface {
       ).run(agentId, now, now, id);
 
       this.updateThread(row.thread_id, { ownerAgent: agentId, channel: row.channel });
+
+      return this.getBacklogById(id);
+    });
+  }
+
+  dropBacklogEntry(id: number, reason: string): BacklogEntry | null {
+    const db = this.getDb();
+
+    return this.withTransaction(() => {
+      const row = db
+        .prepare("SELECT * FROM unrouted_backlog WHERE id = ? AND status = 'pending'")
+        .get(id) as BacklogRow | undefined;
+      if (!row) return null;
+
+      db.prepare(
+        `UPDATE unrouted_backlog
+         SET status = 'dropped',
+             reason = ?,
+             assigned_agent_id = NULL,
+             updated_at = ?
+         WHERE id = ?`,
+      ).run(reason, new Date().toISOString(), id);
 
       return this.getBacklogById(id);
     });


### PR DESCRIPTION
## Summary
- expire targeted a2a backlog once the intended recipient no longer exists in the broker DB
- tighten the disconnected-agent purge grace from 60m to 15m so stale ghost rows clear on a saner schedule
- add maintenance, DB, and integration coverage for the stale backlog / ghost cleanup path

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- broker/maintenance.test.ts broker/helpers.test.ts broker/integration.test.ts

Closes #271