### PR TITLE
feat: add guarded Playwright storageState reuse (#290)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .env*
 .firecrawl/
 slack-api/.tmp/
+.pi/artifacts/browser-playwright/storage-state/

--- a/.pi/extensions/browser-playwright/README.md
+++ b/.pi/extensions/browser-playwright/README.md
@@ -8,6 +8,7 @@ It is designed for real browsing and lightweight web interaction, not just test 
 - navigate public sites
 - snapshot and extract page content
 - click, fill, press, wait, inspect tabs, and capture screenshots
+- explicitly export and reuse Playwright `storageState` JSON under guarded workspace-local paths
 - keep screenshots and artifacts inside the workspace
 - block localhost and private/internal network targets by default
 
@@ -99,10 +100,12 @@ Recommended practice:
 
 Important limitations:
 
-- session state is process-local and in-memory only
+- live browser sessions are still process-local and in-memory only
 - a Pi reload or process restart drops live browser sessions
-- stored Playwright session mounting/import is not supported in #282
-- importing/exporting saved `storageState`, cookies, or localStorage for login reuse is follow-up work, not current behavior
+- explicit Playwright `storageState` JSON import/export is supported only through guarded workspace-local files under `.pi/artifacts/browser-playwright/storage-state/`
+- persistence is explicit opt-in only — there is no auto-save on close, reload, or shutdown
+- arbitrary browser profile mounting, arbitrary absolute host paths, traversal, and symlink escapes are not supported
+- tool output never echoes raw cookies, tokens, or localStorage/auth payloads
 
 ## Artifacts
 
@@ -113,6 +116,12 @@ Screenshots are written under:
 Current screenshot layout:
 
 - `.pi/artifacts/browser-playwright/<session_id>/<timestamp>-<label>.png`
+
+Storage state layout:
+
+- `.pi/artifacts/browser-playwright/storage-state/<name>.json`
+- bare filenames passed to storage-state APIs are rooted there automatically
+- that directory is gitignored in this repo because saved `storageState` files may contain live auth material
 
 `browser_screenshot` returns structured metadata including:
 
@@ -136,8 +145,9 @@ Required tools provided:
 8. `browser_press`
 9. `browser_wait_for`
 10. `browser_screenshot`
-11. `browser_tabs`
-12. `browser_close`
+11. `browser_storage_state_save`
+12. `browser_tabs`
+13. `browser_close`
 
 ## Usage flows
 
@@ -193,7 +203,34 @@ Tool: `browser_wait_for`
 
 Tool: `browser_screenshot`
 
-### 3. Trusted local app after explicit opt-in
+### 3. Save login state and reuse it later
+
+Save the current browser context explicitly:
+
+```json
+{ "session_id": "<session_id>", "path": "github-login.json" }
+```
+
+Tool: `browser_storage_state_save`
+
+Start a new session with that guarded storage state file:
+
+```json
+{
+  "storage_state_path": "github-login.json",
+  "url": "https://github.com"
+}
+```
+
+Tool: `browser_session_start`
+
+Notes:
+
+- `storage_state_path` must resolve under `.pi/artifacts/browser-playwright/storage-state/`
+- bare filenames are rooted there automatically
+- storage-state reuse is explicit only; the extension never auto-saves session state
+
+### 4. Trusted local app after explicit opt-in
 
 First opt in:
 
@@ -218,4 +255,5 @@ Without the env opt-in, that navigation is blocked.
 - keep `page_id` from previous results when a task depends on a specific tab
 - use `browser_snapshot` before interacting when you need a quick page map
 - use `browser_extract` for selector-specific text/attribute reads
+- use `browser_storage_state_save` only when a workflow explicitly needs later authenticated reuse
 - close sessions you no longer need with `browser_close`

--- a/.pi/extensions/browser-playwright/helpers.test.ts
+++ b/.pi/extensions/browser-playwright/helpers.test.ts
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 import {
   assessUrl,
   buildInstallInstructions,
+  normalizeStorageStatePath,
+  resolveStorageStatePath,
   safeRequestPageId,
   sanitizeLabel,
+  STORAGE_STATE_RELATIVE_DIR,
   truncateText,
   type SecurityOptions,
 } from "./helpers.ts";
@@ -117,4 +123,69 @@ test("truncateText trims oversized content and marks truncation", () => {
   const result = truncateText(input, 20, 3);
   assert.match(result, /truncated/);
   assert.doesNotMatch(result, /line-9/);
+});
+
+test("normalizeStorageStatePath keeps storage state files under the guarded directory", () => {
+  assert.equal(
+    normalizeStorageStatePath("github-login.json"),
+    `${STORAGE_STATE_RELATIVE_DIR}/github-login.json`,
+  );
+  assert.equal(
+    normalizeStorageStatePath(`${STORAGE_STATE_RELATIVE_DIR}/nested/auth.json`),
+    `${STORAGE_STATE_RELATIVE_DIR}/nested/auth.json`,
+  );
+});
+
+test("normalizeStorageStatePath rejects absolute paths, traversal, and non-json files", () => {
+  assert.throws(() => normalizeStorageStatePath("/tmp/auth.json"), /workspace-local/);
+  assert.throws(() => normalizeStorageStatePath("../auth.json"), /traversal/i);
+  assert.throws(() => normalizeStorageStatePath("auth.txt"), /\.json/);
+});
+
+test("resolveStorageStatePath prepares safe write targets under the guarded workspace directory", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "browser-playwright-state-write-"));
+  const resolved = await resolveStorageStatePath(workspaceRoot, "team/login.json", "write");
+
+  assert.equal(resolved.relativePath, `${STORAGE_STATE_RELATIVE_DIR}/team/login.json`);
+  assert.equal(
+    resolved.absolutePath,
+    resolve(await realpath(workspaceRoot), `${STORAGE_STATE_RELATIVE_DIR}/team/login.json`),
+  );
+});
+
+test("resolveStorageStatePath reads workspace-local storage state files", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "browser-playwright-state-read-"));
+  const target = resolve(workspaceRoot, `${STORAGE_STATE_RELATIVE_DIR}/saved/login.json`);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, JSON.stringify({ cookies: [], origins: [] }), { encoding: "utf8" });
+
+  const resolved = await resolveStorageStatePath(
+    workspaceRoot,
+    `${STORAGE_STATE_RELATIVE_DIR}/saved/login.json`,
+    "read",
+  );
+
+  assert.equal(resolved.relativePath, `${STORAGE_STATE_RELATIVE_DIR}/saved/login.json`);
+  assert.equal(resolved.absolutePath, await realpath(target));
+});
+
+test("resolveStorageStatePath rejects symlink escapes for reads and writes", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "browser-playwright-state-symlink-"));
+  const outsideRoot = await mkdtemp(join(tmpdir(), "browser-playwright-state-outside-"));
+  const storageRoot = resolve(workspaceRoot, STORAGE_STATE_RELATIVE_DIR);
+  const linkPath = resolve(storageRoot, "linked.json");
+  const outsideFile = resolve(outsideRoot, "outside.json");
+
+  await mkdir(dirname(linkPath), { recursive: true });
+  await writeFile(outsideFile, JSON.stringify({ cookies: [], origins: [] }), { encoding: "utf8" });
+  await symlink(outsideFile, linkPath);
+
+  await assert.rejects(
+    () => resolveStorageStatePath(workspaceRoot, "linked.json", "read"),
+    /symlink|outside the guarded workspace directory/,
+  );
+  await assert.rejects(
+    () => resolveStorageStatePath(workspaceRoot, "linked.json", "write"),
+    /symlink|outside the guarded workspace directory/,
+  );
 });

