### PR TITLE
fix: default Slack access to explicit opt-in (#323) [release backup]

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -137,11 +137,17 @@ Behavior and precedence:
 }
 ```
 
+Slack access is now **default-deny** unless you configure one of these explicitly:
+
+- `allowedUsers` / `SLACK_ALLOWED_USERS` — allow only specific Slack user IDs
+- `allowAllWorkspaceUsers: true` / `SLACK_ALLOW_ALL_WORKSPACE_USERS=true` — explicit workspace-wide opt-in
+
 | Key                            | Required | Description                                                                                             |
 | ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------- |
 | `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                       |
 | `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                            |
-| `allowedUsers`                 | no       | Slack user IDs that can interact (all users if unset)                                                   |
+| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true  |
+| `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                   |
 | `defaultChannel`               | no       | Default channel for `slack_post_channel`                                                                |
 | `logChannel`                   | no       | Channel for broker activity logs                                                                        |
 | `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                       |
@@ -254,7 +260,7 @@ Or set `"autoFollow": true` in settings to auto-connect when a broker is running
 
 ## Security
 
-- **User allowlist**: Set `allowedUsers` to restrict who can interact with Pinet
+- **User access**: Slack access is default-deny. Set `allowedUsers` for a narrow allowlist, or `allowAllWorkspaceUsers: true` only if you explicitly want workspace-wide access
 - **Tool guardrails**: Use `security.requireConfirmation` and `security.blockedTools` to control tool access
 - **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` (or `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH`) to require a shared secret; leave them unset to disable shared-secret auth. Configured followers fail closed on missing secret files or older/no-auth brokers rather than silently downgrading.
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -516,6 +516,7 @@ describe("SlackAdapter", () => {
   const baseConfig = {
     botToken: "xoxb-test-token",
     appToken: "xapp-test-token",
+    allowAllWorkspaceUsers: true,
   };
 
   it("can be constructed with minimal config", () => {
@@ -910,11 +911,18 @@ describe("SlackAdapter — allowlist filtering", () => {
     expect(isUserAllowed(allowlist, "U_AUTHORIZED")).toBe(true);
   });
 
-  it("allows all users when no allowlist is configured", async () => {
+  it("rejects all users by default when no allowlist is configured", async () => {
     const { isUserAllowed, buildAllowlist } = await import("../../helpers.js");
-    const allowlist = buildAllowlist({}, undefined);
+    const allowlist = buildAllowlist({}, undefined, undefined);
+    expect(allowlist).toEqual(new Set());
+    expect(isUserAllowed(allowlist, "U_ANYONE")).toBe(false);
+  });
+
+  it("still supports explicit allow-all mode", async () => {
+    const { isUserAllowed, buildAllowlist } = await import("../../helpers.js");
+    const allowlist = buildAllowlist({ allowAllWorkspaceUsers: true }, undefined, undefined);
     expect(allowlist).toBeNull();
-    expect(isUserAllowed(null, "U_ANYONE")).toBe(true);
+    expect(isUserAllowed(allowlist, "U_ANYONE")).toBe(true);
   });
 });
 
@@ -982,6 +990,7 @@ describe("SlackAdapter — reaction triggers", () => {
     const adapter = new SlackAdapter({
       botToken: "xoxb-test",
       appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
       reactionCommands: { "👀": "review" },
       rememberKnownThread,
     });
@@ -1426,6 +1435,7 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     const adapter = new SlackAdapter({
       botToken: "xoxb-test",
       appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
     });
     const handler = vi.fn();
     adapter.onInbound(handler);

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -31,6 +31,7 @@ export interface SlackAdapterConfig {
   botToken: string;
   appToken: string;
   allowedUsers?: string[];
+  allowAllWorkspaceUsers?: boolean;
   suggestedPrompts?: { title: string; message: string }[];
   reactionCommands?: ReactionCommandSettings;
   /** Check whether a thread_ts belongs to a known thread in the broker DB. */
@@ -245,7 +246,14 @@ export class SlackAdapter implements MessageAdapter {
 
   constructor(config: SlackAdapterConfig) {
     this.config = config;
-    this.allowlist = buildAllowlist({ allowedUsers: config.allowedUsers }, undefined);
+    this.allowlist = buildAllowlist(
+      {
+        allowedUsers: config.allowedUsers,
+        allowAllWorkspaceUsers: config.allowAllWorkspaceUsers,
+      },
+      undefined,
+      undefined,
+    );
     this.reactionCommands = resolveReactionCommands(config.reactionCommands);
   }
 

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -40,6 +40,7 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     dir = tmpDir();
     db = new BrokerDB(path.join(dir, "test.db"));
     db.initialize();
+    db.setAllowedUsers(null);
 
     server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 });
     await server.start();
@@ -787,6 +788,7 @@ describe("broker integration — router with real DB", () => {
   });
 
   it("routes inbound message to thread owner", () => {
+    db.setAllowedUsers(null);
     const router = new MessageRouter(db);
 
     db.registerAgent("agent-1", "Agent One", "1️⃣", process.pid);
@@ -812,6 +814,7 @@ describe("broker integration — router with real DB", () => {
   });
 
   it("routes by agent mention when no thread owner", () => {
+    db.setAllowedUsers(null);
     const router = new MessageRouter(db);
 
     db.registerAgent("code-bot", "CodeBot", "🤖", process.pid);
@@ -830,6 +833,7 @@ describe("broker integration — router with real DB", () => {
   });
 
   it("binds an existing unclaimed thread when a human directly addresses an agent", () => {
+    db.setAllowedUsers(null);
     const router = new MessageRouter(db);
 
     db.registerAgent("code-bot", "CodeBot", "🤖", process.pid);
@@ -867,6 +871,7 @@ describe("broker integration — router with real DB", () => {
   });
 
   it("returns unrouted for unknown thread with no matching agent", () => {
+    db.setAllowedUsers(null);
     const router = new MessageRouter(db);
 
     const decision = router.route({
@@ -948,7 +953,13 @@ describe("broker integration — router with real DB", () => {
     expect(fetched!.ownerAgent).toBeNull();
   });
 
-  it("getAllowedUsers returns null (unconfigured)", () => {
+  it("getAllowedUsers defaults to deny-all and supports explicit allow-all", () => {
+    expect(db.getAllowedUsers()).toEqual(new Set());
+
+    db.setAllowedUsers(["U123", "U456"]);
+    expect(db.getAllowedUsers()).toEqual(new Set(["U123", "U456"]));
+
+    db.setAllowedUsers(null);
     expect(db.getAllowedUsers()).toBeNull();
   });
 

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -362,7 +362,17 @@ describe("MessageRouter — route", () => {
     expect(decision).toEqual({ action: "reject", reason: "User not in allowlist" });
   });
 
-  it("allows all users when allowlist is null", () => {
+  it("rejects all users by default when the allowlist is empty", () => {
+    db.allowedUsers = new Set();
+    db.agents = [makeAgent({ id: "a1", name: "Bot1" })];
+    db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: "a1" }));
+
+    const decision = router.route(makeMessage({ userId: "U001" }));
+
+    expect(decision).toEqual({ action: "reject", reason: "User not in allowlist" });
+  });
+
+  it("allows all users only when allowlist is explicitly null", () => {
     db.allowedUsers = null;
     db.agents = [makeAgent({ id: "a1", name: "Bot1" })];
     db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: "a1" }));

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -577,6 +577,7 @@ function runSchemaMigrations(db: DatabaseSync): void {
 export class BrokerDB implements BrokerDBInterface {
   private db: DatabaseSync | null = null;
   private readonly dbPath: string;
+  private allowedUsers: Set<string> | null = new Set();
 
   constructor(dbPath?: string) {
     this.dbPath = dbPath ?? defaultDbPath();
@@ -1083,8 +1084,12 @@ export class BrokerDB implements BrokerDBInterface {
     return thread?.ownerAgent === agentId;
   }
 
+  setAllowedUsers(users: Iterable<string> | null): void {
+    this.allowedUsers = users === null ? null : new Set(users);
+  }
+
   getAllowedUsers(): Set<string> | null {
-    return null;
+    return this.allowedUsers === null ? null : new Set(this.allowedUsers);
   }
 
   getChannelAssignment(_channel: string): ChannelAssignment | null {

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -159,6 +159,12 @@ export interface BrokerDBInterface {
   getAgentByStableId(stableId: string): AgentInfo | null;
   getAgents(): AgentInfo[];
   getChannelAssignment(channel: string): ChannelAssignment | null;
+  /**
+   * Slack user access policy for inbound routing.
+   * - `null` => explicit allow-all
+   * - non-empty Set => explicit allowlist
+   * - empty Set => default-deny / allow nobody
+   */
   getAllowedUsers(): Set<string> | null;
 
   createThread(thread: ThreadInfo): void;

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -5,7 +5,10 @@ import * as os from "node:os";
 import {
   loadSettings,
   resolvePinetMeshAuth,
+  resolveAllowAllWorkspaceUsers,
   buildAllowlist,
+  describeSlackUserAccess,
+  getSlackUserAccessWarning,
   isUserAllowed,
   formatInboxMessages,
   formatPinetInboxMessages,
@@ -132,6 +135,7 @@ describe("loadSettings", () => {
         appToken: "xapp-test",
         autoConnect: true,
         allowedUsers: ["U123"],
+        allowAllWorkspaceUsers: false,
         defaultChannel: "C456",
         logChannel: "#pinet-logs",
         logLevel: "verbose",
@@ -143,6 +147,7 @@ describe("loadSettings", () => {
     expect(result.appToken).toBe("xapp-test");
     expect(result.autoConnect).toBe(true);
     expect(result.allowedUsers).toEqual(["U123"]);
+    expect(result.allowAllWorkspaceUsers).toBe(false);
     expect(result.defaultChannel).toBe("C456");
     expect(result.logChannel).toBe("#pinet-logs");
     expect(result.logLevel).toBe("verbose");
@@ -308,43 +313,97 @@ describe("resolvePinetMeshAuth", () => {
   });
 });
 
-// ─── buildAllowlist ───────────────────────────────────────
+// ─── Slack user access policy ────────────────────────────
 
-describe("buildAllowlist", () => {
-  it("returns null when no allowlist configured", () => {
-    expect(buildAllowlist({}, undefined)).toBeNull();
+describe("resolveAllowAllWorkspaceUsers", () => {
+  it("defaults to false when unset", () => {
+    expect(resolveAllowAllWorkspaceUsers({}, undefined)).toBe(false);
   });
 
-  it("returns null for empty allowedUsers array", () => {
-    expect(buildAllowlist({ allowedUsers: [] }, undefined)).toBeNull();
+  it("uses settings flag when present", () => {
+    expect(resolveAllowAllWorkspaceUsers({ allowAllWorkspaceUsers: true }, undefined)).toBe(true);
+    expect(resolveAllowAllWorkspaceUsers({ allowAllWorkspaceUsers: false }, "true")).toBe(false);
+  });
+
+  it("supports truthy env opt-in values", () => {
+    expect(resolveAllowAllWorkspaceUsers({}, "true")).toBe(true);
+    expect(resolveAllowAllWorkspaceUsers({}, "1")).toBe(true);
+    expect(resolveAllowAllWorkspaceUsers({}, "yes")).toBe(true);
+    expect(resolveAllowAllWorkspaceUsers({}, "on")).toBe(true);
+  });
+});
+
+describe("buildAllowlist", () => {
+  it("returns an empty set when no allowlist or explicit allow-all is configured", () => {
+    expect(buildAllowlist({}, undefined, undefined)).toEqual(new Set());
+  });
+
+  it("returns an empty set for an empty allowedUsers array", () => {
+    expect(buildAllowlist({ allowedUsers: [] }, undefined, undefined)).toEqual(new Set());
   });
 
   it("builds from settings.allowedUsers", () => {
-    const result = buildAllowlist({ allowedUsers: ["U1", "U2"] }, undefined);
+    const result = buildAllowlist({ allowedUsers: ["U1", " U2 ", ""] }, undefined);
     expect(result).toEqual(new Set(["U1", "U2"]));
   });
 
   it("settings takes priority over env var", () => {
-    const result = buildAllowlist({ allowedUsers: ["U1"] }, "U2,U3");
+    const result = buildAllowlist({ allowedUsers: ["U1"] }, "U2,U3", "true");
     expect(result).toEqual(new Set(["U1"]));
   });
 
   it("falls back to env var when settings empty", () => {
-    const result = buildAllowlist({}, "U2, U3 , U4");
+    const result = buildAllowlist({}, "U2, U3 , U4", undefined);
     expect(result).toEqual(new Set(["U2", "U3", "U4"]));
   });
 
+  it("returns null only for explicit allow-all opt-in", () => {
+    expect(buildAllowlist({ allowAllWorkspaceUsers: true }, undefined, undefined)).toBeNull();
+    expect(buildAllowlist({}, undefined, "true")).toBeNull();
+  });
+
   it("trims and filters empty entries from env var", () => {
-    const result = buildAllowlist({}, " U1 , , U2 , ");
+    const result = buildAllowlist({}, " U1 , , U2 , ", undefined);
     expect(result).toEqual(new Set(["U1", "U2"]));
+  });
+});
+
+describe("describeSlackUserAccess", () => {
+  it("describes default deny when the allowlist is empty", () => {
+    expect(describeSlackUserAccess(new Set())).toBe(
+      "Allowed users: none (default deny; set allowedUsers or allowAllWorkspaceUsers: true)",
+    );
+  });
+
+  it("describes explicit allow-all mode", () => {
+    expect(describeSlackUserAccess(null, { allowAllWorkspaceUsers: true })).toBe(
+      "Allowed users: all (explicit allow-all enabled)",
+    );
+  });
+});
+
+describe("getSlackUserAccessWarning", () => {
+  it("returns a startup warning for default deny mode", () => {
+    expect(getSlackUserAccessWarning(new Set())).toContain(
+      "Slack access is default-deny because no allowedUsers are configured.",
+    );
+  });
+
+  it("returns null when access is explicitly configured", () => {
+    expect(getSlackUserAccessWarning(new Set(["U1"]))).toBeNull();
+    expect(getSlackUserAccessWarning(null)).toBeNull();
   });
 });
 
 // ─── isUserAllowed ────────────────────────────────────────
 
 describe("isUserAllowed", () => {
-  it("allows everyone when allowlist is null", () => {
+  it("allows everyone when explicit allow-all mode is active", () => {
     expect(isUserAllowed(null, "U_ANYONE")).toBe(true);
+  });
+
+  it("rejects everyone when the allowlist is empty", () => {
+    expect(isUserAllowed(new Set(), "U_ANYONE")).toBe(false);
   });
 
   it("allows user in the set", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -12,6 +12,7 @@ export interface SlackBridgeSettings {
   appId?: string;
   appConfigToken?: string;
   allowedUsers?: string[];
+  allowAllWorkspaceUsers?: boolean;
   defaultChannel?: string;
   logChannel?: string;
   logLevel?: "errors" | "actions" | "verbose";
@@ -79,19 +80,73 @@ export function loadSettings(settingsPath?: string): SlackBridgeSettings {
 
 // ─── Allowlist ───────────────────────────────────────────
 
-export function buildAllowlist(settings: SlackBridgeSettings, envVar?: string): Set<string> | null {
-  if (settings.allowedUsers && settings.allowedUsers.length > 0) {
-    return new Set(settings.allowedUsers);
+function parseBooleanOptIn(value?: string | null): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function resolveAllowAllWorkspaceUsers(
+  settings: SlackBridgeSettings,
+  envVar = process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+): boolean {
+  if (typeof settings.allowAllWorkspaceUsers === "boolean") {
+    return settings.allowAllWorkspaceUsers;
   }
-  if (envVar) {
-    return new Set(
-      envVar
-        .split(",")
-        .map((id) => id.trim())
-        .filter(Boolean),
-    );
+  return parseBooleanOptIn(envVar);
+}
+
+export function buildAllowlist(
+  settings: SlackBridgeSettings,
+  envVar?: string,
+  allowAllEnvVar = process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+): Set<string> | null {
+  const configuredUsers = settings.allowedUsers?.map((id) => id.trim()).filter(Boolean) ?? [];
+  if (configuredUsers.length > 0) {
+    return new Set(configuredUsers);
   }
-  return null;
+
+  const envUsers =
+    envVar
+      ?.split(",")
+      .map((id) => id.trim())
+      .filter(Boolean) ?? [];
+  if (envUsers.length > 0) {
+    return new Set(envUsers);
+  }
+
+  if (resolveAllowAllWorkspaceUsers(settings, allowAllEnvVar)) {
+    return null;
+  }
+
+  return new Set();
+}
+
+export function describeSlackUserAccess(
+  allowlist: Set<string> | null,
+  options: { allowAllWorkspaceUsers?: boolean } = {},
+): string {
+  if (allowlist === null) {
+    return options.allowAllWorkspaceUsers
+      ? "Allowed users: all (explicit allow-all enabled)"
+      : "Allowed users: all";
+  }
+
+  if (allowlist.size > 0) {
+    return `Allowed users: ${[...allowlist].join(", ")}`;
+  }
+
+  return "Allowed users: none (default deny; set allowedUsers or allowAllWorkspaceUsers: true)";
+}
+
+export function getSlackUserAccessWarning(allowlist: Set<string> | null): string | null {
+  if (allowlist === null || allowlist.size > 0) {
+    return null;
+  }
+
+  return [
+    "Slack access is default-deny because no allowedUsers are configured.",
+    "Set slack-bridge.allowedUsers or explicit allowAllWorkspaceUsers: true to accept Slack users.",
+  ].join(" ");
 }
 
 export function isUserAllowed(allowlist: Set<string> | null, userId: string): boolean {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -61,6 +61,15 @@ describe("slack-bridge top-level shutdown", () => {
     process.env.SLACK_APP_TOKEN = "xapp-test";
     testHome = fs.mkdtempSync(path.join(os.tmpdir(), "slack-bridge-test-home-"));
     process.env.HOME = testHome;
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "slack-bridge": {
+          allowAllWorkspaceUsers: true,
+        },
+      }),
+    );
   });
 
   afterEach(() => {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -14,6 +14,7 @@ import {
   type RalphLoopEvaluationOptions,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
+  getSlackUserAccessWarning,
   isUserAllowed as checkUserAllowed,
   formatInboxMessages,
   formatPinetInboxMessages,
@@ -54,6 +55,7 @@ import {
   normalizePinetSkinTheme,
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
+  resolveAllowAllWorkspaceUsers,
   resolvePinetMeshAuth,
   syncFollowerInboxEntries,
   syncBrokerInboxEntries,
@@ -195,12 +197,32 @@ export default function (pi: ExtensionAPI) {
     return slackRequests.run((signal) => callSlackAPI(method, token, body, { signal }));
   }
 
-  // allowedUsers: settings.json takes priority, env var as fallback
-  let allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
+  // allowedUsers / allowAllWorkspaceUsers: settings.json takes priority, env vars as fallback
+  let allowedUsers = buildAllowlist(
+    settings,
+    process.env.SLACK_ALLOWED_USERS,
+    process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+  );
   let reactionCommands = resolveReactionCommands(settings.reactionCommands);
 
   function isUserAllowed(userId: string): boolean {
     return checkUserAllowed(allowedUsers, userId);
+  }
+
+  let lastSlackUserAccessWarning = "";
+
+  function maybeWarnSlackUserAccess(ctx?: ExtensionContext): void {
+    const warning = getSlackUserAccessWarning(allowedUsers);
+    if (!warning) {
+      lastSlackUserAccessWarning = "";
+      return;
+    }
+    if (warning === lastSlackUserAccessWarning) {
+      return;
+    }
+    lastSlackUserAccessWarning = warning;
+    console.warn(`[slack-bridge] ${warning}`);
+    ctx?.ui.notify(warning, "warning");
   }
 
   const initialIdentity = resolveAgentIdentity(settings, process.env.PI_NICKNAME, process.cwd());
@@ -329,7 +351,11 @@ export default function (pi: ExtensionAPI) {
     settings = loadSettingsFromFile();
     botToken = settings.botToken ?? process.env.SLACK_BOT_TOKEN;
     appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
-    allowedUsers = buildAllowlist(settings, process.env.SLACK_ALLOWED_USERS);
+    allowedUsers = buildAllowlist(
+      settings,
+      process.env.SLACK_ALLOWED_USERS,
+      process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+    );
     guardrails = settings.security ?? {};
     reactionCommands = resolveReactionCommands(settings.reactionCommands);
     securityPrompt = buildSecurityPrompt(guardrails);
@@ -2926,6 +2952,7 @@ export default function (pi: ExtensionAPI) {
 
   async function connectAsBroker(ctx: ExtensionContext): Promise<void> {
     refreshSettings();
+    maybeWarnSlackUserAccess(ctx);
     const meshAuth = resolvePinetMeshAuth(settings);
     const broker = await startBroker({
       ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
@@ -2935,6 +2962,10 @@ export default function (pi: ExtensionAPI) {
       botToken: botToken!,
       appToken: appToken!,
       allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
+      allowAllWorkspaceUsers: resolveAllowAllWorkspaceUsers(
+        settings,
+        process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+      ),
       suggestedPrompts: settings.suggestedPrompts,
       reactionCommands: settings.reactionCommands,
       isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
@@ -3645,6 +3676,8 @@ export default function (pi: ExtensionAPI) {
       setExtStatus(ctx, "off");
       return;
     }
+
+    maybeWarnSlackUserAccess(ctx);
 
     // Auto-follow: if enabled and broker socket exists, connect as follower
     if (settings.autoFollow && fs.existsSync(DEFAULT_SOCKET_PATH)) {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -2979,6 +2979,7 @@ export default function (pi: ExtensionAPI) {
     let selfId: string | null = null;
 
     try {
+      broker.db.setAllowedUsers(allowedUsers);
       const router = new MessageRouter(broker.db);
       activeSkinTheme =
         broker.db.getSetting<string>(PINET_SKIN_SETTING_KEY) ?? DEFAULT_PINET_SKIN_THEME;

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -1,5 +1,11 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { generateAgentName, agentOwnsThread } from "./helpers.js";
+import {
+  generateAgentName,
+  agentOwnsThread,
+  describeSlackUserAccess,
+  resolveAllowAllWorkspaceUsers,
+  type SlackBridgeSettings,
+} from "./helpers.js";
 import { formatRecentActivityLogEntries, type SlackActivityLogger } from "./activity-log.js";
 
 // ─── Types ───────────────────────────────────────────────
@@ -21,11 +27,7 @@ export interface PinetCommandsDeps {
   allowedUsers: () => Set<string> | null;
   inboxLength: () => number;
   activityLogger: () => SlackActivityLogger;
-  settings: () => {
-    defaultChannel?: string;
-    logChannel?: string;
-    logLevel?: string;
-  };
+  settings: () => SlackBridgeSettings;
   lastBrokerMaintenance: () => {
     pendingBacklogCount: number;
     assignedBacklogCount: number;
@@ -238,10 +240,13 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
         agentOwnsThread(t.owner, deps.agentName(), deps.agentAliases(), deps.agentOwnerToken()),
       ).length;
       const users = deps.allowedUsers();
-      const allowlistInfo = users
-        ? `Allowed users: ${[...users].join(", ")}`
-        : "Allowed users: all (no allowlist set)";
       const s = deps.settings();
+      const allowlistInfo = describeSlackUserAccess(users, {
+        allowAllWorkspaceUsers: resolveAllowAllWorkspaceUsers(
+          s,
+          process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+        ),
+      });
       const defaultChInfo = s.defaultChannel
         ? `Default channel: ${s.defaultChannel}`
         : "Default channel: none";


### PR DESCRIPTION
This is a narrow backup/unblock PR for #333.

Why this exists:
- #333 is currently dirty against main
- the conflict is limited to 3 files: `slack-bridge/index.ts`, `slack-bridge/broker/adapters/slack.ts`, and `slack-bridge/README.md`
- the merged state has already been reproduced and tested on branch `chore/release-gate-333`

Intent:
- keep current main structure for runtime modes + shared Slack access plumbing
- layer #333's default-deny / `allowAllWorkspaceUsers` behavior and docs on top
- provide the lowest-churn release unblock path if updating the original #333 branch is not practical

Checks reported by the worker on this branch:
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- targeted Vitest run (413 tests passed)

If the original #333 branch is updated directly, this PR can be closed. Otherwise this PR can serve as the pre-resolved replacement unblock path.
