### PR TITLE
docs: update pinet mesh auth docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Pinet v0.1.1 is a targeted patch release for `@gugu910/pi-slack-bridge`. The rel
 
 ### Release highlights
 
-- Hardened Pinet coordination with local shared-secret mesh auth, structured control messages, reconnect refresh, and headless-subagent isolation.
+- Hardened Pinet coordination with configurable shared-secret mesh auth, structured control messages, reconnect refresh, and headless-subagent isolation.
+- Documented the v0.1.1 mesh-auth behavior now visible on `main`: optional auth when unset, `meshSecret` / `meshSecretPath` settings and `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH` env fallbacks, friendly missing-secret-file failures for configured followers, and explicit older/no-auth broker compatibility errors with no silent downgrade.
 - Added the Pinet Home tab dashboard, an end-user README refresh, and broker routing fixes such as stable-ID thread binding.
 - Fixed targeted backlog recovery so stale targeted A2A backlog no longer remains stranded after purge and maintenance.
 - Included Slack bridge package surface updates that shipped in the same cut, including `slack_project_create` and channel canvas dedup.
@@ -31,6 +32,8 @@ Pinet v0.1.1 is a targeted patch release for `@gugu910/pi-slack-bridge`. The rel
 - [#258](https://github.com/gugu91/extensions/pull/258) — feat: add slack_project_create tool
 - [#268](https://github.com/gugu91/extensions/pull/268) — fix: thread binding uses stable IDs first, fuzzy name as fallback
 - [#272](https://github.com/gugu91/extensions/pull/272) — fix: drop stale targeted backlog after purge
+- [#289](https://github.com/gugu91/extensions/pull/289) — fix: make Pinet mesh secret config-driven and optional
+- [#292](https://github.com/gugu91/extensions/pull/292) — fix: clarify Pinet auth method mismatch
 
 ## [0.1.0] - 2026-04-02
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -79,7 +79,25 @@ export SLACK_APP_TOKEN="xapp-..."
 
 Settings in `settings.json` take priority over env vars.
 
-Optional Pinet mesh auth can also be configured via environment variables:
+### Optional Pinet mesh auth
+
+Shared-secret mesh auth is **optional**. You can configure it with either settings keys or environment variables:
+
+```json
+{
+  "slack-bridge": {
+    "meshSecret": "shared-secret"
+  }
+}
+```
+
+```json
+{
+  "slack-bridge": {
+    "meshSecretPath": "/Users/alice/.config/pi/pinet.secret"
+  }
+}
+```
 
 ```bash
 export PINET_MESH_SECRET="shared-secret"
@@ -87,7 +105,14 @@ export PINET_MESH_SECRET="shared-secret"
 export PINET_MESH_SECRET_PATH="$HOME/.config/pi/pinet.secret"
 ```
 
-If `meshSecret` and `meshSecretPath` are both unset, broker/follower mesh auth is disabled.
+Behavior and precedence:
+
+- `slack-bridge.meshSecret` and `slack-bridge.meshSecretPath` override the environment fallbacks.
+- Inline secrets win over secret paths. If `meshSecret` or `PINET_MESH_SECRET` is set, the corresponding `*Path` value is ignored.
+- If all four values are unset, broker/follower mesh auth is disabled.
+- A broker started with `meshSecretPath` creates the secret file if it does not exist yet.
+- A follower started with `meshSecretPath` does **not** create the file. If the configured file is missing, follow fails with a clear error telling you to point at an existing file, provide `meshSecret` directly, or leave both unset to disable shared-secret auth.
+- A follower configured for mesh auth will fail closed against an older/no-auth broker with a clear compatibility error. It will **not** silently retry as an unauthenticated follower.
 
 ### Full settings reference
 
@@ -112,21 +137,21 @@ If `meshSecret` and `meshSecretPath` are both unset, broker/follower mesh auth i
 }
 ```
 
-| Key                            | Required | Description                                                                            |
-| ------------------------------ | -------- | -------------------------------------------------------------------------------------- |
-| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                      |
-| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                           |
-| `allowedUsers`                 | no       | Slack user IDs that can interact (all users if unset)                                  |
-| `defaultChannel`               | no       | Default channel for `slack_post_channel`                                               |
-| `logChannel`                   | no       | Channel for broker activity logs                                                       |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                      |
-| `autoFollow`                   | no       | Auto-connect as follower when broker is running                                        |
-| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath`                        |
-| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers read it |
-| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                     |
-| `security.readOnly`            | no       | Block all write tools                                                                  |
-| `security.requireConfirmation` | no       | Tools that need user approval before executing                                         |
-| `security.blockedTools`        | no       | Tools that are completely disabled                                                     |
+| Key                            | Required | Description                                                                                             |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------- |
+| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                       |
+| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                            |
+| `allowedUsers`                 | no       | Slack user IDs that can interact (all users if unset)                                                   |
+| `defaultChannel`               | no       | Default channel for `slack_post_channel`                                                                |
+| `logChannel`                   | no       | Channel for broker activity logs                                                                        |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                       |
+| `autoFollow`                   | no       | Auto-connect as follower when broker is running                                                         |
+| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                       |
+| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file |
+| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                      |
+| `security.readOnly`            | no       | Block all write tools                                                                                   |
+| `security.requireConfirmation` | no       | Tools that need user approval before executing                                                          |
+| `security.blockedTools`        | no       | Tools that are completely disabled                                                                      |
 
 ## Usage
 
@@ -224,14 +249,14 @@ Or set `"autoFollow": true` in settings to auto-connect when a broker is running
 
 - The **broker** runs Slack Socket Mode, routes messages to agents, monitors health via the RALPH loop, and maintains a control plane canvas
 - **Followers** connect to the broker over a local Unix socket, poll for work, and report results
-- Agents can optionally authenticate using a shared local secret (`meshSecret` or `meshSecretPath`)
+- Agents can optionally authenticate using a shared local secret (`meshSecret` or `meshSecretPath`); when both are unset, mesh auth is disabled
 - Thread ownership is first-responder-wins — the first agent to reply claims the thread
 
 ## Security
 
 - **User allowlist**: Set `allowedUsers` to restrict who can interact with Pinet
 - **Tool guardrails**: Use `security.requireConfirmation` and `security.blockedTools` to control tool access
-- **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` to require a shared secret; leave both unset to disable shared-secret auth
+- **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` (or `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH`) to require a shared secret; leave them unset to disable shared-secret auth. Configured followers fail closed on missing secret files or older/no-auth brokers rather than silently downgrading.
 
 Find Slack user IDs: click a user's profile → **More** → **Copy member ID**.
 


### PR DESCRIPTION
## Summary
- document optional/configurable Pinet mesh auth in `slack-bridge/README.md`
- cover `meshSecret` / `meshSecretPath` settings, `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH` env fallbacks, and the broker/follower behavior split
- update the `0.1.1` changelog notes to mention the docs-visible mesh auth behavior and include PRs #289 and #292

## Notes
- mesh auth is optional when unset
- brokers create a configured secret file when starting with `meshSecretPath`; configured followers fail clearly if that file is missing
- configured followers fail closed against older/no-auth brokers rather than silently downgrading

## Testing
- `/Users/guglielmoporcellini/src/gugu910/extensions/node_modules/.bin/prettier --check slack-bridge/README.md CHANGELOG.md`