### PR TITLE
refactor: extract slack runtime access helpers (#401)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -41,7 +41,6 @@ import {
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
   resolveAllowAllWorkspaceUsers,
-  resolveFollowerThreadChannel,
   normalizeOwnedThreads,
   trackBrokerInboundThread,
 } from "./helpers.js";
@@ -73,6 +72,7 @@ import { registerSlackTools } from "./slack-tools.js";
 import { registerPinetCommands } from "./pinet-commands.js";
 import { registerPinetTools } from "./pinet-tools.js";
 import { registerIMessageTools } from "./imessage-tools.js";
+import { createSlackRuntimeAccess } from "./slack-runtime-access.js";
 import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
 import {
   createIMessageAdapter,
@@ -80,14 +80,7 @@ import {
   formatIMessageMvpReadiness,
 } from "@gugu910/pi-imessage-bridge";
 import {
-  addSlackReaction,
-  clearSlackThreadStatus,
-  fetchSlackMessageByTs as fetchSlackMessageByTsFromSlack,
-  removeSlackReaction,
-  resolveSlackChannelId,
   resolveSlackThreadOwnerHint,
-  resolveSlackUserName,
-  setSlackSuggestedPrompts,
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
 } from "./slack-access.js";
@@ -599,49 +592,34 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Helpers ─────────────────────────────────────────
 
-  async function addReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    await addSlackReaction({
-      slack,
-      token: botToken!,
-      channel,
-      timestamp: ts,
-      emoji,
-    });
-  }
-
-  async function removeReaction(channel: string, ts: string, emoji: string): Promise<void> {
-    await removeSlackReaction({
-      slack,
-      token: botToken!,
-      channel,
-      timestamp: ts,
-      emoji,
-    });
-  }
-
-  async function resolveUser(userId: string): Promise<string> {
-    const hadCachedUser = userNames.get(userId) != null;
-    const name = await resolveSlackUserName({
-      slack,
-      token: botToken!,
-      userId,
-      cache: userNames,
-      shouldUseResult: () => !singlePlayerRuntime.isShuttingDown(),
-    });
-    if (!hadCachedUser && userNames.get(userId) != null) {
-      persistState();
-    }
-    return name;
-  }
-
-  async function resolveChannel(nameOrId: string): Promise<string> {
-    return resolveSlackChannelId({
-      slack,
-      token: botToken!,
-      nameOrId,
-      cache: channelCache,
-    });
-  }
+  let isSinglePlayerShuttingDown = () => false;
+  const slackRuntimeAccess = createSlackRuntimeAccess({
+    slack,
+    getBotToken: () => botToken!,
+    userNames,
+    channelCache,
+    persistState,
+    isSinglePlayerShuttingDown: () => isSinglePlayerShuttingDown(),
+    getSuggestedPrompts: () => settings.suggestedPrompts,
+    getAgentName: () => agentName,
+    getThreads: () => threads,
+    getBrokerRole: () => brokerRole,
+    resolveBrokerThreadChannel: (threadTs) =>
+      brokerRuntime.getBroker()?.db.getThread(threadTs)?.channel ?? null,
+    resolveFollowerThreadChannel: async (threadTs) =>
+      (await brokerClient?.client.resolveThread(threadTs)) ?? null,
+  });
+  const {
+    addReaction,
+    removeReaction,
+    resolveUser,
+    rememberChannel,
+    resolveChannel,
+    resolveFollowerReplyChannel,
+    clearThreadStatus,
+    setSuggestedPrompts,
+    fetchSlackMessageByTs,
+  } = slackRuntimeAccess;
 
   function formatTrackedAgent(agentId: string): string {
     const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
@@ -684,66 +662,6 @@ export default function (pi: ExtensionAPI) {
           tone: "info",
         };
     }
