### PR TITLE
fix: clear stale working state after pinet_free

### DIFF
--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1491,6 +1491,297 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("following broker"), "info");
   });
 
+  it("retries follower idle status sync after pinet_free fails once so workers do not stay stuck working", async () => {
+    vi.useFakeTimers();
+
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const sendUserMessage = vi.fn();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage,
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let pollCount = 0;
+    let idleUpdateAttempts = 0;
+    const updateStatus = vi
+      .spyOn(BrokerClient.prototype, "updateStatus")
+      .mockImplementation(async (status: "working" | "idle") => {
+        if (status === "working") {
+          return;
+        }
+        idleUpdateAttempts += 1;
+        if (idleUpdateAttempts === 1) {
+          throw new Error("status sync failed once");
+        }
+      });
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Agent",
+      emoji: "🦙",
+      metadata: { role: "worker", capabilities: { role: "worker" } },
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockImplementation(async () => {
+      if (pollCount > 0) {
+        pollCount += 1;
+        return [];
+      }
+      pollCount += 1;
+      return [
+        {
+          inboxId: 17,
+          message: {
+            id: 17,
+            threadId: "100.1",
+            source: "slack",
+            direction: "inbound",
+            sender: "U_SENDER",
+            body: "hello from broker",
+            createdAt: "100.1",
+            metadata: { channel: "D123" },
+          },
+        },
+      ];
+    });
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+      /* mocked */
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+    const pinetFree = tools.get("pinet_free");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+    expect(pinetFree).toBeDefined();
+
+    try {
+      await sessionStart?.({}, ctx);
+      await follow?.handler("", ctx);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.waitFor(() => {
+        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"), {
+          deliverAs: "followUp",
+        });
+      });
+      expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working"]);
+
+      await expect(pinetFree!.execute("tool-call-1", {})).rejects.toThrow(
+        "status sync failed once",
+      );
+      expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working", "idle"]);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.waitFor(() => {
+        expect(updateStatus.mock.calls.map(([status]) => status)).toEqual([
+          "working",
+          "idle",
+          "idle",
+        ]);
+      });
+
+      await sessionShutdown?.({}, ctx);
+      expect(setStatus).toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("following broker"), "info");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries follower idle status sync after agent_end auto-free fails once", async () => {
+    vi.useFakeTimers();
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const sendUserMessage = vi.fn();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage,
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let pollCount = 0;
+    let idleUpdateAttempts = 0;
+    const updateStatus = vi
+      .spyOn(BrokerClient.prototype, "updateStatus")
+      .mockImplementation(async (status: "working" | "idle") => {
+        if (status === "working") {
+          return;
+        }
+        idleUpdateAttempts += 1;
+        if (idleUpdateAttempts === 1) {
+          throw new Error("status sync failed once");
+        }
+      });
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Agent",
+      emoji: "🦙",
+      metadata: { role: "worker", capabilities: { role: "worker" } },
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockImplementation(async () => {
+      if (pollCount > 0) {
+        pollCount += 1;
+        return [];
+      }
+      pollCount += 1;
+      return [
+        {
+          inboxId: 17,
+          message: {
+            id: 17,
+            threadId: "100.1",
+            source: "slack",
+            direction: "inbound",
+            sender: "U_SENDER",
+            body: "hello from broker",
+            createdAt: "100.1",
+            metadata: { channel: "D123" },
+          },
+        },
+      ];
+    });
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+      /* mocked */
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+    const agentEnd = events.get("agent_end");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+    expect(agentEnd).toBeDefined();
+
+    try {
+      await sessionStart?.({}, ctx);
+      await follow?.handler("", ctx);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.waitFor(() => {
+        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"), {
+          deliverAs: "followUp",
+        });
+      });
+      expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working"]);
+
+      await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
+      expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working", "idle"]);
+      expect(notify).toHaveBeenCalledWith(
+        "Pinet auto-free failed: status sync failed once",
+        "warning",
+      );
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.waitFor(() => {
+        expect(updateStatus.mock.calls.map(([status]) => status)).toEqual([
+          "working",
+          "idle",
+          "idle",
+        ]);
+      });
+
+      await sessionShutdown?.({}, ctx);
+      expect(setStatus).toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("following broker"), "info");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("suppresses automatic inbox drain immediately after Escape so interrupts return control", async () => {
     vi.useFakeTimers();
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1526,6 +1526,10 @@ export default function (pi: ExtensionAPI) {
   let brokerScheduledWakeupRunning = false;
   let lastBrokerMaintenance: BrokerMaintenanceResult | null = null;
   let lastBrokerMaintenanceSignature = "";
+  let desiredAgentStatus: "working" | "idle" = "idle";
+  let syncedFollowerStatus: "working" | "idle" | null = null;
+  let followerStatusSyncPromise: Promise<void> | null = null;
+  let followerStatusSyncTarget: "working" | "idle" | null = null;
 
   function getPinetRegistrationBlockReason(): string {
     return "Pinet is disabled in local subagent sessions to avoid polluting the agent mesh.";
@@ -2435,6 +2439,10 @@ export default function (pi: ExtensionAPI) {
         brokerClient = null;
         resetFollowerDeliveryState(followerDeliveryState);
         followerAckPromise = null;
+        syncedFollowerStatus = null;
+        followerStatusSyncPromise = null;
+        followerStatusSyncTarget = null;
+        desiredAgentStatus = "idle";
         brokerRole = null;
         pinetEnabled = false;
       }
@@ -2444,6 +2452,10 @@ export default function (pi: ExtensionAPI) {
     activityLogger.clearPending();
     brokerRole = null;
     pinetEnabled = false;
+    desiredAgentStatus = "idle";
+    syncedFollowerStatus = null;
+    followerStatusSyncPromise = null;
+    followerStatusSyncTarget = null;
     currentRuntimeMode = "off";
     setExtStatus(ctx, "off");
   }
@@ -2623,7 +2635,7 @@ export default function (pi: ExtensionAPI) {
       requireToolPolicy("pinet_free", undefined, `note=${params.note ?? ""}`);
 
       const note = typeof params.note === "string" ? params.note.trim() : "";
-      const result = signalAgentFree(undefined, { requirePinet: true });
+      const result = await signalAgentFree(undefined, { requirePinet: true });
       const inboxSuffix =
         result.queuedInboxCount > 0
           ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`
@@ -2999,6 +3011,8 @@ export default function (pi: ExtensionAPI) {
       activeSelfId = selfId;
       brokerRole = "broker";
       pinetEnabled = true;
+      desiredAgentStatus = "idle";
+      syncedFollowerStatus = null;
       currentRuntimeMode = "broker";
 
       resetBrokerDeliveryState(brokerDeliveryState);
@@ -3177,6 +3191,9 @@ export default function (pi: ExtensionAPI) {
       await client.connect();
       await registerFollowerRuntime();
 
+      desiredAgentStatus = "idle";
+      syncedFollowerStatus = "idle";
+
       const brokerClientRef: BrokerClientRef = {
         client,
         pollInterval: null,
@@ -3351,6 +3368,9 @@ export default function (pi: ExtensionAPI) {
           } catch {
             /* broker may be restarting */
           } finally {
+            void syncDesiredAgentStatus().catch(() => {
+              /* best effort */
+            });
             followerPollRunning = false;
           }
         }, 2000);
@@ -3388,8 +3408,8 @@ export default function (pi: ExtensionAPI) {
             }
           }
           await resumeThreadClaims();
-          const currentlyIdle = ctx.isIdle?.() ?? true;
-          void client.updateStatus(currentlyIdle ? "idle" : "working").catch(() => {
+          syncedFollowerStatus = "idle";
+          void syncDesiredAgentStatus().catch(() => {
             /* best effort */
           });
           startPolling();
@@ -3447,6 +3467,10 @@ export default function (pi: ExtensionAPI) {
     brokerClient = null;
     resetFollowerDeliveryState(followerDeliveryState);
     followerAckPromise = null;
+    syncedFollowerStatus = null;
+    followerStatusSyncPromise = null;
+    followerStatusSyncTarget = null;
+    desiredAgentStatus = "idle";
     brokerRole = null;
     pinetEnabled = false;
     currentRuntimeMode = "off";
@@ -3597,32 +3621,57 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Agent status reporting ──────────────────────────
 
-  function reportStatus(status: "working" | "idle"): void {
-    if (!pinetEnabled) return;
-    try {
-      if (brokerRole === "broker" && activeBroker && activeSelfId) {
-        activeBroker.db.updateAgentStatus(activeSelfId, status);
-      } else if (brokerRole === "follower" && brokerClient) {
-        brokerClient.client.updateStatus(status).catch(() => {
-          /* best effort */
-        });
+  async function syncDesiredAgentStatus(options: { force?: boolean } = {}): Promise<void> {
+    if (!pinetEnabled) {
+      return;
+    }
+
+    if (brokerRole === "broker" && activeBroker && activeSelfId) {
+      activeBroker.db.updateAgentStatus(activeSelfId, desiredAgentStatus);
+      return;
+    }
+
+    if (brokerRole === "follower" && brokerClient) {
+      if (!options.force && syncedFollowerStatus === desiredAgentStatus) {
+        return;
       }
-    } catch {
-      /* best effort */
+      if (followerStatusSyncPromise && followerStatusSyncTarget === desiredAgentStatus) {
+        await followerStatusSyncPromise;
+        return;
+      }
+
+      const targetStatus = desiredAgentStatus;
+      const request = brokerClient.client.updateStatus(targetStatus).then(() => {
+        syncedFollowerStatus = targetStatus;
+      });
+      followerStatusSyncTarget = targetStatus;
+      const inFlight = request.finally(() => {
+        if (followerStatusSyncPromise === inFlight) {
+          followerStatusSyncPromise = null;
+          followerStatusSyncTarget = null;
+        }
+      });
+      followerStatusSyncPromise = inFlight;
+      await inFlight;
     }
   }
 
-  function signalAgentFree(
+  async function reportStatus(status: "working" | "idle"): Promise<void> {
+    desiredAgentStatus = status;
+    await syncDesiredAgentStatus();
+  }
+
+  async function signalAgentFree(
     ctx?: ExtensionContext,
     options: { requirePinet?: boolean } = {},
-  ): { queuedInboxCount: number; drainedQueuedInbox: boolean } {
+  ): Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }> {
     if (!pinetEnabled && options.requirePinet) {
       throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
     }
 
     const maintenanceCtx = ctx ?? extCtx ?? undefined;
     if (pinetEnabled) {
-      reportStatus("idle");
+      await reportStatus("idle");
       if (brokerRole === "broker" && maintenanceCtx) {
         runBrokerMaintenance(maintenanceCtx);
       }
@@ -3679,7 +3728,9 @@ export default function (pi: ExtensionAPI) {
     const pending = inbox.splice(0, inbox.length);
     const brokerInboxIds = getBrokerInboxIds(pending);
     updateBadge();
-    reportStatus("working");
+    void reportStatus("working").catch(() => {
+      /* best effort */
+    });
 
     let prompt = formatInboxMessages(pending, userNames);
 
@@ -3792,7 +3843,11 @@ export default function (pi: ExtensionAPI) {
     thinking.clear();
     ralphLoopState.followUpPending = false;
 
-    signalAgentFree(ctx);
+    try {
+      await signalAgentFree(ctx);
+    } catch (err) {
+      ctx.ui.notify(`Pinet auto-free failed: ${msg(err)}`, "warning");
+    }
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -60,7 +60,7 @@ export interface PinetCommandsDeps {
   signalAgentFree: (
     ctx: ExtensionContext,
     options: { requirePinet?: boolean },
-  ) => { queuedInboxCount: number; drainedQueuedInbox: boolean };
+  ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
   applyMeshSkin: (themeInput: string) => { theme: string; updatedAgents: string[] };
   applyLocalAgentIdentity: (name: string, emoji: string, personality: string | null) => void;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
@@ -203,7 +203,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       }
 
       try {
-        const result = deps.signalAgentFree(ctx, { requirePinet: true });
+        const result = await deps.signalAgentFree(ctx, { requirePinet: true });
         const suffix = result.drainedQueuedInbox
           ? ` Processing ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? "" : "s"} now.`
           : result.queuedInboxCount > 0


### PR DESCRIPTION
## Summary
- keep a desired/synced follower mesh status so worker status transitions are retried instead of silently getting stuck
- make `pinet_free` / `/pinet-free` await the idle status update instead of reporting success after a dropped best-effort call
- add a regression test that reproduces a failed idle sync and proves the follower retries back to `idle`

## Diagnosis
`signalAgentFree(...)` was synchronous and relied on a fire-and-forget `brokerClient.client.updateStatus("idle")` call.

If that RPC failed once, the worker could locally believe it had stood down while the broker DB kept the last `working` status. Fresh heartbeats then kept the worker `healthy`, and RALPH could keep emitting stale stuck-worker pulses.

## What changed
- track `desiredAgentStatus` and the last synced follower status in `slack-bridge/index.ts`
- retry follower status reconciliation from the normal poll loop and reconnect path
- await idle status updates in:
  - `pinet_free`
  - `/pinet-free`
  - the shared `signalAgentFree(...)` path used by `agent_end`
- warn locally if automatic `agent_end` auto-free cannot mark the worker idle

## Files changed
- `slack-bridge/index.ts`
- `slack-bridge/pinet-commands.ts`
- `slack-bridge/index.test.ts`

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm lint`
- `pnpm typecheck`

## Known unrelated blocker
- repo-wide `pnpm test` is still red on current `main` because of the already-tracked Slack access warning drift in `slack-bridge/index.test.ts`:
  - `keeps explicit off mode free of Slack Socket Mode ingress on session start`
- that failure is unrelated to this #336 fix lane and is already tracked separately in `#377`
