### PR TITLE
fix: recover stranded generic assigned backlog

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1246,12 +1246,74 @@ describe("BrokerDB", () => {
 
     expect(result.assignedBacklogCount).toBe(0);
     expect(result.pendingBacklogCount).toBe(1);
-    expect(result.anomalies).toContain("reset 1 orphaned targeted backlog assignment to pending");
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
     expect(db.getAgentById("receiver")).not.toBeNull();
     expect(repairedBacklog).toEqual({
       status: "pending",
       reason: "agent_disconnected",
       preferred_agent_id: "receiver",
+      assigned_agent_id: null,
+    });
+  });
+
+  it("maintenance resets orphaned assigned generic backlog to pending once the assignee is missing", () => {
+    db.registerAgent("worker-1", "Worker", "🤖", 1);
+
+    const backlog = db.queueUnroutedMessage(
+      {
+        source: "slack",
+        threadId: "1775638755.200989",
+        channel: "C123",
+        userId: "U123",
+        text: "recover this stranded generic backlog",
+        timestamp: "100.200",
+      },
+      "no_route",
+    );
+
+    expect(db.assignBacklogEntry(backlog.id, "worker-1")?.status).toBe("assigned");
+    expect(db.getThread("1775638755.200989")?.ownerAgent).toBe("worker-1");
+
+    const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
+    sqlite
+      .prepare("DELETE FROM inbox WHERE message_id = ? AND agent_id = ?")
+      .run(backlog.messageId, "worker-1");
+    sqlite.prepare("DELETE FROM agents WHERE id = ?").run("worker-1");
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    const repairedBacklog = sqlite
+      .prepare(
+        "SELECT status, reason, preferred_agent_id, assigned_agent_id FROM unrouted_backlog WHERE id = ?",
+      )
+      .get(backlog.id) as
+      | {
+          status: string;
+          reason: string;
+          preferred_agent_id: string | null;
+          assigned_agent_id: string | null;
+        }
+      | undefined;
+    const orphanedInboxCount = (
+      sqlite
+        .prepare("SELECT COUNT(*) AS count FROM inbox WHERE message_id = ? AND agent_id = ?")
+        .get(backlog.messageId, "worker-1") as { count: number }
+    ).count;
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(result.anomalies).toContain("released 1 orphaned thread claim");
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
+    expect(result.anomalies).toContain("pending unrouted backlog has no live workers");
+    expect(db.getThread("1775638755.200989")?.ownerAgent).toBeNull();
+    expect(orphanedInboxCount).toBe(0);
+    expect(repairedBacklog).toEqual({
+      status: "pending",
+      reason: "no_route",
+      preferred_agent_id: null,
       assigned_agent_id: null,
     });
   });

--- a/slack-bridge/broker/maintenance.test.ts
+++ b/slack-bridge/broker/maintenance.test.ts
@@ -51,11 +51,16 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
     let droppedCount = 0;
 
     for (const entry of this.backlog) {
-      if (
-        entry.status !== "assigned" ||
-        !entry.preferredAgentId ||
-        this.healthyAssignedBacklogIds.has(entry.id)
-      ) {
+      if (entry.status !== "assigned" || this.healthyAssignedBacklogIds.has(entry.id)) {
+        continue;
+      }
+
+      if (!entry.preferredAgentId) {
+        if (!entry.assignedAgentId || !this.getAgentById(entry.assignedAgentId)) {
+          entry.status = "pending";
+          entry.assignedAgentId = null;
+          resetToPendingCount += 1;
+        }
         continue;
       }
 
@@ -387,7 +392,30 @@ describe("runBrokerMaintenancePass", () => {
     expect(result.pendingBacklogCount).toBe(1);
     expect(db.backlog[0].status).toBe("pending");
     expect(db.backlog[0].assignedAgentId).toBeNull();
-    expect(result.anomalies).toContain("reset 1 orphaned targeted backlog assignment to pending");
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
+  });
+
+  it("repairs orphaned generic assignments back to pending once the assignee is missing", () => {
+    db.backlog = [
+      makeBacklog({
+        id: 1,
+        threadId: "t-generic-assigned",
+        status: "assigned",
+        assignedAgentId: "missing-worker",
+        reason: "no_route",
+      }),
+    ];
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(db.backlog[0].status).toBe("pending");
+    expect(db.backlog[0].assignedAgentId).toBeNull();
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
   });
 
   it("drops orphaned targeted assignments once the preferred agent is gone", () => {

--- a/slack-bridge/broker/maintenance.ts
+++ b/slack-bridge/broker/maintenance.ts
@@ -179,7 +179,7 @@ export function runBrokerMaintenancePass(
   }
   if (resetAssignedBacklogCount > 0) {
     anomalies.push(
-      `reset ${resetAssignedBacklogCount} orphaned targeted backlog assignment${resetAssignedBacklogCount === 1 ? "" : "s"} to pending`,
+      `reset ${resetAssignedBacklogCount} orphaned backlog assignment${resetAssignedBacklogCount === 1 ? "" : "s"} to pending`,
     );
   }
   if (droppedBacklogCount > 0) {

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -1265,22 +1265,33 @@ export class BrokerDB implements BrokerDBInterface {
           `SELECT id, message_id, preferred_agent_id, assigned_agent_id
            FROM unrouted_backlog
            WHERE status = 'assigned'
-             AND preferred_agent_id IS NOT NULL
              AND (
-               assigned_agent_id IS NULL
-               OR assigned_agent_id NOT IN (SELECT id FROM agents)
-               OR NOT EXISTS (
-                 SELECT 1
-                 FROM inbox
-                 WHERE inbox.message_id = unrouted_backlog.message_id
-                   AND inbox.agent_id = unrouted_backlog.assigned_agent_id
+               (
+                 preferred_agent_id IS NOT NULL
+                 AND (
+                   assigned_agent_id IS NULL
+                   OR assigned_agent_id NOT IN (SELECT id FROM agents)
+                   OR NOT EXISTS (
+                     SELECT 1
+                     FROM inbox
+                     WHERE inbox.message_id = unrouted_backlog.message_id
+                       AND inbox.agent_id = unrouted_backlog.assigned_agent_id
+                   )
+                 )
+               )
+               OR (
+                 preferred_agent_id IS NULL
+                 AND (
+                   assigned_agent_id IS NULL
+                   OR assigned_agent_id NOT IN (SELECT id FROM agents)
+                 )
                )
              )`,
         )
         .all() as Array<{
         id: number;
         message_id: number;
-        preferred_agent_id: string;
+        preferred_agent_id: string | null;
         assigned_agent_id: string | null;
       }>;
 
@@ -1318,6 +1329,11 @@ export class BrokerDB implements BrokerDBInterface {
       for (const row of rows) {
         if (row.assigned_agent_id) {
           clearStaleInbox.run(row.message_id, row.assigned_agent_id);
+        }
+
+        if (!row.preferred_agent_id) {
+          resetToPendingCount += Number(resetPending.run(now, row.id).changes ?? 0);
+          continue;
         }
 
         if (this.getAgentRowById(row.preferred_agent_id)) {


### PR DESCRIPTION
## Summary
- recover generic `assigned` backlog rows when their assignee has disappeared from the broker registry
- keep existing targeted backlog behavior, including reset/drop decisions for preferred recipients
- add regression coverage for the stranded generic-assignment case in both maintenance unit tests and BrokerDB integration tests

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test

Closes #361