### PR TITLE
refactor: extract imessage_send tool registration (#397)

### DIFF
--- a/slack-bridge/imessage-tools.test.ts
+++ b/slack-bridge/imessage-tools.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Broker } from "./broker/index.js";
+import {
+  registerIMessageTools,
+  type IMessageToolSendInput,
+  type RegisterIMessageToolsDeps,
+} from "./imessage-tools.js";
+
+type ToolResponse = {
+  content?: Array<{ type: string; text: string }>;
+  details?: Record<string, unknown>;
+};
+
+type ToolDefinition = {
+  name: string;
+  execute: (id: string, params: Record<string, unknown>) => Promise<ToolResponse>;
+};
+
+function createBrokerStub() {
+  const now = "2026-04-14T12:00:00.000Z";
+  let thread: {
+    threadId: string;
+    source: string;
+    channel: string;
+    ownerAgent: string | null;
+    createdAt: string;
+    updatedAt: string;
+  } | null = null;
+  const adapterSend = vi.fn(async () => undefined);
+  const db = {
+    getThread: vi.fn((threadId: string) => (thread?.threadId === threadId ? thread : null)),
+    createThread: vi.fn(
+      (threadId: string, source: string, channel: string, ownerAgent: string | null) => {
+        thread = {
+          threadId,
+          source,
+          channel,
+          ownerAgent,
+          createdAt: now,
+          updatedAt: now,
+        };
+        return thread;
+      },
+    ),
+    updateThread: vi.fn(
+      (threadId: string, updates: Partial<{ source: string; channel: string }>) => {
+        if (thread?.threadId === threadId) {
+          thread = { ...thread, ...updates };
+        }
+      },
+    ),
+    insertMessage: vi.fn(
+      (
+        threadId: string,
+        source: string,
+        direction: "inbound" | "outbound",
+        sender: string,
+        body: string,
+        _targetAgentIds: string[],
+        metadata?: Record<string, unknown>,
+      ) => ({
+        id: 41,
+        threadId,
+        source,
+        direction,
+        sender,
+        body,
+        metadata: metadata ?? null,
+        createdAt: now,
+      }),
+    ),
+  };
+
+  const broker = {
+    db,
+    adapters: [{ name: "imessage", send: adapterSend }],
+  } as unknown as Broker;
+
+  return { broker, adapterSend };
+}
+
+function createDeps(overrides: Partial<RegisterIMessageToolsDeps> = {}): RegisterIMessageToolsDeps {
+  const { broker } = createBrokerStub();
+
+  return {
+    pinetEnabled: () => true,
+    brokerRole: () => "broker",
+    requireToolPolicy: () => {},
+    getActiveBroker: () => broker,
+    getActiveBrokerSelfId: () => "broker-self",
+    sendFollowerIMessage: async (_input: IMessageToolSendInput) => ({
+      adapter: "imessage",
+      messageId: 77,
+    }),
+    getAgentIdentity: () => ({
+      name: "Cobalt Olive Crane",
+      emoji: "🦩",
+      ownerToken: "owner-token",
+    }),
+    trackOwnedThread: () => {},
+    ...overrides,
+  };
+}
+
+function registerWithDeps(deps: RegisterIMessageToolsDeps): Map<string, ToolDefinition> {
+  const tools = new Map<string, ToolDefinition>();
+  const pi = {
+    registerTool: vi.fn((definition: ToolDefinition) => {
+      tools.set(definition.name, definition);
+    }),
+  } as unknown as ExtensionAPI;
+
+  registerIMessageTools(pi, deps);
+  return tools;
+}
+
+describe("registerIMessageTools", () => {
+  it("registers imessage_send", () => {
+    const tools = registerWithDeps(createDeps());
+
+    expect([...tools.keys()]).toEqual(["imessage_send"]);
+  });
+
+  it("sends through the active broker adapter and tracks the owned thread", async () => {
+    const { broker, adapterSend } = createBrokerStub();
+    const trackOwnedThread = vi.fn();
+    const deps = createDeps({
+      getActiveBroker: () => broker,
+      trackOwnedThread,
+    });
+    const tools = registerWithDeps(deps);
+
+    const result = await tools.get("imessage_send")?.execute("tool-call-1", {
+      to: "chat:alice",
+      text: "hello from pi",
+    });
+
+    expect(adapterSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "imessage:chat:alice",
+        channel: "chat:alice",
+        text: "hello from pi",
+      }),
+    );
+    expect(trackOwnedThread).toHaveBeenCalledWith("imessage:chat:alice", "chat:alice", "imessage");
+    expect(result).toMatchObject({
+      details: {
+        threadId: "imessage:chat:alice",
+        channel: "chat:alice",
+        source: "imessage",
+        adapter: "imessage",
+        messageId: 41,
+      },
+    });
+  });
+
+  it("routes follower sends through the follower callback", async () => {
+    const sendFollowerIMessage = vi.fn(async (_input: IMessageToolSendInput) => ({
+      adapter: "imessage",
+      messageId: 52,
+    }));
+    const trackOwnedThread = vi.fn();
+    const deps = createDeps({
+      brokerRole: () => "follower",
+      sendFollowerIMessage,
+      trackOwnedThread,
+    });
+    const tools = registerWithDeps(deps);
+
+    const result = await tools.get("imessage_send")?.execute("tool-call-2", {
+      to: "+15555550123",
+      text: "follower hello",
+      thread_id: "custom-thread",
+    });
+
+    expect(sendFollowerIMessage).toHaveBeenCalledWith({
+      threadId: "custom-thread",
+      body: "follower hello",
+      source: "imessage",
+      channel: "+15555550123",
+      agentName: "Cobalt Olive Crane",
+      agentEmoji: "🦩",
+      agentOwnerToken: "owner-token",
+      metadata: { recipient: "+15555550123" },
+    });
+    expect(trackOwnedThread).toHaveBeenCalledWith("custom-thread", "+15555550123", "imessage");
+    expect(result).toMatchObject({
+      details: {
+        threadId: "custom-thread",
+        channel: "+15555550123",
+        source: "imessage",
+        adapter: "imessage",
+        messageId: 52,
+      },
+    });
+  });
+
+  it("rejects empty text bodies", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    await expect(
+      tools.get("imessage_send")?.execute("tool-call-3", {
+        to: "chat:alice",
+        text: "   ",
+      }),
+    ).rejects.toThrow("text is required");
+  });
+});

