### PR TITLE
fix: preserve transport source through follower reclaim

### DIFF
--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -353,9 +353,14 @@ export class BrokerClient {
 
   // ─── Thread ownership ─────────────────────────────────
 
-  async claimThread(threadId: string, channel?: string): Promise<{ claimed: boolean }> {
+  async claimThread(
+    threadId: string,
+    channel?: string,
+    source?: string,
+  ): Promise<{ claimed: boolean }> {
     const params: Record<string, unknown> = { threadId };
     if (channel) params.channel = channel;
+    if (source) params.source = source;
     const result = (await this.request("thread.claim", params)) as { claimed: boolean };
     return result;
   }

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -658,6 +658,17 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(thread!.channel).toBe("C-TEST-123");
   });
 
+  it("thread.claim with source stores source on a new thread", async () => {
+    await client.register("imessage-claimer", "💬");
+
+    await client.claimThread("t-imessage", "chat:alice", "imessage");
+
+    const thread = db.getThread("t-imessage");
+    expect(thread).not.toBeNull();
+    expect(thread!.source).toBe("imessage");
+    expect(thread!.channel).toBe("chat:alice");
+  });
+
   it("resolveThread returns the broker channel for an existing thread", async () => {
     await client.register("resolver-agent", "🧭");
     db.createThread("t-resolve", "slack", "C-THREAD-1", null);

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -566,6 +566,17 @@ describe("MessageRouter — claimThread", () => {
     expect(thread?.ownerAgent).toBe("a1");
   });
 
+  it("stores the provided source when claiming a new thread", () => {
+    const claimed = router.claimThread("t-imessage", "a1", "chat:alice", "imessage");
+
+    expect(claimed).toBe(true);
+    const thread = db.threads.get("t-imessage");
+    expect(thread).toBeDefined();
+    expect(thread?.ownerAgent).toBe("a1");
+    expect(thread?.source).toBe("imessage");
+    expect(thread?.channel).toBe("chat:alice");
+  });
+
   it("allows re-claiming by the same agent", () => {
     db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: "a1" }));
 

--- a/slack-bridge/broker/router.ts
+++ b/slack-bridge/broker/router.ts
@@ -341,14 +341,15 @@ export class MessageRouter {
 
   /**
    * Claim a thread for an agent (first-responder-wins).
-   * Optionally provide a channel to set when creating a new thread.
+   * Optionally provide the transport source and channel to store when creating
+   * a new thread. Defaults to Slack for backward compatibility.
    * Returns true if the claim succeeded, false if another agent already owns it.
    *
    * Delegates to the DB layer which performs the claim atomically
    * (single SQL statement) to avoid TOCTOU races. (#125)
    */
-  claimThread(threadId: string, agentId: string, channel?: string): boolean {
-    return this.db.claimThread(threadId, agentId, "slack", channel ?? "");
+  claimThread(threadId: string, agentId: string, channel?: string, source = "slack"): boolean {
+    return this.db.claimThread(threadId, agentId, source, channel ?? "");
   }
 
   /**

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -680,7 +680,11 @@ export class BrokerSocketServer {
     }
 
     const channel = typeof params.channel === "string" ? params.channel : undefined;
-    const claimed = this.router.claimThread(threadId, state.agentId, channel);
+    const source =
+      typeof params.source === "string" && params.source.trim().length > 0
+        ? params.source.trim()
+        : undefined;
+    const claimed = this.router.claimThread(threadId, state.agentId, channel, source);
     return rpcOk(req.id, { claimed });
   }
 
@@ -839,7 +843,7 @@ export class BrokerSocketServer {
         const messageTs = typeof result.ts === "string" ? (result.ts as string) : null;
         const effectiveTs = threadTs ?? messageTs;
         if (effectiveTs) {
-          this.router.claimThread(effectiveTs, state.agentId);
+          this.router.claimThread(effectiveTs, state.agentId, undefined, "slack");
         }
       }
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -2593,13 +2593,19 @@ describe("trackBrokerInboundThread", () => {
     const threads = new Map<string, FollowerThreadState>();
     trackBrokerInboundThread(
       threads,
-      { threadId: "1234.5678", channel: "C0APL58LB1R", userId: "U_ALICE" },
+      {
+        threadId: "1234.5678",
+        channel: "C0APL58LB1R",
+        userId: "U_ALICE",
+        source: "imessage",
+      },
       "TestAgent",
     );
     expect(threads.get("1234.5678")).toEqual({
       channelId: "C0APL58LB1R",
       threadTs: "1234.5678",
       userId: "U_ALICE",
+      source: "imessage",
       owner: "TestAgent",
     });
   });
@@ -2666,6 +2672,7 @@ describe("syncFollowerInboxEntries", () => {
           inboxId: 17,
           message: {
             threadId: "100.1",
+            source: "whatsapp",
             sender: "U_SENDER",
             body: "hello",
             createdAt: "100.1",
@@ -2682,6 +2689,7 @@ describe("syncFollowerInboxEntries", () => {
     expect(result.inboxMessages[0].brokerInboxId).toBe(17);
     expect(result.threadUpdates).toHaveLength(1);
     expect(result.threadUpdates[0].channelId).toBe("C_CHAN");
+    expect(result.threadUpdates[0].source).toBe("whatsapp");
     expect(result.changed).toBe(true);
   });
 
@@ -2928,6 +2936,25 @@ describe("getFollowerOwnedThreadClaims", () => {
 
     expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([
       { threadTs: "t-1", channelId: "C1" },
+    ]);
+  });
+
+  it("preserves thread source for owned-thread reclaim", () => {
+    const threads = new Map<string, FollowerThreadState>([
+      [
+        "t-1",
+        {
+          threadTs: "t-1",
+          channelId: "chat:alice",
+          userId: "alice",
+          source: "imessage",
+          owner: "Sonic Gecko",
+        },
+      ],
+    ]);
+
+    expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([
+      { threadTs: "t-1", channelId: "chat:alice", source: "imessage" },
     ]);
   });
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -77,6 +77,7 @@ import {
   agentOwnsThread,
   normalizeOwnedThreads,
   getFollowerOwnedThreadClaims,
+  getFollowerOwnedThreadReclaims,
   normalizeThreadConfirmationState,
   isThreadConfirmationStateEmpty,
   confirmationRequestMatches,
@@ -2626,6 +2627,29 @@ describe("trackBrokerInboundThread", () => {
     expect(threads.get("1234.5678")?.owner).toBe("First");
   });
 
+  it("backfills source onto an existing cached thread without replacing ownership", () => {
+    const threads = new Map<string, FollowerThreadState>([
+      [
+        "1234.5678",
+        { channelId: "C0APL58LB1R", threadTs: "1234.5678", userId: "U_ORIGINAL", owner: "First" },
+      ],
+    ]);
+
+    trackBrokerInboundThread(
+      threads,
+      { threadId: "1234.5678", channel: "C0APL58LB1R", userId: "U_NEW", source: "imessage" },
+      "Second",
+    );
+
+    expect(threads.get("1234.5678")).toEqual({
+      channelId: "C0APL58LB1R",
+      threadTs: "1234.5678",
+      userId: "U_ORIGINAL",
+      source: "imessage",
+      owner: "First",
+    });
+  });
+
   it("is a no-op when threadId is empty", () => {
     const threads = new Map<string, FollowerThreadState>();
     trackBrokerInboundThread(threads, { threadId: "", channel: "C123", userId: "U1" });
@@ -2955,6 +2979,26 @@ describe("getFollowerOwnedThreadClaims", () => {
 
     expect(getFollowerOwnedThreadClaims(threads, "Sonic Gecko")).toEqual([
       { threadTs: "t-1", channelId: "chat:alice", source: "imessage" },
+    ]);
+  });
+
+  it("only returns sourceful owned threads for reconnect reclaim", () => {
+    const threads = new Map<string, FollowerThreadState>([
+      ["t-1", { threadTs: "t-1", channelId: "C1", userId: "U1", owner: "Sonic Gecko" }],
+      [
+        "t-2",
+        {
+          threadTs: "t-2",
+          channelId: "chat:alice",
+          userId: "alice",
+          source: "imessage",
+          owner: "Sonic Gecko",
+        },
+      ],
+    ]);
+
+    expect(getFollowerOwnedThreadReclaims(threads, "Sonic Gecko")).toEqual([
+      { threadTs: "t-2", channelId: "chat:alice", source: "imessage" },
     ]);
   });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1703,6 +1703,7 @@ export interface FollowerThreadState {
   channelId: string;
   threadTs: string;
   userId: string;
+  source?: string;
   owner?: string;
 }
 
@@ -1710,6 +1711,7 @@ export interface FollowerInboxEntry {
   inboxId?: number;
   message: {
     threadId?: string;
+    source?: string;
     sender?: string;
     body?: string;
     createdAt?: string;
@@ -1762,18 +1764,24 @@ export function syncFollowerInboxEntries(
 
     if (threadTs && channel) {
       const existing = existingThreads.get(threadTs);
+      const source =
+        typeof entry.message.source === "string" && entry.message.source.trim().length > 0
+          ? entry.message.source.trim()
+          : existing?.source;
       const nextThread: FollowerThreadState = {
         channelId: channel,
         threadTs,
         userId: existing?.userId || sender,
         owner: existing?.owner ?? agentOwner,
+        ...(source ? { source } : {}),
       };
 
       if (
         !existing ||
         existing.channelId !== nextThread.channelId ||
         existing.userId !== nextThread.userId ||
-        existing.owner !== nextThread.owner
+        existing.owner !== nextThread.owner ||
+        existing.source !== nextThread.source
       ) {
         changed = true;
       }
@@ -1894,6 +1902,7 @@ export async function resolveFollowerThreadChannel(
         channelId,
         threadTs,
         userId: existingThread?.userId ?? "",
+        ...(existingThread?.source ? { source: existingThread.source } : {}),
         owner: existingThread?.owner,
       },
     };
@@ -1971,11 +1980,14 @@ export function normalizeOwnedThreads(
 }
 
 export function getFollowerOwnedThreadClaims(
-  threads: ReadonlyMap<string, Pick<FollowerThreadState, "threadTs" | "channelId" | "owner">>,
+  threads: ReadonlyMap<
+    string,
+    Pick<FollowerThreadState, "threadTs" | "channelId" | "source" | "owner">
+  >,
   agentName: string,
   agentAliases: Iterable<string> = [],
   ownerToken?: string,
-): Array<{ threadTs: string; channelId: string }> {
+): Array<{ threadTs: string; channelId: string; source?: string }> {
   return [...threads.values()]
     .filter(
       (thread) =>
@@ -1986,6 +1998,7 @@ export function getFollowerOwnedThreadClaims(
     .map((thread) => ({
       threadTs: thread.threadTs,
       channelId: thread.channelId,
+      ...(thread.source ? { source: thread.source } : {}),
     }));
 }
 
@@ -1996,7 +2009,7 @@ export function getFollowerOwnedThreadClaims(
  */
 export function trackBrokerInboundThread(
   threads: Map<string, FollowerThreadState>,
-  inMsg: { threadId: string; channel: string; userId?: string },
+  inMsg: { threadId: string; channel: string; userId?: string; source?: string },
   owner?: string,
 ): void {
   if (!inMsg.threadId || !inMsg.channel) return;
@@ -2005,6 +2018,7 @@ export function trackBrokerInboundThread(
       channelId: inMsg.channel,
       threadTs: inMsg.threadId,
       userId: inMsg.userId ?? "",
+      ...(inMsg.source ? { source: inMsg.source } : {}),
       owner,
     });
   }

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -892,7 +892,9 @@ export function isAgentVisibleInMesh(
 
   const nowMs = options.now ?? Date.now();
   const disconnectedMs = Date.parse(agent.disconnectedAt);
-  return !Number.isNaN(disconnectedMs) && nowMs - disconnectedMs <= options.recentDisconnectWindowMs;
+  return (
+    !Number.isNaN(disconnectedMs) && nowMs - disconnectedMs <= options.recentDisconnectWindowMs
+  );
 }
 
 export function filterAgentsForMeshVisibility<T extends { disconnectedAt?: string | null }>(
@@ -2002,6 +2004,23 @@ export function getFollowerOwnedThreadClaims(
     }));
 }
 
