### PR TITLE
fix: clarify Pinet auth method mismatch

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -13,6 +13,7 @@ import {
   computeReconnectDelay,
 } from "./client.js";
 import type { BrokerConnectOpts } from "./client.js";
+import { RPC_METHOD_NOT_FOUND } from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -216,6 +217,27 @@ describe("BrokerClient — mesh auth", () => {
     await expect(client.connect()).rejects.toThrow("Configured Pinet mesh secret file not found");
     expect(client.isConnected()).toBe(false);
     expect(mock.received).toHaveLength(0);
+  });
+
+  it("surfaces a compatibility error when the broker does not support auth", async () => {
+    const client = new BrokerClient({ ...mock.connectOpts, meshSecret: "shared-secret" });
+    const connectPromise = client.connect();
+
+    await waitFor(() => mock.received.length === 1);
+    const authReq = JSON.parse(mock.received[0]) as { id: number; method: string };
+
+    expect(authReq.method).toBe("auth");
+    mock.respondError(
+      mock.connections[0],
+      authReq.id,
+      RPC_METHOD_NOT_FOUND,
+      "Unknown method: auth",
+    );
+
+    await expect(connectPromise).rejects.toThrow(
+      "Broker does not support Pinet mesh auth (`auth`). Upgrade the broker or disable follower mesh auth when connecting to older/no-auth brokers.",
+    );
+    expect(client.isConnected()).toBe(false);
   });
 });
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -1,6 +1,7 @@
 import * as net from "node:net";
 import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
+import { RPC_METHOD_NOT_FOUND } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -87,9 +88,47 @@ export function computeReconnectDelay(attempt: number, random = Math.random()): 
 // ─── Pending request tracker ─────────────────────────────
 
 interface PendingRequest {
+  method: string;
   resolve: (value: unknown) => void;
   reject: (reason: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+}
+
+interface BrokerRpcRequestError extends Error {
+  code?: number;
+  data?: unknown;
+  method?: string;
+}
+
+function createRpcRequestError(
+  method: string,
+  error: { code: number; message: string; data?: unknown },
+): BrokerRpcRequestError {
+  const err = new Error(error.message) as BrokerRpcRequestError;
+  err.name = "BrokerRpcRequestError";
+  err.code = error.code;
+  err.data = error.data;
+  err.method = method;
+  return err;
+}
+
+function isRpcMethodNotFoundError(err: unknown, method: string): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  const rpcErr = err as BrokerRpcRequestError;
+  if (rpcErr.method !== method) {
+    return false;
+  }
+
+  return rpcErr.code === RPC_METHOD_NOT_FOUND || err.message === `Unknown method: ${method}`;
+}
+
+function getMeshAuthCompatibilityError(): Error {
+  return new Error(
+    "Broker does not support Pinet mesh auth (`auth`). Upgrade the broker or disable follower mesh auth when connecting to older/no-auth brokers.",
+  );
 }
 
 interface RegistrationSnapshot {
@@ -249,7 +288,15 @@ export class BrokerClient {
     if (!meshSecret) {
       return;
     }
-    await this.request("auth", { secret: meshSecret });
+
+    try {
+      await this.request("auth", { secret: meshSecret });
+    } catch (err) {
+      if (isRpcMethodNotFoundError(err, "auth")) {
+        throw getMeshAuthCompatibilityError();
+      }
+      throw err;
+    }
   }
 
   // ─── Registration ────────────────────────────────────
@@ -441,7 +488,7 @@ export class BrokerClient {
         reject(new Error(`Request timed out: ${method}`));
       }, REQUEST_TIMEOUT_MS);
 
-      this.pending.set(id, { resolve, reject, timer });
+      this.pending.set(id, { method, resolve, reject, timer });
 
       const line = JSON.stringify(msg) + "\n";
       this.socket!.write(line, "utf-8", (err) => {
@@ -479,7 +526,7 @@ export class BrokerClient {
     this.pending.delete(msg.id);
 
     if (msg.error) {
-      entry.reject(new Error(msg.error.message));
+      entry.reject(createRpcRequestError(entry.method, msg.error));
     } else {
       entry.resolve(msg.result);
     }


### PR DESCRIPTION
## Summary
- translate follower auth handshakes against older/no-auth brokers into an explicit compatibility error instead of surfacing raw `Unknown method: auth`
- preserve request method/code context inside `BrokerClient` RPC errors so handshake code can distinguish protocol mismatch from ordinary auth failures
- cover the regression with a broker client test for the configured mesh-auth path

## Root cause
- a configured follower sends the `auth` RPC before registering
- older/no-auth brokers answer with JSON-RPC method-not-found for `auth`
- `BrokerClient` previously dropped the RPC error code/method context and surfaced only the raw message, so `/pinet-follow` showed `Unknown method: auth`

## Chosen semantics
- do **not** silently downgrade to unauthenticated follow when the user configured mesh auth
- instead, fail fast with an actionable compatibility error that tells the operator to upgrade the broker or disable follower mesh auth for older/no-auth brokers

## Scope
- changed: `slack-bridge/broker/client.ts`
- changed: `slack-bridge/broker/client.test.ts`
- unchanged on purpose: broker auth config semantics from #289, docs, and broader handshake negotiation

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #287