### PR TITLE
refactor: extract Pinet mesh skin application (#412)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -14,7 +14,6 @@ import {
   isUserAllowed as checkUserAllowed,
   formatInboxMessages,
   buildPinetSkinAssignment,
-  buildPinetSkinMetadata,
   buildPinetSkinPromptGuideline,
   normalizeOutgoingPinetControlMessage,
   queuePinetRemoteControl,
@@ -37,7 +36,6 @@ import {
   buildAgentPersonalityGuidelines,
   buildBrokerPromptGuidelines,
   buildWorkerPromptGuidelines,
-  normalizePinetSkinTheme,
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
   resolveAllowAllWorkspaceUsers,
@@ -116,6 +114,7 @@ import {
 } from "./broker/control-plane-canvas.js";
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
+import { createPinetMeshSkin } from "./pinet-skin.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -655,6 +654,30 @@ export default function (pi: ExtensionAPI) {
     getExtensionContext: () => extCtx ?? undefined,
   });
   const { reportStatus, signalAgentFree } = pinetAgentStatus;
+  const pinetMeshSkin = createPinetMeshSkin({
+    getBrokerRole: () => brokerRole,
+    getActiveBrokerDb,
+    getActiveBrokerSelfId,
+    pinetSkinSettingKey: PINET_SKIN_SETTING_KEY,
+    setActiveSkinTheme: (theme) => {
+      activeSkinTheme = theme;
+    },
+    getMeshRoleFromMetadata: (metadata, fallbackRole) =>
+      getMeshRoleFromMetadata(metadata ?? undefined, fallbackRole),
+    buildSkinMetadata: (metadata, personality) =>
+      buildSkinMetadata(metadata ?? undefined, personality),
+    applyLocalAgentIdentity,
+    getAgentName: () => agentName,
+    dispatchDirectAgentMessage: (input) => {
+      const db = getActiveBrokerDb();
+      if (!db) {
+        return;
+      }
+      dispatchDirectAgentMessage(db, input);
+    },
+    persistState,
+  });
+  const { applyMeshSkin } = pinetMeshSkin;
 
   function formatTrackedAgent(agentId: string): string {
     const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
@@ -1491,67 +1514,6 @@ export default function (pi: ExtensionAPI) {
       disconnectedAt: agent.disconnectedAt,
       resumableUntil: agent.resumableUntil,
     }));