+export function getFollowerOwnedThreadReclaims(
+  threads: ReadonlyMap<
+    string,
+    Pick<FollowerThreadState, "threadTs" | "channelId" | "source" | "owner">
+  >,
+  agentName: string,
+  agentAliases: Iterable<string> = [],
+  ownerToken?: string,
+): Array<{ threadTs: string; channelId: string; source: string }> {
+  return getFollowerOwnedThreadClaims(threads, agentName, agentAliases, ownerToken).flatMap(
+    (thread) =>
+      thread.source
+        ? [{ threadTs: thread.threadTs, channelId: thread.channelId, source: thread.source }]
+        : [],
+  );
+}
+
 /**
  * Cache a thread from a broker inbound message in the local threads map.
  * The broker DB remains the source of truth; this is only a read-through
@@ -2013,7 +2032,9 @@ export function trackBrokerInboundThread(
   owner?: string,
 ): void {
   if (!inMsg.threadId || !inMsg.channel) return;
-  if (!threads.has(inMsg.threadId)) {
+
+  const existing = threads.get(inMsg.threadId);
+  if (!existing) {
     threads.set(inMsg.threadId, {
       channelId: inMsg.channel,
       threadTs: inMsg.threadId,
@@ -2021,6 +2042,11 @@ export function trackBrokerInboundThread(
       ...(inMsg.source ? { source: inMsg.source } : {}),
       owner,
     });
+    return;
+  }
+
+  if (!existing.source && inMsg.source) {
+    existing.source = inMsg.source;
   }
 }
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1129,6 +1129,124 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(setStatus).toHaveBeenCalled();
   });
 
+  it("does not reclaim restored source-less threads as slack on follow or reconnect", async () => {
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const notify = vi.fn();
+    const setStatus = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [
+          {
+            type: "custom",
+            customType: "slack-bridge-state",
+            data: {
+              agentName: "Agent",
+              agentEmoji: "🦙",
+              agentStableId: "stable-worker",
+              threads: [
+                [
+                  "t-imessage",
+                  {
+                    channelId: "chat:alice",
+                    threadTs: "t-imessage",
+                    userId: "alice",
+                    owner: "Agent",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let reconnectHandler: (() => void) | null = null;
+    const claimThread = vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({
+      claimed: true,
+    });
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    const register = vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Agent",
+      emoji: "🦙",
+      metadata: { role: "worker", capabilities: { role: "worker" } },
+    });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation((handler) => {
+      reconnectHandler = handler;
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await follow?.handler("", ctx);
+
+    expect(claimThread).not.toHaveBeenCalled();
+    expect(reconnectHandler).toBeTypeOf("function");
+
+    if (!reconnectHandler) {
+      throw new Error("Reconnect handler was not registered");
+    }
+
+    const runReconnect: () => void = reconnectHandler;
+    runReconnect();
+
+    await vi.waitFor(() => {
+      expect(register).toHaveBeenCalledTimes(2);
+      expect(claimThread).not.toHaveBeenCalled();
+    });
+
+    await sessionShutdown?.({}, ctx);
+    expect(setStatus).toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("following broker"), "info");
+  });
+
   it("suppresses automatic inbox drain immediately after Escape so interrupts return control", async () => {
     vi.useFakeTimers();
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -455,7 +455,12 @@ describe("slack-bridge top-level shutdown", () => {
   it("keeps explicit off mode free of Slack Socket Mode ingress on session start", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
-    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "off" } }));
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        "slack-bridge": { runtimeMode: "off", allowAllWorkspaceUsers: true },
+      }),
+    );
 
     const events = new Map<string, EventHandler>();
     const pi = {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -538,6 +538,7 @@ export default function (pi: ExtensionAPI) {
     channelId: string;
     threadTs: string;
     userId: string;
+    source?: string;
     context?: { channelId: string; teamId: string };
     owner?: string; // agent name that claimed this thread (first-responder-wins)
   }
@@ -1066,6 +1067,7 @@ export default function (pi: ExtensionAPI) {
       channelId: event.channelId,
       threadTs: event.threadTs,
       userId: event.userId,
+      source: "slack",
     };
 
     if (event.context) {
@@ -1159,6 +1161,7 @@ export default function (pi: ExtensionAPI) {
           channelId: item.channel,
           threadTs,
           userId: (reactedMessage.user as string | undefined) ?? user,
+          source: "slack",
         });
       }
 
@@ -1247,7 +1250,7 @@ export default function (pi: ExtensionAPI) {
     const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
 
     if (!threads.has(threadTs)) {
-      threads.set(threadTs, { channelId: channel, threadTs, userId });
+      threads.set(threadTs, { channelId: channel, threadTs, userId, source: "slack" });
     }
 
     const localOwner = threads.get(threadTs)?.owner;
@@ -1338,6 +1341,7 @@ export default function (pi: ExtensionAPI) {
         channelId: normalized.channel,
         threadTs: normalized.threadTs,
         userId: normalized.userId,
+        source: "slack",
       });
     }
 
@@ -1465,6 +1469,7 @@ export default function (pi: ExtensionAPI) {
           channelId,
           threadTs,
           userId: "",
+          source: "slack",
           owner: agentOwnerToken,
         });
       } else {
@@ -1477,9 +1482,9 @@ export default function (pi: ExtensionAPI) {
     getBotUserId: () => botUserId,
     claimThreadOwnership: (threadTs, channelId) => {
       if (brokerRole === "broker" && activeRouter && activeSelfId) {
-        activeRouter.claimThread(threadTs, activeSelfId);
+        activeRouter.claimThread(threadTs, activeSelfId, channelId, "slack");
       } else if (brokerRole === "follower" && brokerClient?.client) {
-        void brokerClient.client.claimThread(threadTs, channelId).catch(() => {
+        void brokerClient.client.claimThread(threadTs, channelId, "slack").catch(() => {
           /* broker gone, best effort */
         });
       }
