### PR TITLE
fix(slack-bridge): reserve broker agent names

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -1416,6 +1416,82 @@ describe("BrokerClient — onReconnect callback", () => {
     client.disconnect();
     await mock.close();
   }, 20000);
+
+  it("re-requests broker-assigned identity after reconnect when the original name was blank", async () => {
+    let mock = await createMockServer();
+    const port = mock.port;
+    const client = new BrokerClient(mock.connectOpts);
+    let disconnectFired = false;
+    let reconnectFired = false;
+
+    client.onDisconnect(() => {
+      disconnectFired = true;
+    });
+    client.onReconnect(() => {
+      reconnectFired = true;
+    });
+
+    await client.connect();
+    const registerPromise = client.register(
+      "",
+      "",
+      { cwd: "/repo", branch: "main" },
+      "host:session:/tmp/broker-assigned",
+    );
+
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(registerReq.method).toBe("register");
+    expect(registerReq.params.name).toBe("");
+    expect(registerReq.params.emoji).toBe("");
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "broker-assigned-agent",
+      name: "Broker Bird",
+      emoji: "🦩",
+    });
+    await registerPromise;
+
+    await mock.close();
+    await waitFor(() => disconnectFired, 2000);
+    await waitFor(() => client.getReconnectAttempt() >= 2, 5000);
+
+    mock = await createMockServer(port);
+    await waitFor(() => mock.received.length > 0, 5000);
+
+    const reRegisterReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(reRegisterReq.method).toBe("register");
+    expect(reRegisterReq.params.name).toBe("");
+    expect(reRegisterReq.params.emoji).toBe("");
+    expect(reRegisterReq.params.stableId).toBe("host:session:/tmp/broker-assigned");
+    expect(reconnectFired).toBe(false);
+
+    mock.respondTo(mock.connections[0], reRegisterReq.id, {
+      agentId: "broker-assigned-agent",
+      name: "Broker Bird",
+      emoji: "🦩",
+    });
+
+    await waitFor(() => reconnectFired, 5000);
+    expect(reconnectFired).toBe(true);
+    expect(client.isConnected()).toBe(true);
+    expect(client.getReconnectAttempt()).toBe(0);
+    expect(client.getRegisteredIdentity()).toEqual({
+      agentId: "broker-assigned-agent",
+      name: "Broker Bird",
+      emoji: "🦩",
+    });
+
+    client.disconnect();
+    await mock.close();
+  }, 20000);
 });
 
 describe("BrokerClient — newline-delimited framing", () => {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -136,6 +136,7 @@ interface RegistrationSnapshot {
   emoji: string;
   metadata?: Record<string, unknown>;
   stableId?: string;
+  brokerAssignedIdentity?: boolean;
 }
 
 interface RegistrationResult {
@@ -317,6 +318,7 @@ export class BrokerClient {
       emoji,
       ...(metadata ? { metadata } : {}),
       ...(stableId ? { stableId } : {}),
+      ...(name.trim().length === 0 ? { brokerAssignedIdentity: true } : {}),
     };
     return this.performRegister(this.registrationSnapshot);
   }
@@ -634,12 +636,17 @@ export class BrokerClient {
       ...(snapshot.metadata ? { metadata: snapshot.metadata } : {}),
       ...(snapshot.stableId ? { stableId: snapshot.stableId } : {}),
     })) as RegistrationResult;
-    this.registrationSnapshot = {
-      ...snapshot,
-      name: result.name,
-      emoji: result.emoji,
-      ...(result.metadata ? { metadata: result.metadata } : {}),
-    };
+    this.registrationSnapshot = snapshot.brokerAssignedIdentity
+      ? {
+          ...snapshot,
+          ...(result.metadata ? { metadata: result.metadata } : {}),
+        }
+      : {
+          ...snapshot,
+          name: result.name,
+          emoji: result.emoji,
+          ...(result.metadata ? { metadata: result.metadata } : {}),
+        };
     this.registeredIdentity = result;
     this.startHeartbeat();
     return result;

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -128,6 +128,59 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(agent!.pid).toBe(process.pid);
   });
 
