### PR TITLE
fix(slack-bridge): correct repository URL typo in package.json

### DIFF
--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gugu910/extensions.git",
+    "url": "git+https://github.com/gugu91/extensions.git",
     "directory": "slack-bridge"
   },
   "publishConfig": {


### PR DESCRIPTION
## Problem

`repository.url` in `slack-bridge/package.json` points to `github.com/gugu910/extensions` (extra `0`) instead of `github.com/gugu91/extensions`.

This means npm's "Repository" link on the package page goes to a 404, and anyone trying to find the source from the published `@gugu910/pi-slack-bridge` package hits a dead end.

## Fix

```diff
-"url": "git+https://github.com/gugu910/extensions.git"
+"url": "git+https://github.com/gugu91/extensions.git"
```

One-character fix — remove the trailing `0` from `gugu910` → `gugu91`.