### PR TITLE
refactor: extract Pinet status/free handling (#410)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -115,6 +115,7 @@ import {
   type BrokerControlPlaneDashboardSnapshot,
 } from "./broker/control-plane-canvas.js";
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
+import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -633,6 +634,27 @@ export default function (pi: ExtensionAPI) {
     getCurrentBranch: async () => (await probeGitBranch(process.cwd())) ?? null,
     getBrokerHomeTabs: () => brokerRuntime,
   });
+  const pinetAgentStatus = createPinetAgentStatus({
+    getPinetEnabled: () => pinetEnabled,
+    getBrokerRole: () => brokerRole,
+    getDesiredAgentStatus: () => desiredAgentStatus,
+    setDesiredAgentStatus: (status) => {
+      desiredAgentStatus = status;
+    },
+    getActiveBrokerDb,
+    getActiveBrokerSelfId,
+    hasFollowerClient: () => brokerClient != null,
+    syncFollowerDesiredStatus: (status, options) =>
+      followerRuntime.syncDesiredStatus(status, options),
+    runBrokerMaintenance: (ctx) => {
+      brokerRuntime.runMaintenance(ctx);
+    },
+    getInboxLength: () => inbox.length,
+    getCurrentRuntimeMode: () => currentRuntimeMode,
+    maybeDrainInboxIfIdle,
+    getExtensionContext: () => extCtx ?? undefined,
+  });
+  const { reportStatus, signalAgentFree } = pinetAgentStatus;
 
   function formatTrackedAgent(agentId: string): string {
     const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
@@ -2178,57 +2200,6 @@ export default function (pi: ExtensionAPI) {
   });
 
   // ─── Agent status reporting ──────────────────────────
