### PR TITLE
refactor: add slack tools thread context port (#350)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1468,27 +1468,27 @@ export default function (pi: ExtensionAPI) {
     getLastDmChannel: () => lastDmChannel,
     updateBadge,
     resolveUser,
-    resolveFollowerReplyChannel,
+    threadContext: {
+      resolveThreadChannel: resolveFollowerReplyChannel,
+      noteThreadReply: (threadTs, channelId) => {
+        trackOwnedThread(threadTs, channelId, "slack");
+        claimOwnedThread(threadTs, channelId, "slack");
+      },
+      clearPendingAttention: (threadTs) => {
+        const pending = pendingEyes.get(threadTs);
+        if (!pending) return;
+        for (const entry of pending) {
+          void removeReaction(entry.channel, entry.messageTs, "eyes");
+        }
+        pendingEyes.delete(threadTs);
+      },
+    },
     resolveChannel,
     rememberChannel: (name, channelId) => {
       channelCache.set(name, channelId);
     },
     requireToolPolicy,
-    trackOutboundThread: (threadTs, channelId) => {
-      trackOwnedThread(threadTs, channelId, "slack");
-    },
     getBotUserId: () => botUserId,
-    claimThreadOwnership: (threadTs, channelId) => {
-      claimOwnedThread(threadTs, channelId, "slack");
-    },
-    clearPendingEyes: (threadTs) => {
-      const pending = pendingEyes.get(threadTs);
-      if (!pending) return;
-      for (const entry of pending) {
-        void removeReaction(entry.channel, entry.messageTs, "eyes");
-      }
-      pendingEyes.delete(threadTs);
-    },
     registerConfirmationRequest,
   });
 

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -194,9 +194,10 @@ describe("registerSlackTools", () => {
       } as SlackResult;
     });
 
