### PR TITLE
fix: stop terminal name-conflict reconnect loops

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -13,7 +13,7 @@ import {
   computeReconnectDelay,
 } from "./client.js";
 import type { BrokerConnectOpts } from "./client.js";
-import { RPC_METHOD_NOT_FOUND } from "./types.js";
+import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -1488,6 +1488,92 @@ describe("BrokerClient — onReconnect callback", () => {
       name: "Broker Bird",
       emoji: "🦩",
     });
+
+    client.disconnect();
+    await mock.close();
+  }, 20000);
+
+  it("stops reconnecting and surfaces a terminal error when an explicit name collides on reconnect", async () => {
+    let mock = await createMockServer();
+    const port = mock.port;
+    const client = new BrokerClient(mock.connectOpts);
+    let disconnectFired = false;
+    let reconnectFired = false;
+    let reconnectFailed: Error | null = null;
+
+    client.onDisconnect(() => {
+      disconnectFired = true;
+    });
+    client.onReconnect(() => {
+      reconnectFired = true;
+    });
+    client.onReconnectFailed((err) => {
+      reconnectFailed = err;
+    });
+
+    await client.connect();
+    const registerPromise = client.register(
+      "Reserved Crane",
+      "🦩",
+      { cwd: "/repo", branch: "main" },
+      "host:session:/tmp/reserved-crane",
+    );
+
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(registerReq.method).toBe("register");
+    expect(registerReq.params.name).toBe("Reserved Crane");
+    expect(registerReq.params.emoji).toBe("🦩");
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "reserved-crane-agent",
+      name: "Reserved Crane",
+      emoji: "🦩",
+    });
+    await registerPromise;
+
+    await mock.close();
+    await waitFor(() => disconnectFired, 2000);
+    await waitFor(() => client.getReconnectAttempt() >= 2, 5000);
+
+    mock = await createMockServer(port);
+    await waitFor(() => mock.received.length > 0, 5000);
+
+    const reRegisterReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(reRegisterReq.method).toBe("register");
+    expect(reRegisterReq.params.name).toBe("Reserved Crane");
+    expect(reRegisterReq.params.emoji).toBe("🦩");
+    expect(reRegisterReq.params.stableId).toBe("host:session:/tmp/reserved-crane");
+
+    mock.respondError(
+      mock.connections[0],
+      reRegisterReq.id,
+      RPC_AGENT_NAME_CONFLICT,
+      'Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.',
+    );
+
+    await waitFor(() => reconnectFailed !== null, 5000);
+    if (!reconnectFailed) {
+      throw new Error("Expected reconnect failure to surface");
+    }
+    const surfacedReconnectFailure = reconnectFailed as Error;
+    expect(surfacedReconnectFailure.message).toContain(
+      'Agent name "Reserved Crane" is already reserved.',
+    );
+    expect(reconnectFired).toBe(false);
+    expect(client.isConnected()).toBe(false);
+    expect(client.getReconnectAttempt()).toBe(0);
+    expect(client.getRegisteredIdentity()).toBeNull();
+
+    await new Promise((resolve) => setTimeout(resolve, INITIAL_RECONNECT_DELAY_MS + 250));
+    expect(mock.received).toHaveLength(1);
 
     client.disconnect();
     await mock.close();

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -1,7 +1,7 @@
 import * as net from "node:net";
 import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
-import { RPC_METHOD_NOT_FOUND } from "./types.js";
+import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -125,6 +125,23 @@ function isRpcMethodNotFoundError(err: unknown, method: string): boolean {
   return rpcErr.code === RPC_METHOD_NOT_FOUND || err.message === `Unknown method: ${method}`;
 }
 
