### PR TITLE
refactor: extract Pinet Home tab publishing (#408)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -114,11 +114,7 @@ import {
   renderBrokerControlPlaneCanvasMarkdown,
   type BrokerControlPlaneDashboardSnapshot,
 } from "./broker/control-plane-canvas.js";
-import {
-  publishSlackHomeTab,
-  renderBrokerControlPlaneHomeTabView,
-  renderStandalonePinetHomeTabView,
-} from "./home-tab.js";
+import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -593,6 +589,7 @@ export default function (pi: ExtensionAPI) {
   // ─── Helpers ─────────────────────────────────────────
 
   let isSinglePlayerShuttingDown = () => false;
+  let isSinglePlayerConnected = () => false;
   const slackRuntimeAccess = createSlackRuntimeAccess({
     slack,
     getBotToken: () => botToken!,
@@ -620,6 +617,22 @@ export default function (pi: ExtensionAPI) {
     setSuggestedPrompts,
     fetchSlackMessageByTs,
   } = slackRuntimeAccess;
+  const pinetHomeTabs = createPinetHomeTabs({
+    slack,
+    getBotToken: () => botToken,
+    formatError: msg,
+    getAgentName: () => agentName,
+    getAgentEmoji: () => agentEmoji,
+    getBrokerRole: () => brokerRole,
+    getRuntimeMode: () => currentRuntimeMode,
+    isFollowerConnected: () => brokerClient != null,
+    isSinglePlayerConnected: () => isSinglePlayerConnected(),
+    getActiveThreads: () => threads.size,
+    getPendingInboxCount: () => inbox.length,
+    getDefaultChannel: () => settings.defaultChannel ?? null,
+    getCurrentBranch: async () => (await probeGitBranch(process.cwd())) ?? null,
+    getBrokerHomeTabs: () => brokerRuntime,
+  });
 
   function formatTrackedAgent(agentId: string): string {
     const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
@@ -693,7 +706,8 @@ export default function (pi: ExtensionAPI) {
     maybeDrainInboxIfIdle,
     resolveThreadChannel: resolveFollowerReplyChannel,
     setSuggestedPrompts,
-    publishCurrentPinetHomeTab: (userId, ctx) => publishCurrentPinetHomeTabSafely(userId, ctx),
+    publishCurrentPinetHomeTab: (userId, ctx) =>
+      pinetHomeTabs.publishCurrentPinetHomeTabSafely(userId, ctx),
     fetchSlackMessageByTs,
     addReaction,
     removeReaction,
@@ -713,6 +727,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   isSinglePlayerShuttingDown = () => singlePlayerRuntime.isShuttingDown();
+  isSinglePlayerConnected = () => singlePlayerRuntime.isConnected();
 
   // ─── Reconnect / status ─────────────────────────────
 
@@ -879,7 +894,7 @@ export default function (pi: ExtensionAPI) {
       }
     },
     onAppHomeOpened: async (userId, ctx) => {
-      await publishCurrentPinetHomeTabSafely(userId, ctx, new Date().toISOString());
+      await pinetHomeTabs.publishCurrentPinetHomeTabSafely(userId, ctx, new Date().toISOString());
     },
     pushInboxMessages: (messages) => {
       inbox.push(...messages);
@@ -921,7 +936,7 @@ export default function (pi: ExtensionAPI) {
       );
     },
     refreshHomeTabs: async (ctx, snapshot, refreshedAt, userIds) => {
-      await refreshBrokerControlPlaneHomeTabs(ctx, snapshot, refreshedAt, userIds);
+      await pinetHomeTabs.refreshBrokerControlPlaneHomeTabs(ctx, snapshot, refreshedAt, userIds);
     },
     buildControlPlaneDashboardSnapshot: (input) =>
       buildBrokerControlPlaneDashboardSnapshot(
@@ -1148,104 +1163,6 @@ export default function (pi: ExtensionAPI) {
       currentBranch,
       homedir: os.homedir(),
     });
-  }
-
-  async function refreshBrokerControlPlaneHomeTabs(
-    ctx: ExtensionContext,
-    snapshot: BrokerControlPlaneDashboardSnapshot,
-    refreshedAt: string,
-    userIds: string[] = brokerRuntime.getHomeTabViewerIds(),
-  ): Promise<void> {
-    if (!botToken || userIds.length === 0) {
-      return;
-    }
-
-    brokerRuntime.setLastHomeTabSnapshot(snapshot);
-    let hadError = false;
-
-    for (const userId of userIds) {
-      try {
-        await publishSlackHomeTab({
-          slack,
-          token: botToken,
-          userId,
-          view: renderBrokerControlPlaneHomeTabView(snapshot),
-        });
-      } catch (err) {
-        hadError = true;
-        const homeTabMessage = `Pinet Home tab publish failed: ${msg(err)}`;
-        if (homeTabMessage !== brokerRuntime.getLastHomeTabError()) {
-          ctx.ui.notify(homeTabMessage, "warning");
-        }
-        brokerRuntime.setLastHomeTabError(homeTabMessage);
-      }
-    }
-
-    if (!hadError) {
-      brokerRuntime.setLastHomeTabError(null);
-    }
-    brokerRuntime.setLastHomeTabRefreshAt(refreshedAt);
-  }
-
-  function reportHomeTabPublishFailure(ctx: ExtensionContext, err: unknown): void {
-    const homeTabMessage = `Pinet Home tab publish failed: ${msg(err)}`;
-    if (homeTabMessage !== brokerRuntime.getLastHomeTabError()) {
-      ctx.ui.notify(homeTabMessage, "warning");
-    }
-    brokerRuntime.setLastHomeTabError(homeTabMessage);
-  }
-
-  async function publishCurrentPinetHomeTab(
-    userId: string,
-    ctx: ExtensionContext,
-    openedAt: string = new Date().toISOString(),
-  ): Promise<void> {
-    if (!botToken) {
-      return;
-    }
-
-    if (brokerRuntime.isConnected() && brokerRole === "broker") {
-      if (await brokerRuntime.publishCurrentHomeTabSafely(userId, ctx, openedAt)) {
-        return;
-      }
-    }
-
-    const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
-    await publishSlackHomeTab({
-      slack,
-      token: botToken,
-      userId,
-      view: renderStandalonePinetHomeTabView({
-        agentName,
-        agentEmoji,
-        connected:
-          currentRuntimeMode === "broker"
-            ? brokerRuntime.isConnected()
-            : currentRuntimeMode === "follower"
-              ? brokerClient != null
-              : currentRuntimeMode === "single"
-                ? singlePlayerRuntime.isConnected()
-                : false,
-        mode: currentRuntimeMode,
-        activeThreads: threads.size,
-        pendingInbox: inbox.length,
-        currentBranch,
-        defaultChannel: settings.defaultChannel ?? null,
-      }),
-    });
-    brokerRuntime.setLastHomeTabError(null);
-  }
-
-  async function publishCurrentPinetHomeTabSafely(
-    userId: string,
-    ctx: ExtensionContext,
-    openedAt: string = new Date().toISOString(),
-  ): Promise<void> {
-    try {
-      await publishCurrentPinetHomeTab(userId, ctx, openedAt);
-    } catch (err) {
-      reportHomeTabPublishFailure(ctx, err);
-    }
   }
 
   async function refreshBrokerControlPlaneCanvasDashboard(

--- a/slack-bridge/pinet-home-tabs.test.ts
+++ b/slack-bridge/pinet-home-tabs.test.ts
@@ -1,0 +1,231 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
+import {
+  createPinetHomeTabs,
+  type PinetHomeTabsBrokerPort,
+  type PinetHomeTabsDeps,
+} from "./pinet-home-tabs.js";
+
+function createBrokerHomeTabs(): PinetHomeTabsBrokerPort {
+  let lastHomeTabError: string | null = null;
+
+  return {
+    isConnected: vi.fn(() => false),
+    publishCurrentHomeTabSafely: vi.fn(async () => false),
+    getHomeTabViewerIds: vi.fn(() => []),
+    getLastHomeTabError: vi.fn(() => lastHomeTabError),
+    setLastHomeTabSnapshot: vi.fn(),
+    setLastHomeTabRefreshAt: vi.fn(),
+    setLastHomeTabError: vi.fn((value: string | null) => {
+      lastHomeTabError = value;
+    }),
+  };
+}
+
+function createContext() {
+  const notify = vi.fn();
+  const ctx = {
+    ui: {
+      notify,
+    },
+  } as unknown as ExtensionContext;
+
+  return { ctx, notify };
+}
+
+function createBrokerSnapshot(): BrokerControlPlaneDashboardSnapshot {
+  return {
+    cycleStartedAt: "2026-04-15T00:00:00.000Z",
+    cycleDurationMs: 2500,
+    currentBranch: "main",
+    totalAgents: 2,
+    liveAgents: 2,
+    brokerCount: 1,
+    workerCount: 1,
+    idleWorkers: 0,
+    workingWorkers: 1,
+    ghostAgents: 1,
+    stuckAgents: 1,
+    pendingBacklogCount: 3,
+    nudgesThisCycle: 1,
+    idleDrainCandidates: 0,
+    assignedBacklogCount: 1,
+    reapedAgents: 1,
+    repairedThreadClaims: 2,
+    maintenanceAnomalies: ["released 2 orphaned thread claims"],
+    anomalies: ["ghost agents detected: ghost-1"],
+    taskCounts: {
+      assigned: 0,
+      branchPushed: 1,
+      openPrs: 1,
+      mergedPrs: 1,
+      closedPrs: 0,
+    },
+    activeTasks: ["#217 PR #225 open"],
+    recentOutcomes: ["#205 PR #205 merged"],
+    roster: [
+      {
+        id: "broker-1",
+        role: "broker",
+        label: "🦦 The Broker Otter",
+        status: "working",
+        health: "healthy",
+        workload: "0 inbox / 0 threads",
+        taskSummary: "—",
+        heartbeat: "2s ago",
+        branch: "main",
+        worktree: "main checkout",
+      },
+    ],
+    recentCycles: [
+      {
+        startedAt: "2026-04-15 00:00Z",
+        duration: "2.5s",
+        agentCount: 2,
+        backlogCount: 3,
+        ghostCount: 1,
+        stuckCount: 1,
+        anomalySummary: "ghost agents detected: ghost-1",
+        followUpDelivered: true,
+      },
+    ],
+  };
+}
+
+function createDeps(overrides: Partial<PinetHomeTabsDeps> = {}) {
+  const brokerHomeTabs = createBrokerHomeTabs();
+  const slack = vi.fn(async () => ({ ok: true }));
+
+  const deps: PinetHomeTabsDeps = {
+    slack,
+    getBotToken: () => "xoxb-test",
+    formatError: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    getAgentName: () => "Cobalt Olive Crane",
+    getAgentEmoji: () => "🦩",
+    getBrokerRole: () => null,
+    getRuntimeMode: () => "single",
+    isFollowerConnected: () => false,
+    isSinglePlayerConnected: () => true,
+    getActiveThreads: () => 3,
+    getPendingInboxCount: () => 1,
+    getDefaultChannel: () => "ops-control",
+    getBrokerHomeTabs: () => brokerHomeTabs,
+    getCurrentBranch: async () => "feat/pinet-home-tabs",
+    ...overrides,
+  };
+
+  return { deps, brokerHomeTabs, slack };
+}
+
+describe("createPinetHomeTabs", () => {
+  it("refreshes broker control-plane home tabs and stores the latest snapshot state", async () => {
+    const brokerHomeTabs = createBrokerHomeTabs();
+    brokerHomeTabs.getHomeTabViewerIds = vi.fn(() => ["U123", "U456"]);
+    const { deps, slack } = createDeps({
+      getBrokerHomeTabs: () => brokerHomeTabs,
+    });
+    const homeTabs = createPinetHomeTabs(deps);
+    const { ctx, notify } = createContext();
+    const snapshot = createBrokerSnapshot();
+
+    await homeTabs.refreshBrokerControlPlaneHomeTabs(ctx, snapshot, "2026-04-15T00:00:00.000Z");
+
+    expect(brokerHomeTabs.setLastHomeTabSnapshot).toHaveBeenCalledWith(snapshot);
+    expect(brokerHomeTabs.setLastHomeTabRefreshAt).toHaveBeenCalledWith("2026-04-15T00:00:00.000Z");
+    expect(brokerHomeTabs.setLastHomeTabError).toHaveBeenLastCalledWith(null);
+    expect(slack).toHaveBeenCalledTimes(2);
+    expect(slack).toHaveBeenNthCalledWith(
+      1,
+      "views.publish",
+      "xoxb-test",
+      expect.objectContaining({ user_id: "U123" }),
+    );
+    expect(slack).toHaveBeenNthCalledWith(
+      2,
+      "views.publish",
+      "xoxb-test",
+      expect.objectContaining({ user_id: "U456" }),
+    );
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("delegates broker home-tab publishes to the broker runtime when available", async () => {
+    const brokerHomeTabs = createBrokerHomeTabs();
+    brokerHomeTabs.isConnected = vi.fn(() => true);
+    brokerHomeTabs.publishCurrentHomeTabSafely = vi.fn(async () => true);
+    const { deps, slack } = createDeps({
+      getBrokerHomeTabs: () => brokerHomeTabs,
+      getBrokerRole: () => "broker",
+      getRuntimeMode: () => "broker",
+    });
+    const homeTabs = createPinetHomeTabs(deps);
+    const { ctx } = createContext();
+
+    await homeTabs.publishCurrentPinetHomeTab("U123", ctx, "2026-04-15T00:00:00.000Z");
+
+    expect(brokerHomeTabs.publishCurrentHomeTabSafely).toHaveBeenCalledWith(
+      "U123",
+      ctx,
+      "2026-04-15T00:00:00.000Z",
+    );
+    expect(slack).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the standalone Home tab when broker publishing does not handle the request", async () => {
+    const brokerHomeTabs = createBrokerHomeTabs();
+    brokerHomeTabs.isConnected = vi.fn(() => true);
+    brokerHomeTabs.publishCurrentHomeTabSafely = vi.fn(async () => false);
+    const { deps, slack } = createDeps({
+      getBrokerHomeTabs: () => brokerHomeTabs,
+      getBrokerRole: () => "broker",
+      getRuntimeMode: () => "follower",
+      isFollowerConnected: () => false,
+      getActiveThreads: () => 5,
+      getPendingInboxCount: () => 2,
+      getDefaultChannel: () => null,
+      getCurrentBranch: async () => "main",
+    });
+    const homeTabs = createPinetHomeTabs(deps);
+    const { ctx } = createContext();
+
+    await homeTabs.publishCurrentPinetHomeTab("U123", ctx);
+
+    expect(slack).toHaveBeenCalledWith(
+      "views.publish",
+      "xoxb-test",
+      expect.objectContaining({
+        user_id: "U123",
+        view: expect.objectContaining({ type: "home" }),
+      }),
+    );
+    const body = (slack.mock.calls[0] as unknown[] | undefined)?.[2] as
+      | Record<string, unknown>
+      | undefined;
+    expect(JSON.stringify(body)).toContain("Cobalt Olive Crane");
+    expect(JSON.stringify(body)).toContain("follower");
+    expect(JSON.stringify(body)).toContain("main");
+    expect(JSON.stringify(body)).toContain("Pending inbox");
+    expect(brokerHomeTabs.setLastHomeTabError).toHaveBeenCalledWith(null);
+  });
+
+  it("reports Home tab publish failures safely", async () => {
+    const { deps, brokerHomeTabs } = createDeps({
+      slack: vi.fn(async () => {
+        throw new Error("views.publish failed");
+      }),
+    });
+    const homeTabs = createPinetHomeTabs(deps);
+    const { ctx, notify } = createContext();
+
+    await homeTabs.publishCurrentPinetHomeTabSafely("U123", ctx);
+
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet Home tab publish failed: views.publish failed",
+      "warning",
+    );
+    expect(brokerHomeTabs.setLastHomeTabError).toHaveBeenCalledWith(
+      "Pinet Home tab publish failed: views.publish failed",
+    );
+  });
+});

--- a/slack-bridge/pinet-home-tabs.ts
+++ b/slack-bridge/pinet-home-tabs.ts
@@ -1,0 +1,186 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
+import { probeGitBranch } from "./git-metadata.js";
+import {
+  publishSlackHomeTab,
+  renderBrokerControlPlaneHomeTabView,
+  renderStandalonePinetHomeTabView,
+  type PublishSlackHomeTabInput,
+} from "./home-tab.js";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
+
+export interface PinetHomeTabsBrokerPort {
+  isConnected: () => boolean;
+  publishCurrentHomeTabSafely: (
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt?: string,
+  ) => Promise<boolean>;
+  getHomeTabViewerIds: () => string[];
+  getLastHomeTabError: () => string | null;
+  setLastHomeTabSnapshot: (snapshot: BrokerControlPlaneDashboardSnapshot | null) => void;
+  setLastHomeTabRefreshAt: (value: string | null) => void;
+  setLastHomeTabError: (value: string | null) => void;
+}
+
+export interface PinetHomeTabsDeps {
+  slack: PublishSlackHomeTabInput["slack"];
+  getBotToken: () => string | undefined;
+  formatError: (error: unknown) => string;
+  getAgentName: () => string;
+  getAgentEmoji: () => string;
+  getBrokerRole: () => "broker" | "follower" | null;
+  getRuntimeMode: () => SlackBridgeRuntimeMode;
+  isFollowerConnected: () => boolean;
+  isSinglePlayerConnected: () => boolean;
+  getActiveThreads: () => number;
+  getPendingInboxCount: () => number;
+  getDefaultChannel: () => string | null | undefined;
+  getBrokerHomeTabs: () => PinetHomeTabsBrokerPort;
+  getCurrentBranch?: () => Promise<string | null>;
+}
+
+export interface PinetHomeTabs {
+  refreshBrokerControlPlaneHomeTabs: (
+    ctx: ExtensionContext,
+    snapshot: BrokerControlPlaneDashboardSnapshot,
+    refreshedAt: string,
+    userIds?: string[],
+  ) => Promise<void>;
+  reportHomeTabPublishFailure: (ctx: ExtensionContext, err: unknown) => void;
+  publishCurrentPinetHomeTab: (
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt?: string,
+  ) => Promise<void>;
+  publishCurrentPinetHomeTabSafely: (
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt?: string,
+  ) => Promise<void>;
+}
+
+function buildHomeTabPublishFailureMessage(
+  formatError: (error: unknown) => string,
+  err: unknown,
+): string {
+  return `Pinet Home tab publish failed: ${formatError(err)}`;
+}
+
+function getConnectedState(deps: PinetHomeTabsDeps): boolean {
+  const mode = deps.getRuntimeMode();
+  const brokerHomeTabs = deps.getBrokerHomeTabs();
+  if (mode === "broker") {
+    return brokerHomeTabs.isConnected();
+  }
+  if (mode === "follower") {
+    return deps.isFollowerConnected();
+  }
+  if (mode === "single") {
+    return deps.isSinglePlayerConnected();
+  }
+  return false;
+}
+
+export function createPinetHomeTabs(deps: PinetHomeTabsDeps): PinetHomeTabs {
+  function reportHomeTabPublishFailure(ctx: ExtensionContext, err: unknown): void {
+    const brokerHomeTabs = deps.getBrokerHomeTabs();
+    const homeTabMessage = buildHomeTabPublishFailureMessage(deps.formatError, err);
+    if (homeTabMessage !== brokerHomeTabs.getLastHomeTabError()) {
+      ctx.ui.notify(homeTabMessage, "warning");
+    }
+    brokerHomeTabs.setLastHomeTabError(homeTabMessage);
+  }
+
+  async function refreshBrokerControlPlaneHomeTabs(
+    ctx: ExtensionContext,
+    snapshot: BrokerControlPlaneDashboardSnapshot,
+    refreshedAt: string,
+    userIds: string[] = deps.getBrokerHomeTabs().getHomeTabViewerIds(),
+  ): Promise<void> {
+    const botToken = deps.getBotToken();
+    if (!botToken || userIds.length === 0) {
+      return;
+    }
+
+    const brokerHomeTabs = deps.getBrokerHomeTabs();
+    brokerHomeTabs.setLastHomeTabSnapshot(snapshot);
+    let hadError = false;
+
+    for (const userId of userIds) {
+      try {
+        await publishSlackHomeTab({
+          slack: deps.slack,
+          token: botToken,
+          userId,
+          view: renderBrokerControlPlaneHomeTabView(snapshot),
+        });
+      } catch (err) {
+        hadError = true;
+        reportHomeTabPublishFailure(ctx, err);
+      }
+    }
+
+    if (!hadError) {
+      brokerHomeTabs.setLastHomeTabError(null);
+    }
+    brokerHomeTabs.setLastHomeTabRefreshAt(refreshedAt);
+  }
+
+  async function publishCurrentPinetHomeTab(
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt: string = new Date().toISOString(),
+  ): Promise<void> {
+    const botToken = deps.getBotToken();
+    if (!botToken) {
+      return;
+    }
+
+    const brokerHomeTabs = deps.getBrokerHomeTabs();
+    if (brokerHomeTabs.isConnected() && deps.getBrokerRole() === "broker") {
+      if (await brokerHomeTabs.publishCurrentHomeTabSafely(userId, ctx, openedAt)) {
+        return;
+      }
+    }
+
+    const currentBranch = deps.getCurrentBranch
+      ? await deps.getCurrentBranch()
+      : ((await probeGitBranch(process.cwd())) ?? null);
+    await publishSlackHomeTab({
+      slack: deps.slack,
+      token: botToken,
+      userId,
+      view: renderStandalonePinetHomeTabView({
+        agentName: deps.getAgentName(),
+        agentEmoji: deps.getAgentEmoji(),
+        connected: getConnectedState(deps),
+        mode: deps.getRuntimeMode(),
+        activeThreads: deps.getActiveThreads(),
+        pendingInbox: deps.getPendingInboxCount(),
+        currentBranch,
+        defaultChannel: deps.getDefaultChannel() ?? null,
+      }),
+    });
+    brokerHomeTabs.setLastHomeTabError(null);
+  }
+
+  async function publishCurrentPinetHomeTabSafely(
+    userId: string,
+    ctx: ExtensionContext,
+    openedAt: string = new Date().toISOString(),
+  ): Promise<void> {
+    try {
+      await publishCurrentPinetHomeTab(userId, ctx, openedAt);
+    } catch (err) {
+      reportHomeTabPublishFailure(ctx, err);
+    }
+  }
+
+  return {
+    refreshBrokerControlPlaneHomeTabs,
+    reportHomeTabPublishFailure,
+    publishCurrentPinetHomeTab,
+    publishCurrentPinetHomeTabSafely,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the Pinet Home tab publishing seam from `slack-bridge/index.ts` into `slack-bridge/pinet-home-tabs.ts`
- keep the cut narrow by wiring the new Home-tab port back into the existing single-player and broker runtime call sites
- add focused coverage for broker Home tab refresh, broker delegation, standalone fallback publishing, and publish-failure reporting

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test