-    let resolveFollowerReplyChannel: (
-      threadTs: string | undefined,
-    ) => Promise<string | null> = async () => null;
+    let resolveThreadChannel: (threadTs: string | undefined) => Promise<string | null> = async () =>
+      null;
+    const noteThreadReply = vi.fn();
+    const clearPendingAttention = vi.fn();
 
     registerSlackTools(pi, {
       getBotToken: () => botToken,
@@ -210,13 +211,14 @@ describe("registerSlackTools", () => {
       getLastDmChannel: () => null,
       updateBadge: () => {},
       resolveUser: async (userId) => resolveUser(userId),
-      resolveFollowerReplyChannel: (threadTs) => resolveFollowerReplyChannel(threadTs),
+      threadContext: {
+        resolveThreadChannel: (threadTs) => resolveThreadChannel(threadTs),
+        noteThreadReply,
+        clearPendingAttention,
+      },
       resolveChannel: async (nameOrId) => `resolved:${nameOrId}`,
       rememberChannel: () => {},
       requireToolPolicy: () => {},
-      trackOutboundThread: () => {},
-      claimThreadOwnership: () => {},
-      clearPendingEyes: () => {},
       registerConfirmationRequest: () => ({ status: "created" }),
       getBotUserId: () => "U_BOT",
     });
@@ -258,11 +260,11 @@ describe("registerSlackTools", () => {
       setDndResponse: (userId: string, response: SlackResult) => {
         dndResponses.set(userId, response);
       },
-      setResolveFollowerReplyChannel: (
-        fn: (threadTs: string | undefined) => Promise<string | null>,
-      ) => {
-        resolveFollowerReplyChannel = fn;
+      setResolveThreadChannel: (fn: (threadTs: string | undefined) => Promise<string | null>) => {
+        resolveThreadChannel = fn;
       },
+      noteThreadReply,
+      clearPendingAttention,
     };
   }
 
@@ -303,8 +305,8 @@ describe("registerSlackTools", () => {
   });
 
   it("uses read-through thread resolution for slack_read", async () => {
-    const { slack, tools, setResolveFollowerReplyChannel } = setup();
-    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+    const { slack, tools, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
     });
@@ -407,8 +409,8 @@ describe("registerSlackTools", () => {
   });
 
   it("adds reactions with normalized emoji names via slack_react", async () => {
-    const { slack, tools, setResolveFollowerReplyChannel } = setup();
-    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+    const { slack, tools, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
     });
@@ -448,8 +450,8 @@ describe("registerSlackTools", () => {
   });
 
   it("uses thread channel resolution for slack_schedule delays", async () => {
-    const { slack, tools, setResolveFollowerReplyChannel } = setup();
-    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+    const { slack, tools, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
     });
@@ -478,8 +480,8 @@ describe("registerSlackTools", () => {
   });
 
   it("handles already_pinned gracefully", async () => {
-    const { slack, tools, setResolveFollowerReplyChannel } = setup();
-    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+    const { slack, tools, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
     });
@@ -545,8 +547,8 @@ describe("registerSlackTools", () => {
   });
 
   it("lists bookmarks from the resolved thread channel", async () => {
-    const { slack, tools, setResolveFollowerReplyChannel } = setup();
-    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+    const { slack, tools, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
     });
@@ -582,14 +584,9 @@ describe("registerSlackTools", () => {
   });
 
   it("exports paginated thread content as markdown", async () => {
-    const {
-      slack,
-      tools,
-      setConversationsReplies,
-      setResolveFollowerReplyChannel,
-      setResolveUser,
-    } = setup();
-    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+    const { slack, tools, setConversationsReplies, setResolveThreadChannel, setResolveUser } =
+      setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
     });
@@ -681,8 +678,9 @@ describe("registerSlackTools", () => {
   });
 
   it("includes blocks when slack_send posts a rich message", async () => {
-    const { slack, tools, setResolveFollowerReplyChannel } = setup();
-    setResolveFollowerReplyChannel(async () => "D123");
+    const { slack, tools, setResolveThreadChannel, noteThreadReply, clearPendingAttention } =
+      setup();
+    setResolveThreadChannel(async () => "D123");
 
     await tools.get("slack_send")!.execute("tool-14", {
       thread_ts: "123.456",
@@ -706,6 +704,8 @@ describe("registerSlackTools", () => {
         ],
       }),
     );
+    expect(noteThreadReply).toHaveBeenCalledWith("123.456", "D123");
+    expect(clearPendingAttention).toHaveBeenCalledWith("123.456");
   });
 
   it("includes blocks when slack_post_channel posts a rich message", async () => {
@@ -814,8 +814,8 @@ describe("registerSlackTools", () => {
   });
 
   it("opens a modal and embeds thread context in private_metadata", async () => {
-    const { slack, tools, setResolveFollowerReplyChannel } = setup();
-    setResolveFollowerReplyChannel(async (threadTs: string | undefined) => {
+    const { slack, tools, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
     });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -51,6 +51,12 @@ import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
 import { TtlCache } from "./ttl-cache.js";
 
+export interface SlackToolsThreadContextPort {
+  resolveThreadChannel: (threadTs: string | undefined) => Promise<string | null>;
+  noteThreadReply: (threadTs: string, channelId: string) => void;
+  clearPendingAttention: (threadTs: string) => void;
+}
+
 export interface RegisterSlackToolsDeps {
   getBotToken: () => string;
   getDefaultChannel: () => string | undefined;
@@ -63,13 +69,10 @@ export interface RegisterSlackToolsDeps {
   getLastDmChannel: () => string | null;
   updateBadge: () => void;
   resolveUser: (userId: string) => Promise<string>;
-  resolveFollowerReplyChannel: (threadTs: string | undefined) => Promise<string | null>;
+  threadContext: SlackToolsThreadContextPort;
   resolveChannel: (nameOrId: string) => Promise<string>;
   rememberChannel: (name: string, channelId: string) => void;
   requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
-  trackOutboundThread: (threadTs: string, channelId: string) => void;
-  claimThreadOwnership: (threadTs: string, channelId: string) => void;
-  clearPendingEyes: (threadTs: string) => void;
   registerConfirmationRequest: (
     threadTs: string,
     tool: string,
@@ -211,16 +214,25 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     getLastDmChannel,
     updateBadge,
     resolveUser,
-    resolveFollowerReplyChannel,
+    threadContext,
     resolveChannel,
     rememberChannel,
     requireToolPolicy,
-    trackOutboundThread,
-    claimThreadOwnership,
-    clearPendingEyes,
     registerConfirmationRequest,
     getBotUserId,
   } = deps;
+
+  async function resolveTrackedThreadChannel(threadTs: string | undefined): Promise<string | null> {
+    return threadContext.resolveThreadChannel(threadTs);
+  }
+
+  function noteThreadReply(threadTs: string, channelId: string): void {
+    threadContext.noteThreadReply(threadTs, channelId);
+  }
+
+  function clearPendingThreadAttention(threadTs: string): void {
+    threadContext.clearPendingAttention(threadTs);
+  }
 
   async function resolveCanvasTarget(
     canvasId: string | undefined,
@@ -278,7 +290,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     threadTs: string | undefined,
     channel: string | undefined,
   ): Promise<string> {
-    const trackedThreadChannel = threadTs ? await resolveFollowerReplyChannel(threadTs) : null;
+    const trackedThreadChannel = threadTs ? await resolveTrackedThreadChannel(threadTs) : null;
     if (trackedThreadChannel) {
       return trackedThreadChannel;
     }
@@ -424,7 +436,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     threadTs: string | undefined,
     channel: string | undefined,
   ): Promise<string> {
-    const trackedThreadChannel = threadTs ? await resolveFollowerReplyChannel(threadTs) : null;
+    const trackedThreadChannel = threadTs ? await resolveTrackedThreadChannel(threadTs) : null;
     if (trackedThreadChannel) {
       return trackedThreadChannel;
     }
@@ -449,7 +461,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       return null;
     }
 
-    const channel = await resolveFollowerReplyChannel(normalizedThreadTs);
+    const channel = await resolveTrackedThreadChannel(normalizedThreadTs);
     if (!channel) {
       throw new Error(
         `No active Slack thread for thread_ts ${normalizedThreadTs}. Pass a live Slack thread so modal submissions can route back correctly.`,
@@ -1097,7 +1109,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         `thread_ts=${params.thread_ts ?? ""} | text=${params.text} | blocks=${summarizeSlackBlocksForPolicy(params.blocks)}`,
       );
 
-      const channel = (await resolveFollowerReplyChannel(params.thread_ts)) ?? getLastDmChannel();
+      const channel = (await resolveTrackedThreadChannel(params.thread_ts)) ?? getLastDmChannel();
       if (!channel) {
         throw new Error(
           "No active Slack thread. If you know the channel and thread_ts, use slack_post_channel instead.",
@@ -1121,11 +1133,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       const ts = (response.message as { ts: string }).ts;
       const actualTs = params.thread_ts ?? ts;
 
-      trackOutboundThread(actualTs, channel);
-      claimThreadOwnership(actualTs, channel);
+      noteThreadReply(actualTs, channel);
 
       if (params.thread_ts) {
-        clearPendingEyes(params.thread_ts);
+        clearPendingThreadAttention(params.thread_ts);
       }
 
       return {
@@ -1271,9 +1282,8 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       });
 
       if (params.thread_ts) {
-        trackOutboundThread(params.thread_ts, channelId);
-        claimThreadOwnership(params.thread_ts, channelId);
-        clearPendingEyes(params.thread_ts);
+        noteThreadReply(params.thread_ts, channelId);
+        clearPendingThreadAttention(params.thread_ts);
       }
 
       const uploadedFiles = Array.isArray(response.files)
@@ -1324,7 +1334,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         `thread_ts=${params.thread_ts} | limit=${params.limit ?? 20}`,
       );
 
-      const channel = (await resolveFollowerReplyChannel(params.thread_ts)) ?? getLastDmChannel();
+      const channel = (await resolveTrackedThreadChannel(params.thread_ts)) ?? getLastDmChannel();
       if (!channel) {
         throw new Error("Unknown thread.");
       }
@@ -1693,7 +1703,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         `channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | text=${params.text} | blocks=${summarizeSlackBlocksForPolicy(params.blocks)}`,
       );
 
-      const resolvedThreadChannel = await resolveFollowerReplyChannel(params.thread_ts);
+      const resolvedThreadChannel = await resolveTrackedThreadChannel(params.thread_ts);
       const channelInput = params.channel ?? getDefaultChannel();
       let channelId = params.channel ? await resolveChannel(params.channel) : resolvedThreadChannel;
 
@@ -1721,8 +1731,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       const ts = (response.message as { ts: string }).ts;
       const actualTs = params.thread_ts ?? ts;
 
-      trackOutboundThread(actualTs, channelId);
-      claimThreadOwnership(actualTs, channelId);
+      noteThreadReply(actualTs, channelId);
 
       const channelLabel = params.channel ?? resolvedThreadChannel ?? channelInput ?? channelId;
       return {
@@ -2435,7 +2444,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       tool: Type.String({ description: "Name of the tool that requires confirmation" }),
     }),
     async execute(_id, params) {
-      const channelId = await resolveFollowerReplyChannel(params.thread_ts);
+      const channelId = await resolveTrackedThreadChannel(params.thread_ts);
       if (!channelId) {
         throw new Error(`No active Slack thread for thread_ts: ${params.thread_ts}`);
       }


### PR DESCRIPTION
## Summary
- add a tiny runtime-agnostic thread-context/coordination port for `slack-tools.ts`
- sever the direct `resolveFollowerReplyChannel(...)` dependency first by routing thread channel lookup through that port
- fold outbound thread reply bookkeeping and pending-eyes cleanup behind the same abstraction without changing Slack API access or tool behavior

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm prepush`

Part of #350.