+  it("lets the broker assign a unique name when the caller leaves the request blank", async () => {
+    server.setAgentRegistrationResolver(({ metadata }) => ({
+      name: "Shared Horizon",
+      emoji: "🧭",
+      metadata,
+    }));
+
+    const first = await client.register("", "", undefined, "host:session:/tmp/blank-1");
+    expect(first.name).toBe("Shared Horizon");
+    expect(first.emoji).toBe("🧭");
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+
+    const second = await client2.register("", "", undefined, "host:session:/tmp/blank-2");
+    expect(second.name).toBe("Shared Horizon 2");
+    expect(second.emoji).toBe("🧭");
+
+    client2.disconnect();
+  });
+
+  it("rejects duplicate explicitly requested agent names with a clear retry path", async () => {
+    server.setAgentRegistrationResolver(({ metadata }) => ({
+      name: "broker-default",
+      emoji: "🧭",
+      metadata,
+    }));
+
+    const first = await client.register(
+      "Reserved Crane",
+      "🦩",
+      undefined,
+      "host:session:/tmp/name-1",
+    );
+    expect(first.name).toBe("Reserved Crane");
+    expect(first.emoji).toBe("🦩");
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+
+    await expect(
+      client2.register("Reserved Crane", "🪿", undefined, "host:session:/tmp/name-2"),
+    ).rejects.toThrow(
+      'Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.',
+    );
+
+    client2.disconnect();
+  });
+
   it("agents.list returns all connected agents", async () => {
     await client.register("agent-alpha", "🅰️");
 

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -962,6 +962,42 @@ export class BrokerDB implements BrokerDBInterface {
     return row ? rowToAgent(row) : null;
   }
 
+  findAgentNameConflict(
+    name: string,
+    id: string,
+    stableId?: string,
+  ): { id: string; stableId: string | null; name: string } | null {
+    const db = this.getDb();
+    const existing = stableId ? this.getAgentRowByStableId(stableId) : null;
+    const existingById = this.getAgentRowById(existing?.id ?? id);
+    const agentId = existing?.id ?? existingById?.id ?? id;
+    const normalizedName = name.trim();
+    if (!normalizedName) {
+      return null;
+    }
+
+    const row = db
+      .prepare(
+        `SELECT id, stable_id, name
+         FROM agents
+         WHERE lower(name) = lower(?) AND id != ?
+         LIMIT 1`,
+      )
+      .get(normalizedName, agentId) as
+      | { id: string; stable_id: string | null; name: string }
+      | undefined;
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      stableId: row.stable_id,
+      name: row.name,
+    };
+  }
+
   private getAgentRowByStableId(stableId: string): AgentRow | null {
     const db = this.getDb();
     const row = db.prepare("SELECT * FROM agents WHERE stable_id = ?").get(stableId) as

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -22,6 +22,7 @@ import {
   RPC_INVALID_PARAMS,
   RPC_INTERNAL_ERROR,
   RPC_AUTH_REQUIRED,
+  RPC_AGENT_NAME_CONFLICT,
 } from "./types.js";
 
 export type SlackProxyFn = (
@@ -284,9 +285,7 @@ export class BrokerSocketServer {
     this.agentRegistrationResolver = resolver;
   }
 
-  setOutboundMessageAdapters(
-    adapters: ReadonlyArray<Pick<MessageAdapter, "name" | "send">>,
-  ): void {
+  setOutboundMessageAdapters(adapters: ReadonlyArray<Pick<MessageAdapter, "name" | "send">>): void {
     this.outboundMessageAdapters = adapters;
   }
 
@@ -514,8 +513,8 @@ export class BrokerSocketServer {
     socket: net.Socket,
   ): JsonRpcResponse {
     const params = req.params ?? {};
-    const name = typeof params.name === "string" ? params.name : "anonymous";
-    const emoji = typeof params.emoji === "string" ? params.emoji : "";
+    const requestedName = typeof params.name === "string" ? params.name.trim() : "";
+    const requestedEmoji = typeof params.emoji === "string" ? params.emoji : "";
     const pid = typeof params.pid === "number" ? params.pid : 0;
     const stableId = typeof params.stableId === "string" ? params.stableId : undefined;
     const metadata =
@@ -526,15 +525,38 @@ export class BrokerSocketServer {
     const candidateId = state.agentId ?? crypto.randomUUID();
     const resolved = this.agentRegistrationResolver?.({
       agentId: candidateId,
-      name,
-      emoji,
+      name: requestedName,
+      emoji: requestedEmoji,
       pid,
       stableId,
       metadata,
     });
-    const finalName = resolved?.name ?? name;
-    const finalEmoji = resolved?.emoji ?? emoji;
+    const explicitNameRequest = requestedName.length > 0;
+    const finalName = explicitNameRequest
+      ? requestedName
+      : (resolved?.name ?? requestedName) || "anonymous";
+    const finalEmoji = explicitNameRequest
+      ? requestedEmoji.trim() || resolved?.emoji?.trim() || ""
+      : (resolved?.emoji ?? requestedEmoji).trim();
     const finalMetadata = resolved?.metadata ?? metadata;
+
+    if (explicitNameRequest) {
+      const conflict = this.db.findAgentNameConflict(finalName, candidateId, stableId);
+      if (conflict) {
+        return rpcError(
+          req.id,
+          RPC_AGENT_NAME_CONFLICT,
+          `Agent name "${finalName}" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.`,
+          {
+            code: "AGENT_NAME_CONFLICT",
+            requestedName: finalName,
+            ownerAgentId: conflict.id,
+            ownerStableId: conflict.stableId,
+            retryable: true,
+          },
+        );
+      }
+    }
 
     const agent = this.db.registerAgent(
       candidateId,

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -136,8 +136,9 @@ export const RPC_METHOD_NOT_FOUND = -32601;
 export const RPC_INVALID_PARAMS = -32602;
 export const RPC_INTERNAL_ERROR = -32603;
 
-// Server-defined broker auth error codes
+// Server-defined broker auth / registration error codes
 export const RPC_AUTH_REQUIRED = -32001;
+export const RPC_AGENT_NAME_CONFLICT = -32002;
 
 // ─── Message adapter (canonical types from adapters) ─────
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -3396,11 +3396,14 @@ export default function (pi: ExtensionAPI) {
         getIdentitySeedForRole("worker", ctx.sessionManager.getSessionFile() ?? undefined),
         "worker",
       );
+      const hasExplicitIdentityRequest =
+        Boolean(settings.agentName?.trim() && settings.agentEmoji?.trim()) ||
+        Boolean(process.env.PI_NICKNAME?.trim());
 
       agentOwnerToken = buildPinetOwnerToken(agentStableId);
       const registration = await client.register(
-        workerIdentity.name,
-        workerIdentity.emoji,
+        hasExplicitIdentityRequest ? workerIdentity.name : "",
+        hasExplicitIdentityRequest ? workerIdentity.emoji : "",
         await getAgentMetadata("worker"),
         agentStableId,
       );


### PR DESCRIPTION
## Summary\n- let followers request broker-assigned names by registering with a blank identity unless they explicitly asked for one\n- have the broker reject duplicate explicit name reservations with a clear retry message and conflict payload\n- preserve broker-assigned identity mode across reconnects so reloads keep going back through the broker reservation path\n\n## Testing\n- pnpm --filter @gugu910/pi-slack-bridge lint\n- pnpm --filter @gugu910/pi-slack-bridge typecheck\n- pnpm --filter @gugu910/pi-slack-bridge test\n\nCloses #382