### PR TITLE
feat: scaffold imessage MVP readiness helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ interactive browsing and screenshots.
 
 ## Extensions
 
-| Package                         | Description                                                                |
-| ------------------------------- | -------------------------------------------------------------------------- |
-| [`slack-bridge`](slack-bridge/) | Slack assistant app (Pinet) — broker mesh, inbox, canvases, deploy tooling |
-| [`slack-api`](slack-api/)       | Typed Slack Web API client + CLI generated from OpenAPI                    |
-| [`nvim-bridge`](nvim-bridge/)   | Neovim editor context sync + PiComms persistent comments                   |
-| [`neon-psql`](neon-psql/)       | Config-driven Neon tunnel + `psql` tool                                    |
-| [`types`](types/)               | Shared ambient type declarations                                           |
+| Package                               | Description                                                                |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| [`slack-bridge`](slack-bridge/)       | Slack assistant app (Pinet) — broker mesh, inbox, canvases, deploy tooling |
+| [`slack-api`](slack-api/)             | Typed Slack Web API client + CLI generated from OpenAPI                    |
+| [`imessage-bridge`](imessage-bridge/) | macOS/iMessage MVP readiness scaffold for a future thin adapter            |
+| [`nvim-bridge`](nvim-bridge/)         | Neovim editor context sync + PiComms persistent comments                   |
+| [`neon-psql`](neon-psql/)             | Config-driven Neon tunnel + `psql` tool                                    |
+| [`types`](types/)                     | Shared ambient type declarations                                           |
 
 ## Current state snapshot
 
@@ -135,6 +136,9 @@ extensions/
 │   ├── generated/      #   generated typed Slack Web API client
 │   ├── cli.ts          #   CLI wrapper around generated methods
 │   └── package.json    #   workspace package + pi manifest
+├── imessage-bridge/    # @gugu910/pi-imessage-bridge (MVP scaffold)
+│   ├── mvp.ts          #   local macOS/iMessage readiness helpers
+│   └── package.json    #   workspace package scaffold
 ├── nvim-bridge/        # @gugu910/pi-nvim-bridge
 │   ├── nvim/           #   Neovim Lua plugin
 │   ├── index.ts        #   extension entry point

--- a/imessage-bridge/README.md
+++ b/imessage-bridge/README.md
@@ -1,0 +1,56 @@
+# @gugu910/pi-imessage-bridge
+
+Tiny macOS/iMessage MVP scaffold for the `extensions` repo.
+
+## What this slice does
+
+This package does **not** wire iMessage into the live broker yet.
+
+Instead, it makes the smallest useful next slice concrete:
+
+- codifies the current MVP assumptions for a local-first iMessage transport
+- detects whether the current host can plausibly support that MVP
+- gives the future adapter a stable, tested home for adapter-local readiness checks
+
+## Current MVP assumptions
+
+A first iMessage transport in this repo is expected to be:
+
+- **macOS only**
+- **local-first**
+- **send-capable via AppleScript** through `/usr/bin/osascript`
+- **history-aware via the local Messages database** at `~/Library/Messages/chat.db`
+
+That keeps the first slice close to the repo's local-hosted operating model and avoids inventing transport/core wiring before the shared messaging seam is ready.
+
+## Why this lands before the shared messaging seam
+
+The unresolved ports/adapters work is about how a future `imessage-bridge` plugs into the shared broker/runtime core.
+
+This package stays below that line:
+
+- no broker registration
+- no routing changes
+- no new runtime mode
+- no Slack/iMessage crossover logic
+
+It is safe to land independently because it only captures adapter-local environment assumptions.
+
+## Out of scope
+
+- inbound iMessage handling
+- AppleScript send implementation
+- chat database queries
+- shared messaging-core wiring
+- any dependency on `#366`
+
+## Example
+
+```ts
+import { detectIMessageMvpEnvironment } from "@gugu910/pi-imessage-bridge";
+
+const environment = detectIMessageMvpEnvironment();
+if (!environment.readyForLocalMvp) {
+  console.log(environment.blockers);
+}
+```

--- a/imessage-bridge/eslint.config.mjs
+++ b/imessage-bridge/eslint.config.mjs
@@ -1,0 +1,3 @@
+import rootConfig from "../eslint.config.mjs";
+
+export default [...rootConfig];

--- a/imessage-bridge/index.ts
+++ b/imessage-bridge/index.ts
@@ -1,0 +1,10 @@
+export {
+  APPLESCRIPT_BINARY_PATH,
+  DEFAULT_MESSAGES_DB_RELATIVE_PATH,
+  type DetectIMessageMvpEnvironmentOptions,
+  detectIMessageMvpEnvironment,
+  formatIMessageMvpReadiness,
+  getDefaultMessagesDbPath,
+  type IMessageMvpEnvironment,
+  type IMessageMvpEnvironmentBlocker,
+} from "./mvp.ts";

