### PR TITLE
refactor: extract Pinet tool registrations from slack-bridge/index.ts

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -6,7 +6,6 @@ import { Type } from "@sinclair/typebox";
 import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-metadata.js";
 import {
   type InboxMessage,
-  type AgentDisplayInfo,
   type ConfirmationRequest,
   type ThreadConfirmationState,
   type RalphLoopAgentWorkload,
@@ -26,12 +25,9 @@ import {
   reloadPinetRuntimeSafely,
   type PinetControlCommand,
   type PinetRemoteControlState,
-  formatAgentList,
   callSlackAPI,
   createAbortableOperationTracker,
-  buildAgentDisplayInfo,
   filterAgentsForMeshVisibility,
-  rankAgentsForRouting,
   evaluateRalphLoopCycle,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
   DEFAULT_CONFIRMATION_REQUEST_TTL_MS,
@@ -89,6 +85,7 @@ import {
 } from "./broker/agent-messaging.js";
 import { registerSlackTools } from "./slack-tools.js";
 import { registerPinetCommands } from "./pinet-commands.js";
+import { registerPinetTools } from "./pinet-tools.js";
 import {
   createIMessageAdapter,
   detectIMessageMvpEnvironment,
@@ -127,7 +124,6 @@ import {
   type ResolvedTaskAssignment,
 } from "./task-assignments.js";
 import { SlackActivityLogger, type ActivityLogTone } from "./activity-log.js";
-import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import {
   createBrokerDeliveryState,
   getBrokerInboxIds,
@@ -1698,6 +1694,119 @@ export default function (pi: ExtensionAPI) {
     throw new Error("Pinet is in an unexpected state.");
   }
 
+  function sendPinetBroadcastMessage(
+    channel: string,
+    body: string,
+  ): { channel: string; messageIds: number[]; recipients: string[] } {
+    const db = getActiveBrokerDb();
+    const selfId = getActiveBrokerSelfId();
+    if (!db || !selfId) {
+      throw new Error("Broker agent identity is unavailable.");
+    }
+
+    const outgoing = prepareOutgoingPinetAgentMessage(body);
+    const result = dispatchBroadcastAgentMessage(db, {
+      senderAgentId: selfId,
+      senderAgentName: agentName,
+      channel,
+      body: outgoing.body,
+      ...(outgoing.metadata ? { metadata: outgoing.metadata } : {}),
+    });
+
+    return {
+      channel: result.channel,
+      messageIds: result.messageIds,
+      recipients: result.targets.map((target) => target.name),
+    };
+  }
+
+  async function scheduleBrokerWakeup(
+    fireAt: string,
+    message: string,
+  ): Promise<{ id: number; fireAt: string }> {
+    const db = getActiveBrokerDb();
+    const selfId = getActiveBrokerSelfId();
+    if (!db || !selfId) {
+      throw new Error("Broker agent identity is unavailable.");
+    }
+
+    return db.scheduleWakeup(selfId, message, fireAt);
+  }
+
+  async function scheduleFollowerWakeup(
+    fireAt: string,
+    message: string,
+  ): Promise<{ id: number; fireAt: string }> {
+    if (!brokerClient) {
+      throw new Error("Pinet is in an unexpected state.");
+    }
+
+    return (brokerClient.client as BrokerClient).scheduleWakeup(fireAt, message);
+  }
+
+  function listBrokerAgents(): Array<{
+    emoji: string;
+    name: string;
+    id: string;
+    pid?: number;
+    status: "working" | "idle";
+    metadata: Record<string, unknown> | null;
+    lastHeartbeat: string;
+    lastSeen?: string;
+    disconnectedAt?: string | null;
+    resumableUntil?: string | null;
+  }> {
+    const db = getActiveBrokerDb();
+    if (!db) {
+      throw new Error("Broker agent identity is unavailable.");
+    }
+
+    return db.getAllAgents().map((agent) => ({
+      emoji: agent.emoji,
+      name: agent.name,
+      id: agent.id,
+      pid: agent.pid,
+      status: agent.status,
+      metadata: agent.metadata,
+      lastHeartbeat: agent.lastHeartbeat,
+      lastSeen: agent.lastSeen,
+      disconnectedAt: agent.disconnectedAt,
+      resumableUntil: agent.resumableUntil,
+    }));
+  }
+
+  async function listFollowerAgents(includeGhosts: boolean): Promise<
+    Array<{
+      emoji: string;
+      name: string;
+      id: string;
+      pid?: number;
+      status: "working" | "idle";
+      metadata: Record<string, unknown> | null;
+      lastHeartbeat: string;
+      lastSeen?: string;
+      disconnectedAt?: string | null;
+      resumableUntil?: string | null;
+    }>
+  > {
+    if (!brokerClient) {
+      throw new Error("Pinet is in an unexpected state.");
+    }
+
+    return (await brokerClient.client.listAgents(includeGhosts)).map((agent) => ({
+      emoji: agent.emoji,
+      name: agent.name,
+      id: agent.id,
+      pid: agent.pid,
+      status: agent.status ?? "idle",
+      metadata: agent.metadata,
+      lastHeartbeat: agent.lastHeartbeat,
+      lastSeen: agent.lastSeen,
+      disconnectedAt: agent.disconnectedAt,
+      resumableUntil: agent.resumableUntil,
+    }));
+  }
+
   function applyMeshSkin(themeInput: string): { theme: string; updatedAgents: string[] } {
     const db = getActiveBrokerDb();
     const selfId = getActiveBrokerSelfId();
@@ -1976,315 +2085,17 @@ export default function (pi: ExtensionAPI) {
     return queued;
   }
 
-  pi.registerTool({
-    name: "pinet_message",
-    label: "Pinet Message",
-    description:
-      "Send a message to another connected Pinet agent, or from the broker to a broadcast channel.",
-    promptSnippet:
-      "Send a message to another connected Pinet agent. When you send a task, sepcify the desired workflow, ideally something like `ack/work/ask/report`: ACK briefly, do the work, report blockers or questions immediately, report the outcome when done. Always reply where the task came from. To trigger remote agent control, send the exact message `/reload` or `/exit`. Broadcast channels like `#all` or `#extensions` are broker-only.",
-    parameters: Type.Object({
-      to: Type.String({
-        description:
-          "Target agent name/ID, or a broker-only broadcast channel like #all or #extensions",
-      }),
-      message: Type.String({ description: "Message body" }),
-    }),
-    async execute(_id, params) {
-      requireToolPolicy("pinet_message", undefined, `to=${params.to} | message=${params.message}`);
-
-      if (brokerRole === "broker" && isBroadcastChannelTarget(params.to)) {
-        const db = getActiveBrokerDb();
-        const selfId = getActiveBrokerSelfId();
-        if (!db || !selfId) {
-          throw new Error("Broker agent identity is unavailable.");
-        }
-
-        const outgoing = prepareOutgoingPinetAgentMessage(params.message);
-        const result = dispatchBroadcastAgentMessage(db, {
-          senderAgentId: selfId,
-          senderAgentName: agentName,
-          channel: params.to,
-          body: outgoing.body,
-          ...(outgoing.metadata ? { metadata: outgoing.metadata } : {}),
-        });
-        const recipients = result.targets.map((target) => target.name);
-        const preview = recipients.slice(0, 5).join(", ");
-        const suffix = recipients.length > 5 ? ", …" : "";
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Broadcast sent to ${result.channel} (${result.targets.length} agents: ${preview}${suffix}).`,
-            },
-          ],
-          details: {
-            channel: result.channel,
-            messageIds: result.messageIds,
-            recipients,
-          },
-        };
-      }
-
-      const result = await sendPinetAgentMessage(params.to, params.message);
-      return {
-        content: [
-          { type: "text", text: `Message sent to ${result.target} (id: ${result.messageId}).` },
-        ],
-        details: { messageId: result.messageId, target: result.target },
-      };
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_free",
-    label: "Pinet Free",
-    description: "Signal that this Pinet agent is idle/free and available for new work.",
-    promptSnippet:
-      "When you have finished all assigned work and already reported the outcome, call this to mark yourself idle/free for new assignments.",
-    parameters: Type.Object({
-      note: Type.Optional(
-        Type.String({ description: "Optional short note about what you just finished" }),
-      ),
-    }),
-    async execute(_id, params) {
-      requireToolPolicy("pinet_free", undefined, `note=${params.note ?? ""}`);
-
-      const note = typeof params.note === "string" ? params.note.trim() : "";
-      const result = await signalAgentFree(undefined, { requirePinet: true });
-      const inboxSuffix =
-        result.queuedInboxCount > 0
-          ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`
-          : "";
-      const noteSuffix = note ? ` Note: ${note}.` : "";
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Marked this Pinet agent idle/free for new work.${noteSuffix}${inboxSuffix}`,
-          },
-        ],
-        details: {
-          status: "idle",
-          note: note || null,
-          queuedInboxCount: result.queuedInboxCount,
-        },
-      };
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_schedule",
-    label: "Pinet Schedule",
-    description: "Schedule a future wake-up message for the current Pinet agent.",
-    promptSnippet:
-      "Schedule a future wake-up for yourself via the Pinet broker. Use this instead of busy-waiting when you need to check back later.",
-    parameters: Type.Object({
-      delay: Type.Optional(
-        Type.String({ description: "Relative delay like 5m, 30s, 1h30m, or 1d" }),
-      ),
-      at: Type.Optional(
-        Type.String({ description: "Absolute ISO-8601 UTC time, e.g. 2026-04-02T14:30:00Z" }),
-      ),
-      message: Type.String({ description: "Reminder or wake-up message to deliver later" }),
-    }),
-    async execute(_id, params) {
-      requireToolPolicy(
-        "pinet_schedule",
-        undefined,
-        `delay=${params.delay ?? ""} | at=${params.at ?? ""} | message=${params.message}`,
-      );
-
-      if (!pinetEnabled) {
-        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
-      }
-
-      const message = params.message.trim();
-      if (!message) {
-        throw new Error("message is required");
-      }
-
-      const fireAt = resolveScheduledWakeupFireAt({ delay: params.delay, at: params.at });
-
-      if (brokerRole === "broker") {
-        const db = getActiveBrokerDb();
-        const selfId = getActiveBrokerSelfId();
-        if (!db || !selfId) {
-          throw new Error("Broker agent identity is unavailable.");
-        }
-        const wakeup = db.scheduleWakeup(selfId, message, fireAt);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
-            },
-          ],
-          details: wakeup,
-        };
-      }
-
-      if (brokerRole === "follower" && brokerClient) {
-        const wakeup = await (brokerClient.client as BrokerClient).scheduleWakeup(fireAt, message);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
-            },
-          ],
-          details: wakeup,
-        };
-      }
-
-      throw new Error("Pinet is in an unexpected state.");
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_agents",
-    label: "Pinet Agents",
-    description: "List Pinet agents, including liveness and capability visibility.",
-    promptSnippet:
-      "List connected Pinet agents with liveness and capability info. Use before delegating work to find available agents, or to check health and status of agents you have assigned work to.",
-    parameters: Type.Object({
-      repo: Type.Optional(Type.String({ description: "Preferred repo name for routing" })),
-      branch: Type.Optional(Type.String({ description: "Preferred branch for routing" })),
-      role: Type.Optional(
-        Type.String({ description: "Preferred agent role, e.g. broker or worker" }),
-      ),
-      required_tools: Type.Optional(
-        Type.String({ description: "Comma-separated required capability/tool tags" }),
-      ),
-      task: Type.Optional(Type.String({ description: "Optional natural-language task hint" })),
-    }),
-    async execute(_toolCallId, params) {
-      requireToolPolicy(
-        "pinet_agents",
-        undefined,
-        `repo=${params.repo ?? ""} | branch=${params.branch ?? ""} | role=${params.role ?? ""} | required_tools=${params.required_tools ?? ""} | task=${params.task ?? ""}`,
-      );
-
-      if (!pinetEnabled) {
-        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
-      }
-
-      const includeGhosts = true;
-      const recentGhostWindowMs = DEFAULT_HEARTBEAT_TIMEOUT_MS * 2;
-      const nowMs = Date.now();
-
-      const toDisplay = (agent: {
-        emoji: string;
-        name: string;
-        id: string;
-        pid?: number;
-        status: "working" | "idle";
-        metadata: Record<string, unknown> | null;
-        lastHeartbeat: string;
-        lastSeen?: string;
-        disconnectedAt?: string | null;
-        resumableUntil?: string | null;
-      }): AgentDisplayInfo =>
-        buildAgentDisplayInfo(agent, {
-          now: nowMs,
-          heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
-          heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
-        });
-
-      let rawAgents: Array<{
-        emoji: string;
-        name: string;
-        id: string;
-        pid?: number;
-        status: "working" | "idle";
-        metadata: Record<string, unknown> | null;
-        lastHeartbeat: string;
-        lastSeen?: string;
-        disconnectedAt?: string | null;
-        resumableUntil?: string | null;
-      }>;
-      if (brokerRole === "broker") {
-        const db = getActiveBrokerDb();
-        if (!db) {
-          throw new Error("Broker agent identity is unavailable.");
-        }
-        rawAgents = filterAgentsForMeshVisibility(db.getAllAgents(), {
-          now: nowMs,
-          includeGhosts,
-          recentDisconnectWindowMs: recentGhostWindowMs,
-        }).map((agent) => ({
-          emoji: agent.emoji,
-          name: agent.name,
-          id: agent.id,
-          pid: agent.pid,
-          status: agent.status,
-          metadata: agent.metadata,
-          lastHeartbeat: agent.lastHeartbeat,
-          lastSeen: agent.lastSeen,
-          disconnectedAt: agent.disconnectedAt,
-          resumableUntil: agent.resumableUntil,
-        }));
-      } else if (brokerRole === "follower" && brokerClient) {
-        rawAgents = filterAgentsForMeshVisibility(
-          await brokerClient.client.listAgents(includeGhosts),
-          {
-            now: nowMs,
-            includeGhosts,
-            recentDisconnectWindowMs: recentGhostWindowMs,
-          },
-        ).map((agent) => ({
-          emoji: agent.emoji,
-          name: agent.name,
-          id: agent.id,
-          pid: agent.pid,
-          status: agent.status ?? "idle",
-          metadata: agent.metadata,
-          lastHeartbeat: agent.lastHeartbeat,
-          lastSeen: agent.lastSeen,
-          disconnectedAt: agent.disconnectedAt,
-          resumableUntil: agent.resumableUntil,
-        }));
-      } else {
-        throw new Error("Pinet is in an unexpected state.");
-      }
-
-      const visibleAgents = rawAgents.map(toDisplay);
-      const hint = {
-        repo: params.repo,
-        branch: params.branch,
-        role: params.role,
-        requiredTools: params.required_tools
-          ?.split(",")
-          .map((tool: string) => tool.trim())
-          .filter(Boolean),
-        task: params.task,
-      };
-      const hasHint = Boolean(
-        hint.repo || hint.branch || hint.role || (hint.requiredTools?.length ?? 0) > 0 || hint.task,
-      );
-      const agents = rankAgentsForRouting(visibleAgents, hint);
-
-      const header = hasHint
-        ? `Agent routing hints: ${[
-            hint.repo ? `repo=${hint.repo}` : null,
-            hint.branch ? `branch=${hint.branch}` : null,
-            hint.role ? `role=${hint.role}` : null,
-            hint.requiredTools && hint.requiredTools.length > 0
-              ? `tools=${hint.requiredTools.join(",")}`
-              : null,
-            hint.task ? `task=${hint.task}` : null,
-          ]
-            .filter((item): item is string => Boolean(item))
-            .join(" · ")}\n\n`
-        : "";
-      const text = `${header}${formatAgentList(agents, os.homedir())}`;
-      return {
-        content: [{ type: "text", text }],
-        details: { agents, hint },
-      };
-    },
+  registerPinetTools(pi, {
+    pinetEnabled: () => pinetEnabled,
+    brokerRole: () => brokerRole,
+    requireToolPolicy,
+    sendPinetAgentMessage,
+    sendPinetBroadcastMessage,
+    signalAgentFree,
+    scheduleBrokerWakeup,
+    scheduleFollowerWakeup,
+    listBrokerAgents,
+    listFollowerAgents,
   });
 
   pi.registerTool({

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  registerPinetTools,
+  type PinetToolsAgentRecord,
+  type RegisterPinetToolsDeps,
+} from "./pinet-tools.js";
+
+type ToolDefinition = {
+  name: string;
+  execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+function makeAgent(overrides: Partial<PinetToolsAgentRecord> = {}): PinetToolsAgentRecord {
+  return {
+    emoji: "🐇",
+    name: "Golden Chalk Rabbit",
+    id: "agent-1",
+    pid: 101,
+    status: "idle",
+    metadata: { repo: "extensions", tools: ["read", "edit"] },
+    lastHeartbeat: new Date(Date.now() - 1_000).toISOString(),
+    lastSeen: new Date(Date.now() - 500).toISOString(),
+    disconnectedAt: null,
+    resumableUntil: null,
+    ...overrides,
+  };
+}
+
+function createDeps(overrides: Partial<RegisterPinetToolsDeps> = {}): RegisterPinetToolsDeps {
+  const defaults: RegisterPinetToolsDeps = {
+    pinetEnabled: () => true,
+    brokerRole: () => "broker",
+    requireToolPolicy: () => {},
+    sendPinetAgentMessage: async (target, _body) => ({ messageId: 17, target }),
+    sendPinetBroadcastMessage: (channel) => ({
+      channel,
+      messageIds: [11, 12],
+      recipients: ["Worker One", "Worker Two"],
+    }),
+    signalAgentFree: async (_ctx: ExtensionContext | undefined, _options) => ({
+      queuedInboxCount: 0,
+      drainedQueuedInbox: false,
+    }),
+    scheduleBrokerWakeup: async (fireAt: string, _message: string) => ({ id: 7, fireAt }),
+    scheduleFollowerWakeup: async (fireAt: string, _message: string) => ({ id: 9, fireAt }),
+    listBrokerAgents: () => [makeAgent()],
+    listFollowerAgents: async (_includeGhosts: boolean) => [makeAgent({ id: "agent-2" })],
+  };
+
+  return { ...defaults, ...overrides };
+}
+
+function registerWithDeps(deps: RegisterPinetToolsDeps): Map<string, ToolDefinition> {
+  const tools = new Map<string, ToolDefinition>();
+  const pi = {
+    registerTool: vi.fn((definition: ToolDefinition) => {
+      tools.set(definition.name, definition);
+    }),
+  } as unknown as ExtensionAPI;
+
+  registerPinetTools(pi, deps);
+  return tools;
+}
+
+describe("registerPinetTools", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("registers the four generic Pinet tools", () => {
+    const tools = registerWithDeps(createDeps());
+
+    expect([...tools.keys()]).toEqual([
+      "pinet_message",
+      "pinet_free",
+      "pinet_schedule",
+      "pinet_agents",
+    ]);
+  });
+
+  it("uses the broker broadcast path for broadcast pinet_message targets", async () => {
+    const sendPinetBroadcastMessage = vi.fn((channel: string, _body: string) => ({
+      channel,
+      messageIds: [21, 22],
+      recipients: ["Worker One", "Worker Two"],
+    }));
+    const deps = createDeps({ sendPinetBroadcastMessage });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet_message")?.execute("tool-call-1", {
+      to: "#extensions",
+      message: "hello mesh",
+    })) as {
+      content: Array<{ text: string }>;
+      details: { channel: string; messageIds: number[]; recipients: string[] };
+    };
+
+    expect(sendPinetBroadcastMessage).toHaveBeenCalledWith("#extensions", "hello mesh");
+    expect(result.content[0]?.text).toBe(
+      "Broadcast sent to #extensions (2 agents: Worker One, Worker Two).",
+    );
+    expect(result.details).toEqual({
+      channel: "#extensions",
+      messageIds: [21, 22],
+      recipients: ["Worker One", "Worker Two"],
+    });
+  });
+
+  it("formats pinet_free responses with note and queued inbox count", async () => {
+    const signalAgentFree = vi.fn(async () => ({
+      queuedInboxCount: 2,
+      drainedQueuedInbox: false,
+    }));
+    const deps = createDeps({ signalAgentFree });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet_free")?.execute("tool-call-2", {
+      note: "wrapped up #395",
+    })) as {
+      content: Array<{ text: string }>;
+      details: { status: string; note: string | null; queuedInboxCount: number };
+    };
+
+    expect(signalAgentFree).toHaveBeenCalledWith(undefined, { requirePinet: true });
+    expect(result.content[0]?.text).toBe(
+      "Marked this Pinet agent idle/free for new work. Note: wrapped up #395. 2 queued inbox items remain.",
+    );
+    expect(result.details).toEqual({
+      status: "idle",
+      note: "wrapped up #395",
+      queuedInboxCount: 2,
+    });
+  });
+
+  it("routes pinet_schedule through the broker wake-up callback", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
+
+    const scheduleBrokerWakeup = vi.fn(async (fireAt: string, _message: string) => ({
+      id: 7,
+      fireAt,
+    }));
+    const deps = createDeps({ scheduleBrokerWakeup });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet_schedule")?.execute("tool-call-3", {
+      delay: "5m",
+      message: "check queue",
+    })) as {
+      content: Array<{ text: string }>;
+      details: { id: number; fireAt: string };
+    };
+
+    expect(scheduleBrokerWakeup).toHaveBeenCalledWith("2026-04-14T12:05:00.000Z", "check queue");
+    expect(result.content[0]?.text).toBe("Wake-up scheduled for 2026-04-14T12:05:00.000Z (id: 7).");
+    expect(result.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
+  });
+
+  it("renders broker pinet_agents output with routing hints", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
+
+    const listBrokerAgents = vi.fn(() => [makeAgent()]);
+    const deps = createDeps({ listBrokerAgents });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet_agents")?.execute("tool-call-4", {
+      repo: "extensions",
+      required_tools: "read, edit",
+      task: "review #395",
+    })) as {
+      content: Array<{ text: string }>;
+      details: { hint: { repo?: string; requiredTools?: string[]; task?: string } };
+    };
+
+    expect(listBrokerAgents).toHaveBeenCalledTimes(1);
+    expect(result.content[0]?.text).toContain(
+      "Agent routing hints: repo=extensions · tools=read,edit · task=review #395",
+    );
+    expect(result.content[0]?.text).toContain("Golden Chalk Rabbit");
+    expect(result.details.hint).toEqual({
+      repo: "extensions",
+      branch: undefined,
+      role: undefined,
+      requiredTools: ["read", "edit"],
+      task: "review #395",
+    });
+  });
+});

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -1,0 +1,312 @@
+import os from "node:os";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import {
+  buildAgentDisplayInfo,
+  filterAgentsForMeshVisibility,
+  formatAgentList,
+  rankAgentsForRouting,
+  type AgentDisplayInfo,
+} from "./helpers.js";
+import { isBroadcastChannelTarget } from "./broker/agent-messaging.js";
+import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
+import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
+
+export interface PinetToolsAgentRecord {
+  emoji: string;
+  name: string;
+  id: string;
+  pid?: number;
+  status: "working" | "idle";
+  metadata: Record<string, unknown> | null;
+  lastHeartbeat: string;
+  lastSeen?: string;
+  disconnectedAt?: string | null;
+  resumableUntil?: string | null;
+}
+
+export interface RegisterPinetToolsDeps {
+  pinetEnabled: () => boolean;
+  brokerRole: () => "broker" | "follower" | null;
+  requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
+  sendPinetAgentMessage: (
+    target: string,
+    body: string,
+  ) => Promise<{ messageId: number; target: string }>;
+  sendPinetBroadcastMessage: (
+    channel: string,
+    body: string,
+  ) => {
+    channel: string;
+    messageIds: number[];
+    recipients: string[];
+  };
+  signalAgentFree: (
+    ctx: ExtensionContext | undefined,
+    options: { requirePinet?: boolean },
+  ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
+  scheduleBrokerWakeup: (
+    fireAt: string,
+    message: string,
+  ) => Promise<{ id: number; fireAt: string }>;
+  scheduleFollowerWakeup: (
+    fireAt: string,
+    message: string,
+  ) => Promise<{ id: number; fireAt: string }>;
+  listBrokerAgents: () => PinetToolsAgentRecord[];
+  listFollowerAgents: (includeGhosts: boolean) => Promise<PinetToolsAgentRecord[]>;
+}
+
+interface PinetAgentsRoutingHint {
+  repo?: string;
+  branch?: string;
+  role?: string;
+  requiredTools?: string[];
+  task?: string;
+}
+
+function buildPinetAgentsHintText(hint: PinetAgentsRoutingHint): string {
+  return `Agent routing hints: ${[
+    hint.repo ? `repo=${hint.repo}` : null,
+    hint.branch ? `branch=${hint.branch}` : null,
+    hint.role ? `role=${hint.role}` : null,
+    hint.requiredTools && hint.requiredTools.length > 0
+      ? `tools=${hint.requiredTools.join(",")}`
+      : null,
+    hint.task ? `task=${hint.task}` : null,
+  ]
+    .filter((item): item is string => Boolean(item))
+    .join(" · ")}`;
+}
+
+export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDeps): void {
+  pi.registerTool({
+    name: "pinet_message",
+    label: "Pinet Message",
+    description:
+      "Send a message to another connected Pinet agent, or from the broker to a broadcast channel.",
+    promptSnippet:
+      "Send a message to another connected Pinet agent. When you send a task, sepcify the desired workflow, ideally something like `ack/work/ask/report`: ACK briefly, do the work, report blockers or questions immediately, report the outcome when done. Always reply where the task came from. To trigger remote agent control, send the exact message `/reload` or `/exit`. Broadcast channels like `#all` or `#extensions` are broker-only.",
+    parameters: Type.Object({
+      to: Type.String({
+        description:
+          "Target agent name/ID, or a broker-only broadcast channel like #all or #extensions",
+      }),
+      message: Type.String({ description: "Message body" }),
+    }),
+    async execute(_id, params) {
+      deps.requireToolPolicy(
+        "pinet_message",
+        undefined,
+        `to=${params.to} | message=${params.message}`,
+      );
+
+      if (deps.brokerRole() === "broker" && isBroadcastChannelTarget(params.to)) {
+        const result = deps.sendPinetBroadcastMessage(params.to, params.message);
+        const preview = result.recipients.slice(0, 5).join(", ");
+        const suffix = result.recipients.length > 5 ? ", …" : "";
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Broadcast sent to ${result.channel} (${result.recipients.length} agents: ${preview}${suffix}).`,
+            },
+          ],
+          details: {
+            channel: result.channel,
+            messageIds: result.messageIds,
+            recipients: result.recipients,
+          },
+        };
+      }
+
+      const result = await deps.sendPinetAgentMessage(params.to, params.message);
+      return {
+        content: [
+          { type: "text", text: `Message sent to ${result.target} (id: ${result.messageId}).` },
+        ],
+        details: { messageId: result.messageId, target: result.target },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "pinet_free",
+    label: "Pinet Free",
+    description: "Signal that this Pinet agent is idle/free and available for new work.",
+    promptSnippet:
+      "When you have finished all assigned work and already reported the outcome, call this to mark yourself idle/free for new assignments.",
+    parameters: Type.Object({
+      note: Type.Optional(
+        Type.String({ description: "Optional short note about what you just finished" }),
+      ),
+    }),
+    async execute(_id, params) {
+      deps.requireToolPolicy("pinet_free", undefined, `note=${params.note ?? ""}`);
+
+      const note = typeof params.note === "string" ? params.note.trim() : "";
+      const result = await deps.signalAgentFree(undefined, { requirePinet: true });
+      const inboxSuffix =
+        result.queuedInboxCount > 0
+          ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`
+          : "";
+      const noteSuffix = note ? ` Note: ${note}.` : "";
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Marked this Pinet agent idle/free for new work.${noteSuffix}${inboxSuffix}`,
+          },
+        ],
+        details: {
+          status: "idle",
+          note: note || null,
+          queuedInboxCount: result.queuedInboxCount,
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "pinet_schedule",
+    label: "Pinet Schedule",
+    description: "Schedule a future wake-up message for the current Pinet agent.",
+    promptSnippet:
+      "Schedule a future wake-up for yourself via the Pinet broker. Use this instead of busy-waiting when you need to check back later.",
+    parameters: Type.Object({
+      delay: Type.Optional(
+        Type.String({ description: "Relative delay like 5m, 30s, 1h30m, or 1d" }),
+      ),
+      at: Type.Optional(
+        Type.String({ description: "Absolute ISO-8601 UTC time, e.g. 2026-04-02T14:30:00Z" }),
+      ),
+      message: Type.String({ description: "Reminder or wake-up message to deliver later" }),
+    }),
+    async execute(_id, params) {
+      deps.requireToolPolicy(
+        "pinet_schedule",
+        undefined,
+        `delay=${params.delay ?? ""} | at=${params.at ?? ""} | message=${params.message}`,
+      );
+
+      if (!deps.pinetEnabled()) {
+        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      }
+
+      const message = params.message.trim();
+      if (!message) {
+        throw new Error("message is required");
+      }
+
+      const fireAt = resolveScheduledWakeupFireAt({ delay: params.delay, at: params.at });
+
+      if (deps.brokerRole() === "broker") {
+        const wakeup = await deps.scheduleBrokerWakeup(fireAt, message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
+            },
+          ],
+          details: wakeup,
+        };
+      }
+
+      if (deps.brokerRole() === "follower") {
+        const wakeup = await deps.scheduleFollowerWakeup(fireAt, message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
+            },
+          ],
+          details: wakeup,
+        };
+      }
+
+      throw new Error("Pinet is in an unexpected state.");
+    },
+  });
+
+  pi.registerTool({
+    name: "pinet_agents",
+    label: "Pinet Agents",
+    description: "List Pinet agents, including liveness and capability visibility.",
+    promptSnippet:
+      "List connected Pinet agents with liveness and capability info. Use before delegating work to find available agents, or to check health and status of agents you have assigned work to.",
+    parameters: Type.Object({
+      repo: Type.Optional(Type.String({ description: "Preferred repo name for routing" })),
+      branch: Type.Optional(Type.String({ description: "Preferred branch for routing" })),
+      role: Type.Optional(
+        Type.String({ description: "Preferred agent role, e.g. broker or worker" }),
+      ),
+      required_tools: Type.Optional(
+        Type.String({ description: "Comma-separated required capability/tool tags" }),
+      ),
+      task: Type.Optional(Type.String({ description: "Optional natural-language task hint" })),
+    }),
+    async execute(_toolCallId, params) {
+      deps.requireToolPolicy(
+        "pinet_agents",
+        undefined,
+        `repo=${params.repo ?? ""} | branch=${params.branch ?? ""} | role=${params.role ?? ""} | required_tools=${params.required_tools ?? ""} | task=${params.task ?? ""}`,
+      );
+
+      if (!deps.pinetEnabled()) {
+        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      }
+
+      const includeGhosts = true;
+      const recentGhostWindowMs = DEFAULT_HEARTBEAT_TIMEOUT_MS * 2;
+      const nowMs = Date.now();
+      const hint: PinetAgentsRoutingHint = {
+        repo: params.repo,
+        branch: params.branch,
+        role: params.role,
+        requiredTools: params.required_tools
+          ?.split(",")
+          .map((tool: string) => tool.trim())
+          .filter(Boolean),
+        task: params.task,
+      };
+      const hasHint = Boolean(
+        hint.repo || hint.branch || hint.role || (hint.requiredTools?.length ?? 0) > 0 || hint.task,
+      );
+
+      const toDisplay = (agent: PinetToolsAgentRecord): AgentDisplayInfo =>
+        buildAgentDisplayInfo(agent, {
+          now: nowMs,
+          heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
+          heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+        });
+
+      let rawAgents: PinetToolsAgentRecord[];
+      if (deps.brokerRole() === "broker") {
+        rawAgents = deps.listBrokerAgents();
+      } else if (deps.brokerRole() === "follower") {
+        rawAgents = await deps.listFollowerAgents(includeGhosts);
+      } else {
+        throw new Error("Pinet is in an unexpected state.");
+      }
+
+      const visibleAgents = filterAgentsForMeshVisibility(rawAgents, {
+        now: nowMs,
+        includeGhosts,
+        recentDisconnectWindowMs: recentGhostWindowMs,
+      }).map(toDisplay);
+      const agents = rankAgentsForRouting(visibleAgents, hint);
+      const header = hasHint ? `${buildPinetAgentsHintText(hint)}\n\n` : "";
+      const text = `${header}${formatAgentList(agents, os.homedir())}`;
+
+      return {
+        content: [{ type: "text", text }],
+        details: { agents, hint },
+      };
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- extract the generic Pinet tool registration cluster into `slack-bridge/pinet-tools.ts`
- keep `slack-bridge/index.ts` delegating through existing callbacks/deps without reopening runtime ownership
- add focused `pinet-tools.test.ts` coverage for the moved tool surface

## Scope
- moves only:
  - `pinet_message`
  - `pinet_free`
  - `pinet_schedule`
  - `pinet_agents`
- leaves `imessage_send`, runtime-mode selection, session bootstrap/reload flow, and broker/follower/single ownership untouched

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm prepush`