-  }
-
-  async function resolveFollowerReplyChannel(threadTs: string | undefined): Promise<string | null> {
-    if (!threadTs) return null;
-
-    const existingThread = threads.get(threadTs);
-    const brokerRef = brokerRole === "broker" ? brokerRuntime.getBroker() : null;
-    const followerClient = brokerRole === "follower" ? brokerClient?.client : null;
-    const resolveThread = brokerRef
-      ? async (nextThreadTs: string) => brokerRef.db.getThread(nextThreadTs)?.channel ?? null
-      : followerClient
-        ? (nextThreadTs: string) => followerClient.resolveThread(nextThreadTs)
-        : undefined;
-    const resolved = await resolveFollowerThreadChannel(threadTs, existingThread, resolveThread);
-
-    if (resolved.threadUpdate && resolved.changed) {
-      threads.set(threadTs, {
-        ...(existingThread ?? {}),
-        ...resolved.threadUpdate,
-      });
-      persistState();
-    }
-
-    return resolved.channelId;
-  }
-
-  async function clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
-    await clearSlackThreadStatus({
-      slack,
-      token: botToken!,
-      channelId,
-      threadTs,
-    });
-  }
-
-  async function setSuggestedPrompts(channelId: string, threadTs: string): Promise<void> {
-    const prompts = settings.suggestedPrompts ?? [
-      { title: "Status", message: `Hey ${agentName}, what are you working on right now?` },
-      { title: "Help", message: `${agentName}, I need help with something in the codebase` },
-      { title: "Review", message: `${agentName}, summarise the recent changes` },
-    ];
-    await setSlackSuggestedPrompts({
-      slack,
-      token: botToken!,
-      channelId,
-      threadTs,
-      prompts,
-    });
-  }
-
-  async function fetchSlackMessageByTs(
-    channel: string,
-    messageTs: string,
-  ): Promise<Record<string, unknown> | null> {
-    return fetchSlackMessageByTsFromSlack({
-      slack,
-      token: botToken!,
-      channel,
-      messageTs,
-    });
   }
 
   // ─── Socket Mode (native WebSocket) ─────────────────
