### PR TITLE
fix: make Pinet mesh secret config-driven and optional

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -79,6 +79,16 @@ export SLACK_APP_TOKEN="xapp-..."
 
 Settings in `settings.json` take priority over env vars.
 
+Optional Pinet mesh auth can also be configured via environment variables:
+
+```bash
+export PINET_MESH_SECRET="shared-secret"
+# or
+export PINET_MESH_SECRET_PATH="$HOME/.config/pi/pinet.secret"
+```
+
+If `meshSecret` and `meshSecretPath` are both unset, broker/follower mesh auth is disabled.
+
 ### Full settings reference
 
 ```json
@@ -91,6 +101,7 @@ Settings in `settings.json` take priority over env vars.
     "logChannel": "#pinet-logs",
     "logLevel": "actions",
     "autoFollow": true,
+    "meshSecretPath": "/Users/alice/.config/pi/pinet.secret",
     "suggestedPrompts": [{ "title": "Status", "message": "What are you working on?" }],
     "security": {
       "readOnly": false,
@@ -101,19 +112,21 @@ Settings in `settings.json` take priority over env vars.
 }
 ```
 
-| Key                            | Required | Description                                           |
-| ------------------------------ | -------- | ----------------------------------------------------- |
-| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                     |
-| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)          |
-| `allowedUsers`                 | no       | Slack user IDs that can interact (all users if unset) |
-| `defaultChannel`               | no       | Default channel for `slack_post_channel`              |
-| `logChannel`                   | no       | Channel for broker activity logs                      |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`     |
-| `autoFollow`                   | no       | Auto-connect as follower when broker is running       |
-| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation    |
-| `security.readOnly`            | no       | Block all write tools                                 |
-| `security.requireConfirmation` | no       | Tools that need user approval before executing        |
-| `security.blockedTools`        | no       | Tools that are completely disabled                    |
+| Key                            | Required | Description                                                                            |
+| ------------------------------ | -------- | -------------------------------------------------------------------------------------- |
+| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                      |
+| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                           |
+| `allowedUsers`                 | no       | Slack user IDs that can interact (all users if unset)                                  |
+| `defaultChannel`               | no       | Default channel for `slack_post_channel`                                               |
+| `logChannel`                   | no       | Channel for broker activity logs                                                       |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                      |
+| `autoFollow`                   | no       | Auto-connect as follower when broker is running                                        |
+| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath`                        |
+| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers read it |
+| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                     |
+| `security.readOnly`            | no       | Block all write tools                                                                  |
+| `security.requireConfirmation` | no       | Tools that need user approval before executing                                         |
+| `security.blockedTools`        | no       | Tools that are completely disabled                                                     |
 
 ## Usage
 
@@ -211,14 +224,14 @@ Or set `"autoFollow": true` in settings to auto-connect when a broker is running
 
 - The **broker** runs Slack Socket Mode, routes messages to agents, monitors health via the RALPH loop, and maintains a control plane canvas
 - **Followers** connect to the broker over a local Unix socket, poll for work, and report results
-- Agents authenticate using a shared local secret (`~/.pi/pinet.secret`, created automatically)
+- Agents can optionally authenticate using a shared local secret (`meshSecret` or `meshSecretPath`)
 - Thread ownership is first-responder-wins — the first agent to reply claims the thread
 
 ## Security
 
 - **User allowlist**: Set `allowedUsers` to restrict who can interact with Pinet
 - **Tool guardrails**: Use `security.requireConfirmation` and `security.blockedTools` to control tool access
