### PR TITLE
fix(slack-bridge): remove invalid presence_change bot event from manifest

### DIFF
--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -47,7 +47,6 @@ settings:
       - assistant_thread_started
       - assistant_thread_context_changed
       - reaction_added
-      - presence_change
       - message.channels
       - message.groups
       - message.im


### PR DESCRIPTION
## Problem

`presence_change` is listed under `settings.event_subscriptions.bot_events` in `slack-bridge/manifest.yaml`, but Slack's manifest API does not accept it as a valid bot event type. This causes app creation/update to fail with an `invalid_manifest` error:

```
failed to validate the app manifest: ... invalid event type: presence_change
```

## Fix

Remove the `- presence_change` line from the `bot_events` list.

## Notes

- `presence_change` events are delivered via the RTM API or `users:read` + subscription calls — they are not available as bot event subscriptions in app manifests.
- No other manifest entries are affected.