### PR TITLE
fix pi install command

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -5,7 +5,7 @@ Slack assistant integration for [pi](https://github.com/badlogic/pi-mono) — mu
 ## Install
 
 ```bash
-pi install @gugu910/pi-slack-bridge
+pi install npm:@gugu910/pi-slack-bridge
 ```
 
 Or with npm:


### PR DESCRIPTION
to pi install from npm you need pi install npm:@

evidence:
~ % pi install @gugu910/pi-slack-bridge
Installing @gugu910/pi-slack-bridge...
Error: Path does not exist: ~/@gugu910/pi-slack-bridge 

~ % pi install npm:@gugu910/pi-slack-bridge
Installing npm:@gugu910/pi-slack-bridge...

added 2 packages in 1s
Installed npm:@gugu910/pi-slack-bridge