### PR TITLE
feat: add slack canvas read tool

### DIFF
--- a/slack-bridge/canvases.test.ts
+++ b/slack-bridge/canvases.test.ts
@@ -6,6 +6,7 @@ import {
   buildSlackCanvasSectionsLookupRequest,
   extractSlackCanvasMarkdown,
   extractSlackChannelCanvasId,
+  getSlackCanvasReadability,
   normalizeSlackCanvasCreateKind,
   normalizeSlackCanvasSectionType,
   normalizeSlackCanvasUpdateMode,
@@ -230,8 +231,27 @@ describe("extractSlackCanvasMarkdown", () => {
     ).toBe("# Header\n\nBody text");
   });
 
+  it("supports nested document_content markdown payloads", () => {
+    expect(
+      extractSlackCanvasMarkdown([
+        { id: "s1", document_content: { type: "markdown", markdown: "# Header" } },
+        { id: "s2", documentContent: { type: "markdown", markdown: "Body text" } },
+      ]),
+    ).toBe("# Header\n\nBody text");
+  });
+
   it("returns an empty string when sections have no markdown", () => {
     expect(extractSlackCanvasMarkdown([{ id: "s1" }, { id: "s2", markdown: "   " }])).toBe("");
+  });
+});
+
+describe("getSlackCanvasReadability", () => {
+  it("reports section counts and readable markdown counts", () => {
+    expect(getSlackCanvasReadability([{ id: "s1", markdown: "# Header" }, { id: "s2" }])).toEqual({
+      sectionCount: 2,
+      readableSectionCount: 1,
+      markdown: "# Header",
+    });
   });
 });
 
@@ -282,7 +302,7 @@ describe("extractSlackChannelCanvasId", () => {
     ).toBe("F234");
   });
 
