### PR TITLE
fix: restore broker default skin naming

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -973,6 +973,24 @@ describe("Pinet skin helpers", () => {
     expect(assignment.personality).toContain("Default whimsical worker skin");
   });
 
+  it("uses the broker naming format for the default whimsical broker skin", () => {
+    const worker = buildPinetSkinAssignment({
+      theme: "default",
+      role: "worker",
+      seed: "shared-seed",
+    });
+    const broker = buildPinetSkinAssignment({
+      theme: "default",
+      role: "broker",
+      seed: "shared-seed",
+    });
+
+    expect(broker.theme).toBe("default");
+    expect(broker.name).toBe(`The Broker ${worker.name.split(" ").at(-1)}`);
+    expect(broker.emoji).toBe(worker.emoji);
+    expect(broker.personality).toContain("Default whimsical broker skin");
+  });
+
   it("builds a custom free-form skin with role-aware identity and bounded voice guidance", () => {
     const broker = buildPinetSkinAssignment({
       theme: "night's watch from ASOIAF",

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -2561,7 +2561,7 @@ export function buildPinetSkinAssignment(options: {
   const normalizedTheme = normalizePinetSkinTheme(options.theme) ?? DEFAULT_PINET_SKIN_THEME;
 
   if (normalizedTheme === DEFAULT_PINET_SKIN_THEME) {
-    const generated = generateAgentName(options.seed);
+    const generated = generateAgentName(options.seed, options.role);
     const personality =
       options.role === "broker"
         ? "Default whimsical broker skin. Be playful but disciplined, delegate clearly, and keep the mesh coordinated."


### PR DESCRIPTION
## Summary
- restore the `The Broker {Animal}` format for the default whimsical broker skin
- keep worker default skin naming unchanged
- add regression coverage so broker default skin generation cannot silently fall back to worker-style names again

## Root cause
The later pinet skin helper path regressed the earlier `#202/#205` broker naming fix: `buildPinetSkinAssignment(...)` called `generateAgentName(options.seed)` without passing the broker role for the default theme, so broker registration on the default skin reused worker-style 3-word names.

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts`
- `pnpm prepush`
