### PR TITLE
feat: make Slack bridge runtime modes explicit (#348)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -123,6 +123,7 @@ Behavior and precedence:
   "slack-bridge": {
     "botToken": "xoxb-...",
     "appToken": "xapp-...",
+    "runtimeMode": "single",
     "allowedUsers": ["U_EXAMPLE_MEMBER_ID"],
     "defaultChannel": "C_EXAMPLE_CHANNEL_ID",
     "logChannel": "#pinet-logs",
@@ -147,7 +148,9 @@ Behavior and precedence:
 | `defaultChannel`               | no       | Default channel for `slack_post_channel`                                                                           |
 | `logChannel`                   | no       | Channel for broker activity logs                                                                                   |
 | `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
-| `autoFollow`                   | no       | Auto-connect as follower when broker is running                                                                    |
+| `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |
+| `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                             |
+| `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                        |
 | `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                  |
 | `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file            |
 | `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                 |
@@ -215,6 +218,25 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 | `/pinet-logs`   | Show recent broker activity log entries             |
 | `/slack-logs`   | Show recent Slack bridge log entries                |
 
+## Runtime modes
+
+`slack-bridge` now treats runtime mode as an explicit concept:
+
+| Mode       | Meaning                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `off`      | Slack bridge is loaded, but no active coordination runtime is started.                                                                                                   |
+| `single`   | One local Pi session owns Slack ingress and local thread/inbox ownership only. No broker DB/socket/client, no RALPH/control plane, no mesh auth, no multi-agent surface. |
+| `broker`   | The session runs the broker coordination runtime.                                                                                                                        |
+| `follower` | The session connects to an existing broker as a worker runtime.                                                                                                          |
+
+Startup selection:
+
+- `runtimeMode` is the explicit startup selector.
+- `autoConnect` is a legacy compatibility alias for `runtimeMode: "single"`.
+- `autoFollow` is a legacy compatibility alias for `runtimeMode: "follower"` when a broker socket is available.
+- explicit `runtimeMode` wins over the legacy flags.
+- `/pinet-start` and `/pinet-follow` still switch the live session into broker/follower runtimes explicitly.
+
 ## Pinet (Multi-Agent Mode)
 
 Pinet supports a broker/follower architecture for coordinating multiple pi agents over Slack.
@@ -233,7 +255,7 @@ Pinet supports a broker/follower architecture for coordinating multiple pi agent
 /pinet-follow
 ```
 
-Or set `"autoFollow": true` in settings to auto-connect when a broker is running.
+Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": true`) to auto-connect when a broker is running.
 
 ### Multi-agent tools
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -224,7 +224,7 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 
 | Mode       | Meaning                                                                                                                                                                  |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `off`      | Slack bridge is loaded, but no active coordination runtime is started.                                                                                                   |
+| `off`      | Slack bridge is loaded, but **no Slack Socket Mode ingress** and no coordination runtime are started.                                                                    |
 | `single`   | One local Pi session owns Slack ingress and local thread/inbox ownership only. No broker DB/socket/client, no RALPH/control plane, no mesh auth, no multi-agent surface. |
 | `broker`   | The session runs the broker coordination runtime.                                                                                                                        |
 | `follower` | The session connects to an existing broker as a worker runtime.                                                                                                          |

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -130,6 +130,7 @@ describe("loadSettings", () => {
       "slack-bridge": {
         botToken: "xoxb-test",
         appToken: "xapp-test",
+        runtimeMode: "single",
         autoConnect: true,
         allowedUsers: ["U123"],
         defaultChannel: "C456",
@@ -141,6 +142,7 @@ describe("loadSettings", () => {
     const result = loadSettings(p);
     expect(result.botToken).toBe("xoxb-test");
     expect(result.appToken).toBe("xapp-test");
+    expect(result.runtimeMode).toBe("single");
     expect(result.autoConnect).toBe(true);
     expect(result.allowedUsers).toEqual(["U123"]);
     expect(result.defaultChannel).toBe("C456");

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -17,6 +17,7 @@ export interface SlackBridgeSettings {
   logLevel?: "errors" | "actions" | "verbose";
   suggestedPrompts?: { title: string; message: string }[];
   reactionCommands?: ReactionCommandSettings;
+  runtimeMode?: "off" | "single" | "broker" | "follower";
   autoConnect?: boolean;
   autoFollow?: boolean;
   agentName?: string;

--- a/slack-bridge/home-tab.test.ts
+++ b/slack-bridge/home-tab.test.ts
@@ -95,7 +95,7 @@ describe("renderStandalonePinetHomeTabView", () => {
       agentName: "Cosmic Crane",
       agentEmoji: "🦩",
       connected: true,
-      mode: "standalone",
+      mode: "single",
       activeThreads: 3,
       pendingInbox: 1,
       currentBranch: "feat/home-tab",
@@ -106,6 +106,7 @@ describe("renderStandalonePinetHomeTabView", () => {
     expect(JSON.stringify(view)).toContain("Cosmic Crane");
     expect(JSON.stringify(view)).toContain("feat/home-tab");
     expect(JSON.stringify(view)).toContain("full control-plane dashboard");
+    expect(JSON.stringify(view)).toContain("single");
   });
 });
 

--- a/slack-bridge/home-tab.ts
+++ b/slack-bridge/home-tab.ts
@@ -1,4 +1,5 @@
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 export type SlackBlock = Record<string, unknown>;
 
@@ -22,7 +23,7 @@ export interface StandalonePinetHomeTabInput {
   agentName: string;
   agentEmoji: string;
   connected: boolean;
-  mode: "broker" | "worker" | "standalone";
+  mode: SlackBridgeRuntimeMode;
   activeThreads: number;
   pendingInbox: number;
   currentBranch?: string | null;
@@ -258,7 +259,7 @@ export function renderBrokerControlPlaneHomeTabView(
 export function renderStandalonePinetHomeTabView(
   input: StandalonePinetHomeTabInput,
 ): SlackHomeView {
-  const modeLabel = input.mode === "standalone" ? "direct" : input.mode;
+  const modeLabel = input.mode;
   const branch = asNonEmptyString(input.currentBranch) ?? "unknown";
   const defaultChannel = asNonEmptyString(input.defaultChannel) ?? "not configured";
 
@@ -289,7 +290,7 @@ export function renderStandalonePinetHomeTabView(
         text: [
           "• Open the *Messages* tab and start a conversation with Pinet.",
           "• Mention Pinet in a channel to continue work in-thread.",
-          "• Start broker mode to expose the full control-plane dashboard here on the Home tab.",
+          '• Use `runtimeMode: "single"` for local Slack-only mode, or `/pinet-start` and `/pinet-follow` for mesh runtimes.',
         ].join("\n"),
       }),
     ],

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -404,6 +404,235 @@ describe("slack-bridge top-level shutdown", () => {
     expect(notify).not.toHaveBeenCalled();
     expect(setStatus).toHaveBeenCalled();
   });
+
+  function createFakeWebSocketClass() {
+    return class FakeWebSocket {
+      static OPEN = 1;
+      static CLOSED = 3;
+      static instances: FakeWebSocket[] = [];
+
+      readonly url: string;
+      readyState = 0;
+      readonly close = vi.fn(() => {
+        this.readyState = FakeWebSocket.CLOSED;
+        this.emit("close");
+      });
+      readonly send = vi.fn();
+      private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+      constructor(url: string) {
+        this.url = url;
+        FakeWebSocket.instances.push(this);
+        queueMicrotask(() => {
+          this.readyState = FakeWebSocket.OPEN;
+          this.emit("open");
+        });
+      }
+
+      addEventListener(type: string, handler: (...args: unknown[]) => void): void {
+        const listeners = this.listeners.get(type) ?? [];
+        listeners.push(handler);
+        this.listeners.set(type, listeners);
+      }
+
+      private emit(type: string, ...args: unknown[]): void {
+        for (const handler of this.listeners.get(type) ?? []) {
+          handler(...args);
+        }
+      }
+    };
+  }
+
+  it("starts explicit single runtime mode on session start and reports it in pinet-status", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStatus = commands.get("pinet-status");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStatus).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://slack.com/api/apps.connections.open",
+      expect.any(Object),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await pinetStatus?.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: single"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
+
+    await sessionShutdown?.({}, ctx);
+    expect(FakeWebSocket.instances[0]?.close).toHaveBeenCalled();
+  });
+
+  it("transitions from single runtime mode to broker mode without leaving the direct Slack socket open", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "broker-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-broker-runtime-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    const restartedDb = new BrokerDB(dbPath);
+    restartedDb.initialize();
+    const brokerStop = vi.fn(async () => {
+      restartedDb.close();
+    });
+
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation(() => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: restartedDb.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    vi.spyOn(brokerModule, "startBroker").mockResolvedValue({
+      db: restartedDb,
+      server: {
+        setAgentRegistrationResolver: vi.fn(),
+        onAgentMessage: vi.fn(),
+        onAgentStatusChange: vi.fn(),
+      },
+      lock: {
+        isLeader: () => true,
+        release: vi.fn(),
+      },
+      adapters: [],
+      addAdapter: vi.fn(),
+      stop: brokerStop,
+    } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStart = commands.get("pinet-start");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStart).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await pinetStart?.handler("", ctx);
+
+    expect(FakeWebSocket.instances[0]?.close).toHaveBeenCalled();
+    expect(brokerModule.startBroker).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await sessionShutdown?.({}, ctx);
+  });
 });
 
 describe("slack-bridge Pinet reconnect", () => {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -443,6 +443,58 @@ describe("slack-bridge top-level shutdown", () => {
     };
   }
 
+  it("keeps explicit off mode free of Slack Socket Mode ingress on session start", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "off" } }));
+
+    const events = new Map<string, EventHandler>();
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "off-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-off-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    const connectSpy = vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+
+    slackBridge(pi);
+
+    await events.get("session_start")?.({}, ctx);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+    expect(setStatus).toHaveBeenCalled();
+  });
+
   it("starts explicit single runtime mode on session start and reports it in pinet-status", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -415,7 +415,7 @@ describe("slack-bridge top-level shutdown", () => {
       readyState = 0;
       readonly close = vi.fn(() => {
         this.readyState = FakeWebSocket.CLOSED;
-        this.emit("close");
+        this.emitEvent("close");
       });
       readonly send = vi.fn();
       private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
@@ -425,7 +425,7 @@ describe("slack-bridge top-level shutdown", () => {
         FakeWebSocket.instances.push(this);
         queueMicrotask(() => {
           this.readyState = FakeWebSocket.OPEN;
-          this.emit("open");
+          this.emitEvent("open");
         });
       }
 
@@ -435,7 +435,7 @@ describe("slack-bridge top-level shutdown", () => {
         this.listeners.set(type, listeners);
       }
 
-      private emit(type: string, ...args: unknown[]): void {
+      emitEvent(type: string, ...args: unknown[]): void {
         for (const handler of this.listeners.get(type) ?? []) {
           handler(...args);
         }
@@ -684,6 +684,254 @@ describe("slack-bridge top-level shutdown", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     await sessionShutdown?.({}, ctx);
+  });
+
+  it("drains queued single-mode Slack inbox work on agent_end even without Pinet enabled", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ "slack-bridge": { runtimeMode: "single", allowedUsers: ["U_SENDER"] } }),
+    );
+
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+    const sendUserMessage = vi.fn();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage,
+    } as unknown as ExtensionAPI;
+
+    let idle = false;
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => idle,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-drain-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-drain-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://slack.com/api/apps.connections.open") {
+        return new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/conversations.replies") {
+        return new Response(JSON.stringify({ ok: true, messages: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/users.info") {
+        return new Response(JSON.stringify({ ok: true, user: { real_name: "Sender" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/reactions.add") {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const agentEnd = events.get("agent_end");
+    const sessionShutdown = events.get("session_shutdown");
+
+    expect(sessionStart).toBeDefined();
+    expect(agentEnd).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+
+    const socket = FakeWebSocket.instances[0] as unknown as {
+      emitEvent: (type: string, ...args: unknown[]) => void;
+    };
+    socket.emitEvent("message", {
+      data: JSON.stringify({
+        envelope_id: "env-1",
+        type: "events_api",
+        payload: {
+          event: {
+            type: "message",
+            channel: "D123",
+            channel_type: "im",
+            user: "U_SENDER",
+            text: "hello from Slack inbox",
+            ts: "100.1",
+          },
+        },
+      }),
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith("https://slack.com/api/users.info", expect.any(Object));
+    });
+    expect(sendUserMessage).not.toHaveBeenCalled();
+
+    idle = true;
+    await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
+
+    await vi.waitFor(() => {
+      expect(sendUserMessage).toHaveBeenCalledWith(
+        expect.stringContaining("hello from Slack inbox"),
+        { deliverAs: "followUp" },
+      );
+    });
+
+    await sessionShutdown?.({}, ctx);
+  });
+
+  it("does not reschedule direct Slack reconnects after aborting a single-mode startup during broker transition", async () => {
+    vi.useFakeTimers();
+
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "abort-single-startup-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-abort-single-startup-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        const rejectAbort = () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        };
+
+        if (signal?.aborted) {
+          rejectAbort();
+          return;
+        }
+
+        signal?.addEventListener("abort", rejectAbort, { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    const restartedDb = new BrokerDB(dbPath);
+    restartedDb.initialize();
+    const brokerStop = vi.fn(async () => {
+      restartedDb.close();
+    });
+
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation(() => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: restartedDb.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    vi.spyOn(brokerModule, "startBroker").mockResolvedValue({
+      db: restartedDb,
+      server: {
+        setAgentRegistrationResolver: vi.fn(),
+        onAgentMessage: vi.fn(),
+        onAgentStatusChange: vi.fn(),
+      },
+      lock: {
+        isLeader: () => true,
+        release: vi.fn(),
+      },
+      adapters: [],
+      addAdapter: vi.fn(),
+      stop: brokerStop,
+    } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStart = commands.get("pinet-start");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStart).toBeDefined();
+
+    try {
+      const startup = sessionStart?.({}, ctx);
+      await Promise.resolve();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      await pinetStart?.handler("", ctx);
+      await startup;
+
+      await vi.advanceTimersByTimeAsync(5_001);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(brokerModule.startBroker).toHaveBeenCalledTimes(1);
+
+      await sessionShutdown?.({}, ctx);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -168,6 +168,10 @@ import {
   renderBrokerControlPlaneHomeTabView,
   renderStandalonePinetHomeTabView,
 } from "./home-tab.js";
+import {
+  type SlackBridgeRuntimeMode,
+  resolveSlackBridgeStartupRuntimeMode,
+} from "./runtime-mode.js";
 
 // Settings and helpers imported from ./helpers.js
 
@@ -1030,7 +1034,7 @@ export default function (pi: ExtensionAPI) {
       });
 
       ws.addEventListener("close", () => {
-        if (!shuttingDown) scheduleReconnect(ctx);
+        if (!shuttingDown && currentRuntimeMode === "single") scheduleReconnect(ctx);
       });
 
       ws.addEventListener("error", () => {
@@ -1649,6 +1653,7 @@ export default function (pi: ExtensionAPI) {
 
   // Forward-declared — assigned in the Commands section below.
   let pinetEnabled = false;
+  let currentRuntimeMode: SlackBridgeRuntimeMode = "off";
   let brokerRole: "broker" | "follower" | null = null;
   let pinetRegistrationBlocked = false;
   let activeBroker: Broker | null = null;
@@ -2096,9 +2101,15 @@ export default function (pi: ExtensionAPI) {
       view: renderStandalonePinetHomeTabView({
         agentName,
         agentEmoji,
-        connected: activeBroker != null || ws?.readyState === WebSocket.OPEN,
-        mode:
-          brokerRole === "broker" ? "broker" : brokerRole === "follower" ? "worker" : "standalone",
+        connected:
+          currentRuntimeMode === "broker"
+            ? activeBroker != null
+            : currentRuntimeMode === "follower"
+              ? brokerClient != null
+              : currentRuntimeMode === "single"
+                ? ws?.readyState === WebSocket.OPEN
+                : false,
+        mode: currentRuntimeMode,
         activeThreads: threads.size,
         pendingInbox: inbox.length,
         currentBranch,
@@ -2468,6 +2479,46 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  async function transitionToRuntimeMode(
+    ctx: ExtensionContext,
+    mode: SlackBridgeRuntimeMode,
+  ): Promise<void> {
+    if (currentRuntimeMode === mode) {
+      if (mode === "off") {
+        setExtStatus(ctx, "off");
+      }
+      return;
+    }
+
+    if (currentRuntimeMode !== "off") {
+      await stopPinetRuntime(ctx, { releaseIdentity: true });
+      // Runtime transitions keep the extension alive in-process, so restore a
+      // fresh top-level Slack request tracker after tearing the prior runtime down.
+      resetTopLevelSlackRequests();
+      shuttingDown = false;
+    }
+
+    if (mode === "off") {
+      currentRuntimeMode = "off";
+      setExtStatus(ctx, "off");
+      return;
+    }
+
+    if (mode === "single") {
+      currentRuntimeMode = "single";
+      setExtStatus(ctx, "reconnecting");
+      await connectSocketMode(ctx);
+      return;
+    }
+
+    if (mode === "broker") {
+      await connectAsBroker(ctx);
+      return;
+    }
+
+    await connectAsFollower(ctx);
+  }
+
   async function stopPinetRuntime(
     ctx: ExtensionContext,
     options: { releaseIdentity: boolean },
@@ -2531,6 +2582,7 @@ export default function (pi: ExtensionAPI) {
     activityLogger.clearPending();
     brokerRole = null;
     pinetEnabled = false;
+    currentRuntimeMode = "off";
     setExtStatus(ctx, "off");
   }
 
@@ -3098,6 +3150,7 @@ export default function (pi: ExtensionAPI) {
       activeSelfId = selfId;
       brokerRole = "broker";
       pinetEnabled = true;
+      currentRuntimeMode = "broker";
 
       resetBrokerDeliveryState(brokerDeliveryState);
       const releasedBrokerClaims = broker.db.releaseThreadClaims(selfId);
@@ -3192,6 +3245,15 @@ export default function (pi: ExtensionAPI) {
   registerPinetCommands(pi, {
     pinetEnabled: () => pinetEnabled,
     pinetRegistrationBlocked: () => pinetRegistrationBlocked,
+    runtimeMode: () => currentRuntimeMode,
+    runtimeConnected: () =>
+      currentRuntimeMode === "broker"
+        ? activeBroker != null
+        : currentRuntimeMode === "follower"
+          ? brokerClient != null
+          : currentRuntimeMode === "single"
+            ? ws?.readyState === WebSocket.OPEN
+            : false,
     brokerRole: () => brokerRole,
     agentName: () => agentName,
     agentEmoji: () => agentEmoji,
@@ -3216,8 +3278,8 @@ export default function (pi: ExtensionAPI) {
     lastBrokerControlPlaneHomeTabRefreshAt: () => lastBrokerControlPlaneHomeTabRefreshAt,
     lastBrokerControlPlaneHomeTabError: () => lastBrokerControlPlaneHomeTabError,
     getPinetRegistrationBlockReason,
-    connectAsBroker,
-    connectAsFollower,
+    connectAsBroker: (ctx) => transitionToRuntimeMode(ctx, "broker"),
+    connectAsFollower: (ctx) => transitionToRuntimeMode(ctx, "follower"),
     disconnectFollower,
     sendPinetAgentMessage,
     signalAgentFree,
@@ -3496,6 +3558,7 @@ export default function (pi: ExtensionAPI) {
       brokerClient = brokerClientRef;
       brokerRole = "follower";
       pinetEnabled = true;
+      currentRuntimeMode = "follower";
       startPolling();
       setExtStatus(ctx, "ok");
     } catch (err) {
@@ -3535,6 +3598,7 @@ export default function (pi: ExtensionAPI) {
     followerAckPromise = null;
     brokerRole = null;
     pinetEnabled = false;
+    currentRuntimeMode = "off";
     setExtStatus(ctx, "off");
 
     return { unregisterError };
@@ -3653,21 +3717,28 @@ export default function (pi: ExtensionAPI) {
 
     if (pinetRegistrationBlocked) {
       console.log("[slack-bridge] detected local subagent context; skipping Pinet registration");
+      currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
       return;
     }
 
-    // Auto-follow: if enabled and broker socket exists, connect as follower
-    if (settings.autoFollow && fs.existsSync(DEFAULT_SOCKET_PATH)) {
-      try {
-        await connectAsFollower(ctx);
-        console.log(`[slack-bridge] autoFollow: connected as follower`);
-      } catch (err) {
-        console.error(`[slack-bridge] autoFollow failed: ${msg(err)}`);
-        setExtStatus(ctx, "off");
+    refreshSettings();
+    const startupMode = resolveSlackBridgeStartupRuntimeMode(settings, {
+      brokerSocketExists: fs.existsSync(DEFAULT_SOCKET_PATH),
+    });
+
+    try {
+      await transitionToRuntimeMode(ctx, startupMode);
+      if (startupMode === "single") {
+        console.log("[slack-bridge] runtime mode: single");
+      } else if (startupMode === "follower") {
+        console.log("[slack-bridge] runtime mode: follower");
+      } else if (startupMode === "broker") {
+        console.log("[slack-bridge] runtime mode: broker");
       }
-    } else {
-      // Use /pinet-start or /pinet-follow to connect
+    } catch (err) {
+      console.error(`[slack-bridge] runtime start (${startupMode}) failed: ${msg(err)}`);
+      currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
     }
   });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1542,10 +1542,13 @@ export default function (pi: ExtensionAPI) {
   // ─── Reconnect / status ─────────────────────────────
 
   function scheduleReconnect(ctx: ExtensionContext): void {
-    if (shuttingDown || reconnectTimer) return;
+    if (shuttingDown || reconnectTimer || currentRuntimeMode !== "single") return;
     setExtStatus(ctx, "reconnecting");
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
+      if (shuttingDown || currentRuntimeMode !== "single") {
+        return;
+      }
       void connectSocketMode(ctx);
     }, 5000);
   }
@@ -3764,21 +3767,24 @@ export default function (pi: ExtensionAPI) {
     ctx?: ExtensionContext,
     options: { requirePinet?: boolean } = {},
   ): { queuedInboxCount: number; drainedQueuedInbox: boolean } {
-    if (!pinetEnabled) {
-      if (options.requirePinet) {
-        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
-      }
-      return { queuedInboxCount: inbox.length, drainedQueuedInbox: false };
+    if (!pinetEnabled && options.requirePinet) {
+      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
     }
 
-    reportStatus("idle");
     const maintenanceCtx = ctx ?? extCtx ?? undefined;
-    if (brokerRole === "broker" && maintenanceCtx) {
-      runBrokerMaintenance(maintenanceCtx);
+    if (pinetEnabled) {
+      reportStatus("idle");
+      if (brokerRole === "broker" && maintenanceCtx) {
+        runBrokerMaintenance(maintenanceCtx);
+      }
     }
 
     const queuedInboxCount = inbox.length;
-    const drainedQueuedInbox = queuedInboxCount > 0 && (ctx ? maybeDrainInboxIfIdle(ctx) : false);
+    const shouldDrainQueuedInbox = pinetEnabled || currentRuntimeMode === "single";
+    const drainedQueuedInbox =
+      shouldDrainQueuedInbox && queuedInboxCount > 0 && maintenanceCtx
+        ? maybeDrainInboxIfIdle(maintenanceCtx)
+        : false;
 
     return { queuedInboxCount, drainedQueuedInbox };
   }

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { generateAgentName, agentOwnsThread } from "./helpers.js";
 import { formatRecentActivityLogEntries, type SlackActivityLogger } from "./activity-log.js";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -8,6 +9,8 @@ export interface PinetCommandsDeps {
   // State accessors
   pinetEnabled: () => boolean;
   pinetRegistrationBlocked: () => boolean;
+  runtimeMode: () => SlackBridgeRuntimeMode;
+  runtimeConnected: () => boolean;
   brokerRole: () => "broker" | "follower" | null;
   agentName: () => string;
   agentEmoji: () => string;
@@ -71,8 +74,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
         ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
         return;
       }
-      if (deps.pinetEnabled()) {
-        ctx.ui.notify(`Pinet already running (${deps.brokerRole()})`, "info");
+      if (deps.runtimeMode() === "broker") {
+        ctx.ui.notify("Pinet already running (broker)", "info");
         return;
       }
       deps.setExtCtx(ctx);
@@ -93,8 +96,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
         ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
         return;
       }
-      if (deps.pinetEnabled()) {
-        ctx.ui.notify(`Pinet already running (${deps.brokerRole()})`, "info");
+      if (deps.runtimeMode() === "follower") {
+        ctx.ui.notify("Pinet already running (follower)", "info");
         return;
       }
       deps.setExtCtx(ctx);
@@ -112,8 +115,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   pi.registerCommand("pinet-unfollow", {
     description: "Disconnect from the Pinet broker and keep working locally",
     handler: async (_args, ctx) => {
-      if (!deps.pinetEnabled() || deps.brokerRole() == null) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
+      if (deps.runtimeMode() !== "follower" || deps.brokerRole() == null) {
+        ctx.ui.notify("Pinet is not running as a follower.", "info");
         return;
       }
 
@@ -181,7 +184,10 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
     description: "Mark this Pinet agent idle/free for new work",
     handler: async (_args, ctx) => {
       if (!deps.pinetEnabled()) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
+        ctx.ui.notify(
+          "Pinet mesh runtime is not active. Use /pinet-start or /pinet-follow.",
+          "info",
+        );
         return;
       }
 
@@ -206,7 +212,10 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
     description: "Regenerate the mesh naming/personality skin from a theme",
     handler: async (args, ctx) => {
       if (!deps.pinetEnabled() || deps.brokerRole() == null) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
+        ctx.ui.notify(
+          "Pinet mesh runtime is not active. Use /pinet-start or /pinet-follow.",
+          "info",
+        );
         return;
       }
       if (deps.brokerRole() !== "broker") {
@@ -229,11 +238,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   pi.registerCommand("pinet-status", {
     description: "Show Pinet status",
     handler: async (_args, ctx) => {
-      if (!deps.pinetEnabled()) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
-        return;
-      }
-      const mode = deps.brokerRole() === "broker" ? "broker" : "follower";
+      const mode = deps.runtimeMode();
       const ownedCount = [...deps.threads().values()].filter((t) =>
         agentOwnsThread(t.owner, deps.agentName(), deps.agentAliases(), deps.agentOwnerToken()),
       ).length;
@@ -286,7 +291,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
           `Mode: ${mode}`,
           `Agent: ${deps.agentEmoji()} ${deps.agentName()}`,
           `Bot: ${deps.botUserId() ?? "unknown"}`,
-          `Connection: ${mode}`,
+          `Connection: ${deps.runtimeConnected() ? "connected" : "disconnected"}`,
           `Skin: ${deps.activeSkinTheme() ?? "(legacy/manual)"}`,
           ...(deps.agentPersonality() ? [`Persona: ${deps.agentPersonality()}`] : []),
           `Threads: ${deps.threads().size} (${ownedCount} owned by ${deps.agentName()})`,
@@ -331,7 +336,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       if (!newName) {
         const fresh = generateAgentName(
           undefined,
-          deps.brokerRole() === "broker" ? "broker" : "worker",
+          deps.runtimeMode() === "broker" ? "broker" : "worker",
         );
         deps.applyLocalAgentIdentity(fresh.name, fresh.emoji, deps.agentPersonality());
       } else {

--- a/slack-bridge/runtime-mode.test.ts
+++ b/slack-bridge/runtime-mode.test.ts
@@ -62,6 +62,15 @@ describe("resolveSlackBridgeStartupRuntimeMode", () => {
     ).toBe("single");
   });
 
+  it("keeps explicit off truly off even when legacy auto flags are set", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "off", autoFollow: true, autoConnect: true },
+        { brokerSocketExists: true },
+      ),
+    ).toBe("off");
+  });
+
   it("allows explicit broker mode at startup", () => {
     expect(resolveSlackBridgeStartupRuntimeMode({ runtimeMode: "broker" })).toBe("broker");
   });

--- a/slack-bridge/runtime-mode.test.ts
+++ b/slack-bridge/runtime-mode.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPinetRuntimeMode,
+  normalizeSlackBridgeRuntimeMode,
+  resolveSlackBridgeStartupRuntimeMode,
+} from "./runtime-mode.js";
+
+describe("normalizeSlackBridgeRuntimeMode", () => {
+  it("accepts the supported runtime modes", () => {
+    expect(normalizeSlackBridgeRuntimeMode("off")).toBe("off");
+    expect(normalizeSlackBridgeRuntimeMode("single")).toBe("single");
+    expect(normalizeSlackBridgeRuntimeMode("broker")).toBe("broker");
+    expect(normalizeSlackBridgeRuntimeMode("follower")).toBe("follower");
+  });
+
+  it("normalizes casing and whitespace", () => {
+    expect(normalizeSlackBridgeRuntimeMode("  SINGLE ")).toBe("single");
+  });
+
+  it("rejects unsupported values", () => {
+    expect(normalizeSlackBridgeRuntimeMode("standalone")).toBeNull();
+    expect(normalizeSlackBridgeRuntimeMode(undefined)).toBeNull();
+  });
+});
+
+describe("isPinetRuntimeMode", () => {
+  it("identifies broker and follower as Pinet runtimes", () => {
+    expect(isPinetRuntimeMode("broker")).toBe(true);
+    expect(isPinetRuntimeMode("follower")).toBe(true);
+    expect(isPinetRuntimeMode("single")).toBe(false);
+    expect(isPinetRuntimeMode("off")).toBe(false);
+  });
+});
+
+describe("resolveSlackBridgeStartupRuntimeMode", () => {
+  it("defaults to off", () => {
+    expect(resolveSlackBridgeStartupRuntimeMode({})).toBe("off");
+  });
+
+  it("treats autoConnect as the legacy single-player alias", () => {
+    expect(resolveSlackBridgeStartupRuntimeMode({ autoConnect: true })).toBe("single");
+  });
+
+  it("treats autoFollow as the legacy follower alias when a broker socket exists", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode({ autoFollow: true }, { brokerSocketExists: true }),
+    ).toBe("follower");
+  });
+
+  it("keeps follower startup off when the broker socket is unavailable", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode({ autoFollow: true }, { brokerSocketExists: false }),
+    ).toBe("off");
+  });
+
+  it("prefers explicit runtimeMode over legacy compatibility flags", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "single", autoFollow: true, autoConnect: true },
+        { brokerSocketExists: true },
+      ),
+    ).toBe("single");
+  });
+
+  it("allows explicit broker mode at startup", () => {
+    expect(resolveSlackBridgeStartupRuntimeMode({ runtimeMode: "broker" })).toBe("broker");
+  });
+
+  it("downgrades explicit follower mode to off when no broker socket exists", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "follower" },
+        { brokerSocketExists: false },
+      ),
+    ).toBe("off");
+  });
+});

--- a/slack-bridge/runtime-mode.ts
+++ b/slack-bridge/runtime-mode.ts
@@ -1,0 +1,51 @@
+import type { SlackBridgeSettings } from "./helpers.js";
+
+export type SlackBridgeRuntimeMode = "off" | "single" | "broker" | "follower";
+
+export function normalizeSlackBridgeRuntimeMode(
+  value: string | null | undefined,
+): SlackBridgeRuntimeMode | null {
+  const normalized = value?.trim().toLowerCase();
+  if (
+    normalized === "off" ||
+    normalized === "single" ||
+    normalized === "broker" ||
+    normalized === "follower"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+export function isPinetRuntimeMode(mode: SlackBridgeRuntimeMode): boolean {
+  return mode === "broker" || mode === "follower";
+}
+
+export interface ResolveSlackBridgeStartupRuntimeModeOptions {
+  brokerSocketExists?: boolean;
+}
+
+export function resolveSlackBridgeStartupRuntimeMode(
+  settings: Pick<SlackBridgeSettings, "runtimeMode" | "autoConnect" | "autoFollow">,
+  options: ResolveSlackBridgeStartupRuntimeModeOptions = {},
+): SlackBridgeRuntimeMode {
+  const explicitMode = normalizeSlackBridgeRuntimeMode(settings.runtimeMode);
+  const brokerSocketExists = options.brokerSocketExists ?? true;
+
+  if (explicitMode) {
+    if (explicitMode === "follower" && !brokerSocketExists) {
+      return "off";
+    }
+    return explicitMode;
+  }
+
+  if (settings.autoFollow) {
+    return brokerSocketExists ? "follower" : "off";
+  }
+
+  if (settings.autoConnect) {
+    return "single";
+  }
+
+  return "off";
+}


### PR DESCRIPTION
## Summary
- make Slack runtime mode an explicit first-class concept in `slack-bridge`
- add the explicit modes `off | single | broker | follower`
- route startup and live mode switching through a narrow runtime-mode boundary without doing the later extraction work from `#349+`

## What changed
- added `slack-bridge/runtime-mode.ts` with:
  - `SlackBridgeRuntimeMode`
  - `resolveSlackBridgeStartupRuntimeMode(...)`
  - compatibility handling for legacy `autoConnect` / `autoFollow`
- updated `session_start` to resolve an explicit startup mode instead of implicitly only auto-following or staying off
- made `single` explicit by starting the legacy direct Slack Socket Mode path only when the runtime mode says `single`
- added a narrow `transitionToRuntimeMode(...)` seam so switching from `single` to `broker` / `follower` tears the previous runtime down first instead of leaving the direct Slack socket around
- updated Home tab + `/pinet-status` to report explicit runtime mode instead of the old `worker/standalone` approximation
- documented runtime-mode semantics in `README.md`

## Scope boundaries kept
- no Slack-access-layer extraction (`#349`)
- no runtime-class extraction (`#351`-`#353`)
- no broker-only observability isolation (`#354`)
- no router / thread-ownership policy rewrite

## Semantics after this PR
- `off`: extension loaded, no active coordination runtime
- `single`: local Slack-only runtime; no broker DB/socket/client, no RALPH/control-plane, no mesh surface
- `broker`: broker coordination runtime
- `follower`: worker/follower coordination runtime

## Compatibility
- `runtimeMode` is the explicit startup selector
- legacy `autoConnect` still maps to `single`
- legacy `autoFollow` still maps to `follower` when a broker socket exists
- explicit `runtimeMode` wins over the legacy flags

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