-  it("returns null when only undocumented tab metadata is present", () => {
+  it("falls back to a channel_canvas tab id when direct canvas metadata is absent", () => {
     expect(
       extractSlackChannelCanvasId({
         channel: {
@@ -291,7 +311,19 @@ describe("extractSlackChannelCanvasId", () => {
           },
         },
       }),
-    ).toBeNull();
+    ).toBe("F345");
+  });
+
+  it("supports tab file_id fallbacks when the tab id is absent", () => {
+    expect(
+      extractSlackChannelCanvasId({
+        channel: {
+          properties: {
+            tabs: [{ file_id: "F456", type: "channel_canvas" }],
+          },
+        },
+      }),
+    ).toBe("F456");
   });
 
   it("returns null when the channel has no canvas metadata", () => {

--- a/slack-bridge/canvases.ts
+++ b/slack-bridge/canvases.ts
@@ -52,6 +52,8 @@ export interface SlackCanvasReadRequest {
 export interface SlackCanvasSectionLookupResult {
   id?: string;
   markdown?: string;
+  document_content?: SlackCanvasDocumentContent;
+  documentContent?: { type?: string; markdown?: string };
 }
 
 function normalizeOptionalString(value?: string): string | undefined {
@@ -209,16 +211,40 @@ export function buildSlackCanvasReadRequest(input: { canvasId: string }): SlackC
   return { canvas_id: canvasId };
 }
 
+function extractSlackCanvasSectionMarkdown(section: SlackCanvasSectionLookupResult): string | null {
+  return (
+    normalizeOptionalString(section.markdown) ??
+    normalizeOptionalString(section.document_content?.markdown) ??
+    normalizeOptionalString(section.documentContent?.markdown) ??
+    null
+  );
+}
+
 export function extractSlackCanvasMarkdown(
   sections: SlackCanvasSectionLookupResult[] | undefined,
 ): string {
-  const markdown = (sections ?? [])
-    .map((section) => normalizeOptionalString(section.markdown))
-    .filter((value): value is string => Boolean(value))
+  return (sections ?? [])
+    .map(extractSlackCanvasSectionMarkdown)
+    .filter((value): value is string => value != null)
     .join("\n\n")
     .trim();
+}
 
-  return markdown;
+export function getSlackCanvasReadability(sections: SlackCanvasSectionLookupResult[] | undefined): {
+  sectionCount: number;
+  readableSectionCount: number;
+  markdown: string;
+} {
+  const normalizedSections = sections ?? [];
+  const readableSectionCount = normalizedSections.filter(
+    (section) => extractSlackCanvasSectionMarkdown(section) != null,
+  ).length;
+
+  return {
+    sectionCount: normalizedSections.length,
+    readableSectionCount,
+    markdown: extractSlackCanvasMarkdown(normalizedSections),
+  };
 }
 
 export function pickSlackCanvasSectionId(
@@ -264,12 +290,34 @@ export function extractSlackChannelCanvasId(response: Record<string, unknown>): 
   if (directCanvas) return directCanvas;
 
   const canvasRecord = asRecord(properties.canvas);
-  const canvasId = asString(canvasRecord?.id) ?? asString(canvasRecord?.canvas_id);
+  const canvasId =
+    asString(canvasRecord?.id) ??
+    asString(canvasRecord?.canvas_id) ??
+    asString(canvasRecord?.file_id);
   if (canvasId) return canvasId;
 
   const channelSolutions = asRecord(properties.channel_solutions);
   const canvasIds = asStringArray(channelSolutions?.canvas_ids);
   if (canvasIds?.[0]) return canvasIds[0];
+
+  const tabs = Array.isArray(properties.tabs)
+    ? (properties.tabs as Array<Record<string, unknown>>)
+    : undefined;
+  const tabCanvasIds = [
+    ...new Set(
+      (tabs ?? [])
+        .filter((tab) => asString(tab.type) === "channel_canvas")
+        .map(
+          (tab) =>
+            asString(tab.canvas_id) ??
+            asString(tab.file_id) ??
+            asString(asRecord(tab.canvas)?.id) ??
+            asString(tab.id),
+        )
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  if (tabCanvasIds.length === 1) return tabCanvasIds[0];
 
   return null;
 }

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -930,6 +930,7 @@ describe("registerSlackTools", () => {
       channel: undefined,
       markdown: "# Results\n\n- Test A ✅\n- Test B ✅",
       section_count: 2,
+      readable_section_count: 2,
       sections: [
         { id: "temp:C:1", markdown: "# Results" },
         { id: "temp:C:2", markdown: "- Test A ✅\n- Test B ✅" },
@@ -967,7 +968,51 @@ describe("registerSlackTools", () => {
       channel: "resolved:eng",
       markdown: "Channel notes",
       section_count: 1,
+      readable_section_count: 1,
     });
+  });
+
+  it("falls back to channel canvas tabs when direct canvas properties are absent", async () => {
+    const { tools, setCanvasSectionsLookupResponse, setConversationsInfoResponse } = setup();
+    setConversationsInfoResponse({
+      ok: true,
+      channel: {
+        id: "resolved:eng",
+        properties: { tabs: [{ id: "FTAB", type: "channel_canvas" }] },
+      },
+    } as SlackResult);
+    setCanvasSectionsLookupResponse({
+      ok: true,
+      sections: [{ id: "temp:C:1", markdown: "Tabbed notes" }],
+    } as SlackResult);
+
+    const result = await tools.get("slack_canvas_read")!.execute("tool-canvas-read-3", {
+      channel: "eng",
+    });
+
+    expect(result.details).toMatchObject({
+      canvas_id: "FTAB",
+      channel: "resolved:eng",
+      markdown: "Tabbed notes",
+      section_count: 1,
+      readable_section_count: 1,
+    });
+  });
+
+  it("fails explicitly when Slack does not return readable markdown sections", async () => {
+    const { tools, setCanvasSectionsLookupResponse } = setup();
+    setCanvasSectionsLookupResponse({
+      ok: true,
+      sections: [{ id: "temp:C:1" }],
+    } as SlackResult);
+
+    await expect(
+      tools.get("slack_canvas_read")!.execute("tool-canvas-read-4", {
+        canvas_id: "F123",
+      }),
+    ).rejects.toThrow(
+      "Slack did not return readable markdown for canvas F123. This may mean the canvas is empty or that this workspace/API response does not expose canvas content through canvases.sections.lookup yet.",
+    );
   });
 
   // ─── slack_project_create ─────────────────────────────

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -8,8 +8,8 @@ import {
   buildSlackCanvasEditRequest,
   buildSlackCanvasReadRequest,
   buildSlackCanvasSectionsLookupRequest,
-  extractSlackCanvasMarkdown,
   extractSlackChannelCanvasId,
+  getSlackCanvasReadability,
   normalizeSlackCanvasCreateKind,
   normalizeSlackCanvasUpdateMode,
   pickSlackCanvasSectionId,
@@ -2268,9 +2268,20 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         getBotToken(),
         request as unknown as Record<string, unknown>,
       );
-      const sections = response.sections as Array<{ id?: string; markdown?: string }> | undefined;
-      const markdown = extractSlackCanvasMarkdown(sections);
-      const sectionCount = sections?.length ?? 0;
+      const sections = response.sections as
+        | Array<{
+            id?: string;
+            markdown?: string;
+            document_content?: { type: "markdown"; markdown: string };
+            documentContent?: { type?: string; markdown?: string };
+          }>
+        | undefined;
+      const { markdown, sectionCount, readableSectionCount } = getSlackCanvasReadability(sections);
+      if (sectionCount === 0 || readableSectionCount === 0) {
+        throw new Error(
+          `Slack did not return readable markdown for canvas ${target.canvasId}. This may mean the canvas is empty or that this workspace/API response does not expose canvas content through canvases.sections.lookup yet.`,
+        );
+      }
       const targetSummary = target.channelLabel
         ? `Read channel canvas ${target.canvasId} for ${target.channelLabel}.`
         : `Read canvas ${target.canvasId}.`;
@@ -2279,7 +2290,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         content: [
           {
             type: "text",
-            text: `${targetSummary}\n\n${markdown || "(empty canvas)"}`,
+            text: `${targetSummary}\n\n${markdown}`,
           },
         ],
         details: {
@@ -2287,6 +2298,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           channel: target.channelId,
           markdown,
           section_count: sectionCount,
+          readable_section_count: readableSectionCount,
           sections,
         },
       };


### PR DESCRIPTION
## Summary
- add `slack_canvas_read` so agents can read canvas content by `canvas_id` or by resolving a channel canvas
- add canvas read helpers for building the request and extracting markdown from returned sections
- add regression coverage for the new helper and tool behavior

## Notes
- this uses `canvases.sections.lookup` to retrieve section payloads and joins section markdown into a single markdown result for agents

## Testing
- pnpm test -- canvases.test slack-tools.test
- pnpm typecheck
- pnpm lint