### PR TITLE
refactor: extract Pinet mesh operations (#418)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -15,7 +15,6 @@ import {
   formatInboxMessages,
   buildPinetSkinAssignment,
   buildPinetSkinPromptGuideline,
-  normalizeOutgoingPinetControlMessage,
   queuePinetRemoteControl,
   finishPinetRemoteControl,
   reloadPinetRuntimeSafely,
@@ -60,12 +59,8 @@ import type { Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { type BrokerMaintenanceResult } from "./broker/maintenance.js";
-import { DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS, type BrokerClient } from "./broker/client.js";
-import {
-  dispatchBroadcastAgentMessage,
-  dispatchDirectAgentMessage,
-  isBroadcastChannelTarget,
-} from "./broker/agent-messaging.js";
+import { DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { registerSlackTools } from "./slack-tools.js";
 import { registerPinetCommands } from "./pinet-commands.js";
 import { registerPinetTools } from "./pinet-tools.js";
@@ -95,7 +90,6 @@ import {
 } from "./single-player-runtime.js";
 import { createBrokerRuntime } from "./broker-runtime.js";
 import {
-  extractTaskAssignmentsFromMessage,
   normalizeTrackedTaskAssignments,
   resolveTaskAssignments,
   type ResolvedTaskAssignment,
@@ -117,6 +111,7 @@ import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
 import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
+import { createPinetMeshOps } from "./pinet-mesh-ops.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -1119,6 +1114,27 @@ export default function (pi: ExtensionAPI) {
     return brokerRuntime.getSelfId();
   }
 
+  const pinetMeshOps = createPinetMeshOps({
+    getPinetEnabled: () => pinetEnabled,
+    getBrokerRole: () => brokerRole,
+    getActiveBrokerDb,
+    getActiveBrokerSelfId,
+    getAgentName: () => agentName,
+    getFollowerClient: () => brokerClient?.client ?? null,
+    formatTrackedAgent,
+    logActivity: (entry) => {
+      brokerRuntime.logActivity(entry);
+    },
+  });
+  const {
+    sendPinetAgentMessage,
+    sendPinetBroadcastMessage,
+    scheduleBrokerWakeup,
+    scheduleFollowerWakeup,
+    listBrokerAgents,
+    listFollowerAgents,
+  } = pinetMeshOps;
+
   function getBrokerControlPlaneHomeTabViewerIds(): string[] {
     return brokerRuntime.getHomeTabViewerIds();
   }
@@ -1307,212 +1323,6 @@ export default function (pi: ExtensionAPI) {
         "info",
       );
     }
-  }
-
-  function prepareOutgoingPinetAgentMessage(
-    body: string,
-    metadata?: Record<string, unknown>,
-  ): { body: string; metadata?: Record<string, unknown> } {
-    const control = normalizeOutgoingPinetControlMessage(body, metadata);
-    if (control) {
-      return {
-        body: control.body,
-        metadata: control.metadata,
-      };
-    }
-
-    return { body, metadata };
-  }
-
-  async function sendPinetAgentMessage(
-    targetRef: string,
-    body: string,
-    metadata?: Record<string, unknown>,
-  ): Promise<{ messageId: number; target: string }> {
-    if (!pinetEnabled) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
-    }
-
-    if (isBroadcastChannelTarget(targetRef)) {
-      throw new Error(
-        "Broadcast channels are broker-only. Send the request to the broker instead.",
-      );
-    }
-
-    const outgoing = prepareOutgoingPinetAgentMessage(body, metadata);
-    const finalBody = outgoing.body;
-    const finalMetadata = outgoing.metadata;
-
-    if (brokerRole === "broker") {
-      const db = getActiveBrokerDb();
-      const selfId = getActiveBrokerSelfId();
-      if (!db || !selfId) {
-        throw new Error("Broker agent identity is unavailable.");
-      }
-
-      const result = dispatchDirectAgentMessage(db, {
-        senderAgentId: selfId,
-        senderAgentName: agentName,
-        target: targetRef,
-        body: finalBody,
-        metadata: finalMetadata,
-      });
-
-      const recordedAssignments = [] as Array<{ issueNumber: number; branch: string | null }>;
-      for (const assignment of extractTaskAssignmentsFromMessage(body)) {
-        const tracked = db.recordTaskAssignment(
-          result.target.id,
-          assignment.issueNumber,
-          assignment.branch,
-          result.threadId,
-          result.messageId,
-        );
-        recordedAssignments.push({ issueNumber: tracked.issueNumber, branch: tracked.branch });
-      }
-
-      if (recordedAssignments.length > 0) {
-        brokerRuntime.logActivity({
-          kind: "task_assignment",
-          level: "actions",
-          title: recordedAssignments.length === 1 ? "Task assigned" : "Tasks assigned",
-          summary: `Assigned ${recordedAssignments.map((assignment) => `#${assignment.issueNumber}`).join(", ")} to ${formatTrackedAgent(result.target.id)}.`,
-          details: recordedAssignments.map((assignment) =>
-            assignment.branch
-              ? `#${assignment.issueNumber} on \`${assignment.branch}\``
-              : `#${assignment.issueNumber}`,
-          ),
-          fields: [
-            { label: "Worker", value: formatTrackedAgent(result.target.id) },
-            { label: "Thread", value: result.threadId },
-            { label: "Message", value: result.messageId },
-          ],
-          tone: "info",
-        });
-      }
-
-      return { messageId: result.messageId, target: result.target.name };
-    }
-
-    if (brokerRole === "follower" && brokerClient) {
-      const client = brokerClient.client as BrokerClient;
-      const messageId = await client.sendAgentMessage(targetRef, finalBody, finalMetadata);
-      return { messageId, target: targetRef };
-    }
-
-    throw new Error("Pinet is in an unexpected state.");
-  }
-
-  function sendPinetBroadcastMessage(
-    channel: string,
-    body: string,
-  ): { channel: string; messageIds: number[]; recipients: string[] } {
-    const db = getActiveBrokerDb();
-    const selfId = getActiveBrokerSelfId();
-    if (!db || !selfId) {
-      throw new Error("Broker agent identity is unavailable.");
-    }
-
-    const outgoing = prepareOutgoingPinetAgentMessage(body);
-    const result = dispatchBroadcastAgentMessage(db, {
-      senderAgentId: selfId,
-      senderAgentName: agentName,
-      channel,
-      body: outgoing.body,
-      ...(outgoing.metadata ? { metadata: outgoing.metadata } : {}),
-    });
-
-    return {
-      channel: result.channel,
-      messageIds: result.messageIds,
-      recipients: result.targets.map((target) => target.name),
-    };
-  }
-
-  async function scheduleBrokerWakeup(
-    fireAt: string,
-    message: string,
-  ): Promise<{ id: number; fireAt: string }> {
-    const db = getActiveBrokerDb();
-    const selfId = getActiveBrokerSelfId();
-    if (!db || !selfId) {
-      throw new Error("Broker agent identity is unavailable.");
-    }
-
-    return db.scheduleWakeup(selfId, message, fireAt);
-  }
-
-  async function scheduleFollowerWakeup(
-    fireAt: string,
-    message: string,
-  ): Promise<{ id: number; fireAt: string }> {
-    if (!brokerClient) {
-      throw new Error("Pinet is in an unexpected state.");
-    }
-
-    return (brokerClient.client as BrokerClient).scheduleWakeup(fireAt, message);
-  }
-
-  function listBrokerAgents(): Array<{
-    emoji: string;
-    name: string;
-    id: string;
-    pid?: number;
-    status: "working" | "idle";
-    metadata: Record<string, unknown> | null;
-    lastHeartbeat: string;
-    lastSeen?: string;
-    disconnectedAt?: string | null;
-    resumableUntil?: string | null;
-  }> {
-    const db = getActiveBrokerDb();
-    if (!db) {
-      throw new Error("Broker agent identity is unavailable.");
-    }
-
-    return db.getAllAgents().map((agent) => ({
-      emoji: agent.emoji,
-      name: agent.name,
-      id: agent.id,
-      pid: agent.pid,
-      status: agent.status,
-      metadata: agent.metadata,
-      lastHeartbeat: agent.lastHeartbeat,
-      lastSeen: agent.lastSeen,
-      disconnectedAt: agent.disconnectedAt,
-      resumableUntil: agent.resumableUntil,
-    }));
-  }
-
-  async function listFollowerAgents(includeGhosts: boolean): Promise<
-    Array<{
-      emoji: string;
-      name: string;
-      id: string;
-      pid?: number;
-      status: "working" | "idle";
-      metadata: Record<string, unknown> | null;
-      lastHeartbeat: string;
-      lastSeen?: string;
-      disconnectedAt?: string | null;
-      resumableUntil?: string | null;
-    }>
-  > {
-    if (!brokerClient) {
-      throw new Error("Pinet is in an unexpected state.");
-    }
-
-    return (await brokerClient.client.listAgents(includeGhosts)).map((agent) => ({
-      emoji: agent.emoji,
-      name: agent.name,
-      id: agent.id,
-      pid: agent.pid,
-      status: agent.status ?? "idle",
-      metadata: agent.metadata,
-      lastHeartbeat: agent.lastHeartbeat,
-      lastSeen: agent.lastSeen,
-      disconnectedAt: agent.disconnectedAt,
-      resumableUntil: agent.resumableUntil,
-    }));
   }
 
   let remoteControlState: PinetRemoteControlState = {

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ActivityLogEntry } from "./activity-log.js";
+import type { AgentInfo, BrokerMessage, TaskAssignmentInfo } from "./broker/types.js";
+import {
+  createPinetMeshOps,
+  type PinetMeshOpsBrokerDbPort,
+  type PinetMeshOpsDeps,
+  type PinetMeshOpsFollowerClientPort,
+} from "./pinet-mesh-ops.js";
+
+function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    id: "agent-1",
+    stableId: "stable-agent-1",
+    name: "Agent One",
+    emoji: "🐇",
+    pid: 101,
+    connectedAt: "2026-04-15T13:00:00.000Z",
+    lastSeen: "2026-04-15T13:04:00.000Z",
+    lastHeartbeat: "2026-04-15T13:04:30.000Z",
+    metadata: { role: "worker", repo: "extensions" },
+    status: "idle",
+    disconnectedAt: null,
+    resumableUntil: null,
+    ...overrides,
+  };
+}
+
+function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
+  const agents: AgentInfo[] = [
+    makeAgent({
+      id: "broker-1",
+      stableId: "stable-broker-1",
+      name: "Broker Crane",
+      emoji: "🦩",
+      metadata: { role: "broker", repo: "extensions" },
+    }),
+    makeAgent({
+      id: "worker-1",
+      stableId: "stable-worker-1",
+      name: "Worker One",
+      emoji: "🦊",
+    }),
+    makeAgent({
+      id: "worker-2",
+      stableId: "stable-worker-2",
+      name: "Worker Two",
+      emoji: "🐻",
+      metadata: { role: "worker", channels: ["all"] },
+    }),
+  ];
+  let nextMessageId = 1;
+  const threads = new Map<string, { threadId: string }>();
+  const insertedMessages: BrokerMessage[] = [];
+  const createThread = vi.fn((threadId: string) => {
+    threads.set(threadId, { threadId });
+  });
+  const insertMessage = vi.fn(
+    (
+      threadId: string,
+      source: string,
+      direction: "inbound" | "outbound",
+      sender: string,
+      body: string,
+      _targetAgentIds: string[],
+      metadata?: Record<string, unknown>,
+    ) => {
+      const message: BrokerMessage = {
+        id: nextMessageId++,
+        threadId,
+        source,
+        direction,
+        sender,
+        body,
+        metadata: metadata ?? null,
+        createdAt: `2026-04-15T13:05:0${nextMessageId}.000Z`,
+      };
+      insertedMessages.push(message);
+      return message;
+    },
+  );
+  const recordTaskAssignment = vi.fn(
+    (
+      agentId: string,
+      issueNumber: number,
+      branch: string | null,
+      threadId: string,
+      sourceMessageId: number,
+    ): TaskAssignmentInfo => ({
+      id: sourceMessageId,
+      agentId,
+      issueNumber,
+      branch,
+      prNumber: null,
+      status: "assigned",
+      threadId,
+      sourceMessageId,
+      createdAt: "2026-04-15T13:06:00.000Z",
+      updatedAt: "2026-04-15T13:06:00.000Z",
+    }),
+  );
+  const scheduleWakeup = vi.fn((agentId: string, message: string, fireAt: string) => ({
+    id: 7,
+    fireAt,
+    agentId,
+    message,
+  }));
+  const logActivity = vi.fn((_entry: ActivityLogEntry) => undefined);
+
+  const db: PinetMeshOpsBrokerDbPort = {
+    getAgents: () => agents,
+    getThread: (threadId) => threads.get(threadId) ?? null,
+    createThread,
+    insertMessage,
+    getAllAgents: () => agents,
+    recordTaskAssignment,
+    scheduleWakeup,
+  };
+
+  const deps: PinetMeshOpsDeps = {
+    getPinetEnabled: () => true,
+    getBrokerRole: () => "broker",
+    getActiveBrokerDb: () => db,
+    getActiveBrokerSelfId: () => "broker-1",
+    getAgentName: () => "Broker Crane",
+    getFollowerClient: () => null,
+    formatTrackedAgent: (agentId) =>
+      agentId === "worker-1" ? "🦊 Worker One" : agentId === "worker-2" ? "🐻 Worker Two" : agentId,
+    logActivity,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    db,
+    agents,
+    createThread,
+    insertMessage,
+    insertedMessages,
+    recordTaskAssignment,
+    scheduleWakeup,
+    logActivity,
+  };
+}
+
+function createFollowerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
+  const sendAgentMessage = vi.fn(
+    async (_target: string, _body: string, _metadata?: Record<string, unknown>) => 17,
+  );
+  const scheduleWakeup = vi.fn(async (fireAt: string, _message: string) => ({ id: 9, fireAt }));
+  const listAgents = vi.fn(async (_includeGhosts: boolean) => [
+    {
+      id: "worker-2",
+      name: "Worker Two",
+      emoji: "🐻",
+      pid: 202,
+      metadata: { role: "worker", repo: "extensions" },
+      lastHeartbeat: "2026-04-15T13:09:00.000Z",
+      lastSeen: "2026-04-15T13:09:30.000Z",
+      disconnectedAt: null,
+      resumableUntil: null,
+    },
+  ]);
+  const followerClient: PinetMeshOpsFollowerClientPort = {
+    sendAgentMessage,
+    scheduleWakeup,
+    listAgents,
+  };
+
+  const deps: PinetMeshOpsDeps = {
+    getPinetEnabled: () => true,
+    getBrokerRole: () => "follower",
+    getActiveBrokerDb: () => null,
+    getActiveBrokerSelfId: () => null,
+    getAgentName: () => "Follower Crane",
+    getFollowerClient: () => followerClient,
+    formatTrackedAgent: (agentId) => agentId,
+    logActivity: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    deps,
+    followerClient,
+    sendAgentMessage,
+    scheduleWakeup,
+    listAgents,
+  };
+}
+
+describe("createPinetMeshOps", () => {
+  it("normalizes broker direct control messages before dispatch", async () => {
+    const { deps, createThread, insertedMessages } = createBrokerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    const result = await pinetMeshOps.sendPinetAgentMessage("worker-1", "/reload");
+
+    expect(result).toEqual({ messageId: 1, target: "Worker One" });
+    expect(createThread).toHaveBeenCalledWith("a2a:broker-1:worker-1", "agent", "", "broker-1");
+    expect(insertedMessages).toHaveLength(1);
+    expect(insertedMessages[0]).toMatchObject({
+      threadId: "a2a:broker-1:worker-1",
+      body: '{"type":"pinet:control","action":"reload"}',
+      metadata: {
+        senderAgent: "Broker Crane",
+        a2a: true,
+        type: "pinet:control",
+        action: "reload",
+      },
+    });
+  });
+
+  it("records broker task assignments and logs assignment activity", async () => {
+    const { deps, recordTaskAssignment, logActivity } = createBrokerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    const message = [
+      "ack/work/ask/report",
+      "Issue: #418",
+      "git worktree add .worktrees/refactor-418-pinet-mesh-ops -b refactor/418-pinet-mesh-ops",
+    ].join("\n");
+
+    await pinetMeshOps.sendPinetAgentMessage("worker-1", message);
+
+    expect(recordTaskAssignment).toHaveBeenCalledWith(
+      "worker-1",
+      418,
+      "refactor/418-pinet-mesh-ops",
+      "a2a:broker-1:worker-1",
+      1,
+    );
+    expect(logActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "task_assignment",
+        title: "Task assigned",
+        summary: "Assigned #418 to 🦊 Worker One.",
+        details: ["#418 on `refactor/418-pinet-mesh-ops`"],
+        fields: [
+          { label: "Worker", value: "🦊 Worker One" },
+          { label: "Thread", value: "a2a:broker-1:worker-1" },
+          { label: "Message", value: 1 },
+        ],
+        tone: "info",
+      }),
+    );
+  });
+
+  it("routes follower direct messages through the follower client", async () => {
+    const { deps, sendAgentMessage } = createFollowerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    const result = await pinetMeshOps.sendPinetAgentMessage("worker-2", "/exit");
+
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      "worker-2",
+      '{"type":"pinet:control","action":"exit"}',
+      { type: "pinet:control", action: "exit" },
+    );
+    expect(result).toEqual({ messageId: 17, target: "worker-2" });
+  });
+
+  it("sends broker broadcasts and returns the subscribed recipients", () => {
+    const { deps, insertedMessages } = createBrokerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    const result = pinetMeshOps.sendPinetBroadcastMessage("#all", "hello mesh");
+
+    expect(result).toEqual({
+      channel: "#all",
+      messageIds: [1, 2],
+      recipients: ["Worker One", "Worker Two"],
+    });
+    expect(insertedMessages.map((message) => message.body)).toEqual(["hello mesh", "hello mesh"]);
+  });
+
+  it("schedules broker and follower wakeups through the extracted ports", async () => {
+    const broker = createBrokerDeps();
+    const brokerMeshOps = createPinetMeshOps(broker.deps);
+    const follower = createFollowerDeps();
+    const followerMeshOps = createPinetMeshOps(follower.deps);
+
+    await expect(
+      brokerMeshOps.scheduleBrokerWakeup("2026-04-15T14:00:00.000Z", "check queue"),
+    ).resolves.toEqual({
+      id: 7,
+      fireAt: "2026-04-15T14:00:00.000Z",
+      agentId: "broker-1",
+      message: "check queue",
+    });
+    await expect(
+      followerMeshOps.scheduleFollowerWakeup("2026-04-15T14:05:00.000Z", "check queue"),
+    ).resolves.toEqual({ id: 9, fireAt: "2026-04-15T14:05:00.000Z" });
+    expect(broker.scheduleWakeup).toHaveBeenCalledWith(
+      "broker-1",
+      "check queue",
+      "2026-04-15T14:00:00.000Z",
+    );
+    expect(follower.scheduleWakeup).toHaveBeenCalledWith("2026-04-15T14:05:00.000Z", "check queue");
+  });
+
+  it("lists broker and follower agents through the extracted ports", async () => {
+    const broker = createBrokerDeps();
+    const brokerMeshOps = createPinetMeshOps(broker.deps);
+    const follower = createFollowerDeps();
+    const followerMeshOps = createPinetMeshOps(follower.deps);
+
+    expect(brokerMeshOps.listBrokerAgents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "worker-1", status: "idle", name: "Worker One" }),
+        expect.objectContaining({ id: "worker-2", status: "idle", name: "Worker Two" }),
+      ]),
+    );
+    await expect(followerMeshOps.listFollowerAgents(true)).resolves.toEqual([
+      expect.objectContaining({ id: "worker-2", status: "idle", name: "Worker Two" }),
+    ]);
+    expect(follower.listAgents).toHaveBeenCalledWith(true);
+  });
+});

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -1,0 +1,290 @@
+import { normalizeOutgoingPinetControlMessage } from "./helpers.js";
+import {
+  dispatchBroadcastAgentMessage,
+  dispatchDirectAgentMessage,
+  isBroadcastChannelTarget,
+  type AgentMessageStorage,
+} from "./broker/agent-messaging.js";
+import type { AgentInfo, TaskAssignmentInfo } from "./broker/types.js";
+import type { ActivityLogEntry } from "./activity-log.js";
+import { extractTaskAssignmentsFromMessage } from "./task-assignments.js";
+
+export interface PinetMeshOpsAgentRecord {
+  emoji: string;
+  name: string;
+  id: string;
+  pid?: number;
+  status: "working" | "idle";
+  metadata: Record<string, unknown> | null;
+  lastHeartbeat: string;
+  lastSeen?: string;
+  disconnectedAt?: string | null;
+  resumableUntil?: string | null;
+}
+
+export interface PinetMeshOpsRecordedAssignment {
+  issueNumber: number;
+  branch: string | null;
+}
+
+export interface PinetMeshOpsBrokerDbPort extends AgentMessageStorage {
+  getAllAgents: () => AgentInfo[];
+  recordTaskAssignment: (
+    agentId: string,
+    issueNumber: number,
+    branch: string | null,
+    threadId: string,
+    sourceMessageId: number,
+  ) => TaskAssignmentInfo;
+  scheduleWakeup: (
+    agentId: string,
+    message: string,
+    fireAt: string,
+  ) => { id: number; fireAt: string } | Promise<{ id: number; fireAt: string }>;
+}
+
+export interface PinetMeshOpsFollowerAgentRecord extends Omit<PinetMeshOpsAgentRecord, "status"> {
+  status?: PinetMeshOpsAgentRecord["status"] | null;
+}
+
+export interface PinetMeshOpsFollowerClientPort {
+  sendAgentMessage: (
+    target: string,
+    body: string,
+    metadata?: Record<string, unknown>,
+  ) => Promise<number>;
+  scheduleWakeup: (fireAt: string, message: string) => Promise<{ id: number; fireAt: string }>;
+  listAgents: (includeGhosts: boolean) => Promise<PinetMeshOpsFollowerAgentRecord[]>;
+}
+
+export interface PinetMeshOpsDeps {
+  getPinetEnabled: () => boolean;
+  getBrokerRole: () => "broker" | "follower" | null;
+  getActiveBrokerDb: () => PinetMeshOpsBrokerDbPort | null;
+  getActiveBrokerSelfId: () => string | null;
+  getAgentName: () => string;
+  getFollowerClient: () => PinetMeshOpsFollowerClientPort | null;
+  formatTrackedAgent: (agentId: string) => string;
+  logActivity: (entry: ActivityLogEntry) => void;
+}
+
+export interface PinetMeshOps {
+  sendPinetAgentMessage: (
+    target: string,
+    body: string,
+    metadata?: Record<string, unknown>,
+  ) => Promise<{ messageId: number; target: string }>;
+  sendPinetBroadcastMessage: (
+    channel: string,
+    body: string,
+  ) => { channel: string; messageIds: number[]; recipients: string[] };
+  scheduleBrokerWakeup: (
+    fireAt: string,
+    message: string,
+  ) => Promise<{ id: number; fireAt: string }>;
+  scheduleFollowerWakeup: (
+    fireAt: string,
+    message: string,
+  ) => Promise<{ id: number; fireAt: string }>;
+  listBrokerAgents: () => PinetMeshOpsAgentRecord[];
+  listFollowerAgents: (includeGhosts: boolean) => Promise<PinetMeshOpsAgentRecord[]>;
+}
+
+function prepareOutgoingPinetAgentMessage(
+  body: string,
+  metadata?: Record<string, unknown>,
+): { body: string; metadata?: Record<string, unknown> } {
+  const control = normalizeOutgoingPinetControlMessage(body, metadata);
+  if (control) {
+    return {
+      body: control.body,
+      metadata: control.metadata,
+    };
+  }
+
+  return { body, metadata };
+}
+
+export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
+  async function sendPinetAgentMessage(
+    targetRef: string,
+    body: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<{ messageId: number; target: string }> {
+    if (!deps.getPinetEnabled()) {
+      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+    }
+
+    if (isBroadcastChannelTarget(targetRef)) {
+      throw new Error(
+        "Broadcast channels are broker-only. Send the request to the broker instead.",
+      );
+    }
+
+    const outgoing = prepareOutgoingPinetAgentMessage(body, metadata);
+    const finalBody = outgoing.body;
+    const finalMetadata = outgoing.metadata;
+
+    if (deps.getBrokerRole() === "broker") {
+      const db = deps.getActiveBrokerDb();
+      const selfId = deps.getActiveBrokerSelfId();
+      if (!db || !selfId) {
+        throw new Error("Broker agent identity is unavailable.");
+      }
+
+      const result = dispatchDirectAgentMessage(db, {
+        senderAgentId: selfId,
+        senderAgentName: deps.getAgentName(),
+        target: targetRef,
+        body: finalBody,
+        metadata: finalMetadata,
+      });
+
+      const recordedAssignments: PinetMeshOpsRecordedAssignment[] = [];
+      for (const assignment of extractTaskAssignmentsFromMessage(body)) {
+        const tracked = db.recordTaskAssignment(
+          result.target.id,
+          assignment.issueNumber,
+          assignment.branch,
+          result.threadId,
+          result.messageId,
+        );
+        recordedAssignments.push({ issueNumber: tracked.issueNumber, branch: tracked.branch });
+      }
+
+      if (recordedAssignments.length > 0) {
+        deps.logActivity({
+          kind: "task_assignment",
+          level: "actions",
+          title: recordedAssignments.length === 1 ? "Task assigned" : "Tasks assigned",
+          summary: `Assigned ${recordedAssignments.map((assignment) => `#${assignment.issueNumber}`).join(", ")} to ${deps.formatTrackedAgent(result.target.id)}.`,
+          details: recordedAssignments.map((assignment) =>
+            assignment.branch
+              ? `#${assignment.issueNumber} on \`${assignment.branch}\``
+              : `#${assignment.issueNumber}`,
+          ),
+          fields: [
+            { label: "Worker", value: deps.formatTrackedAgent(result.target.id) },
+            { label: "Thread", value: result.threadId },
+            { label: "Message", value: result.messageId },
+          ],
+          tone: "info",
+        });
+      }
+
+      return { messageId: result.messageId, target: result.target.name };
+    }
+
+    if (deps.getBrokerRole() === "follower") {
+      const client = deps.getFollowerClient();
+      if (!client) {
+        throw new Error("Pinet is in an unexpected state.");
+      }
+
+      const messageId = await client.sendAgentMessage(targetRef, finalBody, finalMetadata);
+      return { messageId, target: targetRef };
+    }
+
+    throw new Error("Pinet is in an unexpected state.");
+  }
+
+  function sendPinetBroadcastMessage(
+    channel: string,
+    body: string,
+  ): { channel: string; messageIds: number[]; recipients: string[] } {
+    const db = deps.getActiveBrokerDb();
+    const selfId = deps.getActiveBrokerSelfId();
+    if (!db || !selfId) {
+      throw new Error("Broker agent identity is unavailable.");
+    }
+
+    const outgoing = prepareOutgoingPinetAgentMessage(body);
+    const result = dispatchBroadcastAgentMessage(db, {
+      senderAgentId: selfId,
+      senderAgentName: deps.getAgentName(),
+      channel,
+      body: outgoing.body,
+      ...(outgoing.metadata ? { metadata: outgoing.metadata } : {}),
+    });
+
+    return {
+      channel: result.channel,
+      messageIds: result.messageIds,
+      recipients: result.targets.map((target) => target.name),
+    };
+  }
+
+  async function scheduleBrokerWakeup(
+    fireAt: string,
+    message: string,
+  ): Promise<{ id: number; fireAt: string }> {
+    const db = deps.getActiveBrokerDb();
+    const selfId = deps.getActiveBrokerSelfId();
+    if (!db || !selfId) {
+      throw new Error("Broker agent identity is unavailable.");
+    }
+
+    return await db.scheduleWakeup(selfId, message, fireAt);
+  }
+
+  async function scheduleFollowerWakeup(
+    fireAt: string,
+    message: string,
+  ): Promise<{ id: number; fireAt: string }> {
+    const client = deps.getFollowerClient();
+    if (!client) {
+      throw new Error("Pinet is in an unexpected state.");
+    }
+
+    return await client.scheduleWakeup(fireAt, message);
+  }
+
+  function listBrokerAgents(): PinetMeshOpsAgentRecord[] {
+    const db = deps.getActiveBrokerDb();
+    if (!db) {
+      throw new Error("Broker agent identity is unavailable.");
+    }
+
+    return db.getAllAgents().map((agent) => ({
+      emoji: agent.emoji,
+      name: agent.name,
+      id: agent.id,
+      pid: agent.pid,
+      status: agent.status,
+      metadata: agent.metadata,
+      lastHeartbeat: agent.lastHeartbeat,
+      lastSeen: agent.lastSeen,
+      disconnectedAt: agent.disconnectedAt,
+      resumableUntil: agent.resumableUntil,
+    }));
+  }
+
+  async function listFollowerAgents(includeGhosts: boolean): Promise<PinetMeshOpsAgentRecord[]> {
+    const client = deps.getFollowerClient();
+    if (!client) {
+      throw new Error("Pinet is in an unexpected state.");
+    }
+
+    return (await client.listAgents(includeGhosts)).map((agent) => ({
+      emoji: agent.emoji,
+      name: agent.name,
+      id: agent.id,
+      pid: agent.pid,
+      status: agent.status ?? "idle",
+      metadata: agent.metadata,
+      lastHeartbeat: agent.lastHeartbeat,
+      lastSeen: agent.lastSeen,
+      disconnectedAt: agent.disconnectedAt,
+      resumableUntil: agent.resumableUntil,
+    }));
+  }
+
+  return {
+    sendPinetAgentMessage,
+    sendPinetBroadcastMessage,
+    scheduleBrokerWakeup,
+    scheduleFollowerWakeup,
+    listBrokerAgents,
+    listFollowerAgents,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow Pinet mesh-operations seam from `slack-bridge/index.ts` into `slack-bridge/pinet-mesh-ops.ts`
- route the existing broker/follower mesh ops used by `pinet-tools.ts` and `pinet-commands.ts` through the new port only
- add focused coverage for direct mesh sends, broadcast sends, wakeup scheduling, agent listing, and broker task-assignment logging

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-mesh-ops.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test