--- a/imessage-bridge/mvp.test.ts
+++ b/imessage-bridge/mvp.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  APPLESCRIPT_BINARY_PATH,
+  detectIMessageMvpEnvironment,
+  formatIMessageMvpReadiness,
+  getDefaultMessagesDbPath,
+} from "./mvp.ts";
+
+describe("getDefaultMessagesDbPath", () => {
+  it("builds the canonical macOS Messages database path", () => {
+    expect(getDefaultMessagesDbPath("/Users/goose")).toBe("/Users/goose/Library/Messages/chat.db");
+  });
+});
+
+describe("detectIMessageMvpEnvironment", () => {
+  it("reports a ready darwin host when osascript and chat.db are present", () => {
+    const environment = detectIMessageMvpEnvironment({
+      platform: "darwin",
+      homeDir: "/Users/goose",
+      pathExists: (candidatePath) =>
+        candidatePath === APPLESCRIPT_BINARY_PATH ||
+        candidatePath === "/Users/goose/Library/Messages/chat.db",
+    });
+
+    expect(environment.blockers).toEqual([]);
+    expect(environment.canAttemptSend).toBe(true);
+    expect(environment.canAttemptHistoryRead).toBe(true);
+    expect(environment.readyForLocalMvp).toBe(true);
+  });
+
+  it("flags missing chat.db separately from send capability", () => {
+    const environment = detectIMessageMvpEnvironment({
+      platform: "darwin",
+      homeDir: "/Users/goose",
+      pathExists: (candidatePath) => candidatePath === APPLESCRIPT_BINARY_PATH,
+    });
+
+    expect(environment.blockers).toEqual(["missing_messages_db"]);
+    expect(environment.canAttemptSend).toBe(true);
+    expect(environment.canAttemptHistoryRead).toBe(false);
+    expect(environment.readyForLocalMvp).toBe(false);
+  });
+
+  it("treats non-darwin hosts as unsupported regardless of file presence", () => {
+    const environment = detectIMessageMvpEnvironment({
+      platform: "linux",
+      homeDir: "/home/goose",
+      pathExists: () => true,
+    });
+
+    expect(environment.blockers).toEqual(["unsupported_platform"]);
+    expect(environment.canAttemptSend).toBe(false);
+    expect(environment.canAttemptHistoryRead).toBe(false);
+    expect(environment.readyForLocalMvp).toBe(false);
+  });
+});
+
+describe("formatIMessageMvpReadiness", () => {
+  it("includes blockers in the human-readable summary", () => {
+    const lines = formatIMessageMvpReadiness(
+      detectIMessageMvpEnvironment({
+        platform: "darwin",
+        homeDir: "/Users/goose",
+        pathExists: () => false,
+      }),
+    );
+
+    expect(lines).toContain(`osascript: missing (${APPLESCRIPT_BINARY_PATH})`);
+    expect(lines).toContain("mvp blockers: missing_osascript, missing_messages_db");
+  });
+});

