### PR TITLE
fix: stop Pinet closeout acknowledgement echo loops (#299)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   isUserAllowed,
   formatInboxMessages,
   formatPinetInboxMessages,
+  isTerminalPinetStandDownMessage,
   parsePinetControlCommand,
   getPinetControlCommandFromText,
   buildPinetControlMetadata,
@@ -432,6 +433,24 @@ describe("formatInboxMessages", () => {
   });
 });
 
+describe("isTerminalPinetStandDownMessage", () => {
+  it("detects explicit thread closeout instructions", () => {
+    expect(
+      isTerminalPinetStandDownMessage(
+        "Hard stop on this thread now: no further acknowledgements are needed. Stay free and quiet unless I assign a new task here.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not misclassify a fresh task assignment as terminal", () => {
+    expect(
+      isTerminalPinetStandDownMessage(
+        "New implementation lane for you — please ACK/work/ask/report back here. Issue: #299. Worktree setup: git worktree add ...",
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("formatPinetInboxMessages", () => {
   it("formats agent messages with reply guidance", () => {
     const result = formatPinetInboxMessages([
@@ -450,6 +469,7 @@ describe("formatPinetInboxMessages", () => {
       "[thread a2a:broker:worker] broker-id (Broker Bunny): Take issue #175",
     );
     expect(result).toContain("Reply via pinet_message.");
+    expect(result).toContain("ACK briefly, do the work");
   });
 
   it("falls back to the sender id when no senderAgent metadata exists", () => {
@@ -465,6 +485,54 @@ describe("formatPinetInboxMessages", () => {
     ]);
 
     expect(result).toContain("[thread a2a:broker:worker] broker-id: hello");
+  });
+
+  it("marks terminal stand-down messages as closed and suppresses reflex ack guidance", () => {
+    const result = formatPinetInboxMessages([
+      {
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker-id",
+          body: "Hard stop on this thread now: no further acknowledgements are needed. Stay free and quiet unless I assign a new task here.",
+          metadata: { senderAgent: "Broker Bunny", a2a: true },
+        },
+      },
+    ]);
+
+    expect(result).toContain("[terminal stand-down]");
+    expect(result).toContain("Treat messages marked [terminal stand-down] as closed");
+    expect(result).toContain("do NOT send another acknowledgement");
+    expect(result).not.toContain(
+      "ACK briefly, do the work, report blockers immediately, report the outcome when done.",
+    );
+  });
+
+  it("keeps new-task reply guidance when a batch mixes closeout and actionable work", () => {
+    const result = formatPinetInboxMessages([
+      {
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker-id",
+          body: "No further replies are needed on this closed lane; stay free/quiet unless I assign a genuinely new task.",
+          metadata: { senderAgent: "Broker Bunny", a2a: true },
+        },
+      },
+      {
+        message: {
+          threadId: "a2a:broker:worker",
+          sender: "broker-id",
+          body: "New implementation lane for you — please ACK/work/ask/report back here. Issue: #299.",
+          metadata: { senderAgent: "Broker Bunny", a2a: true },
+        },
+      },
+    ]);
+
+    expect(result).toContain("[terminal stand-down]");
+    expect(result).toContain("Reply via pinet_message for actionable work only.");
+    expect(result).toContain("For new tasks, ACK briefly, do the work");
+    expect(result).toContain(
+      "do NOT acknowledge or reply unless you have a real blocker or materially new finding",
+    );
   });
 });
 
@@ -1116,6 +1184,15 @@ describe("buildWorkerPromptGuidelines", () => {
     expect(joined).toContain("pinet_free");
     expect(joined).toContain("/pinet-free");
     expect(joined).toContain("idle/free");
+  });
+
+  it("tells workers not to acknowledge terminal broker stand-downs", () => {
+    const guidelines = buildWorkerPromptGuidelines();
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("no further replies are needed");
+    expect(joined).toContain("hard stop");
+    expect(joined).toContain("Do NOT send another acknowledgement");
+    expect(joined).toContain("genuinely new task");
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -175,14 +175,66 @@ function getPinetSenderLabel(message: FollowerInboxEntry["message"]): string {
   return senderId || senderAgent || "unknown-agent";
 }
 
+const PINET_TERMINAL_STAND_DOWN_PATTERNS = [
+  /\bno further repl(?:y|ies) (?:are|is) needed\b/i,
+  /\bno further acknowledg(?:ement|ements) (?:are|is) needed\b/i,
+  /\bno reply is needed\b/i,
+  /\bhard stop on this [^.\n]*thread\b/i,
+  /\bno more work is needed\b/i,
+  /\bstand down\b/i,
+  /\bstay free(?:\/| and )quiet\b/i,
+  /\bstay quiet(?:\/| and )free\b/i,
+  /\bthread is already satisfied\b/i,
+  /\bunless I (?:assign|ask for) (?:a )?(?:genuinely )?new task\b/i,
+];
+
+const PINET_ACTIONABLE_TASK_PATTERNS = [
+  /\bnew [a-z-]+ lane\b/i,
+  /\bissue:\b/i,
+  /\btask:\b/i,
+  /\bworktree setup:\b/i,
+  /\bplease ACK\/work\/ask\/report\b/i,
+];
+
+export function isTerminalPinetStandDownMessage(body: string | null | undefined): boolean {
+  const normalized = body?.replace(/\s+/g, " ").trim() ?? "";
+  if (!normalized) {
+    return false;
+  }
+
+  const hasTerminalCue = PINET_TERMINAL_STAND_DOWN_PATTERNS.some((pattern) =>
+    pattern.test(normalized),
+  );
+  if (!hasTerminalCue) {
+    return false;
+  }
+
+  return !PINET_ACTIONABLE_TASK_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
 export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string {
-  const lines = entries.map((entry) => {
+  const annotatedEntries = entries.map((entry) => ({
+    entry,
+    terminalStandDown: isTerminalPinetStandDownMessage(entry.message.body),
+  }));
+
+  const lines = annotatedEntries.map(({ entry, terminalStandDown }) => {
     const threadTs = entry.message.threadId ?? "";
     const sender = getPinetSenderLabel(entry.message);
-    return `[thread ${threadTs}] ${sender}: ${entry.message.body ?? ""}`;
+    const standDownSuffix = terminalStandDown ? " [terminal stand-down]" : "";
+    return `[thread ${threadTs}] ${sender}${standDownSuffix}: ${entry.message.body ?? ""}`;
   });
 
-  return `New Pinet messages:\n${lines.join("\n")}\n\nReply via pinet_message. ACK briefly, do the work, report blockers immediately, report the outcome when done.`;
+  const hasTerminalStandDown = annotatedEntries.some((entry) => entry.terminalStandDown);
+  const hasActionableWork = annotatedEntries.some((entry) => !entry.terminalStandDown);
+
+  const guidance = hasTerminalStandDown
+    ? hasActionableWork
+      ? "Reply via pinet_message for actionable work only. For messages marked [terminal stand-down], do NOT acknowledge or reply unless you have a real blocker or materially new finding. For new tasks, ACK briefly, do the work, report blockers immediately, report the outcome when done."
+      : "Reply via pinet_message only if you have a real blocker or materially new finding. Treat messages marked [terminal stand-down] as closed; do NOT send another acknowledgement."
+    : "Reply via pinet_message. ACK briefly, do the work, report blockers immediately, report the outcome when done.";
+
+  return `New Pinet messages:\n${lines.join("\n")}\n\n${guidance}`;
 }
 
 // ─── Pinet control messages ─────────────────────────────
@@ -1241,6 +1293,7 @@ export function buildWorkerPromptGuidelines(): string[] {
     "4. When done, report the outcome (what changed, branch/PR, test results) — the sender needs closure and next steps.",
     "5. When you have finished all assigned work and are waiting for more, call `pinet_free` (or `/pinet-free`) to mark yourself idle/free for the broker.",
     "Always reply where the task came from.",
+    "If a Pinet thread explicitly says things like 'no further replies are needed', 'hard stop', or 'stay free/quiet unless a new task appears', treat it as a terminal closeout. Do NOT send another acknowledgement unless you have a real blocker, a materially new finding, or a genuinely new task arrives in that thread.",
     "",
     "REPLY TOOL RULES:",
     "- If you received a task via `pinet_message`, reply via `pinet_message` to the sender.",


### PR DESCRIPTION
## Summary
- trace the closed-thread echo behavior to the generic Pinet follower reply footer, which always told workers to `ACK briefly` even when the broker message was an explicit stand-down
- detect terminal broker/agent closeout phrases like `no further replies are needed`, `hard stop`, and `stay free/quiet unless a new task appears`
- mark those entries as `[terminal stand-down]` in the follower prompt and swap the footer so workers do **not** reflexively acknowledge closed lanes
- keep normal ack/work/ask/report guidance for actionable task messages, including mixed batches where a closeout and a new task arrive together
- reinforce the same rule in worker prompt guidelines so terminal closeouts are treated as closed unless there is a real blocker, materially new finding, or genuinely new task

## Root cause
Recent broker/worker threads showed repeated closeout echoes because `formatPinetInboxMessages()` always ended with:

`Reply via pinet_message. ACK briefly, do the work, report blockers immediately, report the outcome when done.`

That footer is right for fresh work, but wrong for terminal stand-down messages. The worker kept seeing a strong instruction to ACK again even after the broker explicitly said the lane was closed.

## Testing
- `pnpm install --frozen-lockfile` (worktree bootstrap)
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #299
