### PR TITLE
feat: add explicit browser storage state reuse (#290)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .env*
 .firecrawl/
 slack-api/.tmp/
+.pi/state/browser-playwright/

--- a/.pi/extensions/browser-playwright/README.md
+++ b/.pi/extensions/browser-playwright/README.md
@@ -8,6 +8,7 @@ It is designed for real browsing and lightweight web interaction, not just test 
 - navigate public sites
 - snapshot and extract page content
 - click, fill, press, wait, inspect tabs, and capture screenshots
+- explicitly save and later reuse workspace-local Playwright `storageState` JSON
 - keep screenshots and artifacts inside the workspace
 - block localhost and private/internal network targets by default
 
@@ -99,10 +100,35 @@ Recommended practice:
 
 Important limitations:
 
-- session state is process-local and in-memory only
+- live browser sessions are still process-local and in-memory only
 - a Pi reload or process restart drops live browser sessions
-- stored Playwright session mounting/import is not supported in #282
-- importing/exporting saved `storageState`, cookies, or localStorage for login reuse is follow-up work, not current behavior
+- saved auth reuse is explicit and file-based; it does not keep sessions alive across reloads by itself
+- only Playwright `storageState` JSON reuse is supported; arbitrary browser profile mounting is not
+
+## Stored storage state
+
+Explicit auth-state reuse is supported for Playwright `storageState` JSON only.
+
+Import into a new session:
+
+- pass `storage_state_name` to `browser_session_start`
+
+Export from an existing session:
+
+- use `browser_storage_state_save`
+
+Storage-state files are written under:
+
+- `.pi/state/browser-playwright/<name>.json`
+
+Safety rules:
+
+- storage-state files are **secret-bearing auth material**
+- storage-state reuse is **explicit opt-in only**
+- there is **no** auto-save on session close, Pi reload, or shutdown
+- tool results return only safe metadata like the saved path and counts, never raw cookies or token values
+- saved-state handling stays workspace-local; arbitrary host paths, traversal, symlink escapes, and browser-profile mounting are not supported
+- importing saved auth state does **not** weaken the extension's normal localhost/private-network blocking rules
 
 ## Artifacts
 
@@ -138,6 +164,7 @@ Required tools provided:
 10. `browser_screenshot`
 11. `browser_tabs`
 12. `browser_close`
+13. `browser_storage_state_save`
 
 ## Usage flows
 
@@ -210,6 +237,26 @@ Then navigate:
 Tool: `browser_navigate`
 
 Without the env opt-in, that navigation is blocked.
+
+### 4. Save login state, then reuse it explicitly later
+
+Save state from an authenticated session:
+
+```json
+{ "session_id": "<session_id>", "name": "github-login" }
+```
+
+Tool: `browser_storage_state_save`
+
+Start a new session with that saved state:
+
+```json
+{ "browser": "chromium", "storage_state_name": "github-login", "url": "https://github.com" }
+```
+
+Tool: `browser_session_start`
+
+This reuses the saved Playwright `storageState` JSON from `.pi/state/browser-playwright/github-login.json`.
 
 ## Notes for agents
 

--- a/.pi/extensions/browser-playwright/helpers.test.ts
+++ b/.pi/extensions/browser-playwright/helpers.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 import {
   assessUrl,
   buildInstallInstructions,
+  buildStorageStateFileName,
+  isPlaywrightStorageState,
   safeRequestPageId,
   sanitizeLabel,
+  sanitizeStorageStateName,
   truncateText,
   type SecurityOptions,
 } from "./helpers.ts";
@@ -110,6 +113,25 @@ test("safeRequestPageId returns null for service-worker-style requests without a
 test("sanitizeLabel keeps filenames safe and stable", () => {
   assert.equal(sanitizeLabel("Search Results / Docs"), "search-results-docs");
   assert.equal(sanitizeLabel("   "), "screenshot");
+});
+
+test("sanitizeStorageStateName keeps saved state names workspace-safe", () => {
+  assert.equal(sanitizeStorageStateName(" GitHub Login .json "), "github-login");
+  assert.equal(sanitizeStorageStateName("../../Prod Session"), "prod-session");
+});
+
+test("buildStorageStateFileName appends a normalized json filename", () => {
+  assert.equal(buildStorageStateFileName("QA Session"), "qa-session.json");
+});
+
+test("sanitizeStorageStateName rejects empty names", () => {
+  assert.throws(() => sanitizeStorageStateName("   "), /letter or number/);
+});
+
+test("isPlaywrightStorageState validates the expected top-level shape", () => {
+  assert.equal(isPlaywrightStorageState({ cookies: [], origins: [] }), true);
+  assert.equal(isPlaywrightStorageState({ cookies: [] }), false);
+  assert.equal(isPlaywrightStorageState(null), false);
 });
 
 test("truncateText trims oversized content and marks truncation", () => {

--- a/.pi/extensions/browser-playwright/helpers.ts
+++ b/.pi/extensions/browser-playwright/helpers.ts
@@ -14,8 +14,11 @@ export type SecurityOptions = {
 export type SupportedBrowserEngine = "chromium" | "firefox" | "webkit";
 
 export const EXTENSION_RELATIVE_DIR = ".pi/extensions/browser-playwright";
+export const STORAGE_STATE_RELATIVE_DIR = ".pi/state/browser-playwright";
 export const DEFAULT_TEXT_LINES = 120;
 export const DEFAULT_TEXT_CHARS = 4_000;
+
+const STORAGE_STATE_NAME_MAX_CHARS = 80;
 
 export function parseIntegerEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -33,6 +36,26 @@ export function sanitizeLabel(value: string | undefined): string {
   const base = (value ?? "screenshot").trim().toLowerCase();
   const cleaned = base.replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
   return cleaned.length > 0 ? cleaned.slice(0, 60) : "screenshot";
+}
+
+export function sanitizeStorageStateName(value: string): string {
+  const base = value
+    .trim()
+    .toLowerCase()
+    .replace(/\.json$/i, "")
+    .replace(/\.{2,}/g, "-");
+  const cleaned = base
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^\.+|\.+$/g, "")
+    .replace(/^-+|-+$/g, "");
+  if (!/[a-z0-9]/.test(cleaned)) {
+    throw new Error("Storage state names must contain at least one letter or number.");
+  }
+  return cleaned.slice(0, STORAGE_STATE_NAME_MAX_CHARS);
+}
+
+export function buildStorageStateFileName(value: string): string {
+  return `${sanitizeStorageStateName(value)}.json`;
 }
 
 export function truncateText(
@@ -87,6 +110,17 @@ export function safeRequestPageId<PageLike>(
   } catch {
     return null;
   }
+}
+
+export function isPlaywrightStorageState(
+  value: unknown,
+): value is { cookies: unknown[]; origins: unknown[] } {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as { cookies?: unknown; origins?: unknown };
+  return Array.isArray(record.cookies) && Array.isArray(record.origins);
 }
 
 function normalizeUrl(input: string): URL {

--- a/.pi/extensions/browser-playwright/index.ts
+++ b/.pi/extensions/browser-playwright/index.ts
@@ -1,16 +1,19 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, lstat, readFile, realpath, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import { relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { StringEnum, Type } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import {
   assessUrl,
   buildInstallInstructions,
+  buildStorageStateFileName,
   envFlag,
+  isPlaywrightStorageState,
   parseIntegerEnv,
   safeRequestPageId,
   sanitizeLabel,
+  STORAGE_STATE_RELATIVE_DIR,
   truncateText,
   type SupportedBrowserEngine,
 } from "./helpers.ts";
@@ -28,6 +31,8 @@ import type {
 type PlaywrightModule = typeof import("playwright");
 
 type BrowserEngine = SupportedBrowserEngine;
+type PlaywrightStorageState = Awaited<ReturnType<BrowserContext["storageState"]>>;
+type BrowserNewContextOptions = Exclude<Parameters<Browser["newContext"]>[0], undefined>;
 
 type WaitUntil = "load" | "domcontentloaded" | "networkidle" | "commit";
 
@@ -69,6 +74,13 @@ type BrowserPageRecord = {
   lastActivityAt: string;
 };
 
+type MountedStorageStateSummary = {
+  name: string;
+  path: string;
+  cookie_count: number;
+  origin_count: number;
+};
+
 type BrowserSession = {
   id: string;
   browserEngine: BrowserEngine;
@@ -83,10 +95,13 @@ type BrowserSession = {
   consoleEntries: ConsoleEntry[];
   blockedRequests: BlockedRequestEntry[];
   networkSummary: NetworkSummary;
+  mountedStorageState: MountedStorageStateSummary | null;
 };
 
 const EXTENSION_DIR = fileURLToPath(new URL(".", import.meta.url));
-const ARTIFACT_ROOT = resolve(EXTENSION_DIR, "../../artifacts/browser-playwright");
+const WORKSPACE_ROOT = resolve(EXTENSION_DIR, "../../..");
+const ARTIFACT_ROOT = resolve(WORKSPACE_ROOT, ".pi/artifacts/browser-playwright");
+const STORAGE_STATE_ROOT = resolve(WORKSPACE_ROOT, STORAGE_STATE_RELATIVE_DIR);
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_NAVIGATION_TIMEOUT_MS = 20_000;
@@ -106,6 +121,141 @@ function nowIso(): string {
 function asErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function relativeFromWorkspace(absolutePath: string): string {
+  return relative(WORKSPACE_ROOT, absolutePath);
+}
+
+function isPathInsideDirectory(pathToCheck: string, directoryPath: string): boolean {
+  const rel = relative(directoryPath, pathToCheck);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function summarizeStorageState(storageState: PlaywrightStorageState): {
+  cookie_count: number;
+  origin_count: number;
+} {
+  return {
+    cookie_count: storageState.cookies.length,
+    origin_count: storageState.origins.length,
+  };
+}
+
+async function ensureStorageStateRoot(): Promise<string> {
+  await mkdir(STORAGE_STATE_ROOT, { recursive: true });
+
+  const workspaceRoot = await realpath(WORKSPACE_ROOT);
+  const storageStateRoot = await realpath(STORAGE_STATE_ROOT);
+  if (!isPathInsideDirectory(storageStateRoot, workspaceRoot)) {
+    throw new Error(
+      `Stored browser state directory must stay inside the workspace: \`${STORAGE_STATE_RELATIVE_DIR}\`.`,
+    );
+  }
+
+  return storageStateRoot;
+}
+
+async function assertRegularStorageStateFile(
+  absolutePath: string,
+  relativePath: string,
+  allowMissing: boolean,
+): Promise<void> {
+  try {
+    const stats = await lstat(absolutePath);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Stored browser state paths must not use symlinks: \`${relativePath}\`.`);
+    }
+    if (!stats.isFile()) {
+      throw new Error(`Stored browser state must be a regular file: \`${relativePath}\`.`);
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (allowMissing && code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function resolveStorageStateFile(name: string): Promise<{
+  name: string;
+  absolutePath: string;
+  relativePath: string;
+}> {
+  const fileName = buildStorageStateFileName(name);
+  const storageStateRoot = await ensureStorageStateRoot();
+  const absolutePath = resolve(storageStateRoot, fileName);
+  return {
+    name: fileName.replace(/\.json$/i, ""),
+    absolutePath,
+    relativePath: relativeFromWorkspace(absolutePath),
+  };
+}
+
+async function loadStoredStorageState(name: string): Promise<{
+  storageState: PlaywrightStorageState;
+  mountedStorageState: MountedStorageStateSummary;
+}> {
+  const resolvedState = await resolveStorageStateFile(name);
+  try {
+    await assertRegularStorageStateFile(
+      resolvedState.absolutePath,
+      resolvedState.relativePath,
+      false,
+    );
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      throw new Error(
+        `Stored browser state \`${resolvedState.name}\` was not found at \`${resolvedState.relativePath}\`. Use browser_storage_state_save to create it first.`,
+      );
+    }
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(resolvedState.absolutePath, "utf8"));
+  } catch (error) {
+    throw new Error(`Stored browser state \`${resolvedState.name}\` is not valid JSON.`, {
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+
+  if (!isPlaywrightStorageState(parsed)) {
+    throw new Error(
+      `Stored browser state \`${resolvedState.name}\` is not a valid Playwright storageState JSON file.`,
+    );
+  }
+
+  const summary = summarizeStorageState(parsed as PlaywrightStorageState);
+  return {
+    storageState: parsed as PlaywrightStorageState,
+    mountedStorageState: {
+      name: resolvedState.name,
+      path: resolvedState.relativePath,
+      ...summary,
+    },
+  };
+}
+
+async function saveStoredStorageState(
+  session: BrowserSession,
+  name: string,
+): Promise<MountedStorageStateSummary & { saved_at: string }> {
+  const resolvedState = await resolveStorageStateFile(name);
+  await assertRegularStorageStateFile(resolvedState.absolutePath, resolvedState.relativePath, true);
+
+  const storageState = await session.context.storageState();
+  await writeFile(resolvedState.absolutePath, `${JSON.stringify(storageState, null, 2)}\n`, "utf8");
+
+  return {
+    name: resolvedState.name,
+    path: resolvedState.relativePath,
+    ...summarizeStorageState(storageState),
+    saved_at: nowIso(),
+  };
 }
 
 async function loadPlaywright(browserEngine: BrowserEngine): Promise<PlaywrightModule> {
@@ -475,6 +625,11 @@ async function closeSession(session: BrowserSession): Promise<void> {
   }
 }
 
+export const __testables = {
+  loadStoredStorageState,
+  saveStoredStorageState,
+};
+
 export default function browserPlaywrightExtension(pi: ExtensionAPI) {
   const sessions = new Map<string, BrowserSession>();
   let cleanupTimer: NodeJS.Timeout | null = setInterval(() => {
@@ -531,6 +686,12 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       url: Type.Optional(Type.String({ description: "Optional initial URL to open." })),
       viewport_width: Type.Optional(Type.Number({ description: "Viewport width in pixels." })),
       viewport_height: Type.Optional(Type.Number({ description: "Viewport height in pixels." })),
+      storage_state_name: Type.Optional(
+        Type.String({
+          description:
+            "Optional saved storage state name to import from `.pi/state/browser-playwright/<name>.json`.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal) {
       if (signal?.aborted) {
@@ -544,6 +705,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       const playwright = await loadPlaywright(browserEngine);
       const browserType = playwright[browserEngine] as BrowserType;
       const headless = params.headless ?? true;
+      const loadedStorageState = params.storage_state_name
+        ? await loadStoredStorageState(params.storage_state_name)
+        : null;
 
       let browser: Browser | null = null;
       try {
@@ -562,12 +726,17 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       }
 
       try {
-        const context = await browser.newContext({
+        const contextOptions: BrowserNewContextOptions = {
           viewport:
             params.viewport_width && params.viewport_height
               ? { width: params.viewport_width, height: params.viewport_height }
               : { width: 1280, height: 800 },
-        });
+        };
+        if (loadedStorageState) {
+          contextOptions.storageState = loadedStorageState.storageState;
+        }
+
+        const context = await browser.newContext(contextOptions);
 
         const session: BrowserSession = {
           id: `browser_${randomUUID()}`,
@@ -587,6 +756,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
             blocked_requests: 0,
             failed_requests: 0,
           },
+          mountedStorageState: loadedStorageState?.mountedStorageState ?? null,
         };
 
         await context.route("**/*", async (route: Route) => {
@@ -647,7 +817,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
                   created_at: session.createdAt,
                   active_page_id: activePage?.id ?? null,
                   pages,
-                  artifact_dir: relative(resolve(EXTENSION_DIR, "../../.."), ARTIFACT_ROOT),
+                  artifact_dir: relativeFromWorkspace(ARTIFACT_ROOT),
+                  storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
+                  mounted_storage_state: session.mountedStorageState,
                   safety: {
                     allow_localhost: envFlag("BROWSER_ALLOW_LOCALHOST"),
                     allow_private_network: envFlag("BROWSER_ALLOW_PRIVATE_NETWORK"),
@@ -665,7 +837,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
             created_at: session.createdAt,
             active_page_id: activePage?.id ?? null,
             pages,
-            artifact_dir: relative(resolve(EXTENSION_DIR, "../../.."), ARTIFACT_ROOT),
+            artifact_dir: relativeFromWorkspace(ARTIFACT_ROOT),
+            storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
+            mounted_storage_state: session.mountedStorageState,
             safety: {
               allow_localhost: envFlag("BROWSER_ALLOW_LOCALHOST"),
               allow_private_network: envFlag("BROWSER_ALLOW_PRIVATE_NETWORK"),
@@ -703,9 +877,43 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
         active_page_id: session.activePageId,
         page_count: pages.length,
         pages,
+        mounted_storage_state: session.mountedStorageState,
+        storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
         network_summary: session.networkSummary,
         recent_console: session.consoleEntries,
         blocked_requests: session.blockedRequests,
+      };
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        details: result,
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "browser_storage_state_save",
+    label: "Browser Storage State Save",
+    description: "Save a browser session's Playwright storageState JSON for explicit later reuse.",
+    promptSnippet: "Save a browser session's auth state for later explicit reuse in a new session.",
+    promptGuidelines: [
+      "Saved storage state is secret-bearing auth material. Use it only when explicit reuse is necessary.",
+      "Saved state files are written under `.pi/state/browser-playwright/` inside the workspace and are never echoed inline.",
+    ],
+    parameters: Type.Object({
+      session_id: Type.String({ description: "Browser session_id." }),
+      name: Type.String({
+        description:
+          "Name for the saved storage state. Stored as `<name>.json` under `.pi/state/browser-playwright/`.",
+      }),
+    }),
+    async execute(_toolCallId, params) {
+      await cleanupExpiredSessions();
+      const session = getSessionOrThrow(sessions, params.session_id);
+      const savedStorageState = await saveStoredStorageState(session, params.name);
+      const result = {
+        session_id: session.id,
+        browser: session.browserEngine,
+        saved_storage_state: savedStorageState,
       };
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -1151,7 +1359,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       });
       touchPage(pageRecord);
 
-      const relativePath = relative(resolve(EXTENSION_DIR, "../../.."), absolutePath);
+      const relativePath = relativeFromWorkspace(absolutePath);
       const result = {
         session_id: session.id,
         page_id: pageRecord.id,

--- a/.pi/extensions/browser-playwright/package.json
+++ b/.pi/extensions/browser-playwright/package.json
@@ -7,7 +7,7 @@
     "clean": "echo 'nothing to clean'",
     "build": "echo 'nothing to build'",
     "check": "tsc --noEmit -p tsconfig.json",
-    "test": "node --experimental-strip-types --test helpers.test.ts"
+    "test": "node --experimental-strip-types --test *.test.ts"
   },
   "pi": {
     "extensions": [

--- a/.pi/extensions/browser-playwright/storage-state.test.ts
+++ b/.pi/extensions/browser-playwright/storage-state.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import test from "node:test";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { STORAGE_STATE_RELATIVE_DIR } from "./helpers.ts";
+import { __testables } from "./index.ts";
+
+const EXTENSION_DIR = fileURLToPath(new URL(".", import.meta.url));
+const WORKSPACE_ROOT = resolve(EXTENSION_DIR, "../../..");
+const STORAGE_STATE_ROOT = resolve(WORKSPACE_ROOT, STORAGE_STATE_RELATIVE_DIR);
+
+async function removeStateFile(fileName: string): Promise<void> {
+  await rm(resolve(STORAGE_STATE_ROOT, fileName), { force: true });
+}
+
+test("saveStoredStorageState writes workspace-local storageState JSON and returns metadata", async () => {
+  const fileName = "github-login.json";
+  await mkdir(STORAGE_STATE_ROOT, { recursive: true });
+  await removeStateFile(fileName);
+
+  try {
+    const session = {
+      context: {
+        storageState: async () => ({
+          cookies: [
+            {
+              name: "sid",
+              value: "secret-cookie",
+              domain: "example.com",
+              path: "/",
+              expires: -1,
+              httpOnly: true,
+              secure: true,
+              sameSite: "Lax",
+            },
+          ],
+          origins: [
+            {
+              origin: "https://example.com",
+              localStorage: [{ name: "token", value: "secret-token" }],
+            },
+          ],
+        }),
+      },
+    } as unknown as Parameters<(typeof __testables)["saveStoredStorageState"]>[0];
+
+    const saved = await __testables.saveStoredStorageState(session, "GitHub Login");
+    assert.equal(saved.name, "github-login");
+    assert.equal(saved.path, `${STORAGE_STATE_RELATIVE_DIR}/github-login.json`);
+    assert.equal(saved.cookie_count, 1);
+    assert.equal(saved.origin_count, 1);
+
+    const stored = JSON.parse(await readFile(resolve(STORAGE_STATE_ROOT, fileName), "utf8")) as {
+      cookies: Array<{ name: string }>;
+      origins: Array<{ origin: string }>;
+    };
+    assert.equal(stored.cookies[0]?.name, "sid");
+    assert.equal(stored.origins[0]?.origin, "https://example.com");
+  } finally {
+    await removeStateFile(fileName);
+  }
+});
+
+test("loadStoredStorageState reads a previously saved state by name", async () => {
+  const fileName = "roundtrip-state.json";
+  await mkdir(STORAGE_STATE_ROOT, { recursive: true });
+  await removeStateFile(fileName);
+
+  try {
+    await writeFile(
+      resolve(STORAGE_STATE_ROOT, fileName),
+      `${JSON.stringify(
+        {
+          cookies: [
+            {
+              name: "sid",
+              value: "secret-cookie",
+              domain: "example.com",
+              path: "/",
+              expires: -1,
+              httpOnly: true,
+              secure: true,
+              sameSite: "Lax",
+            },
+          ],
+          origins: [
+            {
+              origin: "https://example.com",
+              localStorage: [{ name: "token", value: "secret-token" }],
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const loaded = await __testables.loadStoredStorageState("roundtrip state");
+    assert.equal(loaded.mountedStorageState.name, "roundtrip-state");
+    assert.equal(
+      loaded.mountedStorageState.path,
+      `${STORAGE_STATE_RELATIVE_DIR}/roundtrip-state.json`,
+    );
+    assert.equal(loaded.mountedStorageState.cookie_count, 1);
+    assert.equal(loaded.mountedStorageState.origin_count, 1);
+    assert.equal(loaded.storageState.cookies.length, 1);
+    assert.equal(loaded.storageState.origins.length, 1);
+  } finally {
+    await removeStateFile(fileName);
+  }
+});
+
+test("loadStoredStorageState rejects symlinked state files", async () => {
+  const sourceFileName = "symlink-source.json";
+  const symlinkFileName = "symlinked.json";
+  await mkdir(STORAGE_STATE_ROOT, { recursive: true });
+  await removeStateFile(sourceFileName);
+  await removeStateFile(symlinkFileName);
+
+  try {
+    await writeFile(
+      resolve(STORAGE_STATE_ROOT, sourceFileName),
+      `${JSON.stringify({ cookies: [], origins: [] }, null, 2)}\n`,
+      "utf8",
+    );
+    await symlink(sourceFileName, resolve(STORAGE_STATE_ROOT, symlinkFileName));
+
+    await assert.rejects(__testables.loadStoredStorageState("symlinked"), /must not use symlinks/);
+  } finally {
+    await removeStateFile(symlinkFileName);
+    await removeStateFile(sourceFileName);
+  }
+});


### PR DESCRIPTION
## Summary
- add explicit Playwright `storageState` JSON reuse to `browser_session_start` via workspace-local saved state names
- add `browser_storage_state_save` for explicit export without exposing raw cookies or auth state in tool output
- enforce workspace-local storage-state guardrails with no arbitrary host paths, no symlinked state files, no auto-save, and docs/tests for the safe-by-default model

## Testing
- `cd .pi/extensions/browser-playwright && npm run check`
- `cd .pi/extensions/browser-playwright && npm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #290
