### PR TITLE
refactor: extract Pinet remote-control ack bookkeeping (#416)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -116,6 +116,7 @@ import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
+import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -687,6 +688,28 @@ export default function (pi: ExtensionAPI) {
     },
   });
   const { sendBrokerMaintenanceMessage, trySendBrokerFollowUp } = pinetMaintenanceDelivery;
+  const pinetRemoteControlAcks = createPinetRemoteControlAcks({
+    queueBrokerInboxIds: (inboxIds) => {
+      queueBrokerInboxIds(brokerDeliveryState, inboxIds);
+    },
+    isBrokerConnected: () => brokerRuntime.isConnected(),
+    markBrokerInboxIdsDelivered: (inboxIds) => {
+      brokerRuntime.markDelivered(inboxIds);
+    },
+    queueFollowerInboxIds: (inboxIds) => {
+      queueFollowerInboxIds(followerDeliveryState, inboxIds);
+    },
+    markFollowerInboxIdsDelivered: (inboxIds) => {
+      markFollowerInboxIdsDelivered(followerDeliveryState, inboxIds);
+    },
+    flushDeliveredFollowerAcks,
+  });
+  const {
+    resetPendingRemoteControlAcks,
+    deferBrokerControlAck,
+    deferFollowerControlAck,
+    flushDeferredRemoteControlAcks,
+  } = pinetRemoteControlAcks;
 
   function formatTrackedAgent(agentId: string): string {
     const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
@@ -1496,46 +1519,6 @@ export default function (pi: ExtensionAPI) {
     currentCommand: null,
     queuedCommand: null,
   };
-  const pendingBrokerControlInboxIds: Record<PinetControlCommand, Set<number>> = {
-    reload: new Set<number>(),
-    exit: new Set<number>(),
-  };
-  const pendingFollowerControlInboxIds: Record<PinetControlCommand, Set<number>> = {
-    reload: new Set<number>(),
-    exit: new Set<number>(),
-  };
-
-  function resetPendingRemoteControlAcks(): void {
-    pendingBrokerControlInboxIds.reload.clear();
-    pendingBrokerControlInboxIds.exit.clear();
-    pendingFollowerControlInboxIds.reload.clear();
-    pendingFollowerControlInboxIds.exit.clear();
-  }
-
-  function deferBrokerControlAck(command: PinetControlCommand, inboxId: number): void {
-    pendingBrokerControlInboxIds[command].add(inboxId);
-    queueBrokerInboxIds(brokerDeliveryState, [inboxId]);
-  }
-
-  function deferFollowerControlAck(command: PinetControlCommand, inboxId: number): void {
-    pendingFollowerControlInboxIds[command].add(inboxId);
-    queueFollowerInboxIds(followerDeliveryState, [inboxId]);
-  }
-
-  function flushDeferredRemoteControlAcks(command: PinetControlCommand): void {
-    const brokerIds = [...pendingBrokerControlInboxIds[command]];
-    if (brokerIds.length > 0 && brokerRuntime.isConnected()) {
-      brokerRuntime.markDelivered(brokerIds);
-      pendingBrokerControlInboxIds[command].clear();
-    }
-
-    const followerIds = [...pendingFollowerControlInboxIds[command]];
-    if (followerIds.length > 0) {
-      markFollowerInboxIdsDelivered(followerDeliveryState, followerIds);
-      pendingFollowerControlInboxIds[command].clear();
-      void flushDeliveredFollowerAcks();
-    }
-  }
 
   async function transitionToRuntimeMode(
     ctx: ExtensionContext,

--- a/slack-bridge/pinet-remote-control-acks.test.ts
+++ b/slack-bridge/pinet-remote-control-acks.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPinetRemoteControlAcks,
+  type PinetRemoteControlAcksDeps,
+} from "./pinet-remote-control-acks.js";
+
+function createDeps(overrides: Partial<PinetRemoteControlAcksDeps> = {}) {
+  let brokerConnected = true;
+  const queueBrokerInboxIds = vi.fn();
+  const markBrokerInboxIdsDelivered = vi.fn();
+  const queueFollowerInboxIds = vi.fn();
+  const markFollowerInboxIdsDelivered = vi.fn();
+  const flushDeliveredFollowerAcks = vi.fn();
+
+  const deps: PinetRemoteControlAcksDeps = {
+    queueBrokerInboxIds,
+    isBrokerConnected: () => brokerConnected,
+    markBrokerInboxIdsDelivered,
+    queueFollowerInboxIds,
+    markFollowerInboxIdsDelivered,
+    flushDeliveredFollowerAcks,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    queueBrokerInboxIds,
+    markBrokerInboxIdsDelivered,
+    queueFollowerInboxIds,
+    markFollowerInboxIdsDelivered,
+    flushDeliveredFollowerAcks,
+    setBrokerConnected: (connected: boolean) => {
+      brokerConnected = connected;
+    },
+  };
+}
+
+describe("createPinetRemoteControlAcks", () => {
+  it("queues and flushes broker control acks when the broker is connected", () => {
+    const { deps, queueBrokerInboxIds, markBrokerInboxIdsDelivered } = createDeps();
+    const pinetRemoteControlAcks = createPinetRemoteControlAcks(deps);
+
+    pinetRemoteControlAcks.deferBrokerControlAck("reload", 11);
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("reload");
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("reload");
+
+    expect(queueBrokerInboxIds).toHaveBeenCalledWith([11]);
+    expect(markBrokerInboxIdsDelivered).toHaveBeenCalledTimes(1);
+    expect(markBrokerInboxIdsDelivered).toHaveBeenCalledWith([11]);
+  });
+
+  it("retains broker control acks until the broker is connected", () => {
+    const { deps, setBrokerConnected, markBrokerInboxIdsDelivered } = createDeps();
+    setBrokerConnected(false);
+    const pinetRemoteControlAcks = createPinetRemoteControlAcks(deps);
+
+    pinetRemoteControlAcks.deferBrokerControlAck("exit", 21);
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("exit");
+    expect(markBrokerInboxIdsDelivered).not.toHaveBeenCalled();
+
+    setBrokerConnected(true);
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("exit");
+    expect(markBrokerInboxIdsDelivered).toHaveBeenCalledWith([21]);
+  });
+
+  it("queues and flushes follower control acks through follower delivery", () => {
+    const {
+      deps,
+      queueFollowerInboxIds,
+      markFollowerInboxIdsDelivered,
+      flushDeliveredFollowerAcks,
+    } = createDeps();
+    const pinetRemoteControlAcks = createPinetRemoteControlAcks(deps);
+
+    pinetRemoteControlAcks.deferFollowerControlAck("reload", 31);
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("reload");
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("reload");
+
+    expect(queueFollowerInboxIds).toHaveBeenCalledWith([31]);
+    expect(markFollowerInboxIdsDelivered).toHaveBeenCalledTimes(1);
+    expect(markFollowerInboxIdsDelivered).toHaveBeenCalledWith([31]);
+    expect(flushDeliveredFollowerAcks).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps broker and follower command buckets isolated", () => {
+    const { deps, markBrokerInboxIdsDelivered, markFollowerInboxIdsDelivered } = createDeps();
+    const pinetRemoteControlAcks = createPinetRemoteControlAcks(deps);
+
+    pinetRemoteControlAcks.deferBrokerControlAck("reload", 41);
+    pinetRemoteControlAcks.deferBrokerControlAck("exit", 42);
+    pinetRemoteControlAcks.deferFollowerControlAck("reload", 43);
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("reload");
+
+    expect(markBrokerInboxIdsDelivered).toHaveBeenCalledWith([41]);
+    expect(markFollowerInboxIdsDelivered).toHaveBeenCalledWith([43]);
+
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("exit");
+    expect(markBrokerInboxIdsDelivered).toHaveBeenNthCalledWith(2, [42]);
+  });
+
+  it("resets deferred control acks for both broker and follower paths", () => {
+    const {
+      deps,
+      markBrokerInboxIdsDelivered,
+      markFollowerInboxIdsDelivered,
+      flushDeliveredFollowerAcks,
+    } = createDeps();
+    const pinetRemoteControlAcks = createPinetRemoteControlAcks(deps);
+
+    pinetRemoteControlAcks.deferBrokerControlAck("reload", 51);
+    pinetRemoteControlAcks.deferFollowerControlAck("exit", 52);
+    pinetRemoteControlAcks.resetPendingRemoteControlAcks();
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("reload");
+    pinetRemoteControlAcks.flushDeferredRemoteControlAcks("exit");
+
+    expect(markBrokerInboxIdsDelivered).not.toHaveBeenCalled();
+    expect(markFollowerInboxIdsDelivered).not.toHaveBeenCalled();
+    expect(flushDeliveredFollowerAcks).not.toHaveBeenCalled();
+  });
+});

--- a/slack-bridge/pinet-remote-control-acks.ts
+++ b/slack-bridge/pinet-remote-control-acks.ts
@@ -1,0 +1,75 @@
+import type { PinetControlCommand } from "./helpers.js";
+
+interface PinetRemoteControlAckBuckets {
+  reload: Set<number>;
+  exit: Set<number>;
+}
+
+export interface PinetRemoteControlAcksDeps {
+  queueBrokerInboxIds: (inboxIds: Iterable<number>) => void;
+  isBrokerConnected: () => boolean;
+  markBrokerInboxIdsDelivered: (inboxIds: number[]) => void;
+  queueFollowerInboxIds: (inboxIds: Iterable<number>) => void;
+  markFollowerInboxIdsDelivered: (inboxIds: Iterable<number>) => void;
+  flushDeliveredFollowerAcks: () => void | Promise<void>;
+}
+
+export interface PinetRemoteControlAcks {
+  resetPendingRemoteControlAcks: () => void;
+  deferBrokerControlAck: (command: PinetControlCommand, inboxId: number) => void;
+  deferFollowerControlAck: (command: PinetControlCommand, inboxId: number) => void;
+  flushDeferredRemoteControlAcks: (command: PinetControlCommand) => void;
+}
+
+function createAckBuckets(): PinetRemoteControlAckBuckets {
+  return {
+    reload: new Set<number>(),
+    exit: new Set<number>(),
+  };
+}
+
+export function createPinetRemoteControlAcks(
+  deps: PinetRemoteControlAcksDeps,
+): PinetRemoteControlAcks {
+  const pendingBrokerControlInboxIds = createAckBuckets();
+  const pendingFollowerControlInboxIds = createAckBuckets();
+
+  function resetPendingRemoteControlAcks(): void {
+    pendingBrokerControlInboxIds.reload.clear();
+    pendingBrokerControlInboxIds.exit.clear();
+    pendingFollowerControlInboxIds.reload.clear();
+    pendingFollowerControlInboxIds.exit.clear();
+  }
+
+  function deferBrokerControlAck(command: PinetControlCommand, inboxId: number): void {
+    pendingBrokerControlInboxIds[command].add(inboxId);
+    deps.queueBrokerInboxIds([inboxId]);
+  }
+
+  function deferFollowerControlAck(command: PinetControlCommand, inboxId: number): void {
+    pendingFollowerControlInboxIds[command].add(inboxId);
+    deps.queueFollowerInboxIds([inboxId]);
+  }
+
+  function flushDeferredRemoteControlAcks(command: PinetControlCommand): void {
+    const brokerIds = [...pendingBrokerControlInboxIds[command]];
+    if (brokerIds.length > 0 && deps.isBrokerConnected()) {
+      deps.markBrokerInboxIdsDelivered(brokerIds);
+      pendingBrokerControlInboxIds[command].clear();
+    }
+
+    const followerIds = [...pendingFollowerControlInboxIds[command]];
+    if (followerIds.length > 0) {
+      deps.markFollowerInboxIdsDelivered(followerIds);
+      pendingFollowerControlInboxIds[command].clear();
+      void deps.flushDeliveredFollowerAcks();
+    }
+  }
+
+  return {
+    resetPendingRemoteControlAcks,
+    deferBrokerControlAck,
+    deferFollowerControlAck,
+    flushDeferredRemoteControlAcks,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow deferred remote-control ack bookkeeping seam from `slack-bridge/index.ts` into `slack-bridge/pinet-remote-control-acks.ts`
- keep broker and follower delivery wiring funneled through the new narrow port only
- add focused coverage for broker/follower deferred ack queueing, flushing, reset behavior, and connection-sensitive broker delivery

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-remote-control-acks.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test