### PR TITLE
fix: suppress repeated ghost reannouncements

### DIFF
--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRalphLoopState,
+  hydrateRalphLoopReportedGhosts,
+} from "./ralph-loop.js";
+import { rewriteRalphLoopGhostAnomalies } from "./helpers.js";
+
+function buildEvaluation(ghostAgentIds: string[]) {
+  return {
+    ghostAgentIds,
+    nudgeAgentIds: [],
+    idleDrainAgentIds: [],
+    stuckAgentIds: [],
+    anomalies:
+      ghostAgentIds.length > 0 ? [`ghost agents detected: ${ghostAgentIds.join(", ")}`] : [],
+  };
+}
+
+describe("hydrateRalphLoopReportedGhosts", () => {
+  it("hydrates the latest persisted ghost ids into a fresh state", () => {
+    const state = createRalphLoopState();
+
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: ["ghost-1", "ghost-2"] }]);
+
+    expect([...state.reportedGhosts]).toEqual(["ghost-1", "ghost-2"]);
+    expect(state.ghostBaselineHydrated).toBe(true);
+  });
+
+  it("does not overwrite active in-memory ghost state", () => {
+    const state = createRalphLoopState();
+    state.reportedGhosts.add("live-ghost");
+
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: ["persisted-ghost"] }]);
+
+    expect([...state.reportedGhosts]).toEqual(["live-ghost"]);
+    expect(state.ghostBaselineHydrated).toBe(true);
+  });
+
+  it("suppresses re-announcing the same persisted ghost ids as NEW after a state reset", () => {
+    const state = createRalphLoopState();
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: ["ghost-1"] }]);
+
+    const rewritten = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"]),
+      state.reportedGhosts,
+    );
+
+    expect(rewritten.evaluation.ghostAgentIds).toEqual(["ghost-1"]);
+    expect(rewritten.evaluation.anomalies).toEqual([]);
+    expect(rewritten.newGhostIds).toEqual([]);
+    expect(rewritten.nextReportedGhostIds).toEqual(["ghost-1"]);
+  });
+
+  it("still announces truly new ghost ids when the latest persisted cycle was healthy", () => {
+    const state = createRalphLoopState();
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: [] }]);
+
+    const rewritten = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"]),
+      state.reportedGhosts,
+    );
+
+    expect(rewritten.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-1"]);
+    expect(rewritten.newGhostIds).toEqual(["ghost-1"]);
+    expect(rewritten.nextReportedGhostIds).toEqual(["ghost-1"]);
+  });
+});

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -37,6 +37,7 @@ export interface RalphLoopState {
   running: boolean;
   nudges: Map<string, number>;
   reportedGhosts: Set<string>;
+  ghostBaselineHydrated: boolean;
   nonGhostSignature: string;
   hadOutstandingAnomalies: boolean;
   followUpAt: number;
@@ -51,6 +52,7 @@ export function createRalphLoopState(): RalphLoopState {
     running: false,
     nudges: new Map(),
     reportedGhosts: new Set(),
+    ghostBaselineHydrated: false,
     nonGhostSignature: "",
     hadOutstandingAnomalies: false,
     followUpAt: 0,
@@ -68,6 +70,7 @@ export function resetRalphLoopState(state: RalphLoopState): void {
   state.running = false;
   state.nudges.clear();
   state.reportedGhosts.clear();
+  state.ghostBaselineHydrated = false;
   state.nonGhostSignature = "";
   state.hadOutstandingAnomalies = false;
   state.followUpAt = 0;
@@ -77,6 +80,25 @@ export function resetRalphLoopState(state: RalphLoopState): void {
 }
 
 // ─── Callbacks ───────────────────────────────────────────
+
+export function hydrateRalphLoopReportedGhosts(
+  state: Pick<RalphLoopState, "reportedGhosts" | "ghostBaselineHydrated">,
+  recentCycles: Array<{ ghostAgentIds: string[] }>,
+): void {
+  if (state.ghostBaselineHydrated) {
+    return;
+  }
+
+  if (state.reportedGhosts.size > 0) {
+    state.ghostBaselineHydrated = true;
+    return;
+  }
+
+  for (const ghostId of recentCycles[0]?.ghostAgentIds ?? []) {
+    state.reportedGhosts.add(ghostId);
+  }
+  state.ghostBaselineHydrated = true;
+}
 
 export interface RalphLoopDeps {
   // Broker access
@@ -132,6 +154,7 @@ export async function runRalphLoopCycle(
   const cycleStartedAt = new Date().toISOString();
   const cycleStartMs = Date.now();
   try {
+    hydrateRalphLoopReportedGhosts(state, db.getRecentRalphCycles(1));
     deps.runMaintenance(ctx);
     const lastMaintenance = deps.getLastMaintenance();
 


### PR DESCRIPTION
## Summary
- persist the last reported ghost-id baseline across RALPH loop state resets by hydrating from the latest recorded broker cycle
- stop re-announcing the same ghost ids as `NEW` after a broker/loop restart when the last persisted cycle already reported them
- add focused regression coverage for the re-announcement case and keep legitimate new-ghost detection intact

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test

Closes #356