### PR TITLE
feat: add explicit browser storage state reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .env*
 .firecrawl/
 slack-api/.tmp/
+.pi/state/browser-playwright/

--- a/.pi/extensions/browser-playwright/README.md
+++ b/.pi/extensions/browser-playwright/README.md
@@ -96,13 +96,44 @@ Recommended practice:
 - `browser_close` can close a tab or the entire session
 - sessions are cleaned up on Pi shutdown
 - idle sessions are also swept automatically after `BROWSER_PLAYWRIGHT_IDLE_TIMEOUT_MS` (default: 15 minutes)
+- saved login state reuse is **explicit opt-in only** via Playwright `storageState` JSON import
 
 Important limitations:
 
-- session state is process-local and in-memory only
-- a Pi reload or process restart drops live browser sessions
-- stored Playwright session mounting/import is not supported in #282
-- importing/exporting saved `storageState`, cookies, or localStorage for login reuse is follow-up work, not current behavior
+- live browser sessions are still process-local and in-memory only
+- a Pi reload or process restart still drops live browser sessions
+- only explicit Playwright `storageState` JSON reuse is supported — not arbitrary browser-profile mounting
+- storage state is never auto-saved on close, reload, or shutdown
+
+## Stored browser state
+
+Saved Playwright login/session state is supported in a deliberately narrow, safety-first way.
+
+How it works:
+
+- place a trusted Playwright `storageState` JSON file under `.pi/state/browser-playwright/`
+- reuse it explicitly by passing `storage_state_name` to `browser_session_start`
+- names are sanitized to `<name>.json`
+- raw cookies / localStorage values are **not** echoed in tool output
+
+Current scope:
+
+- explicit **import/reuse** is supported
+- built-in export/save is intentionally **not** provided in this first safety-focused version
+- browser state is never auto-saved on close, reload, or shutdown
+
+Guardrails:
+
+- no arbitrary absolute host paths
+- no directory traversal inputs
+- no symlink escapes for saved state files or the saved-state root
+- no automatic persistence of auth state
+
+Treat `.pi/state/browser-playwright/` as secret-bearing auth material:
+
+- do not commit it
+- do not share it casually
+- delete saved state files when they are no longer needed
 
 ## Artifacts
 
@@ -193,7 +224,23 @@ Tool: `browser_wait_for`
 
 Tool: `browser_screenshot`
 
-### 3. Trusted local app after explicit opt-in
+### 3. Reuse a trusted saved `storageState` JSON file
+
+Place a trusted Playwright `storageState` JSON file at:
+
+- `.pi/state/browser-playwright/github-login.json`
+
+Then start a new session that reuses that saved state:
+
+```json
+{ "storage_state_name": "github-login" }
+```
+
+Tool: `browser_session_start`
+
+This is explicit opt-in only. The extension does not auto-save state, and tool output does not print raw cookies or localStorage values.
+
+### 4. Trusted local app after explicit opt-in
 
 First opt in:
 

--- a/.pi/extensions/browser-playwright/helpers.test.ts
+++ b/.pi/extensions/browser-playwright/helpers.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 import {
   assessUrl,
   buildInstallInstructions,
+  buildStorageStateFileName,
+  isPlaywrightStorageState,
   safeRequestPageId,
   sanitizeLabel,
+  sanitizeStorageStateName,
   truncateText,
   type SecurityOptions,
 } from "./helpers.ts";
