### PR TITLE
fix: finish slack-bridge 0.1.1 publish hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Pinet v0.1.1 is a targeted patch release for `@gugu910/pi-slack-bridge`. The rel
 - Documented the v0.1.1 mesh-auth behavior now visible on `main`: optional auth when unset, `meshSecret` / `meshSecretPath` settings and `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH` env fallbacks, friendly missing-secret-file failures for configured followers, and explicit older/no-auth broker compatibility errors with no silent downgrade.
 - Added the Pinet Home tab dashboard, an end-user README refresh, and broker routing fixes such as stable-ID thread binding.
 - Fixed targeted backlog recovery so stale targeted A2A backlog no longer remains stranded after purge and maintenance.
+- Fixed broker-targeted startup backlog recovery so persisted post-restart pending backlog is rebound during startup instead of waiting for a later maintenance pass.
 - Included Slack bridge package surface updates that shipped in the same cut, including `slack_project_create` and channel canvas dedup.
 
 ### Included pull requests
@@ -34,6 +35,7 @@ Pinet v0.1.1 is a targeted patch release for `@gugu910/pi-slack-bridge`. The rel
 - [#272](https://github.com/gugu91/extensions/pull/272) — fix: drop stale targeted backlog after purge
 - [#289](https://github.com/gugu91/extensions/pull/289) — fix: make Pinet mesh secret config-driven and optional
 - [#292](https://github.com/gugu91/extensions/pull/292) — fix: clarify Pinet auth method mismatch
+- [#298](https://github.com/gugu91/extensions/pull/298) — fix: recover broker-targeted backlog during startup
 
 ## [0.1.0] - 2026-04-02
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         version: 7.15.0
 
   slack-bridge:
-    devDependencies:
+    dependencies:
       "@sinclair/typebox":
         specifier: ^0.34.49
         version: 0.34.49

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -39,7 +39,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "devDependencies": {
+  "dependencies": {
     "@sinclair/typebox": "^0.34.49"
   }
 }


### PR DESCRIPTION
## Summary
- move `@sinclair/typebox` into `dependencies` for `@gugu910/pi-slack-bridge` because it is used at runtime
- update the `0.1.1` changelog notes to include the startup backlog recovery fix from #298
- keep the release-hygiene follow-up narrow and verify the packed artifact still includes `LICENSE`

## Files changed
- `slack-bridge/package.json`
- `pnpm-lock.yaml`
- `CHANGELOG.md`

## Checks
- `pnpm format:check`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `npm pack --json --dry-run` in `slack-bridge`

Closes #304
