### PR TITLE
fix: align RALPH ghost visibility

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -30,6 +30,8 @@ import {
   formatAgentList,
   shortenPath,
   buildAgentDisplayInfo,
+  isAgentVisibleInMesh,
+  filterAgentsForMeshVisibility,
   rankAgentsForRouting,
   evaluateRalphLoopCycle,
   rewriteRalphLoopGhostAnomalies,
@@ -1636,6 +1638,40 @@ describe("buildAgentDisplayInfo", () => {
     expect(agent.health).toBe("ghost");
     expect(agent.ghost).toBe(true);
     expect(agent.leaseSummary).toBe("lease expired 5s ago");
+  });
+});
+
+describe("mesh visibility helpers", () => {
+  it("keeps connected agents and only recently disconnected ghosts in the visible mesh", () => {
+    const now = Date.parse("2026-01-01T00:01:00.000Z");
+    const agents = [
+      { id: "connected", disconnectedAt: null },
+      { id: "recent-ghost", disconnectedAt: "2026-01-01T00:00:40.000Z" },
+      { id: "stale-ghost", disconnectedAt: "2026-01-01T00:00:20.000Z" },
+    ];
+
+    expect(
+      filterAgentsForMeshVisibility(agents, {
+        now,
+        includeGhosts: true,
+        recentDisconnectWindowMs: 30_000,
+      }).map((agent) => agent.id),
+    ).toEqual(["connected", "recent-ghost"]);
+  });
+
+  it("can exclude ghost rows entirely when a surface wants connected agents only", () => {
+    const now = Date.parse("2026-01-01T00:01:00.000Z");
+
+    expect(
+      isAgentVisibleInMesh(
+        { disconnectedAt: "2026-01-01T00:00:50.000Z" },
+        {
+          now,
+          includeGhosts: false,
+          recentDisconnectWindowMs: 30_000,
+        },
+      ),
+    ).toBe(false);
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -817,6 +817,36 @@ export function buildAgentCapabilityTags(capabilities: AgentCapabilities): strin
   return [...tags];
 }
 
+export interface MeshVisibilityOptions {
+  includeGhosts?: boolean;
+  now?: number;
+  recentDisconnectWindowMs: number;
+}
+
+export function isAgentVisibleInMesh(
+  agent: { disconnectedAt?: string | null },
+  options: MeshVisibilityOptions,
+): boolean {
+  const includeGhosts = options.includeGhosts ?? true;
+  if (!includeGhosts) {
+    return !agent.disconnectedAt;
+  }
+  if (!agent.disconnectedAt) {
+    return true;
+  }
+
+  const nowMs = options.now ?? Date.now();
+  const disconnectedMs = Date.parse(agent.disconnectedAt);
+  return !Number.isNaN(disconnectedMs) && nowMs - disconnectedMs <= options.recentDisconnectWindowMs;
+}
+
+export function filterAgentsForMeshVisibility<T extends { disconnectedAt?: string | null }>(
+  agents: T[],
+  options: MeshVisibilityOptions,
+): T[] {
+  return agents.filter((agent) => isAgentVisibleInMesh(agent, options));
+}
+
 export function buildAgentDisplayInfo(
   agent: AgentVisibilityInput,
   options: AgentVisibilityOptions = {},

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -31,6 +31,7 @@ import {
   createAbortableOperationTracker,
   isAbortError,
   buildAgentDisplayInfo,
+  filterAgentsForMeshVisibility,
   rankAgentsForRouting,
   evaluateRalphLoopCycle,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -1783,14 +1784,20 @@ export default function (pi: ExtensionAPI) {
 
     const db = activeBroker.db;
     const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
-    const workloads = db.getAllAgents().map((agent) => ({
+    const nowMs = Date.now();
+    const recentGhostWindowMs = DEFAULT_HEARTBEAT_TIMEOUT_MS * 2;
+    const workloads = filterAgentsForMeshVisibility(db.getAllAgents(), {
+      now: nowMs,
+      includeGhosts: true,
+      recentDisconnectWindowMs: recentGhostWindowMs,
+    }).map((agent) => ({
       ...agent,
       pendingInboxCount: db.getPendingInboxCount(agent.id),
       ownedThreadCount: db.getOwnedThreadCount(agent.id),
     }));
     const pendingBacklogCount = db.getBacklogCount("pending");
     const evaluationOptions: RalphLoopEvaluationOptions = {
-      now: Date.now(),
+      now: nowMs,
       heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
       heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
       stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -2705,12 +2712,6 @@ export default function (pi: ExtensionAPI) {
       const recentGhostWindowMs = DEFAULT_HEARTBEAT_TIMEOUT_MS * 2;
       const nowMs = Date.now();
 
-      const isRecentDisconnected = (agent: { disconnectedAt?: string | null }): boolean => {
-        if (!agent.disconnectedAt) return true;
-        const disconnectedMs = Date.parse(agent.disconnectedAt);
-        return !Number.isNaN(disconnectedMs) && nowMs - disconnectedMs <= recentGhostWindowMs;
-      };
-
       const toDisplay = (agent: {
         emoji: string;
         name: string;
@@ -2740,36 +2741,37 @@ export default function (pi: ExtensionAPI) {
         resumableUntil?: string | null;
       }>;
       if (brokerRole === "broker" && activeBroker) {
-        rawAgents = activeBroker.db
-          .getAllAgents()
-          .filter((agent) => includeGhosts || !agent.disconnectedAt)
-          .filter((agent) => (includeGhosts ? isRecentDisconnected(agent) : true))
-          .map((agent) => ({
-            emoji: agent.emoji,
-            name: agent.name,
-            id: agent.id,
-            pid: agent.pid,
-            status: agent.status,
-            metadata: agent.metadata,
-            lastHeartbeat: agent.lastHeartbeat,
-            disconnectedAt: agent.disconnectedAt,
-            resumableUntil: agent.resumableUntil,
-          }));
+        rawAgents = filterAgentsForMeshVisibility(activeBroker.db.getAllAgents(), {
+          now: nowMs,
+          includeGhosts,
+          recentDisconnectWindowMs: recentGhostWindowMs,
+        }).map((agent) => ({
+          emoji: agent.emoji,
+          name: agent.name,
+          id: agent.id,
+          pid: agent.pid,
+          status: agent.status,
+          metadata: agent.metadata,
+          lastHeartbeat: agent.lastHeartbeat,
+          disconnectedAt: agent.disconnectedAt,
+          resumableUntil: agent.resumableUntil,
+        }));
       } else if (brokerRole === "follower" && brokerClient) {
-        rawAgents = (await brokerClient.client.listAgents(includeGhosts))
-          .filter((agent) => includeGhosts || !agent.disconnectedAt)
-          .filter((agent) => (includeGhosts ? isRecentDisconnected(agent) : true))
-          .map((agent) => ({
-            emoji: agent.emoji,
-            name: agent.name,
-            id: agent.id,
-            pid: agent.pid,
-            status: agent.status ?? "idle",
-            metadata: agent.metadata,
-            lastHeartbeat: agent.lastHeartbeat,
-            disconnectedAt: agent.disconnectedAt,
-            resumableUntil: agent.resumableUntil,
-          }));
+        rawAgents = filterAgentsForMeshVisibility(await brokerClient.client.listAgents(includeGhosts), {
+          now: nowMs,
+          includeGhosts,
+          recentDisconnectWindowMs: recentGhostWindowMs,
+        }).map((agent) => ({
+          emoji: agent.emoji,
+          name: agent.name,
+          id: agent.id,
+          pid: agent.pid,
+          status: agent.status ?? "idle",
+          metadata: agent.metadata,
+          lastHeartbeat: agent.lastHeartbeat,
+          disconnectedAt: agent.disconnectedAt,
+          resumableUntil: agent.resumableUntil,
+        }));
       } else {
         throw new Error("Pinet is in an unexpected state.");
       }

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -9,6 +9,7 @@ import {
   buildRalphLoopCycleNotifications,
   buildRalphLoopStatusMessage,
   shouldDeliverRalphLoopFollowUp,
+  filterAgentsForMeshVisibility,
   DEFAULT_RALPH_LOOP_INTERVAL_MS,
   DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
@@ -159,15 +160,21 @@ export async function runRalphLoopCycle(
     const lastMaintenance = deps.getLastMaintenance();
 
     const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
+    const now = Date.now();
+    const recentGhostWindowMs = DEFAULT_HEARTBEAT_TIMEOUT_MS * 2;
 
-    const workloads = db.getAllAgents().map((agent) => ({
+    const workloads = filterAgentsForMeshVisibility(db.getAllAgents(), {
+      now,
+      includeGhosts: true,
+      recentDisconnectWindowMs: recentGhostWindowMs,
+    }).map((agent) => ({
       ...agent,
       pendingInboxCount: db.getPendingInboxCount(agent.id),
       ownedThreadCount: db.getOwnedThreadCount(agent.id),
     }));
     const pendingBacklogCount = db.getBacklogCount("pending");
     const evaluationOptions: RalphLoopEvaluationOptions = {
-      now: Date.now(),
+      now,
       heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
       heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
       stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -179,7 +186,6 @@ export async function runRalphLoopCycle(
     };
     const evaluation = evaluateRalphLoopCycle(workloads, evaluationOptions);
 
-    const now = Date.now();
     const nudgeAgentIds = new Set(evaluation.nudgeAgentIds);
     for (const workload of workloads) {
       if (!nudgeAgentIds.has(workload.id)) {


### PR DESCRIPTION
## Summary
- align RALPH cycle evaluation with the same recent-disconnected visibility filter already used by `pinet_agents`
- apply the same visibility filter to the broker control-plane snapshot path
- add focused helper coverage for mesh visibility filtering

## Why
False/stale ghost alerts were repeating because RALPH evaluated older disconnected broker DB rows that the live roster already hid after the short recent-ghost visibility window.

## Scope
This PR is intentionally narrow and only touches the alerting/snapshot visibility path.
It does **not** change purge grace, lease thresholds, or broader mesh behavior.

## Checks
- `pnpm --dir slack-bridge lint`
- `pnpm --dir slack-bridge typecheck`
- `pnpm --dir slack-bridge test`