-
-  async function syncDesiredAgentStatus(options: { force?: boolean } = {}): Promise<void> {
-    if (!pinetEnabled) {
-      return;
-    }
-
-    if (brokerRole === "broker") {
-      const db = getActiveBrokerDb();
-      const selfId = getActiveBrokerSelfId();
-      if (!db || !selfId) {
-        return;
-      }
-      db.updateAgentStatus(selfId, desiredAgentStatus);
-      return;
-    }
-
-    if (brokerRole === "follower" && brokerClient) {
-      await followerRuntime.syncDesiredStatus(desiredAgentStatus, options);
-    }
-  }
-
-  async function reportStatus(status: "working" | "idle"): Promise<void> {
-    desiredAgentStatus = status;
-    await syncDesiredAgentStatus();
-  }
-
-  async function signalAgentFree(
-    ctx?: ExtensionContext,
-    options: { requirePinet?: boolean } = {},
-  ): Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }> {
-    if (!pinetEnabled && options.requirePinet) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
-    }
-
-    const maintenanceCtx = ctx ?? extCtx ?? undefined;
-    if (pinetEnabled) {
-      await reportStatus("idle");
-      if (brokerRole === "broker" && maintenanceCtx) {
-        brokerRuntime.runMaintenance(maintenanceCtx);
-      }
-    }
-
-    const queuedInboxCount = inbox.length;
-    const shouldDrainQueuedInbox = pinetEnabled || currentRuntimeMode === "single";
-    const drainedQueuedInbox =
-      shouldDrainQueuedInbox && queuedInboxCount > 0 && maintenanceCtx
-        ? maybeDrainInboxIfIdle(maintenanceCtx)
-        : false;
-
-    return { queuedInboxCount, drainedQueuedInbox };
-  }
 
   function deliverFollowUpMessage(text: string): boolean {
     try {

--- a/slack-bridge/pinet-agent-status.test.ts
+++ b/slack-bridge/pinet-agent-status.test.ts
@@ -1,0 +1,130 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPinetAgentStatus,
+  type PinetAgentStatusBrokerDbPort,
+  type PinetAgentStatusDeps,
+  type PinetAgentStatusValue,
+} from "./pinet-agent-status.js";
+
+function createContext(): ExtensionContext {
+  return {} as ExtensionContext;
+}
+
+function createDeps(overrides: Partial<PinetAgentStatusDeps> = {}) {
+  let desiredAgentStatus: PinetAgentStatusValue = "working";
+  const ctx = createContext();
+  const updateAgentStatus = vi.fn();
+  const syncFollowerDesiredStatus = vi.fn(async () => undefined);
+  const runBrokerMaintenance = vi.fn();
+  const maybeDrainInboxIfIdle = vi.fn(() => true);
+  const brokerDb: PinetAgentStatusBrokerDbPort = {
+    updateAgentStatus,
+  };
+
+  const deps: PinetAgentStatusDeps = {
+    getPinetEnabled: () => true,
+    getBrokerRole: () => null,
+    getDesiredAgentStatus: () => desiredAgentStatus,
+    setDesiredAgentStatus: (status) => {
+      desiredAgentStatus = status;
+    },
+    getActiveBrokerDb: () => brokerDb,
+    getActiveBrokerSelfId: () => "agent-1",
+    hasFollowerClient: () => false,
+    syncFollowerDesiredStatus,
+    runBrokerMaintenance,
+    getInboxLength: () => 0,
+    getCurrentRuntimeMode: () => "off",
+    maybeDrainInboxIfIdle,
+    getExtensionContext: () => ctx,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    ctx,
+    updateAgentStatus,
+    syncFollowerDesiredStatus,
+    runBrokerMaintenance,
+    maybeDrainInboxIfIdle,
+    getDesiredAgentStatus: () => desiredAgentStatus,
+  };
+}
+
+describe("createPinetAgentStatus", () => {
+  it("updates broker status in the broker db", async () => {
+    const { deps, updateAgentStatus, syncFollowerDesiredStatus } = createDeps({
+      getBrokerRole: () => "broker",
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await pinetAgentStatus.syncDesiredAgentStatus();
+
+    expect(updateAgentStatus).toHaveBeenCalledWith("agent-1", "working");
+    expect(syncFollowerDesiredStatus).not.toHaveBeenCalled();
+  });
+
+  it("stores desired status and syncs followers through the extracted port", async () => {
+    const { deps, syncFollowerDesiredStatus, getDesiredAgentStatus } = createDeps({
+      getBrokerRole: () => "follower",
+      hasFollowerClient: () => true,
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await pinetAgentStatus.reportStatus("idle");
+
+    expect(getDesiredAgentStatus()).toBe("idle");
+    expect(syncFollowerDesiredStatus).toHaveBeenCalledWith("idle", {});
+  });
+
+  it("signals broker free, runs maintenance, and drains queued inbox via the cached context", async () => {
+    const {
+      deps,
+      ctx,
+      updateAgentStatus,
+      runBrokerMaintenance,
+      maybeDrainInboxIfIdle,
+      getDesiredAgentStatus,
+    } = createDeps({
+      getBrokerRole: () => "broker",
+      getInboxLength: () => 2,
+      getCurrentRuntimeMode: () => "broker",
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    const result = await pinetAgentStatus.signalAgentFree();
+
+    expect(getDesiredAgentStatus()).toBe("idle");
+    expect(updateAgentStatus).toHaveBeenCalledWith("agent-1", "idle");
+    expect(runBrokerMaintenance).toHaveBeenCalledWith(ctx);
+    expect(maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
+    expect(result).toEqual({ queuedInboxCount: 2, drainedQueuedInbox: true });
+  });
+
+  it("drains queued inbox in single mode even when Pinet is off", async () => {
+    const { deps, ctx, updateAgentStatus, maybeDrainInboxIfIdle } = createDeps({
+      getPinetEnabled: () => false,
+      getInboxLength: () => 1,
+      getCurrentRuntimeMode: () => "single",
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    const result = await pinetAgentStatus.signalAgentFree();
+
+    expect(updateAgentStatus).not.toHaveBeenCalled();
+    expect(maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
+    expect(result).toEqual({ queuedInboxCount: 1, drainedQueuedInbox: true });
+  });
+
+  it("throws when requirePinet is set but Pinet is not running", async () => {
+    const { deps } = createDeps({
+      getPinetEnabled: () => false,
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await expect(
+      pinetAgentStatus.signalAgentFree(undefined, { requirePinet: true }),
+    ).rejects.toThrow("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+  });
+});

--- a/slack-bridge/pinet-agent-status.ts
+++ b/slack-bridge/pinet-agent-status.ts
@@ -1,0 +1,97 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
+
+export type PinetAgentStatusValue = "working" | "idle";
+
+export interface PinetAgentStatusBrokerDbPort {
+  updateAgentStatus: (agentId: string, status: PinetAgentStatusValue) => void;
+}
+
+export interface PinetAgentStatusDeps {
+  getPinetEnabled: () => boolean;
+  getBrokerRole: () => "broker" | "follower" | null;
+  getDesiredAgentStatus: () => PinetAgentStatusValue;
+  setDesiredAgentStatus: (status: PinetAgentStatusValue) => void;
+  getActiveBrokerDb: () => PinetAgentStatusBrokerDbPort | null;
+  getActiveBrokerSelfId: () => string | null;
+  hasFollowerClient: () => boolean;
+  syncFollowerDesiredStatus: (
+    status: PinetAgentStatusValue,
+    options: { force?: boolean },
+  ) => Promise<void>;
+  runBrokerMaintenance: (ctx: ExtensionContext) => void;
+  getInboxLength: () => number;
+  getCurrentRuntimeMode: () => SlackBridgeRuntimeMode;
+  maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
+  getExtensionContext: () => ExtensionContext | undefined;
+}
+
+export interface PinetAgentStatus {
+  syncDesiredAgentStatus: (options?: { force?: boolean }) => Promise<void>;
+  reportStatus: (status: PinetAgentStatusValue) => Promise<void>;
+  signalAgentFree: (
+    ctx?: ExtensionContext,
+    options?: { requirePinet?: boolean },
+  ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
+}
+
+export function createPinetAgentStatus(deps: PinetAgentStatusDeps): PinetAgentStatus {
+  async function syncDesiredAgentStatus(options: { force?: boolean } = {}): Promise<void> {
+    if (!deps.getPinetEnabled()) {
+      return;
+    }
+
+    const desiredAgentStatus = deps.getDesiredAgentStatus();
+    if (deps.getBrokerRole() === "broker") {
+      const db = deps.getActiveBrokerDb();
+      const selfId = deps.getActiveBrokerSelfId();
+      if (!db || !selfId) {
+        return;
+      }
+      db.updateAgentStatus(selfId, desiredAgentStatus);
+      return;
+    }
+
+    if (deps.getBrokerRole() === "follower" && deps.hasFollowerClient()) {
+      await deps.syncFollowerDesiredStatus(desiredAgentStatus, options);
+    }
+  }
+
+  async function reportStatus(status: PinetAgentStatusValue): Promise<void> {
+    deps.setDesiredAgentStatus(status);
+    await syncDesiredAgentStatus();
+  }
+
+  async function signalAgentFree(
+    ctx?: ExtensionContext,
+    options: { requirePinet?: boolean } = {},
+  ): Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }> {
+    const pinetEnabled = deps.getPinetEnabled();
+    if (!pinetEnabled && options.requirePinet) {
+      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+    }
+
+    const maintenanceCtx = ctx ?? deps.getExtensionContext() ?? undefined;
+    if (pinetEnabled) {
+      await reportStatus("idle");
+      if (deps.getBrokerRole() === "broker" && maintenanceCtx) {
+        deps.runBrokerMaintenance(maintenanceCtx);
+      }
+    }
+
+    const queuedInboxCount = deps.getInboxLength();
+    const shouldDrainQueuedInbox = pinetEnabled || deps.getCurrentRuntimeMode() === "single";
+    const drainedQueuedInbox =
+      shouldDrainQueuedInbox && queuedInboxCount > 0 && maintenanceCtx
+        ? deps.maybeDrainInboxIfIdle(maintenanceCtx)
+        : false;
+
+    return { queuedInboxCount, drainedQueuedInbox };
+  }
+
+  return {
+    syncDesiredAgentStatus,
+    reportStatus,
+    signalAgentFree,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow Pinet status/free handling seam from `slack-bridge/index.ts` into `slack-bridge/pinet-agent-status.ts`
- wire existing callers back through the new status/free port without widening into runtime or tool registration changes
- add focused coverage for broker/follower status sync, broker auto-free maintenance, single-mode inbox draining, and requirePinet enforcement

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-agent-status.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test