### PR TITLE
fix: debounce fresh RALPH ghost alerts (#331)

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -2099,6 +2099,40 @@ describe("rewriteRalphLoopGhostAnomalies", () => {
     expect(cycle4.evaluation.anomalies).toEqual(["ghost agents cleared from registry: ghost-1"]);
     expect(cycle4.clearedGhostIds).toEqual(["ghost-1"]);
   });
+
+  it("suppresses freshly reaped ghost ids until they survive a later cycle", () => {
+    const cycle1 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1", "ghost-2"], ["ghost agents detected: ghost-1, ghost-2"]),
+      [],
+      { suppressedGhostIds: ["ghost-1"] },
+    );
+
+    expect(cycle1.evaluation.ghostAgentIds).toEqual(["ghost-2"]);
+    expect(cycle1.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-2"]);
+    expect(cycle1.nextReportedGhostIds).toEqual(["ghost-2"]);
+
+    const cycle2 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1", "ghost-2"], ["ghost agents detected: ghost-1, ghost-2"]),
+      cycle1.nextReportedGhostIds,
+    );
+
+    expect(cycle2.evaluation.ghostAgentIds).toEqual(["ghost-1", "ghost-2"]);
+    expect(cycle2.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-1"]);
+    expect(cycle2.nextReportedGhostIds).toEqual(["ghost-1", "ghost-2"]);
+  });
+
+  it("does not clear or re-announce a previously reported ghost when it is temporarily suppressed", () => {
+    const cycle = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"], ["ghost agents detected: ghost-1"]),
+      ["ghost-1"],
+      { suppressedGhostIds: ["ghost-1"] },
+    );
+
+    expect(cycle.evaluation.ghostAgentIds).toEqual([]);
+    expect(cycle.evaluation.anomalies).toEqual([]);
+    expect(cycle.clearedGhostIds).toEqual([]);
+    expect(cycle.nextReportedGhostIds).toEqual(["ghost-1"]);
+  });
 });
 
 describe("buildRalphLoopNudgeMessage", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1149,15 +1149,26 @@ export function evaluateRalphLoopCycle(
   };
 }
 
+export interface RalphLoopGhostAnomalyRewriteOptions {
+  suppressedGhostIds?: Iterable<string>;
+}
+
 export function rewriteRalphLoopGhostAnomalies(
   evaluation: RalphLoopEvaluationResult,
   previousGhostIds: Iterable<string> = [],
+  options: RalphLoopGhostAnomalyRewriteOptions = {},
 ): RalphLoopGhostAnomalyRewriteResult {
   const priorGhostIds = new Set(previousGhostIds);
-  const nextReportedGhostIds = [...evaluation.ghostAgentIds];
-  const newGhostIds = evaluation.ghostAgentIds.filter((id) => !priorGhostIds.has(id));
+  const suppressedGhostIds = new Set(options.suppressedGhostIds ?? []);
   const currentGhostIds = new Set(evaluation.ghostAgentIds);
-  const clearedGhostIds = [...priorGhostIds].filter((id) => !currentGhostIds.has(id));
+  const visibleGhostIds = evaluation.ghostAgentIds.filter((id) => !suppressedGhostIds.has(id));
+  const retainedSuppressedGhostIds = [...priorGhostIds].filter(
+    (id) => suppressedGhostIds.has(id) && currentGhostIds.has(id),
+  );
+  const nextReportedGhostIds = [...new Set([...visibleGhostIds, ...retainedSuppressedGhostIds])];
+  const newGhostIds = visibleGhostIds.filter((id) => !priorGhostIds.has(id));
+  const currentReportedGhostIds = new Set(nextReportedGhostIds);
+  const clearedGhostIds = [...priorGhostIds].filter((id) => !currentReportedGhostIds.has(id));
   const nonGhostAnomalies = evaluation.anomalies.filter(
     (anomaly) => !anomaly.startsWith("ghost agents detected:"),
   );
@@ -1173,6 +1184,7 @@ export function rewriteRalphLoopGhostAnomalies(
   return {
     evaluation: {
       ...evaluation,
+      ghostAgentIds: visibleGhostIds,
       anomalies,
     },
     nonGhostAnomalies,

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -133,6 +133,7 @@ export async function runRalphLoopCycle(
   const cycleStartMs = Date.now();
   try {
     deps.runMaintenance(ctx);
+    const lastMaintenance = deps.getLastMaintenance();
 
     const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
 
@@ -179,7 +180,9 @@ export async function runRalphLoopCycle(
       state.nudges.set(workload.id, now);
     }
 
-    const ghostRewrite = rewriteRalphLoopGhostAnomalies(evaluation, state.reportedGhosts);
+    const ghostRewrite = rewriteRalphLoopGhostAnomalies(evaluation, state.reportedGhosts, {
+      suppressedGhostIds: lastMaintenance?.reapedAgentIds ?? [],
+    });
     state.reportedGhosts.clear();
     for (const ghostId of ghostRewrite.nextReportedGhostIds) {
       state.reportedGhosts.add(ghostId);
@@ -188,7 +191,8 @@ export async function runRalphLoopCycle(
     const visibleEvaluation = ghostRewrite.evaluation;
     const visibleSignature = buildRalphLoopAnomalySignature(visibleEvaluation);
     const nonGhostSignature = ghostRewrite.nonGhostAnomalies.join("|");
-    const hasOutstandingAnomalies = evaluation.anomalies.length > 0;
+    const hasOutstandingAnomalies =
+      visibleEvaluation.ghostAgentIds.length > 0 || visibleEvaluation.anomalies.length > 0;
     const ralphNotifications = buildRalphLoopCycleNotifications(visibleEvaluation, cycleStartedAt);
     const followUpPrompt =
       ghostRewrite.newGhostIds.length === 0 &&
@@ -433,7 +437,7 @@ export async function runRalphLoopCycle(
       workloads,
       evaluation: visibleEvaluation,
       evaluationOptions,
-      maintenance: deps.getLastMaintenance(),
+      maintenance: lastMaintenance,
       assignments: projectedAssignments,
       recentCycles: recentRalphCycles,
       cycleStartedAt,


### PR DESCRIPTION
## Summary
- suppress freshly reaped heartbeat-timeout ghosts from the same RALPH cycle that reaped them
- only surface them as `NEW ghost agents detected` if they are still ghosted in a later cycle
- add regression coverage for transient reaps vs persistent ghosts

## Root cause
RALPH currently does this in one pass:
1. broker maintenance runs first and `pruneStaleAgents()` can mark overdue heartbeat rows disconnected
2. the same RALPH cycle immediately evaluates those rows as ghosts
3. ghost rewrite treats every never-before-reported ghost id as `NEW`

That means a transient broker/heartbeat timing race can produce this bad shape:
- a healthy connected worker crosses the stale-heartbeat cutoff just long enough to get reaped
- RALPH announces it as a **NEW ghost** in that same cycle
- the worker heartbeats/reconnects immediately after, so follow-up inspection shows it healthy again
- if the same transient reap happens later, it can be re-announced as `NEW` again because the ghost state cleared between cycles

## Fix
- pass the current maintenance pass `reapedAgentIds` into ghost-anomaly rewriting as suppressed ghost ids for that exact cycle
- keep those freshly reaped ids out of the visible ghost set / `NEW ghost` alert path until they survive into a later cycle
- preserve already-reported ghost memory so suppression does not manufacture false clear/re-announce churn

## Why this is narrow and safe
- no schema change
- no routing change
- no broker pruning change
- real ghost rows still get reported if they remain ghosted after the transient reap window
- immediate maintenance logging still records the reap, so operators still see that something happened

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
