### PR TITLE
refactor: extract broker maintenance delivery helpers (#414)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -115,6 +115,7 @@ import {
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
+import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -678,6 +679,14 @@ export default function (pi: ExtensionAPI) {
     persistState,
   });
   const { applyMeshSkin } = pinetMeshSkin;
+  const pinetMaintenanceDelivery = createPinetMaintenanceDelivery({
+    getActiveBrokerDb,
+    getActiveBrokerSelfId,
+    sendUserMessage: (body, options) => {
+      pi.sendUserMessage(body, options);
+    },
+  });
+  const { sendBrokerMaintenanceMessage, trySendBrokerFollowUp } = pinetMaintenanceDelivery;
 
   function formatTrackedAgent(agentId: string): string {
     const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
@@ -1085,39 +1094,6 @@ export default function (pi: ExtensionAPI) {
 
   function getActiveBrokerSelfId(): string | null {
     return brokerRuntime.getSelfId();
-  }
-
-  function sendBrokerMaintenanceMessage(targetAgentId: string, body: string): void {
-    const db = getActiveBrokerDb();
-    const selfId = getActiveBrokerSelfId();
-    if (!db || !selfId) return;
-    const target = db.getAgentById(targetAgentId);
-    if (!target) return;
-
-    const threadId = `a2a:${selfId}:${target.id}`;
-    if (!db.getThread(threadId)) {
-      db.createThread(threadId, "agent", "", selfId);
-    }
-
-    db.insertMessage(threadId, "agent", "outbound", selfId, body, [target.id], {
-      kind: "ralph_loop_nudge",
-      targetAgentId,
-    });
-  }
-
-  function trySendBrokerFollowUp(body: string, onDelivered: () => void): void {
-    try {
-      pi.sendUserMessage(body, { deliverAs: "followUp" });
-      onDelivered();
-      return;
-    } catch {
-      try {
-        pi.sendUserMessage(body);
-        onDelivered();
-      } catch {
-        /* best effort */
-      }
-    }
   }
 
   function getBrokerControlPlaneHomeTabViewerIds(): string[] {

--- a/slack-bridge/pinet-maintenance-delivery.test.ts
+++ b/slack-bridge/pinet-maintenance-delivery.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPinetMaintenanceDelivery,
+  type PinetMaintenanceDeliveryAgentRecord,
+  type PinetMaintenanceDeliveryBrokerDbPort,
+  type PinetMaintenanceDeliveryDeps,
+} from "./pinet-maintenance-delivery.js";
+
+function createDeps(overrides: Partial<PinetMaintenanceDeliveryDeps> = {}) {
+  const agents = new Map<string, PinetMaintenanceDeliveryAgentRecord>([
+    ["worker-1", { id: "worker-1" }],
+  ]);
+  const threads = new Map<string, { id: string }>();
+  const createThread = vi.fn((threadId: string) => {
+    threads.set(threadId, { id: threadId });
+  });
+  const insertMessage = vi.fn();
+  const sendUserMessage = vi.fn();
+
+  const db: PinetMaintenanceDeliveryBrokerDbPort = {
+    getAgentById: (agentId) => agents.get(agentId) ?? null,
+    getThread: (threadId) => threads.get(threadId) ?? null,
+    createThread,
+    insertMessage,
+  };
+
+  const deps: PinetMaintenanceDeliveryDeps = {
+    getActiveBrokerDb: () => db,
+    getActiveBrokerSelfId: () => "broker-1",
+    sendUserMessage,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    db,
+    agents,
+    threads,
+    createThread,
+    insertMessage,
+    sendUserMessage,
+  };
+}
+
+describe("createPinetMaintenanceDelivery", () => {
+  it("creates a broker thread when needed and inserts a maintenance nudge", () => {
+    const { deps, createThread, insertMessage, threads } = createDeps();
+    const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
+
+    pinetMaintenanceDelivery.sendBrokerMaintenanceMessage("worker-1", "Heads up");
+
+    expect(createThread).toHaveBeenCalledWith("a2a:broker-1:worker-1", "agent", "", "broker-1");
+    expect(threads.has("a2a:broker-1:worker-1")).toBe(true);
+    expect(insertMessage).toHaveBeenCalledWith(
+      "a2a:broker-1:worker-1",
+      "agent",
+      "outbound",
+      "broker-1",
+      "Heads up",
+      ["worker-1"],
+      {
+        kind: "ralph_loop_nudge",
+        targetAgentId: "worker-1",
+      },
+    );
+  });
+
+  it("reuses an existing broker thread and skips unknown targets", () => {
+    const { deps, createThread, insertMessage, threads } = createDeps();
+    threads.set("a2a:broker-1:worker-1", { id: "a2a:broker-1:worker-1" });
+    const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
+
+    pinetMaintenanceDelivery.sendBrokerMaintenanceMessage("worker-1", "Follow up");
+    pinetMaintenanceDelivery.sendBrokerMaintenanceMessage("missing-worker", "Ignored");
+
+    expect(createThread).not.toHaveBeenCalled();
+    expect(insertMessage).toHaveBeenCalledTimes(1);
+    expect(insertMessage).toHaveBeenCalledWith(
+      "a2a:broker-1:worker-1",
+      "agent",
+      "outbound",
+      "broker-1",
+      "Follow up",
+      ["worker-1"],
+      {
+        kind: "ralph_loop_nudge",
+        targetAgentId: "worker-1",
+      },
+    );
+  });
+
+  it("prefers follow-up delivery and marks the callback as delivered", () => {
+    const { deps, sendUserMessage } = createDeps();
+    const onDelivered = vi.fn();
+    const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
+
+    pinetMaintenanceDelivery.trySendBrokerFollowUp("Maintenance report", onDelivered);
+
+    expect(sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(sendUserMessage).toHaveBeenCalledWith("Maintenance report", {
+      deliverAs: "followUp",
+    });
+    expect(onDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to plain delivery when follow-up delivery throws", () => {
+    const { deps, sendUserMessage } = createDeps();
+    sendUserMessage.mockImplementationOnce(() => {
+      throw new Error("followUp failed");
+    });
+    const onDelivered = vi.fn();
+    const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
+
+    pinetMaintenanceDelivery.trySendBrokerFollowUp("Maintenance report", onDelivered);
+
+    expect(sendUserMessage).toHaveBeenNthCalledWith(1, "Maintenance report", {
+      deliverAs: "followUp",
+    });
+    expect(sendUserMessage).toHaveBeenNthCalledWith(2, "Maintenance report");
+    expect(onDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps follow-up delivery best effort when both delivery attempts fail", () => {
+    const { deps, sendUserMessage } = createDeps();
+    sendUserMessage.mockImplementation(() => {
+      throw new Error("delivery failed");
+    });
+    const onDelivered = vi.fn();
+    const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
+
+    expect(() =>
+      pinetMaintenanceDelivery.trySendBrokerFollowUp("Maintenance report", onDelivered),
+    ).not.toThrow();
+    expect(sendUserMessage).toHaveBeenNthCalledWith(1, "Maintenance report", {
+      deliverAs: "followUp",
+    });
+    expect(sendUserMessage).toHaveBeenNthCalledWith(2, "Maintenance report");
+    expect(onDelivered).not.toHaveBeenCalled();
+  });
+});

--- a/slack-bridge/pinet-maintenance-delivery.ts
+++ b/slack-bridge/pinet-maintenance-delivery.ts
@@ -1,0 +1,75 @@
+export interface PinetMaintenanceDeliveryAgentRecord {
+  id: string;
+}
+
+export interface PinetMaintenanceDeliveryBrokerDbPort {
+  getAgentById: (agentId: string) => PinetMaintenanceDeliveryAgentRecord | null;
+  getThread: (threadId: string) => unknown;
+  createThread: (threadId: string, source: string, channel: string, owner: string) => void;
+  insertMessage: (
+    threadId: string,
+    source: string,
+    direction: "outbound" | "inbound",
+    sender: string,
+    body: string,
+    recipients: string[],
+    metadata?: Record<string, unknown>,
+  ) => void;
+}
+
+export interface PinetMaintenanceDeliverySendMessageOptions {
+  deliverAs?: "followUp";
+}
+
+export interface PinetMaintenanceDeliveryDeps {
+  getActiveBrokerDb: () => PinetMaintenanceDeliveryBrokerDbPort | null;
+  getActiveBrokerSelfId: () => string | null;
+  sendUserMessage: (body: string, options?: PinetMaintenanceDeliverySendMessageOptions) => void;
+}
+
+export interface PinetMaintenanceDelivery {
+  sendBrokerMaintenanceMessage: (targetAgentId: string, body: string) => void;
+  trySendBrokerFollowUp: (body: string, onDelivered: () => void) => void;
+}
+
+export function createPinetMaintenanceDelivery(
+  deps: PinetMaintenanceDeliveryDeps,
+): PinetMaintenanceDelivery {
+  function sendBrokerMaintenanceMessage(targetAgentId: string, body: string): void {
+    const db = deps.getActiveBrokerDb();
+    const selfId = deps.getActiveBrokerSelfId();
+    if (!db || !selfId) return;
+    const target = db.getAgentById(targetAgentId);
+    if (!target) return;
+
+    const threadId = `a2a:${selfId}:${target.id}`;
+    if (!db.getThread(threadId)) {
+      db.createThread(threadId, "agent", "", selfId);
+    }
+
+    db.insertMessage(threadId, "agent", "outbound", selfId, body, [target.id], {
+      kind: "ralph_loop_nudge",
+      targetAgentId,
+    });
+  }
+
+  function trySendBrokerFollowUp(body: string, onDelivered: () => void): void {
+    try {
+      deps.sendUserMessage(body, { deliverAs: "followUp" });
+      onDelivered();
+      return;
+    } catch {
+      try {
+        deps.sendUserMessage(body);
+        onDelivered();
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  return {
+    sendBrokerMaintenanceMessage,
+    trySendBrokerFollowUp,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow broker maintenance delivery helper seam from `slack-bridge/index.ts` into `slack-bridge/pinet-maintenance-delivery.ts`
- route the existing broker-runtime maintenance callbacks through `createPinetMaintenanceDelivery(deps)` only
- add focused coverage for broker thread nudges and best-effort follow-up delivery

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-maintenance-delivery.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test