### PR TITLE
refactor: preserve transport source through thread ownership

### DIFF
--- a/neon-psql/python/sitecustomize.py
+++ b/neon-psql/python/sitecustomize.py
@@ -2,19 +2,38 @@ import os
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
+LOCAL_TUNNEL_HOSTS = {"127.0.0.1", "localhost"}
+
+
+def _is_local_tunnel_host(host):
+    return isinstance(host, str) and host.strip().lower() in LOCAL_TUNNEL_HOSTS
+
+
+def _dsn_uses_local_tunnel(dsn, tunnel_port):
+    if not isinstance(dsn, str) or not tunnel_port:
+        return False
+
+    try:
+        parts = urlsplit(dsn)
+    except ValueError:
+        return False
+
+    return _is_local_tunnel_host(parts.hostname) and parts.port is not None and str(parts.port) == tunnel_port
+
+
 def _uses_local_tunnel(args, kwargs):
     tunnel_port = os.getenv("NEON_TUNNEL_PORT", "")
+    if not tunnel_port:
+        return False
+
     host = kwargs.get("host")
     port = kwargs.get("port")
     dsn = kwargs.get("dsn") if isinstance(kwargs.get("dsn"), str) else (args[0] if args and isinstance(args[0], str) else None)
 
-    if isinstance(host, str) and host in {"127.0.0.1", "localhost"}:
+    if _is_local_tunnel_host(host) and port is not None and str(port) == tunnel_port:
         return True
-    if tunnel_port and str(port) == tunnel_port:
-        return True
-    if isinstance(dsn, str) and ("@127.0.0.1:" in dsn or "@localhost:" in dsn):
-        return True
-    return False
+
+    return _dsn_uses_local_tunnel(dsn, tunnel_port)
 
 
 def _extract_options_from_dsn(dsn):