+function isRpcAgentNameConflictError(err: unknown): err is BrokerRpcRequestError {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  const rpcErr = err as BrokerRpcRequestError;
+  if (rpcErr.code === RPC_AGENT_NAME_CONFLICT) {
+    return true;
+  }
+
+  if (typeof rpcErr.data !== "object" || rpcErr.data == null) {
+    return false;
+  }
+
+  return (rpcErr.data as { code?: unknown }).code === "AGENT_NAME_CONFLICT";
+}
+
 function getMeshAuthCompatibilityError(): Error {
   return new Error(
     "Broker does not support Pinet mesh auth (`auth`). Upgrade the broker or disable follower mesh auth when connecting to older/no-auth brokers.",
@@ -182,6 +199,7 @@ export class BrokerClient {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private disconnectHandler: (() => void) | null = null;
   private reconnectHandler: (() => void) | null = null;
+  private reconnectFailedHandler: ((error: Error) => void) | null = null;
   private reconnectAttempt = 0;
   private registrationSnapshot: RegistrationSnapshot | null = null;
   private registeredIdentity: RegistrationResult | null = null;
@@ -496,6 +514,10 @@ export class BrokerClient {
     this.reconnectHandler = handler;
   }
 
+  onReconnectFailed(handler: (error: Error) => void): void {
+    this.reconnectFailedHandler = handler;
+  }
+
   getReconnectAttempt(): number {
     return this.reconnectAttempt;
   }
@@ -667,21 +689,29 @@ export class BrokerClient {
       }
       this.reconnectAttempt = 0;
       this.reconnectHandler?.();
-    } catch {
+    } catch (err) {
       // Re-registration failed after the socket connected. Clear the connection
       // state immediately instead of waiting for the async "close" event so the
       // client cannot stay in a broken "connected but not registered" state.
-      // Then schedule the next reconnect attempt ourselves. (#139)
+      // Then either surface a terminal reconnect failure or schedule the next
+      // retry ourselves. (#139)
+      const reconnectError = err instanceof Error ? err : new Error(String(err));
       const failedSocket = this.socket;
       this.socket = null;
       this.connected = false;
       this.buffer = "";
       this.stopHeartbeat();
       this.rejectAllPending(new Error("Socket closed"));
+      this.registeredIdentity = null;
       try {
         failedSocket?.destroy();
       } catch {
         /* ignore */
+      }
+      if (isRpcAgentNameConflictError(reconnectError)) {
+        this.reconnectAttempt = 0;
+        this.reconnectFailedHandler?.(reconnectError);
+        return;
       }
       this.scheduleReconnect();
     }

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -74,6 +74,7 @@ export interface FollowerRuntimeDeps {
   runRemoteControl: (command: PinetControlCommand, ctx: ExtensionContext) => void;
   deliverFollowUpMessage: (text: string) => boolean;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
+  handleTerminalReconnectFailure: (ctx: ExtensionContext, error: Error) => Promise<void> | void;
   formatError: (error: unknown) => string;
   deliveryState: FollowerDeliveryState;
 }
@@ -435,6 +436,16 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
             ctx.ui.notify(uiUpdate.notify.message, uiUpdate.notify.level);
           }
         })();
+      });
+
+      client.onReconnectFailed((error) => {
+        if (clientRef?.client !== client) {
+          return;
+        }
+        void deps.handleTerminalReconnectFailure(
+          ctx,
+          error instanceof Error ? error : new Error(String(error)),
+        );
       });
 
       await resumeThreadClaims();

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1653,24 +1653,207 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(setStatus).toHaveBeenCalled();
   });
 
