### PR TITLE
refactor: isolate broker observability (#354)

### DIFF
--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
+import { createBrokerRuntime, type BrokerRuntimeDeps } from "./broker-runtime.js";
+import type { SlackActivityLogger } from "./activity-log.js";
+
+function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDeps {
+  return {
+    getSettings: () => ({}),
+    getBotToken: () => "xoxb-test",
+    getAppToken: () => "xapp-test",
+    getAllowedUsers: () => null,
+    shouldAllowAllWorkspaceUsers: () => false,
+    getBrokerStableId: () => "broker-stable-id",
+    setBrokerStableId: vi.fn(),
+    getActiveSkinTheme: () => null,
+    setActiveSkinTheme: vi.fn(),
+    setAgentOwnerToken: vi.fn(),
+    getAgentMetadata: vi.fn(async () => ({})),
+    applyLocalAgentIdentity: vi.fn(),
+    buildSkinMetadata: vi.fn((metadata) => metadata ?? {}),
+    getMeshRoleFromMetadata: vi.fn(
+      () => "broker" as ReturnType<BrokerRuntimeDeps["getMeshRoleFromMetadata"]>,
+    ) as BrokerRuntimeDeps["getMeshRoleFromMetadata"],
+    handleInboundMessage: vi.fn(),
+    onAppHomeOpened: vi.fn(),
+    pushInboxMessages: vi.fn(),
+    updateBadge: vi.fn(),
+    maybeDrainInboxIfIdle: vi.fn(() => false),
+    requestRemoteControl: vi.fn(() => ({
+      accepted: true,
+      shouldStartNow: false,
+      status: "queued" as const,
+      scheduledCommand: "reload" as const,
+      ackDisposition: "immediate" as const,
+      currentCommand: null,
+      queuedCommand: null,
+    })),
+    deferControlAck: vi.fn(),
+    runRemoteControl: vi.fn(),
+    applySkinUpdate: vi.fn(),
+    formatError: (error: unknown) => String(error),
+    deliveryState: {
+      pendingInboxIds: new Set<number>(),
+    },
+    onMaintenanceResult: vi.fn(),
+    onMaintenanceError: vi.fn(),
+    onScheduledWakeupError: vi.fn(),
+    onAgentStatusChange: vi.fn(),
+    createActivityLogger: vi.fn(
+      () =>
+        ({
+          clearPending: vi.fn(),
+          getRecentEntries: vi.fn(() => []),
+          log: vi.fn(),
+        }) as unknown as SlackActivityLogger,
+    ),
+    formatTrackedAgent: vi.fn((agentId: string) => agentId),
+    summarizeTrackedAssignmentStatus: vi.fn(() => ({
+      summary: "assigned",
+      tone: "info" as const,
+    })),
+    sendMaintenanceMessage: vi.fn(),
+    trySendFollowUp: vi.fn(),
+    refreshCanvasDashboard: vi.fn(async () => undefined),
+    refreshHomeTabs: vi.fn(async () => undefined),
+    buildControlPlaneDashboardSnapshot: vi.fn(
+      (input) => input as unknown as BrokerControlPlaneDashboardSnapshot,
+    ),
+    buildCurrentDashboardSnapshot: vi.fn(async () => null),
+    ...overrides,
+  };
+}
+
+describe("broker-runtime", () => {
+  it("keeps reusable control-plane canvas ids while clearing transient observability state", async () => {
+    const runtime = createBrokerRuntime(createDeps());
+
+    runtime.restoreControlPlaneCanvasRuntimeState({
+      canvasId: "F123CANVAS",
+      channelId: "C123CHANNEL",
+    });
+    runtime.setLastControlPlaneCanvasRefreshAt("2026-04-14T18:00:00.000Z");
+    runtime.setLastControlPlaneCanvasError("canvas failed once");
+    runtime.setLastHomeTabSnapshot({
+      roster: [],
+    } as unknown as BrokerControlPlaneDashboardSnapshot);
+    runtime.setLastHomeTabRefreshAt("2026-04-14T18:01:00.000Z");
+    runtime.setLastHomeTabError("home tab failed once");
+
+    await runtime.disconnect();
+
+    expect(runtime.getControlPlaneCanvasRuntimeId()).toBe("F123CANVAS");
+    expect(runtime.getControlPlaneCanvasRuntimeChannelId()).toBe("C123CHANNEL");
+    expect(runtime.getConfiguredBrokerControlPlaneCanvasId()).toBe("F123CANVAS");
+    expect(runtime.getLastControlPlaneCanvasRefreshAt()).toBeNull();
+    expect(runtime.getLastControlPlaneCanvasError()).toBeNull();
+    expect(runtime.getHomeTabViewerIds()).toEqual([]);
+    expect(runtime.getLastHomeTabSnapshot()).toBeNull();
+    expect(runtime.getLastHomeTabRefreshAt()).toBeNull();
+    expect(runtime.getLastHomeTabError()).toBeNull();
+  });
+
+  it("prefers explicit control-plane canvas ids over persisted runtime ids", () => {
+    const runtime = createBrokerRuntime(
+      createDeps({
+        getSettings: () => ({ controlPlaneCanvasId: "FEXPLICIT" }),
+      }),
+    );
+
+    runtime.restoreControlPlaneCanvasRuntimeState({
+      canvasId: "FRUNTIME",
+      channelId: "CRUNTIME",
+    });
+
+    expect(runtime.getConfiguredBrokerControlPlaneCanvasId()).toBe("FEXPLICIT");
+  });
+});

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -31,6 +31,20 @@ import {
   resetBrokerDeliveryState,
 } from "./broker-delivery.js";
 import type { InboundMessage } from "./broker/types.js";
+import {
+  type ActivityLogEntry,
+  type ActivityLogTone,
+  type LoggedActivityLogEntry,
+  type SlackActivityLogger,
+} from "./activity-log.js";
+import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
+import {
+  type RalphLoopDeps,
+  createRalphLoopState,
+  startRalphLoop,
+  stopRalphLoop,
+} from "./ralph-loop.js";
+import { TtlCache } from "./ttl-cache.js";
 
 export interface BrokerRuntimeConnectResult {
   botUserId: string | null;
@@ -95,6 +109,28 @@ export interface BrokerRuntimeDeps {
     changedAgentId: string,
     status: "working" | "idle",
   ) => void;
+  createActivityLogger: (onError: (error: unknown) => void) => SlackActivityLogger;
+  formatTrackedAgent: (agentId: string) => string;
+  summarizeTrackedAssignmentStatus: (
+    status: "assigned" | "branch_pushed" | "pr_open" | "pr_merged" | "pr_closed",
+    prNumber: number | null,
+    branch: string | null,
+  ) => { summary: string; tone: ActivityLogTone };
+  sendMaintenanceMessage: (targetAgentId: string, body: string) => void;
+  trySendFollowUp: (body: string, onDelivered: () => void) => void;
+  refreshCanvasDashboard: (ctx: ExtensionContext, input: Record<string, unknown>) => Promise<void>;
+  refreshHomeTabs: (
+    ctx: ExtensionContext,
+    snapshot: BrokerControlPlaneDashboardSnapshot,
+    refreshedAt: string,
+    userIds?: string[],
+  ) => Promise<void>;
+  buildControlPlaneDashboardSnapshot: (
+    input: Record<string, unknown>,
+  ) => BrokerControlPlaneDashboardSnapshot;
+  buildCurrentDashboardSnapshot: (
+    openedAt?: string,
+  ) => Promise<BrokerControlPlaneDashboardSnapshot | null>;
 }
 
 export interface BrokerRuntime {
@@ -103,12 +139,41 @@ export interface BrokerRuntime {
   claimThread: (threadTs: string, channelId: string, source?: string) => void;
   runMaintenance: (ctx: ExtensionContext) => void;
   markDelivered: (inboxIds: number[]) => void;
+  startObservability: (ctx: ExtensionContext) => void;
+  clearFollowUpPending: () => void;
+  logActivity: (entry: ActivityLogEntry) => void;
+  getRecentActivityEntries: (limit?: number) => ReadonlyArray<LoggedActivityLogEntry>;
   getBroker: () => Broker | null;
   getSelfId: () => string | null;
   getLastMaintenance: () => BrokerMaintenanceResult | null;
   heartbeatTimerActive: () => boolean;
   maintenanceTimerActive: () => boolean;
   isConnected: () => boolean;
+  isBrokerControlPlaneCanvasEnabled: () => boolean;
+  getConfiguredBrokerControlPlaneCanvasId: () => string | null;
+  getConfiguredBrokerControlPlaneCanvasChannel: () => string | null;
+  getControlPlaneCanvasRuntimeId: () => string | null;
+  getControlPlaneCanvasRuntimeChannelId: () => string | null;
+  restoreControlPlaneCanvasRuntimeState: (input: {
+    canvasId: string | null;
+    channelId: string | null;
+  }) => void;
+  getLastControlPlaneCanvasRefreshAt: () => string | null;
+  setLastControlPlaneCanvasRefreshAt: (value: string | null) => void;
+  getLastControlPlaneCanvasError: () => string | null;
+  setLastControlPlaneCanvasError: (value: string | null) => void;
+  getHomeTabViewerIds: () => string[];
+  getLastHomeTabSnapshot: () => BrokerControlPlaneDashboardSnapshot | null;
+  setLastHomeTabSnapshot: (snapshot: BrokerControlPlaneDashboardSnapshot | null) => void;
+  getLastHomeTabRefreshAt: () => string | null;
+  setLastHomeTabRefreshAt: (value: string | null) => void;
+  getLastHomeTabError: () => string | null;
+  setLastHomeTabError: (value: string | null) => void;
+  publishCurrentHomeTabSafely: (
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt?: string,
+  ) => Promise<boolean>;
 }
 
 function normalizeOptionalSetting(value: string | null | undefined): string | null {
@@ -127,6 +192,58 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
   let brokerScheduledWakeupRunning = false;
   let lastBrokerMaintenance: BrokerMaintenanceResult | null = null;
   let lastBrokerMaintenanceSignature = "";
+  let activityLogger: SlackActivityLogger | null = null;
+  let activityLogContext: ExtensionContext | null = null;
+  let lastActivityLogFailureAt = 0;
+  let brokerControlPlaneCanvasRuntimeId: string | null = null;
+  let brokerControlPlaneCanvasRuntimeChannelId: string | null = null;
+  let lastBrokerControlPlaneCanvasRefreshAt: string | null = null;
+  let lastBrokerControlPlaneCanvasError: string | null = null;
+  const brokerControlPlaneHomeTabViewers = new TtlCache<string, { openedAt: string }>({
+    maxSize: 100,
+    ttlMs: 12 * 60 * 60 * 1000,
+  });
+  let lastBrokerControlPlaneHomeTabSnapshot: BrokerControlPlaneDashboardSnapshot | null = null;
+  let lastBrokerControlPlaneHomeTabRefreshAt: string | null = null;
+  let lastBrokerControlPlaneHomeTabError: string | null = null;
+  const ralphLoopState = createRalphLoopState();
+
+  function isBrokerControlPlaneCanvasEnabled(): boolean {
+    return deps.getSettings().controlPlaneCanvasEnabled ?? true;
+  }
+
+  function getExplicitBrokerControlPlaneCanvasId(): string | null {
+    return normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasId);
+  }
+
+  function getConfiguredBrokerControlPlaneCanvasId(): string | null {
+    return getExplicitBrokerControlPlaneCanvasId() ?? brokerControlPlaneCanvasRuntimeId;
+  }
+
+  function getConfiguredBrokerControlPlaneCanvasChannel(): string | null {
+    return (
+      normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasChannel) ??
+      normalizeOptionalSetting(deps.getSettings().defaultChannel)
+    );
+  }
+
+  function ensureActivityLogger(): SlackActivityLogger {
+    if (activityLogger) {
+      return activityLogger;
+    }
+
+    activityLogger = deps.createActivityLogger((error) => {
+      const formatted = deps.formatError(error);
+      console.error(`[slack-bridge] activity log failed: ${formatted}`);
+      const now = Date.now();
+      if (!activityLogContext?.hasUI || now - lastActivityLogFailureAt < 60_000) {
+        return;
+      }
+      lastActivityLogFailureAt = now;
+      activityLogContext.ui.notify(`Pinet activity log failed: ${formatted}`, "warning");
+    });
+    return activityLogger;
+  }
 
   function stopBrokerHeartbeat(): void {
     if (!brokerHeartbeatTimer) return;
@@ -293,7 +410,101 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     runBrokerScheduledWakeups(ctx);
   }
 
+  function getRalphLoopDeps(): RalphLoopDeps {
+    return {
+      getBrokerDb: () => (activeBroker?.db as BrokerDB | undefined) ?? null,
+      getBrokerAgentId: () => activeSelfId,
+      heartbeatTimerActive: () => brokerHeartbeatTimer != null,
+      maintenanceTimerActive: () => brokerMaintenanceTimer != null,
+      runMaintenance: (ctx) => runMaintenance(ctx),
+      sendMaintenanceMessage: (targetAgentId, body) =>
+        deps.sendMaintenanceMessage(targetAgentId, body),
+      trySendFollowUp: (body, onDelivered) => deps.trySendFollowUp(body, onDelivered),
+      logActivity: (entry) => {
+        if (!activeBroker) {
+          return;
+        }
+        ensureActivityLogger().log(entry);
+      },
+      formatTrackedAgent: (agentId) => deps.formatTrackedAgent(agentId),
+      summarizeTrackedAssignmentStatus: (status, prNumber, branch) =>
+        deps.summarizeTrackedAssignmentStatus(
+          status as Parameters<typeof deps.summarizeTrackedAssignmentStatus>[0],
+          prNumber,
+          branch,
+        ),
+      refreshCanvasDashboard: (ctx, input) => deps.refreshCanvasDashboard(ctx, input),
+      refreshHomeTabs: (ctx, snapshot, refreshedAt) =>
+        deps.refreshHomeTabs(ctx, snapshot, refreshedAt),
+      getLastMaintenance: () => lastBrokerMaintenance,
+      buildControlPlaneDashboardSnapshot: (input) => deps.buildControlPlaneDashboardSnapshot(input),
+      setLastHomeTabSnapshot: (snapshot) => {
+        lastBrokerControlPlaneHomeTabSnapshot = snapshot;
+      },
+      getLastCanvasError: () => lastBrokerControlPlaneCanvasError,
+      setLastCanvasError: (error) => {
+        lastBrokerControlPlaneCanvasError = error;
+      },
+      getLastHomeTabError: () => lastBrokerControlPlaneHomeTabError,
+      setLastHomeTabError: (error) => {
+        lastBrokerControlPlaneHomeTabError = error;
+      },
+    };
+  }
+
+  function startObservability(ctx: ExtensionContext): void {
+    if (!activeBroker) {
+      return;
+    }
+    activityLogContext = ctx;
+    startRalphLoop(ctx, ralphLoopState, getRalphLoopDeps());
+  }
+
+  function stopObservability(): void {
+    stopRalphLoop(ralphLoopState);
+    lastBrokerControlPlaneCanvasRefreshAt = null;
+    lastBrokerControlPlaneCanvasError = null;
+    brokerControlPlaneHomeTabViewers.clear();
+    lastBrokerControlPlaneHomeTabSnapshot = null;
+    lastBrokerControlPlaneHomeTabRefreshAt = null;
+    lastBrokerControlPlaneHomeTabError = null;
+    activityLogger?.clearPending();
+    activityLogContext = null;
+  }
+
+  async function publishCurrentHomeTabSafely(
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt: string = new Date().toISOString(),
+  ): Promise<boolean> {
+    if (!activeBroker) {
+      return false;
+    }
+
+    activityLogContext = ctx;
+    brokerControlPlaneHomeTabViewers.set(userId, { openedAt });
+
+    try {
+      const snapshot =
+        (await deps.buildCurrentDashboardSnapshot(openedAt)) ??
+        lastBrokerControlPlaneHomeTabSnapshot;
+      if (!snapshot) {
+        return false;
+      }
+      await deps.refreshHomeTabs(ctx, snapshot, openedAt, [userId]);
+      return true;
+    } catch (error) {
+      const homeTabMessage = `Pinet Home tab publish failed: ${deps.formatError(error)}`;
+      if (homeTabMessage !== lastBrokerControlPlaneHomeTabError) {
+        ctx.ui.notify(homeTabMessage, "warning");
+      }
+      lastBrokerControlPlaneHomeTabError = homeTabMessage;
+      return false;
+    }
+  }
+
   async function disconnect(options: { releaseIdentity?: boolean } = {}): Promise<void> {
+    stopObservability();
     stopBrokerHeartbeat();
     stopBrokerMaintenance();
     stopBrokerScheduledWakeups();
@@ -344,6 +555,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         },
       });
       let selfId: string | null = null;
