### PR TITLE
fix: restore broker-stamped runtime names

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1070,6 +1070,8 @@ describe("Pinet skin helpers", () => {
     });
 
     expect(broker.theme).toBe("night's watch from ASOIAF");
+    expect(broker.name).toBe(generateAgentName("broker-a", "broker").name);
+    expect(broker.name).toMatch(/^The Broker \w+$/);
     expect(broker.name).not.toBe(worker.name);
     expect(broker.personality).toContain("night's watch from ASOIAF");
     expect(worker.personality).toContain("night's watch from ASOIAF");

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -2808,7 +2808,9 @@ export function buildPinetSkinAssignment(options: {
   const roleFocus = pickSkinValue(PINET_SKIN_ROLE_FOCUS[options.role], options.seed, "role-focus");
   const workerCore = secondary === modifier ? primary : secondary;
   const name =
-    options.role === "broker" ? `${primary} ${title}` : `${modifier} ${workerCore} ${title}`;
+    options.role === "broker"
+      ? generateAgentName(options.seed, "broker").name
+      : `${modifier} ${workerCore} ${title}`;
 
   return {
     theme: normalizedTheme,


### PR DESCRIPTION
## Summary
- keep broker skin/runtime names on the broker-stamped `The Broker {Animal}` path
- leave worker custom-skin naming untouched
- add regression coverage for custom broker skins

## Testing
- pnpm --filter @gugu910/pi-slack-bridge exec vitest run helpers.test.ts
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm prepush

Closes #326