-- **Mesh authentication**: Broker/follower connections use a local shared secret file
+- **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` to require a shared secret; leave both unset to disable shared-secret auth
 
 Find Slack user IDs: click a user's profile → **More** → **Copy member ID**.
 

--- a/slack-bridge/broker/auth.test.ts
+++ b/slack-bridge/broker/auth.test.ts
@@ -35,6 +35,11 @@ describe("broker mesh auth helpers", () => {
     );
   });
 
+  it("resolveMeshSecret returns null when mesh auth is unset", () => {
+    expect(resolveMeshSecret()).toBeNull();
+    expect(resolveMeshSecret({ meshSecretPath: "   " })).toBeNull();
+  });
+
   it("resolveMeshSecret reads from a secret file when no explicit secret is provided", () => {
     const secretPath = path.join(dir, "pinet.secret");
     fs.writeFileSync(secretPath, "from-file\n", "utf-8");

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -206,6 +206,17 @@ describe("BrokerClient — mesh auth", () => {
     await expect(connectPromise).rejects.toThrow("Invalid mesh secret.");
     expect(client.isConnected()).toBe(false);
   });
+
+  it("surfaces a friendly error when a configured mesh secret file is missing", async () => {
+    const client = new BrokerClient({
+      ...mock.connectOpts,
+      meshSecretPath: path.join(os.tmpdir(), `missing-${Date.now()}-pinet.secret`),
+    });
+
+    await expect(client.connect()).rejects.toThrow("Configured Pinet mesh secret file not found");
+    expect(client.isConnected()).toBe(false);
+    expect(mock.received).toHaveLength(0);
+  });
 });
 
 describe("BrokerClient — register", () => {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -106,6 +106,14 @@ interface RegistrationResult {
   metadata?: Record<string, unknown> | null;
 }
 
+function getErrorCode(err: unknown): string | null {
+  if (typeof err !== "object" || err == null || !("code" in err)) {
+    return null;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
+
 export interface AgentBroadcastResult {
   channel: string;
   messageIds: number[];
@@ -222,7 +230,16 @@ export class BrokerClient {
       return this.meshSecret;
     }
     if (this.meshSecretPath) {
-      return readMeshSecret(this.meshSecretPath);
+      try {
+        return readMeshSecret(this.meshSecretPath);
+      } catch (err) {
+        if (getErrorCode(err) === "ENOENT") {
+          throw new Error(
+            `Configured Pinet mesh secret file not found: ${this.meshSecretPath}. Set slack-bridge.meshSecretPath to an existing file, provide slack-bridge.meshSecret directly, or leave both unset to disable shared-secret auth.`,
+          );
+        }
+        throw err;
+      }
     }
     return null;
   }

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1944,7 +1944,7 @@ describe("startBroker leader lock", () => {
       dbPath: path.join(dir, `${overrides.dbSuffix ?? "test"}.db`),
       listenTarget: TCP_TARGET,
       lockPath: overrides.lockPath ?? path.join(dir, "broker.lock"),
-      meshSecretPath: overrides.meshSecretPath ?? path.join(dir, "pinet.secret"),
+      ...(overrides.meshSecretPath ? { meshSecretPath: overrides.meshSecretPath } : {}),
     });
     brokers.push(b);
     return b;
@@ -1999,7 +1999,15 @@ describe("startBroker leader lock", () => {
     expect(broker.lock.isLeader()).toBe(true);
   });
 
-  it("creates and persists a mesh secret on startup", async () => {
+  it("starts without creating a mesh secret when none is configured", async () => {
+    const meshSecretPath = path.join(dir, "pinet.secret");
+
+    await launch();
+
+    expect(fs.existsSync(meshSecretPath)).toBe(false);
+  });
+
+  it("creates and persists a mesh secret on startup when a secret path is configured", async () => {
     const meshSecretPath = path.join(dir, "pinet.secret");
 
     await launch({ meshSecretPath });

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -4,7 +4,7 @@ import { loadOrCreateMeshSecret } from "./auth.js";
 import { BrokerSocketServer } from "./socket-server.js";
 import type { ListenTarget } from "./socket-server.js";
 import { LeaderLock } from "./leader.js";
-import { getDefaultMeshSecretPath, getDefaultSocketPath } from "./paths.js";
+import { getDefaultSocketPath } from "./paths.js";
 import type { MessageAdapter } from "./types.js";
 
 export { BrokerDB } from "./schema.js";
@@ -89,10 +89,14 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
     }
   }
 
-  const meshSecretPath = options.meshSecretPath ?? getDefaultMeshSecretPath();
-  const meshSecret = options.meshSecret?.trim() || loadOrCreateMeshSecret(meshSecretPath);
+  const meshSecret = options.meshSecret?.trim() || null;
+  const meshSecretPath = options.meshSecretPath?.trim() || null;
+  const resolvedMeshSecret =
+    meshSecret || (meshSecretPath ? loadOrCreateMeshSecret(meshSecretPath) : null);
 
-  const server = new BrokerSocketServer(db, target, undefined, { meshSecret });
+  const server = new BrokerSocketServer(db, target, undefined, {
+    ...(resolvedMeshSecret ? { meshSecret: resolvedMeshSecret } : {}),
+  });
   try {
     await server.start();
   } catch (err) {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import {
   loadSettings,
+  resolvePinetMeshAuth,
   buildAllowlist,
   isUserAllowed,
   formatInboxMessages,
@@ -214,6 +215,22 @@ describe("loadSettings", () => {
     expect(result.logLevel).toBe("errors");
   });
 
+  it("returns mesh auth settings", () => {
+    const p = path.join(tmpDir, "settings.json");
+    fs.writeFileSync(
+      p,
+      JSON.stringify({
+        "slack-bridge": {
+          meshSecret: "shared-secret",
+          meshSecretPath: "/tmp/pinet.secret",
+        },
+      }),
+    );
+    const result = loadSettings(p);
+    expect(result.meshSecret).toBe("shared-secret");
+    expect(result.meshSecretPath).toBe("/tmp/pinet.secret");
+  });
+
   it("returns control plane canvas settings", () => {
     const p = path.join(tmpDir, "settings.json");
     const settings = {
@@ -230,6 +247,62 @@ describe("loadSettings", () => {
     expect(result.controlPlaneCanvasId).toBe("F123");
     expect(result.controlPlaneCanvasChannel).toBe("ops-control");
     expect(result.controlPlaneCanvasTitle).toBe("Mesh Status");
+  });
+});
+
+describe("resolvePinetMeshAuth", () => {
+  it("returns nulls when no mesh auth is configured", () => {
+    expect(resolvePinetMeshAuth({}, {})).toEqual({
+      meshSecret: null,
+      meshSecretPath: null,
+    });
+  });
+
+  it("prefers settings over environment fallbacks", () => {
+    expect(
+      resolvePinetMeshAuth(
+        { meshSecret: " from-settings ", meshSecretPath: "/settings/secret" },
+        {
+          ...process.env,
+          PINET_MESH_SECRET: "from-env",
+          PINET_MESH_SECRET_PATH: "/env/secret",
+        },
+      ),
+    ).toEqual({
+      meshSecret: "from-settings",
+      meshSecretPath: null,
+    });
+  });
+
+  it("falls back to environment when settings are unset", () => {
+    expect(
+      resolvePinetMeshAuth(
+        {},
+        {
+          ...process.env,
+          PINET_MESH_SECRET_PATH: " /env/secret ",
+        },
+      ),
+    ).toEqual({
+      meshSecret: null,
+      meshSecretPath: "/env/secret",
+    });
+  });
+
+  it("keeps settings meshSecretPath ahead of environment mesh auth", () => {
+    expect(
+      resolvePinetMeshAuth(
+        { meshSecretPath: "/settings/secret" },
+        {
+          ...process.env,
+          PINET_MESH_SECRET: " env-secret ",
+          PINET_MESH_SECRET_PATH: "/env/secret",
+        },
+      ),
+    ).toEqual({
+      meshSecret: null,
+      meshSecretPath: "/settings/secret",
+    });
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -21,6 +21,8 @@ export interface SlackBridgeSettings {
   autoFollow?: boolean;
   agentName?: string;
   agentEmoji?: string;
+  meshSecret?: string;
+  meshSecretPath?: string;
   controlPlaneCanvasEnabled?: boolean;
   controlPlaneCanvasId?: string;
   controlPlaneCanvasChannel?: string;
@@ -29,6 +31,38 @@ export interface SlackBridgeSettings {
     readOnly?: boolean;
     requireConfirmation?: string[];
     blockedTools?: string[];
+  };
+}
+
+export interface ResolvedPinetMeshAuthSettings {
+  meshSecret: string | null;
+  meshSecretPath: string | null;
+}
+
+function normalizeOptionalSetting(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function resolvePinetMeshAuth(
+  settings: SlackBridgeSettings,
+  env = process.env,
+): ResolvedPinetMeshAuthSettings {
+  const settingsMeshSecret = normalizeOptionalSetting(settings.meshSecret);
+  const settingsMeshSecretPath = normalizeOptionalSetting(settings.meshSecretPath);
+  if (settingsMeshSecret || settingsMeshSecretPath) {
+    return {
+      meshSecret: settingsMeshSecret,
+      meshSecretPath: settingsMeshSecret ? null : settingsMeshSecretPath,
+    };
+  }
+
+  const envMeshSecret = normalizeOptionalSetting(env.PINET_MESH_SECRET);
+  const envMeshSecretPath = normalizeOptionalSetting(env.PINET_MESH_SECRET_PATH);
+
+  return {
+    meshSecret: envMeshSecret,
+    meshSecretPath: envMeshSecret ? null : envMeshSecretPath,
   };
 }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -54,6 +54,7 @@ import {
   normalizePinetSkinTheme,
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
+  resolvePinetMeshAuth,
   syncFollowerInboxEntries,
   resolveFollowerThreadChannel,
   getFollowerReconnectUiUpdate,
@@ -95,7 +96,6 @@ import {
   type BrokerMaintenanceResult,
 } from "./broker/maintenance.js";
 import { BrokerClient, DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
-import { getDefaultMeshSecretPath } from "./broker/paths.js";
 import {
   dispatchBroadcastAgentMessage,
   dispatchDirectAgentMessage,
@@ -2808,7 +2808,11 @@ export default function (pi: ExtensionAPI) {
 
   async function connectAsBroker(ctx: ExtensionContext): Promise<void> {
     refreshSettings();
-    const broker = await startBroker();
+    const meshAuth = resolvePinetMeshAuth(settings);
+    const broker = await startBroker({
+      ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
+      ...(meshAuth.meshSecretPath ? { meshSecretPath: meshAuth.meshSecretPath } : {}),
+    });
     const adapter = new SlackAdapter({
       botToken: botToken!,
       appToken: appToken!,
@@ -3048,9 +3052,11 @@ export default function (pi: ExtensionAPI) {
     }
 
     refreshSettings();
+    const meshAuth = resolvePinetMeshAuth(settings);
     const client = new BrokerClient({
       path: DEFAULT_SOCKET_PATH,
-      meshSecretPath: getDefaultMeshSecretPath(),
+      ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
+      ...(meshAuth.meshSecretPath ? { meshSecretPath: meshAuth.meshSecretPath } : {}),
     });
 
     async function registerFollowerRuntime(): Promise<void> {


### PR DESCRIPTION
## Summary
- make Pinet mesh auth config-driven via `meshSecret` / `meshSecretPath` settings (with env fallbacks)
- stop hard-wiring follower auth to `~/.pi/pinet.secret` so follow works when mesh auth is intentionally unset
- keep configured secret-file auth working, with a clearer error when a configured follower secret file is missing
- document the new optional auth semantics and cover them with tests

Closes #286

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts broker/auth.test.ts broker/client.test.ts broker/helpers.test.ts index.test.ts
- pnpm prepush