+      activityLogContext = ctx;
 
       try {
         broker.db.setAllowedUsers(allowedUsers);
@@ -477,6 +689,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         lastBrokerMaintenance = null;
         lastBrokerMaintenanceSignature = "";
         resetBrokerDeliveryState(deps.deliveryState);
+        stopObservability();
         throw error;
       }
     },
@@ -504,6 +717,25 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
       markBrokerInboxIdsHandled(deps.deliveryState, inboxIds);
     },
 
+    startObservability(ctx: ExtensionContext): void {
+      startObservability(ctx);
+    },
+
+    clearFollowUpPending(): void {
+      ralphLoopState.followUpPending = false;
+    },
+
+    logActivity(entry: ActivityLogEntry): void {
+      if (!activeBroker) {
+        return;
+      }
+      ensureActivityLogger().log(entry);
+    },
+
+    getRecentActivityEntries(limit = 20): ReadonlyArray<LoggedActivityLogEntry> {
+      return activityLogger?.getRecentEntries(limit) ?? [];
+    },
+
     getBroker(): Broker | null {
       return activeBroker;
     },
@@ -526,6 +758,86 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
 
     isConnected(): boolean {
       return activeBroker != null;
+    },
+
+    isBrokerControlPlaneCanvasEnabled(): boolean {
+      return isBrokerControlPlaneCanvasEnabled();
+    },
+
+    getConfiguredBrokerControlPlaneCanvasId(): string | null {
+      return getConfiguredBrokerControlPlaneCanvasId();
+    },
+
+    getConfiguredBrokerControlPlaneCanvasChannel(): string | null {
+      return getConfiguredBrokerControlPlaneCanvasChannel();
+    },
+
+    getControlPlaneCanvasRuntimeId(): string | null {
+      return brokerControlPlaneCanvasRuntimeId;
+    },
+
+    getControlPlaneCanvasRuntimeChannelId(): string | null {
+      return brokerControlPlaneCanvasRuntimeChannelId;
+    },
+
+    restoreControlPlaneCanvasRuntimeState(input: {
+      canvasId: string | null;
+      channelId: string | null;
+    }): void {
+      brokerControlPlaneCanvasRuntimeId = normalizeOptionalSetting(input.canvasId);
+      brokerControlPlaneCanvasRuntimeChannelId = normalizeOptionalSetting(input.channelId);
+    },
+
+    getLastControlPlaneCanvasRefreshAt(): string | null {
+      return lastBrokerControlPlaneCanvasRefreshAt;
+    },
+
+    setLastControlPlaneCanvasRefreshAt(value: string | null): void {
+      lastBrokerControlPlaneCanvasRefreshAt = value;
+    },
+
+    getLastControlPlaneCanvasError(): string | null {
+      return lastBrokerControlPlaneCanvasError;
+    },
+
+    setLastControlPlaneCanvasError(value: string | null): void {
+      lastBrokerControlPlaneCanvasError = value;
+    },
+
+    getHomeTabViewerIds(): string[] {
+      return [...brokerControlPlaneHomeTabViewers.entries()].map(([userId]) => userId);
+    },
+
+    getLastHomeTabSnapshot(): BrokerControlPlaneDashboardSnapshot | null {
+      return lastBrokerControlPlaneHomeTabSnapshot;
+    },
+
+    setLastHomeTabSnapshot(snapshot: BrokerControlPlaneDashboardSnapshot | null): void {
+      lastBrokerControlPlaneHomeTabSnapshot = snapshot;
+    },
+
+    getLastHomeTabRefreshAt(): string | null {
+      return lastBrokerControlPlaneHomeTabRefreshAt;
+    },
+
+    setLastHomeTabRefreshAt(value: string | null): void {
+      lastBrokerControlPlaneHomeTabRefreshAt = value;
+    },
+
+    getLastHomeTabError(): string | null {
+      return lastBrokerControlPlaneHomeTabError;
+    },
+
+    setLastHomeTabError(value: string | null): void {
+      lastBrokerControlPlaneHomeTabError = value;
+    },
+
+    async publishCurrentHomeTabSafely(
+      userId: string,
+      ctx: ExtensionContext,
+      openedAt = new Date().toISOString(),
+    ): Promise<boolean> {
+      return publishCurrentHomeTabSafely(userId, ctx, openedAt);
     },
   };
 }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -97,13 +97,6 @@ import {
   normalizeIMessageRecipient,
 } from "@gugu910/pi-imessage-bridge";
 import {
-  type RalphLoopDeps,
-  createRalphLoopState,
-  resetRalphLoopState,
-  startRalphLoop,
-  stopRalphLoop,
-} from "./ralph-loop.js";
-import {
   addSlackReaction,
   clearSlackThreadStatus,
   fetchSlackMessageByTs as fetchSlackMessageByTsFromSlack,
@@ -133,11 +126,7 @@ import {
   resolveTaskAssignments,
   type ResolvedTaskAssignment,
 } from "./task-assignments.js";
-import {
-  SlackActivityLogger,
-  type ActivityLogEntry,
-  type ActivityLogTone,
-} from "./activity-log.js";
+import { SlackActivityLogger, type ActivityLogTone } from "./activity-log.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import {
   createBrokerDeliveryState,
@@ -233,28 +222,14 @@ export default function (pi: ExtensionAPI) {
     return trimmed && trimmed.length > 0 ? trimmed : null;
   }
 
-  let brokerControlPlaneCanvasRuntimeId: string | null = null;
-  let brokerControlPlaneCanvasRuntimeChannelId: string | null = null;
-  let lastBrokerControlPlaneCanvasRefreshAt: string | null = null;
-  let lastBrokerControlPlaneCanvasError: string | null = null;
-  const brokerControlPlaneHomeTabViewers = new TtlCache<string, { openedAt: string }>({
-    maxSize: 100,
-    ttlMs: 12 * 60 * 60 * 1000,
-  });
-  let lastBrokerControlPlaneHomeTabSnapshot: BrokerControlPlaneDashboardSnapshot | null = null;
-  let lastBrokerControlPlaneHomeTabRefreshAt: string | null = null;
-  let lastBrokerControlPlaneHomeTabError: string | null = null;
-
-  function isBrokerControlPlaneCanvasEnabled(): boolean {
-    return settings.controlPlaneCanvasEnabled ?? true;
-  }
-
   function getExplicitBrokerControlPlaneCanvasId(): string | null {
     return normalizeOptionalSetting(settings.controlPlaneCanvasId);
   }
 
   function getConfiguredBrokerControlPlaneCanvasId(): string | null {
-    return getExplicitBrokerControlPlaneCanvasId() ?? brokerControlPlaneCanvasRuntimeId;
+    return (
+      getExplicitBrokerControlPlaneCanvasId() ?? brokerRuntime.getControlPlaneCanvasRuntimeId()
+    );
   }
 
   function getConfiguredBrokerControlPlaneCanvasChannel(): string | null {
@@ -600,8 +575,8 @@ export default function (pi: ExtensionAPI) {
         activeSkinTheme,
         agentPersonality,
         agentAliases: [...agentAliases],
-        brokerControlPlaneCanvasId: brokerControlPlaneCanvasRuntimeId,
-        brokerControlPlaneCanvasChannelId: brokerControlPlaneCanvasRuntimeChannelId,
+        brokerControlPlaneCanvasId: brokerRuntime.getControlPlaneCanvasRuntimeId(),
+        brokerControlPlaneCanvasChannelId: brokerRuntime.getControlPlaneCanvasRuntimeChannelId(),
       });
     } catch (err) {
       console.error(`[slack-bridge] persistState failed: ${msg(err)}`);
@@ -628,7 +603,6 @@ export default function (pi: ExtensionAPI) {
   let suppressAutoDrainUntil = 0;
   let terminalInputUnsubscribe: (() => void) | null = null;
   let extCtx: ExtensionContext | null = null; // cached for badge updates
-  let lastActivityLogFailureAt = 0;
   const pendingSlackToolPolicyTurns: PendingSlackToolPolicyTurn[] = [];
   let nextSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
   let activeSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
@@ -721,35 +695,6 @@ export default function (pi: ExtensionAPI) {
       nameOrId,
       cache: channelCache,
     });
-  }
-
-  const activityLogger = new SlackActivityLogger({
-    getBotToken: () => botToken,
-    getLogChannel: () => settings.logChannel,
-    getLogLevel: () => settings.logLevel,
-    getAgentName: () => agentName,
-    getAgentEmoji: () => agentEmoji,
-    resolveChannel,
-    slack,
-    onError: (error) => {
-      console.error(`[slack-bridge] activity log failed: ${msg(error)}`);
-      const now = Date.now();
-      if (!extCtx?.hasUI || now - lastActivityLogFailureAt < 60_000) {
-        return;
-      }
-      lastActivityLogFailureAt = now;
-      extCtx.ui.notify(`Pinet activity log failed: ${msg(error)}`, "warning");
-    },
-  });
-
-  function logBrokerActivity(entry: ActivityLogEntry): void {
-    if (!settings.logChannel) {
-      return;
-    }
-    if (brokerRole !== "broker" && brokerRuntime.getBroker() == null) {
-      return;
-    }
-    activityLogger.log(entry);
   }
 
   function formatTrackedAgent(agentId: string): string {
@@ -1089,7 +1034,6 @@ export default function (pi: ExtensionAPI) {
   let pinetRegistrationBlocked = false;
   let brokerClient: BrokerClientRef | null = null;
   const followerDeliveryState = createFollowerDeliveryState();
-  const ralphLoopState = createRalphLoopState();
   let desiredAgentStatus: "working" | "idle" = "idle";
 
   function getPinetRegistrationBlockReason(): string {
@@ -1208,6 +1152,40 @@ export default function (pi: ExtensionAPI) {
     },
     formatError: msg,
     deliveryState: brokerDeliveryState,
+    createActivityLogger: (onError) =>
+      new SlackActivityLogger({
+        getBotToken: () => botToken,
+        getLogChannel: () => settings.logChannel,
+        getLogLevel: () => settings.logLevel,
+        getAgentName: () => agentName,
+        getAgentEmoji: () => agentEmoji,
+        resolveChannel,
+        slack,
+        onError,
+      }),
+    formatTrackedAgent,
+    summarizeTrackedAssignmentStatus,
+    sendMaintenanceMessage: (targetAgentId, body) => {
+      sendBrokerMaintenanceMessage(targetAgentId, body);
+    },
+    trySendFollowUp: (body, onDelivered) => {
+      trySendBrokerFollowUp(body, onDelivered);
+    },
+    refreshCanvasDashboard: async (ctx, input) => {
+      await refreshBrokerControlPlaneCanvasDashboard(
+        ctx,
+        input as Parameters<typeof refreshBrokerControlPlaneCanvasDashboard>[1],
+      );
+    },
+    refreshHomeTabs: async (ctx, snapshot, refreshedAt, userIds) => {
+      await refreshBrokerControlPlaneHomeTabs(ctx, snapshot, refreshedAt, userIds);
+    },
+    buildControlPlaneDashboardSnapshot: (input) =>
+      buildBrokerControlPlaneDashboardSnapshot(
+        input as unknown as Parameters<typeof buildBrokerControlPlaneDashboardSnapshot>[0],
+      ),
+    buildCurrentDashboardSnapshot: async (openedAt) =>
+      buildCurrentBrokerControlPlaneDashboardSnapshot(openedAt),
     onMaintenanceResult: (ctx, { result, previousSignature, signature }) => {
       if (signature && signature !== previousSignature) {
         ctx.ui.notify(`Pinet broker: ${result.anomalies.join("; ")}`, "warning");
@@ -1239,7 +1217,7 @@ export default function (pi: ExtensionAPI) {
         result.repairedThreadClaims > 0;
       const shouldLogMaintenance = hasMaintenanceActions || previousSignature !== signature;
       if (shouldLogMaintenance) {
-        logBrokerActivity({
+        brokerRuntime.logActivity({
           kind: "broker_maintenance",
           level: hasMaintenanceActions ? "actions" : "verbose",
           title: signature ? "Broker maintenance anomaly" : "Broker maintenance recovery",
@@ -1264,7 +1242,7 @@ export default function (pi: ExtensionAPI) {
     },
     onMaintenanceError: (ctx, error) => {
       ctx.ui.notify(`Pinet maintenance failed: ${msg(error)}`, "error");
-      logBrokerActivity({
+      brokerRuntime.logActivity({
         kind: "broker_maintenance_error",
         level: "errors",
         title: "Broker maintenance failed",
@@ -1274,7 +1252,7 @@ export default function (pi: ExtensionAPI) {
     },
     onScheduledWakeupError: (ctx, error) => {
       ctx.ui.notify(`Pinet scheduled wake-ups failed: ${msg(error)}`, "error");
-      logBrokerActivity({
+      brokerRuntime.logActivity({
         kind: "scheduled_wakeup_error",
         level: "errors",
         title: "Scheduled wake-up delivery failed",
@@ -1283,7 +1261,7 @@ export default function (pi: ExtensionAPI) {
       });
     },
     onAgentStatusChange: (_ctx, changedAgentId, status) => {
-      logBrokerActivity({
+      brokerRuntime.logActivity({
         kind: "agent_status",
         level: "verbose",
         title: status === "idle" ? "Worker available" : "Worker busy",
@@ -1304,10 +1282,6 @@ export default function (pi: ExtensionAPI) {
 
   function getActiveBrokerSelfId(): string | null {
     return brokerRuntime.getSelfId();
-  }
-
-  function runBrokerMaintenance(ctx: ExtensionContext): void {
-    brokerRuntime.runMaintenance(ctx);
   }
 
   function sendBrokerMaintenanceMessage(targetAgentId: string, body: string): void {
@@ -1344,7 +1318,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   function getBrokerControlPlaneHomeTabViewerIds(): string[] {
-    return [...brokerControlPlaneHomeTabViewers.entries()].map(([userId]) => userId);
+    return brokerRuntime.getHomeTabViewerIds();
   }
 
   async function buildCurrentBrokerControlPlaneDashboardSnapshot(
@@ -1437,13 +1411,13 @@ export default function (pi: ExtensionAPI) {
     ctx: ExtensionContext,
     snapshot: BrokerControlPlaneDashboardSnapshot,
     refreshedAt: string,
-    userIds: string[] = getBrokerControlPlaneHomeTabViewerIds(),
+    userIds: string[] = brokerRuntime.getHomeTabViewerIds(),
   ): Promise<void> {
     if (!botToken || userIds.length === 0) {
       return;
     }
 
-    lastBrokerControlPlaneHomeTabSnapshot = snapshot;
+    brokerRuntime.setLastHomeTabSnapshot(snapshot);
     let hadError = false;
 
     for (const userId of userIds) {
@@ -1457,25 +1431,25 @@ export default function (pi: ExtensionAPI) {
       } catch (err) {
         hadError = true;
         const homeTabMessage = `Pinet Home tab publish failed: ${msg(err)}`;
-        if (homeTabMessage !== lastBrokerControlPlaneHomeTabError) {
+        if (homeTabMessage !== brokerRuntime.getLastHomeTabError()) {
           ctx.ui.notify(homeTabMessage, "warning");
         }
-        lastBrokerControlPlaneHomeTabError = homeTabMessage;
+        brokerRuntime.setLastHomeTabError(homeTabMessage);
       }
     }
 
     if (!hadError) {
-      lastBrokerControlPlaneHomeTabError = null;
+      brokerRuntime.setLastHomeTabError(null);
     }
-    lastBrokerControlPlaneHomeTabRefreshAt = refreshedAt;
+    brokerRuntime.setLastHomeTabRefreshAt(refreshedAt);
   }
 
   function reportHomeTabPublishFailure(ctx: ExtensionContext, err: unknown): void {
     const homeTabMessage = `Pinet Home tab publish failed: ${msg(err)}`;
-    if (homeTabMessage !== lastBrokerControlPlaneHomeTabError) {
+    if (homeTabMessage !== brokerRuntime.getLastHomeTabError()) {
       ctx.ui.notify(homeTabMessage, "warning");
     }
-    lastBrokerControlPlaneHomeTabError = homeTabMessage;
+    brokerRuntime.setLastHomeTabError(homeTabMessage);
   }
 
   async function publishCurrentPinetHomeTab(
@@ -1488,12 +1462,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (brokerRuntime.isConnected() && brokerRole === "broker") {
-      brokerControlPlaneHomeTabViewers.set(userId, { openedAt });
-      const snapshot =
-        (await buildCurrentBrokerControlPlaneDashboardSnapshot(openedAt)) ??
-        lastBrokerControlPlaneHomeTabSnapshot;
-      if (snapshot) {
-        await refreshBrokerControlPlaneHomeTabs(ctx, snapshot, openedAt, [userId]);
+      if (await brokerRuntime.publishCurrentHomeTabSafely(userId, ctx, openedAt)) {
         return;
       }
     }
@@ -1521,7 +1490,7 @@ export default function (pi: ExtensionAPI) {
         defaultChannel: settings.defaultChannel ?? null,
       }),
     });
-    lastBrokerControlPlaneHomeTabError = null;
+    brokerRuntime.setLastHomeTabError(null);
   }
 
   async function publishCurrentPinetHomeTabSafely(
@@ -1560,8 +1529,8 @@ export default function (pi: ExtensionAPI) {
       currentBranch: string | null;
     },
   ): Promise<void> {
-    if (!botToken || !isBrokerControlPlaneCanvasEnabled()) {
-      lastBrokerControlPlaneCanvasError = null;
+    if (!botToken || !brokerRuntime.isBrokerControlPlaneCanvasEnabled()) {
+      brokerRuntime.setLastControlPlaneCanvasError(null);
       return;
     }
 
@@ -1571,10 +1540,10 @@ export default function (pi: ExtensionAPI) {
     if (!effectiveCanvasId && !channelInput) {
       const warning =
         "Pinet broker control plane canvas skipped: set slack-bridge.controlPlaneCanvasChannel, defaultChannel, or controlPlaneCanvasId.";
-      if (lastBrokerControlPlaneCanvasError !== warning) {
+      if (brokerRuntime.getLastControlPlaneCanvasError() !== warning) {
         ctx.ui.notify(warning, "warning");
       }
-      lastBrokerControlPlaneCanvasError = warning;
+      brokerRuntime.setLastControlPlaneCanvasError(warning);
       return;
     }
 
@@ -1594,12 +1563,12 @@ export default function (pi: ExtensionAPI) {
     const channelId = explicitCanvasId || !channelInput ? null : await resolveChannel(channelInput);
     const reusableRuntimeCanvasId =
       !explicitCanvasId &&
-      brokerControlPlaneCanvasRuntimeId &&
-      (!channelId || brokerControlPlaneCanvasRuntimeChannelId === channelId)
-        ? brokerControlPlaneCanvasRuntimeId
+      brokerRuntime.getControlPlaneCanvasRuntimeId() &&
+      (!channelId || brokerRuntime.getControlPlaneCanvasRuntimeChannelId() === channelId)
+        ? brokerRuntime.getControlPlaneCanvasRuntimeId()
         : null;
-    const previousRuntimeId = brokerControlPlaneCanvasRuntimeId;
-    const previousRuntimeChannelId = brokerControlPlaneCanvasRuntimeChannelId;
+    const previousRuntimeId = brokerRuntime.getControlPlaneCanvasRuntimeId();
+    const previousRuntimeChannelId = brokerRuntime.getControlPlaneCanvasRuntimeChannelId();
     const result = await refreshBrokerControlPlaneCanvas({
       slack,
       token: botToken,
@@ -1610,11 +1579,13 @@ export default function (pi: ExtensionAPI) {
     });
 
     if (!explicitCanvasId) {
-      brokerControlPlaneCanvasRuntimeId = result.canvasId;
-      brokerControlPlaneCanvasRuntimeChannelId = channelId;
+      brokerRuntime.restoreControlPlaneCanvasRuntimeState({
+        canvasId: result.canvasId,
+        channelId,
+      });
     }
-    lastBrokerControlPlaneCanvasRefreshAt = input.cycleStartedAt;
-    lastBrokerControlPlaneCanvasError = null;
+    brokerRuntime.setLastControlPlaneCanvasRefreshAt(input.cycleStartedAt);
+    brokerRuntime.setLastControlPlaneCanvasError(null);
 
     if (
       !explicitCanvasId &&
@@ -1632,57 +1603,6 @@ export default function (pi: ExtensionAPI) {
         "info",
       );
     }
-  }
-
-  function getRalphLoopDeps(): RalphLoopDeps {
-    return {
-      getBrokerDb: () => getActiveBrokerDb(),
-      getBrokerAgentId: () => getActiveBrokerSelfId(),
-      heartbeatTimerActive: () => brokerRuntime.heartbeatTimerActive(),
-      maintenanceTimerActive: () => brokerRuntime.maintenanceTimerActive(),
-      runMaintenance: (c) => runBrokerMaintenance(c),
-      sendMaintenanceMessage: (id, body) => sendBrokerMaintenanceMessage(id, body),
-      trySendFollowUp: (body, onDelivered) => trySendBrokerFollowUp(body, onDelivered),
-      logActivity: (entry) => logBrokerActivity(entry),
-      formatTrackedAgent,
-      summarizeTrackedAssignmentStatus: (status, prNumber, branch) =>
-        summarizeTrackedAssignmentStatus(
-          status as Parameters<typeof summarizeTrackedAssignmentStatus>[0],
-          prNumber,
-          branch,
-        ),
-      refreshCanvasDashboard: (c, input) =>
-        refreshBrokerControlPlaneCanvasDashboard(
-          c,
-          input as Parameters<typeof refreshBrokerControlPlaneCanvasDashboard>[1],
-        ),
-      refreshHomeTabs: (c, snapshot, at) => refreshBrokerControlPlaneHomeTabs(c, snapshot, at),
-      getLastMaintenance: () => brokerRuntime.getLastMaintenance(),
-      buildControlPlaneDashboardSnapshot: (input) =>
-        buildBrokerControlPlaneDashboardSnapshot(
-          input as unknown as Parameters<typeof buildBrokerControlPlaneDashboardSnapshot>[0],
-        ),
-      setLastHomeTabSnapshot: (s) => {
-        lastBrokerControlPlaneHomeTabSnapshot = s;
-      },
-      getLastCanvasError: () => lastBrokerControlPlaneCanvasError,
-      setLastCanvasError: (e) => {
-        lastBrokerControlPlaneCanvasError = e;
-      },
-      getLastHomeTabError: () => lastBrokerControlPlaneHomeTabError,
-      setLastHomeTabError: (e) => {
-        lastBrokerControlPlaneHomeTabError = e;
-      },
-    };
-  }
-
-  function startBrokerRalphLoop(ctx: ExtensionContext): void {
-    startRalphLoop(ctx, ralphLoopState, getRalphLoopDeps());
-  }
-
-  function stopBrokerRalphLoop(): void {
-    stopRalphLoop(ralphLoopState);
-    lastBrokerControlPlaneHomeTabSnapshot = null;
   }
 
   function prepareOutgoingPinetAgentMessage(
@@ -1747,7 +1667,7 @@ export default function (pi: ExtensionAPI) {
       }
 
       if (recordedAssignments.length > 0) {
-        logBrokerActivity({
+        brokerRuntime.logActivity({
           kind: "task_assignment",
           level: "actions",
           title: recordedAssignments.length === 1 ? "Task assigned" : "Tasks assigned",
@@ -1930,16 +1850,7 @@ export default function (pi: ExtensionAPI) {
     options: { releaseIdentity: boolean },
   ): Promise<void> {
     flushPersist();
-    stopBrokerRalphLoop();
     await brokerRuntime.disconnect({ releaseIdentity: options.releaseIdentity });
-
-    lastBrokerControlPlaneCanvasRefreshAt = null;
-    lastBrokerControlPlaneCanvasError = null;
-    lastBrokerControlPlaneHomeTabSnapshot = null;
-    lastBrokerControlPlaneHomeTabRefreshAt = null;
-    lastBrokerControlPlaneHomeTabError = null;
-    brokerControlPlaneHomeTabViewers.clear();
-    resetRalphLoopState(ralphLoopState);
 
     if (brokerClient) {
       if (options.releaseIdentity) {
@@ -1958,7 +1869,6 @@ export default function (pi: ExtensionAPI) {
     }
 
     await singlePlayerRuntime.disconnect();
-    activityLogger.clearPending();
     brokerRole = null;
     pinetEnabled = false;
     desiredAgentStatus = "idle";
@@ -2510,7 +2420,7 @@ export default function (pi: ExtensionAPI) {
 
       if (!environment.canAttemptSend) {
         ctx.ui.notify(`iMessage adapter unavailable — ${readinessSummary}`, "warning");
-        logBrokerActivity({
+        brokerRuntime.logActivity({
           kind: "transport_readiness",
           level: "actions",
           title: "iMessage adapter unavailable",
@@ -2525,7 +2435,7 @@ export default function (pi: ExtensionAPI) {
 
           if (environment.blockers.length > 0) {
             ctx.ui.notify(`iMessage send-first mode enabled — ${readinessSummary}`, "warning");
-            logBrokerActivity({
+            brokerRuntime.logActivity({
               kind: "transport_readiness",
               level: "actions",
               title: "iMessage send-first mode enabled",
@@ -2535,7 +2445,7 @@ export default function (pi: ExtensionAPI) {
           }
         } catch (err) {
           ctx.ui.notify(`iMessage adapter failed to start: ${msg(err)}`, "warning");
-          logBrokerActivity({
+          brokerRuntime.logActivity({
             kind: "transport_readiness",
             level: "errors",
             title: "iMessage adapter failed to start",
@@ -2564,9 +2474,9 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    startBrokerRalphLoop(ctx);
+    brokerRuntime.startObservability(ctx);
     setExtStatus(ctx, "ok");
-    logBrokerActivity({
+    brokerRuntime.logActivity({
       kind: "broker_started",
       level: "actions",
       title: "Broker started",
@@ -2666,17 +2576,19 @@ export default function (pi: ExtensionAPI) {
     threads: () => threads,
     allowedUsers: () => allowedUsers,
     inboxLength: () => inbox.length,
-    activityLogger: () => activityLogger,
+    recentActivityLogEntries: (limit) => brokerRuntime.getRecentActivityEntries(limit),
     settings: () => settings,
     lastBrokerMaintenance: () => brokerRuntime.getLastMaintenance(),
-    isBrokerControlPlaneCanvasEnabled,
-    getConfiguredBrokerControlPlaneCanvasId,
-    getConfiguredBrokerControlPlaneCanvasChannel,
-    lastBrokerControlPlaneCanvasRefreshAt: () => lastBrokerControlPlaneCanvasRefreshAt,
-    lastBrokerControlPlaneCanvasError: () => lastBrokerControlPlaneCanvasError,
+    isBrokerControlPlaneCanvasEnabled: () => brokerRuntime.isBrokerControlPlaneCanvasEnabled(),
+    getConfiguredBrokerControlPlaneCanvasId: () =>
+      brokerRuntime.getConfiguredBrokerControlPlaneCanvasId(),
+    getConfiguredBrokerControlPlaneCanvasChannel: () =>
+      brokerRuntime.getConfiguredBrokerControlPlaneCanvasChannel(),
+    lastBrokerControlPlaneCanvasRefreshAt: () => brokerRuntime.getLastControlPlaneCanvasRefreshAt(),
+    lastBrokerControlPlaneCanvasError: () => brokerRuntime.getLastControlPlaneCanvasError(),
     getBrokerControlPlaneHomeTabViewerIds,
-    lastBrokerControlPlaneHomeTabRefreshAt: () => lastBrokerControlPlaneHomeTabRefreshAt,
-    lastBrokerControlPlaneHomeTabError: () => lastBrokerControlPlaneHomeTabError,
+    lastBrokerControlPlaneHomeTabRefreshAt: () => brokerRuntime.getLastHomeTabRefreshAt(),
+    lastBrokerControlPlaneHomeTabError: () => brokerRuntime.getLastHomeTabError(),
     getPinetRegistrationBlockReason,
     connectAsBroker: (ctx) => transitionToRuntimeMode(ctx, "broker"),
     connectAsFollower: (ctx) => transitionToRuntimeMode(ctx, "follower"),
@@ -2829,12 +2741,14 @@ export default function (pi: ExtensionAPI) {
             if (!userNames.has(k)) userNames.set(k, v);
           }
         }
-        brokerControlPlaneCanvasRuntimeId =
-          normalizeOptionalSetting(savedState.brokerControlPlaneCanvasId) ??
-          brokerControlPlaneCanvasRuntimeId;
-        brokerControlPlaneCanvasRuntimeChannelId =
-          normalizeOptionalSetting(savedState.brokerControlPlaneCanvasChannelId) ??
-          brokerControlPlaneCanvasRuntimeChannelId;
+        brokerRuntime.restoreControlPlaneCanvasRuntimeState({
+          canvasId:
+            normalizeOptionalSetting(savedState.brokerControlPlaneCanvasId) ??
+            brokerRuntime.getControlPlaneCanvasRuntimeId(),
+          channelId:
+            normalizeOptionalSetting(savedState.brokerControlPlaneCanvasChannelId) ??
+            brokerRuntime.getControlPlaneCanvasRuntimeChannelId(),
+        });
       }
       persistStateNow();
     } catch (err) {
@@ -3061,7 +2975,7 @@ export default function (pi: ExtensionAPI) {
       if (thread) await clearThreadStatus(thread.channelId, ts);
     }
     thinking.clear();
-    ralphLoopState.followUpPending = false;
+    brokerRuntime.clearFollowUpPending();
 
     try {
       await signalAgentFree(ctx);

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -6,7 +6,7 @@ import {
   resolveAllowAllWorkspaceUsers,
   type SlackBridgeSettings,
 } from "./helpers.js";
-import { formatRecentActivityLogEntries, type SlackActivityLogger } from "./activity-log.js";
+import { formatRecentActivityLogEntries, type LoggedActivityLogEntry } from "./activity-log.js";
 import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 // ─── Types ───────────────────────────────────────────────
@@ -33,7 +33,7 @@ export interface PinetCommandsDeps {
   threads: () => Map<string, { owner?: string }>;
   allowedUsers: () => Set<string> | null;
   inboxLength: () => number;
-  activityLogger: () => SlackActivityLogger;
+  recentActivityLogEntries: (limit: number) => ReadonlyArray<LoggedActivityLogEntry>;
   settings: () => SlackBridgeSettings;
   lastBrokerMaintenance: () => {
     pendingBacklogCount: number;
@@ -344,7 +344,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
     ctx.ui.notify(
       [
         `Activity log channel: ${channelInfo}`,
-        formatRecentActivityLogEntries(deps.activityLogger().getRecentEntries(10)),
+        formatRecentActivityLogEntries(deps.recentActivityLogEntries(10)),
       ].join("\n\n"),
       s.logChannel ? "info" : "warning",
     );


### PR DESCRIPTION
## Summary
- move broker-only observability lifecycle and state behind `BrokerRuntime`
- keep broker control-plane canvas/Home-tab state and broker activity logging owned by the runtime
- move the broker RALPH lifecycle and related reset/start glue off the top-level extension orchestration

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test