@@ -110,6 +113,25 @@ test("safeRequestPageId returns null for service-worker-style requests without a
 test("sanitizeLabel keeps filenames safe and stable", () => {
   assert.equal(sanitizeLabel("Search Results / Docs"), "search-results-docs");
   assert.equal(sanitizeLabel("   "), "screenshot");
+});
+
+test("sanitizeStorageStateName keeps saved state names workspace-safe", () => {
+  assert.equal(sanitizeStorageStateName(" GitHub Login .json "), "github-login");
+  assert.equal(sanitizeStorageStateName("../../Prod Session"), "prod-session");
+});
+
+test("buildStorageStateFileName appends a normalized json filename", () => {
+  assert.equal(buildStorageStateFileName("QA Session"), "qa-session.json");
+});
+
+test("sanitizeStorageStateName rejects empty names", () => {
+  assert.throws(() => sanitizeStorageStateName("   "), /letter or number/);
+});
+
+test("isPlaywrightStorageState validates the expected top-level shape", () => {
+  assert.equal(isPlaywrightStorageState({ cookies: [], origins: [] }), true);
+  assert.equal(isPlaywrightStorageState({ cookies: [] }), false);
+  assert.equal(isPlaywrightStorageState(null), false);
 });
 
 test("truncateText trims oversized content and marks truncation", () => {

--- a/.pi/extensions/browser-playwright/helpers.ts
+++ b/.pi/extensions/browser-playwright/helpers.ts
@@ -13,9 +13,17 @@ export type SecurityOptions = {
 
 export type SupportedBrowserEngine = "chromium" | "firefox" | "webkit";
 
+export interface PlaywrightStorageStateLike {
+  cookies: unknown[];
+  origins: unknown[];
+}
+
 export const EXTENSION_RELATIVE_DIR = ".pi/extensions/browser-playwright";
+export const STORAGE_STATE_RELATIVE_DIR = ".pi/state/browser-playwright";
 export const DEFAULT_TEXT_LINES = 120;
 export const DEFAULT_TEXT_CHARS = 4_000;
+
+const STORAGE_STATE_NAME_MAX_CHARS = 80;
 
 export function parseIntegerEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -33,6 +41,19 @@ export function sanitizeLabel(value: string | undefined): string {
   const base = (value ?? "screenshot").trim().toLowerCase();
   const cleaned = base.replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
   return cleaned.length > 0 ? cleaned.slice(0, 60) : "screenshot";
+}
+
+export function sanitizeStorageStateName(value: string): string {
+  const base = value.trim().toLowerCase().replace(/\.json$/i, "");
+  const cleaned = base.replace(/[^a-z0-9_-]+/g, "-").replace(/^[-_]+|[-_]+$/g, "");
+  if (!/[a-z0-9]/.test(cleaned)) {
+    throw new Error("Storage state names must contain at least one letter or number.");
+  }
+  return cleaned.slice(0, STORAGE_STATE_NAME_MAX_CHARS);
+}
+
+export function buildStorageStateFileName(value: string): string {
+  return `${sanitizeStorageStateName(value)}.json`;
 }
 
 export function truncateText(
@@ -87,6 +108,17 @@ export function safeRequestPageId<PageLike>(
   } catch {
     return null;
   }
+}
+
+export function isPlaywrightStorageState(
+  value: unknown,
+): value is PlaywrightStorageStateLike {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as { cookies?: unknown; origins?: unknown };
+  return Array.isArray(record.cookies) && Array.isArray(record.origins);
 }
 
 function normalizeUrl(input: string): URL {

--- a/.pi/extensions/browser-playwright/index.ts
+++ b/.pi/extensions/browser-playwright/index.ts
@@ -11,9 +11,11 @@ import {
   parseIntegerEnv,
   safeRequestPageId,
   sanitizeLabel,
+  STORAGE_STATE_RELATIVE_DIR,
   truncateText,
   type SupportedBrowserEngine,
 } from "./helpers.ts";
+import { loadStoredStorageState, type StorageStateSummary } from "./storage-state.ts";
 import type {
   Browser,
   BrowserContext,
@@ -28,6 +30,7 @@ import type {
 type PlaywrightModule = typeof import("playwright");
 
 type BrowserEngine = SupportedBrowserEngine;
+type BrowserNewContextOptions = Exclude<Parameters<Browser["newContext"]>[0], undefined>;
 
 type WaitUntil = "load" | "domcontentloaded" | "networkidle" | "commit";
 
@@ -83,10 +86,12 @@ type BrowserSession = {
   consoleEntries: ConsoleEntry[];
   blockedRequests: BlockedRequestEntry[];
   networkSummary: NetworkSummary;
+  mountedStorageState: StorageStateSummary | null;
 };
 
 const EXTENSION_DIR = fileURLToPath(new URL(".", import.meta.url));
-const ARTIFACT_ROOT = resolve(EXTENSION_DIR, "../../artifacts/browser-playwright");
+const WORKSPACE_ROOT = resolve(EXTENSION_DIR, "../../..");
+const ARTIFACT_ROOT = resolve(WORKSPACE_ROOT, ".pi/artifacts/browser-playwright");
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_NAVIGATION_TIMEOUT_MS = 20_000;
@@ -106,6 +111,10 @@ function nowIso(): string {
 function asErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function relativeFromWorkspace(absolutePath: string): string {
+  return relative(WORKSPACE_ROOT, absolutePath);
 }
 
 async function loadPlaywright(browserEngine: BrowserEngine): Promise<PlaywrightModule> {
@@ -531,6 +540,12 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       url: Type.Optional(Type.String({ description: "Optional initial URL to open." })),
       viewport_width: Type.Optional(Type.Number({ description: "Viewport width in pixels." })),
       viewport_height: Type.Optional(Type.Number({ description: "Viewport height in pixels." })),
+      storage_state_name: Type.Optional(
+        Type.String({
+          description:
+            "Optional saved storage state name to import from `.pi/state/browser-playwright/<name>.json`.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal) {
       if (signal?.aborted) {
@@ -544,6 +559,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       const playwright = await loadPlaywright(browserEngine);
       const browserType = playwright[browserEngine] as BrowserType;
       const headless = params.headless ?? true;
+      const loadedStorageState = params.storage_state_name
+        ? await loadStoredStorageState(params.storage_state_name, { workspaceRoot: WORKSPACE_ROOT })
+        : null;
 
       let browser: Browser | null = null;
       try {
@@ -562,12 +580,18 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       }
 
       try {
-        const context = await browser.newContext({
+        const contextOptions: BrowserNewContextOptions = {
           viewport:
             params.viewport_width && params.viewport_height
               ? { width: params.viewport_width, height: params.viewport_height }
               : { width: 1280, height: 800 },
-        });
+        };
+        if (loadedStorageState) {
+          contextOptions.storageState =
+            loadedStorageState.storageState as BrowserNewContextOptions["storageState"];
+        }
+
+        const context = await browser.newContext(contextOptions);
 
         const session: BrowserSession = {
           id: `browser_${randomUUID()}`,
@@ -587,6 +611,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
             blocked_requests: 0,
             failed_requests: 0,
           },
+          mountedStorageState: loadedStorageState?.summary ?? null,
         };
 
         await context.route("**/*", async (route: Route) => {
@@ -647,7 +672,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
                   created_at: session.createdAt,
                   active_page_id: activePage?.id ?? null,
                   pages,
-                  artifact_dir: relative(resolve(EXTENSION_DIR, "../../.."), ARTIFACT_ROOT),
+                  artifact_dir: relativeFromWorkspace(ARTIFACT_ROOT),
+                  storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
+                  mounted_storage_state: session.mountedStorageState,
                   safety: {
                     allow_localhost: envFlag("BROWSER_ALLOW_LOCALHOST"),
                     allow_private_network: envFlag("BROWSER_ALLOW_PRIVATE_NETWORK"),
@@ -665,7 +692,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
             created_at: session.createdAt,
             active_page_id: activePage?.id ?? null,
             pages,
-            artifact_dir: relative(resolve(EXTENSION_DIR, "../../.."), ARTIFACT_ROOT),
+            artifact_dir: relativeFromWorkspace(ARTIFACT_ROOT),
+            storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
+            mounted_storage_state: session.mountedStorageState,
             safety: {
               allow_localhost: envFlag("BROWSER_ALLOW_LOCALHOST"),
               allow_private_network: envFlag("BROWSER_ALLOW_PRIVATE_NETWORK"),
@@ -703,6 +732,8 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
         active_page_id: session.activePageId,
         page_count: pages.length,
         pages,
+        mounted_storage_state: session.mountedStorageState,
+        storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
         network_summary: session.networkSummary,
         recent_console: session.consoleEntries,
         blocked_requests: session.blockedRequests,
@@ -1151,7 +1182,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       });
       touchPage(pageRecord);
 
-      const relativePath = relative(resolve(EXTENSION_DIR, "../../.."), absolutePath);
+      const relativePath = relativeFromWorkspace(absolutePath);
       const result = {
         session_id: session.id,
         page_id: pageRecord.id,

--- a/.pi/extensions/browser-playwright/package.json
+++ b/.pi/extensions/browser-playwright/package.json
@@ -7,7 +7,7 @@
     "clean": "echo 'nothing to clean'",
     "build": "echo 'nothing to build'",
     "check": "tsc --noEmit -p tsconfig.json",
-    "test": "node --experimental-strip-types --test helpers.test.ts"
+    "test": "node --experimental-strip-types --test *.test.ts"
   },
   "pi": {
     "extensions": [

--- a/.pi/extensions/browser-playwright/storage-state.test.ts
+++ b/.pi/extensions/browser-playwright/storage-state.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, open, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { afterEach } from "node:test";
+import { loadStoredStorageState, resolveStorageStateFile } from "./storage-state.ts";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("resolveStorageStateFile keeps saved state under the workspace-local browser-playwright state directory", async () => {
+  const workspace = await makeTempDir("browser-storage-root-");
+  await mkdir(path.join(workspace, ".pi", "state", "browser-playwright"), { recursive: true });
+
+  const resolved = await resolveStorageStateFile(" GitHub Login ", { workspaceRoot: workspace });
+
+  assert.equal(resolved.name, "github-login");
+  assert.match(resolved.relativePath, /^\.pi[\\/]state[\\/]browser-playwright[\\/]github-login\.json$/);
+  assert.match(
+    resolved.absolutePath,
+    new RegExp(`\\${path.sep}\\.pi\\${path.sep}state\\${path.sep}browser-playwright\\${path.sep}github-login\\.json$`),
+  );
+});
+
+test("loadStoredStorageState reuses a trusted saved storageState file", async () => {
+  const workspace = await makeTempDir("browser-storage-roundtrip-");
+  const targetDir = path.join(workspace, ".pi", "state", "browser-playwright");
+  const storageState = {
+    cookies: [{ name: "sid", value: "secret" }],
+    origins: [{ origin: "https://example.com", localStorage: [{ name: "theme", value: "dark" }] }],
+  };
+  await mkdir(targetDir, { recursive: true });
+  await writeFile(path.join(targetDir, "example-session.json"), `${JSON.stringify(storageState, null, 2)}\n`, "utf8");
+
+  const loaded = await loadStoredStorageState("Example Session", { workspaceRoot: workspace });
+  assert.deepEqual(loaded.summary, {
+    name: "example-session",
+    path: ".pi/state/browser-playwright/example-session.json",
+    cookie_count: 1,
+    origin_count: 1,
+  });
+  assert.deepEqual(loaded.storageState, storageState);
+});
+
+test("loadStoredStorageState rejects invalid JSON", async () => {
+  const workspace = await makeTempDir("browser-storage-invalid-json-");
+  const targetDir = path.join(workspace, ".pi", "state", "browser-playwright");
+  await mkdir(targetDir, { recursive: true });
+  await writeFile(path.join(targetDir, "broken.json"), "not-json", "utf8");
+
+  await assert.rejects(
+    () => loadStoredStorageState("broken", { workspaceRoot: workspace }),
+    /is not valid JSON/i,
+  );
+});
+
+test("loadStoredStorageState rejects JSON that is not Playwright storageState-shaped", async () => {
+  const workspace = await makeTempDir("browser-storage-invalid-shape-");
+  const targetDir = path.join(workspace, ".pi", "state", "browser-playwright");
+  await mkdir(targetDir, { recursive: true });
+  await writeFile(path.join(targetDir, "broken.json"), JSON.stringify({ cookies: [] }), "utf8");
+
+  await assert.rejects(
+    () => loadStoredStorageState("broken", { workspaceRoot: workspace }),
+    /not a valid Playwright storageState JSON file/i,
+  );
+});
+
+test("loadStoredStorageState rejects symlinked saved state files", async () => {
+  const workspace = await makeTempDir("browser-storage-symlink-file-");
+  const targetDir = path.join(workspace, ".pi", "state", "browser-playwright");
+  const outside = await makeTempDir("browser-storage-outside-file-");
+  await mkdir(targetDir, { recursive: true });
+  await writeFile(path.join(outside, "secret.json"), JSON.stringify({ cookies: [], origins: [] }), "utf8");
+  await symlink(path.join(outside, "secret.json"), path.join(targetDir, "linked.json"));
+
+  await assert.rejects(
+    () => loadStoredStorageState("linked", { workspaceRoot: workspace }),
+    /must not use symlinks/i,
+  );
+});
+
+test("loadStoredStorageState rejects a symlink swap just before open", async () => {
+  const workspace = await makeTempDir("browser-storage-swap-");
+  const targetDir = path.join(workspace, ".pi", "state", "browser-playwright");
+  const outside = await makeTempDir("browser-storage-swap-outside-");
+  const targetFile = path.join(targetDir, "swap.json");
+  const outsideFile = path.join(outside, "secret.json");
+  await mkdir(targetDir, { recursive: true });
+  await writeFile(targetFile, JSON.stringify({ cookies: [], origins: [] }), "utf8");
+  await writeFile(outsideFile, JSON.stringify({ cookies: [], origins: [] }), "utf8");
+
+  await assert.rejects(
+    () =>
+      loadStoredStorageState("swap", { workspaceRoot: workspace }, {
+        openImpl: async (filePath, flags) => {
+          await rm(filePath, { force: true });
+          await symlink(outsideFile, filePath);
+          return open(filePath, flags);
+        },
+      }),
+    /must not use symlinks/i,
+  );
+});
+
+test("loadStoredStorageState rejects storage roots that escape the workspace via symlink", async () => {
+  const workspace = await makeTempDir("browser-storage-root-symlink-");
+  const outside = await makeTempDir("browser-storage-root-outside-");
+  await mkdir(path.join(workspace, ".pi"), { recursive: true });
+  await mkdir(path.join(outside, "browser-playwright"), { recursive: true });
+  await symlink(outside, path.join(workspace, ".pi", "state"));
+
+  await assert.rejects(
+    () => loadStoredStorageState("Example Session", { workspaceRoot: workspace }),
+    /must stay inside the workspace/i,
+  );
+});

--- a/.pi/extensions/browser-playwright/storage-state.ts
+++ b/.pi/extensions/browser-playwright/storage-state.ts
@@ -1,0 +1,156 @@
+import { constants } from "node:fs";
+import { open, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
+import {
+  buildStorageStateFileName,
+  isPlaywrightStorageState,
+  STORAGE_STATE_RELATIVE_DIR,
+  type PlaywrightStorageStateLike,
+} from "./helpers.ts";
+
+export interface ResolvedStorageStateFile {
+  name: string;
+  absolutePath: string;
+  relativePath: string;
+}
+
+export interface StorageStateSummary {
+  name: string;
+  path: string;
+  cookie_count: number;
+  origin_count: number;
+}
+
+export interface StorageStatePaths {
+  workspaceRoot: string;
+}
+
+interface StorageStateFs {
+  openImpl?: typeof open;
+  realpathImpl?: typeof realpath;
+}
+
+function isPathInsideDirectory(pathToCheck: string, directoryPath: string): boolean {
+  const rel = relative(directoryPath, pathToCheck);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function storageStateRootPath(workspaceRoot: string): string {
+  return resolve(workspaceRoot, STORAGE_STATE_RELATIVE_DIR);
+}
+
+async function resolveWorkspaceRoots(
+  workspaceRoot: string,
+  fsDeps: StorageStateFs = {},
+): Promise<{ workspaceRootReal: string; storageStateRootReal: string }> {
+  const { realpathImpl = realpath } = fsDeps;
+  const storageStateRoot = storageStateRootPath(workspaceRoot);
+
+  const [workspaceRootReal, storageStateRootReal] = await Promise.all([
+    realpathImpl(workspaceRoot),
+    realpathImpl(storageStateRoot),
+  ]);
+
+  if (!isPathInsideDirectory(storageStateRootReal, workspaceRootReal)) {
+    throw new Error(
+      `Stored browser state directory must stay inside the workspace: \`${STORAGE_STATE_RELATIVE_DIR}\`.`,
+    );
+  }
+
+  return { workspaceRootReal, storageStateRootReal };
+}
+
+function summarizeStorageState(storageState: PlaywrightStorageStateLike): {
+  cookie_count: number;
+  origin_count: number;
+} {
+  return {
+    cookie_count: storageState.cookies.length,
+    origin_count: storageState.origins.length,
+  };
+}
+
+export async function resolveStorageStateFile(
+  name: string,
+  paths: StorageStatePaths,
+  fsDeps: StorageStateFs = {},
+): Promise<ResolvedStorageStateFile> {
+  const { workspaceRootReal, storageStateRootReal } = await resolveWorkspaceRoots(
+    paths.workspaceRoot,
+    fsDeps,
+  );
+  const fileName = buildStorageStateFileName(name);
+  const absolutePath = resolve(storageStateRootReal, fileName);
+
+  return {
+    name: fileName.replace(/\.json$/i, ""),
+    absolutePath,
+    relativePath: relative(workspaceRootReal, absolutePath),
+  };
+}
+
+export async function loadStoredStorageState(
+  name: string,
+  paths: StorageStatePaths,
+  fsDeps: StorageStateFs = {},
+): Promise<{ storageState: PlaywrightStorageStateLike; summary: StorageStateSummary }> {
+  let resolvedState: ResolvedStorageStateFile;
+  try {
+    resolvedState = await resolveStorageStateFile(name, paths, fsDeps);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    const fileName = buildStorageStateFileName(name).replace(/\.json$/i, "");
+    if (code === "ENOENT") {
+      throw new Error(
+        `Stored browser state \`${fileName}\` was not found in \`${STORAGE_STATE_RELATIVE_DIR}\`. Place a trusted Playwright storageState JSON file there first.`,
+      );
+    }
+    throw error;
+  }
+
+  const { openImpl = open } = fsDeps;
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    handle = await openImpl(resolvedState.absolutePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stats = await handle.stat();
+    if (!stats.isFile()) {
+      throw new Error(`Stored browser state must be a regular file: \`${resolvedState.relativePath}\`.`);
+    }
+
+    const parsed = JSON.parse(await handle.readFile({ encoding: "utf8" }));
+    if (!isPlaywrightStorageState(parsed)) {
+      throw new Error(
+        `Stored browser state \`${resolvedState.name}\` is not a valid Playwright storageState JSON file.`,
+      );
+    }
+
+    return {
+      storageState: parsed,
+      summary: {
+        name: resolvedState.name,
+        path: resolvedState.relativePath,
+        ...summarizeStorageState(parsed),
+      },
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      throw new Error(
+        `Stored browser state \`${resolvedState.name}\` was not found at \`${resolvedState.relativePath}\`. Place a trusted Playwright storageState JSON file there first.`,
+      );
+    }
+    if (code === "ELOOP") {
+      throw new Error(
+        `Stored browser state paths must not use symlinks: \`${resolvedState.relativePath}\`.`,
+      );
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Stored browser state \`${resolvedState.name}\` is not valid JSON.`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit opt-in Playwright `storageState` reuse for browser-playwright sessions
- keep saved state files workspace-local and name-based under `.pi/state/browser-playwright/` with symlink-safe load guardrails
- document the security model, including why this first pass supports import/reuse but not built-in export
- add focused storage-state tests

## Testing
- cd .pi/extensions/browser-playwright && npm test
- cd .pi/extensions/browser-playwright && npm run check

Closes #290