@@ -794,6 +712,8 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
+  isSinglePlayerShuttingDown = () => singlePlayerRuntime.isShuttingDown();
+
   // ─── Reconnect / status ─────────────────────────────
 
   function setExtStatus(
@@ -838,9 +758,7 @@ export default function (pi: ExtensionAPI) {
     resolveUser,
     threadContext: singlePlayerRuntime.getThreadContextPort(),
     resolveChannel,
-    rememberChannel: (name, channelId) => {
-      channelCache.set(name, channelId);
-    },
+    rememberChannel,
     requireToolPolicy,
     getBotUserId: () => botUserId,
     registerConfirmationRequest,

--- a/slack-bridge/slack-runtime-access.test.ts
+++ b/slack-bridge/slack-runtime-access.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
+import { createSlackRuntimeAccess, type SlackRuntimeAccessDeps } from "./slack-runtime-access.js";
+import { TtlCache } from "./ttl-cache.js";
+
+function createDeps(overrides: Partial<SlackRuntimeAccessDeps> = {}) {
+  const threads = new Map<string, SinglePlayerThreadInfo>();
+  const userNames = new TtlCache<string, string>({ maxSize: 10, ttlMs: 60_000 });
+  const channelCache = new TtlCache<string, string>({ maxSize: 10, ttlMs: 60_000 });
+  const persistState = vi.fn();
+  const slack = vi.fn(async (method: string, _token: string, body?: Record<string, unknown>) => {
+    if (method === "users.info") {
+      return { ok: true, user: { real_name: "Sender" } };
+    }
+    if (method === "conversations.list") {
+      return {
+        ok: true,
+        channels: [{ id: "C_GENERAL", name: "general" }],
+        response_metadata: { next_cursor: "" },
+      };
+    }
+    if (method === "assistant.threads.setSuggestedPrompts") {
+      return { ok: true, body };
+    }
+    if (method === "conversations.history") {
+      return { ok: true, messages: [{ ts: body?.latest, text: "hello" }] };
+    }
+    if (
+      method === "reactions.add" ||
+      method === "reactions.remove" ||
+      method === "assistant.threads.setStatus"
+    ) {
+      return { ok: true };
+    }
+    return { ok: true };
+  });
+
+  const deps: SlackRuntimeAccessDeps = {
+    slack,
+    getBotToken: () => "xoxb-test",
+    userNames,
+    channelCache,
+    persistState,
+    isSinglePlayerShuttingDown: () => false,
+    getSuggestedPrompts: () => undefined,
+    getAgentName: () => "Cobalt Olive Crane",
+    getThreads: () => threads,
+    getBrokerRole: () => null,
+    ...overrides,
+  };
+
+  return { deps, threads, userNames, channelCache, persistState, slack };
+}
+
+describe("createSlackRuntimeAccess", () => {
+  it("caches resolved user names and persists when a new cache entry is written", async () => {
+    const { deps, persistState, slack } = createDeps();
+    const access = createSlackRuntimeAccess(deps);
+
+    await expect(access.resolveUser("U123")).resolves.toBe("Sender");
+    await expect(access.resolveUser("U123")).resolves.toBe("Sender");
+
+    expect(slack).toHaveBeenCalledTimes(1);
+    expect(slack).toHaveBeenCalledWith("users.info", "xoxb-test", { user: "U123" });
+    expect(persistState).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache or persist a resolved user while single-player shutdown is in progress", async () => {
+    const { deps, persistState, userNames } = createDeps({
+      isSinglePlayerShuttingDown: () => true,
+    });
+    const access = createSlackRuntimeAccess(deps);
+
+    await expect(access.resolveUser("U123")).resolves.toBe("U123");
+
+    expect(userNames.get("U123")).toBeUndefined();
+    expect(persistState).not.toHaveBeenCalled();
+  });
+
+  it("remembers resolved channels and reuses the cache without another Slack lookup", async () => {
+    const { deps, slack, channelCache } = createDeps();
+    const access = createSlackRuntimeAccess(deps);
+
+    access.rememberChannel("#general", "C_GENERAL");
+    await expect(access.resolveChannel("#general")).resolves.toBe("C_GENERAL");
+
+    expect(channelCache.get("general")).toBe("C_GENERAL");
+    expect(slack).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a follower reply channel into local thread state and persists the change", async () => {
+    const { deps, threads, persistState } = createDeps({
+      getBrokerRole: () => "follower",
+      resolveFollowerThreadChannel: async (threadTs: string) =>
+        threadTs === "100.1" ? "C_REFRESHED" : null,
+    });
+    threads.set("100.1", {
+      channelId: "C_STALE",
+      threadTs: "100.1",
+      userId: "U123",
+      source: "slack",
+      context: { channelId: "C_STALE", teamId: "T1" },
+    });
+    const access = createSlackRuntimeAccess(deps);
+
+    await expect(access.resolveFollowerReplyChannel("100.1")).resolves.toBe("C_REFRESHED");
+
+    expect(threads.get("100.1")).toMatchObject({
+      channelId: "C_REFRESHED",
+      threadTs: "100.1",
+      userId: "U123",
+      source: "slack",
+      context: { channelId: "C_STALE", teamId: "T1" },
+    });
+    expect(persistState).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses agent-specific fallback suggested prompts when no custom prompts are configured", async () => {
+    const { deps, slack } = createDeps();
+    const access = createSlackRuntimeAccess(deps);
+
+    await access.setSuggestedPrompts("C123", "100.1");
+
+    expect(slack).toHaveBeenCalledWith(
+      "assistant.threads.setSuggestedPrompts",
+      "xoxb-test",
+      expect.objectContaining({
+        channel_id: "C123",
+        thread_ts: "100.1",
+        prompts: [
+          {
+            title: "Status",
+            message: "Hey Cobalt Olive Crane, what are you working on right now?",
+          },
+          {
+            title: "Help",
+            message: "Cobalt Olive Crane, I need help with something in the codebase",
+          },
+          {
+            title: "Review",
+            message: "Cobalt Olive Crane, summarise the recent changes",
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/slack-bridge/slack-runtime-access.ts
+++ b/slack-bridge/slack-runtime-access.ts
@@ -1,0 +1,169 @@
+import { resolveFollowerThreadChannel as resolveFollowerThreadChannelState } from "./helpers.js";
+import {
+  addSlackReaction,
+  clearSlackThreadStatus,
+  fetchSlackMessageByTs as fetchSlackMessageByTsFromSlack,
+  removeSlackReaction,
+  resolveSlackChannelId,
+  resolveSlackUserName,
+  setSlackSuggestedPrompts,
+  type SlackAccessCache,
+  type SlackCall,
+  type SlackSuggestedPrompt,
+} from "./slack-access.js";
+import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
+
+export interface SlackRuntimeAccessDeps {
+  slack: SlackCall;
+  getBotToken: () => string;
+  userNames: SlackAccessCache<string, string>;
+  channelCache: SlackAccessCache<string, string>;
+  persistState: () => void;
+  isSinglePlayerShuttingDown: () => boolean;
+  getSuggestedPrompts: () => SlackSuggestedPrompt[] | undefined;
+  getAgentName: () => string;
+  getThreads: () => Map<string, SinglePlayerThreadInfo>;
+  getBrokerRole: () => "broker" | "follower" | null;
+  resolveBrokerThreadChannel?: (threadTs: string) => string | null;
+  resolveFollowerThreadChannel?: (threadTs: string) => Promise<string | null>;
+}
+
+export interface SlackRuntimeAccess {
+  addReaction: (channel: string, ts: string, emoji: string) => Promise<void>;
+  removeReaction: (channel: string, ts: string, emoji: string) => Promise<void>;
+  resolveUser: (userId: string) => Promise<string>;
+  rememberChannel: (name: string, channelId: string) => void;
+  resolveChannel: (nameOrId: string) => Promise<string>;
+  resolveFollowerReplyChannel: (threadTs: string | undefined) => Promise<string | null>;
+  clearThreadStatus: (channelId: string, threadTs: string) => Promise<void>;
+  setSuggestedPrompts: (channelId: string, threadTs: string) => Promise<void>;
+  fetchSlackMessageByTs: (
+    channel: string,
+    messageTs: string,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+export function createSlackRuntimeAccess(deps: SlackRuntimeAccessDeps): SlackRuntimeAccess {
+  return {
+    addReaction: async (channel: string, ts: string, emoji: string): Promise<void> => {
+      await addSlackReaction({
+        slack: deps.slack,
+        token: deps.getBotToken(),
+        channel,
+        timestamp: ts,
+        emoji,
+      });
+    },
+
+    removeReaction: async (channel: string, ts: string, emoji: string): Promise<void> => {
+      await removeSlackReaction({
+        slack: deps.slack,
+        token: deps.getBotToken(),
+        channel,
+        timestamp: ts,
+        emoji,
+      });
+    },
+
+    resolveUser: async (userId: string): Promise<string> => {
+      const hadCachedUser = deps.userNames.get(userId) != null;
+      const name = await resolveSlackUserName({
+        slack: deps.slack,
+        token: deps.getBotToken(),
+        userId,
+        cache: deps.userNames,
+        shouldUseResult: () => !deps.isSinglePlayerShuttingDown(),
+      });
+      if (!hadCachedUser && deps.userNames.get(userId) != null) {
+        deps.persistState();
+      }
+      return name;
+    },
+
+    rememberChannel: (name: string, channelId: string): void => {
+      deps.channelCache.set(name.replace(/^#/, ""), channelId);
+    },
+
+    resolveChannel: async (nameOrId: string): Promise<string> => {
+      return resolveSlackChannelId({
+        slack: deps.slack,
+        token: deps.getBotToken(),
+        nameOrId,
+        cache: deps.channelCache,
+      });
+    },
+
+    resolveFollowerReplyChannel: async (threadTs: string | undefined): Promise<string | null> => {
+      if (!threadTs) {
+        return null;
+      }
+
+      const threads = deps.getThreads();
+      const existingThread = threads.get(threadTs);
+      const brokerRole = deps.getBrokerRole();
+      const resolveThread =
+        brokerRole === "broker"
+          ? async (nextThreadTs: string) => deps.resolveBrokerThreadChannel?.(nextThreadTs) ?? null
+          : brokerRole === "follower"
+            ? deps.resolveFollowerThreadChannel
+            : undefined;
+      const resolved = await resolveFollowerThreadChannelState(
+        threadTs,
+        existingThread,
+        resolveThread,
+      );
+
+      if (resolved.threadUpdate && resolved.changed) {
+        threads.set(threadTs, {
+          ...(existingThread ?? {}),
+          ...resolved.threadUpdate,
+        });
+        deps.persistState();
+      }
+
+      return resolved.channelId;
+    },
+
+    clearThreadStatus: async (channelId: string, threadTs: string): Promise<void> => {
+      await clearSlackThreadStatus({
+        slack: deps.slack,
+        token: deps.getBotToken(),
+        channelId,
+        threadTs,
+      });
+    },
+
+    setSuggestedPrompts: async (channelId: string, threadTs: string): Promise<void> => {
+      const prompts = deps.getSuggestedPrompts() ?? [
+        {
+          title: "Status",
+          message: `Hey ${deps.getAgentName()}, what are you working on right now?`,
+        },
+        {
+          title: "Help",
+          message: `${deps.getAgentName()}, I need help with something in the codebase`,
+        },
+        { title: "Review", message: `${deps.getAgentName()}, summarise the recent changes` },
+      ];
+      await setSlackSuggestedPrompts({
+        slack: deps.slack,
+        token: deps.getBotToken(),
+        channelId,
+        threadTs,
+        prompts,
+      });
+    },
+
+    fetchSlackMessageByTs: async (
+      channel: string,
+      messageTs: string,
+    ): Promise<Record<string, unknown> | null> => {
+      return fetchSlackMessageByTsFromSlack({
+        slack: deps.slack,
+        token: deps.getBotToken(),
+        channel,
+        messageTs,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract the stateful Slack runtime access helper cluster from `slack-bridge/index.ts` into `slack-bridge/slack-runtime-access.ts`
- keep the cut narrow by wiring the new port back only into the existing single-player runtime and Slack tools consumers
- add focused coverage for user/channel caching, follower reply-channel refresh, and suggested prompt defaults

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test