### PR TITLE
refactor: extract shared Slack access layer

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -8,6 +8,7 @@ import {
   SlackAdapter,
   RECONNECT_DELAY_MS,
 } from "./slack.js";
+import { SlackSocketModeClient } from "../../slack-access.js";
 import type { OutboundMessage } from "./types.js";
 
 async function waitForAssertion(assertion: () => void, attempts = 50): Promise<void> {
@@ -726,6 +727,19 @@ describe("SlackAdapter", () => {
       )
       .mockResolvedValue(undefined);
 
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({})),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      dedup: new Set<string>(),
+      onMessage: (event) =>
+        (
+          adapter as unknown as {
+            onMessage: (input: Record<string, unknown>) => Promise<void>;
+          }
+        ).onMessage(event),
+    });
+
     const firstFrame = JSON.stringify({
       envelope_id: "env-1",
       type: "events_api",
@@ -758,12 +772,12 @@ describe("SlackAdapter", () => {
     });
 
     await (
-      adapter as unknown as {
+      client as unknown as {
         handleFrame: (raw: string) => Promise<void>;
       }
     ).handleFrame(firstFrame);
     await (
-      adapter as unknown as {
+      client as unknown as {
         handleFrame: (raw: string) => Promise<void>;
       }
     ).handleFrame(secondFrame);
@@ -786,31 +800,56 @@ describe("SlackAdapter", () => {
       "resolveUser",
     ).mockResolvedValue("Will");
 
-    await (
-      adapter as unknown as {
-        onBlockActions: (payload: Record<string, unknown>) => Promise<void>;
-      }
-    ).onBlockActions({
-      type: "block_actions",
-      trigger_id: "trigger-1",
-      user: { id: "U123" },
-      channel: { id: "C123" },
-      container: {
-        channel_id: "C123",
-        message_ts: "123.456",
-        thread_ts: "123.000",
-      },
-      actions: [
-        {
-          action_id: "review.approve",
-          block_id: "review-actions",
-          type: "button",
-          text: { type: "plain_text", text: "Approve" },
-          value: '{"decision":"approve"}',
-          action_ts: "123.789",
-        },
-      ],
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({})),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      onInteractive: (event) =>
+        (
+          adapter as unknown as {
+            emitInteractiveInbound: (input: {
+              channel: string;
+              threadTs: string;
+              userId: string;
+              text: string;
+              timestamp: string;
+              metadata: Record<string, unknown>;
+            }) => Promise<void>;
+          }
+        ).emitInteractiveInbound(event),
     });
+
+    await (
+      client as unknown as {
+        handleFrame: (raw: string) => Promise<void>;
+      }
+    ).handleFrame(
+      JSON.stringify({
+        envelope_id: "env-1",
+        type: "interactive",
+        payload: {
+          type: "block_actions",
+          trigger_id: "trigger-1",
+          user: { id: "U123" },
+          channel: { id: "C123" },
+          container: {
+            channel_id: "C123",
+            message_ts: "123.456",
+            thread_ts: "123.000",
+          },
+          actions: [
+            {
+              action_id: "review.approve",
+              block_id: "review-actions",
+              type: "button",
+              text: { type: "plain_text", text: "Approve" },
+              value: '{"decision":"approve"}',
+              action_ts: "123.789",
+            },
+          ],
+        },
+      }),
+    );
 
     expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123");
     expect(handler).toHaveBeenCalledWith({
@@ -865,32 +904,57 @@ describe("SlackAdapter", () => {
       "resolveUser",
     ).mockResolvedValue("Will");
 
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({})),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      onInteractive: (event) =>
+        (
+          adapter as unknown as {
+            emitInteractiveInbound: (input: {
+              channel: string;
+              threadTs: string;
+              userId: string;
+              text: string;
+              timestamp: string;
+              metadata: Record<string, unknown>;
+            }) => Promise<void>;
+          }
+        ).emitInteractiveInbound(event),
+    });
+
     await (
-      adapter as unknown as {
-        onViewSubmission: (payload: Record<string, unknown>) => Promise<void>;
+      client as unknown as {
+        handleFrame: (raw: string) => Promise<void>;
       }
-    ).onViewSubmission({
-      type: "view_submission",
-      trigger_id: "trigger-1",
-      user: { id: "U123" },
-      view: {
-        id: "V123",
-        callback_id: "deploy.confirm",
-        title: { type: "plain_text", text: "Deploy approval" },
-        private_metadata:
-          '{"workflow":"deploy","__piSlackModalContext":{"threadTs":"123.000","channel":"C123"}}',
-        state: {
-          values: {
-            confirm_phrase: {
-              confirm_phrase: {
-                type: "plain_text_input",
-                value: "CONFIRM",
+    ).handleFrame(
+      JSON.stringify({
+        envelope_id: "env-1",
+        type: "interactive",
+        payload: {
+          type: "view_submission",
+          trigger_id: "trigger-1",
+          user: { id: "U123" },
+          view: {
+            id: "V123",
+            callback_id: "deploy.confirm",
+            title: { type: "plain_text", text: "Deploy approval" },
+            private_metadata:
+              '{"workflow":"deploy","__piSlackModalContext":{"threadTs":"123.000","channel":"C123"}}',
+            state: {
+              values: {
+                confirm_phrase: {
+                  confirm_phrase: {
+                    type: "plain_text_input",
+                    value: "CONFIRM",
+                  },
+                },
               },
             },
           },
         },
-      },
-    });
+      }),
+    );
 
     expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123");
     expect(handler).toHaveBeenCalledWith({

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -1,12 +1,22 @@
 import {
-  callSlackAPI,
-  createAbortableOperationTracker,
-  isAbortError,
-  buildAllowlist,
-  isUserAllowed,
-  stripBotMention,
-} from "../../helpers.js";
-import { buildSlackInboundMessageText } from "../../slack-message-context.js";
+  addSlackReaction,
+  buildSlackUserAllowlist,
+  classifyMessage,
+  clearSlackThreadStatus,
+  extractAppHomeOpened,
+  extractThreadContextChanged,
+  extractThreadStarted,
+  fetchSlackMessageByTs,
+  isSlackUserAllowed,
+  removeSlackReaction,
+  resolveSlackUserName,
+  setSlackSuggestedPrompts,
+  SlackSocketModeClient,
+  type ParsedAppHomeOpened,
+  type ParsedThreadContextChanged,
+  type ParsedThreadStarted,
+} from "../../slack-access.js";
+import { createAbortableOperationTracker, callSlackAPI, isAbortError } from "../../helpers.js";
 import {
   buildReactionTriggerMessage,
   normalizeReactionName,
@@ -15,18 +25,19 @@ import {
 } from "../../reaction-triggers.js";
 import { TtlCache, TtlSet } from "../../ttl-cache.js";
 import {
-  extractSlackSocketDedupKey,
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
-} from "../../slack-socket-dedup.js";
-import {
-  extractSlackInteractivePayloadFromEnvelope,
-  normalizeSlackBlockActionPayload,
-  normalizeSlackViewSubmissionPayload,
-} from "../../slack-block-kit.js";
+} from "../../slack-access.js";
 import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
 
-// ─── Config ──────────────────────────────────────────────
+export {
+  classifyMessage,
+  extractAppHomeOpened,
+  extractThreadStarted,
+  parseMemberJoinedChannel,
+  parseSocketFrame,
+  RECONNECT_DELAY_MS,
+} from "../../slack-access.js";
 
 export interface SlackAdapterConfig {
   botToken: string;
@@ -49,177 +60,6 @@ interface SlackThreadInfo {
   context?: { channelId: string; teamId: string };
 }
 
-// ─── Internal thread tracking ────────────────────────────
-
-// ─── Slack API result ────────────────────────────────────
-
-export interface ParsedEnvelope {
-  envelopeId?: string;
-  type: string;
-  dedupKey?: string;
-  event?: Record<string, unknown>;
-  interactivePayload?: Record<string, unknown>;
-}
-
-/**
- * Parse a raw Socket Mode WebSocket frame into a structured envelope.
- * Returns null if the frame is malformed JSON.
- */
-export function parseSocketFrame(raw: string): ParsedEnvelope | null {
-  try {
-    const data = JSON.parse(raw) as Record<string, unknown>;
-    const result: ParsedEnvelope = {
-      type: (data.type as string) ?? "",
-    };
-    if (data.envelope_id) {
-      result.envelopeId = data.envelope_id as string;
-    }
-    const dedupKey = extractSlackSocketDedupKey(data);
-    if (dedupKey) {
-      result.dedupKey = dedupKey;
-    }
-    if (data.type === "events_api") {
-      const payload = data.payload as { event?: Record<string, unknown> } | undefined;
-      result.event = payload?.event;
-    }
-
-    const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
-    if (interactivePayload) {
-      result.interactivePayload = interactivePayload;
-    }
-    return result;
-  } catch {
-    /* malformed JSON */
-    return null;
-  }
-}
-
-export interface ParsedThreadStarted {
-  channelId: string;
-  threadTs: string;
-  userId: string;
-  context?: { channelId: string; teamId: string };
-}
-
-export interface ParsedAppHomeOpened {
-  userId: string;
-  tab: string;
-  eventTs: string | null;
-}
-
-/**
- * Extract thread info from an assistant_thread_started event.
- */
-export function extractThreadStarted(evt: Record<string, unknown>): ParsedThreadStarted | null {
-  const t = evt.assistant_thread as Record<string, unknown> | undefined;
-  if (!t) return null;
-
-  const result: ParsedThreadStarted = {
-    channelId: t.channel_id as string,
-    threadTs: t.thread_ts as string,
-    userId: t.user_id as string,
-  };
-
-  const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-  if (ctx?.channel_id) {
-    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
-  }
-
-  return result;
-}
-
-export function extractAppHomeOpened(evt: Record<string, unknown>): ParsedAppHomeOpened | null {
-  const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
-  if (!userId) return null;
-
-  const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
-  return {
-    userId,
-    tab,
-    eventTs: typeof evt.event_ts === "string" && evt.event_ts.length > 0 ? evt.event_ts : null,
-  };
-}
-
-/**
- * Classification result for an incoming message event.
- * Uses a discriminated union so TypeScript narrows fields when relevant is true.
- */
-export type MessageClassification =
-  | { relevant: false }
-  | {
-      relevant: true;
-      threadTs: string;
-      channel: string;
-      userId: string;
-      text: string;
-      isDM: boolean;
-      isChannelMention: boolean;
-      messageTs: string;
-    };
-
-/**
- * Classify an incoming Slack message event. Determines whether the
- * message is relevant (DM, known thread, or bot mention) and
- * extracts the cleaned fields.
- */
-export function classifyMessage(
-  evt: Record<string, unknown>,
-  botUserId: string | null,
-  trackedThreadIds: Set<string>,
-  isKnownThread?: (threadTs: string) => boolean,
-): MessageClassification {
-  // Skip bot messages and messages with subtypes (joins, edits, etc.)
-  if (evt.subtype || evt.bot_id) return { relevant: false };
-
-  const text = (evt.text as string) ?? "";
-  const user = evt.user as string;
-  const threadTs = evt.thread_ts as string | undefined;
-  const channel = evt.channel as string;
-  const channelType = evt.channel_type as string | undefined;
-
-  const isKnown = !!threadTs && (isKnownThread?.(threadTs) ?? trackedThreadIds.has(threadTs));
-  const isDM = channelType === "im";
-  const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
-
-  if (!isKnown && !isDM && !isMention) return { relevant: false };
-
-  const effectiveTs = threadTs ?? (evt.ts as string);
-  const isChannelMention = isMention && !isDM && !isKnown;
-
-  const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
-
-  return {
-    relevant: true,
-    threadTs: effectiveTs,
-    channel,
-    userId: user,
-    text: buildSlackInboundMessageText(cleanText, evt),
-    isDM,
-    isChannelMention,
-    messageTs: (evt.ts as string) ?? effectiveTs,
-  };
-}
-
-/**
- * Parse a member_joined_channel event. Returns null if required fields
- * are missing.
- */
-export function parseMemberJoinedChannel(
-  evt: Record<string, unknown>,
-  botUserId: string | null,
-): { channel: string; isSelf: boolean } | null {
-  const user = evt.user as string | undefined;
-  const channel = evt.channel as string | undefined;
-  if (!user || !channel) return null;
-  return { channel, isSelf: user === botUserId };
-}
-
-// ─── Reconnect delay (exported for testing) ──────────────
-
-export const RECONNECT_DELAY_MS = 5000;
-
-// ─── Slack Adapter ───────────────────────────────────────
-
 export class SlackAdapter implements MessageAdapter {
   readonly name = "slack";
 
@@ -227,8 +67,7 @@ export class SlackAdapter implements MessageAdapter {
   private readonly allowlist: Set<string> | null;
   private slackRequests = createAbortableOperationTracker();
   private botUserId: string | null = null;
-  private ws: WebSocket | null = null;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private socketMode: SlackSocketModeClient | null = null;
   private shuttingDown = false;
   private inboundHandler: ((msg: InboundMessage) => void) | null = null;
   private readonly reactionCommands: Map<string, { action: string; prompt: string }>;
@@ -246,7 +85,7 @@ export class SlackAdapter implements MessageAdapter {
 
   constructor(config: SlackAdapterConfig) {
     this.config = config;
-    this.allowlist = buildAllowlist({ allowedUsers: config.allowedUsers }, undefined);
+    this.allowlist = buildSlackUserAllowlist(config.allowedUsers);
     this.reactionCommands = resolveReactionCommands(config.reactionCommands);
   }
 
@@ -254,28 +93,40 @@ export class SlackAdapter implements MessageAdapter {
     return this.slackRequests.run((signal) => callSlackAPI(method, token, body, { signal }));
   }
 
-  // ─── MessageAdapter interface ─────────────────────────
-
   async connect(): Promise<void> {
     this.shuttingDown = false;
     this.slackRequests = createAbortableOperationTracker();
-    const auth = await this.callSlack("auth.test", this.config.botToken);
-    this.botUserId = auth.user_id as string;
-    await this.connectSocketMode();
+    this.socketMode = new SlackSocketModeClient({
+      slack: this.callSlack.bind(this),
+      botToken: this.config.botToken,
+      appToken: this.config.appToken,
+      dedup: this.processedSocketDeliveries,
+      abortAndWait: () => this.slackRequests.abortAndWait(),
+      onThreadStarted: (event) => this.onThreadStarted(event),
+      onThreadContextChanged: (event) => this.onContextChanged(event),
+      onMessage: (event) => this.onMessage(event),
+      onReactionAdded: (event) => this.onReactionAdded(event),
+      onMemberJoinedChannel: (event) => this.onMemberJoined(event),
+      onAppHomeOpened: (event) => this.onAppHomeOpened(event),
+      onInteractive: (event) => this.emitInteractiveInbound(event),
+      onError: (error) => {
+        if (!isAbortError(error)) {
+          console.error(`[slack-adapter] Socket Mode: ${errorMsg(error)}`);
+        }
+      },
+    });
+    await this.socketMode.connect();
+    this.botUserId = this.socketMode.getBotUserId();
   }
 
   async disconnect(): Promise<void> {
     this.shuttingDown = true;
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
+    const socketMode = this.socketMode;
+    this.socketMode = null;
+    if (socketMode) {
+      await socketMode.disconnect();
+      return;
     }
-    try {
-      this.ws?.close();
-    } catch {
-      /* ignore close errors */
-    }
-    this.ws = null;
     await this.slackRequests.abortAndWait();
   }
 
@@ -305,23 +156,19 @@ export class SlackAdapter implements MessageAdapter {
     await this.callSlack("chat.postMessage", this.config.botToken, body);
     if (this.shuttingDown) return;
 
-    // Remove pending eyes for this thread
     const pending = this.pendingEyes.get(msg.threadId);
     if (pending) {
-      for (const p of pending) {
-        void this.removeReaction(p.channel, p.messageTs, "eyes");
+      for (const entry of pending) {
+        void this.removeReaction(entry.channel, entry.messageTs, "eyes");
       }
       this.pendingEyes.delete(msg.threadId);
     }
 
-    // Clear thread status
     void this.clearThreadStatus(msg.channel, msg.threadId);
   }
 
-  // ─── Getters (for inspection / testing) ────────────────
-
   getBotUserId(): string | null {
-    return this.botUserId;
+    return this.socketMode?.getBotUserId() ?? this.botUserId;
   }
 
   getTrackedThreadIds(): Set<string> {
@@ -329,110 +176,15 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   isConnected(): boolean {
-    return this.ws?.readyState === WebSocket.OPEN;
+    return this.socketMode?.isConnected() ?? false;
   }
 
-  // ─── Socket Mode connection ────────────────────────────
-
-  private async connectSocketMode(): Promise<void> {
+  private async onThreadStarted(
+    event: ParsedThreadStarted | Record<string, unknown>,
+  ): Promise<void> {
     if (this.shuttingDown) return;
 
-    try {
-      const res = await this.callSlack("apps.connections.open", this.config.appToken);
-      this.ws = new WebSocket(res.url as string);
-
-      this.ws.addEventListener("message", (event) => {
-        void this.handleFrame(String(event.data));
-      });
-
-      this.ws.addEventListener("close", () => {
-        if (!this.shuttingDown) this.scheduleReconnect();
-      });
-
-      this.ws.addEventListener("error", () => {
-        /* close fires after error — handled there */
-      });
-    } catch (err) {
-      if (!isAbortError(err)) {
-        console.error(`[slack-adapter] Socket Mode: ${errorMsg(err)}`);
-      }
-      this.scheduleReconnect();
-    }
-  }
-
-  private async handleFrame(raw: string): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const envelope = parseSocketFrame(raw);
-    if (!envelope) return;
-
-    // ACK every envelope
-    if (envelope.envelopeId) {
-      this.ws?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
-    }
-
-    const dedupKey: string | null = envelope.dedupKey ?? null;
-
-    try {
-      if (dedupKey) {
-        if (this.processedSocketDeliveries.has(dedupKey)) {
-          return;
-        }
-        this.processedSocketDeliveries.add(dedupKey);
-      }
-
-      if (envelope.type === "disconnect") {
-        this.scheduleReconnect();
-        return;
-      }
-
-      if (envelope.interactivePayload) {
-        if (envelope.interactivePayload.type === "block_actions") {
-          await this.onBlockActions(envelope.interactivePayload);
-        } else if (envelope.interactivePayload.type === "view_submission") {
-          await this.onViewSubmission(envelope.interactivePayload);
-        }
-        return;
-      }
-
-      if (!envelope.event) return;
-
-      const evt = envelope.event;
-
-      switch (evt.type) {
-        case "assistant_thread_started":
-          await this.onThreadStarted(evt);
-          break;
-        case "assistant_thread_context_changed":
-          this.onContextChanged(evt);
-          break;
-        case "message":
-          await this.onMessage(evt);
-          break;
-        case "reaction_added":
-          await this.onReactionAdded(evt);
-          break;
-        case "member_joined_channel":
-          this.onMemberJoined(evt);
-          break;
-        case "app_home_opened":
-          await this.onAppHomeOpened(evt);
-          break;
-      }
-    } catch (err) {
-      if (dedupKey) {
-        this.processedSocketDeliveries.delete(dedupKey);
-      }
-      throw err;
-    }
-  }
-
-  // ─── Event handlers ────────────────────────────────────
-
-  private async onThreadStarted(evt: Record<string, unknown>): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const parsed = extractThreadStarted(evt);
+    const parsed = isParsedThreadStarted(event) ? event : extractThreadStarted(event);
     if (!parsed) return;
 
     const info: SlackThreadInfo = {
@@ -454,36 +206,32 @@ export class SlackAdapter implements MessageAdapter {
     await this.setSuggestedPrompts(info.channelId, info.threadTs);
   }
 
-  private onContextChanged(evt: Record<string, unknown>): void {
+  private onContextChanged(event: ParsedThreadContextChanged | Record<string, unknown>): void {
     if (this.shuttingDown) return;
 
-    const t = evt.assistant_thread as Record<string, unknown> | undefined;
-    if (!t) return;
+    const parsed = isParsedThreadContextChanged(event) ? event : extractThreadContextChanged(event);
+    if (!parsed) return;
 
-    const existing = this.threads.get(t.thread_ts as string);
-    if (!existing) return;
+    const existing = this.threads.get(parsed.threadTs);
+    if (!existing || !parsed.context) return;
 
-    const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-    if (ctx?.channel_id) {
-      existing.context = {
-        channelId: ctx.channel_id,
-        teamId: ctx.team_id ?? "",
-      };
-    }
+    existing.context = parsed.context;
   }
 
-  private async onAppHomeOpened(evt: Record<string, unknown>): Promise<void> {
+  private async onAppHomeOpened(
+    event: ParsedAppHomeOpened | Record<string, unknown>,
+  ): Promise<void> {
     if (this.shuttingDown) return;
 
-    const parsed = extractAppHomeOpened(evt);
+    const parsed = isParsedAppHomeOpened(event) ? event : extractAppHomeOpened(event);
     if (!parsed || parsed.tab !== "home") {
       return;
     }
 
     try {
       await this.config.onAppHomeOpened?.(parsed);
-    } catch (err) {
-      console.error(`[slack-adapter] Home tab callback failed: ${errorMsg(err)}`);
+    } catch (error) {
+      console.error(`[slack-adapter] Home tab callback failed: ${errorMsg(error)}`);
     }
   }
 
@@ -491,19 +239,12 @@ export class SlackAdapter implements MessageAdapter {
     channel: string,
     messageTs: string,
   ): Promise<Record<string, unknown> | null> {
-    try {
-      const response = await this.callSlack("conversations.history", this.config.botToken, {
-        channel,
-        oldest: messageTs,
-        latest: messageTs,
-        inclusive: true,
-        limit: 1,
-      });
-      const messages = (response.messages as Record<string, unknown>[]) ?? [];
-      return messages.find((message) => message.ts === messageTs) ?? messages[0] ?? null;
-    } catch {
-      return null;
-    }
+    return fetchSlackMessageByTs({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channel,
+      messageTs,
+    });
   }
 
   private async onReactionAdded(evt: Record<string, unknown>): Promise<void> {
@@ -526,7 +267,7 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     const command = this.reactionCommands.get(reactionName);
-    if (!command || !isUserAllowed(this.allowlist, userId)) {
+    if (!command || !isSlackUserAllowed(this.allowlist, userId)) {
       return;
     }
 
@@ -590,9 +331,8 @@ export class SlackAdapter implements MessageAdapter {
       });
 
       await this.addReaction(item.channel, item.ts, "white_check_mark");
-    } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err);
-      console.error(`[slack-adapter] reaction trigger failed: ${errorMsg}`);
+    } catch (error) {
+      console.error(`[slack-adapter] reaction trigger failed: ${errorMsg(error)}`);
       await this.addReaction(item.channel, item.ts, "x");
     }
   }
@@ -610,7 +350,6 @@ export class SlackAdapter implements MessageAdapter {
 
     const { threadTs, channel, userId, text, isChannelMention, messageTs } = classified;
 
-    // Track thread if new
     if (!this.threads.has(threadTs)) {
       this.threads.set(threadTs, {
         channelId: channel,
@@ -619,20 +358,16 @@ export class SlackAdapter implements MessageAdapter {
       });
     }
 
-    // Allowlist check — silently drop unauthorized users
-    if (!isUserAllowed(this.allowlist, userId)) return;
+    if (!isSlackUserAllowed(this.allowlist, userId)) return;
 
-    // React with eyes to acknowledge
     void this.addReaction(channel, messageTs, "eyes");
     const pending = this.pendingEyes.get(threadTs) ?? [];
     pending.push({ channel, messageTs });
     this.pendingEyes.set(threadTs, pending);
 
-    // Resolve user name
     const userName = await this.resolveUser(userId);
     if (this.shuttingDown) return;
 
-    // Emit inbound message
     this.inboundHandler?.({
       source: "slack",
       threadId: threadTs,
@@ -667,7 +402,7 @@ export class SlackAdapter implements MessageAdapter {
       /* best effort — DB cache sync must not break Slack event handling */
     }
 
-    if (!isUserAllowed(this.allowlist, normalized.userId)) return;
+    if (!isSlackUserAllowed(this.allowlist, normalized.userId)) return;
 
     const userName = await this.resolveUser(normalized.userId);
     if (this.shuttingDown) return;
@@ -684,90 +419,56 @@ export class SlackAdapter implements MessageAdapter {
     });
   }
 
-  private async onBlockActions(payload: Record<string, unknown>): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const normalized = normalizeSlackBlockActionPayload(payload);
-    if (!normalized) return;
-    await this.emitInteractiveInbound(normalized);
-  }
-
-  private async onViewSubmission(payload: Record<string, unknown>): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const normalized = normalizeSlackViewSubmissionPayload(payload);
-    if (!normalized) return;
-    await this.emitInteractiveInbound(normalized);
-  }
-
-  private onMemberJoined(evt: Record<string, unknown>): void {
-    const parsed = parseMemberJoinedChannel(evt, this.botUserId);
-    if (!parsed || !parsed.isSelf) return;
+  private onMemberJoined(event: { channel: string; isSelf: boolean }): void {
+    if (!event.isSelf) return;
 
     this.inboundHandler?.({
       source: "slack",
       threadId: "",
-      channel: parsed.channel,
+      channel: event.channel,
       userId: "system",
-      text: `Bot was added to channel ${parsed.channel}`,
+      text: `Bot was added to channel ${event.channel}`,
       timestamp: String(Date.now() / 1000),
     });
   }
 
-  // ─── Slack API helpers ─────────────────────────────────
-
   private async addReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await this.callSlack("reactions.add", this.config.botToken, {
-        channel,
-        timestamp: ts,
-        name: emoji,
-      });
-    } catch {
-      /* already_reacted or non-critical */
-    }
+    await addSlackReaction({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   private async removeReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await this.callSlack("reactions.remove", this.config.botToken, {
-        channel,
-        timestamp: ts,
-        name: emoji,
-      });
-    } catch {
-      /* not_reacted or non-critical */
-    }
+    await removeSlackReaction({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   private async resolveUser(userId: string): Promise<string> {
-    const cached = this.userNames.get(userId);
-    if (cached) return cached;
-    try {
-      const res = await this.callSlack("users.info", this.config.botToken, {
-        user: userId,
-      });
-      if (this.shuttingDown) return userId;
-      const u = res.user as { real_name?: string; name?: string };
-      const name = u.real_name ?? u.name ?? userId;
-      this.userNames.set(userId, name);
-      return name;
-    } catch {
-      /* non-critical — return raw userId */
-      return userId;
-    }
+    return resolveSlackUserName({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      userId,
+      cache: this.userNames,
+      shouldUseResult: () => !this.shuttingDown,
+    });
   }
 
   private async clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
-    try {
-      await this.callSlack("assistant.threads.setStatus", this.config.botToken, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        status: "",
-      });
-    } catch {
-      /* non-critical */
-    }
+    await clearSlackThreadStatus({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channelId,
+      threadTs,
+    });
   }
 
   private async setSuggestedPrompts(channelId: string, threadTs: string): Promise<void> {
@@ -776,30 +477,38 @@ export class SlackAdapter implements MessageAdapter {
       { title: "Help", message: "I need help with something in the codebase" },
       { title: "Review", message: "Summarise the recent changes" },
     ];
-    try {
-      await this.callSlack("assistant.threads.setSuggestedPrompts", this.config.botToken, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        prompts,
-      });
-    } catch {
-      /* non-critical */
-    }
-  }
-
-  // ─── Reconnect ─────────────────────────────────────────
-
-  private scheduleReconnect(): void {
-    if (this.shuttingDown || this.reconnectTimer) return;
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null;
-      void this.connectSocketMode();
-    }, RECONNECT_DELAY_MS);
+    await setSlackSuggestedPrompts({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channelId,
+      threadTs,
+      prompts,
+    });
   }
 }
 
-// ─── Utility ─────────────────────────────────────────────
+function isParsedThreadStarted(
+  value: ParsedThreadStarted | Record<string, unknown>,
+): value is ParsedThreadStarted {
+  return (
+    typeof value.channelId === "string" &&
+    typeof value.threadTs === "string" &&
+    typeof value.userId === "string"
+  );
+}
 
-function errorMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+function isParsedThreadContextChanged(
+  value: ParsedThreadContextChanged | Record<string, unknown>,
+): value is ParsedThreadContextChanged {
+  return typeof value.threadTs === "string";
+}
+
+function isParsedAppHomeOpened(
+  value: ParsedAppHomeOpened | Record<string, unknown>,
+): value is ParsedAppHomeOpened {
+  return typeof value.userId === "string" && typeof value.tab === "string";
+}
+
+function errorMsg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -13,8 +13,6 @@ import {
   type RalphLoopEvaluationResult,
   type RalphLoopEvaluationOptions,
   loadSettings as loadSettingsFromFile,
-  buildAllowlist,
-  isUserAllowed as checkUserAllowed,
   formatInboxMessages,
   formatPinetInboxMessages,
   buildPinetSkinAssignment,
@@ -29,8 +27,6 @@ import {
   type PinetControlCommand,
   type PinetRemoteControlState,
   formatAgentList,
-  stripBotMention,
-  isChannelId,
   callSlackAPI,
   createAbortableOperationTracker,
   isAbortError,
@@ -84,7 +80,6 @@ import {
   deliverTrackedSlackFollowUpMessage,
   type PendingSlackToolPolicyTurn,
 } from "./slack-turn-guardrails.js";
-import { buildSlackInboundMessageText } from "./slack-message-context.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import {
   buildReactionPromptGuidelines,
@@ -96,7 +91,7 @@ import { startBroker, type Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
-import { MessageRouter, extractPiAgentThreadOwnerHint } from "./broker/router.js";
+import { MessageRouter } from "./broker/router.js";
 import {
   DEFAULT_BROKER_MAINTENANCE_INTERVAL_MS,
   DEFAULT_BUSY_ASSIGNMENT_AGE_MS,
@@ -119,15 +114,24 @@ import {
   stopRalphLoop,
 } from "./ralph-loop.js";
 import {
-  extractSlackInteractivePayloadFromEnvelope,
-  normalizeSlackBlockActionPayload,
-  normalizeSlackViewSubmissionPayload,
-} from "./slack-block-kit.js";
-import {
-  extractSlackSocketDedupKey,
+  addSlackReaction,
+  buildSlackUserAllowlist,
+  classifyMessage,
+  clearSlackThreadStatus,
+  fetchSlackMessageByTs as fetchSlackMessageByTsFromSlack,
+  isSlackUserAllowed,
+  removeSlackReaction,
+  resolveSlackChannelId,
+  resolveSlackThreadOwnerHint,
+  resolveSlackUserName,
+  setSlackSuggestedPrompts,
+  SlackSocketModeClient,
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
-} from "./slack-socket-dedup.js";
+  type ParsedAppHomeOpened,
+  type ParsedThreadContextChanged,
+  type ParsedThreadStarted,
+} from "./slack-access.js";
 import {
   createFollowerDeliveryState,
   drainFollowerAckBatches,
@@ -207,11 +211,14 @@ export default function (pi: ExtensionAPI) {
   }
 
   // allowedUsers: settings.json takes priority, env var as fallback
-  let allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
+  let allowedUsers = buildSlackUserAllowlist(
+    settings.allowedUsers,
+    process.env.SLACK_ALLOWED_USERS,
+  );
   let reactionCommands = resolveReactionCommands(settings.reactionCommands);
 
   function isUserAllowed(userId: string): boolean {
-    return checkUserAllowed(allowedUsers, userId);
+    return isSlackUserAllowed(allowedUsers, userId);
   }
 
   const initialIdentity = resolveAgentIdentity(settings, process.env.PI_NICKNAME, process.cwd());
@@ -340,7 +347,7 @@ export default function (pi: ExtensionAPI) {
     settings = loadSettingsFromFile();
     botToken = settings.botToken ?? process.env.SLACK_BOT_TOKEN;
     appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
-    allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
+    allowedUsers = buildSlackUserAllowlist(settings.allowedUsers, process.env.SLACK_ALLOWED_USERS);
     guardrails = settings.security ?? {};
     reactionCommands = resolveReactionCommands(settings.reactionCommands);
     securityPrompt = buildSecurityPrompt(guardrails);
@@ -512,8 +519,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   let botUserId: string | null = null;
-  let ws: WebSocket | null = null;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let singleRuntimeSlackSocket: SlackSocketModeClient | null = null;
   let shuttingDown = false;
 
   const threads = new Map<string, ThreadInfo>();
@@ -670,60 +676,47 @@ export default function (pi: ExtensionAPI) {
   // ─── Helpers ─────────────────────────────────────────
 
   async function addReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await slack("reactions.add", botToken!, { channel, timestamp: ts, name: emoji });
-    } catch {
-      /* already_reacted or non-critical */
-    }
+    await addSlackReaction({
+      slack,
+      token: botToken!,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   async function removeReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await slack("reactions.remove", botToken!, { channel, timestamp: ts, name: emoji });
-    } catch {
-      /* not_reacted or non-critical */
-    }
+    await removeSlackReaction({
+      slack,
+      token: botToken!,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   async function resolveUser(userId: string): Promise<string> {
-    const cached = userNames.get(userId);
-    if (cached) return cached;
-    try {
-      const res = await slack("users.info", botToken!, { user: userId });
-      if (shuttingDown) return userId;
-      const u = res.user as { real_name?: string; name?: string };
-      const name = u.real_name ?? u.name ?? userId;
-      userNames.set(userId, name);
+    const hadCachedUser = userNames.get(userId) != null;
+    const name = await resolveSlackUserName({
+      slack,
+      token: botToken!,
+      userId,
+      cache: userNames,
+      shouldUseResult: () => !shuttingDown,
+    });
+    if (!hadCachedUser && userNames.get(userId) != null) {
       persistState();
-      return name;
-    } catch {
-      return userId;
     }
+    return name;
   }
 
   async function resolveChannel(nameOrId: string): Promise<string> {
-    if (isChannelId(nameOrId)) return nameOrId;
-    const name = nameOrId.replace(/^#/, "");
-    const cached = channelCache.get(name);
-    if (cached) return cached;
-
-    let cursor: string | undefined;
-    do {
-      const body: Record<string, unknown> = {
-        types: "public_channel,private_channel",
-        limit: 200,
-      };
-      if (cursor) body.cursor = cursor;
-      const res = await slack("conversations.list", botToken!, body);
-      const channels = res.channels as { id: string; name: string }[];
-      for (const ch of channels) {
-        channelCache.set(ch.name, ch.id);
-      }
-      if (channelCache.has(name)) return channelCache.get(name)!;
-      cursor = (res.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-    } while (cursor);
-
-    throw new Error(`Channel "${name}" not found.`);
+    return resolveSlackChannelId({
+      slack,
+      token: botToken!,
+      nameOrId,
+      cache: channelCache,
+    });
   }
 
   const activityLogger = new SlackActivityLogger({
@@ -823,15 +816,12 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
-    try {
-      await slack("assistant.threads.setStatus", botToken!, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        status: "",
-      });
-    } catch {
-      /* non-critical */
-    }
+    await clearSlackThreadStatus({
+      slack,
+      token: botToken!,
+      channelId,
+      threadTs,
+    });
   }
 
   async function setSuggestedPrompts(channelId: string, threadTs: string): Promise<void> {
@@ -840,15 +830,13 @@ export default function (pi: ExtensionAPI) {
       { title: "Help", message: `${agentName}, I need help with something in the codebase` },
       { title: "Review", message: `${agentName}, summarise the recent changes` },
     ];
-    try {
-      await slack("assistant.threads.setSuggestedPrompts", botToken!, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        prompts,
-      });
-    } catch {
-      /* non-critical */
-    }
+    await setSlackSuggestedPrompts({
+      slack,
+      token: botToken!,
+      channelId,
+      threadTs,
+      prompts,
+    });
   }
 
   function formatConfirmationAction(action: string): string {
@@ -988,34 +976,14 @@ export default function (pi: ExtensionAPI) {
   // next incoming message once it sees the winner's metadata.
 
   async function resolveThreadOwner(channel: string, threadTs: string): Promise<string | null> {
-    try {
-      const res = await slack("conversations.replies", botToken!, {
-        channel,
-        ts: threadTs,
-        limit: 50,
-        include_all_metadata: true,
-      });
-      const msgs = (res.messages as Record<string, unknown>[]) ?? [];
-      for (const m of msgs) {
-        if (!m.bot_id) continue;
-        const meta = m.metadata as
-          | {
-              event_type?: string;
-              event_payload?: { agent?: string; agent_owner?: string };
-            }
-          | undefined;
-        if (meta?.event_type !== "pi_agent_msg") continue;
-        if (typeof meta.event_payload?.agent_owner === "string" && meta.event_payload.agent_owner) {
-          return meta.event_payload.agent_owner;
-        }
-        if (meta.event_payload?.agent) {
-          return meta.event_payload.agent;
-        }
-      }
-    } catch {
-      // If we can't check, allow the message through rather than blocking
-    }
-    return null;
+    const hint = await resolveSlackThreadOwnerHint({
+      slack,
+      token: botToken!,
+      channel,
+      threadTs,
+      limit: 50,
+    });
+    return hint?.agentOwner ?? hint?.agentName ?? null;
   }
 
   // ─── Socket Mode (native WebSocket) ─────────────────
@@ -1023,128 +991,61 @@ export default function (pi: ExtensionAPI) {
   async function connectSocketMode(ctx: ExtensionContext): Promise<void> {
     if (shuttingDown) return;
 
-    try {
-      const res = await slack("apps.connections.open", appToken!);
-      ws = new WebSocket(res.url as string);
-
-      ws.addEventListener("open", () => setExtStatus(ctx, "ok"));
-
-      ws.addEventListener("message", (event) => {
-        void handleFrame(String(event.data), ctx);
-      });
-
-      ws.addEventListener("close", () => {
-        if (!shuttingDown && currentRuntimeMode === "single") scheduleReconnect(ctx);
-      });
-
-      ws.addEventListener("error", () => {
-        /* close fires after */
-      });
-    } catch (err) {
-      if (!isAbortError(err)) {
-        console.error(`[slack-bridge] Socket Mode: ${msg(err)}`);
-      }
-      scheduleReconnect(ctx);
-    }
-  }
-
-  async function handleFrame(raw: string, ctx: ExtensionContext): Promise<void> {
-    if (shuttingDown) return;
-
-    let dedupKey: string | null = null;
-
-    try {
-      const data = JSON.parse(raw) as Record<string, unknown>;
-
-      // ack every envelope
-      if (data.envelope_id) {
-        ws?.send(JSON.stringify({ envelope_id: data.envelope_id }));
-      }
-
-      dedupKey = extractSlackSocketDedupKey(data);
-      if (dedupKey) {
-        if (processedSlackSocketDeliveries.has(dedupKey)) {
-          return;
+    singleRuntimeSlackSocket = new SlackSocketModeClient({
+      slack,
+      botToken: botToken!,
+      appToken: appToken!,
+      resolveBotUserIdOnConnect: false,
+      dedup: processedSlackSocketDeliveries,
+      abortAndWait: () => slackRequests.abortAndWait(),
+      onOpen: () => setExtStatus(ctx, "ok"),
+      onReconnectScheduled: () => {
+        if (!shuttingDown && currentRuntimeMode === "single") {
+          setExtStatus(ctx, "reconnecting");
         }
-        processedSlackSocketDeliveries.add(dedupKey);
-      }
-
-      if (data.type === "disconnect") {
-        scheduleReconnect(ctx);
-        return;
-      }
-
-      const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
-      if (interactivePayload) {
-        if (interactivePayload.type === "block_actions") {
-          await onBlockActions(interactivePayload, ctx);
-        } else if (interactivePayload.type === "view_submission") {
-          await onViewSubmission(interactivePayload, ctx);
+      },
+      onError: (err) => {
+        if (!isAbortError(err)) {
+          console.error(`[slack-bridge] Slack access: ${msg(err)}`);
         }
-        return;
-      }
-
-      if (data.type !== "events_api") return;
-
-      const evt = (data.payload as { event: Record<string, unknown> }).event;
-
-      switch (evt.type) {
-        case "assistant_thread_started":
-          await onThreadStarted(evt);
-          break;
-        case "assistant_thread_context_changed":
-          onContextChanged(evt);
-          break;
-        case "app_home_opened":
-          await onAppHomeOpened(evt, ctx);
-          break;
-        case "message":
-          if (!evt.subtype && !evt.bot_id) await onMessage(evt, ctx);
-          break;
-        case "reaction_added":
-          await onReactionAdded(evt, ctx);
-          break;
-        case "member_joined_channel":
-          if ((evt.user as string) === botUserId) {
-            const ch = evt.channel as string;
-            ctx.ui.notify(`Pinet added to channel ${ch}`, "info");
-            inbox.push({
-              channel: ch,
-              threadTs: "",
-              userId: "system",
-              text: `Pinet was added to channel <#${ch}>. You can now post messages there.`,
-              timestamp: String(Date.now() / 1000),
-            });
-            updateBadge();
-            maybeDrainInboxIfIdle(ctx);
-          }
-          break;
-      }
-    } catch {
-      if (dedupKey) {
-        processedSlackSocketDeliveries.delete(dedupKey);
-      }
-      /* malformed frame */
-    }
+      },
+      onThreadStarted: (event) => onThreadStarted(event),
+      onThreadContextChanged: (event) => onContextChanged(event),
+      onAppHomeOpened: (event) => onAppHomeOpened(event, ctx),
+      onMessage: (event) => onMessage(event, ctx),
+      onReactionAdded: (event) => onReactionAdded(event, ctx),
+      onMemberJoinedChannel: async ({ channel, isSelf }) => {
+        if (!isSelf) return;
+        ctx.ui.notify(`Pinet added to channel ${channel}`, "info");
+        inbox.push({
+          channel,
+          threadTs: "",
+          userId: "system",
+          text: `Pinet was added to channel <#${channel}>. You can now post messages there.`,
+          timestamp: String(Date.now() / 1000),
+        });
+        updateBadge();
+        maybeDrainInboxIfIdle(ctx);
+      },
+      onInteractive: (event) => queueInteractiveInboxEvent(event, ctx),
+    });
+    await singleRuntimeSlackSocket.connect();
+    botUserId = singleRuntimeSlackSocket?.getBotUserId() ?? botUserId;
   }
 
   // ─── Assistant events ───────────────────────────────
 
-  async function onThreadStarted(evt: Record<string, unknown>): Promise<void> {
+  async function onThreadStarted(event: ParsedThreadStarted): Promise<void> {
     if (shuttingDown) return;
 
-    const t = evt.assistant_thread as Record<string, unknown>;
-    if (!t) return;
-
     const info: ThreadInfo = {
-      channelId: t.channel_id as string,
-      threadTs: t.thread_ts as string,
-      userId: t.user_id as string,
+      channelId: event.channelId,
+      threadTs: event.threadTs,
+      userId: event.userId,
     };
 
-    const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-    if (ctx?.channel_id) {
-      info.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+    if (event.context) {
+      info.context = event.context;
     }
 
     threads.set(info.threadTs, info);
@@ -1154,54 +1055,32 @@ export default function (pi: ExtensionAPI) {
     await setSuggestedPrompts(info.channelId, info.threadTs);
   }
 
-  function onContextChanged(evt: Record<string, unknown>): void {
+  function onContextChanged(event: ParsedThreadContextChanged): void {
     if (shuttingDown) return;
 
-    const t = evt.assistant_thread as Record<string, unknown>;
-    if (!t) return;
+    const existing = threads.get(event.threadTs);
+    if (!existing || !event.context) return;
 
-    const existing = threads.get(t.thread_ts as string);
-    if (!existing) return;
-
-    const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-    if (ctx?.channel_id) {
-      existing.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
-      persistState();
-    }
+    existing.context = event.context;
+    persistState();
   }
 
-  async function onAppHomeOpened(
-    evt: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ): Promise<void> {
+  async function onAppHomeOpened(event: ParsedAppHomeOpened, ctx: ExtensionContext): Promise<void> {
     if (shuttingDown) return;
 
-    const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
-    const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
-    if (!userId || tab !== "home") {
-      return;
-    }
-
-    await publishCurrentPinetHomeTabSafely(userId, ctx);
+    await publishCurrentPinetHomeTabSafely(event.userId, ctx);
   }
 
   async function fetchSlackMessageByTs(
     channel: string,
     messageTs: string,
   ): Promise<Record<string, unknown> | null> {
-    try {
-      const response = await slack("conversations.history", botToken!, {
-        channel,
-        oldest: messageTs,
-        latest: messageTs,
-        inclusive: true,
-        limit: 1,
-      });
-      const messages = (response.messages as Record<string, unknown>[]) ?? [];
-      return messages.find((message) => message.ts === messageTs) ?? messages[0] ?? null;
-    } catch {
-      return null;
-    }
+    return fetchSlackMessageByTsFromSlack({
+      slack,
+      token: botToken!,
+      channel,
+      messageTs,
+    });
   }
 
   async function onReactionAdded(
@@ -1338,104 +1217,84 @@ export default function (pi: ExtensionAPI) {
   async function onMessage(evt: Record<string, unknown>, ctx: ExtensionContext): Promise<void> {
     if (shuttingDown) return;
 
-    const text = (evt.text as string) ?? "";
-    const user = evt.user as string;
-    const threadTs = evt.thread_ts as string | undefined;
-    const channel = evt.channel as string;
-    const channelType = evt.channel_type as string | undefined;
+    const classified = classifyMessage(evt, botUserId, new Set(threads.keys()));
+    if (!classified.relevant) return;
 
-    const isTracked = !!threadTs && threads.has(threadTs);
-    const isDM = channelType === "im";
-    const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
+    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
 
-    if (!isTracked && !isDM && !isMention) return;
-
-    const effectiveTs = threadTs ?? (evt.ts as string);
-
-    // track if new (needed for ownership check below)
-    if (!threads.has(effectiveTs)) {
-      threads.set(effectiveTs, { channelId: channel, threadTs: effectiveTs, userId: user });
+    if (!threads.has(threadTs)) {
+      threads.set(threadTs, { channelId: channel, threadTs, userId });
     }
 
-    // ── Thread ownership check (before allowlist so only the owning agent rejects) ──
-    const localOwner = threads.get(effectiveTs)?.owner;
+    const localOwner = threads.get(threadTs)?.owner;
     if (localOwner && !agentOwnsThread(localOwner, agentName, agentAliases, agentOwnerToken)) {
       return;
     }
     if (localOwner) {
-      const thread = threads.get(effectiveTs);
+      const thread = threads.get(threadTs);
       if (thread) {
         normalizeOwnedThreads([thread], agentName, agentOwnerToken, agentAliases);
       }
     }
 
-    if (!localOwner && !unclaimedThreads.has(effectiveTs)) {
-      const remoteOwner = await resolveThreadOwner(channel, effectiveTs);
+    if (!localOwner && !unclaimedThreads.has(threadTs)) {
+      const remoteOwner = await resolveThreadOwner(channel, threadTs);
       if (shuttingDown) return;
       if (remoteOwner && !agentOwnsThread(remoteOwner, agentName, agentAliases, agentOwnerToken)) {
-        const t = threads.get(effectiveTs);
-        if (t) t.owner = remoteOwner; // cache so we skip instantly next time
+        const thread = threads.get(threadTs);
+        if (thread) thread.owner = remoteOwner;
         return;
       }
       if (agentOwnsThread(remoteOwner ?? undefined, agentName, agentAliases, agentOwnerToken)) {
-        const t = threads.get(effectiveTs);
-        if (t) t.owner = agentOwnerToken;
+        const thread = threads.get(threadTs);
+        if (thread) thread.owner = agentOwnerToken;
       }
       if (!remoteOwner) {
-        unclaimedThreads.add(effectiveTs); // negative cache: no owner found yet
+        unclaimedThreads.add(threadTs);
       }
     }
 
-    // ── User allowlist check ──
-    if (!isUserAllowed(user)) {
+    if (!isUserAllowed(userId)) {
       await slack("chat.postMessage", botToken!, {
         channel,
-        thread_ts: effectiveTs,
+        thread_ts: threadTs,
         text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
       });
       return;
     }
 
-    if (isDM) lastDmChannel = channel;
+    if (isDM) {
+      lastDmChannel = channel;
+    }
     persistState();
 
-    // Determine if this is a new channel mention (not DM, not already tracked)
-    const isChannelMention = isMention && !isDM && !isTracked;
-
-    // Strip <@BOT_ID> from text for channel mentions
-    const cleanText = isChannelMention ? stripBotMention(text, botUserId!) : text;
-    const enrichedText = buildSlackInboundMessageText(cleanText, evt);
-    const confirmationResult = consumeConfirmationReply(effectiveTs, cleanText);
+    const confirmationResult = consumeConfirmationReply(threadTs, text);
     const messageText =
       confirmationResult === null
-        ? enrichedText
+        ? text
         : confirmationResult.approved
-          ? `${enrichedText}\n\n✅ User approved security confirmation request in this thread.`
-          : `${enrichedText}\n\n❌ User denied security confirmation request in this thread.`;
+          ? `${text}\n\n✅ User approved security confirmation request in this thread.`
+          : `${text}\n\n❌ User denied security confirmation request in this thread.`;
 
-    const name = await resolveUser(user);
+    const name = await resolveUser(userId);
     if (shuttingDown) return;
-    ctx.ui.notify(`${name}: ${cleanText.slice(0, 100)}`, "info");
+    ctx.ui.notify(`${name}: ${text.slice(0, 100)}`, "info");
 
-    // React with 👀 to acknowledge (no chat lock)
-    const messageTs = (evt.ts as string) ?? effectiveTs;
     void addReaction(channel, messageTs, "eyes");
-    const pending = pendingEyes.get(effectiveTs) ?? [];
+    const pending = pendingEyes.get(threadTs) ?? [];
     pending.push({ channel, messageTs });
-    pendingEyes.set(effectiveTs, pending);
+    pendingEyes.set(threadTs, pending);
 
-    // Queue in inbox
     inbox.push({
       channel,
-      threadTs: effectiveTs,
-      userId: user,
+      threadTs,
+      userId,
       text: messageText,
-      timestamp: (evt.ts as string) ?? effectiveTs,
+      timestamp: messageTs,
       ...(isChannelMention && { isChannelMention: true }),
     });
     updateBadge();
 
-    // If agent is idle, trigger immediately — otherwise agent_end drains it
     maybeDrainInboxIfIdle(ctx);
   }
 
@@ -1517,52 +1376,16 @@ export default function (pi: ExtensionAPI) {
     maybeDrainInboxIfIdle(ctx);
   }
 
-  async function onBlockActions(
-    payload: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ): Promise<void> {
-    if (shuttingDown) return;
-
-    const normalized = normalizeSlackBlockActionPayload(payload);
-    if (!normalized) return;
-    await queueInteractiveInboxEvent(normalized, ctx);
-  }
-
-  async function onViewSubmission(
-    payload: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ): Promise<void> {
-    if (shuttingDown) return;
-
-    const normalized = normalizeSlackViewSubmissionPayload(payload);
-    if (!normalized) return;
-    await queueInteractiveInboxEvent(normalized, ctx);
-  }
-
   // ─── Reconnect / status ─────────────────────────────
-
-  function scheduleReconnect(ctx: ExtensionContext): void {
-    if (shuttingDown || reconnectTimer || currentRuntimeMode !== "single") return;
-    setExtStatus(ctx, "reconnecting");
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      if (shuttingDown || currentRuntimeMode !== "single") {
-        return;
-      }
-      void connectSocketMode(ctx);
-    }, 5000);
-  }
 
   async function disconnect(): Promise<void> {
     shuttingDown = true;
-    if (reconnectTimer) clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-    try {
-      ws?.close();
-    } catch {
-      /* ignore */
+    const socket = singleRuntimeSlackSocket;
+    singleRuntimeSlackSocket = null;
+    if (socket) {
+      await socket.disconnect();
+      return;
     }
-    ws = null;
     await slackRequests.abortAndWait();
   }
 
@@ -2110,7 +1933,7 @@ export default function (pi: ExtensionAPI) {
             : currentRuntimeMode === "follower"
               ? brokerClient != null
               : currentRuntimeMode === "single"
-                ? ws?.readyState === WebSocket.OPEN
+                ? (singleRuntimeSlackSocket?.isConnected() ?? false)
                 : false,
         mode: currentRuntimeMode,
         activeThreads: threads.size,
@@ -3061,30 +2884,13 @@ export default function (pi: ExtensionAPI) {
         channel: string,
         threadTs: string,
       ): Promise<{ agentOwner?: string; agentName?: string } | null> {
-        if (!channel || !threadTs) return null;
-
-        const cacheKey = `${channel}:${threadTs}`;
-        const cached = brokerThreadOwnerHintCache.get(cacheKey);
-        if (cached) {
-          return cached;
-        }
-
-        try {
-          const response = await slack("conversations.replies", botToken!, {
-            channel,
-            ts: threadTs,
-            limit: 200,
-            include_all_metadata: true,
-          });
-          const replies = (response.messages as Record<string, unknown>[]) ?? [];
-          const hint = extractPiAgentThreadOwnerHint(replies);
-          if (hint) {
-            brokerThreadOwnerHintCache.set(cacheKey, hint);
-          }
-          return hint;
-        } catch {
-          return null;
-        }
+        return resolveSlackThreadOwnerHint({
+          slack,
+          token: botToken!,
+          channel,
+          threadTs,
+          cache: brokerThreadOwnerHintCache,
+        });
       }
 
       adapter.onInbound((inMsg) => {
@@ -3255,7 +3061,7 @@ export default function (pi: ExtensionAPI) {
         : currentRuntimeMode === "follower"
           ? brokerClient != null
           : currentRuntimeMode === "single"
-            ? ws?.readyState === WebSocket.OPEN
+            ? (singleRuntimeSlackSocket?.isConnected() ?? false)
             : false,
     brokerRole: () => brokerRole,
     agentName: () => agentName,

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -1,0 +1,653 @@
+import {
+  buildAllowlist,
+  isUserAllowed,
+  isChannelId,
+  stripBotMention,
+  isAbortError,
+} from "./helpers.js";
+import { buildSlackInboundMessageText } from "./slack-message-context.js";
+import {
+  extractSlackInteractivePayloadFromEnvelope,
+  normalizeSlackBlockActionPayload,
+  normalizeSlackViewSubmissionPayload,
+  type SlackInteractiveInboxEvent,
+} from "./slack-block-kit.js";
+import { extractSlackSocketDedupKey } from "./slack-socket-dedup.js";
+import { extractPiAgentThreadOwnerHint, type ThreadOwnerHint } from "./broker/router.js";
+
+export {
+  SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
+  SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
+} from "./slack-socket-dedup.js";
+
+export type SlackCall = (
+  method: string,
+  token: string,
+  body?: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+export interface SlackAccessCache<K, V> {
+  get(key: K): V | undefined;
+  set(key: K, value: V): unknown;
+  has?(key: K): boolean;
+}
+
+export interface SlackAccessSet<K> {
+  has(key: K): boolean;
+  add(key: K): unknown;
+  delete?(key: K): unknown;
+}
+
+export interface SlackThreadContext {
+  channelId: string;
+  teamId: string;
+}
+
+export interface ParsedEnvelope {
+  envelopeId?: string;
+  type: string;
+  dedupKey?: string;
+  event?: Record<string, unknown>;
+  interactivePayload?: Record<string, unknown>;
+}
+
+export function buildSlackUserAllowlist(
+  allowedUsers?: string[],
+  envAllowedUsers?: string,
+): Set<string> | null {
+  return buildAllowlist({ allowedUsers }, envAllowedUsers);
+}
+
+export function isSlackUserAllowed(allowlist: Set<string> | null, userId: string): boolean {
+  return isUserAllowed(allowlist, userId);
+}
+
+/**
+ * Parse a raw Socket Mode WebSocket frame into a structured envelope.
+ * Returns null if the frame is malformed JSON.
+ */
+export function parseSocketFrame(raw: string): ParsedEnvelope | null {
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    const result: ParsedEnvelope = {
+      type: (data.type as string) ?? "",
+    };
+    if (data.envelope_id) {
+      result.envelopeId = data.envelope_id as string;
+    }
+    const dedupKey = extractSlackSocketDedupKey(data);
+    if (dedupKey) {
+      result.dedupKey = dedupKey;
+    }
+    if (data.type === "events_api") {
+      const payload = data.payload as { event?: Record<string, unknown> } | undefined;
+      result.event = payload?.event;
+    }
+
+    const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
+    if (interactivePayload) {
+      result.interactivePayload = interactivePayload;
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedThreadStarted {
+  channelId: string;
+  threadTs: string;
+  userId: string;
+  context?: SlackThreadContext;
+}
+
+/**
+ * Extract thread info from an assistant_thread_started event.
+ */
+export function extractThreadStarted(evt: Record<string, unknown>): ParsedThreadStarted | null {
+  const t = evt.assistant_thread as Record<string, unknown> | undefined;
+  if (!t) return null;
+
+  const channelId =
+    typeof t.channel_id === "string" && t.channel_id.length > 0 ? t.channel_id : null;
+  const threadTs = typeof t.thread_ts === "string" && t.thread_ts.length > 0 ? t.thread_ts : null;
+  const userId = typeof t.user_id === "string" && t.user_id.length > 0 ? t.user_id : null;
+  if (!channelId || !threadTs || !userId) {
+    return null;
+  }
+
+  const result: ParsedThreadStarted = {
+    channelId,
+    threadTs,
+    userId,
+  };
+
+  const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
+  if (ctx?.channel_id) {
+    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+  }
+
+  return result;
+}
+
+export interface ParsedThreadContextChanged {
+  threadTs: string;
+  context?: SlackThreadContext;
+}
+
+export function extractThreadContextChanged(
+  evt: Record<string, unknown>,
+): ParsedThreadContextChanged | null {
+  const t = evt.assistant_thread as Record<string, unknown> | undefined;
+  if (!t) return null;
+
+  const threadTs = typeof t.thread_ts === "string" && t.thread_ts.length > 0 ? t.thread_ts : null;
+  if (!threadTs) {
+    return null;
+  }
+
+  const result: ParsedThreadContextChanged = { threadTs };
+  const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
+  if (ctx?.channel_id) {
+    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+  }
+
+  return result;
+}
+
+export interface ParsedAppHomeOpened {
+  userId: string;
+  tab: string;
+  eventTs: string | null;
+}
+
+export function extractAppHomeOpened(evt: Record<string, unknown>): ParsedAppHomeOpened | null {
+  const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
+  if (!userId) return null;
+
+  const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
+  return {
+    userId,
+    tab,
+    eventTs: typeof evt.event_ts === "string" && evt.event_ts.length > 0 ? evt.event_ts : null,
+  };
+}
+
+/**
+ * Classification result for an incoming message event.
+ * Uses a discriminated union so TypeScript narrows fields when relevant is true.
+ */
+export type MessageClassification =
+  | { relevant: false }
+  | {
+      relevant: true;
+      threadTs: string;
+      channel: string;
+      userId: string;
+      text: string;
+      isDM: boolean;
+      isChannelMention: boolean;
+      messageTs: string;
+    };
+
+/**
+ * Classify an incoming Slack message event. Determines whether the
+ * message is relevant (DM, known thread, or bot mention) and
+ * extracts the cleaned fields.
+ */
+export function classifyMessage(
+  evt: Record<string, unknown>,
+  botUserId: string | null,
+  trackedThreadIds: Set<string>,
+  isKnownThread?: (threadTs: string) => boolean,
+): MessageClassification {
+  if (evt.subtype || evt.bot_id) return { relevant: false };
+
+  const text = (evt.text as string) ?? "";
+  const user = evt.user as string;
+  const threadTs = evt.thread_ts as string | undefined;
+  const channel = evt.channel as string;
+  const channelType = evt.channel_type as string | undefined;
+
+  const isKnown = !!threadTs && (isKnownThread?.(threadTs) ?? trackedThreadIds.has(threadTs));
+  const isDM = channelType === "im";
+  const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
+
+  if (!isKnown && !isDM && !isMention) return { relevant: false };
+
+  const effectiveTs = threadTs ?? (evt.ts as string);
+  const isChannelMention = isMention && !isDM && !isKnown;
+  const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
+
+  return {
+    relevant: true,
+    threadTs: effectiveTs,
+    channel,
+    userId: user,
+    text: buildSlackInboundMessageText(cleanText, evt),
+    isDM,
+    isChannelMention,
+    messageTs: (evt.ts as string) ?? effectiveTs,
+  };
+}
+
+/**
+ * Parse a member_joined_channel event. Returns null if required fields
+ * are missing.
+ */
+export function parseMemberJoinedChannel(
+  evt: Record<string, unknown>,
+  botUserId: string | null,
+): { channel: string; isSelf: boolean } | null {
+  const user = evt.user as string | undefined;
+  const channel = evt.channel as string | undefined;
+  if (!user || !channel) return null;
+  return { channel, isSelf: user === botUserId };
+}
+
+export interface FetchSlackMessageByTsInput {
+  slack: SlackCall;
+  token: string;
+  channel: string;
+  messageTs: string;
+}
+
+export async function fetchSlackMessageByTs(
+  input: FetchSlackMessageByTsInput,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await input.slack("conversations.history", input.token, {
+      channel: input.channel,
+      oldest: input.messageTs,
+      latest: input.messageTs,
+      inclusive: true,
+      limit: 1,
+    });
+    const messages = (response.messages as Record<string, unknown>[]) ?? [];
+    return messages.find((message) => message.ts === input.messageTs) ?? messages[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface SlackReactionInput {
+  slack: SlackCall;
+  token: string;
+  channel: string;
+  timestamp: string;
+  emoji: string;
+}
+
+export async function addSlackReaction(input: SlackReactionInput): Promise<void> {
+  try {
+    await input.slack("reactions.add", input.token, {
+      channel: input.channel,
+      timestamp: input.timestamp,
+      name: input.emoji,
+    });
+  } catch {
+    /* already_reacted or non-critical */
+  }
+}
+
+export async function removeSlackReaction(input: SlackReactionInput): Promise<void> {
+  try {
+    await input.slack("reactions.remove", input.token, {
+      channel: input.channel,
+      timestamp: input.timestamp,
+      name: input.emoji,
+    });
+  } catch {
+    /* not_reacted or non-critical */
+  }
+}
+
+export interface ResolveSlackUserNameInput {
+  slack: SlackCall;
+  token: string;
+  userId: string;
+  cache?: SlackAccessCache<string, string>;
+  shouldUseResult?: () => boolean;
+}
+
+export async function resolveSlackUserName(input: ResolveSlackUserNameInput): Promise<string> {
+  const cached = input.cache?.get(input.userId);
+  if (cached) return cached;
+
+  try {
+    const response = await input.slack("users.info", input.token, {
+      user: input.userId,
+    });
+    if (input.shouldUseResult && !input.shouldUseResult()) {
+      return input.userId;
+    }
+    const user = response.user as { real_name?: string; name?: string };
+    const name = user.real_name ?? user.name ?? input.userId;
+    input.cache?.set(input.userId, name);
+    return name;
+  } catch {
+    return input.userId;
+  }
+}
+
+export interface ResolveSlackChannelIdInput {
+  slack: SlackCall;
+  token: string;
+  nameOrId: string;
+  cache?: SlackAccessCache<string, string>;
+}
+
+export async function resolveSlackChannelId(input: ResolveSlackChannelIdInput): Promise<string> {
+  if (isChannelId(input.nameOrId)) return input.nameOrId;
+
+  const name = input.nameOrId.replace(/^#/, "");
+  const cached = input.cache?.get(name);
+  if (cached) return cached;
+
+  let cursor: string | undefined;
+  do {
+    const body: Record<string, unknown> = {
+      types: "public_channel,private_channel",
+      limit: 200,
+    };
+    if (cursor) {
+      body.cursor = cursor;
+    }
+    const response = await input.slack("conversations.list", input.token, body);
+    const channels = (response.channels as { id: string; name: string }[]) ?? [];
+    for (const channel of channels) {
+      input.cache?.set(channel.name, channel.id);
+    }
+    const resolved =
+      input.cache?.get(name) ?? channels.find((channel) => channel.name === name)?.id;
+    if (resolved) {
+      return resolved;
+    }
+    cursor =
+      (response.response_metadata as { next_cursor?: string } | undefined)?.next_cursor ||
+      undefined;
+  } while (cursor);
+
+  throw new Error(`Channel "${name}" not found.`);
+}
+
+export interface ClearSlackThreadStatusInput {
+  slack: SlackCall;
+  token: string;
+  channelId: string;
+  threadTs: string;
+}
+
+export async function clearSlackThreadStatus(input: ClearSlackThreadStatusInput): Promise<void> {
+  try {
+    await input.slack("assistant.threads.setStatus", input.token, {
+      channel_id: input.channelId,
+      thread_ts: input.threadTs,
+      status: "",
+    });
+  } catch {
+    /* non-critical */
+  }
+}
+
+export interface SlackSuggestedPrompt {
+  title: string;
+  message: string;
+}
+
+export interface SetSlackSuggestedPromptsInput {
+  slack: SlackCall;
+  token: string;
+  channelId: string;
+  threadTs: string;
+  prompts: SlackSuggestedPrompt[];
+}
+
+export async function setSlackSuggestedPrompts(
+  input: SetSlackSuggestedPromptsInput,
+): Promise<void> {
+  try {
+    await input.slack("assistant.threads.setSuggestedPrompts", input.token, {
+      channel_id: input.channelId,
+      thread_ts: input.threadTs,
+      prompts: input.prompts,
+    });
+  } catch {
+    /* non-critical */
+  }
+}
+
+export interface ResolveSlackThreadOwnerHintInput {
+  slack: SlackCall;
+  token: string;
+  channel: string;
+  threadTs: string;
+  cache?: SlackAccessCache<string, ThreadOwnerHint>;
+  limit?: number;
+}
+
+export async function resolveSlackThreadOwnerHint(
+  input: ResolveSlackThreadOwnerHintInput,
+): Promise<ThreadOwnerHint | null> {
+  if (!input.channel || !input.threadTs) {
+    return null;
+  }
+
+  const cacheKey = `${input.channel}:${input.threadTs}`;
+  const cached = input.cache?.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const response = await input.slack("conversations.replies", input.token, {
+      channel: input.channel,
+      ts: input.threadTs,
+      limit: input.limit ?? 200,
+      include_all_metadata: true,
+    });
+    const replies = (response.messages as Record<string, unknown>[]) ?? [];
+    const hint = extractPiAgentThreadOwnerHint(replies);
+    if (hint) {
+      input.cache?.set(cacheKey, hint);
+    }
+    return hint;
+  } catch {
+    return null;
+  }
+}
+
+export const RECONNECT_DELAY_MS = 5000;
+
+export interface SlackSocketModeClientConfig {
+  slack: SlackCall;
+  botToken: string;
+  appToken: string;
+  resolveBotUserIdOnConnect?: boolean;
+  reconnectDelayMs?: number;
+  dedup?: SlackAccessSet<string>;
+  abortAndWait?: () => Promise<void>;
+  onOpen?: () => void;
+  onReconnectScheduled?: () => void;
+  onError?: (error: unknown) => void;
+  onThreadStarted?: (event: ParsedThreadStarted) => Promise<void> | void;
+  onThreadContextChanged?: (event: ParsedThreadContextChanged) => Promise<void> | void;
+  onMessage?: (event: Record<string, unknown>) => Promise<void> | void;
+  onReactionAdded?: (event: Record<string, unknown>) => Promise<void> | void;
+  onMemberJoinedChannel?: (event: { channel: string; isSelf: boolean }) => Promise<void> | void;
+  onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
+  onInteractive?: (event: SlackInteractiveInboxEvent) => Promise<void> | void;
+}
+
+export class SlackSocketModeClient {
+  private readonly config: SlackSocketModeClientConfig;
+  private botUserId: string | null = null;
+  private ws: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private shuttingDown = false;
+
+  constructor(config: SlackSocketModeClientConfig) {
+    this.config = config;
+  }
+
+  getBotUserId(): string | null {
+    return this.botUserId;
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  async connect(): Promise<void> {
+    this.shuttingDown = false;
+    if (this.config.resolveBotUserIdOnConnect ?? true) {
+      const auth = await this.config.slack("auth.test", this.config.botToken);
+      this.botUserId = typeof auth.user_id === "string" ? auth.user_id : null;
+    }
+    await this.connectSocketMode();
+  }
+
+  async disconnect(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    try {
+      this.ws?.close();
+    } catch {
+      /* ignore close errors */
+    }
+    this.ws = null;
+    await this.config.abortAndWait?.();
+  }
+
+  private async connectSocketMode(): Promise<void> {
+    if (this.shuttingDown) return;
+
+    try {
+      const response = await this.config.slack("apps.connections.open", this.config.appToken);
+      this.ws = new WebSocket(response.url as string);
+
+      this.ws.addEventListener("open", () => {
+        this.config.onOpen?.();
+      });
+
+      this.ws.addEventListener("message", (event) => {
+        void this.handleFrame(String(event.data)).catch((error) => {
+          this.config.onError?.(error);
+        });
+      });
+
+      this.ws.addEventListener("close", () => {
+        if (!this.shuttingDown) {
+          this.scheduleReconnect();
+        }
+      });
+
+      this.ws.addEventListener("error", () => {
+        /* close fires after error — handled there */
+      });
+    } catch (error) {
+      if (!isAbortError(error)) {
+        this.config.onError?.(error);
+      }
+      this.scheduleReconnect();
+    }
+  }
+
+  private async handleFrame(raw: string): Promise<void> {
+    if (this.shuttingDown) return;
+
+    const envelope = parseSocketFrame(raw);
+    if (!envelope) return;
+
+    if (envelope.envelopeId) {
+      this.ws?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
+    }
+
+    const dedupKey = envelope.dedupKey ?? null;
+
+    try {
+      if (dedupKey) {
+        if (this.config.dedup?.has(dedupKey)) {
+          return;
+        }
+        this.config.dedup?.add(dedupKey);
+      }
+
+      if (envelope.type === "disconnect") {
+        this.scheduleReconnect();
+        return;
+      }
+
+      if (envelope.interactivePayload) {
+        let normalized: SlackInteractiveInboxEvent | null = null;
+        if (envelope.interactivePayload.type === "block_actions") {
+          normalized = normalizeSlackBlockActionPayload(envelope.interactivePayload);
+        } else if (envelope.interactivePayload.type === "view_submission") {
+          normalized = normalizeSlackViewSubmissionPayload(envelope.interactivePayload);
+        }
+        if (normalized) {
+          await this.config.onInteractive?.(normalized);
+        }
+        return;
+      }
+
+      if (!envelope.event) return;
+
+      const evt = envelope.event;
+      switch (evt.type) {
+        case "assistant_thread_started": {
+          const parsed = extractThreadStarted(evt);
+          if (parsed) {
+            await this.config.onThreadStarted?.(parsed);
+          }
+          break;
+        }
+        case "assistant_thread_context_changed": {
+          const parsed = extractThreadContextChanged(evt);
+          if (parsed) {
+            await this.config.onThreadContextChanged?.(parsed);
+          }
+          break;
+        }
+        case "message":
+          await this.config.onMessage?.(evt);
+          break;
+        case "reaction_added":
+          await this.config.onReactionAdded?.(evt);
+          break;
+        case "member_joined_channel": {
+          const parsed = parseMemberJoinedChannel(evt, this.botUserId);
+          if (parsed) {
+            await this.config.onMemberJoinedChannel?.(parsed);
+          }
+          break;
+        }
+        case "app_home_opened": {
+          const parsed = extractAppHomeOpened(evt);
+          if (parsed && parsed.tab === "home") {
+            await this.config.onAppHomeOpened?.(parsed);
+          }
+          break;
+        }
+      }
+    } catch (error) {
+      if (dedupKey) {
+        this.config.dedup?.delete?.(dedupKey);
+      }
+      throw error;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.shuttingDown || this.reconnectTimer) return;
+    this.config.onReconnectScheduled?.();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connectSocketMode();
+    }, this.config.reconnectDelayMs ?? RECONNECT_DELAY_MS);
+    this.reconnectTimer.unref?.();
+  }
+}


### PR DESCRIPTION
## Summary
- extract a shared `slack-access.ts` layer for Socket Mode ingress and common Slack Web API helpers
- refactor single-mode runtime and broker Slack adapter to consume the shared Slack access layer
- keep scope tight to shared Slack access, owner-hint lookup, Home tab ingress, and focused tests

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #349