### PR TITLE
fix: stop operator update task residue (#309)

### DIFF
--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -74,6 +74,18 @@ describe("extractTaskAssignmentsFromMessage", () => {
 
     expect(extractTaskAssignmentsFromMessage(message)).toEqual([]);
   });
+
+  it("does not treat issue-opened update bullets as assignments", () => {
+    const message = [
+      "Update from the thicket:",
+      "- PR #272 merged",
+      "- PR #274 closed as superseded",
+      "- issue #275 opened to preserve the separate purge-grace idea",
+      "No further action needed unless you want to acknowledge cleanup complete and return idle/free.",
+    ].join("\n");
+
+    expect(extractTaskAssignmentsFromMessage(message)).toEqual([]);
+  });
 });
 
 describe("normalizeTrackedTaskAssignments", () => {
@@ -96,6 +108,15 @@ describe("normalizeTrackedTaskAssignments", () => {
         status: "assigned",
         sourceMessageId: 1822,
         updatedAt: "2026-04-08T10:30:48.213Z",
+      }),
+      makeAssignment({
+        id: 17,
+        agentId: "worker-3",
+        issueNumber: 275,
+        branch: "hygiene",
+        status: "assigned",
+        sourceMessageId: 1573,
+        updatedAt: "2026-04-08T09:28:12.227Z",
       }),
       makeAssignment({
         id: 15,
@@ -128,6 +149,16 @@ describe("normalizeTrackedTaskAssignments", () => {
             "Your lane:",
             "- Issue/PR: #287 / PR #292",
             "- Branch: `fix/pinet-follow-auth-method`",
+          ].join("\n"),
+        ],
+        [
+          1573,
+          [
+            "Update from the thicket:",
+            "- PR #272 merged",
+            "- PR #274 closed as superseded",
+            "- issue #275 opened to preserve the separate purge-grace idea",
+            "No further action needed unless you want to acknowledge cleanup complete and return idle/free.",
           ].join("\n"),
         ],
         [

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -41,7 +41,7 @@ const EXPLICIT_BRANCH_LABEL_REGEX =
   /\bbranch(?:\s+to\s+work\s+on|\s+name)?\s*:\s*[`"']?([A-Za-z0-9._/-]+)\b/i;
 const ISSUE_PR_LINE_REGEX = /(?:^|\n)\s*(?:[-*]\s*)?issue\/pr\s*:\s*#(\d+)\b/gi;
 const ISSUE_LINE_REGEX = /(?:^|\n)\s*(?:[-*]\s*)?issue\s*:\s*#(\d+)\b/gi;
-const ISSUE_HEADING_REGEX = /(?:^|\n)\s*(?:[-*]\s*)?issue\s+#(\d+)\b/gi;
+const ISSUE_HEADING_REGEX = /(?:^|\n)\s*(?:[-*]\s*)?issue\s+#(\d+)(?=\s*(?:[—–:-]|$))/gi;
 const TASK_ISSUE_REGEX = /(?:^|\n)\s*(?:[-*]\s*)?task\s*:\s*[^\n#]*\bissue\s*#(\d+)\b/gi;
 const NEW_TASK_ISSUE_REGEX =
   /(?:^|\n)\s*(?:[-*]\s*)?new(?:\s+[a-z-]+){0,3}\s+task\b[^\n#]*\bissue\s*#(\d+)\b/gi;


### PR DESCRIPTION
## Summary
- narrow task-assignment extraction so `Issue #...` headings only count as assignment cues when the issue token is followed by heading punctuation or line end
- stop broker/operator update bullets like `- issue #275 opened ...` from being recorded or surviving as tracked worker assignments
- add focused regression coverage for the live `#275` / source-message-1573 residue shape

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #309
