### PR TITLE
fix: stop false live ghost pulses

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1747,6 +1747,28 @@ describe("buildAgentDisplayInfo", () => {
     expect(agent.ghost).toBe(true);
     expect(agent.leaseSummary).toBe("lease expired 5s ago");
   });
+
+  it("downgrades connected agents with stale heartbeats to stale when lastSeen is still fresh", () => {
+    const agent = buildAgentDisplayInfo(
+      {
+        emoji: "🛰️",
+        name: "Seen Bot",
+        id: "seen-1",
+        status: "idle",
+        lastHeartbeat: "2026-01-01T00:00:00.000Z",
+        lastSeen: "2026-01-01T00:00:18.000Z",
+        metadata: { role: "worker" },
+      },
+      {
+        now: Date.parse("2026-01-01T00:00:20.000Z"),
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(agent.health).toBe("stale");
+    expect(agent.ghost).toBe(false);
+  });
 });
 
 describe("mesh visibility helpers", () => {
@@ -1932,6 +1954,32 @@ describe("evaluateRalphLoopCycle", () => {
     expect(result.anomalies).toContain("broker heartbeat timer is not running");
     expect(result.anomalies).toContain("broker maintenance timer is not running");
     expect(result.anomalies.some((item) => item.includes("expected `main`"))).toBe(true);
+  });
+
+  it("does not flag connected agents as ghosts when only the heartbeat is stale but lastSeen is fresh", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🛰️",
+          name: "Seen Fox",
+          id: "seen-worker",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:01:52.000Z",
+          lastHeartbeat: "2026-04-01T00:01:40.000Z",
+          pendingInboxCount: 0,
+          ownedThreadCount: 0,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:02:00.000Z"),
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(result.ghostAgentIds).toEqual([]);
+    expect(result.anomalies).toEqual([]);
   });
 
   it("skips the broker agent id when flagging idle agents with assigned work", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -738,6 +738,7 @@ export interface AgentVisibilityInput {
   status: "working" | "idle";
   metadata?: Record<string, unknown> | null;
   lastHeartbeat?: string;
+  lastSeen?: string;
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
   idleSince?: string | null;
@@ -916,6 +917,8 @@ export function buildAgentDisplayInfo(
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_AGENT_HEARTBEAT_INTERVAL_MS;
   const heartbeatMs = parseIsoMs(agent.lastHeartbeat);
   const heartbeatAgeMs = heartbeatMs == null ? null : Math.max(0, nowMs - heartbeatMs);
+  const lastSeenMs = parseIsoMs(agent.lastSeen);
+  const lastSeenAgeMs = lastSeenMs == null ? null : Math.max(0, nowMs - lastSeenMs);
   const computedLeaseExpiresAt =
     agent.resumableUntil ??
     (heartbeatMs == null ? null : new Date(heartbeatMs + heartbeatTimeoutMs).toISOString());
@@ -925,13 +928,15 @@ export function buildAgentDisplayInfo(
     heartbeatIntervalMs * 2,
     heartbeatTimeoutMs - heartbeatIntervalMs,
   );
+  const connectedButRecentlySeen =
+    disconnectedAtMs == null && lastSeenAgeMs != null && lastSeenAgeMs <= heartbeatTimeoutMs;
 
   let health: AgentHealth = "healthy";
   if (disconnectedAtMs != null && resumableUntilMs != null && resumableUntilMs > nowMs) {
     health = "resumable";
   } else if (
     disconnectedAtMs != null ||
-    (heartbeatAgeMs != null && heartbeatAgeMs > heartbeatTimeoutMs)
+    (heartbeatAgeMs != null && heartbeatAgeMs > heartbeatTimeoutMs && !connectedButRecentlySeen)
   ) {
     health = "ghost";
   } else if (heartbeatAgeMs != null && heartbeatAgeMs > staleThresholdMs) {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -331,11 +331,13 @@ export default function (pi: ExtensionAPI) {
     role: "broker" | "worker",
     sessionFile = extCtx?.sessionManager.getSessionFile() ?? undefined,
   ): string {
-    return role === "broker" ? brokerStableId : sessionFile ?? agentStableId;
+    return role === "broker" ? brokerStableId : (sessionFile ?? agentStableId);
   }
 
   function getSkinSeed(preferredSeed?: string): string {
-    return preferredSeed?.trim() || getStableIdForRole(brokerRole === "broker" ? "broker" : "worker");
+    return (
+      preferredSeed?.trim() || getStableIdForRole(brokerRole === "broker" ? "broker" : "worker")
+    );
   }
 
   function rememberAgentAlias(name: string | undefined): void {
@@ -447,7 +449,9 @@ export default function (pi: ExtensionAPI) {
     agentEmoji = snapshot.agentEmoji;
     activeSkinTheme = snapshot.activeSkinTheme;
     agentPersonality = snapshot.agentPersonality;
-    agentOwnerToken = buildPinetOwnerToken(getStableIdForRole(brokerRole === "broker" ? "broker" : "worker"));
+    agentOwnerToken = buildPinetOwnerToken(
+      getStableIdForRole(brokerRole === "broker" ? "broker" : "worker"),
+    );
     agentAliases.clear();
     for (const alias of snapshot.agentAliases) {
       if (alias && alias !== agentName) {
@@ -2795,6 +2799,7 @@ export default function (pi: ExtensionAPI) {
         status: "working" | "idle";
         metadata: Record<string, unknown> | null;
         lastHeartbeat: string;
+        lastSeen?: string;
         disconnectedAt?: string | null;
         resumableUntil?: string | null;
       }): AgentDisplayInfo =>
@@ -2812,6 +2817,7 @@ export default function (pi: ExtensionAPI) {
         status: "working" | "idle";
         metadata: Record<string, unknown> | null;
         lastHeartbeat: string;
+        lastSeen?: string;
         disconnectedAt?: string | null;
         resumableUntil?: string | null;
       }>;
@@ -2828,6 +2834,7 @@ export default function (pi: ExtensionAPI) {
           status: agent.status,
           metadata: agent.metadata,
           lastHeartbeat: agent.lastHeartbeat,
+          lastSeen: agent.lastSeen,
           disconnectedAt: agent.disconnectedAt,
           resumableUntil: agent.resumableUntil,
         }));
@@ -2847,6 +2854,7 @@ export default function (pi: ExtensionAPI) {
           status: agent.status ?? "idle",
           metadata: agent.metadata,
           lastHeartbeat: agent.lastHeartbeat,
+          lastSeen: agent.lastSeen,
           disconnectedAt: agent.disconnectedAt,
           resumableUntil: agent.resumableUntil,
         }));
@@ -2894,11 +2902,14 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "imessage_send",
     label: "iMessage Send",
-    description: "Send a message through the local send-first iMessage adapter on the active broker.",
+    description:
+      "Send a message through the local send-first iMessage adapter on the active broker.",
     promptSnippet:
       "Send a message through the local send-first iMessage adapter on the active Pinet broker. Use when a task needs a narrow macOS iMessage send path.",
     parameters: Type.Object({
-      to: Type.String({ description: "Recipient handle, phone number, email, or local chat identifier" }),
+      to: Type.String({
+        description: "Recipient handle, phone number, email, or local chat identifier",
+      }),
       text: Type.String({ description: "Message body" }),
       thread_id: Type.Optional(
         Type.String({
@@ -3030,7 +3041,9 @@ export default function (pi: ExtensionAPI) {
       broker.db.setSetting(PINET_SKIN_SETTING_KEY, activeSkinTheme);
 
       const persistedBrokerStableId =
-        normalizeOptionalSetting(broker.db.getSetting<string>(PINET_BROKER_STABLE_ID_SETTING_KEY)) ??
+        normalizeOptionalSetting(
+          broker.db.getSetting<string>(PINET_BROKER_STABLE_ID_SETTING_KEY),
+        ) ??
         broker.db
           .getAllAgents()
           .flatMap((agent) => {
@@ -3044,7 +3057,9 @@ export default function (pi: ExtensionAPI) {
             const lastSeenMs = Date.parse(agent.lastSeen);
             const connectedAtMs = Date.parse(agent.connectedAt);
             const recencyMs = Number.isNaN(lastSeenMs)
-              ? (Number.isNaN(connectedAtMs) ? 0 : connectedAtMs)
+              ? Number.isNaN(connectedAtMs)
+                ? 0
+                : connectedAtMs
               : lastSeenMs;
             return [{ stableId, recencyMs }];
           })


### PR DESCRIPTION
## Summary
- stop classifying connected agents as ghosts on heartbeat staleness alone when `lastSeen` is still fresh
- keep explicitly disconnected rows ghost-worthy
- thread `lastSeen` through the `pinet_agents` display path so live mesh views use the same liveness signal
- add focused regression coverage for the false-live-ghost case in `buildAgentDisplayInfo()` and `evaluateRalphLoopCycle()`

## Why
Repeated RALPH pulses were naming agents that were simultaneously visible as healthy/idle in the live mesh. The root issue was that ghost classification keyed off stale heartbeat alone, even when the broker had fresh `lastSeen` proof that the connected agent was still alive.

## Checks
- `pnpm install --frozen-lockfile`
- `pnpm --dir slack-bridge exec vitest run helpers.test.ts`
- `pnpm --dir slack-bridge lint`
- `pnpm --dir slack-bridge typecheck`
- `pnpm --dir slack-bridge test`
- repo prepush on push: `pnpm lint && pnpm typecheck && pnpm test`