-  }
-
-  function applyMeshSkin(themeInput: string): { theme: string; updatedAgents: string[] } {
-    const db = getActiveBrokerDb();
-    const selfId = getActiveBrokerSelfId();
-    if (brokerRole !== "broker" || !db) {
-      throw new Error("/pinet-skin can only run on the active broker.");
-    }
-
-    const theme = normalizePinetSkinTheme(themeInput);
-    if (!theme) {
-      throw new Error("Usage: /pinet-skin <theme>");
-    }
-
-    if (!selfId) {
-      throw new Error("Broker agent identity is unavailable.");
-    }
-
-    activeSkinTheme = theme;
-    db.setSetting(PINET_SKIN_SETTING_KEY, theme);
-
-    const updatedAgents: string[] = [];
-    for (const agent of db.getAgents()) {
-      const role =
-        agent.id === selfId
-          ? "broker"
-          : getMeshRoleFromMetadata(agent.metadata ?? undefined, "worker");
-      const assignment = buildPinetSkinAssignment({
-        theme,
-        role,
-        seed: agent.stableId ?? agent.id,
-      });
-      const updated = db.updateAgentIdentity(agent.id, {
-        name: assignment.name,
-        emoji: assignment.emoji,
-        metadata: buildSkinMetadata(agent.metadata ?? undefined, assignment.personality),
-      });
-      if (!updated) continue;
-
-      if (agent.id === selfId) {
-        applyLocalAgentIdentity(updated.name, updated.emoji, assignment.personality);
-      } else {
-        dispatchDirectAgentMessage(db, {
-          senderAgentId: selfId,
-          senderAgentName: agentName,
-          target: updated.id,
-          body: `Mesh skin changed to ${theme}`,
-          metadata: buildPinetSkinMetadata({
-            theme,
-            name: updated.name,
-            emoji: updated.emoji,
-            personality: assignment.personality,
-          }),
-        });
-      }
-
-      updatedAgents.push(updated.name);
-    }
-
-    persistState();
-    return { theme, updatedAgents };
   }
 
   let remoteControlState: PinetRemoteControlState = {

--- a/slack-bridge/pinet-skin.test.ts
+++ b/slack-bridge/pinet-skin.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPinetMeshSkin,
+  type PinetMeshSkinAgentRecord,
+  type PinetMeshSkinBrokerDbPort,
+  type PinetMeshSkinDeps,
+} from "./pinet-skin.js";
+
+function createDeps(overrides: Partial<PinetMeshSkinDeps> = {}) {
+  let activeSkinTheme: string | null = null;
+  const agents: PinetMeshSkinAgentRecord[] = [
+    {
+      id: "broker-1",
+      stableId: "stable-broker-1",
+      metadata: { role: "broker", existing: "broker-meta" },
+    },
+    {
+      id: "worker-1",
+      stableId: "stable-worker-1",
+      metadata: { role: "worker", existing: "worker-meta" },
+    },
+  ];
+  const setSetting = vi.fn();
+  const updateAgentIdentity = vi.fn(
+    (
+      id: string,
+      update: {
+        name: string;
+        emoji: string;
+        metadata: Record<string, unknown>;
+      },
+    ) => ({ id, name: update.name, emoji: update.emoji }),
+  );
+  const db: PinetMeshSkinBrokerDbPort = {
+    setSetting,
+    getAgents: () => agents,
+    updateAgentIdentity,
+  };
+  const applyLocalAgentIdentity = vi.fn();
+  const dispatchDirectAgentMessage = vi.fn();
+  const persistState = vi.fn();
+
+  const deps: PinetMeshSkinDeps = {
+    getBrokerRole: () => "broker",
+    getActiveBrokerDb: () => db,
+    getActiveBrokerSelfId: () => "broker-1",
+    pinetSkinSettingKey: "pinet.skinTheme",
+    setActiveSkinTheme: (theme) => {
+      activeSkinTheme = theme;
+    },
+    getMeshRoleFromMetadata: (metadata, fallback) =>
+      metadata?.role === "broker" ? "broker" : fallback,
+    buildSkinMetadata: (metadata, personality) => ({
+      ...(metadata ?? {}),
+      ...(activeSkinTheme ? { skinTheme: activeSkinTheme } : {}),
+      personality,
+    }),
+    applyLocalAgentIdentity,
+    getAgentName: () => "Broker Crane",
+    dispatchDirectAgentMessage,
+    persistState,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    setSetting,
+    updateAgentIdentity,
+    applyLocalAgentIdentity,
+    dispatchDirectAgentMessage,
+    persistState,
+    getActiveSkinTheme: () => activeSkinTheme,
+  };
+}
+
+describe("createPinetMeshSkin", () => {
+  it("rejects non-broker callers", () => {
+    const { deps } = createDeps({
+      getBrokerRole: () => "follower",
+    });
+    const pinetMeshSkin = createPinetMeshSkin(deps);
+
+    expect(() => pinetMeshSkin.applyMeshSkin("cyberpunk neon")).toThrow(
+      "/pinet-skin can only run on the active broker.",
+    );
+  });
+
+  it("rejects empty themes", () => {
+    const { deps } = createDeps();
+    const pinetMeshSkin = createPinetMeshSkin(deps);
+
+    expect(() => pinetMeshSkin.applyMeshSkin("   ")).toThrow("Usage: /pinet-skin <theme>");
+  });
+
+  it("requires the broker identity to be available", () => {
+    const { deps } = createDeps({
+      getActiveBrokerSelfId: () => null,
+    });
+    const pinetMeshSkin = createPinetMeshSkin(deps);
+
+    expect(() => pinetMeshSkin.applyMeshSkin("cyberpunk neon")).toThrow(
+      "Broker agent identity is unavailable.",
+    );
+  });
+
+  it("applies the mesh skin, updates local identity, and notifies other agents", () => {
+    const {
+      deps,
+      setSetting,
+      updateAgentIdentity,
+      applyLocalAgentIdentity,
+      dispatchDirectAgentMessage,
+      persistState,
+      getActiveSkinTheme,
+    } = createDeps();
+    const pinetMeshSkin = createPinetMeshSkin(deps);
+
+    const result = pinetMeshSkin.applyMeshSkin("  cyberpunk neon  ");
+
+    expect(result.theme).toBe("cyberpunk neon");
+    expect(result.updatedAgents).toHaveLength(2);
+    expect(getActiveSkinTheme()).toBe("cyberpunk neon");
+    expect(setSetting).toHaveBeenCalledWith("pinet.skinTheme", "cyberpunk neon");
+    expect(updateAgentIdentity).toHaveBeenCalledTimes(2);
+    expect(updateAgentIdentity).toHaveBeenNthCalledWith(
+      1,
+      "broker-1",
+      expect.objectContaining({
+        name: expect.any(String),
+        emoji: expect.any(String),
+        metadata: expect.objectContaining({
+          role: "broker",
+          existing: "broker-meta",
+          skinTheme: "cyberpunk neon",
+          personality: expect.any(String),
+        }),
+      }),
+    );
+    expect(updateAgentIdentity).toHaveBeenNthCalledWith(
+      2,
+      "worker-1",
+      expect.objectContaining({
+        name: expect.any(String),
+        emoji: expect.any(String),
+        metadata: expect.objectContaining({
+          role: "worker",
+          existing: "worker-meta",
+          skinTheme: "cyberpunk neon",
+          personality: expect.any(String),
+        }),
+      }),
+    );
+    expect(applyLocalAgentIdentity).toHaveBeenCalledWith(
+      result.updatedAgents[0],
+      expect.any(String),
+      expect.any(String),
+    );
+    expect(dispatchDirectAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senderAgentId: "broker-1",
+        senderAgentName: "Broker Crane",
+        target: "worker-1",
+        body: "Mesh skin changed to cyberpunk neon",
+        metadata: expect.objectContaining({
+          kind: "pinet_skin",
+          theme: "cyberpunk neon",
+          name: result.updatedAgents[1],
+          emoji: expect.any(String),
+          personality: expect.any(String),
+        }),
+      }),
+    );
+    expect(persistState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/slack-bridge/pinet-skin.ts
+++ b/slack-bridge/pinet-skin.ts
@@ -1,0 +1,135 @@
+import {
+  buildPinetSkinAssignment,
+  buildPinetSkinMetadata,
+  normalizePinetSkinTheme,
+} from "./helpers.js";
+
+export interface PinetMeshSkinAgentRecord {
+  id: string;
+  stableId?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface PinetMeshSkinUpdatedAgentRecord {
+  id: string;
+  name: string;
+  emoji: string;
+}
+
+export interface PinetMeshSkinBrokerDbPort {
+  setSetting: (key: string, value: string) => void;
+  getAgents: () => PinetMeshSkinAgentRecord[];
+  updateAgentIdentity: (
+    agentId: string,
+    update: {
+      name: string;
+      emoji: string;
+      metadata: Record<string, unknown>;
+    },
+  ) => PinetMeshSkinUpdatedAgentRecord | null;
+}
+
+export interface PinetMeshSkinDispatchInput {
+  senderAgentId: string;
+  senderAgentName: string;
+  target: string;
+  body: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface PinetMeshSkinDeps {
+  getBrokerRole: () => "broker" | "follower" | null;
+  getActiveBrokerDb: () => PinetMeshSkinBrokerDbPort | null;
+  getActiveBrokerSelfId: () => string | null;
+  pinetSkinSettingKey: string;
+  setActiveSkinTheme: (theme: string) => void;
+  getMeshRoleFromMetadata: (
+    metadata: Record<string, unknown> | undefined,
+    fallback: "broker" | "worker",
+  ) => "broker" | "worker";
+  buildSkinMetadata: (
+    metadata: Record<string, unknown> | undefined,
+    personality: string,
+  ) => Record<string, unknown>;
+  applyLocalAgentIdentity: (
+    nextName: string,
+    nextEmoji: string,
+    nextPersonality: string | null,
+  ) => void;
+  getAgentName: () => string;
+  dispatchDirectAgentMessage: (input: PinetMeshSkinDispatchInput) => void;
+  persistState: () => void;
+}
+
+export interface PinetMeshSkin {
+  applyMeshSkin: (themeInput: string) => { theme: string; updatedAgents: string[] };
+}
+
+export function createPinetMeshSkin(deps: PinetMeshSkinDeps): PinetMeshSkin {
+  function applyMeshSkin(themeInput: string): { theme: string; updatedAgents: string[] } {
+    const db = deps.getActiveBrokerDb();
+    const selfId = deps.getActiveBrokerSelfId();
+    if (deps.getBrokerRole() !== "broker" || !db) {
+      throw new Error("/pinet-skin can only run on the active broker.");
+    }
+
+    const theme = normalizePinetSkinTheme(themeInput);
+    if (!theme) {
+      throw new Error("Usage: /pinet-skin <theme>");
+    }
+
+    if (!selfId) {
+      throw new Error("Broker agent identity is unavailable.");
+    }
+
+    deps.setActiveSkinTheme(theme);
+    db.setSetting(deps.pinetSkinSettingKey, theme);
+
+    const updatedAgents: string[] = [];
+    for (const agent of db.getAgents()) {
+      const role =
+        agent.id === selfId
+          ? "broker"
+          : deps.getMeshRoleFromMetadata(agent.metadata ?? undefined, "worker");
+      const assignment = buildPinetSkinAssignment({
+        theme,
+        role,
+        seed: agent.stableId ?? agent.id,
+      });
+      const updated = db.updateAgentIdentity(agent.id, {
+        name: assignment.name,
+        emoji: assignment.emoji,
+        metadata: deps.buildSkinMetadata(agent.metadata ?? undefined, assignment.personality),
+      });
+      if (!updated) {
+        continue;
+      }
+
+      if (agent.id === selfId) {
+        deps.applyLocalAgentIdentity(updated.name, updated.emoji, assignment.personality);
+      } else {
+        deps.dispatchDirectAgentMessage({
+          senderAgentId: selfId,
+          senderAgentName: deps.getAgentName(),
+          target: updated.id,
+          body: `Mesh skin changed to ${theme}`,
+          metadata: buildPinetSkinMetadata({
+            theme,
+            name: updated.name,
+            emoji: updated.emoji,
+            personality: assignment.personality,
+          }),
+        });
+      }
+
+      updatedAgents.push(updated.name);
+    }
+
+    deps.persistState();
+    return { theme, updatedAgents };
+  }
+
+  return {
+    applyMeshSkin,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow mesh-skin application seam from `slack-bridge/index.ts` into `slack-bridge/pinet-skin.ts`
- keep the command-facing surface to `applyMeshSkin(themeInput)` via `createPinetMeshSkin(deps)` only
- add focused coverage for broker-only enforcement, empty-theme validation, missing broker identity, and broker mesh-skin fanout updates

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-skin.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test