### PR TITLE
chore: prep Pinet v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this repository are documented in this file.
 
+## [0.1.1] - 2026-04-08
+
+Pinet v0.1.1 is a targeted patch release for `@gugu910/pi-slack-bridge`. The release surface is intentionally minimal: the Slack bridge package bumps to `0.1.1`, the private monorepo package moves to `0.1.1` for repo-level version tracking, and the other workspace packages stay at their current versions.
+
+### Version verification
+
+- `pi-extensions` — `0.1.1` (private repo package)
+- `@gugu910/pi-slack-bridge` — `0.1.1`
+- `@gugu910/pi-nvim-bridge` — `0.1.0` (unchanged)
+- `@gugu910/pi-neon-psql` — `0.1.0` (unchanged)
+- `@gugu910/pi-slack-api` — `0.2.0` (unchanged)
+
+### Release highlights
+
+- Hardened Pinet coordination with local shared-secret mesh auth, structured control messages, reconnect refresh, and headless-subagent isolation.
+- Added the Pinet Home tab dashboard, an end-user README refresh, and broker routing fixes such as stable-ID thread binding.
+- Fixed targeted backlog recovery so stale targeted A2A backlog no longer remains stranded after purge and maintenance.
+- Included Slack bridge package surface updates that shipped in the same cut, including `slack_project_create` and channel canvas dedup.
+
+### Included pull requests
+
+- [#231](https://github.com/gugu91/extensions/pull/231) — feat: add Pinet Home tab dashboard
+- [#243](https://github.com/gugu91/extensions/pull/243) — fix: auto-refresh Pinet registration on reconnect
+- [#244](https://github.com/gugu91/extensions/pull/244) — fix: stop headless subagents from joining Pinet
+- [#250](https://github.com/gugu91/extensions/pull/250) — feat: structure Pinet control messages
+- [#257](https://github.com/gugu91/extensions/pull/257) — feat: add pinet mesh authentication with local shared secret
+- [#258](https://github.com/gugu91/extensions/pull/258) — feat: add slack_project_create tool
+- [#268](https://github.com/gugu91/extensions/pull/268) — fix: thread binding uses stable IDs first, fuzzy name as fallback
+- [#272](https://github.com/gugu91/extensions/pull/272) — fix: drop stale targeted backlog after purge
+
 ## [0.1.0] - 2026-04-02
 
 First public release prep for the Pi extensions monorepo. This cut rolls up 66 pull requests merged on 2026-04-02 and aligns with the publish-ready package metadata landed in [#222](https://github.com/gugu91/extensions/pull/222).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.18.1",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gugu910/pi-slack-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Slack assistant integration for pi (Pinet) — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- confirm the minimal Pinet v0.1.1 release surface as `@gugu910/pi-slack-bridge` plus repo-level release tracking in the root package/changelog
- bump `@gugu910/pi-slack-bridge` to `0.1.1` and move the private root package to `0.1.1` for repo-level version tracking
- add a focused `0.1.1` changelog entry covering the Slack bridge / Pinet changes included in this cut

## Scope chosen
- changed: `slack-bridge/package.json`
- changed: `package.json` (private monorepo version only)
- changed: `CHANGELOG.md`
- unchanged on purpose: other workspace package versions, Slack manifest, READMEs, and publish itself

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm --filter @gugu910/pi-slack-bridge build`
- `cd slack-bridge && npm pack --json --dry-run`
- `cd slack-bridge && npm publish --dry-run`
- repo `pnpm lint && pnpm typecheck && pnpm test` via pre-push

## Dry-run results
- tarball: `gugu910-pi-slack-bridge-0.1.1.tgz`
- package: `@gugu910/pi-slack-bridge@0.1.1`
- package size: `134.0 kB`
- unpacked size: `636.4 kB`
- files: `41`
- publish dry-run targeted npm public access without errors

Closes #285