--- a/neon-psql/sitecustomize.test.ts
+++ b/neon-psql/sitecustomize.test.ts
@@ -1,0 +1,133 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PYTHON_SHIM_DIR = path.join(TEST_DIR, "python");
+
+function resolvePythonBin(): string | null {
+  for (const candidate of ["python3", "python"]) {
+    const result = spawnSync(candidate, ["-V"], { encoding: "utf8" });
+    if (result.status === 0) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+const PYTHON_BIN = resolvePythonBin();
+const describeWithPython = PYTHON_BIN ? describe : describe.skip;
+
+const PYTHON_DRIVER = [
+  "import asyncio, json, os, asyncpg",
+  "spec = json.loads(os.environ['CALL_SPEC'])",
+  "async def main():",
+  "    method = getattr(asyncpg, spec.get('method', 'connect'))",
+  "    await method(*spec.get('args', []), **spec.get('kwargs', {}))",
+  "asyncio.run(main())",
+].join("\n");
+
+const FAKE_ASYNCPG_MODULE = [
+  "import json, os",
+  "async def connect(*args, **kwargs):",
+  "    with open(os.environ['OUTFILE'], 'w', encoding='utf-8') as handle:",
+  "        json.dump({'args': list(args), 'kwargs': kwargs}, handle)",
+  "    return {'args': list(args), 'kwargs': kwargs}",
+  "async def create_pool(*args, **kwargs):",
+  "    return await connect(*args, **kwargs)",
+].join("\n");
+
+type AsyncpgCallSpec = {
+  args?: unknown[];
+  kwargs?: Record<string, unknown>;
+  method?: "connect" | "create_pool";
+};
+
+function runPatchedAsyncpg(spec: AsyncpgCallSpec): {
+  args: unknown[];
+  kwargs: Record<string, unknown>;
+} {
+  if (!PYTHON_BIN) {
+    throw new Error("python is required for neon-psql sitecustomize tests");
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "neon-sitecustomize-test-"));
+  const outputPath = path.join(tmpDir, "call.json");
+  fs.writeFileSync(path.join(tmpDir, "asyncpg.py"), FAKE_ASYNCPG_MODULE, "utf8");
+
+  try {
+    execFileSync(PYTHON_BIN, ["-c", PYTHON_DRIVER], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OUTFILE: outputPath,
+        CALL_SPEC: JSON.stringify(spec),
+        PYTHONPATH: [PYTHON_SHIM_DIR, tmpDir].join(path.delimiter),
+        NEON_TUNNEL_ACTIVE: "1",
+        NEON_TUNNEL_PORT: "6543",
+        NEON_TUNNEL_ENDPOINT: "ep-cool-river",
+        NEON_TUNNEL_SSL_MODE: "require",
+      },
+    });
+
+    return JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+      args: unknown[];
+      kwargs: Record<string, unknown>;
+    };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describeWithPython("neon-psql python sitecustomize shim", () => {
+  it("patches asyncpg kwargs when the connection targets the exact local tunnel port", () => {
+    const result = runPatchedAsyncpg({
+      kwargs: {
+        host: "127.0.0.1",
+        port: 6543,
+        user: "user",
+        password: "secret",
+        database: "app",
+      },
+    });
+
+    expect(result.kwargs.server_settings).toEqual({ options: "endpoint=ep-cool-river" });
+    expect(result.kwargs.ssl).toBe("require");
+  });
+
+  it("patches asyncpg DSNs when they target the exact local tunnel port", () => {
+    const result = runPatchedAsyncpg({
+      args: ["postgresql://user:secret@127.0.0.1:6543/app"],
+    });
+
+    expect(result.kwargs.server_settings).toEqual({ options: "endpoint=ep-cool-river" });
+    expect(result.kwargs.ssl).toBe("require");
+  });
+
+  it("does not patch unrelated localhost kwargs on a different port", () => {
+    const result = runPatchedAsyncpg({
+      kwargs: {
+        host: "127.0.0.1",
+        port: 5432,
+        user: "user",
+        password: "secret",
+        database: "app",
+      },
+    });
+
+    expect(result.kwargs.server_settings).toBeUndefined();
+    expect(result.kwargs.ssl).toBeUndefined();
+  });
+
+  it("does not patch unrelated localhost DSNs on a different port", () => {
+    const result = runPatchedAsyncpg({
+      args: ["postgresql://user:secret@127.0.0.1:5432/app"],
+    });
+
+    expect(result.kwargs.server_settings).toBeUndefined();
+    expect(result.kwargs.ssl).toBeUndefined();
+  });
+});

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -123,6 +123,7 @@ Behavior and precedence:
   "slack-bridge": {
     "botToken": "xoxb-...",
     "appToken": "xapp-...",
+    "runtimeMode": "single",
     "allowedUsers": ["U_EXAMPLE_MEMBER_ID"],
     "defaultChannel": "C_EXAMPLE_CHANNEL_ID",
     "logChannel": "#pinet-logs",
@@ -147,7 +148,9 @@ Behavior and precedence:
 | `defaultChannel`               | no       | Default channel for `slack_post_channel`                                                                           |
 | `logChannel`                   | no       | Channel for broker activity logs                                                                                   |
 | `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
-| `autoFollow`                   | no       | Auto-connect as follower when broker is running                                                                    |
+| `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |
+| `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                             |
+| `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                        |
 | `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                  |
 | `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file            |
 | `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                 |
@@ -215,6 +218,25 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 | `/pinet-logs`   | Show recent broker activity log entries             |
 | `/slack-logs`   | Show recent Slack bridge log entries                |
 
+## Runtime modes
+
+`slack-bridge` now treats runtime mode as an explicit concept:
+
+| Mode       | Meaning                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `off`      | Slack bridge is loaded, but no active coordination runtime is started.                                                                                                   |
+| `single`   | One local Pi session owns Slack ingress and local thread/inbox ownership only. No broker DB/socket/client, no RALPH/control plane, no mesh auth, no multi-agent surface. |
+| `broker`   | The session runs the broker coordination runtime.                                                                                                                        |
+| `follower` | The session connects to an existing broker as a worker runtime.                                                                                                          |
+
+Startup selection:
+
+- `runtimeMode` is the explicit startup selector.
+- `autoConnect` is a legacy compatibility alias for `runtimeMode: "single"`.
+- `autoFollow` is a legacy compatibility alias for `runtimeMode: "follower"` when a broker socket is available.
+- explicit `runtimeMode` wins over the legacy flags.
+- `/pinet-start` and `/pinet-follow` still switch the live session into broker/follower runtimes explicitly.
+
 ## Pinet (Multi-Agent Mode)
 
 Pinet supports a broker/follower architecture for coordinating multiple pi agents over Slack.
@@ -233,7 +255,7 @@ Pinet supports a broker/follower architecture for coordinating multiple pi agent
 /pinet-follow
 ```
 
-Or set `"autoFollow": true` in settings to auto-connect when a broker is running.
+Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": true`) to auto-connect when a broker is running.
 
 ### Multi-agent tools
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -5,7 +5,7 @@ Slack assistant integration for [pi](https://github.com/badlogic/pi-mono) — mu
 ## Install
 
 ```bash
-pi install @gugu910/pi-slack-bridge
+pi install npm:@gugu910/pi-slack-bridge
 ```
 
 Or with npm:

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -49,10 +49,10 @@ These are included in the manifest, but for reference:
 app_mentions:read    assistant:write      bookmarks:read
 bookmarks:write      canvases:read        canvases:write
 channels:history     channels:read        chat:write
-files:write          groups:history       groups:read
-im:history           im:read              im:write
-pins:read            pins:write           reactions:read
-reactions:write      users:read
+files:read           files:write          groups:history
+groups:read          im:history           im:read
+im:write             pins:read            pins:write
+reactions:read       reactions:write      users:read
 ```
 
 ## Configuration
@@ -170,30 +170,31 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 
 ### Available tools
 
-| Tool                   | Description                                                    |
-| ---------------------- | -------------------------------------------------------------- |
-| `slack_send`           | Reply in a Slack assistant thread                              |
-| `slack_react`          | Add an emoji reaction to a message                             |
-| `slack_read`           | Read messages from a thread                                    |
-| `slack_inbox`          | Check pending incoming messages                                |
-| `slack_upload`         | Upload files, snippets, or diffs into Slack                    |
-| `slack_schedule`       | Schedule a message for later delivery                          |
-| `slack_post_channel`   | Post to a channel (by name or ID)                              |
-| `slack_read_channel`   | Read channel history or a thread in a channel                  |
-| `slack_create_channel` | Create a new Slack channel                                     |
-| `slack_project_create` | Create a project channel + RFC canvas + bot invite in one call |
-| `slack_pin`            | Pin or unpin a message                                         |
-| `slack_bookmark`       | Add, list, or remove channel bookmarks                         |
-| `slack_export`         | Export a thread as markdown, plain text, or JSON               |
-| `slack_presence`       | Check if users are active, away, or in DND                     |
-| `slack_canvas_create`  | Create a standalone or channel canvas                          |
-| `slack_canvas_update`  | Append, prepend, or replace canvas content                     |
-| `slack_blocks_build`   | Build Block Kit message templates                              |
-| `slack_modal_build`    | Build Slack modal templates                                    |
-| `slack_modal_open`     | Open a modal from a trigger interaction                        |
-| `slack_modal_push`     | Push a new step onto a modal stack                             |
-| `slack_modal_update`   | Update an existing open modal                                  |
-| `slack_confirm_action` | Request user confirmation before a dangerous action            |
+| Tool                         | Description                                                              |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `slack_send`                 | Reply in a Slack assistant thread                                        |
+| `slack_react`                | Add an emoji reaction to a message                                       |
+| `slack_read`                 | Read messages from a thread                                              |
+| `slack_inbox`                | Check pending incoming messages                                          |
+| `slack_upload`               | Upload files, snippets, or diffs into Slack                              |
+| `slack_schedule`             | Schedule a message for later delivery                                    |
+| `slack_post_channel`         | Post to a channel (by name or ID)                                        |
+| `slack_read_channel`         | Read channel history or a thread in a channel                            |
+| `slack_create_channel`       | Create a new Slack channel                                               |
+| `slack_project_create`       | Create a project channel + RFC canvas + bot invite in one call           |
+| `slack_pin`                  | Pin or unpin a message                                                   |
+| `slack_bookmark`             | Add, list, or remove channel bookmarks                                   |
+| `slack_export`               | Export a thread as markdown, plain text, or JSON                         |
+| `slack_presence`             | Check if users are active, away, or in DND                               |
+| `slack_canvas_comments_read` | Read comments attached to a canvas by canvas ID or channel canvas lookup |
+| `slack_canvas_create`        | Create a standalone or channel canvas                                    |
+| `slack_canvas_update`        | Append, prepend, or replace canvas content                               |
+| `slack_blocks_build`         | Build Block Kit message templates                                        |
+| `slack_modal_build`          | Build Slack modal templates                                              |
+| `slack_modal_open`           | Open a modal from a trigger interaction                                  |
+| `slack_modal_push`           | Push a new step onto a modal stack                                       |
+| `slack_modal_update`         | Update an existing open modal                                            |
+| `slack_confirm_action`       | Request user confirmation before a dangerous action                      |
 
 ### Slash commands
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -137,21 +137,21 @@ Behavior and precedence:
 }
 ```
 
-| Key                            | Required | Description                                                                                             |
-| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------- |
-| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                       |
-| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                            |
-| `allowedUsers`                 | no       | Slack user IDs that can interact (all users if unset)                                                   |
-| `defaultChannel`               | no       | Default channel for `slack_post_channel`                                                                |
-| `logChannel`                   | no       | Channel for broker activity logs                                                                        |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                       |
-| `autoFollow`                   | no       | Auto-connect as follower when broker is running                                                         |
-| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                       |
-| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file |
-| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                      |
-| `security.readOnly`            | no       | Block all write tools                                                                                   |
-| `security.requireConfirmation` | no       | Tools that need user approval before executing                                                          |
-| `security.blockedTools`        | no       | Tools that are completely disabled                                                                      |
+| Key                            | Required | Description                                                                                                        |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                                  |
+| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                       |
+| `allowedUsers`                 | no       | Slack user IDs that can interact (all users if unset)                                                              |
+| `defaultChannel`               | no       | Default channel for `slack_post_channel`                                                                           |
+| `logChannel`                   | no       | Channel for broker activity logs                                                                                   |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
+| `autoFollow`                   | no       | Auto-connect as follower when broker is running                                                                    |
+| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                  |
+| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file            |
+| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                 |
+| `security.readOnly`            | no       | Runtime-block write-capable tools for Slack-triggered turns, including core tools like `bash`, `edit`, and `write` |
+| `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context      |
+| `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                       |
 
 ## Usage
 
@@ -255,7 +255,7 @@ Or set `"autoFollow": true` in settings to auto-connect when a broker is running
 ## Security
 
 - **User allowlist**: Set `allowedUsers` to restrict who can interact with Pinet
-- **Tool guardrails**: Use `security.requireConfirmation` and `security.blockedTools` to control tool access
+- **Tool guardrails**: `security.readOnly`, `security.requireConfirmation`, and `security.blockedTools` are runtime-enforced for Slack-triggered turns, including core tools such as `bash`, `edit`, and `write`
 - **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` (or `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH`) to require a shared secret; leave them unset to disable shared-secret auth. Configured followers fail closed on missing secret files or older/no-auth brokers rather than silently downgrading.
 
 Find Slack user IDs: click a user's profile → **More** → **Copy member ID**.

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -224,7 +224,7 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 
 | Mode       | Meaning                                                                                                                                                                  |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `off`      | Slack bridge is loaded, but no active coordination runtime is started.                                                                                                   |
+| `off`      | Slack bridge is loaded, but **no Slack Socket Mode ingress** and no coordination runtime are started.                                                                    |
 | `single`   | One local Pi session owns Slack ingress and local thread/inbox ownership only. No broker DB/socket/client, no RALPH/control plane, no mesh auth, no multi-agent surface. |
 | `broker`   | The session runs the broker coordination runtime.                                                                                                                        |
 | `follower` | The session connects to an existing broker as a worker runtime.                                                                                                          |

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -55,6 +55,8 @@ im:write             pins:read            pins:write
 reactions:read       reactions:write      users:read
 ```
 
+`files:read` is required because Slack exposes canvas comment pagination through `files.info`, even when the target is first validated via canvas-specific APIs.
+
 ## Configuration
 
 Add your tokens to `~/.pi/agent/settings.json`:
@@ -170,31 +172,39 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 
 ### Available tools
 
-| Tool                         | Description                                                              |
-| ---------------------------- | ------------------------------------------------------------------------ |
-| `slack_send`                 | Reply in a Slack assistant thread                                        |
-| `slack_react`                | Add an emoji reaction to a message                                       |
-| `slack_read`                 | Read messages from a thread                                              |
-| `slack_inbox`                | Check pending incoming messages                                          |
-| `slack_upload`               | Upload files, snippets, or diffs into Slack                              |
-| `slack_schedule`             | Schedule a message for later delivery                                    |
-| `slack_post_channel`         | Post to a channel (by name or ID)                                        |
-| `slack_read_channel`         | Read channel history or a thread in a channel                            |
-| `slack_create_channel`       | Create a new Slack channel                                               |
-| `slack_project_create`       | Create a project channel + RFC canvas + bot invite in one call           |
-| `slack_pin`                  | Pin or unpin a message                                                   |
-| `slack_bookmark`             | Add, list, or remove channel bookmarks                                   |
-| `slack_export`               | Export a thread as markdown, plain text, or JSON                         |
-| `slack_presence`             | Check if users are active, away, or in DND                               |
-| `slack_canvas_comments_read` | Read comments attached to a canvas by canvas ID or channel canvas lookup |
-| `slack_canvas_create`        | Create a standalone or channel canvas                                    |
-| `slack_canvas_update`        | Append, prepend, or replace canvas content                               |
-| `slack_blocks_build`         | Build Block Kit message templates                                        |
-| `slack_modal_build`          | Build Slack modal templates                                              |
-| `slack_modal_open`           | Open a modal from a trigger interaction                                  |
-| `slack_modal_push`           | Push a new step onto a modal stack                                       |
-| `slack_modal_update`         | Update an existing open modal                                            |
-| `slack_confirm_action`       | Request user confirmation before a dangerous action                      |
+| Tool                         | Description                                                                       |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| `slack_send`                 | Reply in a Slack assistant thread                                                 |
+| `slack_react`                | Add an emoji reaction to a message                                                |
+| `slack_read`                 | Read messages from a thread                                                       |
+| `slack_inbox`                | Check pending incoming messages                                                   |
+| `slack_upload`               | Upload files, snippets, or diffs into Slack                                       |
+| `slack_schedule`             | Schedule a message for later delivery                                             |
+| `slack_post_channel`         | Post to a channel (by name or ID)                                                 |
+| `slack_read_channel`         | Read channel history or a thread in a channel                                     |
+| `slack_create_channel`       | Create a new Slack channel                                                        |
+| `slack_project_create`       | Create a project channel + RFC canvas + bot invite in one call                    |
+| `slack_pin`                  | Pin or unpin a message                                                            |
+| `slack_bookmark`             | Add, list, or remove channel bookmarks                                            |
+| `slack_export`               | Export a thread as markdown, plain text, or JSON                                  |
+| `slack_presence`             | Check if users are active, away, or in DND                                        |
+| `slack_canvas_comments_read` | Read comments attached to a verified canvas by canvas ID or channel canvas lookup |
+| `slack_canvas_create`        | Create a standalone or channel canvas                                             |
+| `slack_canvas_update`        | Append, prepend, or replace canvas content                                        |
+| `slack_blocks_build`         | Build Block Kit message templates                                                 |
+| `slack_modal_build`          | Build Slack modal templates                                                       |
+| `slack_modal_open`           | Open a modal from a trigger interaction                                           |
+| `slack_modal_push`           | Push a new step onto a modal stack                                                |
+| `slack_modal_update`         | Update an existing open modal                                                     |
+| `slack_confirm_action`       | Request user confirmation before a dangerous action                               |
+
+#### Canvas comment inspection
+
+`slack_canvas_comments_read` is intentionally narrow:
+
+- it validates the target with `canvases.sections.lookup` before reading comment pages via `files.info`
+- it needs `files:read` because Slack exposes canvas comments through the file API surface
+- it will **not** inspect generic Slack files, non-canvas file comments, or full canvas body/history
 
 ### Slash commands
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -310,6 +310,46 @@ describe("classifyMessage", () => {
     }
   });
 
+  it("preserves extra visible message context for canvas-style mentions", () => {
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "<@U_BOT> Alice mentioned you in a comment",
+      channel: "C1",
+      channel_type: "channel",
+      ts: "1.1",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_quote",
+              elements: [{ type: "text", text: "Can you update the rollout checklist?" }],
+            },
+          ],
+        },
+        {
+          type: "context",
+          elements: [{ type: "plain_text", text: "Canvas: Launch plan > Rollout" }],
+        },
+      ],
+    };
+    const result = classifyMessage(evt, botId, emptyTracked);
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.isChannelMention).toBe(true);
+      expect(result.text).toBe(
+        [
+          "Alice mentioned you in a comment",
+          "",
+          "Slack message context:",
+          "- Can you update the rollout checklist?",
+          "- Canvas: Launch plan > Rollout",
+        ].join("\n"),
+      );
+    }
+  });
+
   it("does not strip mention in tracked threads", () => {
     const tracked = new Set(["1.1"]);
     const evt = {

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -8,6 +8,7 @@ import {
   SlackAdapter,
   RECONNECT_DELAY_MS,
 } from "./slack.js";
+import { SlackSocketModeClient } from "../../slack-access.js";
 import type { OutboundMessage } from "./types.js";
 
 async function waitForAssertion(assertion: () => void, attempts = 50): Promise<void> {
@@ -726,6 +727,19 @@ describe("SlackAdapter", () => {
       )
       .mockResolvedValue(undefined);
 
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({})),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      dedup: new Set<string>(),
+      onMessage: (event) =>
+        (
+          adapter as unknown as {
+            onMessage: (input: Record<string, unknown>) => Promise<void>;
+          }
+        ).onMessage(event),
+    });
+
     const firstFrame = JSON.stringify({
       envelope_id: "env-1",
       type: "events_api",
@@ -758,12 +772,12 @@ describe("SlackAdapter", () => {
     });
 
     await (
-      adapter as unknown as {
+      client as unknown as {
         handleFrame: (raw: string) => Promise<void>;
       }
     ).handleFrame(firstFrame);
     await (
-      adapter as unknown as {
+      client as unknown as {
         handleFrame: (raw: string) => Promise<void>;
       }
     ).handleFrame(secondFrame);
@@ -786,31 +800,56 @@ describe("SlackAdapter", () => {
       "resolveUser",
     ).mockResolvedValue("Will");
 
-    await (
-      adapter as unknown as {
-        onBlockActions: (payload: Record<string, unknown>) => Promise<void>;
-      }
-    ).onBlockActions({
-      type: "block_actions",
-      trigger_id: "trigger-1",
-      user: { id: "U123" },
-      channel: { id: "C123" },
-      container: {
-        channel_id: "C123",
-        message_ts: "123.456",
-        thread_ts: "123.000",
-      },
-      actions: [
-        {
-          action_id: "review.approve",
-          block_id: "review-actions",
-          type: "button",
-          text: { type: "plain_text", text: "Approve" },
-          value: '{"decision":"approve"}',
-          action_ts: "123.789",
-        },
-      ],
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({})),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      onInteractive: (event) =>
+        (
+          adapter as unknown as {
+            emitInteractiveInbound: (input: {
+              channel: string;
+              threadTs: string;
+              userId: string;
+              text: string;
+              timestamp: string;
+              metadata: Record<string, unknown>;
+            }) => Promise<void>;
+          }
+        ).emitInteractiveInbound(event),
     });
+
+    await (
+      client as unknown as {
+        handleFrame: (raw: string) => Promise<void>;
+      }
+    ).handleFrame(
+      JSON.stringify({
+        envelope_id: "env-1",
+        type: "interactive",
+        payload: {
+          type: "block_actions",
+          trigger_id: "trigger-1",
+          user: { id: "U123" },
+          channel: { id: "C123" },
+          container: {
+            channel_id: "C123",
+            message_ts: "123.456",
+            thread_ts: "123.000",
+          },
+          actions: [
+            {
+              action_id: "review.approve",
+              block_id: "review-actions",
+              type: "button",
+              text: { type: "plain_text", text: "Approve" },
+              value: '{"decision":"approve"}',
+              action_ts: "123.789",
+            },
+          ],
+        },
+      }),
+    );
 
     expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123");
     expect(handler).toHaveBeenCalledWith({
@@ -865,32 +904,57 @@ describe("SlackAdapter", () => {
       "resolveUser",
     ).mockResolvedValue("Will");
 
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({})),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      onInteractive: (event) =>
+        (
+          adapter as unknown as {
+            emitInteractiveInbound: (input: {
+              channel: string;
+              threadTs: string;
+              userId: string;
+              text: string;
+              timestamp: string;
+              metadata: Record<string, unknown>;
+            }) => Promise<void>;
+          }
+        ).emitInteractiveInbound(event),
+    });
+
     await (
-      adapter as unknown as {
-        onViewSubmission: (payload: Record<string, unknown>) => Promise<void>;
+      client as unknown as {
+        handleFrame: (raw: string) => Promise<void>;
       }
-    ).onViewSubmission({
-      type: "view_submission",
-      trigger_id: "trigger-1",
-      user: { id: "U123" },
-      view: {
-        id: "V123",
-        callback_id: "deploy.confirm",
-        title: { type: "plain_text", text: "Deploy approval" },
-        private_metadata:
-          '{"workflow":"deploy","__piSlackModalContext":{"threadTs":"123.000","channel":"C123"}}',
-        state: {
-          values: {
-            confirm_phrase: {
-              confirm_phrase: {
-                type: "plain_text_input",
-                value: "CONFIRM",
+    ).handleFrame(
+      JSON.stringify({
+        envelope_id: "env-1",
+        type: "interactive",
+        payload: {
+          type: "view_submission",
+          trigger_id: "trigger-1",
+          user: { id: "U123" },
+          view: {
+            id: "V123",
+            callback_id: "deploy.confirm",
+            title: { type: "plain_text", text: "Deploy approval" },
+            private_metadata:
+              '{"workflow":"deploy","__piSlackModalContext":{"threadTs":"123.000","channel":"C123"}}',
+            state: {
+              values: {
+                confirm_phrase: {
+                  confirm_phrase: {
+                    type: "plain_text_input",
+                    value: "CONFIRM",
+                  },
+                },
               },
             },
           },
         },
-      },
-    });
+      }),
+    );
 
     expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123");
     expect(handler).toHaveBeenCalledWith({

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -6,6 +6,7 @@ import {
   isUserAllowed,
   stripBotMention,
 } from "../../helpers.js";
+import { buildSlackInboundMessageText } from "../../slack-message-context.js";
 import {
   buildReactionTriggerMessage,
   normalizeReactionName,
@@ -192,7 +193,7 @@ export function classifyMessage(
     threadTs: effectiveTs,
     channel,
     userId: user,
-    text: cleanText,
+    text: buildSlackInboundMessageText(cleanText, evt),
     isDM,
     isChannelMention,
     messageTs: (evt.ts as string) ?? effectiveTs,

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -1,12 +1,22 @@
 import {
-  callSlackAPI,
-  createAbortableOperationTracker,
-  isAbortError,
-  buildAllowlist,
-  isUserAllowed,
-  stripBotMention,
-} from "../../helpers.js";
-import { buildSlackInboundMessageText } from "../../slack-message-context.js";
+  addSlackReaction,
+  buildSlackUserAllowlist,
+  classifyMessage,
+  clearSlackThreadStatus,
+  extractAppHomeOpened,
+  extractThreadContextChanged,
+  extractThreadStarted,
+  fetchSlackMessageByTs,
+  isSlackUserAllowed,
+  removeSlackReaction,
+  resolveSlackUserName,
+  setSlackSuggestedPrompts,
+  SlackSocketModeClient,
+  type ParsedAppHomeOpened,
+  type ParsedThreadContextChanged,
+  type ParsedThreadStarted,
+} from "../../slack-access.js";
+import { createAbortableOperationTracker, callSlackAPI, isAbortError } from "../../helpers.js";
 import {
   buildReactionTriggerMessage,
   normalizeReactionName,
@@ -15,18 +25,19 @@ import {
 } from "../../reaction-triggers.js";
 import { TtlCache, TtlSet } from "../../ttl-cache.js";
 import {
-  extractSlackSocketDedupKey,
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
-} from "../../slack-socket-dedup.js";
-import {
-  extractSlackInteractivePayloadFromEnvelope,
-  normalizeSlackBlockActionPayload,
-  normalizeSlackViewSubmissionPayload,
-} from "../../slack-block-kit.js";
+} from "../../slack-access.js";
 import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
 
-// ─── Config ──────────────────────────────────────────────
+export {
+  classifyMessage,
+  extractAppHomeOpened,
+  extractThreadStarted,
+  parseMemberJoinedChannel,
+  parseSocketFrame,
+  RECONNECT_DELAY_MS,
+} from "../../slack-access.js";
 
 export interface SlackAdapterConfig {
   botToken: string;
@@ -49,177 +60,6 @@ interface SlackThreadInfo {
   context?: { channelId: string; teamId: string };
 }
 
-// ─── Internal thread tracking ────────────────────────────
-
-// ─── Slack API result ────────────────────────────────────
-
-export interface ParsedEnvelope {
-  envelopeId?: string;
-  type: string;
-  dedupKey?: string;
-  event?: Record<string, unknown>;
-  interactivePayload?: Record<string, unknown>;
-}
-
-/**
- * Parse a raw Socket Mode WebSocket frame into a structured envelope.
- * Returns null if the frame is malformed JSON.
- */
-export function parseSocketFrame(raw: string): ParsedEnvelope | null {
-  try {
-    const data = JSON.parse(raw) as Record<string, unknown>;
-    const result: ParsedEnvelope = {
-      type: (data.type as string) ?? "",
-    };
-    if (data.envelope_id) {
-      result.envelopeId = data.envelope_id as string;
-    }
-    const dedupKey = extractSlackSocketDedupKey(data);
-    if (dedupKey) {
-      result.dedupKey = dedupKey;
-    }
-    if (data.type === "events_api") {
-      const payload = data.payload as { event?: Record<string, unknown> } | undefined;
-      result.event = payload?.event;
-    }
-
-    const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
-    if (interactivePayload) {
-      result.interactivePayload = interactivePayload;
-    }
-    return result;
-  } catch {
-    /* malformed JSON */
-    return null;
-  }
-}
-
-export interface ParsedThreadStarted {
-  channelId: string;
-  threadTs: string;
-  userId: string;
-  context?: { channelId: string; teamId: string };
-}
-
-export interface ParsedAppHomeOpened {
-  userId: string;
-  tab: string;
-  eventTs: string | null;
-}
-
-/**
- * Extract thread info from an assistant_thread_started event.
- */
-export function extractThreadStarted(evt: Record<string, unknown>): ParsedThreadStarted | null {
-  const t = evt.assistant_thread as Record<string, unknown> | undefined;
-  if (!t) return null;
-
-  const result: ParsedThreadStarted = {
-    channelId: t.channel_id as string,
-    threadTs: t.thread_ts as string,
-    userId: t.user_id as string,
-  };
-
-  const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-  if (ctx?.channel_id) {
-    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
-  }
-
-  return result;
-}
-
-export function extractAppHomeOpened(evt: Record<string, unknown>): ParsedAppHomeOpened | null {
-  const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
-  if (!userId) return null;
-
-  const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
-  return {
-    userId,
-    tab,
-    eventTs: typeof evt.event_ts === "string" && evt.event_ts.length > 0 ? evt.event_ts : null,
-  };
-}
-
-/**
- * Classification result for an incoming message event.
- * Uses a discriminated union so TypeScript narrows fields when relevant is true.
- */
-export type MessageClassification =
-  | { relevant: false }
-  | {
-      relevant: true;
-      threadTs: string;
-      channel: string;
-      userId: string;
-      text: string;
-      isDM: boolean;
-      isChannelMention: boolean;
-      messageTs: string;
-    };
-
-/**
- * Classify an incoming Slack message event. Determines whether the
- * message is relevant (DM, known thread, or bot mention) and
- * extracts the cleaned fields.
- */
-export function classifyMessage(
-  evt: Record<string, unknown>,
-  botUserId: string | null,
-  trackedThreadIds: Set<string>,
-  isKnownThread?: (threadTs: string) => boolean,
-): MessageClassification {
-  // Skip bot messages and messages with subtypes (joins, edits, etc.)
-  if (evt.subtype || evt.bot_id) return { relevant: false };
-
-  const text = (evt.text as string) ?? "";
-  const user = evt.user as string;
-  const threadTs = evt.thread_ts as string | undefined;
-  const channel = evt.channel as string;
-  const channelType = evt.channel_type as string | undefined;
-
-  const isKnown = !!threadTs && (isKnownThread?.(threadTs) ?? trackedThreadIds.has(threadTs));
-  const isDM = channelType === "im";
-  const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
-
-  if (!isKnown && !isDM && !isMention) return { relevant: false };
-
-  const effectiveTs = threadTs ?? (evt.ts as string);
-  const isChannelMention = isMention && !isDM && !isKnown;
-
-  const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
-
-  return {
-    relevant: true,
-    threadTs: effectiveTs,
-    channel,
-    userId: user,
-    text: buildSlackInboundMessageText(cleanText, evt),
-    isDM,
-    isChannelMention,
-    messageTs: (evt.ts as string) ?? effectiveTs,
-  };
-}
-
-/**
- * Parse a member_joined_channel event. Returns null if required fields
- * are missing.
- */
-export function parseMemberJoinedChannel(
-  evt: Record<string, unknown>,
-  botUserId: string | null,
-): { channel: string; isSelf: boolean } | null {
-  const user = evt.user as string | undefined;
-  const channel = evt.channel as string | undefined;
-  if (!user || !channel) return null;
-  return { channel, isSelf: user === botUserId };
-}
-
-// ─── Reconnect delay (exported for testing) ──────────────
-
-export const RECONNECT_DELAY_MS = 5000;
-
-// ─── Slack Adapter ───────────────────────────────────────
-
 export class SlackAdapter implements MessageAdapter {
   readonly name = "slack";
 
@@ -227,8 +67,7 @@ export class SlackAdapter implements MessageAdapter {
   private readonly allowlist: Set<string> | null;
   private slackRequests = createAbortableOperationTracker();
   private botUserId: string | null = null;
-  private ws: WebSocket | null = null;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private socketMode: SlackSocketModeClient | null = null;
   private shuttingDown = false;
   private inboundHandler: ((msg: InboundMessage) => void) | null = null;
   private readonly reactionCommands: Map<string, { action: string; prompt: string }>;
@@ -246,7 +85,7 @@ export class SlackAdapter implements MessageAdapter {
 
   constructor(config: SlackAdapterConfig) {
     this.config = config;
-    this.allowlist = buildAllowlist({ allowedUsers: config.allowedUsers }, undefined);
+    this.allowlist = buildSlackUserAllowlist(config.allowedUsers);
     this.reactionCommands = resolveReactionCommands(config.reactionCommands);
   }
 
@@ -254,28 +93,40 @@ export class SlackAdapter implements MessageAdapter {
     return this.slackRequests.run((signal) => callSlackAPI(method, token, body, { signal }));
   }
 
-  // ─── MessageAdapter interface ─────────────────────────
-
   async connect(): Promise<void> {
     this.shuttingDown = false;
     this.slackRequests = createAbortableOperationTracker();
-    const auth = await this.callSlack("auth.test", this.config.botToken);
-    this.botUserId = auth.user_id as string;
-    await this.connectSocketMode();
+    this.socketMode = new SlackSocketModeClient({
+      slack: this.callSlack.bind(this),
+      botToken: this.config.botToken,
+      appToken: this.config.appToken,
+      dedup: this.processedSocketDeliveries,
+      abortAndWait: () => this.slackRequests.abortAndWait(),
+      onThreadStarted: (event) => this.onThreadStarted(event),
+      onThreadContextChanged: (event) => this.onContextChanged(event),
+      onMessage: (event) => this.onMessage(event),
+      onReactionAdded: (event) => this.onReactionAdded(event),
+      onMemberJoinedChannel: (event) => this.onMemberJoined(event),
+      onAppHomeOpened: (event) => this.onAppHomeOpened(event),
+      onInteractive: (event) => this.emitInteractiveInbound(event),
+      onError: (error) => {
+        if (!isAbortError(error)) {
+          console.error(`[slack-adapter] Socket Mode: ${errorMsg(error)}`);
+        }
+      },
+    });
+    await this.socketMode.connect();
+    this.botUserId = this.socketMode.getBotUserId();
   }
 
   async disconnect(): Promise<void> {
     this.shuttingDown = true;
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
+    const socketMode = this.socketMode;
+    this.socketMode = null;
+    if (socketMode) {
+      await socketMode.disconnect();
+      return;
     }
-    try {
-      this.ws?.close();
-    } catch {
-      /* ignore close errors */
-    }
-    this.ws = null;
     await this.slackRequests.abortAndWait();
   }
 
@@ -305,23 +156,19 @@ export class SlackAdapter implements MessageAdapter {
     await this.callSlack("chat.postMessage", this.config.botToken, body);
     if (this.shuttingDown) return;
 
-    // Remove pending eyes for this thread
     const pending = this.pendingEyes.get(msg.threadId);
     if (pending) {
-      for (const p of pending) {
-        void this.removeReaction(p.channel, p.messageTs, "eyes");
+      for (const entry of pending) {
+        void this.removeReaction(entry.channel, entry.messageTs, "eyes");
       }
       this.pendingEyes.delete(msg.threadId);
     }
 
-    // Clear thread status
     void this.clearThreadStatus(msg.channel, msg.threadId);
   }
 
-  // ─── Getters (for inspection / testing) ────────────────
-
   getBotUserId(): string | null {
-    return this.botUserId;
+    return this.socketMode?.getBotUserId() ?? this.botUserId;
   }
 
   getTrackedThreadIds(): Set<string> {
@@ -329,110 +176,15 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   isConnected(): boolean {
-    return this.ws?.readyState === WebSocket.OPEN;
+    return this.socketMode?.isConnected() ?? false;
   }
 
-  // ─── Socket Mode connection ────────────────────────────
-
-  private async connectSocketMode(): Promise<void> {
+  private async onThreadStarted(
+    event: ParsedThreadStarted | Record<string, unknown>,
+  ): Promise<void> {
     if (this.shuttingDown) return;
 
-    try {
-      const res = await this.callSlack("apps.connections.open", this.config.appToken);
-      this.ws = new WebSocket(res.url as string);
-
-      this.ws.addEventListener("message", (event) => {
-        void this.handleFrame(String(event.data));
-      });
-
-      this.ws.addEventListener("close", () => {
-        if (!this.shuttingDown) this.scheduleReconnect();
-      });
-
-      this.ws.addEventListener("error", () => {
-        /* close fires after error — handled there */
-      });
-    } catch (err) {
-      if (!isAbortError(err)) {
-        console.error(`[slack-adapter] Socket Mode: ${errorMsg(err)}`);
-      }
-      this.scheduleReconnect();
-    }
-  }
-
-  private async handleFrame(raw: string): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const envelope = parseSocketFrame(raw);
-    if (!envelope) return;
-
-    // ACK every envelope
-    if (envelope.envelopeId) {
-      this.ws?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
-    }
-
-    const dedupKey: string | null = envelope.dedupKey ?? null;
-
-    try {
-      if (dedupKey) {
-        if (this.processedSocketDeliveries.has(dedupKey)) {
-          return;
-        }
-        this.processedSocketDeliveries.add(dedupKey);
-      }
-
-      if (envelope.type === "disconnect") {
-        this.scheduleReconnect();
-        return;
-      }
-
-      if (envelope.interactivePayload) {
-        if (envelope.interactivePayload.type === "block_actions") {
-          await this.onBlockActions(envelope.interactivePayload);
-        } else if (envelope.interactivePayload.type === "view_submission") {
-          await this.onViewSubmission(envelope.interactivePayload);
-        }
-        return;
-      }
-
-      if (!envelope.event) return;
-
-      const evt = envelope.event;
-
-      switch (evt.type) {
-        case "assistant_thread_started":
-          await this.onThreadStarted(evt);
-          break;
-        case "assistant_thread_context_changed":
-          this.onContextChanged(evt);
-          break;
-        case "message":
-          await this.onMessage(evt);
-          break;
-        case "reaction_added":
-          await this.onReactionAdded(evt);
-          break;
-        case "member_joined_channel":
-          this.onMemberJoined(evt);
-          break;
-        case "app_home_opened":
-          await this.onAppHomeOpened(evt);
-          break;
-      }
-    } catch (err) {
-      if (dedupKey) {
-        this.processedSocketDeliveries.delete(dedupKey);
-      }
-      throw err;
-    }
-  }
-
-  // ─── Event handlers ────────────────────────────────────
-
-  private async onThreadStarted(evt: Record<string, unknown>): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const parsed = extractThreadStarted(evt);
+    const parsed = isParsedThreadStarted(event) ? event : extractThreadStarted(event);
     if (!parsed) return;
 
     const info: SlackThreadInfo = {
@@ -454,36 +206,32 @@ export class SlackAdapter implements MessageAdapter {
     await this.setSuggestedPrompts(info.channelId, info.threadTs);
   }
 
-  private onContextChanged(evt: Record<string, unknown>): void {
+  private onContextChanged(event: ParsedThreadContextChanged | Record<string, unknown>): void {
     if (this.shuttingDown) return;
 
-    const t = evt.assistant_thread as Record<string, unknown> | undefined;
-    if (!t) return;
+    const parsed = isParsedThreadContextChanged(event) ? event : extractThreadContextChanged(event);
+    if (!parsed) return;
 
-    const existing = this.threads.get(t.thread_ts as string);
-    if (!existing) return;
+    const existing = this.threads.get(parsed.threadTs);
+    if (!existing || !parsed.context) return;
 
-    const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-    if (ctx?.channel_id) {
-      existing.context = {
-        channelId: ctx.channel_id,
-        teamId: ctx.team_id ?? "",
-      };
-    }
+    existing.context = parsed.context;
   }
 
-  private async onAppHomeOpened(evt: Record<string, unknown>): Promise<void> {
+  private async onAppHomeOpened(
+    event: ParsedAppHomeOpened | Record<string, unknown>,
+  ): Promise<void> {
     if (this.shuttingDown) return;
 
-    const parsed = extractAppHomeOpened(evt);
+    const parsed = isParsedAppHomeOpened(event) ? event : extractAppHomeOpened(event);
     if (!parsed || parsed.tab !== "home") {
       return;
     }
 
     try {
       await this.config.onAppHomeOpened?.(parsed);
-    } catch (err) {
-      console.error(`[slack-adapter] Home tab callback failed: ${errorMsg(err)}`);
+    } catch (error) {
+      console.error(`[slack-adapter] Home tab callback failed: ${errorMsg(error)}`);
     }
   }
 
@@ -491,19 +239,12 @@ export class SlackAdapter implements MessageAdapter {
     channel: string,
     messageTs: string,
   ): Promise<Record<string, unknown> | null> {
-    try {
-      const response = await this.callSlack("conversations.history", this.config.botToken, {
-        channel,
-        oldest: messageTs,
-        latest: messageTs,
-        inclusive: true,
-        limit: 1,
-      });
-      const messages = (response.messages as Record<string, unknown>[]) ?? [];
-      return messages.find((message) => message.ts === messageTs) ?? messages[0] ?? null;
-    } catch {
-      return null;
-    }
+    return fetchSlackMessageByTs({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channel,
+      messageTs,
+    });
   }
 
   private async onReactionAdded(evt: Record<string, unknown>): Promise<void> {
@@ -526,7 +267,7 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     const command = this.reactionCommands.get(reactionName);
-    if (!command || !isUserAllowed(this.allowlist, userId)) {
+    if (!command || !isSlackUserAllowed(this.allowlist, userId)) {
       return;
     }
 
@@ -590,9 +331,8 @@ export class SlackAdapter implements MessageAdapter {
       });
 
       await this.addReaction(item.channel, item.ts, "white_check_mark");
-    } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err);
-      console.error(`[slack-adapter] reaction trigger failed: ${errorMsg}`);
+    } catch (error) {
+      console.error(`[slack-adapter] reaction trigger failed: ${errorMsg(error)}`);
       await this.addReaction(item.channel, item.ts, "x");
     }
   }
@@ -610,7 +350,6 @@ export class SlackAdapter implements MessageAdapter {
 
     const { threadTs, channel, userId, text, isChannelMention, messageTs } = classified;
 
-    // Track thread if new
     if (!this.threads.has(threadTs)) {
       this.threads.set(threadTs, {
         channelId: channel,
@@ -619,20 +358,16 @@ export class SlackAdapter implements MessageAdapter {
       });
     }
 
-    // Allowlist check — silently drop unauthorized users
-    if (!isUserAllowed(this.allowlist, userId)) return;
+    if (!isSlackUserAllowed(this.allowlist, userId)) return;
 
-    // React with eyes to acknowledge
     void this.addReaction(channel, messageTs, "eyes");
     const pending = this.pendingEyes.get(threadTs) ?? [];
     pending.push({ channel, messageTs });
     this.pendingEyes.set(threadTs, pending);
 
-    // Resolve user name
     const userName = await this.resolveUser(userId);
     if (this.shuttingDown) return;
 
-    // Emit inbound message
     this.inboundHandler?.({
       source: "slack",
       threadId: threadTs,
@@ -667,7 +402,7 @@ export class SlackAdapter implements MessageAdapter {
       /* best effort — DB cache sync must not break Slack event handling */
     }
 
-    if (!isUserAllowed(this.allowlist, normalized.userId)) return;
+    if (!isSlackUserAllowed(this.allowlist, normalized.userId)) return;
 
     const userName = await this.resolveUser(normalized.userId);
     if (this.shuttingDown) return;
@@ -684,90 +419,56 @@ export class SlackAdapter implements MessageAdapter {
     });
   }
 
-  private async onBlockActions(payload: Record<string, unknown>): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const normalized = normalizeSlackBlockActionPayload(payload);
-    if (!normalized) return;
-    await this.emitInteractiveInbound(normalized);
-  }
-
-  private async onViewSubmission(payload: Record<string, unknown>): Promise<void> {
-    if (this.shuttingDown) return;
-
-    const normalized = normalizeSlackViewSubmissionPayload(payload);
-    if (!normalized) return;
-    await this.emitInteractiveInbound(normalized);
-  }
-
-  private onMemberJoined(evt: Record<string, unknown>): void {
-    const parsed = parseMemberJoinedChannel(evt, this.botUserId);
-    if (!parsed || !parsed.isSelf) return;
+  private onMemberJoined(event: { channel: string; isSelf: boolean }): void {
+    if (!event.isSelf) return;
 
     this.inboundHandler?.({
       source: "slack",
       threadId: "",
-      channel: parsed.channel,
+      channel: event.channel,
       userId: "system",
-      text: `Bot was added to channel ${parsed.channel}`,
+      text: `Bot was added to channel ${event.channel}`,
       timestamp: String(Date.now() / 1000),
     });
   }
 
-  // ─── Slack API helpers ─────────────────────────────────
-
   private async addReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await this.callSlack("reactions.add", this.config.botToken, {
-        channel,
-        timestamp: ts,
-        name: emoji,
-      });
-    } catch {
-      /* already_reacted or non-critical */
-    }
+    await addSlackReaction({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   private async removeReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await this.callSlack("reactions.remove", this.config.botToken, {
-        channel,
-        timestamp: ts,
-        name: emoji,
-      });
-    } catch {
-      /* not_reacted or non-critical */
-    }
+    await removeSlackReaction({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   private async resolveUser(userId: string): Promise<string> {
-    const cached = this.userNames.get(userId);
-    if (cached) return cached;
-    try {
-      const res = await this.callSlack("users.info", this.config.botToken, {
-        user: userId,
-      });
-      if (this.shuttingDown) return userId;
-      const u = res.user as { real_name?: string; name?: string };
-      const name = u.real_name ?? u.name ?? userId;
-      this.userNames.set(userId, name);
-      return name;
-    } catch {
-      /* non-critical — return raw userId */
-      return userId;
-    }
+    return resolveSlackUserName({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      userId,
+      cache: this.userNames,
+      shouldUseResult: () => !this.shuttingDown,
+    });
   }
 
   private async clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
-    try {
-      await this.callSlack("assistant.threads.setStatus", this.config.botToken, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        status: "",
-      });
-    } catch {
-      /* non-critical */
-    }
+    await clearSlackThreadStatus({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channelId,
+      threadTs,
+    });
   }
 
   private async setSuggestedPrompts(channelId: string, threadTs: string): Promise<void> {
@@ -776,30 +477,38 @@ export class SlackAdapter implements MessageAdapter {
       { title: "Help", message: "I need help with something in the codebase" },
       { title: "Review", message: "Summarise the recent changes" },
     ];
-    try {
-      await this.callSlack("assistant.threads.setSuggestedPrompts", this.config.botToken, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        prompts,
-      });
-    } catch {
-      /* non-critical */
-    }
-  }
-
-  // ─── Reconnect ─────────────────────────────────────────
-
-  private scheduleReconnect(): void {
-    if (this.shuttingDown || this.reconnectTimer) return;
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null;
-      void this.connectSocketMode();
-    }, RECONNECT_DELAY_MS);
+    await setSlackSuggestedPrompts({
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      channelId,
+      threadTs,
+      prompts,
+    });
   }
 }
 
-// ─── Utility ─────────────────────────────────────────────
+function isParsedThreadStarted(
+  value: ParsedThreadStarted | Record<string, unknown>,
+): value is ParsedThreadStarted {
+  return (
+    typeof value.channelId === "string" &&
+    typeof value.threadTs === "string" &&
+    typeof value.userId === "string"
+  );
+}
 
-function errorMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+function isParsedThreadContextChanged(
+  value: ParsedThreadContextChanged | Record<string, unknown>,
+): value is ParsedThreadContextChanged {
+  return typeof value.threadTs === "string";
+}
+
+function isParsedAppHomeOpened(
+  value: ParsedAppHomeOpened | Record<string, unknown>,
+): value is ParsedAppHomeOpened {
+  return typeof value.userId === "string" && typeof value.tab === "string";
+}
+
+function errorMsg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -353,9 +353,14 @@ export class BrokerClient {
 
   // ─── Thread ownership ─────────────────────────────────
 
-  async claimThread(threadId: string, channel?: string): Promise<{ claimed: boolean }> {
+  async claimThread(
+    threadId: string,
+    channel?: string,
+    source?: string,
+  ): Promise<{ claimed: boolean }> {
     const params: Record<string, unknown> = { threadId };
     if (channel) params.channel = channel;
+    if (source) params.source = source;
     const result = (await this.request("thread.claim", params)) as { claimed: boolean };
     return result;
   }

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1246,12 +1246,74 @@ describe("BrokerDB", () => {
 
     expect(result.assignedBacklogCount).toBe(0);
     expect(result.pendingBacklogCount).toBe(1);
-    expect(result.anomalies).toContain("reset 1 orphaned targeted backlog assignment to pending");
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
     expect(db.getAgentById("receiver")).not.toBeNull();
     expect(repairedBacklog).toEqual({
       status: "pending",
       reason: "agent_disconnected",
       preferred_agent_id: "receiver",
+      assigned_agent_id: null,
+    });
+  });
+
+  it("maintenance resets orphaned assigned generic backlog to pending once the assignee is missing", () => {
+    db.registerAgent("worker-1", "Worker", "🤖", 1);
+
+    const backlog = db.queueUnroutedMessage(
+      {
+        source: "slack",
+        threadId: "1775638755.200989",
+        channel: "C123",
+        userId: "U123",
+        text: "recover this stranded generic backlog",
+        timestamp: "100.200",
+      },
+      "no_route",
+    );
+
+    expect(db.assignBacklogEntry(backlog.id, "worker-1")?.status).toBe("assigned");
+    expect(db.getThread("1775638755.200989")?.ownerAgent).toBe("worker-1");
+
+    const sqlite = (db as unknown as { getDb(): DatabaseSync }).getDb();
+    sqlite
+      .prepare("DELETE FROM inbox WHERE message_id = ? AND agent_id = ?")
+      .run(backlog.messageId, "worker-1");
+    sqlite.prepare("DELETE FROM agents WHERE id = ?").run("worker-1");
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    const repairedBacklog = sqlite
+      .prepare(
+        "SELECT status, reason, preferred_agent_id, assigned_agent_id FROM unrouted_backlog WHERE id = ?",
+      )
+      .get(backlog.id) as
+      | {
+          status: string;
+          reason: string;
+          preferred_agent_id: string | null;
+          assigned_agent_id: string | null;
+        }
+      | undefined;
+    const orphanedInboxCount = (
+      sqlite
+        .prepare("SELECT COUNT(*) AS count FROM inbox WHERE message_id = ? AND agent_id = ?")
+        .get(backlog.messageId, "worker-1") as { count: number }
+    ).count;
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(result.anomalies).toContain("released 1 orphaned thread claim");
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
+    expect(result.anomalies).toContain("pending unrouted backlog has no live workers");
+    expect(db.getThread("1775638755.200989")?.ownerAgent).toBeNull();
+    expect(orphanedInboxCount).toBe(0);
+    expect(repairedBacklog).toEqual({
+      status: "pending",
+      reason: "no_route",
+      preferred_agent_id: null,
       assigned_agent_id: null,
     });
   });

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -657,6 +657,17 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(thread!.channel).toBe("C-TEST-123");
   });
 
+  it("thread.claim with source stores source on a new thread", async () => {
+    await client.register("imessage-claimer", "💬");
+
+    await client.claimThread("t-imessage", "chat:alice", "imessage");
+
+    const thread = db.getThread("t-imessage");
+    expect(thread).not.toBeNull();
+    expect(thread!.source).toBe("imessage");
+    expect(thread!.channel).toBe("chat:alice");
+  });
+
   it("resolveThread returns the broker channel for an existing thread", async () => {
     await client.register("resolver-agent", "🧭");
     db.createThread("t-resolve", "slack", "C-THREAD-1", null);

--- a/slack-bridge/broker/maintenance.test.ts
+++ b/slack-bridge/broker/maintenance.test.ts
@@ -51,11 +51,16 @@ class StubMaintenanceDB implements BrokerMaintenanceDB {
     let droppedCount = 0;
 
     for (const entry of this.backlog) {
-      if (
-        entry.status !== "assigned" ||
-        !entry.preferredAgentId ||
-        this.healthyAssignedBacklogIds.has(entry.id)
-      ) {
+      if (entry.status !== "assigned" || this.healthyAssignedBacklogIds.has(entry.id)) {
+        continue;
+      }
+
+      if (!entry.preferredAgentId) {
+        if (!entry.assignedAgentId || !this.getAgentById(entry.assignedAgentId)) {
+          entry.status = "pending";
+          entry.assignedAgentId = null;
+          resetToPendingCount += 1;
+        }
         continue;
       }
 
@@ -387,7 +392,30 @@ describe("runBrokerMaintenancePass", () => {
     expect(result.pendingBacklogCount).toBe(1);
     expect(db.backlog[0].status).toBe("pending");
     expect(db.backlog[0].assignedAgentId).toBeNull();
-    expect(result.anomalies).toContain("reset 1 orphaned targeted backlog assignment to pending");
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
+  });
+
+  it("repairs orphaned generic assignments back to pending once the assignee is missing", () => {
+    db.backlog = [
+      makeBacklog({
+        id: 1,
+        threadId: "t-generic-assigned",
+        status: "assigned",
+        assignedAgentId: "missing-worker",
+        reason: "no_route",
+      }),
+    ];
+
+    const result = runBrokerMaintenancePass(db, {
+      staleAfterMs: 15_000,
+      now: Date.parse("2026-04-01T00:00:10.000Z"),
+    });
+
+    expect(result.assignedBacklogCount).toBe(0);
+    expect(result.pendingBacklogCount).toBe(1);
+    expect(db.backlog[0].status).toBe("pending");
+    expect(db.backlog[0].assignedAgentId).toBeNull();
+    expect(result.anomalies).toContain("reset 1 orphaned backlog assignment to pending");
   });
 
   it("drops orphaned targeted assignments once the preferred agent is gone", () => {

--- a/slack-bridge/broker/maintenance.ts
+++ b/slack-bridge/broker/maintenance.ts
@@ -179,7 +179,7 @@ export function runBrokerMaintenancePass(
   }
   if (resetAssignedBacklogCount > 0) {
     anomalies.push(
-      `reset ${resetAssignedBacklogCount} orphaned targeted backlog assignment${resetAssignedBacklogCount === 1 ? "" : "s"} to pending`,
+      `reset ${resetAssignedBacklogCount} orphaned backlog assignment${resetAssignedBacklogCount === 1 ? "" : "s"} to pending`,
     );
   }
   if (droppedBacklogCount > 0) {

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -556,6 +556,17 @@ describe("MessageRouter — claimThread", () => {
     expect(thread?.ownerAgent).toBe("a1");
   });
 
+  it("stores the provided source when claiming a new thread", () => {
+    const claimed = router.claimThread("t-imessage", "a1", "chat:alice", "imessage");
+
+    expect(claimed).toBe(true);
+    const thread = db.threads.get("t-imessage");
+    expect(thread).toBeDefined();
+    expect(thread?.ownerAgent).toBe("a1");
+    expect(thread?.source).toBe("imessage");
+    expect(thread?.channel).toBe("chat:alice");
+  });
+
   it("allows re-claiming by the same agent", () => {
     db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: "a1" }));
 

--- a/slack-bridge/broker/router.ts
+++ b/slack-bridge/broker/router.ts
@@ -341,14 +341,15 @@ export class MessageRouter {
 
   /**
    * Claim a thread for an agent (first-responder-wins).
-   * Optionally provide a channel to set when creating a new thread.
+   * Optionally provide the transport source and channel to store when creating
+   * a new thread. Defaults to Slack for backward compatibility.
    * Returns true if the claim succeeded, false if another agent already owns it.
    *
    * Delegates to the DB layer which performs the claim atomically
    * (single SQL statement) to avoid TOCTOU races. (#125)
    */
-  claimThread(threadId: string, agentId: string, channel?: string): boolean {
-    return this.db.claimThread(threadId, agentId, "slack", channel ?? "");
+  claimThread(threadId: string, agentId: string, channel?: string, source = "slack"): boolean {
+    return this.db.claimThread(threadId, agentId, source, channel ?? "");
   }
 
   /**

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -1265,22 +1265,33 @@ export class BrokerDB implements BrokerDBInterface {
           `SELECT id, message_id, preferred_agent_id, assigned_agent_id
            FROM unrouted_backlog
            WHERE status = 'assigned'
-             AND preferred_agent_id IS NOT NULL
              AND (
-               assigned_agent_id IS NULL
-               OR assigned_agent_id NOT IN (SELECT id FROM agents)
-               OR NOT EXISTS (
-                 SELECT 1
-                 FROM inbox
-                 WHERE inbox.message_id = unrouted_backlog.message_id
-                   AND inbox.agent_id = unrouted_backlog.assigned_agent_id
+               (
+                 preferred_agent_id IS NOT NULL
+                 AND (
+                   assigned_agent_id IS NULL
+                   OR assigned_agent_id NOT IN (SELECT id FROM agents)
+                   OR NOT EXISTS (
+                     SELECT 1
+                     FROM inbox
+                     WHERE inbox.message_id = unrouted_backlog.message_id
+                       AND inbox.agent_id = unrouted_backlog.assigned_agent_id
+                   )
+                 )
+               )
+               OR (
+                 preferred_agent_id IS NULL
+                 AND (
+                   assigned_agent_id IS NULL
+                   OR assigned_agent_id NOT IN (SELECT id FROM agents)
+                 )
                )
              )`,
         )
         .all() as Array<{
         id: number;
         message_id: number;
-        preferred_agent_id: string;
+        preferred_agent_id: string | null;
         assigned_agent_id: string | null;
       }>;
 
@@ -1318,6 +1329,11 @@ export class BrokerDB implements BrokerDBInterface {
       for (const row of rows) {
         if (row.assigned_agent_id) {
           clearStaleInbox.run(row.message_id, row.assigned_agent_id);
+        }
+
+        if (!row.preferred_agent_id) {
+          resetToPendingCount += Number(resetPending.run(now, row.id).changes ?? 0);
+          continue;
         }
 
         if (this.getAgentRowById(row.preferred_agent_id)) {

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -680,7 +680,11 @@ export class BrokerSocketServer {
     }
 
     const channel = typeof params.channel === "string" ? params.channel : undefined;
-    const claimed = this.router.claimThread(threadId, state.agentId, channel);
+    const source =
+      typeof params.source === "string" && params.source.trim().length > 0
+        ? params.source.trim()
+        : undefined;
+    const claimed = this.router.claimThread(threadId, state.agentId, channel, source);
     return rpcOk(req.id, { claimed });
   }
 
@@ -839,7 +843,7 @@ export class BrokerSocketServer {
         const messageTs = typeof result.ts === "string" ? (result.ts as string) : null;
         const effectiveTs = threadTs ?? messageTs;
         if (effectiveTs) {
-          this.router.claimThread(effectiveTs, state.agentId);
+          this.router.claimThread(effectiveTs, state.agentId, undefined, "slack");
         }
       }
 

--- a/slack-bridge/canvases.test.ts
+++ b/slack-bridge/canvases.test.ts
@@ -3,7 +3,9 @@ import {
   buildSlackCanvasCreateRequest,
   buildSlackCanvasEditRequest,
   buildSlackCanvasSectionsLookupRequest,
+  extractSlackCanvasCommentsPage,
   extractSlackChannelCanvasId,
+  normalizeSlackCanvasCommentsLimit,
   normalizeSlackCanvasCreateKind,
   normalizeSlackCanvasSectionType,
   normalizeSlackCanvasUpdateMode,
@@ -56,6 +58,29 @@ describe("normalizeSlackCanvasSectionType", () => {
   it("rejects unsupported section types", () => {
     expect(() => normalizeSlackCanvasSectionType("paragraph")).toThrow(
       "Unsupported canvas section type. Use 'h1', 'h2', 'h3', or 'any_header'.",
+    );
+  });
+});
+
+describe("normalizeSlackCanvasCommentsLimit", () => {
+  it("defaults to 20", () => {
+    expect(normalizeSlackCanvasCommentsLimit()).toBe(20);
+  });
+
+  it("accepts bounded integer limits", () => {
+    expect(normalizeSlackCanvasCommentsLimit(1)).toBe(1);
+    expect(normalizeSlackCanvasCommentsLimit(200)).toBe(200);
+  });
+
+  it("rejects invalid limits", () => {
+    expect(() => normalizeSlackCanvasCommentsLimit(0)).toThrow(
+      "Canvas comment reads require limit to be an integer between 1 and 200.",
+    );
+    expect(() => normalizeSlackCanvasCommentsLimit(201)).toThrow(
+      "Canvas comment reads require limit to be an integer between 1 and 200.",
+    );
+    expect(() => normalizeSlackCanvasCommentsLimit(1.5)).toThrow(
+      "Canvas comment reads require limit to be an integer between 1 and 200.",
     );
   });
 });
@@ -225,6 +250,63 @@ describe("pickSlackCanvasSectionId", () => {
     expect(() => pickSlackCanvasSectionId([{ id: "temp:C:1" }], 2)).toThrow(
       "Canvas section lookup matched 1 sections; section_index 2 is out of range.",
     );
+  });
+});
+
+describe("extractSlackCanvasCommentsPage", () => {
+  it("extracts canvas comment pages from files.info responses", () => {
+    expect(
+      extractSlackCanvasCommentsPage({
+        file: {
+          id: "F123",
+          title: "Launch plan",
+          permalink: "https://example.slack.com/docs/T/F123",
+          comments_count: 3,
+        },
+        comments: [
+          { id: "Fc1", user: "U123", comment: "First comment", created: 1715000000 },
+          { id: 2, user: "U234", text: "Second comment", ts: "1715000100" },
+        ],
+        paging: { page: 1, pages: 2, total: 3 },
+        response_metadata: { next_cursor: "cursor-2" },
+      }),
+    ).toEqual({
+      canvasId: "F123",
+      title: "Launch plan",
+      permalink: "https://example.slack.com/docs/T/F123",
+      commentsCount: 3,
+      returnedCount: 2,
+      page: 1,
+      pages: 2,
+      nextCursor: "cursor-2",
+      comments: [
+        { id: "Fc1", userId: "U123", createdTs: "1715000000", text: "First comment" },
+        { id: "2", userId: "U234", createdTs: "1715000100", text: "Second comment" },
+      ],
+    });
+  });
+
+  it("falls back to the requested canvas id and placeholder text when Slack omits fields", () => {
+    expect(
+      extractSlackCanvasCommentsPage(
+        {
+          file: {},
+          comments: [{ id: "Fc1", user: "U123" }],
+        },
+        "F999",
+      ),
+    ).toEqual({
+      canvasId: "F999",
+      commentsCount: 1,
+      returnedCount: 1,
+      comments: [
+        {
+          id: "Fc1",
+          userId: "U123",
+          text: "(no comment text exposed by Slack)",
+        },
+      ],
+    });
   });
 });
 

--- a/slack-bridge/canvases.ts
+++ b/slack-bridge/canvases.ts
@@ -9,6 +9,25 @@ export type SlackCanvasUpdateMode = "append" | "prepend" | "replace";
 export type SlackCanvasSectionType = "h1" | "h2" | "h3" | "any_header";
 export type SlackCanvasEditOperation = "insert_at_end" | "insert_at_start" | "replace";
 
+export interface SlackCanvasCommentRecord {
+  id?: string;
+  userId?: string;
+  createdTs?: string;
+  text: string;
+}
+
+export interface SlackCanvasCommentsPage {
+  canvasId: string;
+  title?: string;
+  permalink?: string;
+  commentsCount: number;
+  returnedCount: number;
+  page?: number;
+  pages?: number;
+  comments: SlackCanvasCommentRecord[];
+  nextCursor?: string;
+}
+
 export interface SlackCanvasCreateInput {
   kind?: string;
   title?: string;
@@ -67,6 +86,20 @@ function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringifiedNumber(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
 function asStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const strings = value.map(asString).filter((item): item is string => Boolean(item));
@@ -103,6 +136,14 @@ export function normalizeSlackCanvasSectionType(type?: string): SlackCanvasSecti
     return normalized;
   }
   throw new Error("Unsupported canvas section type. Use 'h1', 'h2', 'h3', or 'any_header'.");
+}
+
+export function normalizeSlackCanvasCommentsLimit(limit?: number): number {
+  if (limit == null) return 20;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+    throw new Error("Canvas comment reads require limit to be an integer between 1 and 200.");
+  }
+  return limit;
 }
 
 export function buildSlackCanvasCreateRequest(
@@ -246,6 +287,58 @@ export function extractSlackChannelCanvasId(response: Record<string, unknown>): 
   if (canvasIds?.[0]) return canvasIds[0];
 
   return null;
+}
+
+function extractSlackCanvasCommentText(comment: Record<string, unknown>): string {
+  return (
+    asString(comment.comment) ??
+    asString(comment.comment_text) ??
+    asString(comment.text) ??
+    asString(comment.plain_text) ??
+    "(no comment text exposed by Slack)"
+  );
+}
+
+export function extractSlackCanvasCommentsPage(
+  response: Record<string, unknown>,
+  fallbackCanvasId?: string,
+): SlackCanvasCommentsPage {
+  const file = asRecord(response.file) ?? {};
+  const comments = Array.isArray(response.comments)
+    ? (response.comments as Record<string, unknown>[])
+    : [];
+  const paging = asRecord(response.paging);
+  const responseMetadata = asRecord(response.response_metadata);
+  const canvasId = asString(file.id) ?? normalizeOptionalString(fallbackCanvasId);
+
+  if (!canvasId) {
+    throw new Error("Slack did not return a canvas/file id for this canvas comment read.");
+  }
+
+  const parsedComments: SlackCanvasCommentRecord[] = comments.map((comment) => ({
+    ...(asStringifiedNumber(comment.id) ? { id: asStringifiedNumber(comment.id) } : {}),
+    ...(asString(comment.user) ? { userId: asString(comment.user) } : {}),
+    ...(asStringifiedNumber(comment.created ?? comment.timestamp ?? comment.ts)
+      ? { createdTs: asStringifiedNumber(comment.created ?? comment.timestamp ?? comment.ts) }
+      : {}),
+    text: extractSlackCanvasCommentText(comment),
+  }));
+
+  const nextCursor = asString(responseMetadata?.next_cursor);
+  const totalFromPaging = asNumber(paging?.total);
+  const commentCount = asNumber(file.comments_count) ?? totalFromPaging ?? parsedComments.length;
+
+  return {
+    canvasId,
+    ...(asString(file.title) ? { title: asString(file.title) } : {}),
+    ...(asString(file.permalink) ? { permalink: asString(file.permalink) } : {}),
+    commentsCount: commentCount,
+    returnedCount: parsedComments.length,
+    ...(asNumber(paging?.page) ? { page: asNumber(paging?.page) } : {}),
+    ...(asNumber(paging?.pages) ? { pages: asNumber(paging?.pages) } : {}),
+    comments: parsedComments,
+    ...(nextCursor ? { nextCursor } : {}),
+  };
 }
 
 export function extractExistingChannelCanvasId(response: Record<string, unknown>): string | null {

--- a/slack-bridge/core-tool-guardrails.test.ts
+++ b/slack-bridge/core-tool-guardrails.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateSlackOriginCoreToolPolicy,
+  summarizeCoreToolAction,
+} from "./core-tool-guardrails.js";
+
+describe("core tool Slack guardrails", () => {
+  it("blocks Slack-triggered core tools covered by readOnly or blockedTools", () => {
+    const turn = { threadTs: "100.1", threadCount: 1 };
+
+    const bashBlocked = evaluateSlackOriginCoreToolPolicy({
+      turn,
+      toolName: "bash",
+      input: { command: "touch nope" },
+      guardrails: { blockedTools: ["bash"] },
+      requireToolPolicy: () => {
+        throw new Error("should not reach confirmation layer");
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+    expect(bashBlocked).toEqual({
+      block: true,
+      reason: 'Tool "bash" is blocked by Slack security guardrails.',
+    });
+
+    const editBlocked = evaluateSlackOriginCoreToolPolicy({
+      turn,
+      toolName: "edit",
+      input: { path: "README.md", edits: [{ oldText: "a", newText: "b" }] },
+      guardrails: { readOnly: true },
+      requireToolPolicy: () => {
+        throw new Error("should not reach confirmation layer");
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+    expect(editBlocked).toEqual({
+      block: true,
+      reason: 'Tool "edit" is blocked by Slack security guardrails.',
+    });
+
+    const writeBlocked = evaluateSlackOriginCoreToolPolicy({
+      turn,
+      toolName: "write",
+      input: { path: "README.md", content: "hi" },
+      guardrails: { readOnly: true },
+      requireToolPolicy: () => {
+        throw new Error("should not reach confirmation layer");
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+    expect(writeBlocked).toEqual({
+      block: true,
+      reason: 'Tool "write" is blocked by Slack security guardrails.',
+    });
+  });
+
+  it("requires confirmation for Slack-triggered core tools with a real Slack thread", () => {
+    const result = evaluateSlackOriginCoreToolPolicy({
+      turn: { threadTs: "100.1", threadCount: 1 },
+      toolName: "bash",
+      input: { command: "echo hello" },
+      guardrails: { requireConfirmation: ["bash"] },
+      requireToolPolicy: (toolName, threadTs, action) => {
+        throw new Error(
+          `Tool "${toolName}" requires confirmation for action ${JSON.stringify(action)}. Call slack_confirm_action in thread ${threadTs} first.`,
+        );
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason:
+        'Tool "bash" requires confirmation for action "command=echo hello". Call slack_confirm_action in thread 100.1 first.',
+    });
+  });
+
+  it("refuses confirmation-required core tools when a Slack batch spans multiple threads", () => {
+    const result = evaluateSlackOriginCoreToolPolicy({
+      turn: { threadTs: undefined, threadCount: 2 },
+      toolName: "bash",
+      input: { command: "echo hello" },
+      guardrails: { requireConfirmation: ["bash"] },
+      requireToolPolicy: () => {
+        throw new Error("should not reach confirmation layer");
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason:
+        'Tool "bash" requires Slack confirmation for action "command=echo hello", but this Slack-triggered turn currently batches 2 threads. Process one Slack thread at a time before using that tool.',
+    });
+  });
+
+  it("does not interfere with non-Slack turns or non-core tools", () => {
+    expect(
+      evaluateSlackOriginCoreToolPolicy({
+        turn: null,
+        toolName: "bash",
+        input: { command: "pwd" },
+        guardrails: { readOnly: true },
+        requireToolPolicy: () => {
+          throw new Error("should not run");
+        },
+        formatAction: (action) => JSON.stringify(action),
+        formatError: (error) => (error instanceof Error ? error.message : String(error)),
+      }),
+    ).toBeUndefined();
+
+    expect(
+      evaluateSlackOriginCoreToolPolicy({
+        turn: { threadTs: "100.1", threadCount: 1 },
+        toolName: "slack_send",
+        input: { thread_ts: "100.1", text: "hi" },
+        guardrails: { blockedTools: ["slack_send"] },
+        requireToolPolicy: () => {
+          throw new Error("should not run");
+        },
+        formatAction: (action) => JSON.stringify(action),
+        formatError: (error) => (error instanceof Error ? error.message : String(error)),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps core confirmation summaries compact and deterministic", () => {
+    expect(
+      summarizeCoreToolAction({
+        toolName: "write",
+        input: { path: "README.md", content: "hello" },
+      }),
+    ).toBe("path=README.md | content_length=5");
+    expect(
+      summarizeCoreToolAction({ toolName: "edit", input: { path: "README.md", edits: [{}, {}] } }),
+    ).toBe("path=README.md | edits=2");
+  });
+});

--- a/slack-bridge/core-tool-guardrails.ts
+++ b/slack-bridge/core-tool-guardrails.ts
@@ -1,0 +1,92 @@
+import { isToolBlocked, toolNeedsConfirmation, type SecurityGuardrails } from "./guardrails.js";
+
+export interface SlackToolPolicyTurn {
+  threadTs: string | undefined;
+  threadCount: number;
+}
+
+export const GUARDED_CORE_TOOLS = new Set(["bash", "read", "edit", "write", "grep", "find", "ls"]);
+
+export function isGuardedCoreTool(toolName: string): boolean {
+  return GUARDED_CORE_TOOLS.has(toolName);
+}
+
+export function getGuardrailToolName(toolName: string): string {
+  return toolName === "grep" ? "rg" : toolName;
+}
+
+export function summarizeCoreToolAction(event: {
+  toolName: string;
+  input: Record<string, unknown>;
+}): string {
+  const input = event.input;
+  switch (event.toolName) {
+    case "bash":
+      return `command=${String(input.command ?? "")}`;
+    case "read":
+      return `path=${String(input.path ?? "")} | offset=${String(input.offset ?? "")} | limit=${String(input.limit ?? "")}`;
+    case "edit":
+      return `path=${String(input.path ?? "")} | edits=${Array.isArray(input.edits) ? input.edits.length : 0}`;
+    case "write": {
+      const content = typeof input.content === "string" ? input.content : "";
+      return `path=${String(input.path ?? "")} | content_length=${content.length}`;
+    }
+    case "grep":
+      return `pattern=${String(input.pattern ?? "")} | path=${String(input.path ?? "")} | glob=${String(input.glob ?? "")}`;
+    case "find":
+      return `pattern=${String(input.pattern ?? "")} | path=${String(input.path ?? "")} | limit=${String(input.limit ?? "")}`;
+    case "ls":
+      return `path=${String(input.path ?? "")} | limit=${String(input.limit ?? "")}`;
+    default:
+      return JSON.stringify(input);
+  }
+}
+
+export function evaluateSlackOriginCoreToolPolicy(options: {
+  turn: SlackToolPolicyTurn | null;
+  toolName: string;
+  input: Record<string, unknown>;
+  guardrails: SecurityGuardrails;
+  requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
+  formatAction: (action: string) => string;
+  formatError: (error: unknown) => string;
+}): { block: true; reason: string } | undefined {
+  const { turn, toolName, input, guardrails, requireToolPolicy, formatAction, formatError } =
+    options;
+  if (!turn || !isGuardedCoreTool(toolName)) {
+    return undefined;
+  }
+
+  const guardrailToolName = getGuardrailToolName(toolName);
+  if (isToolBlocked(guardrailToolName, guardrails)) {
+    return {
+      block: true,
+      reason: `Tool "${guardrailToolName}" is blocked by Slack security guardrails.`,
+    };
+  }
+
+  if (!toolNeedsConfirmation(guardrailToolName, guardrails)) {
+    return undefined;
+  }
+
+  const action = summarizeCoreToolAction({ toolName, input });
+  if (!turn.threadTs) {
+    return {
+      block: true,
+      reason:
+        turn.threadCount > 1
+          ? `Tool "${guardrailToolName}" requires Slack confirmation for action ${formatAction(action)}, but this Slack-triggered turn currently batches ${turn.threadCount} threads. Process one Slack thread at a time before using that tool.`
+          : `Tool "${guardrailToolName}" requires Slack confirmation for action ${formatAction(action)}, but there is no tracked Slack thread available for this turn. Retry from a specific Slack thread and call slack_confirm_action there first.`,
+    };
+  }
+
+  try {
+    requireToolPolicy(guardrailToolName, turn.threadTs, action);
+    return undefined;
+  } catch (error) {
+    return {
+      block: true,
+      reason: formatError(error),
+    };
+  }
+}

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1830,7 +1830,7 @@ describe("evaluateRalphLoopCycle", () => {
     expect(result.anomalies).toContain("Busy Fox idle with assigned work (1 inbox, 1 threads)");
   });
 
-  it("detects stuck agents: working with no activity for > threshold", () => {
+  it("detects stuck agents when quiet activity crosses the threshold under queue pressure", () => {
     const now = Date.parse("2026-04-01T00:10:00.000Z");
     const result = evaluateRalphLoopCycle(
       [
@@ -1843,7 +1843,7 @@ describe("evaluateRalphLoopCycle", () => {
           lastSeen: "2026-04-01T00:09:55.000Z",
           lastHeartbeat: "2026-04-01T00:09:55.000Z",
           lastActivity: "2026-04-01T00:03:00.000Z", // 7 min ago
-          pendingInboxCount: 0,
+          pendingInboxCount: 1,
           ownedThreadCount: 1,
         },
         {
@@ -1868,9 +1868,120 @@ describe("evaluateRalphLoopCycle", () => {
     );
 
     expect(result.stuckAgentIds).toEqual(["stuck-worker"]);
-    expect(result.anomalies.some((a) => a.includes("Stuck Wolf appears stuck"))).toBe(true);
+    expect(result.anomalies).toContain(
+      "Stuck Wolf appears stuck (working with no activity beyond 5m threshold)",
+    );
     // Active Fox should NOT be flagged as stuck
     expect(result.stuckAgentIds).not.toContain("active-worker");
+  });
+
+  it("does not flag healthy quiet workers as stuck when there is no queue pressure", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🐗",
+          name: "Quiet Boar",
+          id: "quiet-worker",
+          status: "working",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:09:55.000Z",
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          lastActivity: "2026-04-01T00:03:00.000Z", // 7 min ago
+          pendingInboxCount: 0,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:10:00.000Z"),
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+        pendingBacklogCount: 0,
+      },
+    );
+
+    expect(result.stuckAgentIds).toEqual([]);
+    expect(result.anomalies).toEqual([]);
+  });
+
+  it("still flags quiet workers when backlog pressure exists on their claimed work", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🦌",
+          name: "Busy Deer",
+          id: "busy-worker",
+          status: "working",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:09:55.000Z",
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          lastActivity: "2026-04-01T00:03:00.000Z",
+          pendingInboxCount: 0,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:10:00.000Z"),
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+        pendingBacklogCount: 2,
+      },
+    );
+
+    expect(result.stuckAgentIds).toEqual(["busy-worker"]);
+    expect(result.anomalies).toContain(
+      "Busy Deer appears stuck (working with no activity beyond 5m threshold)",
+    );
+  });
+
+  it("keeps the stuck anomaly text stable across repeated quiet-pressure cycles", () => {
+    const cycle1 = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🐺",
+          name: "Stuck Wolf",
+          id: "stuck-worker",
+          status: "working",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:09:55.000Z",
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          lastActivity: "2026-04-01T00:03:00.000Z",
+          pendingInboxCount: 1,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:10:00.000Z"),
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+    const cycle2 = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🐺",
+          name: "Stuck Wolf",
+          id: "stuck-worker",
+          status: "working",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:10:55.000Z",
+          lastHeartbeat: "2026-04-01T00:10:55.000Z",
+          lastActivity: "2026-04-01T00:03:00.000Z",
+          pendingInboxCount: 1,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:11:00.000Z"),
+        stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(cycle1.anomalies).toEqual(cycle2.anomalies);
   });
 
   it("does not flag idle agents as stuck", () => {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -2472,13 +2472,19 @@ describe("trackBrokerInboundThread", () => {
     const threads = new Map<string, FollowerThreadState>();
     trackBrokerInboundThread(
       threads,
-      { threadId: "1234.5678", channel: "C0APL58LB1R", userId: "U_ALICE" },
+      {
+        threadId: "1234.5678",
+        channel: "C0APL58LB1R",
+        userId: "U_ALICE",
+        source: "imessage",
+      },
       "TestAgent",
     );
     expect(threads.get("1234.5678")).toEqual({
       channelId: "C0APL58LB1R",
       threadTs: "1234.5678",
       userId: "U_ALICE",
+      source: "imessage",
       owner: "TestAgent",
     });
   });
@@ -2545,6 +2551,7 @@ describe("syncFollowerInboxEntries", () => {
           inboxId: 17,
           message: {
             threadId: "100.1",
+            source: "whatsapp",
             sender: "U_SENDER",
             body: "hello",
             createdAt: "100.1",
@@ -2561,6 +2568,7 @@ describe("syncFollowerInboxEntries", () => {
     expect(result.inboxMessages[0].brokerInboxId).toBe(17);
     expect(result.threadUpdates).toHaveLength(1);
     expect(result.threadUpdates[0].channelId).toBe("C_CHAN");
+    expect(result.threadUpdates[0].source).toBe("whatsapp");
     expect(result.changed).toBe(true);
   });
 
@@ -2807,6 +2815,25 @@ describe("getFollowerOwnedThreadClaims", () => {
 
     expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([
       { threadTs: "t-1", channelId: "C1" },
+    ]);
+  });
+
+  it("preserves thread source for owned-thread reclaim", () => {
+    const threads = new Map<string, FollowerThreadState>([
+      [
+        "t-1",
+        {
+          threadTs: "t-1",
+          channelId: "chat:alice",
+          userId: "alice",
+          source: "imessage",
+          owner: "Sonic Gecko",
+        },
+      ],
+    ]);
+
+    expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([
+      { threadTs: "t-1", channelId: "chat:alice", source: "imessage" },
     ]);
   });
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -2099,6 +2099,40 @@ describe("rewriteRalphLoopGhostAnomalies", () => {
     expect(cycle4.evaluation.anomalies).toEqual(["ghost agents cleared from registry: ghost-1"]);
     expect(cycle4.clearedGhostIds).toEqual(["ghost-1"]);
   });
+
+  it("suppresses freshly reaped ghost ids until they survive a later cycle", () => {
+    const cycle1 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1", "ghost-2"], ["ghost agents detected: ghost-1, ghost-2"]),
+      [],
+      { suppressedGhostIds: ["ghost-1"] },
+    );
+
+    expect(cycle1.evaluation.ghostAgentIds).toEqual(["ghost-2"]);
+    expect(cycle1.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-2"]);
+    expect(cycle1.nextReportedGhostIds).toEqual(["ghost-2"]);
+
+    const cycle2 = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1", "ghost-2"], ["ghost agents detected: ghost-1, ghost-2"]),
+      cycle1.nextReportedGhostIds,
+    );
+
+    expect(cycle2.evaluation.ghostAgentIds).toEqual(["ghost-1", "ghost-2"]);
+    expect(cycle2.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-1"]);
+    expect(cycle2.nextReportedGhostIds).toEqual(["ghost-1", "ghost-2"]);
+  });
+
+  it("does not clear or re-announce a previously reported ghost when it is temporarily suppressed", () => {
+    const cycle = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"], ["ghost agents detected: ghost-1"]),
+      ["ghost-1"],
+      { suppressedGhostIds: ["ghost-1"] },
+    );
+
+    expect(cycle.evaluation.ghostAgentIds).toEqual([]);
+    expect(cycle.evaluation.anomalies).toEqual([]);
+    expect(cycle.clearedGhostIds).toEqual([]);
+    expect(cycle.nextReportedGhostIds).toEqual(["ghost-1"]);
+  });
 });
 
 describe("buildRalphLoopNudgeMessage", () => {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -130,6 +130,7 @@ describe("loadSettings", () => {
       "slack-bridge": {
         botToken: "xoxb-test",
         appToken: "xapp-test",
+        runtimeMode: "single",
         autoConnect: true,
         allowedUsers: ["U123"],
         defaultChannel: "C456",
@@ -141,6 +142,7 @@ describe("loadSettings", () => {
     const result = loadSettings(p);
     expect(result.botToken).toBe("xoxb-test");
     expect(result.appToken).toBe("xapp-test");
+    expect(result.runtimeMode).toBe("single");
     expect(result.autoConnect).toBe(true);
     expect(result.allowedUsers).toEqual(["U123"]);
     expect(result.defaultChannel).toBe("C456");

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1904,13 +1904,13 @@ describe("evaluateRalphLoopCycle", () => {
     expect(result.anomalies).toEqual([]);
   });
 
-  it("still flags quiet workers when backlog pressure exists on their claimed work", () => {
+  it("does not treat unrelated global backlog as pressure on a quiet claimed worker", () => {
     const result = evaluateRalphLoopCycle(
       [
         {
-          emoji: "🦌",
-          name: "Busy Deer",
-          id: "busy-worker",
+          emoji: "🐗",
+          name: "Quiet Boar",
+          id: "quiet-worker",
           status: "working",
           metadata: { role: "worker" },
           lastSeen: "2026-04-01T00:09:55.000Z",
@@ -1918,6 +1918,17 @@ describe("evaluateRalphLoopCycle", () => {
           lastActivity: "2026-04-01T00:03:00.000Z",
           pendingInboxCount: 0,
           ownedThreadCount: 1,
+        },
+        {
+          emoji: "🦉",
+          name: "Ready Owl",
+          id: "ready-worker",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:09:55.000Z",
+          lastHeartbeat: "2026-04-01T00:09:55.000Z",
+          pendingInboxCount: 0,
+          ownedThreadCount: 0,
         },
       ],
       {
@@ -1929,9 +1940,11 @@ describe("evaluateRalphLoopCycle", () => {
       },
     );
 
-    expect(result.stuckAgentIds).toEqual(["busy-worker"]);
-    expect(result.anomalies).toContain(
-      "Busy Deer appears stuck (working with no activity beyond 5m threshold)",
+    expect(result.stuckAgentIds).toEqual([]);
+    expect(result.idleDrainAgentIds).toEqual(["ready-worker"]);
+    expect(result.anomalies).toContain("pending backlog (2) with 1 idle worker");
+    expect(result.anomalies).not.toContain(
+      "Quiet Boar appears stuck (working with no activity beyond 5m threshold)",
     );
   });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1149,15 +1149,26 @@ export function evaluateRalphLoopCycle(
   };
 }
 
+export interface RalphLoopGhostAnomalyRewriteOptions {
+  suppressedGhostIds?: Iterable<string>;
+}
+
 export function rewriteRalphLoopGhostAnomalies(
   evaluation: RalphLoopEvaluationResult,
   previousGhostIds: Iterable<string> = [],
+  options: RalphLoopGhostAnomalyRewriteOptions = {},
 ): RalphLoopGhostAnomalyRewriteResult {
   const priorGhostIds = new Set(previousGhostIds);
-  const nextReportedGhostIds = [...evaluation.ghostAgentIds];
-  const newGhostIds = evaluation.ghostAgentIds.filter((id) => !priorGhostIds.has(id));
+  const suppressedGhostIds = new Set(options.suppressedGhostIds ?? []);
   const currentGhostIds = new Set(evaluation.ghostAgentIds);
-  const clearedGhostIds = [...priorGhostIds].filter((id) => !currentGhostIds.has(id));
+  const visibleGhostIds = evaluation.ghostAgentIds.filter((id) => !suppressedGhostIds.has(id));
+  const retainedSuppressedGhostIds = [...priorGhostIds].filter(
+    (id) => suppressedGhostIds.has(id) && currentGhostIds.has(id),
+  );
+  const nextReportedGhostIds = [...new Set([...visibleGhostIds, ...retainedSuppressedGhostIds])];
+  const newGhostIds = visibleGhostIds.filter((id) => !priorGhostIds.has(id));
+  const currentReportedGhostIds = new Set(nextReportedGhostIds);
+  const clearedGhostIds = [...priorGhostIds].filter((id) => !currentReportedGhostIds.has(id));
   const nonGhostAnomalies = evaluation.anomalies.filter(
     (anomaly) => !anomaly.startsWith("ghost agents detected:"),
   );
@@ -1173,6 +1184,7 @@ export function rewriteRalphLoopGhostAnomalies(
   return {
     evaluation: {
       ...evaluation,
+      ghostAgentIds: visibleGhostIds,
       anomalies,
     },
     nonGhostAnomalies,

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1089,17 +1089,17 @@ export function evaluateRalphLoopCycle(
     // Stuck detection: agent reports "working" and stale activity long past the threshold,
     // but heartbeats alone only prove liveness, not lack of progress. Quiet workers can stay
     // healthy with a claimed thread and fresh heartbeats while doing non-chatty work, so only
-    // escalate when there is actual queue pressure.
+    // escalate when there is worker-local pressure (queued inbox work) or heartbeat evidence is
+    // missing. Global backlog is too broad to attribute to a specific quiet worker here.
     if (workload.status === "working" && display.health === "healthy") {
       const lastActivityMs = parseIsoMs(workload.lastActivity);
       const activityAgeMs = lastActivityMs == null ? null : Math.max(0, nowMs - lastActivityMs);
       const hasFreshHeartbeat = display.heartbeatAgeMs != null;
-      const hasQueuePressure =
-        workload.pendingInboxCount > 0 || (pendingBacklogCount > 0 && hasAssignedWork);
+      const hasWorkerLocalQueuePressure = workload.pendingInboxCount > 0;
       if (
         activityAgeMs != null &&
         activityAgeMs >= stuckWorkingThresholdMs &&
-        (hasQueuePressure || !hasFreshHeartbeat)
+        (hasWorkerLocalQueuePressure || !hasFreshHeartbeat)
       ) {
         stuckAgentIds.push(workload.id);
         const thresholdMinutes = Math.max(1, Math.round(stuckWorkingThresholdMs / 60_000));

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1617,6 +1617,7 @@ export interface FollowerThreadState {
   channelId: string;
   threadTs: string;
   userId: string;
+  source?: string;
   owner?: string;
 }
 
@@ -1624,6 +1625,7 @@ export interface FollowerInboxEntry {
   inboxId?: number;
   message: {
     threadId?: string;
+    source?: string;
     sender?: string;
     body?: string;
     createdAt?: string;
@@ -1676,18 +1678,24 @@ export function syncFollowerInboxEntries(
 
     if (threadTs && channel) {
       const existing = existingThreads.get(threadTs);
+      const source =
+        typeof entry.message.source === "string" && entry.message.source.trim().length > 0
+          ? entry.message.source.trim()
+          : existing?.source;
       const nextThread: FollowerThreadState = {
         channelId: channel,
         threadTs,
         userId: existing?.userId || sender,
         owner: existing?.owner ?? agentOwner,
+        ...(source ? { source } : {}),
       };
 
       if (
         !existing ||
         existing.channelId !== nextThread.channelId ||
         existing.userId !== nextThread.userId ||
-        existing.owner !== nextThread.owner
+        existing.owner !== nextThread.owner ||
+        existing.source !== nextThread.source
       ) {
         changed = true;
       }
@@ -1808,6 +1816,7 @@ export async function resolveFollowerThreadChannel(
         channelId,
         threadTs,
         userId: existingThread?.userId ?? "",
+        ...(existingThread?.source ? { source: existingThread.source } : {}),
         owner: existingThread?.owner,
       },
     };
@@ -1885,11 +1894,14 @@ export function normalizeOwnedThreads(
 }
 
 export function getFollowerOwnedThreadClaims(
-  threads: ReadonlyMap<string, Pick<FollowerThreadState, "threadTs" | "channelId" | "owner">>,
+  threads: ReadonlyMap<
+    string,
+    Pick<FollowerThreadState, "threadTs" | "channelId" | "source" | "owner">
+  >,
   agentName: string,
   agentAliases: Iterable<string> = [],
   ownerToken?: string,
-): Array<{ threadTs: string; channelId: string }> {
+): Array<{ threadTs: string; channelId: string; source?: string }> {
   return [...threads.values()]
     .filter(
       (thread) =>
@@ -1900,6 +1912,7 @@ export function getFollowerOwnedThreadClaims(
     .map((thread) => ({
       threadTs: thread.threadTs,
       channelId: thread.channelId,
+      ...(thread.source ? { source: thread.source } : {}),
     }));
 }
 
@@ -1910,7 +1923,7 @@ export function getFollowerOwnedThreadClaims(
  */
 export function trackBrokerInboundThread(
   threads: Map<string, FollowerThreadState>,
-  inMsg: { threadId: string; channel: string; userId?: string },
+  inMsg: { threadId: string; channel: string; userId?: string; source?: string },
   owner?: string,
 ): void {
   if (!inMsg.threadId || !inMsg.channel) return;
@@ -1919,6 +1932,7 @@ export function trackBrokerInboundThread(
       channelId: inMsg.channel,
       threadTs: inMsg.threadId,
       userId: inMsg.userId ?? "",
+      ...(inMsg.source ? { source: inMsg.source } : {}),
       owner,
     });
   }

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -17,6 +17,7 @@ export interface SlackBridgeSettings {
   logLevel?: "errors" | "actions" | "verbose";
   suggestedPrompts?: { title: string; message: string }[];
   reactionCommands?: ReactionCommandSettings;
+  runtimeMode?: "off" | "single" | "broker" | "follower";
   autoConnect?: boolean;
   autoFollow?: boolean;
   agentName?: string;

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1086,15 +1086,25 @@ export function evaluateRalphLoopCycle(
       continue;
     }
 
-    // Stuck detection: agent reports "working" but no activity for > threshold
+    // Stuck detection: agent reports "working" and stale activity long past the threshold,
+    // but heartbeats alone only prove liveness, not lack of progress. Quiet workers can stay
+    // healthy with a claimed thread and fresh heartbeats while doing non-chatty work, so only
+    // escalate when there is actual queue pressure.
     if (workload.status === "working" && display.health === "healthy") {
       const lastActivityMs = parseIsoMs(workload.lastActivity);
       const activityAgeMs = lastActivityMs == null ? null : Math.max(0, nowMs - lastActivityMs);
-      if (activityAgeMs != null && activityAgeMs >= stuckWorkingThresholdMs) {
+      const hasFreshHeartbeat = display.heartbeatAgeMs != null;
+      const hasQueuePressure =
+        workload.pendingInboxCount > 0 || (pendingBacklogCount > 0 && hasAssignedWork);
+      if (
+        activityAgeMs != null &&
+        activityAgeMs >= stuckWorkingThresholdMs &&
+        (hasQueuePressure || !hasFreshHeartbeat)
+      ) {
         stuckAgentIds.push(workload.id);
-        const ageMinutes = Math.round(activityAgeMs / 60_000);
+        const thresholdMinutes = Math.max(1, Math.round(stuckWorkingThresholdMs / 60_000));
         anomalies.push(
-          `${workload.name} appears stuck (working with no activity for ${ageMinutes}m)`,
+          `${workload.name} appears stuck (working with no activity beyond ${thresholdMinutes}m threshold)`,
         );
         continue;
       }

--- a/slack-bridge/home-tab.test.ts
+++ b/slack-bridge/home-tab.test.ts
@@ -95,7 +95,7 @@ describe("renderStandalonePinetHomeTabView", () => {
       agentName: "Cosmic Crane",
       agentEmoji: "🦩",
       connected: true,
-      mode: "standalone",
+      mode: "single",
       activeThreads: 3,
       pendingInbox: 1,
       currentBranch: "feat/home-tab",
@@ -106,6 +106,7 @@ describe("renderStandalonePinetHomeTabView", () => {
     expect(JSON.stringify(view)).toContain("Cosmic Crane");
     expect(JSON.stringify(view)).toContain("feat/home-tab");
     expect(JSON.stringify(view)).toContain("full control-plane dashboard");
+    expect(JSON.stringify(view)).toContain("single");
   });
 });
 

--- a/slack-bridge/home-tab.ts
+++ b/slack-bridge/home-tab.ts
@@ -1,4 +1,5 @@
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 export type SlackBlock = Record<string, unknown>;
 
@@ -22,7 +23,7 @@ export interface StandalonePinetHomeTabInput {
   agentName: string;
   agentEmoji: string;
   connected: boolean;
-  mode: "broker" | "worker" | "standalone";
+  mode: SlackBridgeRuntimeMode;
   activeThreads: number;
   pendingInbox: number;
   currentBranch?: string | null;
@@ -258,7 +259,7 @@ export function renderBrokerControlPlaneHomeTabView(
 export function renderStandalonePinetHomeTabView(
   input: StandalonePinetHomeTabInput,
 ): SlackHomeView {
-  const modeLabel = input.mode === "standalone" ? "direct" : input.mode;
+  const modeLabel = input.mode;
   const branch = asNonEmptyString(input.currentBranch) ?? "unknown";
   const defaultChannel = asNonEmptyString(input.defaultChannel) ?? "not configured";
 
@@ -289,7 +290,7 @@ export function renderStandalonePinetHomeTabView(
         text: [
           "• Open the *Messages* tab and start a conversation with Pinet.",
           "• Mention Pinet in a channel to continue work in-thread.",
-          "• Start broker mode to expose the full control-plane dashboard here on the Home tab.",
+          '• Use `runtimeMode: "single"` for local Slack-only mode, or `/pinet-start` and `/pinet-follow` for mesh runtimes.',
         ].join("\n"),
       }),
     ],

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -404,6 +404,235 @@ describe("slack-bridge top-level shutdown", () => {
     expect(notify).not.toHaveBeenCalled();
     expect(setStatus).toHaveBeenCalled();
   });
+
+  function createFakeWebSocketClass() {
+    return class FakeWebSocket {
+      static OPEN = 1;
+      static CLOSED = 3;
+      static instances: FakeWebSocket[] = [];
+
+      readonly url: string;
+      readyState = 0;
+      readonly close = vi.fn(() => {
+        this.readyState = FakeWebSocket.CLOSED;
+        this.emit("close");
+      });
+      readonly send = vi.fn();
+      private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+      constructor(url: string) {
+        this.url = url;
+        FakeWebSocket.instances.push(this);
+        queueMicrotask(() => {
+          this.readyState = FakeWebSocket.OPEN;
+          this.emit("open");
+        });
+      }
+
+      addEventListener(type: string, handler: (...args: unknown[]) => void): void {
+        const listeners = this.listeners.get(type) ?? [];
+        listeners.push(handler);
+        this.listeners.set(type, listeners);
+      }
+
+      private emit(type: string, ...args: unknown[]): void {
+        for (const handler of this.listeners.get(type) ?? []) {
+          handler(...args);
+        }
+      }
+    };
+  }
+
+  it("starts explicit single runtime mode on session start and reports it in pinet-status", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStatus = commands.get("pinet-status");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStatus).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://slack.com/api/apps.connections.open",
+      expect.any(Object),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await pinetStatus?.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: single"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
+
+    await sessionShutdown?.({}, ctx);
+    expect(FakeWebSocket.instances[0]?.close).toHaveBeenCalled();
+  });
+
+  it("transitions from single runtime mode to broker mode without leaving the direct Slack socket open", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "broker-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-broker-runtime-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    const restartedDb = new BrokerDB(dbPath);
+    restartedDb.initialize();
+    const brokerStop = vi.fn(async () => {
+      restartedDb.close();
+    });
+
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation(() => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: restartedDb.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    vi.spyOn(brokerModule, "startBroker").mockResolvedValue({
+      db: restartedDb,
+      server: {
+        setAgentRegistrationResolver: vi.fn(),
+        onAgentMessage: vi.fn(),
+        onAgentStatusChange: vi.fn(),
+      },
+      lock: {
+        isLeader: () => true,
+        release: vi.fn(),
+      },
+      adapters: [],
+      addAdapter: vi.fn(),
+      stop: brokerStop,
+    } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStart = commands.get("pinet-start");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStart).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await pinetStart?.handler("", ctx);
+
+    expect(FakeWebSocket.instances[0]?.close).toHaveBeenCalled();
+    expect(brokerModule.startBroker).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await sessionShutdown?.({}, ctx);
+  });
 });
 
 describe("slack-bridge Pinet reconnect", () => {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -443,6 +443,58 @@ describe("slack-bridge top-level shutdown", () => {
     };
   }
 
+  it("keeps explicit off mode free of Slack Socket Mode ingress on session start", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "off" } }));
+
+    const events = new Map<string, EventHandler>();
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "off-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-off-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    const connectSpy = vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+
+    slackBridge(pi);
+
+    await events.get("session_start")?.({}, ctx);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+    expect(setStatus).toHaveBeenCalled();
+  });
+
   it("starts explicit single runtime mode on session start and reports it in pinet-status", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -415,7 +415,7 @@ describe("slack-bridge top-level shutdown", () => {
       readyState = 0;
       readonly close = vi.fn(() => {
         this.readyState = FakeWebSocket.CLOSED;
-        this.emit("close");
+        this.emitEvent("close");
       });
       readonly send = vi.fn();
       private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
@@ -425,7 +425,7 @@ describe("slack-bridge top-level shutdown", () => {
         FakeWebSocket.instances.push(this);
         queueMicrotask(() => {
           this.readyState = FakeWebSocket.OPEN;
-          this.emit("open");
+          this.emitEvent("open");
         });
       }
 
@@ -435,7 +435,7 @@ describe("slack-bridge top-level shutdown", () => {
         this.listeners.set(type, listeners);
       }
 
-      private emit(type: string, ...args: unknown[]): void {
+      emitEvent(type: string, ...args: unknown[]): void {
         for (const handler of this.listeners.get(type) ?? []) {
           handler(...args);
         }
@@ -684,6 +684,254 @@ describe("slack-bridge top-level shutdown", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     await sessionShutdown?.({}, ctx);
+  });
+
+  it("drains queued single-mode Slack inbox work on agent_end even without Pinet enabled", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ "slack-bridge": { runtimeMode: "single", allowedUsers: ["U_SENDER"] } }),
+    );
+
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+    const sendUserMessage = vi.fn();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage,
+    } as unknown as ExtensionAPI;
+
+    let idle = false;
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => idle,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-drain-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-drain-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://slack.com/api/apps.connections.open") {
+        return new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/conversations.replies") {
+        return new Response(JSON.stringify({ ok: true, messages: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/users.info") {
+        return new Response(JSON.stringify({ ok: true, user: { real_name: "Sender" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/reactions.add") {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const agentEnd = events.get("agent_end");
+    const sessionShutdown = events.get("session_shutdown");
+
+    expect(sessionStart).toBeDefined();
+    expect(agentEnd).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+
+    const socket = FakeWebSocket.instances[0] as unknown as {
+      emitEvent: (type: string, ...args: unknown[]) => void;
+    };
+    socket.emitEvent("message", {
+      data: JSON.stringify({
+        envelope_id: "env-1",
+        type: "events_api",
+        payload: {
+          event: {
+            type: "message",
+            channel: "D123",
+            channel_type: "im",
+            user: "U_SENDER",
+            text: "hello from Slack inbox",
+            ts: "100.1",
+          },
+        },
+      }),
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith("https://slack.com/api/users.info", expect.any(Object));
+    });
+    expect(sendUserMessage).not.toHaveBeenCalled();
+
+    idle = true;
+    await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
+
+    await vi.waitFor(() => {
+      expect(sendUserMessage).toHaveBeenCalledWith(
+        expect.stringContaining("hello from Slack inbox"),
+        { deliverAs: "followUp" },
+      );
+    });
+
+    await sessionShutdown?.({}, ctx);
+  });
+
+  it("does not reschedule direct Slack reconnects after aborting a single-mode startup during broker transition", async () => {
+    vi.useFakeTimers();
+
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "abort-single-startup-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-abort-single-startup-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        const rejectAbort = () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        };
+
+        if (signal?.aborted) {
+          rejectAbort();
+          return;
+        }
+
+        signal?.addEventListener("abort", rejectAbort, { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    const restartedDb = new BrokerDB(dbPath);
+    restartedDb.initialize();
+    const brokerStop = vi.fn(async () => {
+      restartedDb.close();
+    });
+
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation(() => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: restartedDb.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    vi.spyOn(brokerModule, "startBroker").mockResolvedValue({
+      db: restartedDb,
+      server: {
+        setAgentRegistrationResolver: vi.fn(),
+        onAgentMessage: vi.fn(),
+        onAgentStatusChange: vi.fn(),
+      },
+      lock: {
+        isLeader: () => true,
+        release: vi.fn(),
+      },
+      adapters: [],
+      addAdapter: vi.fn(),
+      stop: brokerStop,
+    } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStart = commands.get("pinet-start");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStart).toBeDefined();
+
+    try {
+      const startup = sessionStart?.({}, ctx);
+      await Promise.resolve();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      await pinetStart?.handler("", ctx);
+      await startup;
+
+      await vi.advanceTimersByTimeAsync(5_001);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(brokerModule.startBroker).toHaveBeenCalledTimes(1);
+
+      await sessionShutdown?.({}, ctx);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -514,6 +514,7 @@ export default function (pi: ExtensionAPI) {
     channelId: string;
     threadTs: string;
     userId: string;
+    source?: string;
     context?: { channelId: string; teamId: string };
     owner?: string; // agent name that claimed this thread (first-responder-wins)
   }
@@ -1042,6 +1043,7 @@ export default function (pi: ExtensionAPI) {
       channelId: event.channelId,
       threadTs: event.threadTs,
       userId: event.userId,
+      source: "slack",
     };
 
     if (event.context) {
@@ -1135,6 +1137,7 @@ export default function (pi: ExtensionAPI) {
           channelId: item.channel,
           threadTs,
           userId: (reactedMessage.user as string | undefined) ?? user,
+          source: "slack",
         });
       }
 
@@ -1223,7 +1226,7 @@ export default function (pi: ExtensionAPI) {
     const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
 
     if (!threads.has(threadTs)) {
-      threads.set(threadTs, { channelId: channel, threadTs, userId });
+      threads.set(threadTs, { channelId: channel, threadTs, userId, source: "slack" });
     }
 
     const localOwner = threads.get(threadTs)?.owner;
@@ -1314,6 +1317,7 @@ export default function (pi: ExtensionAPI) {
         channelId: normalized.channel,
         threadTs: normalized.threadTs,
         userId: normalized.userId,
+        source: "slack",
       });
     }
 
@@ -1441,6 +1445,7 @@ export default function (pi: ExtensionAPI) {
           channelId,
           threadTs,
           userId: "",
+          source: "slack",
           owner: agentOwnerToken,
         });
       } else {
@@ -1453,9 +1458,9 @@ export default function (pi: ExtensionAPI) {
     getBotUserId: () => botUserId,
     claimThreadOwnership: (threadTs, channelId) => {
       if (brokerRole === "broker" && activeRouter && activeSelfId) {
-        activeRouter.claimThread(threadTs, activeSelfId);
+        activeRouter.claimThread(threadTs, activeSelfId, channelId, "slack");
       } else if (brokerRole === "follower" && brokerClient?.client) {
-        void brokerClient.client.claimThread(threadTs, channelId).catch(() => {
+        void brokerClient.client.claimThread(threadTs, channelId, "slack").catch(() => {
           /* broker gone, best effort */
         });
       }
@@ -3153,7 +3158,7 @@ export default function (pi: ExtensionAPI) {
           agentOwnerToken,
         )) {
           try {
-            await client.claimThread(thread.threadTs, thread.channelId);
+            await client.claimThread(thread.threadTs, thread.channelId, thread.source ?? "slack");
           } catch {
             break;
           }
@@ -3293,6 +3298,7 @@ export default function (pi: ExtensionAPI) {
                 existing.threadTs = nextThread.threadTs;
                 existing.userId = nextThread.userId;
                 existing.owner = nextThread.owner;
+                existing.source = nextThread.source ?? existing.source;
               }
               lastDmChannel = synced.lastDmChannel;
               inbox.push(...synced.inboxMessages);

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -13,8 +13,6 @@ import {
   type RalphLoopEvaluationResult,
   type RalphLoopEvaluationOptions,
   loadSettings as loadSettingsFromFile,
-  buildAllowlist,
-  isUserAllowed as checkUserAllowed,
   formatInboxMessages,
   formatPinetInboxMessages,
   buildPinetSkinAssignment,
@@ -29,8 +27,6 @@ import {
   type PinetControlCommand,
   type PinetRemoteControlState,
   formatAgentList,
-  stripBotMention,
-  isChannelId,
   callSlackAPI,
   createAbortableOperationTracker,
   isAbortError,
@@ -84,7 +80,6 @@ import {
   deliverTrackedSlackFollowUpMessage,
   type PendingSlackToolPolicyTurn,
 } from "./slack-turn-guardrails.js";
-import { buildSlackInboundMessageText } from "./slack-message-context.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import {
   buildReactionPromptGuidelines,
@@ -96,7 +91,7 @@ import { startBroker, type Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
-import { MessageRouter, extractPiAgentThreadOwnerHint } from "./broker/router.js";
+import { MessageRouter } from "./broker/router.js";
 import {
   DEFAULT_BROKER_MAINTENANCE_INTERVAL_MS,
   DEFAULT_BUSY_ASSIGNMENT_AGE_MS,
@@ -119,15 +114,24 @@ import {
   stopRalphLoop,
 } from "./ralph-loop.js";
 import {
-  extractSlackInteractivePayloadFromEnvelope,
-  normalizeSlackBlockActionPayload,
-  normalizeSlackViewSubmissionPayload,
-} from "./slack-block-kit.js";
-import {
-  extractSlackSocketDedupKey,
+  addSlackReaction,
+  buildSlackUserAllowlist,
+  classifyMessage,
+  clearSlackThreadStatus,
+  fetchSlackMessageByTs as fetchSlackMessageByTsFromSlack,
+  isSlackUserAllowed,
+  removeSlackReaction,
+  resolveSlackChannelId,
+  resolveSlackThreadOwnerHint,
+  resolveSlackUserName,
+  setSlackSuggestedPrompts,
+  SlackSocketModeClient,
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
-} from "./slack-socket-dedup.js";
+  type ParsedAppHomeOpened,
+  type ParsedThreadContextChanged,
+  type ParsedThreadStarted,
+} from "./slack-access.js";
 import {
   createFollowerDeliveryState,
   drainFollowerAckBatches,
@@ -207,11 +211,14 @@ export default function (pi: ExtensionAPI) {
   }
 
   // allowedUsers: settings.json takes priority, env var as fallback
-  let allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
+  let allowedUsers = buildSlackUserAllowlist(
+    settings.allowedUsers,
+    process.env.SLACK_ALLOWED_USERS,
+  );
   let reactionCommands = resolveReactionCommands(settings.reactionCommands);
 
   function isUserAllowed(userId: string): boolean {
-    return checkUserAllowed(allowedUsers, userId);
+    return isSlackUserAllowed(allowedUsers, userId);
   }
 
   const initialIdentity = resolveAgentIdentity(settings, process.env.PI_NICKNAME, process.cwd());
@@ -340,7 +347,7 @@ export default function (pi: ExtensionAPI) {
     settings = loadSettingsFromFile();
     botToken = settings.botToken ?? process.env.SLACK_BOT_TOKEN;
     appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
-    allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
+    allowedUsers = buildSlackUserAllowlist(settings.allowedUsers, process.env.SLACK_ALLOWED_USERS);
     guardrails = settings.security ?? {};
     reactionCommands = resolveReactionCommands(settings.reactionCommands);
     securityPrompt = buildSecurityPrompt(guardrails);
@@ -512,8 +519,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   let botUserId: string | null = null;
-  let ws: WebSocket | null = null;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let singleRuntimeSlackSocket: SlackSocketModeClient | null = null;
   let shuttingDown = false;
 
   const threads = new Map<string, ThreadInfo>();
@@ -670,60 +676,47 @@ export default function (pi: ExtensionAPI) {
   // ─── Helpers ─────────────────────────────────────────
 
   async function addReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await slack("reactions.add", botToken!, { channel, timestamp: ts, name: emoji });
-    } catch {
-      /* already_reacted or non-critical */
-    }
+    await addSlackReaction({
+      slack,
+      token: botToken!,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   async function removeReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    try {
-      await slack("reactions.remove", botToken!, { channel, timestamp: ts, name: emoji });
-    } catch {
-      /* not_reacted or non-critical */
-    }
+    await removeSlackReaction({
+      slack,
+      token: botToken!,
+      channel,
+      timestamp: ts,
+      emoji,
+    });
   }
 
   async function resolveUser(userId: string): Promise<string> {
-    const cached = userNames.get(userId);
-    if (cached) return cached;
-    try {
-      const res = await slack("users.info", botToken!, { user: userId });
-      if (shuttingDown) return userId;
-      const u = res.user as { real_name?: string; name?: string };
-      const name = u.real_name ?? u.name ?? userId;
-      userNames.set(userId, name);
+    const hadCachedUser = userNames.get(userId) != null;
+    const name = await resolveSlackUserName({
+      slack,
+      token: botToken!,
+      userId,
+      cache: userNames,
+      shouldUseResult: () => !shuttingDown,
+    });
+    if (!hadCachedUser && userNames.get(userId) != null) {
       persistState();
-      return name;
-    } catch {
-      return userId;
     }
+    return name;
   }
 
   async function resolveChannel(nameOrId: string): Promise<string> {
-    if (isChannelId(nameOrId)) return nameOrId;
-    const name = nameOrId.replace(/^#/, "");
-    const cached = channelCache.get(name);
-    if (cached) return cached;
-
-    let cursor: string | undefined;
-    do {
-      const body: Record<string, unknown> = {
-        types: "public_channel,private_channel",
-        limit: 200,
-      };
-      if (cursor) body.cursor = cursor;
-      const res = await slack("conversations.list", botToken!, body);
-      const channels = res.channels as { id: string; name: string }[];
-      for (const ch of channels) {
-        channelCache.set(ch.name, ch.id);
-      }
-      if (channelCache.has(name)) return channelCache.get(name)!;
-      cursor = (res.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-    } while (cursor);
-
-    throw new Error(`Channel "${name}" not found.`);
+    return resolveSlackChannelId({
+      slack,
+      token: botToken!,
+      nameOrId,
+      cache: channelCache,
+    });
   }
 
   const activityLogger = new SlackActivityLogger({
@@ -823,15 +816,12 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
-    try {
-      await slack("assistant.threads.setStatus", botToken!, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        status: "",
-      });
-    } catch {
-      /* non-critical */
-    }
+    await clearSlackThreadStatus({
+      slack,
+      token: botToken!,
+      channelId,
+      threadTs,
+    });
   }
 
   async function setSuggestedPrompts(channelId: string, threadTs: string): Promise<void> {
@@ -840,15 +830,13 @@ export default function (pi: ExtensionAPI) {
       { title: "Help", message: `${agentName}, I need help with something in the codebase` },
       { title: "Review", message: `${agentName}, summarise the recent changes` },
     ];
-    try {
-      await slack("assistant.threads.setSuggestedPrompts", botToken!, {
-        channel_id: channelId,
-        thread_ts: threadTs,
-        prompts,
-      });
-    } catch {
-      /* non-critical */
-    }
+    await setSlackSuggestedPrompts({
+      slack,
+      token: botToken!,
+      channelId,
+      threadTs,
+      prompts,
+    });
   }
 
   function formatConfirmationAction(action: string): string {
@@ -988,34 +976,14 @@ export default function (pi: ExtensionAPI) {
   // next incoming message once it sees the winner's metadata.
 
   async function resolveThreadOwner(channel: string, threadTs: string): Promise<string | null> {
-    try {
-      const res = await slack("conversations.replies", botToken!, {
-        channel,
-        ts: threadTs,
-        limit: 50,
-        include_all_metadata: true,
-      });
-      const msgs = (res.messages as Record<string, unknown>[]) ?? [];
-      for (const m of msgs) {
-        if (!m.bot_id) continue;
-        const meta = m.metadata as
-          | {
-              event_type?: string;
-              event_payload?: { agent?: string; agent_owner?: string };
-            }
-          | undefined;
-        if (meta?.event_type !== "pi_agent_msg") continue;
-        if (typeof meta.event_payload?.agent_owner === "string" && meta.event_payload.agent_owner) {
-          return meta.event_payload.agent_owner;
-        }
-        if (meta.event_payload?.agent) {
-          return meta.event_payload.agent;
-        }
-      }
-    } catch {
-      // If we can't check, allow the message through rather than blocking
-    }
-    return null;
+    const hint = await resolveSlackThreadOwnerHint({
+      slack,
+      token: botToken!,
+      channel,
+      threadTs,
+      limit: 50,
+    });
+    return hint?.agentOwner ?? hint?.agentName ?? null;
   }
 
   // ─── Socket Mode (native WebSocket) ─────────────────
@@ -1023,128 +991,61 @@ export default function (pi: ExtensionAPI) {
   async function connectSocketMode(ctx: ExtensionContext): Promise<void> {
     if (shuttingDown) return;
 
-    try {
-      const res = await slack("apps.connections.open", appToken!);
-      ws = new WebSocket(res.url as string);
-
-      ws.addEventListener("open", () => setExtStatus(ctx, "ok"));
-
-      ws.addEventListener("message", (event) => {
-        void handleFrame(String(event.data), ctx);
-      });
-
-      ws.addEventListener("close", () => {
-        if (!shuttingDown && currentRuntimeMode === "single") scheduleReconnect(ctx);
-      });
-
-      ws.addEventListener("error", () => {
-        /* close fires after */
-      });
-    } catch (err) {
-      if (!isAbortError(err)) {
-        console.error(`[slack-bridge] Socket Mode: ${msg(err)}`);
-      }
-      scheduleReconnect(ctx);
-    }
-  }
-
-  async function handleFrame(raw: string, ctx: ExtensionContext): Promise<void> {
-    if (shuttingDown) return;
-
-    let dedupKey: string | null = null;
-
-    try {
-      const data = JSON.parse(raw) as Record<string, unknown>;
-
-      // ack every envelope
-      if (data.envelope_id) {
-        ws?.send(JSON.stringify({ envelope_id: data.envelope_id }));
-      }
-
-      dedupKey = extractSlackSocketDedupKey(data);
-      if (dedupKey) {
-        if (processedSlackSocketDeliveries.has(dedupKey)) {
-          return;
+    singleRuntimeSlackSocket = new SlackSocketModeClient({
+      slack,
+      botToken: botToken!,
+      appToken: appToken!,
+      resolveBotUserIdOnConnect: false,
+      dedup: processedSlackSocketDeliveries,
+      abortAndWait: () => slackRequests.abortAndWait(),
+      onOpen: () => setExtStatus(ctx, "ok"),
+      onReconnectScheduled: () => {
+        if (!shuttingDown && currentRuntimeMode === "single") {
+          setExtStatus(ctx, "reconnecting");
         }
-        processedSlackSocketDeliveries.add(dedupKey);
-      }
-
-      if (data.type === "disconnect") {
-        scheduleReconnect(ctx);
-        return;
-      }
-
-      const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
-      if (interactivePayload) {
-        if (interactivePayload.type === "block_actions") {
-          await onBlockActions(interactivePayload, ctx);
-        } else if (interactivePayload.type === "view_submission") {
-          await onViewSubmission(interactivePayload, ctx);
+      },
+      onError: (err) => {
+        if (!isAbortError(err)) {
+          console.error(`[slack-bridge] Slack access: ${msg(err)}`);
         }
-        return;
-      }
-
-      if (data.type !== "events_api") return;
-
-      const evt = (data.payload as { event: Record<string, unknown> }).event;
-
-      switch (evt.type) {
-        case "assistant_thread_started":
-          await onThreadStarted(evt);
-          break;
-        case "assistant_thread_context_changed":
-          onContextChanged(evt);
-          break;
-        case "app_home_opened":
-          await onAppHomeOpened(evt, ctx);
-          break;
-        case "message":
-          if (!evt.subtype && !evt.bot_id) await onMessage(evt, ctx);
-          break;
-        case "reaction_added":
-          await onReactionAdded(evt, ctx);
-          break;
-        case "member_joined_channel":
-          if ((evt.user as string) === botUserId) {
-            const ch = evt.channel as string;
-            ctx.ui.notify(`Pinet added to channel ${ch}`, "info");
-            inbox.push({
-              channel: ch,
-              threadTs: "",
-              userId: "system",
-              text: `Pinet was added to channel <#${ch}>. You can now post messages there.`,
-              timestamp: String(Date.now() / 1000),
-            });
-            updateBadge();
-            maybeDrainInboxIfIdle(ctx);
-          }
-          break;
-      }
-    } catch {
-      if (dedupKey) {
-        processedSlackSocketDeliveries.delete(dedupKey);
-      }
-      /* malformed frame */
-    }
+      },
+      onThreadStarted: (event) => onThreadStarted(event),
+      onThreadContextChanged: (event) => onContextChanged(event),
+      onAppHomeOpened: (event) => onAppHomeOpened(event, ctx),
+      onMessage: (event) => onMessage(event, ctx),
+      onReactionAdded: (event) => onReactionAdded(event, ctx),
+      onMemberJoinedChannel: async ({ channel, isSelf }) => {
+        if (!isSelf) return;
+        ctx.ui.notify(`Pinet added to channel ${channel}`, "info");
+        inbox.push({
+          channel,
+          threadTs: "",
+          userId: "system",
+          text: `Pinet was added to channel <#${channel}>. You can now post messages there.`,
+          timestamp: String(Date.now() / 1000),
+        });
+        updateBadge();
+        maybeDrainInboxIfIdle(ctx);
+      },
+      onInteractive: (event) => queueInteractiveInboxEvent(event, ctx),
+    });
+    await singleRuntimeSlackSocket.connect();
+    botUserId = singleRuntimeSlackSocket?.getBotUserId() ?? botUserId;
   }
 
   // ─── Assistant events ───────────────────────────────
 
-  async function onThreadStarted(evt: Record<string, unknown>): Promise<void> {
+  async function onThreadStarted(event: ParsedThreadStarted): Promise<void> {
     if (shuttingDown) return;
 
-    const t = evt.assistant_thread as Record<string, unknown>;
-    if (!t) return;
-
     const info: ThreadInfo = {
-      channelId: t.channel_id as string,
-      threadTs: t.thread_ts as string,
-      userId: t.user_id as string,
+      channelId: event.channelId,
+      threadTs: event.threadTs,
+      userId: event.userId,
     };
 
-    const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-    if (ctx?.channel_id) {
-      info.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+    if (event.context) {
+      info.context = event.context;
     }
 
     threads.set(info.threadTs, info);
@@ -1154,54 +1055,32 @@ export default function (pi: ExtensionAPI) {
     await setSuggestedPrompts(info.channelId, info.threadTs);
   }
 
-  function onContextChanged(evt: Record<string, unknown>): void {
+  function onContextChanged(event: ParsedThreadContextChanged): void {
     if (shuttingDown) return;
 
-    const t = evt.assistant_thread as Record<string, unknown>;
-    if (!t) return;
+    const existing = threads.get(event.threadTs);
+    if (!existing || !event.context) return;
 
-    const existing = threads.get(t.thread_ts as string);
-    if (!existing) return;
-
-    const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
-    if (ctx?.channel_id) {
-      existing.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
-      persistState();
-    }
+    existing.context = event.context;
+    persistState();
   }
 
-  async function onAppHomeOpened(
-    evt: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ): Promise<void> {
+  async function onAppHomeOpened(event: ParsedAppHomeOpened, ctx: ExtensionContext): Promise<void> {
     if (shuttingDown) return;
 
-    const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
-    const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
-    if (!userId || tab !== "home") {
-      return;
-    }
-
-    await publishCurrentPinetHomeTabSafely(userId, ctx);
+    await publishCurrentPinetHomeTabSafely(event.userId, ctx);
   }
 
   async function fetchSlackMessageByTs(
     channel: string,
     messageTs: string,
   ): Promise<Record<string, unknown> | null> {
-    try {
-      const response = await slack("conversations.history", botToken!, {
-        channel,
-        oldest: messageTs,
-        latest: messageTs,
-        inclusive: true,
-        limit: 1,
-      });
-      const messages = (response.messages as Record<string, unknown>[]) ?? [];
-      return messages.find((message) => message.ts === messageTs) ?? messages[0] ?? null;
-    } catch {
-      return null;
-    }
+    return fetchSlackMessageByTsFromSlack({
+      slack,
+      token: botToken!,
+      channel,
+      messageTs,
+    });
   }
 
   async function onReactionAdded(
@@ -1338,104 +1217,84 @@ export default function (pi: ExtensionAPI) {
   async function onMessage(evt: Record<string, unknown>, ctx: ExtensionContext): Promise<void> {
     if (shuttingDown) return;
 
-    const text = (evt.text as string) ?? "";
-    const user = evt.user as string;
-    const threadTs = evt.thread_ts as string | undefined;
-    const channel = evt.channel as string;
-    const channelType = evt.channel_type as string | undefined;
+    const classified = classifyMessage(evt, botUserId, new Set(threads.keys()));
+    if (!classified.relevant) return;
 
-    const isTracked = !!threadTs && threads.has(threadTs);
-    const isDM = channelType === "im";
-    const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
+    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
 
-    if (!isTracked && !isDM && !isMention) return;
-
-    const effectiveTs = threadTs ?? (evt.ts as string);
-
-    // track if new (needed for ownership check below)
-    if (!threads.has(effectiveTs)) {
-      threads.set(effectiveTs, { channelId: channel, threadTs: effectiveTs, userId: user });
+    if (!threads.has(threadTs)) {
+      threads.set(threadTs, { channelId: channel, threadTs, userId });
     }
 
-    // ── Thread ownership check (before allowlist so only the owning agent rejects) ──
-    const localOwner = threads.get(effectiveTs)?.owner;
+    const localOwner = threads.get(threadTs)?.owner;
     if (localOwner && !agentOwnsThread(localOwner, agentName, agentAliases, agentOwnerToken)) {
       return;
     }
     if (localOwner) {
-      const thread = threads.get(effectiveTs);
+      const thread = threads.get(threadTs);
       if (thread) {
         normalizeOwnedThreads([thread], agentName, agentOwnerToken, agentAliases);
       }
     }
 
-    if (!localOwner && !unclaimedThreads.has(effectiveTs)) {
-      const remoteOwner = await resolveThreadOwner(channel, effectiveTs);
+    if (!localOwner && !unclaimedThreads.has(threadTs)) {
+      const remoteOwner = await resolveThreadOwner(channel, threadTs);
       if (shuttingDown) return;
       if (remoteOwner && !agentOwnsThread(remoteOwner, agentName, agentAliases, agentOwnerToken)) {
-        const t = threads.get(effectiveTs);
-        if (t) t.owner = remoteOwner; // cache so we skip instantly next time
+        const thread = threads.get(threadTs);
+        if (thread) thread.owner = remoteOwner;
         return;
       }
       if (agentOwnsThread(remoteOwner ?? undefined, agentName, agentAliases, agentOwnerToken)) {
-        const t = threads.get(effectiveTs);
-        if (t) t.owner = agentOwnerToken;
+        const thread = threads.get(threadTs);
+        if (thread) thread.owner = agentOwnerToken;
       }
       if (!remoteOwner) {
-        unclaimedThreads.add(effectiveTs); // negative cache: no owner found yet
+        unclaimedThreads.add(threadTs);
       }
     }
 
-    // ── User allowlist check ──
-    if (!isUserAllowed(user)) {
+    if (!isUserAllowed(userId)) {
       await slack("chat.postMessage", botToken!, {
         channel,
-        thread_ts: effectiveTs,
+        thread_ts: threadTs,
         text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
       });
       return;
     }
 
-    if (isDM) lastDmChannel = channel;
+    if (isDM) {
+      lastDmChannel = channel;
+    }
     persistState();
 
-    // Determine if this is a new channel mention (not DM, not already tracked)
-    const isChannelMention = isMention && !isDM && !isTracked;
-
-    // Strip <@BOT_ID> from text for channel mentions
-    const cleanText = isChannelMention ? stripBotMention(text, botUserId!) : text;
-    const enrichedText = buildSlackInboundMessageText(cleanText, evt);
-    const confirmationResult = consumeConfirmationReply(effectiveTs, cleanText);
+    const confirmationResult = consumeConfirmationReply(threadTs, text);
     const messageText =
       confirmationResult === null
-        ? enrichedText
+        ? text
         : confirmationResult.approved
-          ? `${enrichedText}\n\n✅ User approved security confirmation request in this thread.`
-          : `${enrichedText}\n\n❌ User denied security confirmation request in this thread.`;
+          ? `${text}\n\n✅ User approved security confirmation request in this thread.`
+          : `${text}\n\n❌ User denied security confirmation request in this thread.`;
 
-    const name = await resolveUser(user);
+    const name = await resolveUser(userId);
     if (shuttingDown) return;
-    ctx.ui.notify(`${name}: ${cleanText.slice(0, 100)}`, "info");
+    ctx.ui.notify(`${name}: ${text.slice(0, 100)}`, "info");
 
-    // React with 👀 to acknowledge (no chat lock)
-    const messageTs = (evt.ts as string) ?? effectiveTs;
     void addReaction(channel, messageTs, "eyes");
-    const pending = pendingEyes.get(effectiveTs) ?? [];
+    const pending = pendingEyes.get(threadTs) ?? [];
     pending.push({ channel, messageTs });
-    pendingEyes.set(effectiveTs, pending);
+    pendingEyes.set(threadTs, pending);
 
-    // Queue in inbox
     inbox.push({
       channel,
-      threadTs: effectiveTs,
-      userId: user,
+      threadTs,
+      userId,
       text: messageText,
-      timestamp: (evt.ts as string) ?? effectiveTs,
+      timestamp: messageTs,
       ...(isChannelMention && { isChannelMention: true }),
     });
     updateBadge();
 
-    // If agent is idle, trigger immediately — otherwise agent_end drains it
     maybeDrainInboxIfIdle(ctx);
   }
 
@@ -1517,52 +1376,16 @@ export default function (pi: ExtensionAPI) {
     maybeDrainInboxIfIdle(ctx);
   }
 
-  async function onBlockActions(
-    payload: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ): Promise<void> {
-    if (shuttingDown) return;
-
-    const normalized = normalizeSlackBlockActionPayload(payload);
-    if (!normalized) return;
-    await queueInteractiveInboxEvent(normalized, ctx);
-  }
-
-  async function onViewSubmission(
-    payload: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ): Promise<void> {
-    if (shuttingDown) return;
-
-    const normalized = normalizeSlackViewSubmissionPayload(payload);
-    if (!normalized) return;
-    await queueInteractiveInboxEvent(normalized, ctx);
-  }
-
   // ─── Reconnect / status ─────────────────────────────
-
-  function scheduleReconnect(ctx: ExtensionContext): void {
-    if (shuttingDown || reconnectTimer || currentRuntimeMode !== "single") return;
-    setExtStatus(ctx, "reconnecting");
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      if (shuttingDown || currentRuntimeMode !== "single") {
-        return;
-      }
-      void connectSocketMode(ctx);
-    }, 5000);
-  }
 
   async function disconnect(): Promise<void> {
     shuttingDown = true;
-    if (reconnectTimer) clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-    try {
-      ws?.close();
-    } catch {
-      /* ignore */
+    const socket = singleRuntimeSlackSocket;
+    singleRuntimeSlackSocket = null;
+    if (socket) {
+      await socket.disconnect();
+      return;
     }
-    ws = null;
     await slackRequests.abortAndWait();
   }
 
@@ -2110,7 +1933,7 @@ export default function (pi: ExtensionAPI) {
             : currentRuntimeMode === "follower"
               ? brokerClient != null
               : currentRuntimeMode === "single"
-                ? ws?.readyState === WebSocket.OPEN
+                ? (singleRuntimeSlackSocket?.isConnected() ?? false)
                 : false,
         mode: currentRuntimeMode,
         activeThreads: threads.size,
@@ -3061,30 +2884,13 @@ export default function (pi: ExtensionAPI) {
         channel: string,
         threadTs: string,
       ): Promise<{ agentOwner?: string; agentName?: string } | null> {
-        if (!channel || !threadTs) return null;
-
-        const cacheKey = `${channel}:${threadTs}`;
-        const cached = brokerThreadOwnerHintCache.get(cacheKey);
-        if (cached) {
-          return cached;
-        }
-
-        try {
-          const response = await slack("conversations.replies", botToken!, {
-            channel,
-            ts: threadTs,
-            limit: 200,
-            include_all_metadata: true,
-          });
-          const replies = (response.messages as Record<string, unknown>[]) ?? [];
-          const hint = extractPiAgentThreadOwnerHint(replies);
-          if (hint) {
-            brokerThreadOwnerHintCache.set(cacheKey, hint);
-          }
-          return hint;
-        } catch {
-          return null;
-        }
+        return resolveSlackThreadOwnerHint({
+          slack,
+          token: botToken!,
+          channel,
+          threadTs,
+          cache: brokerThreadOwnerHintCache,
+        });
       }
 
       adapter.onInbound((inMsg) => {
@@ -3255,7 +3061,7 @@ export default function (pi: ExtensionAPI) {
         : currentRuntimeMode === "follower"
           ? brokerClient != null
           : currentRuntimeMode === "single"
-            ? ws?.readyState === WebSocket.OPEN
+            ? (singleRuntimeSlackSocket?.isConnected() ?? false)
             : false,
     brokerRole: () => brokerRole,
     agentName: () => agentName,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -79,6 +79,11 @@ import {
   type SecurityGuardrails,
 } from "./guardrails.js";
 import { evaluateSlackOriginCoreToolPolicy } from "./core-tool-guardrails.js";
+import {
+  consumePendingSlackToolPolicyTurn,
+  deliverTrackedSlackFollowUpMessage,
+  type PendingSlackToolPolicyTurn,
+} from "./slack-turn-guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import {
   buildReactionPromptGuidelines,
@@ -602,12 +607,6 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Inbox queue ────────────────────────────────────
 
-  interface PendingSlackToolPolicyTurn {
-    prompt: string;
-    threadTs: string | undefined;
-    threadCount: number;
-  }
-
   const inbox: InboxMessage[] = [];
   const brokerDeliveryState = createBrokerDeliveryState();
   const AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS = 1_500;
@@ -618,22 +617,6 @@ export default function (pi: ExtensionAPI) {
   const pendingSlackToolPolicyTurns: PendingSlackToolPolicyTurn[] = [];
   let nextSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
   let activeSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
-
-  function rememberPendingSlackToolPolicyTurn(prompt: string, messages: InboxMessage[]): void {
-    const threadIds = [...new Set(messages.map((message) => message.threadTs).filter(Boolean))];
-    pendingSlackToolPolicyTurns.push({
-      prompt,
-      threadTs: threadIds.length === 1 ? threadIds[0] : undefined,
-      threadCount: threadIds.length,
-    });
-  }
-
-  function consumePendingSlackToolPolicyTurn(text: string): PendingSlackToolPolicyTurn | null {
-    const index = pendingSlackToolPolicyTurns.findIndex((entry) => entry.prompt === text);
-    if (index < 0) return null;
-    const [entry] = pendingSlackToolPolicyTurns.splice(index, 1);
-    return entry ?? null;
-  }
 
   function updateBadge(): void {
     if (!extCtx?.hasUI) return;
@@ -3777,8 +3760,14 @@ export default function (pi: ExtensionAPI) {
       prompt = securityPrompt + "\n\n" + prompt;
     }
 
-    if (deliverFollowUpMessage(prompt)) {
-      rememberPendingSlackToolPolicyTurn(prompt, pending);
+    if (
+      deliverTrackedSlackFollowUpMessage({
+        queue: pendingSlackToolPolicyTurns,
+        prompt,
+        messages: pending,
+        deliver: deliverFollowUpMessage,
+      })
+    ) {
       if (brokerInboxIds.length > 0) {
         if (brokerRole === "follower") {
           markFollowerInboxIdsDelivered(followerDeliveryState, brokerInboxIds);
@@ -3804,7 +3793,10 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    nextSlackToolPolicyTurn = consumePendingSlackToolPolicyTurn(event.text);
+    nextSlackToolPolicyTurn = consumePendingSlackToolPolicyTurn(
+      pendingSlackToolPolicyTurns,
+      event.text,
+    );
   });
 
   pi.on("turn_start", async () => {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -168,6 +168,10 @@ import {
   renderBrokerControlPlaneHomeTabView,
   renderStandalonePinetHomeTabView,
 } from "./home-tab.js";
+import {
+  type SlackBridgeRuntimeMode,
+  resolveSlackBridgeStartupRuntimeMode,
+} from "./runtime-mode.js";
 
 // Settings and helpers imported from ./helpers.js
 
@@ -1030,7 +1034,7 @@ export default function (pi: ExtensionAPI) {
       });
 
       ws.addEventListener("close", () => {
-        if (!shuttingDown) scheduleReconnect(ctx);
+        if (!shuttingDown && currentRuntimeMode === "single") scheduleReconnect(ctx);
       });
 
       ws.addEventListener("error", () => {
@@ -1649,6 +1653,7 @@ export default function (pi: ExtensionAPI) {
 
   // Forward-declared — assigned in the Commands section below.
   let pinetEnabled = false;
+  let currentRuntimeMode: SlackBridgeRuntimeMode = "off";
   let brokerRole: "broker" | "follower" | null = null;
   let pinetRegistrationBlocked = false;
   let activeBroker: Broker | null = null;
@@ -2096,9 +2101,15 @@ export default function (pi: ExtensionAPI) {
       view: renderStandalonePinetHomeTabView({
         agentName,
         agentEmoji,
-        connected: activeBroker != null || ws?.readyState === WebSocket.OPEN,
-        mode:
-          brokerRole === "broker" ? "broker" : brokerRole === "follower" ? "worker" : "standalone",
+        connected:
+          currentRuntimeMode === "broker"
+            ? activeBroker != null
+            : currentRuntimeMode === "follower"
+              ? brokerClient != null
+              : currentRuntimeMode === "single"
+                ? ws?.readyState === WebSocket.OPEN
+                : false,
+        mode: currentRuntimeMode,
         activeThreads: threads.size,
         pendingInbox: inbox.length,
         currentBranch,
@@ -2468,6 +2479,46 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  async function transitionToRuntimeMode(
+    ctx: ExtensionContext,
+    mode: SlackBridgeRuntimeMode,
+  ): Promise<void> {
+    if (currentRuntimeMode === mode) {
+      if (mode === "off") {
+        setExtStatus(ctx, "off");
+      }
+      return;
+    }
+
+    if (currentRuntimeMode !== "off") {
+      await stopPinetRuntime(ctx, { releaseIdentity: true });
+      // Runtime transitions keep the extension alive in-process, so restore a
+      // fresh top-level Slack request tracker after tearing the prior runtime down.
+      resetTopLevelSlackRequests();
+      shuttingDown = false;
+    }
+
+    if (mode === "off") {
+      currentRuntimeMode = "off";
+      setExtStatus(ctx, "off");
+      return;
+    }
+
+    if (mode === "single") {
+      currentRuntimeMode = "single";
+      setExtStatus(ctx, "reconnecting");
+      await connectSocketMode(ctx);
+      return;
+    }
+
+    if (mode === "broker") {
+      await connectAsBroker(ctx);
+      return;
+    }
+
+    await connectAsFollower(ctx);
+  }
+
   async function stopPinetRuntime(
     ctx: ExtensionContext,
     options: { releaseIdentity: boolean },
@@ -2531,6 +2582,7 @@ export default function (pi: ExtensionAPI) {
     activityLogger.clearPending();
     brokerRole = null;
     pinetEnabled = false;
+    currentRuntimeMode = "off";
     setExtStatus(ctx, "off");
   }
 
@@ -3098,6 +3150,7 @@ export default function (pi: ExtensionAPI) {
       activeSelfId = selfId;
       brokerRole = "broker";
       pinetEnabled = true;
+      currentRuntimeMode = "broker";
 
       resetBrokerDeliveryState(brokerDeliveryState);
       const releasedBrokerClaims = broker.db.releaseThreadClaims(selfId);
@@ -3192,6 +3245,15 @@ export default function (pi: ExtensionAPI) {
   registerPinetCommands(pi, {
     pinetEnabled: () => pinetEnabled,
     pinetRegistrationBlocked: () => pinetRegistrationBlocked,
+    runtimeMode: () => currentRuntimeMode,
+    runtimeConnected: () =>
+      currentRuntimeMode === "broker"
+        ? activeBroker != null
+        : currentRuntimeMode === "follower"
+          ? brokerClient != null
+          : currentRuntimeMode === "single"
+            ? ws?.readyState === WebSocket.OPEN
+            : false,
     brokerRole: () => brokerRole,
     agentName: () => agentName,
     agentEmoji: () => agentEmoji,
@@ -3216,8 +3278,8 @@ export default function (pi: ExtensionAPI) {
     lastBrokerControlPlaneHomeTabRefreshAt: () => lastBrokerControlPlaneHomeTabRefreshAt,
     lastBrokerControlPlaneHomeTabError: () => lastBrokerControlPlaneHomeTabError,
     getPinetRegistrationBlockReason,
-    connectAsBroker,
-    connectAsFollower,
+    connectAsBroker: (ctx) => transitionToRuntimeMode(ctx, "broker"),
+    connectAsFollower: (ctx) => transitionToRuntimeMode(ctx, "follower"),
     disconnectFollower,
     sendPinetAgentMessage,
     signalAgentFree,
@@ -3496,6 +3558,7 @@ export default function (pi: ExtensionAPI) {
       brokerClient = brokerClientRef;
       brokerRole = "follower";
       pinetEnabled = true;
+      currentRuntimeMode = "follower";
       startPolling();
       setExtStatus(ctx, "ok");
     } catch (err) {
@@ -3535,6 +3598,7 @@ export default function (pi: ExtensionAPI) {
     followerAckPromise = null;
     brokerRole = null;
     pinetEnabled = false;
+    currentRuntimeMode = "off";
     setExtStatus(ctx, "off");
 
     return { unregisterError };
@@ -3653,21 +3717,28 @@ export default function (pi: ExtensionAPI) {
 
     if (pinetRegistrationBlocked) {
       console.log("[slack-bridge] detected local subagent context; skipping Pinet registration");
+      currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
       return;
     }
 
-    // Auto-follow: if enabled and broker socket exists, connect as follower
-    if (settings.autoFollow && fs.existsSync(DEFAULT_SOCKET_PATH)) {
-      try {
-        await connectAsFollower(ctx);
-        console.log(`[slack-bridge] autoFollow: connected as follower`);
-      } catch (err) {
-        console.error(`[slack-bridge] autoFollow failed: ${msg(err)}`);
-        setExtStatus(ctx, "off");
+    refreshSettings();
+    const startupMode = resolveSlackBridgeStartupRuntimeMode(settings, {
+      brokerSocketExists: fs.existsSync(DEFAULT_SOCKET_PATH),
+    });
+
+    try {
+      await transitionToRuntimeMode(ctx, startupMode);
+      if (startupMode === "single") {
+        console.log("[slack-bridge] runtime mode: single");
+      } else if (startupMode === "follower") {
+        console.log("[slack-bridge] runtime mode: follower");
+      } else if (startupMode === "broker") {
+        console.log("[slack-bridge] runtime mode: broker");
       }
-    } else {
-      // Use /pinet-start or /pinet-follow to connect
+    } catch (err) {
+      console.error(`[slack-bridge] runtime start (${startupMode}) failed: ${msg(err)}`);
+      currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
     }
   });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -78,6 +78,7 @@ import {
   buildBrokerToolGuardrailsPrompt,
   type SecurityGuardrails,
 } from "./guardrails.js";
+import { evaluateSlackOriginCoreToolPolicy } from "./core-tool-guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import {
   buildReactionPromptGuidelines,
@@ -601,6 +602,12 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Inbox queue ────────────────────────────────────
 
+  interface PendingSlackToolPolicyTurn {
+    prompt: string;
+    threadTs: string | undefined;
+    threadCount: number;
+  }
+
   const inbox: InboxMessage[] = [];
   const brokerDeliveryState = createBrokerDeliveryState();
   const AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS = 1_500;
@@ -608,6 +615,25 @@ export default function (pi: ExtensionAPI) {
   let terminalInputUnsubscribe: (() => void) | null = null;
   let extCtx: ExtensionContext | null = null; // cached for badge updates
   let lastActivityLogFailureAt = 0;
+  const pendingSlackToolPolicyTurns: PendingSlackToolPolicyTurn[] = [];
+  let nextSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
+  let activeSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
+
+  function rememberPendingSlackToolPolicyTurn(prompt: string, messages: InboxMessage[]): void {
+    const threadIds = [...new Set(messages.map((message) => message.threadTs).filter(Boolean))];
+    pendingSlackToolPolicyTurns.push({
+      prompt,
+      threadTs: threadIds.length === 1 ? threadIds[0] : undefined,
+      threadCount: threadIds.length,
+    });
+  }
+
+  function consumePendingSlackToolPolicyTurn(text: string): PendingSlackToolPolicyTurn | null {
+    const index = pendingSlackToolPolicyTurns.findIndex((entry) => entry.prompt === text);
+    if (index < 0) return null;
+    const [entry] = pendingSlackToolPolicyTurns.splice(index, 1);
+    return entry ?? null;
+  }
 
   function updateBadge(): void {
     if (!extCtx?.hasUI) return;
@@ -3752,6 +3778,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (deliverFollowUpMessage(prompt)) {
+      rememberPendingSlackToolPolicyTurn(prompt, pending);
       if (brokerInboxIds.length > 0) {
         if (brokerRole === "follower") {
           markFollowerInboxIdsDelivered(followerDeliveryState, brokerInboxIds);
@@ -3772,7 +3799,29 @@ export default function (pi: ExtensionAPI) {
     updateBadge();
   }
 
+  pi.on("input", async (event) => {
+    if (event.source !== "extension") {
+      return;
+    }
+
+    nextSlackToolPolicyTurn = consumePendingSlackToolPolicyTurn(event.text);
+  });
+
+  pi.on("turn_start", async () => {
+    activeSlackToolPolicyTurn = nextSlackToolPolicyTurn;
+    nextSlackToolPolicyTurn = null;
+  });
+
+  pi.on("turn_end", async () => {
+    activeSlackToolPolicyTurn = null;
+  });
+
+  pi.on("agent_end", async () => {
+    activeSlackToolPolicyTurn = null;
+  });
+
   // Hard-block forbidden tools when broker role is active.
+  // Also hard-enforce Slack-origin guardrails for core built-in tools.
   pi.on("tool_call", async (event) => {
     if (brokerRole === "broker" && isBrokerForbiddenTool(event.toolName)) {
       return {
@@ -3780,6 +3829,16 @@ export default function (pi: ExtensionAPI) {
         reason: `Tool "${event.toolName}" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.`,
       };
     }
+
+    return evaluateSlackOriginCoreToolPolicy({
+      turn: activeSlackToolPolicyTurn,
+      toolName: event.toolName,
+      input: event.input,
+      guardrails,
+      requireToolPolicy,
+      formatAction: formatConfirmationAction,
+      formatError: msg,
+    });
   });
 
   // Inject dynamic identity guidance every turn so reload/session restore keeps prompts in sync.

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -84,6 +84,7 @@ import {
   deliverTrackedSlackFollowUpMessage,
   type PendingSlackToolPolicyTurn,
 } from "./slack-turn-guardrails.js";
+import { buildSlackInboundMessageText } from "./slack-message-context.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import {
   buildReactionPromptGuidelines,
@@ -1399,13 +1400,14 @@ export default function (pi: ExtensionAPI) {
 
     // Strip <@BOT_ID> from text for channel mentions
     const cleanText = isChannelMention ? stripBotMention(text, botUserId!) : text;
+    const enrichedText = buildSlackInboundMessageText(cleanText, evt);
     const confirmationResult = consumeConfirmationReply(effectiveTs, cleanText);
     const messageText =
       confirmationResult === null
-        ? cleanText
+        ? enrichedText
         : confirmationResult.approved
-          ? `${cleanText}\n\n✅ User approved security confirmation request in this thread.`
-          : `${cleanText}\n\n❌ User denied security confirmation request in this thread.`;
+          ? `${enrichedText}\n\n✅ User approved security confirmation request in this thread.`
+          : `${enrichedText}\n\n❌ User denied security confirmation request in this thread.`;
 
     const name = await resolveUser(user);
     if (shuttingDown) return;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1542,10 +1542,13 @@ export default function (pi: ExtensionAPI) {
   // ─── Reconnect / status ─────────────────────────────
 
   function scheduleReconnect(ctx: ExtensionContext): void {
-    if (shuttingDown || reconnectTimer) return;
+    if (shuttingDown || reconnectTimer || currentRuntimeMode !== "single") return;
     setExtStatus(ctx, "reconnecting");
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
+      if (shuttingDown || currentRuntimeMode !== "single") {
+        return;
+      }
       void connectSocketMode(ctx);
     }, 5000);
   }
@@ -3764,21 +3767,24 @@ export default function (pi: ExtensionAPI) {
     ctx?: ExtensionContext,
     options: { requirePinet?: boolean } = {},
   ): { queuedInboxCount: number; drainedQueuedInbox: boolean } {
-    if (!pinetEnabled) {
-      if (options.requirePinet) {
-        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
-      }
-      return { queuedInboxCount: inbox.length, drainedQueuedInbox: false };
+    if (!pinetEnabled && options.requirePinet) {
+      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
     }
 
-    reportStatus("idle");
     const maintenanceCtx = ctx ?? extCtx ?? undefined;
-    if (brokerRole === "broker" && maintenanceCtx) {
-      runBrokerMaintenance(maintenanceCtx);
+    if (pinetEnabled) {
+      reportStatus("idle");
+      if (brokerRole === "broker" && maintenanceCtx) {
+        runBrokerMaintenance(maintenanceCtx);
+      }
     }
 
     const queuedInboxCount = inbox.length;
-    const drainedQueuedInbox = queuedInboxCount > 0 && (ctx ? maybeDrainInboxIfIdle(ctx) : false);
+    const shouldDrainQueuedInbox = pinetEnabled || currentRuntimeMode === "single";
+    const drainedQueuedInbox =
+      shouldDrainQueuedInbox && queuedInboxCount > 0 && maintenanceCtx
+        ? maybeDrainInboxIfIdle(maintenanceCtx)
+        : false;
 
     return { queuedInboxCount, drainedQueuedInbox };
   }

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -23,6 +23,7 @@ oauth_config:
       - channels:history
       - channels:read
       - chat:write
+      - files:read
       - files:write
       - bookmarks:read
       - bookmarks:write

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -47,7 +47,6 @@ settings:
       - assistant_thread_started
       - assistant_thread_context_changed
       - reaction_added
-      - presence_change
       - message.channels
       - message.groups
       - message.im

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gugu910/extensions.git",
+    "url": "git+https://github.com/gugu91/extensions.git",
     "directory": "slack-bridge"
   },
   "publishConfig": {

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { generateAgentName, agentOwnsThread } from "./helpers.js";
 import { formatRecentActivityLogEntries, type SlackActivityLogger } from "./activity-log.js";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -8,6 +9,8 @@ export interface PinetCommandsDeps {
   // State accessors
   pinetEnabled: () => boolean;
   pinetRegistrationBlocked: () => boolean;
+  runtimeMode: () => SlackBridgeRuntimeMode;
+  runtimeConnected: () => boolean;
   brokerRole: () => "broker" | "follower" | null;
   agentName: () => string;
   agentEmoji: () => string;
@@ -71,8 +74,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
         ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
         return;
       }
-      if (deps.pinetEnabled()) {
-        ctx.ui.notify(`Pinet already running (${deps.brokerRole()})`, "info");
+      if (deps.runtimeMode() === "broker") {
+        ctx.ui.notify("Pinet already running (broker)", "info");
         return;
       }
       deps.setExtCtx(ctx);
@@ -93,8 +96,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
         ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
         return;
       }
-      if (deps.pinetEnabled()) {
-        ctx.ui.notify(`Pinet already running (${deps.brokerRole()})`, "info");
+      if (deps.runtimeMode() === "follower") {
+        ctx.ui.notify("Pinet already running (follower)", "info");
         return;
       }
       deps.setExtCtx(ctx);
@@ -112,8 +115,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   pi.registerCommand("pinet-unfollow", {
     description: "Disconnect from the Pinet broker and keep working locally",
     handler: async (_args, ctx) => {
-      if (!deps.pinetEnabled() || deps.brokerRole() == null) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
+      if (deps.runtimeMode() !== "follower" || deps.brokerRole() == null) {
+        ctx.ui.notify("Pinet is not running as a follower.", "info");
         return;
       }
 
@@ -181,7 +184,10 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
     description: "Mark this Pinet agent idle/free for new work",
     handler: async (_args, ctx) => {
       if (!deps.pinetEnabled()) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
+        ctx.ui.notify(
+          "Pinet mesh runtime is not active. Use /pinet-start or /pinet-follow.",
+          "info",
+        );
         return;
       }
 
@@ -206,7 +212,10 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
     description: "Regenerate the mesh naming/personality skin from a theme",
     handler: async (args, ctx) => {
       if (!deps.pinetEnabled() || deps.brokerRole() == null) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
+        ctx.ui.notify(
+          "Pinet mesh runtime is not active. Use /pinet-start or /pinet-follow.",
+          "info",
+        );
         return;
       }
       if (deps.brokerRole() !== "broker") {
@@ -229,11 +238,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   pi.registerCommand("pinet-status", {
     description: "Show Pinet status",
     handler: async (_args, ctx) => {
-      if (!deps.pinetEnabled()) {
-        ctx.ui.notify("Pinet not running. Use /pinet-start or /pinet-follow.", "info");
-        return;
-      }
-      const mode = deps.brokerRole() === "broker" ? "broker" : "follower";
+      const mode = deps.runtimeMode();
       const ownedCount = [...deps.threads().values()].filter((t) =>
         agentOwnsThread(t.owner, deps.agentName(), deps.agentAliases(), deps.agentOwnerToken()),
       ).length;
@@ -286,7 +291,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
           `Mode: ${mode}`,
           `Agent: ${deps.agentEmoji()} ${deps.agentName()}`,
           `Bot: ${deps.botUserId() ?? "unknown"}`,
-          `Connection: ${mode}`,
+          `Connection: ${deps.runtimeConnected() ? "connected" : "disconnected"}`,
           `Skin: ${deps.activeSkinTheme() ?? "(legacy/manual)"}`,
           ...(deps.agentPersonality() ? [`Persona: ${deps.agentPersonality()}`] : []),
           `Threads: ${deps.threads().size} (${ownedCount} owned by ${deps.agentName()})`,
@@ -331,7 +336,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       if (!newName) {
         const fresh = generateAgentName(
           undefined,
-          deps.brokerRole() === "broker" ? "broker" : "worker",
+          deps.runtimeMode() === "broker" ? "broker" : "worker",
         );
         deps.applyLocalAgentIdentity(fresh.name, fresh.emoji, deps.agentPersonality());
       } else {

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRalphLoopState,
+  hydrateRalphLoopReportedGhosts,
+} from "./ralph-loop.js";
+import { rewriteRalphLoopGhostAnomalies } from "./helpers.js";
+
+function buildEvaluation(ghostAgentIds: string[]) {
+  return {
+    ghostAgentIds,
+    nudgeAgentIds: [],
+    idleDrainAgentIds: [],
+    stuckAgentIds: [],
+    anomalies:
+      ghostAgentIds.length > 0 ? [`ghost agents detected: ${ghostAgentIds.join(", ")}`] : [],
+  };
+}
+
+describe("hydrateRalphLoopReportedGhosts", () => {
+  it("hydrates the latest persisted ghost ids into a fresh state", () => {
+    const state = createRalphLoopState();
+
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: ["ghost-1", "ghost-2"] }]);
+
+    expect([...state.reportedGhosts]).toEqual(["ghost-1", "ghost-2"]);
+    expect(state.ghostBaselineHydrated).toBe(true);
+  });
+
+  it("does not overwrite active in-memory ghost state", () => {
+    const state = createRalphLoopState();
+    state.reportedGhosts.add("live-ghost");
+
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: ["persisted-ghost"] }]);
+
+    expect([...state.reportedGhosts]).toEqual(["live-ghost"]);
+    expect(state.ghostBaselineHydrated).toBe(true);
+  });
+
+  it("suppresses re-announcing the same persisted ghost ids as NEW after a state reset", () => {
+    const state = createRalphLoopState();
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: ["ghost-1"] }]);
+
+    const rewritten = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"]),
+      state.reportedGhosts,
+    );
+
+    expect(rewritten.evaluation.ghostAgentIds).toEqual(["ghost-1"]);
+    expect(rewritten.evaluation.anomalies).toEqual([]);
+    expect(rewritten.newGhostIds).toEqual([]);
+    expect(rewritten.nextReportedGhostIds).toEqual(["ghost-1"]);
+  });
+
+  it("still announces truly new ghost ids when the latest persisted cycle was healthy", () => {
+    const state = createRalphLoopState();
+    hydrateRalphLoopReportedGhosts(state, [{ ghostAgentIds: [] }]);
+
+    const rewritten = rewriteRalphLoopGhostAnomalies(
+      buildEvaluation(["ghost-1"]),
+      state.reportedGhosts,
+    );
+
+    expect(rewritten.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-1"]);
+    expect(rewritten.newGhostIds).toEqual(["ghost-1"]);
+    expect(rewritten.nextReportedGhostIds).toEqual(["ghost-1"]);
+  });
+});

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -37,6 +37,7 @@ export interface RalphLoopState {
   running: boolean;
   nudges: Map<string, number>;
   reportedGhosts: Set<string>;
+  ghostBaselineHydrated: boolean;
   nonGhostSignature: string;
   hadOutstandingAnomalies: boolean;
   followUpAt: number;
@@ -51,6 +52,7 @@ export function createRalphLoopState(): RalphLoopState {
     running: false,
     nudges: new Map(),
     reportedGhosts: new Set(),
+    ghostBaselineHydrated: false,
     nonGhostSignature: "",
     hadOutstandingAnomalies: false,
     followUpAt: 0,
@@ -68,6 +70,7 @@ export function resetRalphLoopState(state: RalphLoopState): void {
   state.running = false;
   state.nudges.clear();
   state.reportedGhosts.clear();
+  state.ghostBaselineHydrated = false;
   state.nonGhostSignature = "";
   state.hadOutstandingAnomalies = false;
   state.followUpAt = 0;
@@ -77,6 +80,25 @@ export function resetRalphLoopState(state: RalphLoopState): void {
 }
 
 // ─── Callbacks ───────────────────────────────────────────
+
+export function hydrateRalphLoopReportedGhosts(
+  state: Pick<RalphLoopState, "reportedGhosts" | "ghostBaselineHydrated">,
+  recentCycles: Array<{ ghostAgentIds: string[] }>,
+): void {
+  if (state.ghostBaselineHydrated) {
+    return;
+  }
+
+  if (state.reportedGhosts.size > 0) {
+    state.ghostBaselineHydrated = true;
+    return;
+  }
+
+  for (const ghostId of recentCycles[0]?.ghostAgentIds ?? []) {
+    state.reportedGhosts.add(ghostId);
+  }
+  state.ghostBaselineHydrated = true;
+}
 
 export interface RalphLoopDeps {
   // Broker access
@@ -132,6 +154,7 @@ export async function runRalphLoopCycle(
   const cycleStartedAt = new Date().toISOString();
   const cycleStartMs = Date.now();
   try {
+    hydrateRalphLoopReportedGhosts(state, db.getRecentRalphCycles(1));
     deps.runMaintenance(ctx);
     const lastMaintenance = deps.getLastMaintenance();
 

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -133,6 +133,7 @@ export async function runRalphLoopCycle(
   const cycleStartMs = Date.now();
   try {
     deps.runMaintenance(ctx);
+    const lastMaintenance = deps.getLastMaintenance();
 
     const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
 
@@ -179,7 +180,9 @@ export async function runRalphLoopCycle(
       state.nudges.set(workload.id, now);
     }
 
-    const ghostRewrite = rewriteRalphLoopGhostAnomalies(evaluation, state.reportedGhosts);
+    const ghostRewrite = rewriteRalphLoopGhostAnomalies(evaluation, state.reportedGhosts, {
+      suppressedGhostIds: lastMaintenance?.reapedAgentIds ?? [],
+    });
     state.reportedGhosts.clear();
     for (const ghostId of ghostRewrite.nextReportedGhostIds) {
       state.reportedGhosts.add(ghostId);
@@ -188,7 +191,8 @@ export async function runRalphLoopCycle(
     const visibleEvaluation = ghostRewrite.evaluation;
     const visibleSignature = buildRalphLoopAnomalySignature(visibleEvaluation);
     const nonGhostSignature = ghostRewrite.nonGhostAnomalies.join("|");
-    const hasOutstandingAnomalies = evaluation.anomalies.length > 0;
+    const hasOutstandingAnomalies =
+      visibleEvaluation.ghostAgentIds.length > 0 || visibleEvaluation.anomalies.length > 0;
     const ralphNotifications = buildRalphLoopCycleNotifications(visibleEvaluation, cycleStartedAt);
     const followUpPrompt =
       ghostRewrite.newGhostIds.length === 0 &&
@@ -433,7 +437,7 @@ export async function runRalphLoopCycle(
       workloads,
       evaluation: visibleEvaluation,
       evaluationOptions,
-      maintenance: deps.getLastMaintenance(),
+      maintenance: lastMaintenance,
       assignments: projectedAssignments,
       recentCycles: recentRalphCycles,
       cycleStartedAt,

--- a/slack-bridge/runtime-mode.test.ts
+++ b/slack-bridge/runtime-mode.test.ts
@@ -62,6 +62,15 @@ describe("resolveSlackBridgeStartupRuntimeMode", () => {
     ).toBe("single");
   });
 
+  it("keeps explicit off truly off even when legacy auto flags are set", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "off", autoFollow: true, autoConnect: true },
+        { brokerSocketExists: true },
+      ),
+    ).toBe("off");
+  });
+
   it("allows explicit broker mode at startup", () => {
     expect(resolveSlackBridgeStartupRuntimeMode({ runtimeMode: "broker" })).toBe("broker");
   });

--- a/slack-bridge/runtime-mode.test.ts
+++ b/slack-bridge/runtime-mode.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPinetRuntimeMode,
+  normalizeSlackBridgeRuntimeMode,
+  resolveSlackBridgeStartupRuntimeMode,
+} from "./runtime-mode.js";
+
+describe("normalizeSlackBridgeRuntimeMode", () => {
+  it("accepts the supported runtime modes", () => {
+    expect(normalizeSlackBridgeRuntimeMode("off")).toBe("off");
+    expect(normalizeSlackBridgeRuntimeMode("single")).toBe("single");
+    expect(normalizeSlackBridgeRuntimeMode("broker")).toBe("broker");
+    expect(normalizeSlackBridgeRuntimeMode("follower")).toBe("follower");
+  });
+
+  it("normalizes casing and whitespace", () => {
+    expect(normalizeSlackBridgeRuntimeMode("  SINGLE ")).toBe("single");
+  });
+
+  it("rejects unsupported values", () => {
+    expect(normalizeSlackBridgeRuntimeMode("standalone")).toBeNull();
+    expect(normalizeSlackBridgeRuntimeMode(undefined)).toBeNull();
+  });
+});
+
+describe("isPinetRuntimeMode", () => {
+  it("identifies broker and follower as Pinet runtimes", () => {
+    expect(isPinetRuntimeMode("broker")).toBe(true);
+    expect(isPinetRuntimeMode("follower")).toBe(true);
+    expect(isPinetRuntimeMode("single")).toBe(false);
+    expect(isPinetRuntimeMode("off")).toBe(false);
+  });
+});
+
+describe("resolveSlackBridgeStartupRuntimeMode", () => {
+  it("defaults to off", () => {
+    expect(resolveSlackBridgeStartupRuntimeMode({})).toBe("off");
+  });
+
+  it("treats autoConnect as the legacy single-player alias", () => {
+    expect(resolveSlackBridgeStartupRuntimeMode({ autoConnect: true })).toBe("single");
+  });
+
+  it("treats autoFollow as the legacy follower alias when a broker socket exists", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode({ autoFollow: true }, { brokerSocketExists: true }),
+    ).toBe("follower");
+  });
+
+  it("keeps follower startup off when the broker socket is unavailable", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode({ autoFollow: true }, { brokerSocketExists: false }),
+    ).toBe("off");
+  });
+
+  it("prefers explicit runtimeMode over legacy compatibility flags", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "single", autoFollow: true, autoConnect: true },
+        { brokerSocketExists: true },
+      ),
+    ).toBe("single");
+  });
+
+  it("allows explicit broker mode at startup", () => {
+    expect(resolveSlackBridgeStartupRuntimeMode({ runtimeMode: "broker" })).toBe("broker");
+  });
+
+  it("downgrades explicit follower mode to off when no broker socket exists", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "follower" },
+        { brokerSocketExists: false },
+      ),
+    ).toBe("off");
+  });
+});

--- a/slack-bridge/runtime-mode.ts
+++ b/slack-bridge/runtime-mode.ts
@@ -1,0 +1,51 @@
+import type { SlackBridgeSettings } from "./helpers.js";
+
+export type SlackBridgeRuntimeMode = "off" | "single" | "broker" | "follower";
+
+export function normalizeSlackBridgeRuntimeMode(
+  value: string | null | undefined,
+): SlackBridgeRuntimeMode | null {
+  const normalized = value?.trim().toLowerCase();
+  if (
+    normalized === "off" ||
+    normalized === "single" ||
+    normalized === "broker" ||
+    normalized === "follower"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+export function isPinetRuntimeMode(mode: SlackBridgeRuntimeMode): boolean {
+  return mode === "broker" || mode === "follower";
+}
+
+export interface ResolveSlackBridgeStartupRuntimeModeOptions {
+  brokerSocketExists?: boolean;
+}
+
+export function resolveSlackBridgeStartupRuntimeMode(
+  settings: Pick<SlackBridgeSettings, "runtimeMode" | "autoConnect" | "autoFollow">,
+  options: ResolveSlackBridgeStartupRuntimeModeOptions = {},
+): SlackBridgeRuntimeMode {
+  const explicitMode = normalizeSlackBridgeRuntimeMode(settings.runtimeMode);
+  const brokerSocketExists = options.brokerSocketExists ?? true;
+
+  if (explicitMode) {
+    if (explicitMode === "follower" && !brokerSocketExists) {
+      return "off";
+    }
+    return explicitMode;
+  }
+
+  if (settings.autoFollow) {
+    return brokerSocketExists ? "follower" : "off";
+  }
+
+  if (settings.autoConnect) {
+    return "single";
+  }
+
+  return "off";
+}

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -1,0 +1,653 @@
+import {
+  buildAllowlist,
+  isUserAllowed,
+  isChannelId,
+  stripBotMention,
+  isAbortError,
+} from "./helpers.js";
+import { buildSlackInboundMessageText } from "./slack-message-context.js";
+import {
+  extractSlackInteractivePayloadFromEnvelope,
+  normalizeSlackBlockActionPayload,
+  normalizeSlackViewSubmissionPayload,
+  type SlackInteractiveInboxEvent,
+} from "./slack-block-kit.js";
+import { extractSlackSocketDedupKey } from "./slack-socket-dedup.js";
+import { extractPiAgentThreadOwnerHint, type ThreadOwnerHint } from "./broker/router.js";
+
+export {
+  SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
+  SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
+} from "./slack-socket-dedup.js";
+
+export type SlackCall = (
+  method: string,
+  token: string,
+  body?: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+export interface SlackAccessCache<K, V> {
+  get(key: K): V | undefined;
+  set(key: K, value: V): unknown;
+  has?(key: K): boolean;
+}
+
+export interface SlackAccessSet<K> {
+  has(key: K): boolean;
+  add(key: K): unknown;
+  delete?(key: K): unknown;
+}
+
+export interface SlackThreadContext {
+  channelId: string;
+  teamId: string;
+}
+
+export interface ParsedEnvelope {
+  envelopeId?: string;
+  type: string;
+  dedupKey?: string;
+  event?: Record<string, unknown>;
+  interactivePayload?: Record<string, unknown>;
+}
+
+export function buildSlackUserAllowlist(
+  allowedUsers?: string[],
+  envAllowedUsers?: string,
+): Set<string> | null {
+  return buildAllowlist({ allowedUsers }, envAllowedUsers);
+}
+
+export function isSlackUserAllowed(allowlist: Set<string> | null, userId: string): boolean {
+  return isUserAllowed(allowlist, userId);
+}
+
+/**
+ * Parse a raw Socket Mode WebSocket frame into a structured envelope.
+ * Returns null if the frame is malformed JSON.
+ */
+export function parseSocketFrame(raw: string): ParsedEnvelope | null {
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    const result: ParsedEnvelope = {
+      type: (data.type as string) ?? "",
+    };
+    if (data.envelope_id) {
+      result.envelopeId = data.envelope_id as string;
+    }
+    const dedupKey = extractSlackSocketDedupKey(data);
+    if (dedupKey) {
+      result.dedupKey = dedupKey;
+    }
+    if (data.type === "events_api") {
+      const payload = data.payload as { event?: Record<string, unknown> } | undefined;
+      result.event = payload?.event;
+    }
+
+    const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
+    if (interactivePayload) {
+      result.interactivePayload = interactivePayload;
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedThreadStarted {
+  channelId: string;
+  threadTs: string;
+  userId: string;
+  context?: SlackThreadContext;
+}
+
+/**
+ * Extract thread info from an assistant_thread_started event.
+ */
+export function extractThreadStarted(evt: Record<string, unknown>): ParsedThreadStarted | null {
+  const t = evt.assistant_thread as Record<string, unknown> | undefined;
+  if (!t) return null;
+
+  const channelId =
+    typeof t.channel_id === "string" && t.channel_id.length > 0 ? t.channel_id : null;
+  const threadTs = typeof t.thread_ts === "string" && t.thread_ts.length > 0 ? t.thread_ts : null;
+  const userId = typeof t.user_id === "string" && t.user_id.length > 0 ? t.user_id : null;
+  if (!channelId || !threadTs || !userId) {
+    return null;
+  }
+
+  const result: ParsedThreadStarted = {
+    channelId,
+    threadTs,
+    userId,
+  };
+
+  const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
+  if (ctx?.channel_id) {
+    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+  }
+
+  return result;
+}
+
+export interface ParsedThreadContextChanged {
+  threadTs: string;
+  context?: SlackThreadContext;
+}
+
+export function extractThreadContextChanged(
+  evt: Record<string, unknown>,
+): ParsedThreadContextChanged | null {
+  const t = evt.assistant_thread as Record<string, unknown> | undefined;
+  if (!t) return null;
+
+  const threadTs = typeof t.thread_ts === "string" && t.thread_ts.length > 0 ? t.thread_ts : null;
+  if (!threadTs) {
+    return null;
+  }
+
+  const result: ParsedThreadContextChanged = { threadTs };
+  const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
+  if (ctx?.channel_id) {
+    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+  }
+
+  return result;
+}
+
+export interface ParsedAppHomeOpened {
+  userId: string;
+  tab: string;
+  eventTs: string | null;
+}
+
+export function extractAppHomeOpened(evt: Record<string, unknown>): ParsedAppHomeOpened | null {
+  const userId = typeof evt.user === "string" && evt.user.length > 0 ? evt.user : null;
+  if (!userId) return null;
+
+  const tab = typeof evt.tab === "string" && evt.tab.length > 0 ? evt.tab : "home";
+  return {
+    userId,
+    tab,
+    eventTs: typeof evt.event_ts === "string" && evt.event_ts.length > 0 ? evt.event_ts : null,
+  };
+}
+
+/**
+ * Classification result for an incoming message event.
+ * Uses a discriminated union so TypeScript narrows fields when relevant is true.
+ */
+export type MessageClassification =
+  | { relevant: false }
+  | {
+      relevant: true;
+      threadTs: string;
+      channel: string;
+      userId: string;
+      text: string;
+      isDM: boolean;
+      isChannelMention: boolean;
+      messageTs: string;
+    };
+
+/**
+ * Classify an incoming Slack message event. Determines whether the
+ * message is relevant (DM, known thread, or bot mention) and
+ * extracts the cleaned fields.
+ */
+export function classifyMessage(
+  evt: Record<string, unknown>,
+  botUserId: string | null,
+  trackedThreadIds: Set<string>,
+  isKnownThread?: (threadTs: string) => boolean,
+): MessageClassification {
+  if (evt.subtype || evt.bot_id) return { relevant: false };
+
+  const text = (evt.text as string) ?? "";
+  const user = evt.user as string;
+  const threadTs = evt.thread_ts as string | undefined;
+  const channel = evt.channel as string;
+  const channelType = evt.channel_type as string | undefined;
+
+  const isKnown = !!threadTs && (isKnownThread?.(threadTs) ?? trackedThreadIds.has(threadTs));
+  const isDM = channelType === "im";
+  const isMention = botUserId != null && text.includes(`<@${botUserId}>`);
+
+  if (!isKnown && !isDM && !isMention) return { relevant: false };
+
+  const effectiveTs = threadTs ?? (evt.ts as string);
+  const isChannelMention = isMention && !isDM && !isKnown;
+  const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
+
+  return {
+    relevant: true,
+    threadTs: effectiveTs,
+    channel,
+    userId: user,
+    text: buildSlackInboundMessageText(cleanText, evt),
+    isDM,
+    isChannelMention,
+    messageTs: (evt.ts as string) ?? effectiveTs,
+  };
+}
+
+/**
+ * Parse a member_joined_channel event. Returns null if required fields
+ * are missing.
+ */
+export function parseMemberJoinedChannel(
+  evt: Record<string, unknown>,
+  botUserId: string | null,
+): { channel: string; isSelf: boolean } | null {
+  const user = evt.user as string | undefined;
+  const channel = evt.channel as string | undefined;
+  if (!user || !channel) return null;
+  return { channel, isSelf: user === botUserId };
+}
+
+export interface FetchSlackMessageByTsInput {
+  slack: SlackCall;
+  token: string;
+  channel: string;
+  messageTs: string;
+}
+
+export async function fetchSlackMessageByTs(
+  input: FetchSlackMessageByTsInput,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await input.slack("conversations.history", input.token, {
+      channel: input.channel,
+      oldest: input.messageTs,
+      latest: input.messageTs,
+      inclusive: true,
+      limit: 1,
+    });
+    const messages = (response.messages as Record<string, unknown>[]) ?? [];
+    return messages.find((message) => message.ts === input.messageTs) ?? messages[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface SlackReactionInput {
+  slack: SlackCall;
+  token: string;
+  channel: string;
+  timestamp: string;
+  emoji: string;
+}
+
+export async function addSlackReaction(input: SlackReactionInput): Promise<void> {
+  try {
+    await input.slack("reactions.add", input.token, {
+      channel: input.channel,
+      timestamp: input.timestamp,
+      name: input.emoji,
+    });
+  } catch {
+    /* already_reacted or non-critical */
+  }
+}
+
+export async function removeSlackReaction(input: SlackReactionInput): Promise<void> {
+  try {
+    await input.slack("reactions.remove", input.token, {
+      channel: input.channel,
+      timestamp: input.timestamp,
+      name: input.emoji,
+    });
+  } catch {
+    /* not_reacted or non-critical */
+  }
+}
+
+export interface ResolveSlackUserNameInput {
+  slack: SlackCall;
+  token: string;
+  userId: string;
+  cache?: SlackAccessCache<string, string>;
+  shouldUseResult?: () => boolean;
+}
+
+export async function resolveSlackUserName(input: ResolveSlackUserNameInput): Promise<string> {
+  const cached = input.cache?.get(input.userId);
+  if (cached) return cached;
+
+  try {
+    const response = await input.slack("users.info", input.token, {
+      user: input.userId,
+    });
+    if (input.shouldUseResult && !input.shouldUseResult()) {
+      return input.userId;
+    }
+    const user = response.user as { real_name?: string; name?: string };
+    const name = user.real_name ?? user.name ?? input.userId;
+    input.cache?.set(input.userId, name);
+    return name;
+  } catch {
+    return input.userId;
+  }
+}
+
+export interface ResolveSlackChannelIdInput {
+  slack: SlackCall;
+  token: string;
+  nameOrId: string;
+  cache?: SlackAccessCache<string, string>;
+}
+
+export async function resolveSlackChannelId(input: ResolveSlackChannelIdInput): Promise<string> {
+  if (isChannelId(input.nameOrId)) return input.nameOrId;
+
+  const name = input.nameOrId.replace(/^#/, "");
+  const cached = input.cache?.get(name);
+  if (cached) return cached;
+
+  let cursor: string | undefined;
+  do {
+    const body: Record<string, unknown> = {
+      types: "public_channel,private_channel",
+      limit: 200,
+    };
+    if (cursor) {
+      body.cursor = cursor;
+    }
+    const response = await input.slack("conversations.list", input.token, body);
+    const channels = (response.channels as { id: string; name: string }[]) ?? [];
+    for (const channel of channels) {
+      input.cache?.set(channel.name, channel.id);
+    }
+    const resolved =
+      input.cache?.get(name) ?? channels.find((channel) => channel.name === name)?.id;
+    if (resolved) {
+      return resolved;
+    }
+    cursor =
+      (response.response_metadata as { next_cursor?: string } | undefined)?.next_cursor ||
+      undefined;
+  } while (cursor);
+
+  throw new Error(`Channel "${name}" not found.`);
+}
+
+export interface ClearSlackThreadStatusInput {
+  slack: SlackCall;
+  token: string;
+  channelId: string;
+  threadTs: string;
+}
+
+export async function clearSlackThreadStatus(input: ClearSlackThreadStatusInput): Promise<void> {
+  try {
+    await input.slack("assistant.threads.setStatus", input.token, {
+      channel_id: input.channelId,
+      thread_ts: input.threadTs,
+      status: "",
+    });
+  } catch {
+    /* non-critical */
+  }
+}
+
+export interface SlackSuggestedPrompt {
+  title: string;
+  message: string;
+}
+
+export interface SetSlackSuggestedPromptsInput {
+  slack: SlackCall;
+  token: string;
+  channelId: string;
+  threadTs: string;
+  prompts: SlackSuggestedPrompt[];
+}
+
+export async function setSlackSuggestedPrompts(
+  input: SetSlackSuggestedPromptsInput,
+): Promise<void> {
+  try {
+    await input.slack("assistant.threads.setSuggestedPrompts", input.token, {
+      channel_id: input.channelId,
+      thread_ts: input.threadTs,
+      prompts: input.prompts,
+    });
+  } catch {
+    /* non-critical */
+  }
+}
+
+export interface ResolveSlackThreadOwnerHintInput {
+  slack: SlackCall;
+  token: string;
+  channel: string;
+  threadTs: string;
+  cache?: SlackAccessCache<string, ThreadOwnerHint>;
+  limit?: number;
+}
+
+export async function resolveSlackThreadOwnerHint(
+  input: ResolveSlackThreadOwnerHintInput,
+): Promise<ThreadOwnerHint | null> {
+  if (!input.channel || !input.threadTs) {
+    return null;
+  }
+
+  const cacheKey = `${input.channel}:${input.threadTs}`;
+  const cached = input.cache?.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const response = await input.slack("conversations.replies", input.token, {
+      channel: input.channel,
+      ts: input.threadTs,
+      limit: input.limit ?? 200,
+      include_all_metadata: true,
+    });
+    const replies = (response.messages as Record<string, unknown>[]) ?? [];
+    const hint = extractPiAgentThreadOwnerHint(replies);
+    if (hint) {
+      input.cache?.set(cacheKey, hint);
+    }
+    return hint;
+  } catch {
+    return null;
+  }
+}
+
+export const RECONNECT_DELAY_MS = 5000;
+
+export interface SlackSocketModeClientConfig {
+  slack: SlackCall;
+  botToken: string;
+  appToken: string;
+  resolveBotUserIdOnConnect?: boolean;
+  reconnectDelayMs?: number;
+  dedup?: SlackAccessSet<string>;
+  abortAndWait?: () => Promise<void>;
+  onOpen?: () => void;
+  onReconnectScheduled?: () => void;
+  onError?: (error: unknown) => void;
+  onThreadStarted?: (event: ParsedThreadStarted) => Promise<void> | void;
+  onThreadContextChanged?: (event: ParsedThreadContextChanged) => Promise<void> | void;
+  onMessage?: (event: Record<string, unknown>) => Promise<void> | void;
+  onReactionAdded?: (event: Record<string, unknown>) => Promise<void> | void;
+  onMemberJoinedChannel?: (event: { channel: string; isSelf: boolean }) => Promise<void> | void;
+  onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
+  onInteractive?: (event: SlackInteractiveInboxEvent) => Promise<void> | void;
+}
+
+export class SlackSocketModeClient {
+  private readonly config: SlackSocketModeClientConfig;
+  private botUserId: string | null = null;
+  private ws: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private shuttingDown = false;
+
+  constructor(config: SlackSocketModeClientConfig) {
+    this.config = config;
+  }
+
+  getBotUserId(): string | null {
+    return this.botUserId;
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  async connect(): Promise<void> {
+    this.shuttingDown = false;
+    if (this.config.resolveBotUserIdOnConnect ?? true) {
+      const auth = await this.config.slack("auth.test", this.config.botToken);
+      this.botUserId = typeof auth.user_id === "string" ? auth.user_id : null;
+    }
+    await this.connectSocketMode();
+  }
+
+  async disconnect(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    try {
+      this.ws?.close();
+    } catch {
+      /* ignore close errors */
+    }
+    this.ws = null;
+    await this.config.abortAndWait?.();
+  }
+
+  private async connectSocketMode(): Promise<void> {
+    if (this.shuttingDown) return;
+
+    try {
+      const response = await this.config.slack("apps.connections.open", this.config.appToken);
+      this.ws = new WebSocket(response.url as string);
+
+      this.ws.addEventListener("open", () => {
+        this.config.onOpen?.();
+      });
+
+      this.ws.addEventListener("message", (event) => {
+        void this.handleFrame(String(event.data)).catch((error) => {
+          this.config.onError?.(error);
+        });
+      });
+
+      this.ws.addEventListener("close", () => {
+        if (!this.shuttingDown) {
+          this.scheduleReconnect();
+        }
+      });
+
+      this.ws.addEventListener("error", () => {
+        /* close fires after error — handled there */
+      });
+    } catch (error) {
+      if (!isAbortError(error)) {
+        this.config.onError?.(error);
+      }
+      this.scheduleReconnect();
+    }
+  }
+
+  private async handleFrame(raw: string): Promise<void> {
+    if (this.shuttingDown) return;
+
+    const envelope = parseSocketFrame(raw);
+    if (!envelope) return;
+
+    if (envelope.envelopeId) {
+      this.ws?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
+    }
+
+    const dedupKey = envelope.dedupKey ?? null;
+
+    try {
+      if (dedupKey) {
+        if (this.config.dedup?.has(dedupKey)) {
+          return;
+        }
+        this.config.dedup?.add(dedupKey);
+      }
+
+      if (envelope.type === "disconnect") {
+        this.scheduleReconnect();
+        return;
+      }
+
+      if (envelope.interactivePayload) {
+        let normalized: SlackInteractiveInboxEvent | null = null;
+        if (envelope.interactivePayload.type === "block_actions") {
+          normalized = normalizeSlackBlockActionPayload(envelope.interactivePayload);
+        } else if (envelope.interactivePayload.type === "view_submission") {
+          normalized = normalizeSlackViewSubmissionPayload(envelope.interactivePayload);
+        }
+        if (normalized) {
+          await this.config.onInteractive?.(normalized);
+        }
+        return;
+      }
+
+      if (!envelope.event) return;
+
+      const evt = envelope.event;
+      switch (evt.type) {
+        case "assistant_thread_started": {
+          const parsed = extractThreadStarted(evt);
+          if (parsed) {
+            await this.config.onThreadStarted?.(parsed);
+          }
+          break;
+        }
+        case "assistant_thread_context_changed": {
+          const parsed = extractThreadContextChanged(evt);
+          if (parsed) {
+            await this.config.onThreadContextChanged?.(parsed);
+          }
+          break;
+        }
+        case "message":
+          await this.config.onMessage?.(evt);
+          break;
+        case "reaction_added":
+          await this.config.onReactionAdded?.(evt);
+          break;
+        case "member_joined_channel": {
+          const parsed = parseMemberJoinedChannel(evt, this.botUserId);
+          if (parsed) {
+            await this.config.onMemberJoinedChannel?.(parsed);
+          }
+          break;
+        }
+        case "app_home_opened": {
+          const parsed = extractAppHomeOpened(evt);
+          if (parsed && parsed.tab === "home") {
+            await this.config.onAppHomeOpened?.(parsed);
+          }
+          break;
+        }
+      }
+    } catch (error) {
+      if (dedupKey) {
+        this.config.dedup?.delete?.(dedupKey);
+      }
+      throw error;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.shuttingDown || this.reconnectTimer) return;
+    this.config.onReconnectScheduled?.();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connectSocketMode();
+    }, this.config.reconnectDelayMs ?? RECONNECT_DELAY_MS);
+    this.reconnectTimer.unref?.();
+  }
+}

--- a/slack-bridge/slack-message-context.test.ts
+++ b/slack-bridge/slack-message-context.test.ts
@@ -78,6 +78,21 @@ describe("slack message context extraction", () => {
     );
   });
 
+  it("keeps richer context when it only contains a short base-text word", () => {
+    const evt = {
+      blocks: [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Please review the rollout checklist" },
+        },
+      ],
+    } satisfies Record<string, unknown>;
+
+    expect(extractSlackMessageContextLines(evt, "review")).toEqual([
+      "Please review the rollout checklist",
+    ]);
+  });
+
   it("dedupes repeated context lines and limits the attached snippet count", () => {
     const evt = {
       blocks: [

--- a/slack-bridge/slack-message-context.test.ts
+++ b/slack-bridge/slack-message-context.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackInboundMessageText,
+  extractSlackMessageContextLines,
+} from "./slack-message-context.js";
+
+describe("slack message context extraction", () => {
+  it("returns the original text when there is no extra visible context", () => {
+    expect(buildSlackInboundMessageText("hello", { text: "hello" })).toBe("hello");
+  });
+
+  it("appends compact canvas-style context from message blocks and attachments", () => {
+    const evt = {
+      text: "Alice mentioned you in a comment",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_quote",
+              elements: [{ type: "text", text: "Can you update the rollout checklist?" }],
+            },
+          ],
+        },
+        {
+          type: "context",
+          elements: [{ type: "plain_text", text: "Canvas: Launch plan > Rollout" }],
+        },
+      ],
+      attachments: [
+        {
+          title: "Launch plan",
+          text: "Section: Rollout",
+        },
+      ],
+    } satisfies Record<string, unknown>;
+
+    expect(buildSlackInboundMessageText("Alice mentioned you in a comment", evt)).toBe(
+      [
+        "Alice mentioned you in a comment",
+        "",
+        "Slack message context:",
+        "- Can you update the rollout checklist?",
+        "- Canvas: Launch plan > Rollout",
+        "- Launch plan",
+        "- Section: Rollout",
+      ].join("\n"),
+    );
+  });
+
+  it("can build useful text when Slack sends only rich blocks without plain text", () => {
+    const evt = {
+      blocks: [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Canvas comment mention" },
+        },
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "Please tighten the acceptance criteria." }],
+            },
+          ],
+        },
+      ],
+    } satisfies Record<string, unknown>;
+
+    expect(buildSlackInboundMessageText("", evt)).toBe(
+      [
+        "(Slack message had no plain-text body)",
+        "",
+        "Slack message context:",
+        "- Canvas comment mention",
+        "- Please tighten the acceptance criteria.",
+      ].join("\n"),
+    );
+  });
+
+  it("dedupes repeated context lines and limits the attached snippet count", () => {
+    const evt = {
+      blocks: [
+        { type: "section", text: { type: "mrkdwn", text: "hello" } },
+        { type: "context", elements: [{ type: "plain_text", text: "alpha" }] },
+        { type: "context", elements: [{ type: "plain_text", text: "beta" }] },
+        { type: "context", elements: [{ type: "plain_text", text: "gamma" }] },
+        { type: "context", elements: [{ type: "plain_text", text: "delta" }] },
+        { type: "context", elements: [{ type: "plain_text", text: "epsilon" }] },
+      ],
+    } satisfies Record<string, unknown>;
+
+    expect(extractSlackMessageContextLines(evt, "hello")).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+      "delta",
+    ]);
+  });
+});

--- a/slack-bridge/slack-message-context.ts
+++ b/slack-bridge/slack-message-context.ts
@@ -1,0 +1,208 @@
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter(
+        (item): item is Record<string, unknown> => typeof item === "object" && item !== null,
+      )
+    : [];
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function clipLine(value: string, maxLength = 220): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function pushContextLine(lines: string[], rawValue: string | null | undefined): void {
+  if (!rawValue) return;
+  const normalized = clipLine(normalizeWhitespace(rawValue));
+  if (!normalized) return;
+  lines.push(normalized);
+}
+
+function extractTextObject(value: unknown): string[] {
+  const record = asRecord(value);
+  if (!record) return [];
+
+  const text = asString(record.text);
+  return text ? [text] : [];
+}
+
+function extractRichTextElementText(element: Record<string, unknown>): string[] {
+  const type = asString(element.type) ?? "";
+
+  switch (type) {
+    case "text": {
+      const text = asString(element.text);
+      return text ? [text] : [];
+    }
+    case "link": {
+      const text = asString(element.text);
+      const url = asString(element.url);
+      if (text && url && text !== url) {
+        return [`${text} (${url})`];
+      }
+      return text ? [text] : url ? [url] : [];
+    }
+    case "emoji": {
+      const name = asString(element.name);
+      return name ? [`:${name}:`] : [];
+    }
+    case "user": {
+      const userId = asString(element.user_id);
+      return userId ? [`<@${userId}>`] : [];
+    }
+    case "channel": {
+      const channelId = asString(element.channel_id);
+      return channelId ? [`<#${channelId}>`] : [];
+    }
+    case "rich_text_section":
+    case "rich_text_list":
+    case "rich_text_quote":
+    case "rich_text_preformatted": {
+      return asRecordArray(element.elements).flatMap((child) => extractRichTextElementText(child));
+    }
+    default:
+      return [];
+  }
+}
+
+function extractBlockContextLines(blocks: unknown): string[] {
+  const lines: string[] = [];
+
+  for (const block of asRecordArray(blocks)) {
+    const type = asString(block.type) ?? "";
+
+    switch (type) {
+      case "header":
+      case "section": {
+        for (const value of extractTextObject(block.text)) {
+          pushContextLine(lines, value);
+        }
+        for (const field of asRecordArray(block.fields)) {
+          for (const value of extractTextObject(field)) {
+            pushContextLine(lines, value);
+          }
+        }
+        break;
+      }
+      case "context": {
+        for (const element of asRecordArray(block.elements)) {
+          for (const value of extractTextObject(element)) {
+            pushContextLine(lines, value);
+          }
+        }
+        break;
+      }
+      case "image": {
+        pushContextLine(lines, asString(block.alt_text));
+        break;
+      }
+      case "rich_text": {
+        for (const element of asRecordArray(block.elements)) {
+          const text = extractRichTextElementText(element).join("");
+          pushContextLine(lines, text);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return lines;
+}
+
+function extractAttachmentContextLines(attachments: unknown): string[] {
+  const lines: string[] = [];
+
+  for (const attachment of asRecordArray(attachments)) {
+    pushContextLine(lines, asString(attachment.pretext));
+    pushContextLine(lines, asString(attachment.title));
+    pushContextLine(lines, asString(attachment.text));
+    pushContextLine(lines, asString(attachment.fallback));
+    pushContextLine(lines, asString(attachment.footer));
+    lines.push(...extractBlockContextLines(attachment.blocks));
+  }
+
+  return lines;
+}
+
+function extractFileContextLines(files: unknown): string[] {
+  const lines: string[] = [];
+
+  for (const file of asRecordArray(files)) {
+    const title = asString(file.title) ?? asString(file.name);
+    const prettyType = asString(file.pretty_type) ?? asString(file.filetype);
+    const mode = asString(file.mode);
+
+    const parts = [title, prettyType, mode].filter((part): part is string => Boolean(part));
+    if (parts.length === 0) continue;
+
+    pushContextLine(lines, parts.join(" — "));
+  }
+
+  return lines;
+}
+
+function dedupeContextLines(baseText: string, lines: string[]): string[] {
+  const baseNormalized = normalizeWhitespace(baseText).toLowerCase();
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const line of lines) {
+    const normalized = normalizeWhitespace(line).toLowerCase();
+    if (!normalized) continue;
+    if (
+      baseNormalized &&
+      (baseNormalized.includes(normalized) || normalized.includes(baseNormalized))
+    ) {
+      continue;
+    }
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    deduped.push(line);
+  }
+
+  return deduped;
+}
+
+export function extractSlackMessageContextLines(
+  evt: Record<string, unknown>,
+  baseText = "",
+): string[] {
+  const lines = [
+    ...extractBlockContextLines(evt.blocks),
+    ...extractAttachmentContextLines(evt.attachments),
+    ...extractFileContextLines(evt.files),
+  ];
+
+  return dedupeContextLines(baseText, lines).slice(0, 4);
+}
+
+export function buildSlackInboundMessageText(
+  baseText: string,
+  evt: Record<string, unknown>,
+): string {
+  const trimmedBase = baseText.trim();
+  const contextLines = extractSlackMessageContextLines(evt, trimmedBase);
+
+  if (contextLines.length === 0) {
+    return trimmedBase;
+  }
+
+  const prefix = trimmedBase.length > 0 ? trimmedBase : "(Slack message had no plain-text body)";
+  return `${prefix}\n\nSlack message context:\n${contextLines.map((line) => `- ${line}`).join("\n")}`;
+}

--- a/slack-bridge/slack-message-context.ts
+++ b/slack-bridge/slack-message-context.ts
@@ -165,10 +165,7 @@ function dedupeContextLines(baseText: string, lines: string[]): string[] {
   for (const line of lines) {
     const normalized = normalizeWhitespace(line).toLowerCase();
     if (!normalized) continue;
-    if (
-      baseNormalized &&
-      (baseNormalized.includes(normalized) || normalized.includes(baseNormalized))
-    ) {
+    if (baseNormalized && normalized === baseNormalized) {
       continue;
     }
     if (seen.has(normalized)) continue;

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -38,6 +38,10 @@ describe("registerSlackTools", () => {
       ok: true,
       channel: { id: "C_PROJ", properties: {} },
     } as SlackResult;
+    let canvasesSectionsLookupResponse: SlackResult = {
+      ok: true,
+      sections: [],
+    } as SlackResult;
     let filesInfoResponse: SlackResult = {
       ok: true,
       file: {
@@ -174,6 +178,10 @@ describe("registerSlackTools", () => {
         return conversationsInfoResponse;
       }
 
+      if (method === "canvases.sections.lookup") {
+        return canvasesSectionsLookupResponse;
+      }
+
       if (method === "files.info") {
         return filesInfoResponse;
       }
@@ -237,6 +245,9 @@ describe("registerSlackTools", () => {
       },
       setConversationsInfoResponse: (response: SlackResult) => {
         conversationsInfoResponse = response;
+      },
+      setCanvasesSectionsLookupResponse: (response: SlackResult) => {
+        canvasesSectionsLookupResponse = response;
       },
       setFilesInfoResponse: (response: SlackResult) => {
         filesInfoResponse = response;
@@ -912,7 +923,7 @@ describe("registerSlackTools", () => {
     });
   });
 
-  it("reads canvas comments by canvas id via files.info", async () => {
+  it("validates a direct canvas id before reading its comments", async () => {
     const { slack, tools, setFilesInfoResponse, setResolveUser } = setup();
     setResolveUser(async (userId) => (userId === "U123" ? "Alice" : userId));
     setFilesInfoResponse({
@@ -931,6 +942,10 @@ describe("registerSlackTools", () => {
       canvas_id: "F123",
     });
 
+    expect(slack).toHaveBeenCalledWith("canvases.sections.lookup", "xoxb-initial", {
+      canvas_id: "F123",
+      criteria: { section_types: ["any_header"] },
+    });
     expect(slack).toHaveBeenCalledWith("files.info", "xoxb-initial", {
       file: "F123",
       limit: 20,
@@ -950,7 +965,7 @@ describe("registerSlackTools", () => {
     );
   });
 
-  it("resolves a channel canvas before reading its comments", async () => {
+  it("resolves and validates a channel canvas before reading its comments", async () => {
     const { slack, tools, setConversationsInfoResponse, setFilesInfoResponse } = setup();
     setConversationsInfoResponse({
       ok: true,
@@ -978,6 +993,10 @@ describe("registerSlackTools", () => {
     expect(slack).toHaveBeenCalledWith("conversations.info", "xoxb-initial", {
       channel: "resolved:proj-alpha",
     });
+    expect(slack).toHaveBeenCalledWith("canvases.sections.lookup", "xoxb-initial", {
+      canvas_id: "F_CANVAS_1",
+      criteria: { section_types: ["any_header"] },
+    });
     expect(slack).toHaveBeenCalledWith("files.info", "xoxb-initial", {
       file: "F_CANVAS_1",
       limit: 5,
@@ -992,6 +1011,75 @@ describe("registerSlackTools", () => {
         returned_count: 0,
       }),
     );
+  });
+
+  it("rejects non-canvas file ids before calling files.info", async () => {
+    const { slack, tools } = setup();
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "canvases.sections.lookup") {
+          throw new Error("Slack canvases.sections.lookup: canvas_not_found");
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    await expect(
+      tools.get("slack_canvas_comments_read")!.execute("tool-canvas-3", {
+        canvas_id: "F_NOT_A_CANVAS",
+      }),
+    ).rejects.toThrow(
+      "Canvas F_NOT_A_CANVAS is unavailable, inaccessible, or not a canvas. This tool only reads comments for Slack canvases.",
+    );
+    expect(slack.mock.calls.some(([method]) => method === "files.info")).toBe(false);
+  });
+
+  it("surfaces inaccessible canvases clearly", async () => {
+    const { slack, tools } = setup();
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "canvases.sections.lookup") {
+          throw new Error("Slack canvases.sections.lookup: access_denied");
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    await expect(
+      tools.get("slack_canvas_comments_read")!.execute("tool-canvas-4", {
+        canvas_id: "F_PRIVATE_CANVAS",
+      }),
+    ).rejects.toThrow("Canvas F_PRIVATE_CANVAS is not accessible with the current bot token.");
+    expect(slack.mock.calls.some(([method]) => method === "files.info")).toBe(false);
+  });
+
+  it("surfaces deleted channel canvases clearly", async () => {
+    const { slack, tools, setConversationsInfoResponse } = setup();
+    setConversationsInfoResponse({
+      ok: true,
+      channel: {
+        id: "resolved:proj-alpha",
+        properties: { canvas: { id: "F_CANVAS_1" } },
+      },
+    } as SlackResult);
+
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "files.info") {
+          throw new Error("Slack files.info: channel_canvas_deleted");
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    await expect(
+      tools.get("slack_canvas_comments_read")!.execute("tool-canvas-5", {
+        channel: "proj-alpha",
+      }),
+    ).rejects.toThrow("Canvas F_CANVAS_1 is no longer available.");
   });
 
   // ─── slack_project_create ─────────────────────────────

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -34,6 +34,20 @@ describe("registerSlackTools", () => {
       members: [],
       response_metadata: { next_cursor: "" },
     } as SlackResult;
+    let conversationsInfoResponse: SlackResult = {
+      ok: true,
+      channel: { id: "C_PROJ", properties: {} },
+    } as SlackResult;
+    let filesInfoResponse: SlackResult = {
+      ok: true,
+      file: {
+        id: "F_CANVAS",
+        title: "Canvas",
+        comments_count: 0,
+      },
+      comments: [],
+      response_metadata: { next_cursor: "" },
+    } as SlackResult;
     const presenceResponses = new Map<string, SlackResult>();
     const dndResponses = new Map<string, SlackResult>();
 
@@ -157,10 +171,11 @@ describe("registerSlackTools", () => {
       }
 
       if (method === "conversations.info") {
-        return {
-          ok: true,
-          channel: { id: body?.channel ?? "C_PROJ", properties: {} },
-        } as unknown as SlackResult;
+        return conversationsInfoResponse;
+      }
+
+      if (method === "files.info") {
+        return filesInfoResponse;
       }
 
       return {
@@ -219,6 +234,12 @@ describe("registerSlackTools", () => {
       },
       setUsersListResponse: (response: SlackResult) => {
         usersListResponse = response;
+      },
+      setConversationsInfoResponse: (response: SlackResult) => {
+        conversationsInfoResponse = response;
+      },
+      setFilesInfoResponse: (response: SlackResult) => {
+        filesInfoResponse = response;
       },
       setPresenceResponse: (userId: string, response: SlackResult) => {
         presenceResponses.set(userId, response);
@@ -889,6 +910,88 @@ describe("registerSlackTools", () => {
         },
       ],
     });
+  });
+
+  it("reads canvas comments by canvas id via files.info", async () => {
+    const { slack, tools, setFilesInfoResponse, setResolveUser } = setup();
+    setResolveUser(async (userId) => (userId === "U123" ? "Alice" : userId));
+    setFilesInfoResponse({
+      ok: true,
+      file: {
+        id: "F123",
+        title: "Launch plan",
+        permalink: "https://example.slack.com/docs/T/F123",
+        comments_count: 2,
+      },
+      comments: [{ id: "Fc1", user: "U123", comment: "Please update rollout" }],
+      response_metadata: { next_cursor: "cursor-2" },
+    } as SlackResult);
+
+    const result = await tools.get("slack_canvas_comments_read")!.execute("tool-canvas-1", {
+      canvas_id: "F123",
+    });
+
+    expect(slack).toHaveBeenCalledWith("files.info", "xoxb-initial", {
+      file: "F123",
+      limit: 20,
+    });
+    expect(result.content?.[0]?.text).toContain("Canvas comments for Launch plan (F123)");
+    expect(result.content?.[0]?.text).toContain("Alice: Please update rollout");
+    expect(result.content?.[0]?.text).toContain("cursor=cursor-2");
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        canvas_id: "F123",
+        title: "Launch plan",
+        permalink: "https://example.slack.com/docs/T/F123",
+        comments_count: 2,
+        returned_count: 1,
+        next_cursor: "cursor-2",
+      }),
+    );
+  });
+
+  it("resolves a channel canvas before reading its comments", async () => {
+    const { slack, tools, setConversationsInfoResponse, setFilesInfoResponse } = setup();
+    setConversationsInfoResponse({
+      ok: true,
+      channel: {
+        id: "resolved:proj-alpha",
+        properties: { canvas: { id: "F_CANVAS_1" } },
+      },
+    } as SlackResult);
+    setFilesInfoResponse({
+      ok: true,
+      file: {
+        id: "F_CANVAS_1",
+        title: "Project canvas",
+        comments_count: 0,
+      },
+      comments: [],
+      response_metadata: { next_cursor: "" },
+    } as SlackResult);
+
+    const result = await tools.get("slack_canvas_comments_read")!.execute("tool-canvas-2", {
+      channel: "proj-alpha",
+      limit: 5,
+    });
+
+    expect(slack).toHaveBeenCalledWith("conversations.info", "xoxb-initial", {
+      channel: "resolved:proj-alpha",
+    });
+    expect(slack).toHaveBeenCalledWith("files.info", "xoxb-initial", {
+      file: "F_CANVAS_1",
+      limit: 5,
+    });
+    expect(result.content?.[0]?.text).toContain("Returned 0 of 0 comment(s).");
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        canvas_id: "F_CANVAS_1",
+        channel: "resolved:proj-alpha",
+        title: "Project canvas",
+        comments_count: 0,
+        returned_count: 0,
+      }),
+    );
   });
 
   // ─── slack_project_create ─────────────────────────────

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -252,6 +252,28 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     };
   }
 
+  async function assertCanvasCommentsTargetIsCanvas(canvasId: string): Promise<void> {
+    try {
+      await slack("canvases.sections.lookup", getBotToken(), {
+        canvas_id: canvasId,
+        criteria: { section_types: ["any_header"] },
+      });
+    } catch (err) {
+      if (isSlackMethodError(err, "canvases.sections.lookup", "canvas_deleted")) {
+        throw new Error(`Canvas ${canvasId} is no longer available.`);
+      }
+      if (isSlackMethodError(err, "canvases.sections.lookup", "access_denied")) {
+        throw new Error(`Canvas ${canvasId} is not accessible with the current bot token.`);
+      }
+      if (isSlackMethodError(err, "canvases.sections.lookup", "canvas_not_found")) {
+        throw new Error(
+          `Canvas ${canvasId} is unavailable, inaccessible, or not a canvas. This tool only reads comments for Slack canvases.`,
+        );
+      }
+      throw err;
+    }
+  }
+
   async function resolveSlackTargetChannel(
     threadTs: string | undefined,
     channel: string | undefined,
@@ -2092,11 +2114,17 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
   pi.registerTool({
     name: "slack_canvas_comments_read",
     label: "Slack Canvas Comments Read",
-    description: "Read comments attached to a Slack canvas by canvas ID or channel canvas lookup.",
+    description:
+      "Read comments attached to a Slack canvas after validating the target with Slack's canvas APIs.",
     promptSnippet:
-      "Inspect comments attached to a Slack canvas in read-only mode. Use cursor pagination when a canvas has many comments.",
+      "Inspect comments attached to a Slack canvas in read-only mode. This tool validates canvas targets before using files.info, and it does not inspect generic Slack files.",
     parameters: Type.Object({
-      canvas_id: Type.Optional(Type.String({ description: "Canvas ID to inspect" })),
+      canvas_id: Type.Optional(
+        Type.String({
+          description:
+            "Canvas ID to inspect. The ID is validated as a canvas before comments are read.",
+        }),
+      ),
       channel: Type.Optional(
         Type.String({ description: "Channel name or ID whose channel canvas should be inspected" }),
       ),
@@ -2119,15 +2147,45 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       const target = await resolveCanvasTarget(params.canvas_id, params.channel);
       const limit = normalizeSlackCanvasCommentsLimit(params.limit);
       const cursor = normalizeOptionalSlackCursor(params.cursor);
-      const response = await slack("files.info", getBotToken(), {
-        file: target.canvasId,
-        limit,
-        ...(cursor ? { cursor } : {}),
-      });
+
+      await assertCanvasCommentsTargetIsCanvas(target.canvasId);
+
+      let response: SlackResult;
+      try {
+        response = await slack("files.info", getBotToken(), {
+          file: target.canvasId,
+          limit,
+          ...(cursor ? { cursor } : {}),
+        });
+      } catch (err) {
+        if (
+          isSlackMethodError(
+            err,
+            "files.info",
+            "channel_canvas_deleted",
+            "file_deleted",
+            "file_not_found",
+          )
+        ) {
+          throw new Error(`Canvas ${target.canvasId} is no longer available.`);
+        }
+        if (isSlackMethodError(err, "files.info", "access_denied")) {
+          throw new Error(
+            `Canvas ${target.canvasId} is not accessible with the current bot token.`,
+          );
+        }
+        throw err;
+      }
+
       const page = extractSlackCanvasCommentsPage(
         response as unknown as Record<string, unknown>,
         target.canvasId,
       );
+      if (page.canvasId !== target.canvasId) {
+        throw new Error(
+          `Slack files.info returned comments for ${page.canvasId}, but canvas comment inspection requested ${target.canvasId}.`,
+        );
+      }
       const comments = await Promise.all(
         page.comments.map(async (comment) => ({
           ...comment,

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -7,7 +7,9 @@ import {
   buildSlackCanvasCreateRequest,
   buildSlackCanvasEditRequest,
   buildSlackCanvasSectionsLookupRequest,
+  extractSlackCanvasCommentsPage,
   extractSlackChannelCanvasId,
+  normalizeSlackCanvasCommentsLimit,
   normalizeSlackCanvasCreateKind,
   normalizeSlackCanvasUpdateMode,
   pickSlackCanvasSectionId,
@@ -109,6 +111,47 @@ function getSlackCanvasSummary(markdown?: string): string {
   const collapsed = markdown.replace(/\s+/g, " ").trim();
   if (collapsed.length <= 80) return collapsed;
   return `${collapsed.slice(0, 77)}...`;
+}
+
+function normalizeOptionalSlackCursor(cursor?: string): string | undefined {
+  const trimmed = cursor?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function buildSlackCanvasCommentsSummaryText(input: {
+  canvasId: string;
+  title?: string;
+  commentsCount: number;
+  returnedCount: number;
+  nextCursor?: string;
+  comments: Array<{
+    userName?: string;
+    userId?: string;
+    createdTs?: string;
+    text: string;
+  }>;
+}): string {
+  const label = input.title ? `${input.title} (${input.canvasId})` : input.canvasId;
+  const lines = [
+    `Canvas comments for ${label}`,
+    `Returned ${input.returnedCount} of ${input.commentsCount} comment(s).`,
+  ];
+
+  if (input.comments.length === 0) {
+    lines.push("(no comments)");
+  } else {
+    for (const comment of input.comments) {
+      const author = comment.userName ?? comment.userId ?? "unknown";
+      const created = comment.createdTs ?? "unknown-ts";
+      lines.push(`[${created}] ${author}: ${comment.text}`);
+    }
+  }
+
+  if (input.nextCursor) {
+    lines.push(`More comments are available. Re-run with cursor=${input.nextCursor}.`);
+  }
+
+  return lines.join("\n");
 }
 
 function isSlackMethodError(err: unknown, method: string, ...codes: string[]): boolean {
@@ -2042,6 +2085,88 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       return {
         content: [{ type: "text", text: lines.join("\n") || "(no messages)" }],
         details: { count: messages.length, channel: channelId },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_canvas_comments_read",
+    label: "Slack Canvas Comments Read",
+    description: "Read comments attached to a Slack canvas by canvas ID or channel canvas lookup.",
+    promptSnippet:
+      "Inspect comments attached to a Slack canvas in read-only mode. Use cursor pagination when a canvas has many comments.",
+    parameters: Type.Object({
+      canvas_id: Type.Optional(Type.String({ description: "Canvas ID to inspect" })),
+      channel: Type.Optional(
+        Type.String({ description: "Channel name or ID whose channel canvas should be inspected" }),
+      ),
+      limit: Type.Optional(
+        Type.Number({ description: "Max comments to return per call (default 20, max 200)" }),
+      ),
+      cursor: Type.Optional(
+        Type.String({
+          description: "Pagination cursor returned by a previous canvas comment read",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_canvas_comments_read",
+        undefined,
+        `canvas_id=${params.canvas_id ?? ""} | channel=${params.channel ?? ""} | limit=${params.limit ?? 20} | cursor=${params.cursor ?? ""}`,
+      );
+
+      const target = await resolveCanvasTarget(params.canvas_id, params.channel);
+      const limit = normalizeSlackCanvasCommentsLimit(params.limit);
+      const cursor = normalizeOptionalSlackCursor(params.cursor);
+      const response = await slack("files.info", getBotToken(), {
+        file: target.canvasId,
+        limit,
+        ...(cursor ? { cursor } : {}),
+      });
+      const page = extractSlackCanvasCommentsPage(
+        response as unknown as Record<string, unknown>,
+        target.canvasId,
+      );
+      const comments = await Promise.all(
+        page.comments.map(async (comment) => ({
+          ...comment,
+          ...(comment.userId ? { userName: await resolveUser(comment.userId) } : {}),
+        })),
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: buildSlackCanvasCommentsSummaryText({
+              canvasId: page.canvasId,
+              title: page.title,
+              commentsCount: page.commentsCount,
+              returnedCount: page.returnedCount,
+              nextCursor: page.nextCursor,
+              comments,
+            }),
+          },
+        ],
+        details: {
+          canvas_id: page.canvasId,
+          channel: target.channelId,
+          title: page.title,
+          permalink: page.permalink,
+          comments_count: page.commentsCount,
+          returned_count: page.returnedCount,
+          ...(page.page ? { page: page.page } : {}),
+          ...(page.pages ? { pages: page.pages } : {}),
+          ...(page.nextCursor ? { next_cursor: page.nextCursor } : {}),
+          comments: comments.map((comment) => ({
+            id: comment.id,
+            user_id: comment.userId,
+            user_name: comment.userName,
+            created_ts: comment.createdTs,
+            text: comment.text,
+          })),
+        },
       };
     },
   });

--- a/slack-bridge/slack-turn-guardrails.test.ts
+++ b/slack-bridge/slack-turn-guardrails.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPendingSlackToolPolicyTurn,
+  consumePendingSlackToolPolicyTurn,
+  deliverTrackedSlackFollowUpMessage,
+} from "./slack-turn-guardrails.js";
+
+describe("Slack turn guardrail delivery ordering", () => {
+  it("arms the pending Slack turn before delivery so synchronous input handlers can consume it", () => {
+    const queue: ReturnType<typeof buildPendingSlackToolPolicyTurn>[] = [];
+    let consumed: ReturnType<typeof buildPendingSlackToolPolicyTurn> | null = null;
+
+    const delivered = deliverTrackedSlackFollowUpMessage({
+      queue,
+      prompt: "guarded slack prompt",
+      messages: [{ threadTs: "100.1" }],
+      deliver: (prompt) => {
+        consumed = consumePendingSlackToolPolicyTurn(queue, prompt);
+        return true;
+      },
+    });
+
+    expect(delivered).toBe(true);
+    expect(consumed).toEqual({
+      prompt: "guarded slack prompt",
+      threadTs: "100.1",
+      threadCount: 1,
+    });
+    expect(queue).toEqual([]);
+  });
+
+  it("rolls back the pending Slack turn if follow-up delivery fails", () => {
+    const queue: ReturnType<typeof buildPendingSlackToolPolicyTurn>[] = [];
+
+    const delivered = deliverTrackedSlackFollowUpMessage({
+      queue,
+      prompt: "guarded slack prompt",
+      messages: [{ threadTs: "100.1" }],
+      deliver: () => false,
+    });
+
+    expect(delivered).toBe(false);
+    expect(queue).toEqual([]);
+  });
+
+  it("tracks batched multi-thread Slack turns without inventing a confirmation thread", () => {
+    const entry = buildPendingSlackToolPolicyTurn("batched", [
+      { threadTs: "100.1" },
+      { threadTs: "200.2" },
+      { threadTs: "100.1" },
+    ]);
+
+    expect(entry).toEqual({
+      prompt: "batched",
+      threadTs: undefined,
+      threadCount: 2,
+    });
+  });
+});

--- a/slack-bridge/slack-turn-guardrails.ts
+++ b/slack-bridge/slack-turn-guardrails.ts
@@ -1,0 +1,63 @@
+import type { InboxMessage } from "./helpers.js";
+
+export interface PendingSlackToolPolicyTurn {
+  prompt: string;
+  threadTs: string | undefined;
+  threadCount: number;
+}
+
+export function buildPendingSlackToolPolicyTurn(
+  prompt: string,
+  messages: Pick<InboxMessage, "threadTs">[],
+): PendingSlackToolPolicyTurn {
+  const threadIds = [...new Set(messages.map((message) => message.threadTs).filter(Boolean))];
+  return {
+    prompt,
+    threadTs: threadIds.length === 1 ? threadIds[0] : undefined,
+    threadCount: threadIds.length,
+  };
+}
+
+export function enqueuePendingSlackToolPolicyTurn(
+  queue: PendingSlackToolPolicyTurn[],
+  prompt: string,
+  messages: Pick<InboxMessage, "threadTs">[],
+): PendingSlackToolPolicyTurn {
+  const entry = buildPendingSlackToolPolicyTurn(prompt, messages);
+  queue.push(entry);
+  return entry;
+}
+
+export function consumePendingSlackToolPolicyTurn(
+  queue: PendingSlackToolPolicyTurn[],
+  text: string,
+): PendingSlackToolPolicyTurn | null {
+  const index = queue.findIndex((entry) => entry.prompt === text);
+  if (index < 0) return null;
+  const [entry] = queue.splice(index, 1);
+  return entry ?? null;
+}
+
+export function removePendingSlackToolPolicyTurn(
+  queue: PendingSlackToolPolicyTurn[],
+  entry: PendingSlackToolPolicyTurn,
+): void {
+  const index = queue.indexOf(entry);
+  if (index >= 0) {
+    queue.splice(index, 1);
+  }
+}
+
+export function deliverTrackedSlackFollowUpMessage(options: {
+  queue: PendingSlackToolPolicyTurn[];
+  prompt: string;
+  messages: Pick<InboxMessage, "threadTs">[];
+  deliver: (prompt: string) => boolean;
+}): boolean {
+  const entry = enqueuePendingSlackToolPolicyTurn(options.queue, options.prompt, options.messages);
+  if (options.deliver(options.prompt)) {
+    return true;
+  }
+  removePendingSlackToolPolicyTurn(options.queue, entry);
+  return false;
+}


### PR DESCRIPTION
## Summary
- plumb transport `source` through broker thread claims instead of hardcoding Slack
- preserve that `source` in follower thread cache + owned-thread reclaim on resume
- keep Slack explicit at the adapter edge while leaving the seam small and transport-oriented

## Why
This is a narrow ports/adapters seam for the future Symphony split: it removes a core broker assumption that every claimed or resumed thread is Slack, without folding in package moves or broader Slack UX changes.

## Checks
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `cd slack-bridge && pnpm test -- helpers.test.ts broker/router.test.ts broker/integration.test.ts`

## Stack / release handling
- Stacked on #333 via base branch `fix/323-slack-allowlist-defaults`
- Scope frozen to the transport-source ownership seam
- Queue behind #333; only pull into tonight's release if there's still room after the gate clears

## Release note
Preserve message transport source through broker thread ownership so future non-Slack adapters can claim and resume threads without being recorded as Slack.