### PR TITLE
refactor: move single-player ingress into runtime (#351)

### DIFF
--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1457,6 +1457,194 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionShutdown?.({}, ctx);
   });
 
+  it("keeps single-mode Slack thread context local after ingress moves into SinglePlayerRuntime", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ "slack-bridge": { runtimeMode: "single", allowedUsers: ["U_SENDER"] } }),
+    );
+
+    const tools = new Map<string, ToolDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+    const sendUserMessage = vi.fn();
+    const appendEntry = vi.fn();
+
+    const pi = {
+      appendEntry,
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage,
+    } as unknown as ExtensionAPI;
+
+    const idle = false;
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => idle,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-thread-context-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-thread-context-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://slack.com/api/apps.connections.open") {
+        return new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/conversations.replies") {
+        return new Response(JSON.stringify({ ok: true, messages: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/users.info") {
+        return new Response(JSON.stringify({ ok: true, user: { real_name: "Sender" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/reactions.add") {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/reactions.remove") {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/chat.postMessage") {
+        return new Response(JSON.stringify({ ok: true, message: { ts: "300.1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const slackSend = tools.get("slack_send");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(slackSend).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+
+    const socket = FakeWebSocket.instances[0] as unknown as {
+      emitEvent: (type: string, ...args: unknown[]) => void;
+    };
+    socket.emitEvent("message", {
+      data: JSON.stringify({
+        envelope_id: "env-1",
+        type: "events_api",
+        payload: {
+          event: {
+            type: "message",
+            channel: "D123",
+            channel_type: "im",
+            user: "U_SENDER",
+            text: "hello from the first direct thread",
+            ts: "100.1",
+          },
+        },
+      }),
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith("https://slack.com/api/users.info", expect.any(Object));
+    });
+
+    socket.emitEvent("message", {
+      data: JSON.stringify({
+        envelope_id: "env-2",
+        type: "events_api",
+        payload: {
+          event: {
+            type: "message",
+            channel: "D999",
+            channel_type: "im",
+            user: "U_SENDER",
+            text: "hello from a newer direct thread",
+            ts: "200.1",
+          },
+        },
+      }),
+    });
+
+    await slackSend!.execute("tool-1", {
+      thread_ts: "100.1",
+      text: "reply from the agent",
+    });
+
+    const chatPostMessageCall = fetchSpy.mock.calls.find(
+      ([input]) => String(input) === "https://slack.com/api/chat.postMessage",
+    );
+    expect(chatPostMessageCall).toBeDefined();
+    const chatPostMessageBody = JSON.parse(String(chatPostMessageCall?.[1]?.body ?? "{}")) as {
+      channel?: string;
+      metadata?: {
+        event_payload?: { agent_owner?: string };
+      };
+      thread_ts?: string;
+    };
+    expect(chatPostMessageBody.channel).toBe("D123");
+    expect(chatPostMessageBody.thread_ts).toBe("100.1");
+
+    const reactionsRemoveCall = fetchSpy.mock.calls.find(
+      ([input]) => String(input) === "https://slack.com/api/reactions.remove",
+    );
+    expect(reactionsRemoveCall).toBeDefined();
+    const reactionsRemoveBody = JSON.parse(String(reactionsRemoveCall?.[1]?.body ?? "{}")) as {
+      channel?: string;
+      name?: string;
+      timestamp?: string;
+    };
+    expect(reactionsRemoveBody).toMatchObject({
+      channel: "D123",
+      name: "eyes",
+      timestamp: "100.1",
+    });
+
+    expect(sendUserMessage).not.toHaveBeenCalled();
+
+    await sessionShutdown?.({}, ctx);
+
+    const persistedState = appendEntry.mock.calls.at(-1)?.[1] as {
+      threads?: Array<[string, { owner?: string }]>;
+    };
+    const firstThread = persistedState.threads?.find(([threadTs]) => threadTs === "100.1")?.[1];
+    expect(firstThread?.owner).toBe(chatPostMessageBody.metadata?.event_payload?.agent_owner);
+  });
+
   it("does not reschedule direct Slack reconnects after aborting a single-mode startup during broker transition", async () => {
     vi.useFakeTimers();
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -35,7 +35,6 @@ import {
   evaluateRalphLoopCycle,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
   DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
-  agentOwnsThread,
   buildPinetOwnerToken,
   resolveAgentIdentity,
   resolvePersistedAgentIdentity,
@@ -76,12 +75,7 @@ import {
   type PendingSlackToolPolicyTurn,
 } from "./slack-turn-guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
-import {
-  buildReactionPromptGuidelines,
-  buildReactionTriggerMessage,
-  normalizeReactionName,
-  resolveReactionCommands,
-} from "./reaction-triggers.js";
+import { buildReactionPromptGuidelines, resolveReactionCommands } from "./reaction-triggers.js";
 import type { Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { sendBrokerMessage } from "./broker/message-send.js";
@@ -111,7 +105,6 @@ import {
 } from "./ralph-loop.js";
 import {
   addSlackReaction,
-  classifyMessage,
   clearSlackThreadStatus,
   fetchSlackMessageByTs as fetchSlackMessageByTsFromSlack,
   removeSlackReaction,
@@ -121,9 +114,6 @@ import {
   setSlackSuggestedPrompts,
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
-  type ParsedAppHomeOpened,
-  type ParsedThreadContextChanged,
-  type ParsedThreadStarted,
 } from "./slack-access.js";
 import {
   createFollowerDeliveryState,
@@ -131,7 +121,11 @@ import {
   queueFollowerInboxIds,
 } from "./follower-delivery.js";
 import { createFollowerRuntime, type BrokerClientRef } from "./follower-runtime.js";
-import { createSinglePlayerRuntime } from "./single-player-runtime.js";
+import {
+  createSinglePlayerRuntime,
+  type SinglePlayerPendingAttentionEntry,
+  type SinglePlayerThreadInfo,
+} from "./single-player-runtime.js";
 import { createBrokerRuntime } from "./broker-runtime.js";
 import {
   extractTaskAssignmentsFromMessage,
@@ -528,20 +522,11 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
-  interface ThreadInfo {
-    channelId: string;
-    threadTs: string;
-    userId: string;
-    source?: string;
-    context?: { channelId: string; teamId: string };
-    owner?: string; // agent name that claimed this thread (first-responder-wins)
-  }
-
   let botUserId: string | null = null;
 
-  const threads = new Map<string, ThreadInfo>();
+  const threads = new Map<string, SinglePlayerThreadInfo>();
   const thinking = new Set<string>();
-  const pendingEyes = new Map<string, { channel: string; messageTs: string }[]>(); // thread_ts → message ts list // thread_ts values showing "is thinking…"
+  const pendingEyes = new Map<string, SinglePlayerPendingAttentionEntry[]>(); // thread_ts → message ts list // thread_ts values showing "is thinking…"
   const userNames = new TtlCache<string, string>({ maxSize: 2000, ttlMs: 60 * 60 * 1000 });
   let lastDmChannel: string | null = null;
   const channelCache = new TtlCache<string, string>({ maxSize: 500, ttlMs: 30 * 60 * 1000 });
@@ -979,30 +964,16 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
-  // ─── Thread ownership ────────────────────────────────
-  //
-  // Follows a "first responder wins" model. When an agent sends its
-  // first reply to a thread via slack_send, it embeds its identity in
-  // Slack message metadata, claiming the thread. Before queuing an
-  // incoming message, we call conversations.replies to look for bot
-  // messages with agent metadata. If another agent has already replied,
-  // we skip the message.
-  //
-  // Race condition: there is a small window between the ownership check
-  // and the actual reply where two agents could both see zero bot
-  // replies and both decide to respond. The first reply to land
-  // effectively claims the thread; the losing agent backs off on the
-  // next incoming message once it sees the winner's metadata.
-
-  async function resolveThreadOwner(channel: string, threadTs: string): Promise<string | null> {
-    const hint = await resolveSlackThreadOwnerHint({
+  async function fetchSlackMessageByTs(
+    channel: string,
+    messageTs: string,
+  ): Promise<Record<string, unknown> | null> {
+    return fetchSlackMessageByTsFromSlack({
       slack,
       token: botToken!,
       channel,
-      threadTs,
-      limit: 50,
+      messageTs,
     });
-    return hint?.agentOwner ?? hint?.agentName ?? null;
   }
 
   // ─── Socket Mode (native WebSocket) ─────────────────
@@ -1016,372 +987,42 @@ export default function (pi: ExtensionAPI) {
     isSingleRuntimeActive: () => currentRuntimeMode === "single",
     setExtStatus,
     formatError: msg,
-    handleThreadStarted: (event) => onThreadStarted(event),
-    handleThreadContextChanged: (event) => onContextChanged(event),
-    handleAppHomeOpened: (event, ctx) => onAppHomeOpened(event, ctx),
-    handleMessage: (event, ctx) => onMessage(event, ctx),
-    handleReactionAdded: (event, ctx) => onReactionAdded(event, ctx),
-    handleMemberJoinedChannel: async ({ channel, isSelf }, ctx) => {
-      if (!isSelf) return;
-      ctx.ui.notify(`Pinet added to channel ${channel}`, "info");
-      inbox.push({
-        channel,
-        threadTs: "",
-        userId: "system",
-        text: `Pinet was added to channel <#${channel}>. You can now post messages there.`,
-        timestamp: String(Date.now() / 1000),
-      });
-      updateBadge();
-      maybeDrainInboxIfIdle(ctx);
+    getAgentName: () => agentName,
+    getAgentAliases: () => agentAliases,
+    getAgentOwnerToken: () => agentOwnerToken,
+    getBotUserId: () => botUserId,
+    getThreads: () => threads,
+    getPendingEyes: () => pendingEyes,
+    getUnclaimedThreads: () => unclaimedThreads,
+    pushInboxMessage: (message) => {
+      inbox.push(message);
     },
-    handleInteractive: (event, ctx) => queueInteractiveInboxEvent(event, ctx),
-  });
-
-  // ─── Assistant events ───────────────────────────────
-
-  async function onThreadStarted(event: ParsedThreadStarted): Promise<void> {
-    if (singlePlayerRuntime.isShuttingDown()) return;
-
-    const info: ThreadInfo = {
-      channelId: event.channelId,
-      threadTs: event.threadTs,
-      userId: event.userId,
-      source: "slack",
-    };
-
-    if (event.context) {
-      info.context = event.context;
-    }
-
-    threads.set(info.threadTs, info);
-    lastDmChannel = info.channelId;
-    persistState();
-
-    await setSuggestedPrompts(info.channelId, info.threadTs);
-  }
-
-  function onContextChanged(event: ParsedThreadContextChanged): void {
-    if (singlePlayerRuntime.isShuttingDown()) return;
-
-    const existing = threads.get(event.threadTs);
-    if (!existing || !event.context) return;
-
-    existing.context = event.context;
-    persistState();
-  }
-
-  async function onAppHomeOpened(event: ParsedAppHomeOpened, ctx: ExtensionContext): Promise<void> {
-    if (singlePlayerRuntime.isShuttingDown()) return;
-
-    await publishCurrentPinetHomeTabSafely(event.userId, ctx);
-  }
-
-  async function fetchSlackMessageByTs(
-    channel: string,
-    messageTs: string,
-  ): Promise<Record<string, unknown> | null> {
-    return fetchSlackMessageByTsFromSlack({
-      slack,
-      token: botToken!,
-      channel,
-      messageTs,
-    });
-  }
-
-  async function onReactionAdded(
-    evt: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ): Promise<void> {
-    if (singlePlayerRuntime.isShuttingDown()) return;
-
-    const item = evt.item as { type?: string; channel?: string; ts?: string } | undefined;
-    const user = evt.user as string | undefined;
-    const rawReactionName = evt.reaction as string | undefined;
-    if (
-      !item ||
-      item.type !== "message" ||
-      !item.channel ||
-      !item.ts ||
-      !user ||
-      !rawReactionName
-    ) {
-      return;
-    }
-
-    if (user === botUserId) {
-      return;
-    }
-
-    let reactionName: string;
-    try {
-      reactionName = normalizeReactionName(rawReactionName);
-    } catch {
-      return;
-    }
-
-    const command = reactionCommands.get(reactionName);
-    if (!command || !isUserAllowed(user)) {
-      return;
-    }
-
-    try {
-      const reactedMessage = await fetchSlackMessageByTs(item.channel, item.ts);
-      if (!reactedMessage) {
-        throw new Error(`Unable to fetch reacted message ${item.ts} in channel ${item.channel}`);
-      }
-
-      const threadTs =
-        (reactedMessage.thread_ts as string | undefined) ??
-        (reactedMessage.ts as string | undefined) ??
-        item.ts;
-
-      if (!threads.has(threadTs)) {
-        threads.set(threadTs, {
-          channelId: item.channel,
-          threadTs,
-          userId: (reactedMessage.user as string | undefined) ?? user,
-          source: "slack",
+    setLastDmChannel: (channelId) => {
+      lastDmChannel = channelId;
+    },
+    persistState,
+    updateBadge,
+    maybeDrainInboxIfIdle,
+    resolveThreadChannel: resolveFollowerReplyChannel,
+    setSuggestedPrompts,
+    publishCurrentPinetHomeTab: (userId, ctx) => publishCurrentPinetHomeTabSafely(userId, ctx),
+    fetchSlackMessageByTs,
+    addReaction,
+    removeReaction,
+    resolveUser,
+    isUserAllowed,
+    getReactionCommand: (reactionName) => reactionCommands.get(reactionName),
+    consumeConfirmationReply,
+    claimOwnedThread: (threadTs, channelId, source = "slack") => {
+      if (brokerRole === "broker") {
+        brokerRuntime.claimThread(threadTs, channelId, source);
+      } else if (brokerRole === "follower" && brokerClient?.client) {
+        void brokerClient.client.claimThread(threadTs, channelId, source).catch(() => {
+          /* broker gone, best effort */
         });
       }
-
-      const localOwner = threads.get(threadTs)?.owner;
-      if (localOwner && !agentOwnsThread(localOwner, agentName, agentAliases, agentOwnerToken)) {
-        return;
-      }
-      if (localOwner) {
-        const thread = threads.get(threadTs);
-        if (thread) {
-          normalizeOwnedThreads([thread], agentName, agentOwnerToken, agentAliases);
-        }
-      }
-
-      if (!localOwner && !unclaimedThreads.has(threadTs)) {
-        const remoteOwner = await resolveThreadOwner(item.channel, threadTs);
-        if (singlePlayerRuntime.isShuttingDown()) return;
-        if (
-          remoteOwner &&
-          !agentOwnsThread(remoteOwner, agentName, agentAliases, agentOwnerToken)
-        ) {
-          const thread = threads.get(threadTs);
-          if (thread) thread.owner = remoteOwner;
-          return;
-        }
-        if (agentOwnsThread(remoteOwner ?? undefined, agentName, agentAliases, agentOwnerToken)) {
-          const thread = threads.get(threadTs);
-          if (thread) thread.owner = agentOwnerToken;
-        }
-        if (!remoteOwner) {
-          unclaimedThreads.add(threadTs);
-        }
-      }
-
-      const reactorName = await resolveUser(user);
-      if (singlePlayerRuntime.isShuttingDown()) return;
-      const reactedMessageAuthorId =
-        (reactedMessage.user as string | undefined) ?? (evt.item_user as string | undefined);
-      const reactedMessageAuthor = reactedMessageAuthorId
-        ? await resolveUser(reactedMessageAuthorId)
-        : (reactedMessage.bot_id as string | undefined)
-          ? "bot"
-          : "unknown";
-      if (singlePlayerRuntime.isShuttingDown()) return;
-
-      const reactedMessageText =
-        typeof reactedMessage.text === "string" && reactedMessage.text.trim().length > 0
-          ? reactedMessage.text
-          : "(no text)";
-      const reactionMessage = buildReactionTriggerMessage({
-        reactionName,
-        command,
-        reactorName,
-        channel: item.channel,
-        threadTs,
-        messageTs: item.ts,
-        reactedMessageText,
-        reactedMessageAuthor,
-      });
-
-      ctx.ui.notify(`${reactorName} reacted with :${reactionName}:`, "info");
-      inbox.push({
-        channel: item.channel,
-        threadTs,
-        userId: user,
-        text: reactionMessage,
-        timestamp: (evt.event_ts as string) ?? item.ts,
-      });
-      persistState();
-      updateBadge();
-      await addReaction(item.channel, item.ts, "white_check_mark");
-
-      maybeDrainInboxIfIdle(ctx);
-    } catch (err) {
-      console.error(`[slack-bridge] reaction trigger failed: ${msg(err)}`);
-      await addReaction(item.channel, item.ts, "x");
-    }
-  }
-
-  async function onMessage(evt: Record<string, unknown>, ctx: ExtensionContext): Promise<void> {
-    if (singlePlayerRuntime.isShuttingDown()) return;
-
-    const classified = classifyMessage(evt, botUserId, new Set(threads.keys()));
-    if (!classified.relevant) return;
-
-    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
-
-    if (!threads.has(threadTs)) {
-      threads.set(threadTs, { channelId: channel, threadTs, userId, source: "slack" });
-    }
-
-    const localOwner = threads.get(threadTs)?.owner;
-    if (localOwner && !agentOwnsThread(localOwner, agentName, agentAliases, agentOwnerToken)) {
-      return;
-    }
-    if (localOwner) {
-      const thread = threads.get(threadTs);
-      if (thread) {
-        normalizeOwnedThreads([thread], agentName, agentOwnerToken, agentAliases);
-      }
-    }
-
-    if (!localOwner && !unclaimedThreads.has(threadTs)) {
-      const remoteOwner = await resolveThreadOwner(channel, threadTs);
-      if (singlePlayerRuntime.isShuttingDown()) return;
-      if (remoteOwner && !agentOwnsThread(remoteOwner, agentName, agentAliases, agentOwnerToken)) {
-        const thread = threads.get(threadTs);
-        if (thread) thread.owner = remoteOwner;
-        return;
-      }
-      if (agentOwnsThread(remoteOwner ?? undefined, agentName, agentAliases, agentOwnerToken)) {
-        const thread = threads.get(threadTs);
-        if (thread) thread.owner = agentOwnerToken;
-      }
-      if (!remoteOwner) {
-        unclaimedThreads.add(threadTs);
-      }
-    }
-
-    if (!isUserAllowed(userId)) {
-      await slack("chat.postMessage", botToken!, {
-        channel,
-        thread_ts: threadTs,
-        text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
-      });
-      return;
-    }
-
-    if (isDM) {
-      lastDmChannel = channel;
-    }
-    persistState();
-
-    const confirmationResult = consumeConfirmationReply(threadTs, text);
-    const messageText =
-      confirmationResult === null
-        ? text
-        : confirmationResult.approved
-          ? `${text}\n\n✅ User approved security confirmation request in this thread.`
-          : `${text}\n\n❌ User denied security confirmation request in this thread.`;
-
-    const name = await resolveUser(userId);
-    if (singlePlayerRuntime.isShuttingDown()) return;
-    ctx.ui.notify(`${name}: ${text.slice(0, 100)}`, "info");
-
-    void addReaction(channel, messageTs, "eyes");
-    const pending = pendingEyes.get(threadTs) ?? [];
-    pending.push({ channel, messageTs });
-    pendingEyes.set(threadTs, pending);
-
-    inbox.push({
-      channel,
-      threadTs,
-      userId,
-      text: messageText,
-      timestamp: messageTs,
-      ...(isChannelMention && { isChannelMention: true }),
-    });
-    updateBadge();
-
-    maybeDrainInboxIfIdle(ctx);
-  }
-
-  async function queueInteractiveInboxEvent(
-    normalized: {
-      channel: string;
-      threadTs: string;
-      userId: string;
-      text: string;
-      timestamp: string;
-      metadata: Record<string, unknown>;
     },
-    ctx: ExtensionContext,
-  ): Promise<void> {
-    if (!threads.has(normalized.threadTs)) {
-      threads.set(normalized.threadTs, {
-        channelId: normalized.channel,
-        threadTs: normalized.threadTs,
-        userId: normalized.userId,
-        source: "slack",
-      });
-    }
-
-    const localOwner = threads.get(normalized.threadTs)?.owner;
-    if (localOwner && !agentOwnsThread(localOwner, agentName, agentAliases, agentOwnerToken)) {
-      return;
-    }
-    if (localOwner) {
-      const thread = threads.get(normalized.threadTs);
-      if (thread) {
-        normalizeOwnedThreads([thread], agentName, agentOwnerToken, agentAliases);
-      }
-    }
-
-    if (!localOwner && !unclaimedThreads.has(normalized.threadTs)) {
-      const remoteOwner = await resolveThreadOwner(normalized.channel, normalized.threadTs);
-      if (singlePlayerRuntime.isShuttingDown()) return;
-      if (remoteOwner && !agentOwnsThread(remoteOwner, agentName, agentAliases, agentOwnerToken)) {
-        const thread = threads.get(normalized.threadTs);
-        if (thread) thread.owner = remoteOwner;
-        return;
-      }
-      if (agentOwnsThread(remoteOwner ?? undefined, agentName, agentAliases, agentOwnerToken)) {
-        const thread = threads.get(normalized.threadTs);
-        if (thread) thread.owner = agentOwnerToken;
-      }
-      if (!remoteOwner) {
-        unclaimedThreads.add(normalized.threadTs);
-      }
-    }
-
-    if (!isUserAllowed(normalized.userId)) {
-      await slack("chat.postMessage", botToken!, {
-        channel: normalized.channel,
-        thread_ts: normalized.threadTs,
-        text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
-      });
-      return;
-    }
-
-    if (normalized.channel.startsWith("D")) {
-      lastDmChannel = normalized.channel;
-    }
-    persistState();
-
-    const name = await resolveUser(normalized.userId);
-    if (singlePlayerRuntime.isShuttingDown()) return;
-    ctx.ui.notify(`${name}: ${normalized.text.slice(0, 100)}`, "info");
-
-    inbox.push({
-      channel: normalized.channel,
-      threadTs: normalized.threadTs,
-      userId: normalized.userId,
-      text: normalized.text,
-      timestamp: normalized.timestamp,
-      metadata: normalized.metadata,
-    });
-    updateBadge();
-
-    maybeDrainInboxIfIdle(ctx);
-  }
+  });
 
   // ─── Reconnect / status ─────────────────────────────
 
@@ -1408,36 +1049,6 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Tools ──────────────────────────────────────────
 
-  function trackOwnedThread(threadTs: string, channelId: string, source = "slack"): void {
-    if (!threads.has(threadTs)) {
-      threads.set(threadTs, {
-        channelId,
-        threadTs,
-        userId: "",
-        source,
-        owner: agentOwnerToken,
-      });
-    } else {
-      const thread = threads.get(threadTs)!;
-      if (!thread.owner) thread.owner = agentOwnerToken;
-      if (!thread.source) {
-        thread.source = source;
-      }
-    }
-    unclaimedThreads.delete(threadTs);
-    persistState();
-  }
-
-  function claimOwnedThread(threadTs: string, channelId: string, source = "slack"): void {
-    if (brokerRole === "broker") {
-      brokerRuntime.claimThread(threadTs, channelId, source);
-    } else if (brokerRole === "follower" && brokerClient?.client) {
-      void brokerClient.client.claimThread(threadTs, channelId, source).catch(() => {
-        /* broker gone, best effort */
-      });
-    }
-  }
-
   registerSlackTools(pi, {
     getBotToken: () => {
       if (!botToken) {
@@ -1455,21 +1066,7 @@ export default function (pi: ExtensionAPI) {
     getLastDmChannel: () => lastDmChannel,
     updateBadge,
     resolveUser,
-    threadContext: {
-      resolveThreadChannel: resolveFollowerReplyChannel,
-      noteThreadReply: (threadTs, channelId) => {
-        trackOwnedThread(threadTs, channelId, "slack");
-        claimOwnedThread(threadTs, channelId, "slack");
-      },
-      clearPendingAttention: (threadTs) => {
-        const pending = pendingEyes.get(threadTs);
-        if (!pending) return;
-        for (const entry of pending) {
-          void removeReaction(entry.channel, entry.messageTs, "eyes");
-        }
-        pendingEyes.delete(threadTs);
-      },
-    },
+    threadContext: singlePlayerRuntime.getThreadContextPort(),
     resolveChannel,
     rememberChannel: (name, channelId) => {
       channelCache.set(name, channelId);
@@ -2869,7 +2466,7 @@ export default function (pi: ExtensionAPI) {
         throw new Error("Pinet is in an unexpected state.");
       }
 
-      trackOwnedThread(threadId, recipient, "imessage");
+      singlePlayerRuntime.trackOwnedThread(threadId, recipient, "imessage");
 
       return {
         content: [
@@ -3163,7 +2760,7 @@ export default function (pi: ExtensionAPI) {
 
     // Restore persisted thread state (always restore, even before /pinet)
     interface PersistedState {
-      threads?: [string, ThreadInfo][];
+      threads?: [string, SinglePlayerThreadInfo][];
       lastDmChannel?: string | null;
       userNames?: [string, string][];
       agentName?: string;

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -1,0 +1,286 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackSocketModeClientConfig } from "./slack-access.js";
+import {
+  createSinglePlayerRuntime,
+  type SinglePlayerPendingAttention,
+  type SinglePlayerRuntimeDeps,
+  type SinglePlayerThreadState,
+} from "./single-player-runtime.js";
+
+const socketState = vi.hoisted(() => ({
+  config: null as unknown,
+  connected: false,
+  botUserId: "U_BOT",
+}));
+
+vi.mock("./slack-access.js", async () => {
+  const actual = await vi.importActual("./slack-access.js");
+
+  class FakeSlackSocketModeClient {
+    private readonly config: SlackSocketModeClientConfig;
+
+    constructor(config: SlackSocketModeClientConfig) {
+      this.config = config;
+      socketState.config = config;
+    }
+
+    getBotUserId(): string | null {
+      return socketState.botUserId;
+    }
+
+    isConnected(): boolean {
+      return socketState.connected;
+    }
+
+    async connect(): Promise<void> {
+      socketState.connected = true;
+    }
+
+    async disconnect(): Promise<void> {
+      socketState.connected = false;
+      await this.config.abortAndWait?.();
+    }
+  }
+
+  return {
+    ...(actual as object),
+    SlackSocketModeClient: FakeSlackSocketModeClient,
+  };
+});
+
+type TestState = {
+  threads: Map<string, SinglePlayerThreadState>;
+  pendingEyes: Map<string, SinglePlayerPendingAttention[]>;
+  unclaimedThreads: Set<string>;
+  inbox: Array<{ text: string; channel: string; threadTs: string }>;
+  lastDmChannel: string | null;
+};
+
+function createContext(notify = vi.fn()): ExtensionContext {
+  return {
+    hasUI: true,
+    ui: {
+      notify,
+      setStatus: vi.fn(),
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+    },
+  } as unknown as ExtensionContext;
+}
+
+function createDeps(state: TestState, overrides: Partial<SinglePlayerRuntimeDeps> = {}) {
+  const pushInboxMessage = vi.fn((message: { text: string; channel: string; threadTs: string }) => {
+    state.inbox.push(message);
+  });
+  const persistState = vi.fn();
+  const updateBadge = vi.fn();
+  const maybeDrainInboxIfIdle = vi.fn(() => true);
+  const claimOwnedThread = vi.fn();
+  const addReaction = vi.fn(async () => undefined);
+  const removeReaction = vi.fn(async () => undefined);
+  const resolveUser = vi.fn(async () => "Sender");
+  const slack = vi.fn(async (method: string) =>
+    method === "conversations.replies" ? { ok: true, messages: [] } : { ok: true },
+  );
+  const resolveThreadChannel = vi.fn(async (threadTs: string | undefined) =>
+    threadTs ? `channel-for-${threadTs}` : null,
+  );
+  const setSuggestedPrompts = vi.fn(async () => undefined);
+  const publishCurrentPinetHomeTab = vi.fn(async () => undefined);
+  const fetchSlackMessageByTs = vi.fn(async () => null);
+  const consumeConfirmationReply = vi.fn(() => null);
+  const deps = {
+    slack,
+    getBotToken: () => "xoxb-test",
+    getAppToken: () => "xapp-test",
+    dedup: new Set<string>(),
+    abortSlackRequests: vi.fn(async () => undefined),
+    isSingleRuntimeActive: () => true,
+    setExtStatus: vi.fn(),
+    formatError: (error: unknown) => String(error),
+    getAgentName: () => "Cobalt Olive Crane",
+    getAgentAliases: () => ["Cobalt Olive Crane"],
+    getAgentOwnerToken: () => "owner:crane",
+    getBotUserId: () => socketState.botUserId,
+    getThreads: () => state.threads,
+    getPendingEyes: () => state.pendingEyes,
+    getUnclaimedThreads: () => state.unclaimedThreads,
+    pushInboxMessage,
+    setLastDmChannel: (channelId) => {
+      state.lastDmChannel = channelId;
+    },
+    persistState,
+    updateBadge,
+    maybeDrainInboxIfIdle,
+    resolveThreadChannel,
+    setSuggestedPrompts,
+    publishCurrentPinetHomeTab,
+    fetchSlackMessageByTs,
+    addReaction,
+    removeReaction,
+    resolveUser,
+    isUserAllowed: () => true,
+    getReactionCommand: () => undefined,
+    consumeConfirmationReply,
+    claimOwnedThread,
+    ...overrides,
+  } as SinglePlayerRuntimeDeps;
+
+  return {
+    deps,
+    spies: {
+      pushInboxMessage,
+      persistState,
+      updateBadge,
+      maybeDrainInboxIfIdle,
+      claimOwnedThread,
+      addReaction,
+      removeReaction,
+      resolveUser,
+      slack,
+      resolveThreadChannel,
+      setSuggestedPrompts,
+      publishCurrentPinetHomeTab,
+      fetchSlackMessageByTs,
+      consumeConfirmationReply,
+    },
+  };
+}
+
+describe("single-player-runtime", () => {
+  beforeEach(() => {
+    socketState.config = null;
+    socketState.connected = false;
+    socketState.botUserId = "U_BOT";
+  });
+
+  it("owns the slack tool thread-context port for local thread tracking", async () => {
+    const state: TestState = {
+      threads: new Map([
+        [
+          "123.456",
+          { channelId: "C123", threadTs: "123.456", userId: "U_SENDER", source: undefined },
+        ],
+      ]),
+      pendingEyes: new Map([
+        [
+          "123.456",
+          [
+            { channel: "C123", messageTs: "111.1" },
+            { channel: "C123", messageTs: "111.2" },
+          ],
+        ],
+      ]),
+      unclaimedThreads: new Set(["123.456"]),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const { deps, spies } = createDeps(state);
+    const runtime = createSinglePlayerRuntime(deps);
+
+    const threadContext = runtime.getThreadContextPort();
+    await expect(threadContext.resolveThreadChannel("123.456")).resolves.toBe(
+      "channel-for-123.456",
+    );
+
+    threadContext.noteThreadReply("123.456", "C123");
+
+    expect(state.threads.get("123.456")).toMatchObject({
+      channelId: "C123",
+      threadTs: "123.456",
+      owner: "owner:crane",
+      source: "slack",
+    });
+    expect(state.unclaimedThreads.has("123.456")).toBe(false);
+    expect(spies.persistState).toHaveBeenCalledTimes(1);
+    expect(spies.claimOwnedThread).toHaveBeenCalledWith("123.456", "C123", "slack");
+
+    threadContext.clearPendingAttention("123.456");
+    await Promise.resolve();
+
+    expect(spies.removeReaction).toHaveBeenNthCalledWith(1, "C123", "111.1", "eyes");
+    expect(spies.removeReaction).toHaveBeenNthCalledWith(2, "C123", "111.2", "eyes");
+    expect(state.pendingEyes.has("123.456")).toBe(false);
+  });
+
+  it("tracks non-slack outbound threads without invoking remote claims", () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(["chat:alice"]),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const { deps, spies } = createDeps(state);
+    const runtime = createSinglePlayerRuntime(deps);
+
+    runtime.trackOwnedThread("chat:alice", "chat:alice", "imessage");
+
+    expect(state.threads.get("chat:alice")).toMatchObject({
+      channelId: "chat:alice",
+      threadTs: "chat:alice",
+      userId: "",
+      owner: "owner:crane",
+      source: "imessage",
+    });
+    expect(state.unclaimedThreads.has("chat:alice")).toBe(false);
+    expect(spies.persistState).toHaveBeenCalledTimes(1);
+    expect(spies.claimOwnedThread).not.toHaveBeenCalled();
+  });
+
+  it("handles direct Slack messages inside the runtime and queues inbox work", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const notify = vi.fn();
+    const ctx = createContext(notify);
+    const { deps, spies } = createDeps(state);
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    expect(socketConfig?.onMessage).toBeDefined();
+
+    await socketConfig?.onMessage?.({
+      type: "message",
+      channel: "D123",
+      channel_type: "im",
+      user: "U_SENDER",
+      text: "hello from Slack",
+      ts: "100.1",
+    });
+
+    expect(state.threads.get("100.1")).toMatchObject({
+      channelId: "D123",
+      threadTs: "100.1",
+      userId: "U_SENDER",
+      source: "slack",
+    });
+    expect(state.lastDmChannel).toBe("D123");
+    expect(spies.slack).toHaveBeenCalledWith(
+      "conversations.replies",
+      "xoxb-test",
+      expect.objectContaining({ channel: "D123", ts: "100.1", include_all_metadata: true }),
+    );
+    expect(spies.persistState).toHaveBeenCalledTimes(1);
+    expect(spies.resolveUser).toHaveBeenCalledWith("U_SENDER");
+    expect(spies.addReaction).toHaveBeenCalledWith("D123", "100.1", "eyes");
+    expect(state.pendingEyes.get("100.1")).toEqual([{ channel: "D123", messageTs: "100.1" }]);
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith({
+      channel: "D123",
+      threadTs: "100.1",
+      userId: "U_SENDER",
+      text: "hello from Slack",
+      timestamp: "100.1",
+    });
+    expect(spies.updateBadge).toHaveBeenCalledTimes(1);
+    expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
+  });
+});

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -1,7 +1,15 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { isAbortError } from "./helpers.js";
-import type { SlackInteractiveInboxEvent } from "./slack-block-kit.js";
+import { agentOwnsThread, type InboxMessage, normalizeOwnedThreads } from "./helpers.js";
 import {
+  buildReactionTriggerMessage,
+  normalizeReactionName,
+  type ReactionCommandTemplate,
+} from "./reaction-triggers.js";
+import type { SlackInteractiveInboxEvent } from "./slack-block-kit.js";
+import type { SlackToolsThreadContextPort } from "./slack-tools.js";
+import {
+  classifyMessage,
+  resolveSlackThreadOwnerHint,
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
   type ParsedThreadContextChanged,
@@ -9,6 +17,30 @@ import {
   type SlackAccessSet,
   type SlackCall,
 } from "./slack-access.js";
+import { isAbortError } from "./helpers.js";
+
+export interface SinglePlayerThreadState {
+  channelId: string;
+  threadTs: string;
+  userId: string;
+  source?: string;
+  context?: ParsedThreadStarted["context"];
+  owner?: string;
+}
+
+export interface SinglePlayerPendingAttention {
+  channel: string;
+  messageTs: string;
+}
+
+export type SinglePlayerThreadInfo = SinglePlayerThreadState;
+export type SinglePlayerPendingAttentionEntry = SinglePlayerPendingAttention;
+
+export interface SinglePlayerUnclaimedThreads {
+  has: (threadTs: string) => boolean;
+  add: (threadTs: string) => void;
+  delete: (threadTs: string) => void;
+}
 
 export interface SinglePlayerRuntimeDeps {
   slack: SlackCall;
@@ -19,22 +51,32 @@ export interface SinglePlayerRuntimeDeps {
   isSingleRuntimeActive: () => boolean;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
   formatError: (error: unknown) => string;
-  handleThreadStarted: (event: ParsedThreadStarted) => Promise<void> | void;
-  handleThreadContextChanged: (event: ParsedThreadContextChanged) => Promise<void> | void;
-  handleAppHomeOpened: (event: ParsedAppHomeOpened, ctx: ExtensionContext) => Promise<void> | void;
-  handleMessage: (event: Record<string, unknown>, ctx: ExtensionContext) => Promise<void> | void;
-  handleReactionAdded: (
-    event: Record<string, unknown>,
-    ctx: ExtensionContext,
-  ) => Promise<void> | void;
-  handleMemberJoinedChannel: (
-    event: { channel: string; isSelf: boolean },
-    ctx: ExtensionContext,
-  ) => Promise<void> | void;
-  handleInteractive: (
-    event: SlackInteractiveInboxEvent,
-    ctx: ExtensionContext,
-  ) => Promise<void> | void;
+  getAgentName: () => string;
+  getAgentAliases: () => Iterable<string>;
+  getAgentOwnerToken: () => string;
+  getBotUserId: () => string | null;
+  getThreads: () => Map<string, SinglePlayerThreadState>;
+  getPendingEyes: () => Map<string, SinglePlayerPendingAttention[]>;
+  getUnclaimedThreads: () => SinglePlayerUnclaimedThreads;
+  pushInboxMessage: (message: InboxMessage) => void;
+  setLastDmChannel: (channelId: string | null) => void;
+  persistState: () => void;
+  updateBadge: () => void;
+  maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
+  resolveThreadChannel: (threadTs: string | undefined) => Promise<string | null>;
+  setSuggestedPrompts: (channelId: string, threadTs: string) => Promise<void>;
+  publishCurrentPinetHomeTab: (userId: string, ctx: ExtensionContext) => Promise<void>;
+  fetchSlackMessageByTs: (
+    channel: string,
+    messageTs: string,
+  ) => Promise<Record<string, unknown> | null>;
+  addReaction: (channel: string, ts: string, emoji: string) => Promise<void>;
+  removeReaction: (channel: string, ts: string, emoji: string) => Promise<void>;
+  resolveUser: (userId: string) => Promise<string>;
+  isUserAllowed: (userId: string) => boolean;
+  getReactionCommand: (reactionName: string) => ReactionCommandTemplate | undefined;
+  consumeConfirmationReply: (threadTs: string, text: string) => { approved: boolean } | null;
+  claimOwnedThread: (threadTs: string, channelId: string, source?: string) => void;
 }
 
 export interface SinglePlayerRuntime {
@@ -44,11 +86,389 @@ export interface SinglePlayerRuntime {
   isConnected: () => boolean;
   isShuttingDown: () => boolean;
   resetShutdownState: () => void;
+  trackOwnedThread: (threadTs: string, channelId: string, source?: string) => void;
+  getThreadContextPort: () => SlackToolsThreadContextPort;
 }
+
+type SinglePlayerThreadOwnershipResult = "continue" | "skip" | "shutdown";
 
 export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): SinglePlayerRuntime {
   let slackSocket: SlackSocketModeClient | null = null;
   let shuttingDown = false;
+
+  function getCurrentBotUserId(): string | null {
+    return slackSocket?.getBotUserId() ?? deps.getBotUserId();
+  }
+
+  function getAgentState(): {
+    agentName: string;
+    agentAliases: Iterable<string>;
+    agentOwnerToken: string;
+  } {
+    return {
+      agentName: deps.getAgentName(),
+      agentAliases: deps.getAgentAliases(),
+      agentOwnerToken: deps.getAgentOwnerToken(),
+    };
+  }
+
+  function trackOwnedThread(threadTs: string, channelId: string, source = "slack"): void {
+    const threads = deps.getThreads();
+    const agentOwnerToken = deps.getAgentOwnerToken();
+    if (!threads.has(threadTs)) {
+      threads.set(threadTs, {
+        channelId,
+        threadTs,
+        userId: "",
+        source,
+        owner: agentOwnerToken,
+      });
+    } else {
+      const thread = threads.get(threadTs)!;
+      if (!thread.owner) thread.owner = agentOwnerToken;
+      if (!thread.source) {
+        thread.source = source;
+      }
+    }
+    deps.getUnclaimedThreads().delete(threadTs);
+    deps.persistState();
+  }
+
+  function clearPendingAttention(threadTs: string): void {
+    const pending = deps.getPendingEyes().get(threadTs);
+    if (!pending) return;
+    for (const entry of pending) {
+      void deps.removeReaction(entry.channel, entry.messageTs, "eyes");
+    }
+    deps.getPendingEyes().delete(threadTs);
+  }
+
+  async function resolveThreadOwner(channel: string, threadTs: string): Promise<string | null> {
+    const hint = await resolveSlackThreadOwnerHint({
+      slack: deps.slack,
+      token: deps.getBotToken(),
+      channel,
+      threadTs,
+      limit: 50,
+    });
+    return hint?.agentOwner ?? hint?.agentName ?? null;
+  }
+
+  async function ensureLocalThreadOwnership(
+    channel: string,
+    threadTs: string,
+  ): Promise<SinglePlayerThreadOwnershipResult> {
+    const threads = deps.getThreads();
+    const { agentName, agentAliases, agentOwnerToken } = getAgentState();
+    const localOwner = threads.get(threadTs)?.owner;
+    if (localOwner && !agentOwnsThread(localOwner, agentName, agentAliases, agentOwnerToken)) {
+      return "skip";
+    }
+    if (localOwner) {
+      const thread = threads.get(threadTs);
+      if (thread) {
+        normalizeOwnedThreads([thread], agentName, agentOwnerToken, agentAliases);
+      }
+      return "continue";
+    }
+
+    const unclaimedThreads = deps.getUnclaimedThreads();
+    if (unclaimedThreads.has(threadTs)) {
+      return "continue";
+    }
+
+    const remoteOwner = await resolveThreadOwner(channel, threadTs);
+    if (shuttingDown) {
+      return "shutdown";
+    }
+
+    const thread = threads.get(threadTs);
+    if (remoteOwner && !agentOwnsThread(remoteOwner, agentName, agentAliases, agentOwnerToken)) {
+      if (thread) thread.owner = remoteOwner;
+      return "skip";
+    }
+    if (agentOwnsThread(remoteOwner ?? undefined, agentName, agentAliases, agentOwnerToken)) {
+      if (thread) thread.owner = agentOwnerToken;
+    }
+    if (!remoteOwner) {
+      unclaimedThreads.add(threadTs);
+    }
+    return "continue";
+  }
+
+  async function onThreadStarted(event: ParsedThreadStarted): Promise<void> {
+    if (shuttingDown) return;
+
+    const info: SinglePlayerThreadState = {
+      channelId: event.channelId,
+      threadTs: event.threadTs,
+      userId: event.userId,
+      source: "slack",
+    };
+
+    if (event.context) {
+      info.context = event.context;
+    }
+
+    deps.getThreads().set(info.threadTs, info);
+    deps.setLastDmChannel(info.channelId);
+    deps.persistState();
+
+    await deps.setSuggestedPrompts(info.channelId, info.threadTs);
+  }
+
+  function onContextChanged(event: ParsedThreadContextChanged): void {
+    if (shuttingDown) return;
+
+    const existing = deps.getThreads().get(event.threadTs);
+    if (!existing || !event.context) return;
+
+    existing.context = event.context;
+    deps.persistState();
+  }
+
+  async function onAppHomeOpened(event: ParsedAppHomeOpened, ctx: ExtensionContext): Promise<void> {
+    if (shuttingDown) return;
+
+    await deps.publishCurrentPinetHomeTab(event.userId, ctx);
+  }
+
+  async function onReactionAdded(
+    evt: Record<string, unknown>,
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    if (shuttingDown) return;
+
+    const item = evt.item as { type?: string; channel?: string; ts?: string } | undefined;
+    const user = evt.user as string | undefined;
+    const rawReactionName = evt.reaction as string | undefined;
+    if (
+      !item ||
+      item.type !== "message" ||
+      !item.channel ||
+      !item.ts ||
+      !user ||
+      !rawReactionName
+    ) {
+      return;
+    }
+
+    if (user === getCurrentBotUserId()) {
+      return;
+    }
+
+    let reactionName: string;
+    try {
+      reactionName = normalizeReactionName(rawReactionName);
+    } catch {
+      return;
+    }
+
+    const command = deps.getReactionCommand(reactionName);
+    if (!command || !deps.isUserAllowed(user)) {
+      return;
+    }
+
+    try {
+      const reactedMessage = await deps.fetchSlackMessageByTs(item.channel, item.ts);
+      if (!reactedMessage) {
+        throw new Error(`Unable to fetch reacted message ${item.ts} in channel ${item.channel}`);
+      }
+
+      const threadTs =
+        (reactedMessage.thread_ts as string | undefined) ??
+        (reactedMessage.ts as string | undefined) ??
+        item.ts;
+
+      const threads = deps.getThreads();
+      if (!threads.has(threadTs)) {
+        threads.set(threadTs, {
+          channelId: item.channel,
+          threadTs,
+          userId: (reactedMessage.user as string | undefined) ?? user,
+          source: "slack",
+        });
+      }
+
+      const ownership = await ensureLocalThreadOwnership(item.channel, threadTs);
+      if (ownership !== "continue") {
+        return;
+      }
+
+      const reactorName = await deps.resolveUser(user);
+      if (shuttingDown) return;
+      const reactedMessageAuthorId =
+        (reactedMessage.user as string | undefined) ?? (evt.item_user as string | undefined);
+      const reactedMessageAuthor = reactedMessageAuthorId
+        ? await deps.resolveUser(reactedMessageAuthorId)
+        : (reactedMessage.bot_id as string | undefined)
+          ? "bot"
+          : "unknown";
+      if (shuttingDown) return;
+
+      const reactedMessageText =
+        typeof reactedMessage.text === "string" && reactedMessage.text.trim().length > 0
+          ? reactedMessage.text
+          : "(no text)";
+      const reactionMessage = buildReactionTriggerMessage({
+        reactionName,
+        command,
+        reactorName,
+        channel: item.channel,
+        threadTs,
+        messageTs: item.ts,
+        reactedMessageText,
+        reactedMessageAuthor,
+      });
+
+      ctx.ui.notify(`${reactorName} reacted with :${reactionName}:`, "info");
+      deps.pushInboxMessage({
+        channel: item.channel,
+        threadTs,
+        userId: user,
+        text: reactionMessage,
+        timestamp: (evt.event_ts as string) ?? item.ts,
+      });
+      deps.persistState();
+      deps.updateBadge();
+      await deps.addReaction(item.channel, item.ts, "white_check_mark");
+
+      deps.maybeDrainInboxIfIdle(ctx);
+    } catch (err) {
+      console.error(`[slack-bridge] reaction trigger failed: ${deps.formatError(err)}`);
+      await deps.addReaction(item.channel, item.ts, "x");
+    }
+  }
+
+  async function onMessage(evt: Record<string, unknown>, ctx: ExtensionContext): Promise<void> {
+    if (shuttingDown) return;
+
+    const threads = deps.getThreads();
+    const classified = classifyMessage(evt, getCurrentBotUserId(), new Set(threads.keys()));
+    if (!classified.relevant) return;
+
+    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
+
+    if (!threads.has(threadTs)) {
+      threads.set(threadTs, { channelId: channel, threadTs, userId, source: "slack" });
+    }
+
+    const ownership = await ensureLocalThreadOwnership(channel, threadTs);
+    if (ownership !== "continue") {
+      return;
+    }
+
+    if (!deps.isUserAllowed(userId)) {
+      await deps.slack("chat.postMessage", deps.getBotToken(), {
+        channel,
+        thread_ts: threadTs,
+        text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
+      });
+      return;
+    }
+
+    if (isDM) {
+      deps.setLastDmChannel(channel);
+    }
+    deps.persistState();
+
+    const confirmationResult = deps.consumeConfirmationReply(threadTs, text);
+    const messageText =
+      confirmationResult === null
+        ? text
+        : confirmationResult.approved
+          ? `${text}\n\n✅ User approved security confirmation request in this thread.`
+          : `${text}\n\n❌ User denied security confirmation request in this thread.`;
+
+    const name = await deps.resolveUser(userId);
+    if (shuttingDown) return;
+    ctx.ui.notify(`${name}: ${text.slice(0, 100)}`, "info");
+
+    void deps.addReaction(channel, messageTs, "eyes");
+    const pending = deps.getPendingEyes().get(threadTs) ?? [];
+    pending.push({ channel, messageTs });
+    deps.getPendingEyes().set(threadTs, pending);
+
+    deps.pushInboxMessage({
+      channel,
+      threadTs,
+      userId,
+      text: messageText,
+      timestamp: messageTs,
+      ...(isChannelMention && { isChannelMention: true }),
+    });
+    deps.updateBadge();
+
+    deps.maybeDrainInboxIfIdle(ctx);
+  }
+
+  async function queueInteractiveInboxEvent(
+    normalized: {
+      channel: string;
+      threadTs: string;
+      userId: string;
+      text: string;
+      timestamp: string;
+      metadata: Record<string, unknown>;
+    },
+    ctx: ExtensionContext,
+  ): Promise<void> {
+    const threads = deps.getThreads();
+    if (!threads.has(normalized.threadTs)) {
+      threads.set(normalized.threadTs, {
+        channelId: normalized.channel,
+        threadTs: normalized.threadTs,
+        userId: normalized.userId,
+        source: "slack",
+      });
+    }
+
+    const ownership = await ensureLocalThreadOwnership(normalized.channel, normalized.threadTs);
+    if (ownership !== "continue") {
+      return;
+    }
+
+    if (!deps.isUserAllowed(normalized.userId)) {
+      await deps.slack("chat.postMessage", deps.getBotToken(), {
+        channel: normalized.channel,
+        thread_ts: normalized.threadTs,
+        text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
+      });
+      return;
+    }
+
+    if (normalized.channel.startsWith("D")) {
+      deps.setLastDmChannel(normalized.channel);
+    }
+    deps.persistState();
+
+    const name = await deps.resolveUser(normalized.userId);
+    if (shuttingDown) return;
+    ctx.ui.notify(`${name}: ${normalized.text.slice(0, 100)}`, "info");
+
+    deps.pushInboxMessage({
+      channel: normalized.channel,
+      threadTs: normalized.threadTs,
+      userId: normalized.userId,
+      text: normalized.text,
+      timestamp: normalized.timestamp,
+      metadata: normalized.metadata,
+    });
+    deps.updateBadge();
+
+    deps.maybeDrainInboxIfIdle(ctx);
+  }
+
+  const threadContextPort: SlackToolsThreadContextPort = {
+    resolveThreadChannel: (threadTs) => deps.resolveThreadChannel(threadTs),
+    noteThreadReply: (threadTs, channelId) => {
+      trackOwnedThread(threadTs, channelId, "slack");
+      deps.claimOwnedThread(threadTs, channelId, "slack");
+    },
+    clearPendingAttention: (threadTs) => {
+      clearPendingAttention(threadTs);
+    },
+  };
 
   return {
     async connect(ctx: ExtensionContext): Promise<void> {
@@ -72,13 +492,26 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
             console.error(`[slack-bridge] Slack access: ${deps.formatError(error)}`);
           }
         },
-        onThreadStarted: (event) => deps.handleThreadStarted(event),
-        onThreadContextChanged: (event) => deps.handleThreadContextChanged(event),
-        onAppHomeOpened: (event) => deps.handleAppHomeOpened(event, ctx),
-        onMessage: (event) => deps.handleMessage(event, ctx),
-        onReactionAdded: (event) => deps.handleReactionAdded(event, ctx),
-        onMemberJoinedChannel: (event) => deps.handleMemberJoinedChannel(event, ctx),
-        onInteractive: (event) => deps.handleInteractive(event, ctx),
+        onThreadStarted: (event) => onThreadStarted(event),
+        onThreadContextChanged: (event) => onContextChanged(event),
+        onAppHomeOpened: (event) => onAppHomeOpened(event, ctx),
+        onMessage: (event) => onMessage(event, ctx),
+        onReactionAdded: (event) => onReactionAdded(event, ctx),
+        onMemberJoinedChannel: async ({ channel, isSelf }) => {
+          if (!isSelf) return;
+          ctx.ui.notify(`Pinet added to channel ${channel}`, "info");
+          deps.pushInboxMessage({
+            channel,
+            threadTs: "",
+            userId: "system",
+            text: `Pinet was added to channel <#${channel}>. You can now post messages there.`,
+            timestamp: String(Date.now() / 1000),
+          });
+          deps.updateBadge();
+          deps.maybeDrainInboxIfIdle(ctx);
+        },
+        onInteractive: (event: SlackInteractiveInboxEvent) =>
+          queueInteractiveInboxEvent(event, ctx),
       });
 
       slackSocket = socket;
@@ -110,6 +543,14 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
 
     resetShutdownState(): void {
       shuttingDown = false;
+    },
+
+    trackOwnedThread(threadTs: string, channelId: string, source = "slack"): void {
+      trackOwnedThread(threadTs, channelId, source);
+    },
+
+    getThreadContextPort(): SlackToolsThreadContextPort {
+      return threadContextPort;
     },
   };
 }


### PR DESCRIPTION
## Summary
- move the single-mode direct Slack ingress handlers into `slack-bridge/single-player-runtime.ts`
- move local thread ownership + Slack tools thread-context handling behind the single-player runtime
- keep shared Slack API helpers, confirmation state, Home tab publish callback, and broker/follower claim plumbing in `slack-bridge/index.ts`

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test