### PR TITLE
fix: keep broker identity stable

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -59,6 +59,8 @@ import {
   resolveRuntimeAgentIdentity,
   buildAgentStableId,
   resolveAgentStableId,
+  buildBrokerStableId,
+  resolveBrokerStableId,
   isLikelyLocalSubagentContext,
   buildSlackRequest,
   createAbortableOperationTracker,
@@ -1420,6 +1422,26 @@ describe("resolveAgentStableId", () => {
   it("falls back to buildAgentStableId when no persisted stable id exists", () => {
     expect(resolveAgentStableId(undefined, "/tmp/pi/session.json", "macbook", "/repo")).toBe(
       `macbook:session:${path.resolve("/tmp/pi/session.json")}`,
+    );
+  });
+});
+
+describe("buildBrokerStableId", () => {
+  it("anchors broker stable ids to the repo checkout instead of the session file", () => {
+    expect(buildBrokerStableId("macbook", "/repo")).toBe(`macbook:broker:${path.resolve("/repo")}`);
+  });
+});
+
+describe("resolveBrokerStableId", () => {
+  it("prefers the persisted broker stable id across reloads and restarts", () => {
+    expect(resolveBrokerStableId("persisted:broker:123", "macbook", "/repo")).toBe(
+      "persisted:broker:123",
+    );
+  });
+
+  it("falls back to the repo-anchored broker stable id when none is persisted", () => {
+    expect(resolveBrokerStableId(undefined, "macbook", "/repo")).toBe(
+      `macbook:broker:${path.resolve("/repo")}`,
     );
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1653,6 +1653,18 @@ export function resolveAgentStableId(
   return persistedStableId || buildAgentStableId(sessionFile, host, cwd, leafId);
 }
 
+export function buildBrokerStableId(host = os.hostname(), cwd = process.cwd()): string {
+  return `${host}:broker:${path.resolve(cwd)}`;
+}
+
+export function resolveBrokerStableId(
+  persistedStableId?: string,
+  host = os.hostname(),
+  cwd = process.cwd(),
+): string {
+  return persistedStableId || buildBrokerStableId(host, cwd);
+}
+
 export interface PinetRegistrationContext {
   sessionHeader?: {
     parentSession?: string;

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1373,6 +1373,368 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(setStatus).toHaveBeenCalled();
   });
 
+  it("keeps worker identities session-scoped across clean restarts in the same repo checkout", async () => {
+    const registerCalls: Array<{ stableId?: string }> = [];
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async (
+      _name: string,
+      _emoji: string,
+      _metadata?: Record<string, unknown>,
+      stableId?: string,
+    ) => {
+      registerCalls.push({ stableId });
+      return {
+        agentId: "worker-1",
+        name: "Agent",
+        emoji: "🦙",
+        metadata: { role: "worker", capabilities: { role: "worker" } },
+      };
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+      /* mocked */
+    });
+
+    function buildFollowerRuntime(sessionFile: string, leafId: string) {
+      const commands = new Map<string, CommandDefinition>();
+      const events = new Map<string, EventHandler>();
+      const pi = {
+        appendEntry: vi.fn(),
+        registerTool: vi.fn(),
+        registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+          commands.set(name, definition);
+        }),
+        on: vi.fn((eventName: string, handler: EventHandler) => {
+          events.set(eventName, handler);
+        }),
+        sendUserMessage: vi.fn(),
+      } as unknown as ExtensionAPI;
+
+      const ctx = {
+        cwd: process.cwd(),
+        hasUI: true,
+        isIdle: () => true,
+        ui: {
+          theme: {
+            fg: (_color: string, text: string) => text,
+          },
+          notify: vi.fn(),
+          setStatus: vi.fn(),
+        },
+        sessionManager: {
+          getEntries: () => [],
+          getHeader: () => null,
+          getLeafId: () => leafId,
+          getSessionFile: () => sessionFile,
+        },
+      } as unknown as ExtensionContext;
+
+      slackBridge(pi);
+      return {
+        ctx,
+        sessionStart: events.get("session_start"),
+        sessionShutdown: events.get("session_shutdown"),
+        follow: commands.get("pinet-follow"),
+      };
+    }
+
+    const first = buildFollowerRuntime("/tmp/slack-bridge-worker-a.json", "worker-leaf-a");
+    expect(first.sessionStart).toBeDefined();
+    expect(first.sessionShutdown).toBeDefined();
+    expect(first.follow).toBeDefined();
+    await first.sessionStart?.({}, first.ctx);
+    await first.follow?.handler("", first.ctx);
+    await first.sessionShutdown?.({}, first.ctx);
+
+    const second = buildFollowerRuntime("/tmp/slack-bridge-worker-b.json", "worker-leaf-b");
+    expect(second.sessionStart).toBeDefined();
+    expect(second.sessionShutdown).toBeDefined();
+    expect(second.follow).toBeDefined();
+    await second.sessionStart?.({}, second.ctx);
+    await second.follow?.handler("", second.ctx);
+    await second.sessionShutdown?.({}, second.ctx);
+
+    expect(registerCalls).toHaveLength(2);
+    expect(registerCalls[0]?.stableId).toBeTruthy();
+    expect(registerCalls[1]?.stableId).toBeTruthy();
+    expect(registerCalls[0]?.stableId).not.toBe(registerCalls[1]?.stableId);
+    expect(registerCalls[0]?.stableId).toContain(":session:");
+    expect(registerCalls[1]?.stableId).toContain(":session:");
+  });
+
+  it("keeps broker identity stable across a top-level reload in the same session", async () => {
+    const dbPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "slack-bridge-broker-reload-")),
+      "pinet-broker.db",
+    );
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const startedDbs: BrokerDB[] = [];
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation((db) => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: db.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    vi.spyOn(brokerModule, "startBroker").mockImplementation(async () => {
+      const db = new BrokerDB(dbPath);
+      db.initialize();
+      startedDbs.push(db);
+      return {
+        db,
+        server: {
+          setAgentRegistrationResolver: vi.fn(),
+          onAgentMessage: vi.fn(),
+          onAgentStatusChange: vi.fn(),
+        },
+        lock: {
+          isLeader: () => true,
+          release: vi.fn(),
+        },
+        adapters: [],
+        addAdapter: vi.fn(),
+        stop: vi.fn(async () => {
+          db.close();
+        }),
+      } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
+    });
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    function readBrokerIdentity(db: BrokerDB) {
+      const broker = db.getAllAgents().find((agent) => agent.metadata?.role === "broker");
+      if (!broker) {
+        throw new Error("Expected broker to be registered");
+      }
+      return {
+        id: broker.id,
+        stableId: broker.stableId ?? null,
+        name: broker.name,
+        emoji: broker.emoji,
+      };
+    }
+
+    function buildBrokerRuntime(savedState: Record<string, unknown> | null) {
+      const commands = new Map<string, CommandDefinition>();
+      const events = new Map<string, EventHandler>();
+      let persistedState: Record<string, unknown> | null = null;
+      const pi = {
+        appendEntry: vi.fn((customType: string, data: Record<string, unknown>) => {
+          if (customType === "slack-bridge-state") {
+            persistedState = data;
+          }
+        }),
+        registerTool: vi.fn(),
+        registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+          commands.set(name, definition);
+        }),
+        on: vi.fn((eventName: string, handler: EventHandler) => {
+          events.set(eventName, handler);
+        }),
+        sendUserMessage: vi.fn(),
+      } as unknown as ExtensionAPI;
+
+      const ctx = {
+        cwd: process.cwd(),
+        hasUI: true,
+        isIdle: () => true,
+        ui: {
+          theme: {
+            fg: (_color: string, text: string) => text,
+          },
+          notify: vi.fn(),
+          setStatus: vi.fn(),
+        },
+        sessionManager: {
+          getEntries: () =>
+            savedState
+              ? [{ type: "custom", customType: "slack-bridge-state", data: savedState }]
+              : [],
+          getHeader: () => null,
+          getLeafId: () => "broker-reload-leaf",
+          getSessionFile: () => "/tmp/slack-bridge-broker-reload-session.json",
+        },
+      } as unknown as ExtensionContext;
+
+      slackBridge(pi);
+      return {
+        ctx,
+        sessionStart: events.get("session_start"),
+        sessionShutdown: events.get("session_shutdown"),
+        pinetStart: commands.get("pinet-start"),
+        getPersistedState: () => persistedState,
+      };
+    }
+
+    const first = buildBrokerRuntime(null);
+    expect(first.sessionStart).toBeDefined();
+    expect(first.sessionShutdown).toBeDefined();
+    expect(first.pinetStart).toBeDefined();
+    await first.sessionStart?.({}, first.ctx);
+    await first.pinetStart?.handler("", first.ctx);
+    const initialBrokerIdentity = readBrokerIdentity(startedDbs[0]!);
+    await first.sessionShutdown?.({}, first.ctx);
+
+    const persistedState = first.getPersistedState();
+    expect(persistedState).toMatchObject({
+      brokerStableId: initialBrokerIdentity.stableId,
+      lastPinetRole: "broker",
+    });
+
+    const second = buildBrokerRuntime(persistedState);
+    expect(second.sessionStart).toBeDefined();
+    expect(second.sessionShutdown).toBeDefined();
+    expect(second.pinetStart).toBeDefined();
+    await second.sessionStart?.({}, second.ctx);
+    await second.pinetStart?.handler("", second.ctx);
+    const reloadedBrokerIdentity = readBrokerIdentity(startedDbs[1]!);
+
+    expect(reloadedBrokerIdentity).toEqual(initialBrokerIdentity);
+
+    await second.sessionShutdown?.({}, second.ctx);
+  });
+
+  it("keeps broker identity stable across clean restarts in the same repo checkout", async () => {
+    const dbPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "slack-bridge-broker-restart-")),
+      "pinet-broker.db",
+    );
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const startedDbs: BrokerDB[] = [];
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation((db) => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: db.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    vi.spyOn(brokerModule, "startBroker").mockImplementation(async () => {
+      const db = new BrokerDB(dbPath);
+      db.initialize();
+      startedDbs.push(db);
+      return {
+        db,
+        server: {
+          setAgentRegistrationResolver: vi.fn(),
+          onAgentMessage: vi.fn(),
+          onAgentStatusChange: vi.fn(),
+        },
+        lock: {
+          isLeader: () => true,
+          release: vi.fn(),
+        },
+        adapters: [],
+        addAdapter: vi.fn(),
+        stop: vi.fn(async () => {
+          db.close();
+        }),
+      } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
+    });
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    function readBrokerIdentity(db: BrokerDB) {
+      const broker = db.getAllAgents().find((agent) => agent.metadata?.role === "broker");
+      if (!broker) {
+        throw new Error("Expected broker to be registered");
+      }
+      return {
+        id: broker.id,
+        stableId: broker.stableId ?? null,
+        name: broker.name,
+        emoji: broker.emoji,
+      };
+    }
+
+    function buildBrokerRuntime(sessionFile: string, leafId: string) {
+      const commands = new Map<string, CommandDefinition>();
+      const events = new Map<string, EventHandler>();
+      const pi = {
+        appendEntry: vi.fn(),
+        registerTool: vi.fn(),
+        registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+          commands.set(name, definition);
+        }),
+        on: vi.fn((eventName: string, handler: EventHandler) => {
+          events.set(eventName, handler);
+        }),
+        sendUserMessage: vi.fn(),
+      } as unknown as ExtensionAPI;
+
+      const ctx = {
+        cwd: process.cwd(),
+        hasUI: true,
+        isIdle: () => true,
+        ui: {
+          theme: {
+            fg: (_color: string, text: string) => text,
+          },
+          notify: vi.fn(),
+          setStatus: vi.fn(),
+        },
+        sessionManager: {
+          getEntries: () => [],
+          getHeader: () => null,
+          getLeafId: () => leafId,
+          getSessionFile: () => sessionFile,
+        },
+      } as unknown as ExtensionContext;
+
+      slackBridge(pi);
+      return {
+        ctx,
+        sessionStart: events.get("session_start"),
+        sessionShutdown: events.get("session_shutdown"),
+        pinetStart: commands.get("pinet-start"),
+      };
+    }
+
+    const first = buildBrokerRuntime(
+      "/tmp/slack-bridge-broker-restart-a.json",
+      "broker-restart-leaf-a",
+    );
+    expect(first.sessionStart).toBeDefined();
+    expect(first.sessionShutdown).toBeDefined();
+    expect(first.pinetStart).toBeDefined();
+    await first.sessionStart?.({}, first.ctx);
+    await first.pinetStart?.handler("", first.ctx);
+    const initialBrokerIdentity = readBrokerIdentity(startedDbs[0]!);
+    await first.sessionShutdown?.({}, first.ctx);
+
+    const second = buildBrokerRuntime(
+      "/tmp/slack-bridge-broker-restart-b.json",
+      "broker-restart-leaf-b",
+    );
+    expect(second.sessionStart).toBeDefined();
+    expect(second.sessionShutdown).toBeDefined();
+    expect(second.pinetStart).toBeDefined();
+    await second.sessionStart?.({}, second.ctx);
+    await second.pinetStart?.handler("", second.ctx);
+    const restartedBrokerIdentity = readBrokerIdentity(startedDbs[1]!);
+
+    expect(restartedBrokerIdentity).toEqual(initialBrokerIdentity);
+
+    await second.sessionShutdown?.({}, second.ctx);
+  });
+
   it("does not reclaim restored source-less threads as slack on follow or reconnect", async () => {
     const commands = new Map<string, CommandDefinition>();
     const events = new Map<string, EventHandler>();

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -45,6 +45,7 @@ import {
   resolveAgentIdentity,
   resolvePersistedAgentIdentity,
   resolveRuntimeAgentIdentity,
+  resolveBrokerStableId,
   shortenPath,
   buildIdentityReplyGuidelines,
   buildAgentPersonalityGuidelines,
@@ -245,11 +246,13 @@ export default function (pi: ExtensionAPI) {
   let agentName = initialIdentity.name;
   let agentEmoji = initialIdentity.emoji;
   let agentStableId = resolveAgentStableId(undefined, undefined, os.hostname(), process.cwd());
+  let brokerStableId = resolveBrokerStableId(undefined, os.hostname(), process.cwd());
   let agentOwnerToken = buildPinetOwnerToken(agentStableId);
   let activeSkinTheme: string | null = null;
   let agentPersonality: string | null = null;
   const agentAliases = new Set<string>();
   const PINET_SKIN_SETTING_KEY = "pinet.skinTheme";
+  const PINET_BROKER_STABLE_ID_SETTING_KEY = "pinet.brokerStableId";
 
   // Security guardrails
   let guardrails: SecurityGuardrails = settings.security ?? {};
@@ -312,8 +315,19 @@ export default function (pi: ExtensionAPI) {
     agentAliases: string[];
   }
 
+  function getStableIdForRole(role: "broker" | "worker"): string {
+    return role === "broker" ? brokerStableId : agentStableId;
+  }
+
+  function getIdentitySeedForRole(
+    role: "broker" | "worker",
+    sessionFile = extCtx?.sessionManager.getSessionFile() ?? undefined,
+  ): string {
+    return role === "broker" ? brokerStableId : sessionFile ?? agentStableId;
+  }
+
   function getSkinSeed(preferredSeed?: string): string {
-    return preferredSeed?.trim() || agentStableId;
+    return preferredSeed?.trim() || getStableIdForRole(brokerRole === "broker" ? "broker" : "worker");
   }
 
   function rememberAgentAlias(name: string | undefined): void {
@@ -375,8 +389,8 @@ export default function (pi: ExtensionAPI) {
     guardrails = settings.security ?? {};
     reactionCommands = resolveReactionCommands(settings.reactionCommands);
     securityPrompt = buildSecurityPrompt(guardrails);
-    const identitySeed = extCtx?.sessionManager.getSessionFile() ?? agentStableId;
     const role = brokerRole === "broker" ? "broker" : "worker";
+    const identitySeed = getIdentitySeedForRole(role);
     const skinIdentity = resolveSkinAssignment(role, identitySeed);
     if (skinIdentity) {
       agentName = skinIdentity.name;
@@ -425,7 +439,7 @@ export default function (pi: ExtensionAPI) {
     agentEmoji = snapshot.agentEmoji;
     activeSkinTheme = snapshot.activeSkinTheme;
     agentPersonality = snapshot.agentPersonality;
-    agentOwnerToken = buildPinetOwnerToken(agentStableId);
+    agentOwnerToken = buildPinetOwnerToken(getStableIdForRole(brokerRole === "broker" ? "broker" : "worker"));
     agentAliases.clear();
     for (const alias of snapshot.agentAliases) {
       if (alias && alias !== agentName) {
@@ -618,6 +632,8 @@ export default function (pi: ExtensionAPI) {
         agentName,
         agentEmoji,
         agentStableId,
+        brokerStableId,
+        lastPinetRole: brokerRole === "broker" ? "broker" : "worker",
         activeSkinTheme,
         agentPersonality,
         agentAliases: [...agentAliases],
@@ -2893,6 +2909,31 @@ export default function (pi: ExtensionAPI) {
       activeSkinTheme =
         broker.db.getSetting<string>(PINET_SKIN_SETTING_KEY) ?? DEFAULT_PINET_SKIN_THEME;
       broker.db.setSetting(PINET_SKIN_SETTING_KEY, activeSkinTheme);
+
+      const persistedBrokerStableId =
+        normalizeOptionalSetting(broker.db.getSetting<string>(PINET_BROKER_STABLE_ID_SETTING_KEY)) ??
+        broker.db
+          .getAllAgents()
+          .flatMap((agent) => {
+            const stableId = normalizeOptionalSetting(agent.stableId);
+            if (!stableId) {
+              return [];
+            }
+            if (getMeshRoleFromMetadata(agent.metadata ?? undefined, "worker") !== "broker") {
+              return [];
+            }
+            const lastSeenMs = Date.parse(agent.lastSeen);
+            const connectedAtMs = Date.parse(agent.connectedAt);
+            const recencyMs = Number.isNaN(lastSeenMs)
+              ? (Number.isNaN(connectedAtMs) ? 0 : connectedAtMs)
+              : lastSeenMs;
+            return [{ stableId, recencyMs }];
+          })
+          .sort((left, right) => right.recencyMs - left.recencyMs)[0]?.stableId ??
+        null;
+      brokerStableId = persistedBrokerStableId ?? brokerStableId;
+      broker.db.setSetting(PINET_BROKER_STABLE_ID_SETTING_KEY, brokerStableId);
+      agentOwnerToken = buildPinetOwnerToken(brokerStableId);
       broker.server.setAgentRegistrationResolver((registration) => {
         const theme = activeSkinTheme ?? DEFAULT_PINET_SKIN_THEME;
         const role = getMeshRoleFromMetadata(registration.metadata, "worker");
@@ -2911,7 +2952,7 @@ export default function (pi: ExtensionAPI) {
       const selfAssignment = buildPinetSkinAssignment({
         theme: activeSkinTheme,
         role: "broker",
-        seed: agentStableId,
+        seed: brokerStableId,
       });
       const selfAgent = broker.db.registerAgent(
         ctx.sessionManager.getLeafId() ?? `broker-${process.pid}`,
@@ -2919,7 +2960,7 @@ export default function (pi: ExtensionAPI) {
         selfAssignment.emoji,
         process.pid,
         buildSkinMetadata(await getAgentMetadata("broker"), selfAssignment.personality),
-        agentStableId,
+        brokerStableId,
       );
       selfId = selfAgent.id;
       applyLocalAgentIdentity(selfAgent.name, selfAgent.emoji, selfAssignment.personality);
@@ -3174,10 +3215,11 @@ export default function (pi: ExtensionAPI) {
         { name: agentName, emoji: agentEmoji },
         settings,
         process.env.PI_NICKNAME,
-        ctx.sessionManager.getSessionFile() ?? agentStableId,
+        getIdentitySeedForRole("worker", ctx.sessionManager.getSessionFile() ?? undefined),
         "worker",
       );
 
+      agentOwnerToken = buildPinetOwnerToken(agentStableId);
       const registration = await client.register(
         workerIdentity.name,
         workerIdentity.emoji,
@@ -3522,6 +3564,8 @@ export default function (pi: ExtensionAPI) {
       agentName?: string;
       agentEmoji?: string;
       agentStableId?: string;
+      brokerStableId?: string;
+      lastPinetRole?: "broker" | "worker";
       activeSkinTheme?: string | null;
       agentPersonality?: string | null;
       agentAliases?: string[];
@@ -3536,6 +3580,7 @@ export default function (pi: ExtensionAPI) {
         }
       }
 
+      const restoredRole = savedState?.lastPinetRole === "broker" ? "broker" : "worker";
       agentStableId = resolveAgentStableId(
         savedState?.agentStableId,
         ctx.sessionManager.getSessionFile(),
@@ -3543,8 +3588,12 @@ export default function (pi: ExtensionAPI) {
         ctx.cwd,
         ctx.sessionManager.getLeafId(),
       );
-      agentOwnerToken = buildPinetOwnerToken(agentStableId);
-      const identitySeed = ctx.sessionManager.getSessionFile() ?? agentStableId;
+      brokerStableId = resolveBrokerStableId(savedState?.brokerStableId, os.hostname(), ctx.cwd);
+      agentOwnerToken = buildPinetOwnerToken(getStableIdForRole(restoredRole));
+      const identitySeed = getIdentitySeedForRole(
+        restoredRole,
+        ctx.sessionManager.getSessionFile() ?? undefined,
+      );
       activeSkinTheme = savedState?.activeSkinTheme ?? null;
       agentPersonality = savedState?.agentPersonality ?? null;
       agentAliases.clear();
@@ -3559,7 +3608,7 @@ export default function (pi: ExtensionAPI) {
         savedState?.agentEmoji,
         process.env.PI_NICKNAME,
         identitySeed,
-        brokerRole === "broker" ? "broker" : "worker",
+        restoredRole,
       );
       agentName = restoredIdentity.name;
       agentEmoji = restoredIdentity.emoji;


### PR DESCRIPTION
## Summary
- decouple broker stable-id continuity from per-session-file drift while leaving worker identities session-scoped
- thread the broker-stable seed through broker restore, broker skin/name assignment, and broker DB registration continuity
- add focused coverage for broker continuity across top-level reload and clean restart, plus a worker no-regression check

## Diagnosis carried forward
Broker identity drift was caused by the broker path effectively seeding identity from a session-file-derived stable id. That stable id fed both broker skin/name generation and broker DB reconnect continuity, so top-level reload/restart could produce a new broker identity.

## Scope
This is intentionally broker-only.
It does not widen into worker identity policy, transport seams, or unrelated adapter work.

## Checks
- `pnpm --dir slack-bridge exec vitest run helpers.test.ts index.test.ts`
- `pnpm --dir slack-bridge lint`
- `pnpm --dir slack-bridge typecheck`
- `pnpm --dir slack-bridge test`