@@ -3184,7 +3189,7 @@ export default function (pi: ExtensionAPI) {
           agentOwnerToken,
         )) {
           try {
-            await client.claimThread(thread.threadTs, thread.channelId);
+            await client.claimThread(thread.threadTs, thread.channelId, thread.source ?? "slack");
           } catch {
             break;
           }
@@ -3324,6 +3329,7 @@ export default function (pi: ExtensionAPI) {
                 existing.threadTs = nextThread.threadTs;
                 existing.userId = nextThread.userId;
                 existing.owner = nextThread.owner;
+                existing.source = nextThread.source ?? existing.source;
               }
               lastDmChannel = synced.lastDmChannel;
               inbox.push(...synced.inboxMessages);

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -60,7 +60,7 @@ import {
   syncBrokerInboxEntries,
   resolveFollowerThreadChannel,
   getFollowerReconnectUiUpdate,
-  getFollowerOwnedThreadClaims,
+  getFollowerOwnedThreadReclaims,
   normalizeThreadConfirmationState,
   normalizeOwnedThreads,
   isThreadConfirmationStateEmpty,
@@ -1475,6 +1475,7 @@ export default function (pi: ExtensionAPI) {
       } else {
         const thread = threads.get(threadTs)!;
         if (!thread.owner) thread.owner = agentOwnerToken;
+        if (!thread.source) thread.source = "slack";
       }
       unclaimedThreads.delete(threadTs);
       persistState();
@@ -2785,11 +2786,14 @@ export default function (pi: ExtensionAPI) {
           resumableUntil: agent.resumableUntil,
         }));
       } else if (brokerRole === "follower" && brokerClient) {
-        rawAgents = filterAgentsForMeshVisibility(await brokerClient.client.listAgents(includeGhosts), {
-          now: nowMs,
-          includeGhosts,
-          recentDisconnectWindowMs: recentGhostWindowMs,
-        }).map((agent) => ({
+        rawAgents = filterAgentsForMeshVisibility(
+          await brokerClient.client.listAgents(includeGhosts),
+          {
+            now: nowMs,
+            includeGhosts,
+            recentDisconnectWindowMs: recentGhostWindowMs,
+          },
+        ).map((agent) => ({
           emoji: agent.emoji,
           name: agent.name,
           id: agent.id,
@@ -3182,14 +3186,14 @@ export default function (pi: ExtensionAPI) {
       let followerPollRunning = false;
 
       async function resumeThreadClaims(): Promise<void> {
-        for (const thread of getFollowerOwnedThreadClaims(
+        for (const thread of getFollowerOwnedThreadReclaims(
           threads,
           agentName,
           agentAliases,
           agentOwnerToken,
         )) {
           try {
-            await client.claimThread(thread.threadTs, thread.channelId, thread.source ?? "slack");
+            await client.claimThread(thread.threadTs, thread.channelId, thread.source);
           } catch {
             break;
           }


### PR DESCRIPTION
## Summary
- preserve transport `source` through broker thread-claim plumbing instead of hardcoding Slack
- carry source through follower thread cache and only reclaim sourceful owned threads on follow/reconnect
- backfill missing cached source when broker inbox data later confirms it

## Why
This is the smallest current-main successor to #366. It keeps the transport-source ownership seam, but fixes the reconnect/restore regression that could have reclaimed older source-less cached threads as `slack` before inbox sync refreshed them.

## Notes
- Supersedes #366 rather than updating it in place because #366 is stacked on a stale base and was previously classified as blocked.
- Recommended follow-up: close #366 once this successor is accepted.

## Checks
- `cd slack-bridge && pnpm test`
- `cd slack-bridge && pnpm typecheck`
- `cd slack-bridge && pnpm lint`
- repo prepush on push: `pnpm lint && pnpm typecheck && pnpm test`

## Release note
Preserve transport source through follower thread reclaim so non-Slack adapters don't get re-recorded as Slack during reconnect.