+  it("stops follower reconnect retries after a terminal name conflict and allows a clean retry", async () => {
+    const originalNickname = process.env.PI_NICKNAME;
+    process.env.PI_NICKNAME = "Reserved Crane";
+
+    try {
+      const tools = new Map<string, ToolDefinition>();
+      const commands = new Map<string, CommandDefinition>();
+      const events = new Map<string, EventHandler>();
+
+      const pi = {
+        appendEntry: vi.fn(),
+        registerTool: vi.fn((definition: ToolDefinition) => {
+          tools.set(definition.name, definition);
+        }),
+        registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+          commands.set(name, definition);
+        }),
+        on: vi.fn((eventName: string, handler: EventHandler) => {
+          events.set(eventName, handler);
+        }),
+        sendUserMessage: vi.fn(),
+      } as unknown as ExtensionAPI;
+
+      const setStatus = vi.fn();
+      const notify = vi.fn();
+      const ctx = {
+        cwd: process.cwd(),
+        hasUI: true,
+        isIdle: () => false,
+        ui: {
+          theme: {
+            fg: (_color: string, text: string) => text,
+          },
+          notify,
+          setStatus,
+        },
+        sessionManager: {
+          getEntries: () => [],
+          getHeader: () => null,
+          getLeafId: () => "leaf",
+          getSessionFile: () => "/tmp/slack-bridge-session.json",
+        },
+      } as unknown as ExtensionContext;
+
+      let disconnectHandler: (() => void) | null = null;
+      let reconnectFailedHandler: ((error: Error) => void) | null = null;
+      const registerCalls: Array<{
+        name: string;
+        emoji: string;
+        metadata?: Record<string, unknown>;
+        stableId?: string;
+      }> = [];
+
+      const connect = vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+      vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async function (
+        this: BrokerClient,
+        name: string,
+        emoji: string,
+        metadata?: Record<string, unknown>,
+        stableId?: string,
+      ) {
+        const result = {
+          agentId: "worker-1",
+          name,
+          emoji,
+          metadata: metadata ?? null,
+        };
+        (
+          this as unknown as {
+            registeredIdentity: typeof result | null;
+            registrationSnapshot: {
+              name: string;
+              emoji: string;
+              metadata?: Record<string, unknown>;
+              stableId?: string;
+            } | null;
+          }
+        ).registeredIdentity = result;
+        (
+          this as unknown as {
+            registrationSnapshot: {
+              name: string;
+              emoji: string;
+              metadata?: Record<string, unknown>;
+              stableId?: string;
+            } | null;
+          }
+        ).registrationSnapshot = {
+          name,
+          emoji,
+          ...(metadata ? { metadata } : {}),
+          ...(stableId ? { stableId } : {}),
+        };
+        registerCalls.push({ name, emoji, metadata, stableId });
+        return result;
+      });
+      vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+      vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+      vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+      vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+      const disconnectGracefully = vi
+        .spyOn(BrokerClient.prototype, "disconnectGracefully")
+        .mockResolvedValue(undefined);
+      vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+      vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+        /* mocked */
+      });
+      vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation((handler) => {
+        disconnectHandler = handler;
+      });
+      vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+        /* mocked */
+      });
+      vi.spyOn(BrokerClient.prototype, "onReconnectFailed").mockImplementation((handler) => {
+        reconnectFailedHandler = handler;
+      });
+
+      slackBridge(pi);
+
+      const sessionStart = events.get("session_start");
+      const sessionShutdown = events.get("session_shutdown");
+      const follow = commands.get("pinet-follow");
+
+      expect(sessionStart).toBeDefined();
+      expect(sessionShutdown).toBeDefined();
+      expect(follow).toBeDefined();
+
+      await sessionStart?.({}, ctx);
+      await follow?.handler("", ctx);
+
+      expect(registerCalls).toHaveLength(1);
+      expect(registerCalls[0]?.name).toBe("Reserved Crane");
+      expect(disconnectHandler).toBeTypeOf("function");
+      expect(reconnectFailedHandler).toBeTypeOf("function");
+
+      if (!disconnectHandler || !reconnectFailedHandler) {
+        throw new Error("Reconnect handlers were not registered");
+      }
+
+      const runDisconnect: () => void = disconnectHandler;
+      const runReconnectFailed: (error: Error) => void = reconnectFailedHandler;
+
+      runDisconnect();
+      runReconnectFailed(
+        new Error(
+          'Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.',
+        ),
+      );
+
+      await vi.waitFor(() => {
+        expect(disconnectGracefully).toHaveBeenCalledTimes(1);
+      });
+
+      await Promise.resolve();
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(registerCalls).toHaveLength(1);
+
+      expect(notify).toHaveBeenCalledWith("Pinet broker disconnected — reconnecting...", "warning");
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pinet reconnect stopped: Agent name "Reserved Crane" is already reserved.',
+        ),
+        "error",
+      );
+      expect(setStatus).toHaveBeenCalledWith("slack-bridge", expect.stringContaining("✗"));
+
+      await follow?.handler("", ctx);
+      expect(connect).toHaveBeenCalledTimes(2);
+      expect(registerCalls).toHaveLength(2);
+      expect(registerCalls[1]?.name).toBe("Reserved Crane");
+
+      await sessionShutdown?.({}, ctx);
+    } finally {
+      if (originalNickname === undefined) {
+        delete process.env.PI_NICKNAME;
+      } else {
+        process.env.PI_NICKNAME = originalNickname;
+      }
+    }
+  });
+
   it("keeps worker identities session-scoped across clean restarts in the same repo checkout", async () => {
     const registerCalls: Array<{ stableId?: string }> = [];
 
     vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
-    vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async (
-      _name: string,
-      _emoji: string,
-      _metadata?: Record<string, unknown>,
-      stableId?: string,
-    ) => {
-      registerCalls.push({ stableId });
-      return {
-        agentId: "worker-1",
-        name: "Agent",
-        emoji: "🦙",
-        metadata: { role: "worker", capabilities: { role: "worker" } },
-      };
-    });
+    vi.spyOn(BrokerClient.prototype, "register").mockImplementation(
+      async (
+        _name: string,
+        _emoji: string,
+        _metadata?: Record<string, unknown>,
+        stableId?: string,
+      ) => {
+        registerCalls.push({ stableId });
+        return {
+          agentId: "worker-1",
+          name: "Agent",
+          emoji: "🦙",
+          metadata: { role: "worker", capabilities: { role: "worker" } },
+        };
+      },
+    );
     vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
     vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
     vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -3319,6 +3319,17 @@ export default function (pi: ExtensionAPI) {
     runRemoteControl,
     deliverFollowUpMessage,
     setExtStatus,
+    handleTerminalReconnectFailure: async (ctx, error) => {
+      console.error(`[slack-bridge] follower reconnect failed: ${msg(error)}`);
+      await disconnectFollower(ctx, { preserveErrorState: true }).catch(() => {
+        /* best effort */
+      });
+      setExtStatus(ctx, "error");
+      ctx.ui.notify(
+        `Pinet reconnect stopped: ${msg(error)} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.`,
+        "error",
+      );
+    },
     formatError: msg,
     deliveryState: followerDeliveryState,
   });
@@ -3389,6 +3400,7 @@ export default function (pi: ExtensionAPI) {
 
   async function disconnectFollower(
     ctx: ExtensionContext,
+    options: { preserveErrorState?: boolean } = {},
   ): Promise<{ unregisterError: string | null }> {
     const result = await followerRuntime.disconnect(ctx);
     brokerClient = null;
@@ -3396,7 +3408,9 @@ export default function (pi: ExtensionAPI) {
     brokerRole = null;
     pinetEnabled = false;
     currentRuntimeMode = "off";
-    setExtStatus(ctx, "off");
+    if (!options.preserveErrorState) {
+      setExtStatus(ctx, "off");
+    }
 
     return result;
   }


### PR DESCRIPTION
## Summary
- stop follower reconnect loops when the broker returns a terminal explicit-name conflict
- surface a clear reconnect-failed callback/path so the runtime tears down cleanly and can be retried
- add reconnect-conflict coverage in both broker client and slack-bridge follower runtime tests

## Testing
- pnpm --filter @gugu910/pi-slack-bridge exec vitest run broker/integration.test.ts broker/client.test.ts index.test.ts
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm prepush

Follow-up to #382 / merged PR #384.