--- a/.pi/extensions/browser-playwright/helpers.ts
+++ b/.pi/extensions/browser-playwright/helpers.ts
@@ -1,3 +1,9 @@
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { lstat, mkdir, open, realpath, rename, rm } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, normalize, relative, resolve } from "node:path";
+import type { BrowserContextOptions } from "playwright";
+
 export type UrlDecision =
   | { allowed: true }
   | {
@@ -14,8 +20,13 @@ export type SecurityOptions = {
 export type SupportedBrowserEngine = "chromium" | "firefox" | "webkit";
 
 export const EXTENSION_RELATIVE_DIR = ".pi/extensions/browser-playwright";
+export const STORAGE_STATE_RELATIVE_DIR = ".pi/artifacts/browser-playwright/storage-state";
 export const DEFAULT_TEXT_LINES = 120;
 export const DEFAULT_TEXT_CHARS = 4_000;
+
+export type StorageStatePayload = Exclude<BrowserContextOptions["storageState"], string | undefined>;
+
+const NOFOLLOW_FLAG = fsConstants.O_NOFOLLOW ?? 0;
 
 export function parseIntegerEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -87,6 +98,229 @@ export function safeRequestPageId<PageLike>(
   } catch {
     return null;
   }
+}
+
+function isSubpath(basePath: string, targetPath: string): boolean {
+  const rel = relative(basePath, targetPath);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+export function normalizeStorageStatePath(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    throw new Error("storage_state_path must be a non-empty relative JSON path.");
+  }
+  if (trimmed.includes("\0")) {
+    throw new Error("storage_state_path must not contain NUL bytes.");
+  }
+  if (trimmed.split(/[\\/]+/).some((segment) => segment === "..")) {
+    throw new Error(
+      `storage_state_path must stay within \`${STORAGE_STATE_RELATIVE_DIR}/\` and cannot use traversal segments.`,
+    );
+  }
+
+  const normalizedInput = normalize(trimmed).replace(/\\/g, "/").replace(/^\.\//, "");
+  if (isAbsolute(normalizedInput) || /^[A-Za-z]:\//.test(normalizedInput)) {
+    throw new Error("storage_state_path must be relative and workspace-local.");
+  }
+
+  const relativePath =
+    normalizedInput === STORAGE_STATE_RELATIVE_DIR ||
+    normalizedInput.startsWith(`${STORAGE_STATE_RELATIVE_DIR}/`)
+      ? normalizedInput
+      : `${STORAGE_STATE_RELATIVE_DIR}/${normalizedInput}`;
+
+  if (
+    relativePath === STORAGE_STATE_RELATIVE_DIR ||
+    relativePath.endsWith("/") ||
+    relativePath.split("/").some((segment) => segment === "..")
+  ) {
+    throw new Error(
+      `storage_state_path must stay within \`${STORAGE_STATE_RELATIVE_DIR}/\` and cannot use traversal segments.`,
+    );
+  }
+
+  if (extname(relativePath).toLowerCase() !== ".json") {
+    throw new Error("storage_state_path must end with `.json`.");
+  }
+
+  return relativePath;
+}
+
+export async function resolveStorageStatePath(
+  workspaceRoot: string,
+  input: string,
+  mode: "read" | "write",
+): Promise<{ absolutePath: string; relativePath: string }> {
+  const workspaceRootReal = await realpath(workspaceRoot);
+  const relativePath = normalizeStorageStatePath(input);
+  const absolutePath = resolve(workspaceRootReal, relativePath);
+  const storageStateRoot = resolve(workspaceRootReal, STORAGE_STATE_RELATIVE_DIR);
+
+  if (!isSubpath(storageStateRoot, absolutePath)) {
+    throw new Error(
+      `storage_state_path must resolve inside \`${STORAGE_STATE_RELATIVE_DIR}/\` within the workspace.`,
+    );
+  }
+
+  if (mode === "write") {
+    await mkdir(dirname(absolutePath), { recursive: true });
+    const parentReal = await realpath(dirname(absolutePath));
+    if (!isSubpath(storageStateRoot, parentReal)) {
+      throw new Error("Refusing to write storage state outside the guarded workspace directory.");
+    }
+
+    try {
+      const existing = await lstat(absolutePath);
+      if (existing.isSymbolicLink()) {
+        throw new Error(`Refusing to write storage state through symlink: ${relativePath}`);
+      }
+      if (!existing.isFile()) {
+        throw new Error(`Storage state path must point to a regular JSON file: ${relativePath}`);
+      }
+      const existingReal = await realpath(absolutePath);
+      if (!isSubpath(storageStateRoot, existingReal)) {
+        throw new Error("Refusing to write storage state outside the guarded workspace directory.");
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    return { absolutePath, relativePath };
+  }
+
+  let statResult: Awaited<ReturnType<typeof lstat>>;
+  try {
+    statResult = await lstat(absolutePath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new Error(`Storage state file not found: ${relativePath}`);
+    }
+    throw error;
+  }
+
+  if (statResult.isSymbolicLink()) {
+    throw new Error(`Refusing to read storage state through symlink: ${relativePath}`);
+  }
+  if (!statResult.isFile()) {
+    throw new Error(`Storage state path must point to a regular JSON file: ${relativePath}`);
+  }
+
+  const realFilePath = await realpath(absolutePath);
+  if (!isSubpath(storageStateRoot, realFilePath)) {
+    throw new Error("Refusing to read storage state outside the guarded workspace directory.");
+  }
+
+  return { absolutePath: realFilePath, relativePath };
+}
+
+function parseStorageStatePayload(
+  text: string,
+  relativePath: string,
+): StorageStatePayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Invalid storage state JSON: ${relativePath}`, {
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+
+  if (typeof parsed !== "object" || parsed == null || Array.isArray(parsed)) {
+    throw new Error(`Storage state file must contain a JSON object: ${relativePath}`);
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if ("cookies" in record && !Array.isArray(record.cookies)) {
+    throw new Error(`Storage state \`cookies\` must be an array: ${relativePath}`);
+  }
+  if ("origins" in record && !Array.isArray(record.origins)) {
+    throw new Error(`Storage state \`origins\` must be an array: ${relativePath}`);
+  }
+
+  return {
+    ...record,
+    cookies: Array.isArray(record.cookies) ? record.cookies : [],
+    origins: Array.isArray(record.origins) ? record.origins : [],
+  } as StorageStatePayload;
+}
+
+export async function readStorageStateFile(
+  workspaceRoot: string,
+  input: string,
+): Promise<{
+  absolutePath: string;
+  relativePath: string;
+  storageState: StorageStatePayload;
+}> {
+  const { absolutePath, relativePath } = await resolveStorageStatePath(workspaceRoot, input, "read");
+  const handle = await open(absolutePath, fsConstants.O_RDONLY | NOFOLLOW_FLAG);
+  try {
+    const text = await handle.readFile({ encoding: "utf8" });
+    return {
+      absolutePath,
+      relativePath,
+      storageState: parseStorageStatePayload(text, relativePath),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function writeStorageStateFile(
+  workspaceRoot: string,
+  input: string,
+  payload: StorageStatePayload,
+): Promise<{ absolutePath: string; relativePath: string; sizeBytes: number }> {
+  const { absolutePath, relativePath } = await resolveStorageStatePath(workspaceRoot, input, "write");
+  const parentReal = await realpath(dirname(absolutePath));
+  const finalPath = resolve(parentReal, basename(absolutePath));
+  const tempPath = resolve(parentReal, `.tmp-${randomUUID()}.json`);
+  const text = `${JSON.stringify(payload, null, 2)}\n`;
+
+  const handle = await open(
+    tempPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | NOFOLLOW_FLAG,
+    0o600,
+  );
+  try {
+    await handle.writeFile(text, { encoding: "utf8" });
+  } finally {
+    await handle.close();
+  }
+
+  try {
+    try {
+      const existing = await lstat(finalPath);
+      if (existing.isSymbolicLink()) {
+        throw new Error(`Refusing to write storage state through symlink: ${relativePath}`);
+      }
+      if (!existing.isFile()) {
+        throw new Error(`Storage state path must point to a regular JSON file: ${relativePath}`);
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    await rename(tempPath, finalPath);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+
+  return {
+    absolutePath: finalPath,
+    relativePath,
+    sizeBytes: Buffer.byteLength(text),
+  };
 }
 
 function normalizeUrl(input: string): URL {

--- a/.pi/extensions/browser-playwright/index.test.ts
+++ b/.pi/extensions/browser-playwright/index.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import browserPlaywrightExtension from "./index.ts";
+import { STORAGE_STATE_RELATIVE_DIR } from "./helpers.ts";
+
+type RegisteredTool = {
+  name: string;
+  execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ details: unknown }>;
+};
+
+class FakePage {
+  private readonly frameRef = {};
+
+  on(_event: string, _handler: (...args: unknown[]) => void): void {
+    // no-op for focused storageState tests
+  }
+
+  url(): string {
+    return "about:blank";
+  }
+
+  async title(): Promise<string> {
+    return "Browser Playwright Test";
+  }
+
+  isClosed(): boolean {
+    return false;
+  }
+
+  mainFrame(): object {
+    return this.frameRef;
+  }
+}
+
+class FakeContext {
+  readonly page: FakePage;
+  lastStorageStateOptions: { path?: string } | undefined;
+
+  constructor(page: FakePage) {
+    this.page = page;
+  }
+
+  async newPage(): Promise<FakePage> {
+    return this.page;
+  }
+
+  async route(_pattern: string, _handler: (...args: unknown[]) => Promise<void>): Promise<void> {
+    // no-op for focused storageState tests
+  }
+
+  on(_event: string, _handler: (...args: unknown[]) => void): void {
+    // no-op for focused storageState tests
+  }
+
+  async storageState(options?: { path?: string }): Promise<{ cookies: unknown[]; origins: unknown[] }> {
+    this.lastStorageStateOptions = options;
+    const payload = {
+      cookies: [{ name: "session", value: "super-secret-cookie" }],
+      origins: [],
+    };
+
+    if (options?.path) {
+      await mkdir(dirname(options.path), { recursive: true });
+      await writeFile(options.path, JSON.stringify(payload), { encoding: "utf8" });
+    }
+
+    return payload;
+  }
+}
+
+class FakeBrowser {
+  contextOptions: Record<string, unknown> | null = null;
+  readonly context: FakeContext;
+
+  constructor(context: FakeContext) {
+    this.context = context;
+  }
+
+  async newContext(options: Record<string, unknown>): Promise<FakeContext> {
+    this.contextOptions = options;
+    return this.context;
+  }
+
+  async close(): Promise<void> {
+    // no-op for focused storageState tests
+  }
+}
+
+async function setupExtension(workspaceRoot: string): Promise<{
+  tools: Map<string, RegisteredTool>;
+  shutdown: () => Promise<void>;
+  browser: FakeBrowser;
+  context: FakeContext;
+}> {
+  const tools = new Map<string, RegisteredTool>();
+  const events = new Map<string, (_event: unknown) => Promise<void>>();
+  const fakePage = new FakePage();
+  const fakeContext = new FakeContext(fakePage);
+  const fakeBrowser = new FakeBrowser(fakeContext);
+
+  const playwright = await import("playwright");
+  const chromium = playwright.chromium as unknown as {
+    launch: (options: Record<string, unknown>) => Promise<unknown>;
+  };
+  const originalLaunch = chromium.launch;
+  chromium.launch = async () => fakeBrowser as unknown;
+
+  browserPlaywrightExtension(
+    {
+      registerTool(definition: RegisteredTool) {
+        tools.set(definition.name, definition);
+      },
+      on(eventName: string, handler: (_event: unknown) => Promise<void>) {
+        events.set(eventName, handler);
+      },
+    } as never,
+    { workspaceRoot },
+  );
+
+  return {
+    tools,
+    browser: fakeBrowser,
+    context: fakeContext,
+    shutdown: async () => {
+      chromium.launch = originalLaunch;
+      await events.get("session_shutdown")?.({});
+    },
+  };
+}
+
+test("browser_session_start loads guarded storageState JSON and reports the mounted path", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "browser-playwright-index-load-"));
+  const storageStatePath = resolve(workspaceRoot, STORAGE_STATE_RELATIVE_DIR, "tests/login.json");
+  await mkdir(dirname(storageStatePath), { recursive: true });
+  await writeFile(storageStatePath, JSON.stringify({ cookies: [], origins: [] }), {
+    encoding: "utf8",
+  });
+
+  const { tools, shutdown, browser } = await setupExtension(workspaceRoot);
+
+  try {
+    const start = tools.get("browser_session_start");
+    const info = tools.get("browser_session_info");
+    assert.ok(start);
+    assert.ok(info);
+
+    const started = await start!.execute("tool-start", {
+      storage_state_path: "tests/login.json",
+    });
+    const details = started.details as { session_id: string; storage_state_path: string | null };
+
+    assert.equal(details.storage_state_path, `${STORAGE_STATE_RELATIVE_DIR}/tests/login.json`);
+    assert.deepEqual(browser.contextOptions?.storageState, { cookies: [], origins: [] });
+
+    const sessionInfo = await info!.execute("tool-info", { session_id: details.session_id });
+    assert.equal(
+      (sessionInfo.details as { storage_state_path: string | null }).storage_state_path,
+      `${STORAGE_STATE_RELATIVE_DIR}/tests/login.json`,
+    );
+  } finally {
+    await shutdown();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("browser_session_start rejects absolute storage state paths", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "browser-playwright-index-reject-"));
+  const { tools, shutdown } = await setupExtension(workspaceRoot);
+
+  try {
+    const start = tools.get("browser_session_start");
+    assert.ok(start);
+
+    await assert.rejects(
+      () => start!.execute("tool-start", { storage_state_path: "/tmp/evil.json" }),
+      /workspace-local/,
+    );
+  } finally {
+    await shutdown();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("browser_storage_state_save writes guarded JSON without echoing raw auth state", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "browser-playwright-index-save-"));
+  const savePath = resolve(workspaceRoot, STORAGE_STATE_RELATIVE_DIR, "tests/exported.json");
+  const { tools, shutdown, context } = await setupExtension(workspaceRoot);
+
+  try {
+    const start = tools.get("browser_session_start");
+    const save = tools.get("browser_storage_state_save");
+    assert.ok(start);
+    assert.ok(save);
+
+    const started = await start!.execute("tool-start", {});
+    const sessionId = (started.details as { session_id: string }).session_id;
+
+    const saved = await save!.execute("tool-save", {
+      session_id: sessionId,
+      path: "tests/exported.json",
+    });
+    const details = saved.details as { path: string; size_bytes: number };
+    const fileContent = await readFile(savePath, "utf8");
+
+    assert.equal(details.path, `${STORAGE_STATE_RELATIVE_DIR}/tests/exported.json`);
+    assert.ok(details.size_bytes > 0);
+    assert.match(fileContent, /super-secret-cookie/);
+    assert.doesNotMatch(JSON.stringify(saved.details), /super-secret-cookie/);
+    assert.equal(context.lastStorageStateOptions, undefined);
+  } finally {
+    await shutdown();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("browser_storage_state_save rejects symlink targets inside the guarded directory", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "browser-playwright-index-symlink-"));
+  const savePath = resolve(workspaceRoot, STORAGE_STATE_RELATIVE_DIR, "tests/linked.json");
+  await mkdir(dirname(savePath), { recursive: true });
+  await writeFile(resolve(workspaceRoot, "outside.json"), JSON.stringify({ outside: true }), {
+    encoding: "utf8",
+  });
+  await symlink(resolve(workspaceRoot, "outside.json"), savePath);
+
+  const { tools, shutdown } = await setupExtension(workspaceRoot);
+
+  try {
+    const start = tools.get("browser_session_start");
+    const save = tools.get("browser_storage_state_save");
+    assert.ok(start);
+    assert.ok(save);
+
+    const started = await start!.execute("tool-start", {});
+    const sessionId = (started.details as { session_id: string }).session_id;
+
+    await assert.rejects(
+      () =>
+        save!.execute("tool-save", {
+          session_id: sessionId,
+          path: "tests/linked.json",
+        }),
+      /symlink/,
+    );
+  } finally {
+    await shutdown();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/.pi/extensions/browser-playwright/index.ts
+++ b/.pi/extensions/browser-playwright/index.ts
@@ -9,9 +9,12 @@ import {
   buildInstallInstructions,
   envFlag,
   parseIntegerEnv,
+  readStorageStateFile,
   safeRequestPageId,
   sanitizeLabel,
+  STORAGE_STATE_RELATIVE_DIR,
   truncateText,
+  writeStorageStateFile,
   type SupportedBrowserEngine,
 } from "./helpers.ts";
 import type {
@@ -83,10 +86,12 @@ type BrowserSession = {
   consoleEntries: ConsoleEntry[];
   blockedRequests: BlockedRequestEntry[];
   networkSummary: NetworkSummary;
+  storageStatePath: string | null;
 };
 
 const EXTENSION_DIR = fileURLToPath(new URL(".", import.meta.url));
-const ARTIFACT_ROOT = resolve(EXTENSION_DIR, "../../artifacts/browser-playwright");
+const DEFAULT_WORKSPACE_ROOT = resolve(EXTENSION_DIR, "../../..");
+const ARTIFACT_RELATIVE_DIR = ".pi/artifacts/browser-playwright";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_NAVIGATION_TIMEOUT_MS = 20_000;
@@ -380,8 +385,8 @@ async function waitForPossibleNavigation(
   }
 }
 
-async function ensureArtifactsDir(): Promise<void> {
-  await mkdir(ARTIFACT_ROOT, { recursive: true });
+async function ensureArtifactsDir(artifactRoot: string): Promise<void> {
+  await mkdir(artifactRoot, { recursive: true });
 }
 
 async function buildElementSummary(
@@ -475,7 +480,16 @@ async function closeSession(session: BrowserSession): Promise<void> {
   }
 }
 
-export default function browserPlaywrightExtension(pi: ExtensionAPI) {
+type BrowserPlaywrightExtensionOptions = {
+  workspaceRoot?: string;
+};
+
+export default function browserPlaywrightExtension(
+  pi: ExtensionAPI,
+  options: BrowserPlaywrightExtensionOptions = {},
+) {
+  const workspaceRoot = resolve(options.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT);
+  const artifactRoot = resolve(workspaceRoot, ARTIFACT_RELATIVE_DIR);
   const sessions = new Map<string, BrowserSession>();
   let cleanupTimer: NodeJS.Timeout | null = setInterval(() => {
     void cleanupExpiredSessions();
@@ -520,6 +534,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
     promptGuidelines: [
       "Reuse browser session_id values across related browsing steps instead of starting a fresh browser every time.",
       "Use browser_navigate to visit public sites and browser_tabs to inspect or switch tabs.",
+      "Only load saved storageState when the workflow explicitly needs authenticated session reuse.",
     ],
     parameters: Type.Object({
       browser: Type.Optional(
@@ -531,6 +546,12 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       url: Type.Optional(Type.String({ description: "Optional initial URL to open." })),
       viewport_width: Type.Optional(Type.Number({ description: "Viewport width in pixels." })),
       viewport_height: Type.Optional(Type.Number({ description: "Viewport height in pixels." })),
+      storage_state_path: Type.Optional(
+        Type.String({
+          description:
+            "Optional guarded JSON path for Playwright storageState reuse. Relative paths are rooted under `.pi/artifacts/browser-playwright/storage-state/`.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal) {
       if (signal?.aborted) {
@@ -538,7 +559,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       }
 
       await cleanupExpiredSessions();
-      await ensureArtifactsDir();
+      await ensureArtifactsDir(artifactRoot);
 
       const browserEngine = (params.browser ?? "chromium") as BrowserEngine;
       const playwright = await loadPlaywright(browserEngine);
@@ -562,11 +583,15 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       }
 
       try {
+        const storageState = params.storage_state_path
+          ? await readStorageStateFile(workspaceRoot, params.storage_state_path)
+          : null;
         const context = await browser.newContext({
           viewport:
             params.viewport_width && params.viewport_height
               ? { width: params.viewport_width, height: params.viewport_height }
               : { width: 1280, height: 800 },
+          ...(storageState ? { storageState: storageState.storageState } : {}),
         });
 
         const session: BrowserSession = {
@@ -587,6 +612,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
             blocked_requests: 0,
             failed_requests: 0,
           },
+          storageStatePath: storageState?.relativePath ?? null,
         };
 
         await context.route("**/*", async (route: Route) => {
@@ -647,7 +673,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
                   created_at: session.createdAt,
                   active_page_id: activePage?.id ?? null,
                   pages,
-                  artifact_dir: relative(resolve(EXTENSION_DIR, "../../.."), ARTIFACT_ROOT),
+                  artifact_dir: relative(workspaceRoot, artifactRoot),
+                  storage_state_path: session.storageStatePath,
+                  storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
                   safety: {
                     allow_localhost: envFlag("BROWSER_ALLOW_LOCALHOST"),
                     allow_private_network: envFlag("BROWSER_ALLOW_PRIVATE_NETWORK"),
@@ -665,7 +693,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
             created_at: session.createdAt,
             active_page_id: activePage?.id ?? null,
             pages,
-            artifact_dir: relative(resolve(EXTENSION_DIR, "../../.."), ARTIFACT_ROOT),
+            artifact_dir: relative(workspaceRoot, artifactRoot),
+            storage_state_path: session.storageStatePath,
+            storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
             safety: {
               allow_localhost: envFlag("BROWSER_ALLOW_LOCALHOST"),
               allow_private_network: envFlag("BROWSER_ALLOW_PRIVATE_NETWORK"),
@@ -703,6 +733,8 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
         active_page_id: session.activePageId,
         page_count: pages.length,
         pages,
+        storage_state_path: session.storageStatePath,
+        storage_state_dir: STORAGE_STATE_RELATIVE_DIR,
         network_summary: session.networkSummary,
         recent_console: session.consoleEntries,
         blocked_requests: session.blockedRequests,
@@ -1134,11 +1166,11 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
     async execute(_toolCallId, params, signal) {
       if (signal?.aborted) throw new Error("Cancelled before screenshot.");
       await cleanupExpiredSessions();
-      await ensureArtifactsDir();
+      await ensureArtifactsDir(artifactRoot);
       const session = getSessionOrThrow(sessions, params.session_id);
       const pageRecord = await resolvePageRecord(session, params.page_id, false);
       const page = pageRecord.page;
-      const sessionArtifactDir = resolve(ARTIFACT_ROOT, session.id);
+      const sessionArtifactDir = resolve(artifactRoot, session.id);
       await mkdir(sessionArtifactDir, { recursive: true });
 
       const timestamp = nowIso().replace(/[:.]/g, "-");
@@ -1151,7 +1183,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       });
       touchPage(pageRecord);
 
-      const relativePath = relative(resolve(EXTENSION_DIR, "../../.."), absolutePath);
+      const relativePath = relative(workspaceRoot, absolutePath);
       const result = {
         session_id: session.id,
         page_id: pageRecord.id,
@@ -1160,6 +1192,46 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
         title: await safeTitle(page),
         timestamp: nowIso(),
         full_page: params.full_page ?? false,
+      };
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        details: result,
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "browser_storage_state_save",
+    label: "Browser Storage State Save",
+    description:
+      "Export explicit Playwright storageState JSON into a guarded workspace-local path for later reuse.",
+    promptSnippet:
+      "Persist explicit opt-in Playwright storageState JSON under a guarded workspace-local path.",
+    promptGuidelines: [
+      "Only save storageState when the workflow explicitly needs later authenticated session reuse.",
+      "Do not expose raw cookies, tokens, or localStorage values in tool output.",
+    ],
+    parameters: Type.Object({
+      session_id: Type.String({ description: "Browser session_id." }),
+      path: Type.String({
+        description:
+          "Guarded JSON path to save under `.pi/artifacts/browser-playwright/storage-state/`. Bare filenames are rooted there automatically.",
+      }),
+    }),
+    async execute(_toolCallId, params, signal) {
+      if (signal?.aborted) throw new Error("Cancelled before saving storage state.");
+      await cleanupExpiredSessions();
+      await ensureArtifactsDir(artifactRoot);
+      const session = getSessionOrThrow(sessions, params.session_id);
+      const storageState = await session.context.storageState();
+      const storageStatePath = await writeStorageStateFile(workspaceRoot, params.path, storageState);
+      touchSession(session);
+
+      const result = {
+        session_id: session.id,
+        path: storageStatePath.relativePath,
+        saved_at: nowIso(),
+        size_bytes: storageStatePath.sizeBytes,
       };
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/.pi/extensions/browser-playwright/package.json
+++ b/.pi/extensions/browser-playwright/package.json
@@ -7,7 +7,7 @@
     "clean": "echo 'nothing to clean'",
     "build": "echo 'nothing to build'",
     "check": "tsc --noEmit -p tsconfig.json",
-    "test": "node --experimental-strip-types --test helpers.test.ts"
+    "test": "node --experimental-strip-types --test helpers.test.ts index.test.ts"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary
- add explicit opt-in Playwright `storageState` reuse to `browser_session_start` with guarded workspace-local JSON paths
- add `browser_storage_state_save` for explicit export without echoing raw auth state in tool output
- keep auth-state file I/O inside guarded Node helpers instead of handing validated paths to Playwright
- document the security model and add focused helper/integration tests for guarded save/load flows

## Testing
- cd .pi/extensions/browser-playwright && npm run check
- cd .pi/extensions/browser-playwright && npm test

Closes #290