--- a/imessage-bridge/mvp.ts
+++ b/imessage-bridge/mvp.ts
@@ -1,0 +1,96 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { existsSync } from "node:fs";
+
+export const APPLESCRIPT_BINARY_PATH = "/usr/bin/osascript";
+export const DEFAULT_MESSAGES_DB_RELATIVE_PATH = path.join("Library", "Messages", "chat.db");
+
+export type IMessageMvpEnvironmentBlocker =
+  | "unsupported_platform"
+  | "missing_osascript"
+  | "missing_messages_db";
+
+export interface IMessageMvpEnvironment {
+  platform: NodeJS.Platform;
+  homeDir: string;
+  messagesDbPath: string;
+  osascriptPath: string;
+  osascriptAvailable: boolean;
+  messagesDbAvailable: boolean;
+  canAttemptSend: boolean;
+  canAttemptHistoryRead: boolean;
+  readyForLocalMvp: boolean;
+  blockers: IMessageMvpEnvironmentBlocker[];
+}
+
+export interface DetectIMessageMvpEnvironmentOptions {
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  pathExists?: (candidatePath: string) => boolean;
+}
+
+export function getDefaultMessagesDbPath(homeDir = os.homedir()): string {
+  return path.join(homeDir, DEFAULT_MESSAGES_DB_RELATIVE_PATH);
+}
+
+export function detectIMessageMvpEnvironment(
+  options: DetectIMessageMvpEnvironmentOptions = {},
+): IMessageMvpEnvironment {
+  const platform = options.platform ?? process.platform;
+  const homeDir = options.homeDir ?? os.homedir();
+  const pathExists = options.pathExists ?? existsSync;
+  const osascriptPath = APPLESCRIPT_BINARY_PATH;
+  const messagesDbPath = getDefaultMessagesDbPath(homeDir);
+
+  const supportedPlatform = platform === "darwin";
+  const osascriptAvailable = supportedPlatform && pathExists(osascriptPath);
+  const messagesDbAvailable = supportedPlatform && pathExists(messagesDbPath);
+
+  const blockers: IMessageMvpEnvironmentBlocker[] = [];
+  if (!supportedPlatform) {
+    blockers.push("unsupported_platform");
+  }
+  if (supportedPlatform && !osascriptAvailable) {
+    blockers.push("missing_osascript");
+  }
+  if (supportedPlatform && !messagesDbAvailable) {
+    blockers.push("missing_messages_db");
+  }
+
+  const canAttemptSend = supportedPlatform && osascriptAvailable;
+  const canAttemptHistoryRead = supportedPlatform && messagesDbAvailable;
+
+  return {
+    platform,
+    homeDir,
+    messagesDbPath,
+    osascriptPath,
+    osascriptAvailable,
+    messagesDbAvailable,
+    canAttemptSend,
+    canAttemptHistoryRead,
+    readyForLocalMvp: canAttemptSend && canAttemptHistoryRead,
+    blockers,
+  };
+}
+
+export function formatIMessageMvpReadiness(environment: IMessageMvpEnvironment): string[] {
+  const lines = [
+    `platform: ${environment.platform}`,
+    `osascript: ${environment.osascriptAvailable ? "ready" : "missing"} (${environment.osascriptPath})`,
+    `messages-db: ${environment.messagesDbAvailable ? "ready" : "missing"} (${environment.messagesDbPath})`,
+  ];
+
+  if (environment.readyForLocalMvp) {
+    lines.push("mvp: local macOS iMessage send/history scaffold is ready");
+    return lines;
+  }
+
+  if (environment.blockers.length === 0) {
+    lines.push("mvp: not ready");
+    return lines;
+  }
+
+  lines.push(`mvp blockers: ${environment.blockers.join(", ")}`);
+  return lines;
+}

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@gugu910/pi-imessage-bridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "macOS/iMessage MVP readiness helpers and future adapter scaffold for pi",
+  "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gugu910/extensions.git",
+    "directory": "imessage-bridge"
+  },
+  "main": "./index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./package.json": "./package.json"
+  },
+  "pi": {},
+  "scripts": {
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  }
+}

--- a/imessage-bridge/tsconfig.json
+++ b/imessage-bridge/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["**/*.ts", "../types/**/*.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@22.19.11)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2))
 
+  imessage-bridge: {}
+
   neon-psql:
     devDependencies:
       "@sinclair/typebox":

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - slack-bridge
   - slack-api
+  - imessage-bridge
   - nvim-bridge
   - neon-psql

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": [
+    "imessage-bridge/**/*.ts",
     "nvim-bridge/**/*.ts",
     "neon-psql/**/*.ts",
     "slack-api/**/*.ts",


### PR DESCRIPTION
## Summary
- add a tiny `imessage-bridge/` workspace scaffold for the future sibling iMessage adapter
- codify the smallest local-first iMessage MVP assumptions in tested readiness helpers
- document the package in the workspace layout and open the follow-on adapter issue

## What this slice does
This intentionally stays **below** the unresolved shared messaging seam.

It does **not** wire iMessage into the broker yet.
Instead it ships the smallest safe slice that can land now without depending on `#366`:
- macOS/iMessage MVP readiness detection
- canonical AppleScript + Messages DB assumptions
- a tested home for adapter-local logic that can later stay thin when the core seam is ready

## Why now
This turns the iMessage track from hand-wavy architecture into something concrete while avoiding new coupling inside `slack-bridge`.

## Follow-up
- Follow-on adapter wiring is tracked in **#373** and should wait for `#366` or its successor seam

## Testing
- `pnpm --filter @gugu910/pi-imessage-bridge lint`
- `pnpm --filter @gugu910/pi-imessage-bridge typecheck`
- `pnpm --filter @gugu910/pi-imessage-bridge test`
- `pnpm lint`
- `pnpm typecheck`

## Known validation blocker
- `pnpm test` on current `main` is already red in `slack-bridge/index.test.ts` (`keeps explicit off mode free of Slack Socket Mode ingress on session start`) because that test now sees the new default-deny Slack access warning notify. This scaffold does not touch `slack-bridge`, but I am calling the pre-existing repo-wide failure out explicitly.