--- a/slack-bridge/imessage-tools.ts
+++ b/slack-bridge/imessage-tools.ts
@@ -1,0 +1,149 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import {
+  getDefaultIMessageThreadId,
+  normalizeIMessageRecipient,
+} from "@gugu910/pi-imessage-bridge";
+import type { Broker } from "./broker/index.js";
+import { sendBrokerMessage } from "./broker/message-send.js";
+
+export interface IMessageToolSendInput {
+  threadId: string;
+  body: string;
+  source: "imessage";
+  channel: string;
+  agentName: string;
+  agentEmoji: string;
+  agentOwnerToken: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface IMessageToolSendResult {
+  adapter: string;
+  messageId: number;
+}
+
+export interface RegisterIMessageToolsDeps {
+  pinetEnabled: () => boolean;
+  brokerRole: () => "broker" | "follower" | null;
+  requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
+  getActiveBroker: () => Broker | null;
+  getActiveBrokerSelfId: () => string | null;
+  sendFollowerIMessage: (input: IMessageToolSendInput) => Promise<IMessageToolSendResult>;
+  getAgentIdentity: () => {
+    name: string;
+    emoji: string;
+    ownerToken: string;
+  };
+  trackOwnedThread: (threadId: string, channel: string, source: "imessage") => void;
+}
+
+export function registerIMessageTools(pi: ExtensionAPI, deps: RegisterIMessageToolsDeps): void {
+  pi.registerTool({
+    name: "imessage_send",
+    label: "iMessage Send",
+    description:
+      "Send a message through the local send-first iMessage adapter on the active broker.",
+    promptSnippet:
+      "Send a message through the local send-first iMessage adapter on the active Pinet broker. Use when a task needs a narrow macOS iMessage send path.",
+    parameters: Type.Object({
+      to: Type.String({
+        description: "Recipient handle, phone number, email, or local chat identifier",
+      }),
+      text: Type.String({ description: "Message body" }),
+      thread_id: Type.Optional(
+        Type.String({
+          description:
+            "Optional transport thread id. Defaults to a stable iMessage thread id derived from the recipient.",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      deps.requireToolPolicy(
+        "imessage_send",
+        undefined,
+        `to=${params.to} | thread_id=${params.thread_id ?? ""} | text=${params.text}`,
+      );
+
+      if (!deps.pinetEnabled()) {
+        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      }
+
+      const recipient = normalizeIMessageRecipient(params.to);
+      const text = params.text.trim();
+      if (!text) {
+        throw new Error("text is required");
+      }
+      const threadId = params.thread_id?.trim() || getDefaultIMessageThreadId(recipient);
+      const { name, emoji, ownerToken } = deps.getAgentIdentity();
+      const request: IMessageToolSendInput = {
+        threadId,
+        body: text,
+        source: "imessage",
+        channel: recipient,
+        agentName: name,
+        agentEmoji: emoji,
+        agentOwnerToken: ownerToken,
+        metadata: { recipient },
+      };
+
+      let result: IMessageToolSendResult;
+      if (deps.brokerRole() === "broker") {
+        const broker = deps.getActiveBroker();
+        const selfId = deps.getActiveBrokerSelfId();
+        if (!broker || !selfId) {
+          throw new Error("Broker agent identity is unavailable.");
+        }
+        if (!broker.adapters.some((candidate) => candidate.name === "imessage")) {
+          throw new Error(
+            "iMessage adapter is not enabled or not ready on the active broker. Set slack-bridge.imessage.enabled: true and restart /pinet-start.",
+          );
+        }
+
+        const brokerResult = await sendBrokerMessage(
+          {
+            db: broker.db,
+            adapters: broker.adapters,
+          },
+          {
+            threadId,
+            body: text,
+            senderAgentId: selfId,
+            source: request.source,
+            channel: request.channel,
+            agentName: request.agentName,
+            agentEmoji: request.agentEmoji,
+            agentOwnerToken: request.agentOwnerToken,
+            metadata: request.metadata,
+          },
+        );
+        result = {
+          adapter: brokerResult.adapter,
+          messageId: brokerResult.message.id,
+        };
+      } else if (deps.brokerRole() === "follower") {
+        result = await deps.sendFollowerIMessage(request);
+      } else {
+        throw new Error("Pinet is in an unexpected state.");
+      }
+
+      deps.trackOwnedThread(threadId, recipient, "imessage");
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Sent iMessage to ${recipient} (thread_id: ${threadId}).`,
+          },
+        ],
+        details: {
+          threadId,
+          channel: recipient,
+          source: "imessage",
+          adapter: result.adapter,
+          messageId: result.messageId,
+        },
+      };
+    },
+  });
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
 import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-metadata.js";
 import {
   type InboxMessage,
@@ -74,7 +73,6 @@ import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { buildReactionPromptGuidelines, resolveReactionCommands } from "./reaction-triggers.js";
 import type { Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
-import { sendBrokerMessage } from "./broker/message-send.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { type BrokerMaintenanceResult } from "./broker/maintenance.js";
 import { DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS, type BrokerClient } from "./broker/client.js";
@@ -86,12 +84,11 @@ import {
 import { registerSlackTools } from "./slack-tools.js";
 import { registerPinetCommands } from "./pinet-commands.js";
 import { registerPinetTools } from "./pinet-tools.js";
+import { registerIMessageTools } from "./imessage-tools.js";
 import {
   createIMessageAdapter,
   detectIMessageMvpEnvironment,
   formatIMessageMvpReadiness,
-  getDefaultIMessageThreadId,
-  normalizeIMessageRecipient,
 } from "@gugu910/pi-imessage-bridge";
 import {
   addSlackReaction,
@@ -2098,112 +2095,30 @@ export default function (pi: ExtensionAPI) {
     listFollowerAgents,
   });
 
-  pi.registerTool({
-    name: "imessage_send",
-    label: "iMessage Send",
-    description:
-      "Send a message through the local send-first iMessage adapter on the active broker.",
-    promptSnippet:
-      "Send a message through the local send-first iMessage adapter on the active Pinet broker. Use when a task needs a narrow macOS iMessage send path.",
-    parameters: Type.Object({
-      to: Type.String({
-        description: "Recipient handle, phone number, email, or local chat identifier",
-      }),
-      text: Type.String({ description: "Message body" }),
-      thread_id: Type.Optional(
-        Type.String({
-          description:
-            "Optional transport thread id. Defaults to a stable iMessage thread id derived from the recipient.",
-        }),
-      ),
-    }),
-    async execute(_id, params) {
-      requireToolPolicy(
-        "imessage_send",
-        undefined,
-        `to=${params.to} | thread_id=${params.thread_id ?? ""} | text=${params.text}`,
-      );
-
-      if (!pinetEnabled) {
-        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
-      }
-
-      const recipient = normalizeIMessageRecipient(params.to);
-      const text = params.text.trim();
-      if (!text) {
-        throw new Error("text is required");
-      }
-      const threadId = params.thread_id?.trim() || getDefaultIMessageThreadId(recipient);
-      const metadata = { recipient };
-
-      let adapter = "imessage";
-      let messageId: number | null = null;
-
-      if (brokerRole === "broker") {
-        const broker = getActiveBroker();
-        const selfId = getActiveBrokerSelfId();
-        if (!broker || !selfId) {
-          throw new Error("Broker agent identity is unavailable.");
-        }
-        if (!broker.adapters.some((candidate) => candidate.name === "imessage")) {
-          throw new Error(
-            "iMessage adapter is not enabled or not ready on the active broker. Set slack-bridge.imessage.enabled: true and restart /pinet-start.",
-          );
-        }
-
-        const result = await sendBrokerMessage(
-          {
-            db: broker.db,
-            adapters: broker.adapters,
-          },
-          {
-            threadId,
-            body: text,
-            senderAgentId: selfId,
-            source: "imessage",
-            channel: recipient,
-            agentName,
-            agentEmoji,
-            agentOwnerToken,
-            metadata,
-          },
-        );
-        adapter = result.adapter;
-        messageId = result.message.id;
-      } else if (brokerRole === "follower" && brokerClient?.client) {
-        const result = await brokerClient.client.sendMessage({
-          threadId,
-          body: text,
-          source: "imessage",
-          channel: recipient,
-          agentName,
-          agentEmoji,
-          agentOwnerToken,
-          metadata,
-        });
-        adapter = result.adapter;
-        messageId = result.messageId;
-      } else {
+  registerIMessageTools(pi, {
+    pinetEnabled: () => pinetEnabled,
+    brokerRole: () => brokerRole,
+    requireToolPolicy,
+    getActiveBroker,
+    getActiveBrokerSelfId,
+    sendFollowerIMessage: async (input) => {
+      if (!brokerClient?.client) {
         throw new Error("Pinet is in an unexpected state.");
       }
 
-      singlePlayerRuntime.trackOwnedThread(threadId, recipient, "imessage");
-
+      const result = await brokerClient.client.sendMessage(input);
       return {
-        content: [
-          {
-            type: "text",
-            text: `Sent iMessage to ${recipient} (thread_id: ${threadId}).`,
-          },
-        ],
-        details: {
-          threadId,
-          channel: recipient,
-          source: "imessage",
-          adapter,
-          messageId,
-        },
+        adapter: result.adapter,
+        messageId: result.messageId,
       };
+    },
+    getAgentIdentity: () => ({
+      name: agentName,
+      emoji: agentEmoji,
+      ownerToken: agentOwnerToken,
+    }),
+    trackOwnedThread: (threadId, channel, source) => {
+      singlePlayerRuntime.trackOwnedThread(threadId, channel, source);
     },
   });
 


### PR DESCRIPTION
## Summary
- move the `imessage_send` tool registration out of `slack-bridge/index.ts` into `slack-bridge/imessage-tools.ts`
- keep broker startup iMessage adapter wiring in `slack-bridge/index.ts` where it already lives
- add focused `imessage_send` tool tests alongside the new module

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test