### PR TITLE
fix: expire stale targeted broker backlog

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -22,6 +22,31 @@ function cleanup(dir: string): void {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
+function getBacklogRows(db: BrokerDB): Array<{
+  id: number;
+  thread_id: string;
+  status: string;
+  preferred_agent_id: string | null;
+  assigned_agent_id: string | null;
+  reason: string;
+}> {
+  const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
+  return sqlite
+    .prepare(
+      `SELECT id, thread_id, status, preferred_agent_id, assigned_agent_id, reason
+       FROM unrouted_backlog
+       ORDER BY id ASC`,
+    )
+    .all() as Array<{
+    id: number;
+    thread_id: string;
+    status: string;
+    preferred_agent_id: string | null;
+    assigned_agent_id: string | null;
+    reason: string;
+  }>;
+}
+
 /**
  * JSON-RPC client over TCP for testing.
  */
@@ -1196,6 +1221,136 @@ describe("BrokerDB", () => {
     expect(db.getInbox("gone")).toHaveLength(0);
     expect(db.getPendingBacklog().map((entry) => entry.threadId)).toContain("t-gone-maint");
     expect(db.getThread("t-gone-maint")?.ownerAgent).toBeNull();
+  });
+
+  it("maintenance drops irrecoverable targeted a2a backlog rows across one stale thread", () => {
+    db.registerAgent("sender", "Sender", "📤", 1);
+    db.registerAgent("target", "Target", "📥", 2);
+    db.registerAgent("idle-1", "Idle One", "🪨", 3);
+    db.registerAgent("idle-2", "Idle Two", "🪨", 4);
+    db.createThread("a2a:sender:target", "agent", "", "sender");
+
+    for (const body of ["first follow-up", "second follow-up", "third follow-up"]) {
+      db.insertMessage("a2a:sender:target", "agent", "inbound", "sender", body, ["target"], {
+        senderAgent: "Sender",
+        a2a: true,
+      });
+    }
+
+    db.unregisterAgent("target");
+    expect(db.getPendingBacklog()).toHaveLength(3);
+    expect(db.purgeDisconnectedAgents(0)).toContain("target");
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.pendingBacklogCount).toBe(0);
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(db.getPendingBacklog()).toHaveLength(0);
+    expect(db.getBacklogCount("dropped")).toBe(3);
+    expect(db.getInbox("idle-1")).toHaveLength(0);
+    expect(db.getInbox("idle-2")).toHaveLength(0);
+    expect(getBacklogRows(db).map((row) => row.status)).toEqual(["dropped", "dropped", "dropped"]);
+    expect(getBacklogRows(db).map((row) => row.reason)).toEqual([
+      "preferred_agent_missing",
+      "preferred_agent_missing",
+      "preferred_agent_missing",
+    ]);
+  });
+
+  it("maintenance repairs orphaned targeted backlog assignments while the intended recipient is still recoverable", () => {
+    db.registerAgent("sender", "Sender", "📤", 1);
+    db.registerAgent("target", "Target", "📥", 2);
+    db.createThread("a2a:sender:target", "agent", "", "sender");
+    db.insertMessage(
+      "a2a:sender:target",
+      "agent",
+      "inbound",
+      "sender",
+      "hold for target",
+      ["target"],
+      {
+        senderAgent: "Sender",
+        a2a: true,
+      },
+    );
+
+    expect(db.requeueUndeliveredMessages("target")).toBe(1);
+    const [backlog] = db.getPendingBacklog();
+    expect(db.assignBacklogEntry(backlog.id, "target")?.status).toBe("assigned");
+
+    const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
+    sqlite
+      .prepare("DELETE FROM inbox WHERE message_id = ? AND agent_id = ?")
+      .run(backlog.messageId, "target");
+    db.disconnectAgent("target", 60_000);
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.anomalies).toContain("repaired 1 orphaned targeted backlog assignment");
+    expect(db.getBacklogCount("dropped")).toBe(0);
+    expect(db.getPendingBacklog()).toHaveLength(1);
+    expect(db.getPendingBacklog()[0].id).toBe(backlog.id);
+    expect(getBacklogRows(db)[0]).toMatchObject({
+      id: backlog.id,
+      status: "pending",
+      preferred_agent_id: "target",
+      assigned_agent_id: null,
+      reason: "agent_disconnected",
+    });
+  });
+
+  it("maintenance drops orphaned targeted backlog assignments when the intended recipient is irrecoverably gone", () => {
+    db.registerAgent("sender", "Sender", "📤", 1);
+    db.registerAgent("target", "Target", "📥", 2);
+    db.createThread("a2a:sender:target", "agent", "", "sender");
+    db.insertMessage(
+      "a2a:sender:target",
+      "agent",
+      "inbound",
+      "sender",
+      "stuck forever",
+      ["target"],
+      {
+        senderAgent: "Sender",
+        a2a: true,
+      },
+    );
+
+    expect(db.requeueUndeliveredMessages("target")).toBe(1);
+    const [backlog] = db.getPendingBacklog();
+    expect(db.assignBacklogEntry(backlog.id, "target")?.status).toBe("assigned");
+
+    const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
+    sqlite
+      .prepare("DELETE FROM inbox WHERE message_id = ? AND agent_id = ?")
+      .run(backlog.messageId, "target");
+    sqlite.prepare("DELETE FROM agents WHERE id = ?").run("target");
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.pendingBacklogCount).toBe(0);
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.anomalies).toContain("dropped 1 irrecoverable targeted backlog row");
+    expect(db.getPendingBacklog()).toHaveLength(0);
+    expect(db.getBacklogCount("dropped")).toBe(1);
+    expect(getBacklogRows(db)[0]).toMatchObject({
+      id: backlog.id,
+      status: "dropped",
+      preferred_agent_id: "target",
+      assigned_agent_id: null,
+      reason: "preferred_agent_missing",
+    });
   });
 
   it("createThread and getThread", () => {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -469,6 +469,43 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("requeued a2a work drops after purge when the intended recipient is irrecoverably gone", async () => {
+    await client.register("sender-agent", "📤", undefined, "host:session:/tmp/sender-rebind");
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    const receiverStableId = "host:session:/tmp/receiver-rebind";
+    const reg2 = await client2.register("receiver-agent", "📥", undefined, receiverStableId);
+
+    const messageId = await client.sendAgentMessage("receiver-agent", "Still for the same worker");
+    expect(messageId).toBeGreaterThan(0);
+    await waitFor(() => db.getInbox(reg2.agentId).length === 1);
+
+    await client2.unregister();
+    expect(db.purgeDisconnectedAgents(0)).toContain(reg2.agentId);
+    expect(db.getPendingBacklog()).toHaveLength(1);
+
+    const reg3 = await client2.register("receiver-agent", "📥", undefined, receiverStableId);
+    expect(reg3.agentId).not.toBe(reg2.agentId);
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:20.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(0);
+    expect(result.anomalies).toContain("dropped 1 irrecoverable targeted backlog row");
+    expect(db.getPendingBacklog()).toHaveLength(0);
+    expect(db.getBacklogCount("dropped")).toBe(1);
+    expect(await client2.pollInbox()).toHaveLength(0);
+    expect(await client.pollInbox()).toHaveLength(0);
+
+    client2.disconnect();
+  });
+
   it("agent.message returns error for unknown target", async () => {
     await client.register("lonely-agent", "😢");
     await expect(client.sendAgentMessage("ghost-agent", "Hello?")).rejects.toThrow(

--- a/slack-bridge/broker/maintenance.test.ts
+++ b/slack-bridge/broker/maintenance.test.ts
@@ -17,6 +17,7 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
   repairedThreadClaims = 0;
   repairedAgentIds: string[] = [];
   requeuedAgents: string[] = [];
+  targetedBacklogRepair = { repairedAssignedCount: 0, droppedCount: 0 };
   methodCalls: string[] = [];
 
   pruneStaleAgents(_staleAfterMs: number): string[] {
@@ -40,6 +41,11 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
   requeueUndeliveredMessages(agentId: string): number {
     this.requeuedAgents.push(agentId);
     return 0;
+  }
+
+  repairTargetedBacklog(): { repairedAssignedCount: number; droppedCount: number } {
+    this.methodCalls.push("backlog");
+    return { ...this.targetedBacklogRepair };
   }
 
   getPendingBacklog(limit = 50): BacklogEntry[] {
@@ -278,7 +284,7 @@ describe("runBrokerMaintenancePass", () => {
       now: Date.parse("2026-04-01T00:00:10.000Z"),
     });
 
-    expect(db.methodCalls.slice(0, 3)).toEqual(["prune", "purge", "repair"]);
+    expect(db.methodCalls.slice(0, 4)).toEqual(["prune", "purge", "repair", "backlog"]);
   });
 
   it("surfaces stale-agent and orphaned-thread repair activity", () => {
@@ -293,6 +299,18 @@ describe("runBrokerMaintenancePass", () => {
 
     expect(result.anomalies).toContain("reaped 1 stale agent");
     expect(result.anomalies).toContain("released 2 orphaned thread claims");
+  });
+
+  it("surfaces targeted backlog repair activity", () => {
+    db.targetedBacklogRepair = { repairedAssignedCount: 1, droppedCount: 2 };
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.anomalies).toContain("repaired 1 orphaned targeted backlog assignment");
+    expect(result.anomalies).toContain("dropped 2 irrecoverable targeted backlog rows");
   });
 
   it("reports overloaded workers", () => {

--- a/slack-bridge/broker/maintenance.ts
+++ b/slack-bridge/broker/maintenance.ts
@@ -9,11 +9,17 @@ export interface ThreadRepairResult {
   releasedAgentIds: string[];
 }
 
+export interface TargetedBacklogRepairResult {
+  repairedAssignedCount: number;
+  droppedCount: number;
+}
+
 export interface BrokerMaintenanceDB {
   pruneStaleAgents(staleAfterMs: number): string[];
   purgeDisconnectedAgents(graceMs?: number): string[];
   repairThreadOwnership(): ThreadRepairResult;
   requeueUndeliveredMessages(agentId: string, reason?: string): number;
+  repairTargetedBacklog(): TargetedBacklogRepairResult;
   getPendingBacklog(limit?: number): BacklogEntry[];
   getBacklogCount(status?: BacklogEntry["status"]): number;
   getAgents(): AgentInfo[];
@@ -81,6 +87,7 @@ export function runBrokerMaintenancePass(
     db.requeueUndeliveredMessages(agentId, "agent_disconnected");
   }
   const repairedThreadClaims = repaired.releasedClaimCount;
+  const targetedBacklogRepair = db.repairTargetedBacklog();
   const brokerAgentId = options.brokerAgentId;
 
   const agents = db
@@ -140,6 +147,16 @@ export function runBrokerMaintenancePass(
   if (repairedThreadClaims > 0) {
     anomalies.push(
       `released ${repairedThreadClaims} orphaned thread claim${repairedThreadClaims === 1 ? "" : "s"}`,
+    );
+  }
+  if (targetedBacklogRepair.repairedAssignedCount > 0) {
+    anomalies.push(
+      `repaired ${targetedBacklogRepair.repairedAssignedCount} orphaned targeted backlog assignment${targetedBacklogRepair.repairedAssignedCount === 1 ? "" : "s"}`,
+    );
+  }
+  if (targetedBacklogRepair.droppedCount > 0) {
+    anomalies.push(
+      `dropped ${targetedBacklogRepair.droppedCount} irrecoverable targeted backlog row${targetedBacklogRepair.droppedCount === 1 ? "" : "s"}`,
     );
   }
   if (pendingBacklogCount > 0 && agentLoads.length === 0) {

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -1188,6 +1188,65 @@ export class BrokerDB implements BrokerDBInterface {
     });
   }
 
+  repairTargetedBacklog(): { repairedAssignedCount: number; droppedCount: number } {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+
+    return this.withTransaction(() => {
+      const repairedAssignedCount = Number(
+        db
+          .prepare(
+            `UPDATE unrouted_backlog
+             SET status = 'pending',
+                 assigned_agent_id = NULL,
+                 updated_at = ?
+             WHERE status = 'assigned'
+               AND preferred_agent_id IS NOT NULL
+               AND EXISTS (
+                 SELECT 1 FROM agents a WHERE a.id = unrouted_backlog.preferred_agent_id
+               )
+               AND NOT EXISTS (
+                 SELECT 1 FROM inbox i
+                 WHERE i.message_id = unrouted_backlog.message_id
+                   AND i.agent_id = unrouted_backlog.assigned_agent_id
+                   AND i.delivered = 0
+               )`,
+          )
+          .run(now).changes ?? 0,
+      );
+
+      const droppedCount = Number(
+        db
+          .prepare(
+            `UPDATE unrouted_backlog
+             SET status = 'dropped',
+                 assigned_agent_id = NULL,
+                 reason = 'preferred_agent_missing',
+                 updated_at = ?
+             WHERE preferred_agent_id IS NOT NULL
+               AND NOT EXISTS (
+                 SELECT 1 FROM agents a WHERE a.id = unrouted_backlog.preferred_agent_id
+               )
+               AND (
+                 status = 'pending'
+                 OR (
+                   status = 'assigned'
+                   AND NOT EXISTS (
+                     SELECT 1 FROM inbox i
+                     WHERE i.message_id = unrouted_backlog.message_id
+                       AND i.agent_id = unrouted_backlog.assigned_agent_id
+                       AND i.delivered = 0
+                   )
+                 )
+               )`,
+          )
+          .run(now).changes ?? 0,
+      );
+
+      return { repairedAssignedCount, droppedCount };
+    });
+  }
+
   requeueUndeliveredMessages(agentId: string, reason = "agent_disconnected"): number {
     return this.withTransaction(() => this.requeueUndeliveredMessagesInternal(agentId, reason));
   }


### PR DESCRIPTION
## Summary
- drop irrecoverable targeted A2A backlog once the intended recipient is gone
- preserve hold-and-drain semantics for targeted backlog while the intended recipient is still recoverable
- repair orphaned targeted assigned backlog rows with no inbox so they either return to pending or expire safely

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #271