### PR TITLE
refactor: extract Pinet remote-control flow (#422)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -15,11 +15,7 @@ import {
   formatInboxMessages,
   buildPinetSkinAssignment,
   buildPinetSkinPromptGuideline,
-  queuePinetRemoteControl,
-  finishPinetRemoteControl,
   reloadPinetRuntimeSafely,
-  type PinetControlCommand,
-  type PinetRemoteControlState,
   callSlackAPI,
   createAbortableOperationTracker,
   filterAgentsForMeshVisibility,
@@ -111,6 +107,7 @@ import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
 import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
+import { createPinetRemoteControl } from "./pinet-remote-control.js";
 import { createPinetMeshOps } from "./pinet-mesh-ops.js";
 import {
   type SlackBridgeRuntimeMode,
@@ -118,11 +115,6 @@ import {
 } from "./runtime-mode.js";
 
 // Settings and helpers imported from ./helpers.js
-
-type PinetRuntimeControlContext = ExtensionContext & {
-  abort?: () => void;
-  shutdown?: () => void;
-};
 
 export default function (pi: ExtensionAPI) {
   let settings = loadSettingsFromFile();
@@ -705,6 +697,12 @@ export default function (pi: ExtensionAPI) {
     deferFollowerControlAck,
     flushDeferredRemoteControlAcks,
   } = pinetRemoteControlAcks;
+  const pinetRemoteControl = createPinetRemoteControl({
+    flushDeferredRemoteControlAcks,
+    reloadPinetRuntime,
+    formatError: msg,
+  });
+  const { requestRemoteControl, runRemoteControl, resetRemoteControlState } = pinetRemoteControl;
 
   function formatTrackedAgent(agentId: string): string {
     const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
@@ -1325,11 +1323,6 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
-  let remoteControlState: PinetRemoteControlState = {
-    currentCommand: null,
-    queuedCommand: null,
-  };
-
   async function transitionToRuntimeMode(
     ctx: ExtensionContext,
     mode: SlackBridgeRuntimeMode,
@@ -1435,71 +1428,6 @@ export default function (pi: ExtensionAPI) {
         await connectAsFollower(ctx);
       },
     });
-  }
-
-  function runRemoteControl(command: PinetControlCommand, ctx: ExtensionContext): void {
-    flushDeferredRemoteControlAcks(command);
-
-    const controlCtx = ctx as PinetRuntimeControlContext;
-    if (!(ctx.isIdle?.() ?? true)) {
-      try {
-        controlCtx.abort?.();
-      } catch {
-        /* best effort */
-      }
-    }
-
-    ctx.ui.notify(`Pinet remote control requested: /${command}`, "warning");
-    void (async () => {
-      try {
-        if (command === "reload") {
-          await reloadPinetRuntime(ctx);
-          return;
-        }
-
-        if (typeof controlCtx.shutdown !== "function") {
-          throw new Error("Shutdown is not available in this extension context.");
-        }
-        controlCtx.shutdown();
-      } catch (err) {
-        ctx.ui.notify(`Pinet remote control failed: ${msg(err)}`, "error");
-      } finally {
-        const next = finishPinetRemoteControl(remoteControlState);
-        remoteControlState = {
-          currentCommand: next.currentCommand,
-          queuedCommand: next.queuedCommand,
-        };
-        if (next.nextCommand) {
-          ctx.ui.notify(
-            `Pinet remote control continuing with queued /${next.nextCommand}`,
-            "warning",
-          );
-          runRemoteControl(next.nextCommand, ctx);
-        }
-      }
-    })();
-  }
-
-  function requestRemoteControl(
-    command: PinetControlCommand,
-    ctx: ExtensionContext,
-  ): ReturnType<typeof queuePinetRemoteControl> {
-    const queued = queuePinetRemoteControl(remoteControlState, command);
-    remoteControlState = {
-      currentCommand: queued.currentCommand,
-      queuedCommand: queued.queuedCommand,
-    };
-
-    if (queued.status === "queued") {
-      ctx.ui.notify(`Pinet remote control queued: /${queued.queuedCommand ?? command}`, "warning");
-    } else if (!queued.shouldStartNow) {
-      ctx.ui.notify(
-        `Pinet remote control already scheduled — keeping /${queued.scheduledCommand}`,
-        "warning",
-      );
-    }
-
-    return queued;
   }
 
   registerPinetTools(pi, {
@@ -1786,7 +1714,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     singlePlayerRuntime.resetShutdownState();
     resetTopLevelSlackRequests();
-    remoteControlState = { currentCommand: null, queuedCommand: null };
+    resetRemoteControlState();
     resetPendingRemoteControlAcks();
     suppressAutoDrainUntil = 0;
     terminalInputUnsubscribe?.();
@@ -2080,7 +2008,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
-    remoteControlState = { currentCommand: null, queuedCommand: null };
+    resetRemoteControlState();
     resetPendingRemoteControlAcks();
     terminalInputUnsubscribe?.();
     terminalInputUnsubscribe = null;

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -7,13 +7,8 @@ import {
   type SlackBridgeSettings,
 } from "./helpers.js";
 import { formatRecentActivityLogEntries, type LoggedActivityLogEntry } from "./activity-log.js";
+import type { PinetRuntimeControlContext } from "./pinet-remote-control.js";
 import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
-
-// ─── Types ───────────────────────────────────────────────
-
-type PinetRuntimeControlContext = ExtensionContext & {
-  abort?: () => void;
-};
 
 export interface PinetCommandsDeps {
   // State accessors

--- a/slack-bridge/pinet-remote-control.test.ts
+++ b/slack-bridge/pinet-remote-control.test.ts
@@ -1,0 +1,186 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPinetRemoteControl,
+  type PinetRemoteControlDeps,
+  type PinetRuntimeControlContext,
+} from "./pinet-remote-control.js";
+
+function createDeps(overrides: Partial<PinetRemoteControlDeps> = {}) {
+  const flushDeferredRemoteControlAcks = vi.fn();
+  const reloadPinetRuntime = vi.fn(async () => {
+    /* noop */
+  });
+
+  const deps: PinetRemoteControlDeps = {
+    flushDeferredRemoteControlAcks,
+    reloadPinetRuntime,
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    ...overrides,
+  };
+
+  return {
+    deps,
+    flushDeferredRemoteControlAcks,
+    reloadPinetRuntime,
+  };
+}
+
+function createCtx(
+  options: {
+    idle?: boolean;
+    shutdown?: () => void;
+    abort?: () => void;
+  } = {},
+) {
+  const notify = vi.fn();
+  const abort = options.abort ?? vi.fn();
+  const shutdown = options.shutdown;
+  const ctx = {
+    isIdle: () => options.idle ?? true,
+    ui: {
+      notify,
+    },
+  } as unknown as PinetRuntimeControlContext;
+
+  ctx.abort = abort;
+  if (shutdown) {
+    ctx.shutdown = shutdown;
+  }
+
+  return {
+    ctx: ctx as ExtensionContext,
+    notify,
+    abort,
+  };
+}
+
+async function settleRemoteControl(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("createPinetRemoteControl", () => {
+  it("starts the first remote-control command immediately without warning", () => {
+    const { deps } = createDeps();
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx, notify } = createCtx();
+
+    const result = pinetRemoteControl.requestRemoteControl("reload", ctx);
+
+    expect(result).toMatchObject({
+      currentCommand: "reload",
+      queuedCommand: null,
+      shouldStartNow: true,
+      status: "start",
+      scheduledCommand: "reload",
+      ackDisposition: "immediate",
+    });
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("warns when commands are queued or already covered", () => {
+    const { deps } = createDeps();
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx, notify } = createCtx();
+
+    pinetRemoteControl.requestRemoteControl("reload", ctx);
+    const queued = pinetRemoteControl.requestRemoteControl("exit", ctx);
+    const covered = pinetRemoteControl.requestRemoteControl("reload", ctx);
+
+    expect(queued).toMatchObject({
+      currentCommand: "reload",
+      queuedCommand: "exit",
+      shouldStartNow: false,
+      status: "queued",
+      scheduledCommand: "exit",
+      ackDisposition: "on_start",
+    });
+    expect(covered).toMatchObject({
+      currentCommand: "reload",
+      queuedCommand: "exit",
+      shouldStartNow: false,
+      status: "covered",
+      scheduledCommand: "exit",
+      ackDisposition: "on_start",
+    });
+    expect(notify).toHaveBeenNthCalledWith(1, "Pinet remote control queued: /exit", "warning");
+    expect(notify).toHaveBeenNthCalledWith(
+      2,
+      "Pinet remote control already scheduled — keeping /exit",
+      "warning",
+    );
+  });
+
+  it("flushes deferred acks, aborts busy work, and reloads the runtime", async () => {
+    const { deps, flushDeferredRemoteControlAcks, reloadPinetRuntime } = createDeps();
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx, notify, abort } = createCtx({ idle: false });
+
+    pinetRemoteControl.requestRemoteControl("reload", ctx);
+    pinetRemoteControl.runRemoteControl("reload", ctx);
+    await settleRemoteControl();
+
+    expect(flushDeferredRemoteControlAcks).toHaveBeenCalledTimes(1);
+    expect(flushDeferredRemoteControlAcks).toHaveBeenCalledWith("reload");
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(reloadPinetRuntime).toHaveBeenCalledTimes(1);
+    expect(reloadPinetRuntime).toHaveBeenCalledWith(ctx);
+    expect(notify).toHaveBeenCalledWith("Pinet remote control requested: /reload", "warning");
+  });
+
+  it("continues with a queued command after the active command finishes", async () => {
+    const { deps, flushDeferredRemoteControlAcks, reloadPinetRuntime } = createDeps();
+    const shutdown = vi.fn();
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx, notify, abort } = createCtx({ idle: true, shutdown });
+
+    pinetRemoteControl.requestRemoteControl("reload", ctx);
+    pinetRemoteControl.requestRemoteControl("exit", ctx);
+    pinetRemoteControl.runRemoteControl("reload", ctx);
+    await settleRemoteControl();
+
+    expect(flushDeferredRemoteControlAcks).toHaveBeenNthCalledWith(1, "reload");
+    expect(flushDeferredRemoteControlAcks).toHaveBeenNthCalledWith(2, "exit");
+    expect(reloadPinetRuntime).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(abort).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenNthCalledWith(1, "Pinet remote control queued: /exit", "warning");
+    expect(notify).toHaveBeenNthCalledWith(2, "Pinet remote control requested: /reload", "warning");
+    expect(notify).toHaveBeenNthCalledWith(
+      3,
+      "Pinet remote control continuing with queued /exit",
+      "warning",
+    );
+    expect(notify).toHaveBeenNthCalledWith(4, "Pinet remote control requested: /exit", "warning");
+  });
+
+  it("reports remote-control failures and resets cleanly", async () => {
+    const { deps, flushDeferredRemoteControlAcks } = createDeps();
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx, notify } = createCtx();
+
+    pinetRemoteControl.requestRemoteControl("exit", ctx);
+    pinetRemoteControl.runRemoteControl("exit", ctx);
+    await settleRemoteControl();
+
+    expect(flushDeferredRemoteControlAcks).toHaveBeenCalledWith("exit");
+    expect(notify).toHaveBeenNthCalledWith(1, "Pinet remote control requested: /exit", "warning");
+    expect(notify).toHaveBeenNthCalledWith(
+      2,
+      "Pinet remote control failed: Shutdown is not available in this extension context.",
+      "error",
+    );
+
+    pinetRemoteControl.resetRemoteControlState();
+    const restarted = pinetRemoteControl.requestRemoteControl("reload", ctx);
+    expect(restarted).toMatchObject({
+      currentCommand: "reload",
+      queuedCommand: null,
+      shouldStartNow: true,
+      status: "start",
+      scheduledCommand: "reload",
+    });
+  });
+});

--- a/slack-bridge/pinet-remote-control.ts
+++ b/slack-bridge/pinet-remote-control.ts
@@ -1,0 +1,114 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  finishPinetRemoteControl,
+  queuePinetRemoteControl,
+  type PinetControlCommand,
+  type PinetRemoteControlRequestResult,
+  type PinetRemoteControlState,
+} from "./helpers.js";
+
+export type PinetRuntimeControlContext = ExtensionContext & {
+  abort?: () => void;
+  shutdown?: () => void;
+};
+
+export interface PinetRemoteControlDeps {
+  flushDeferredRemoteControlAcks: (command: PinetControlCommand) => void;
+  reloadPinetRuntime: (ctx: ExtensionContext) => Promise<void>;
+  formatError: (error: unknown) => string;
+}
+
+export interface PinetRemoteControl {
+  requestRemoteControl: (
+    command: PinetControlCommand,
+    ctx: ExtensionContext,
+  ) => PinetRemoteControlRequestResult;
+  runRemoteControl: (command: PinetControlCommand, ctx: ExtensionContext) => void;
+  resetRemoteControlState: () => void;
+}
+
+function createInitialRemoteControlState(): PinetRemoteControlState {
+  return {
+    currentCommand: null,
+    queuedCommand: null,
+  };
+}
+
+export function createPinetRemoteControl(deps: PinetRemoteControlDeps): PinetRemoteControl {
+  let remoteControlState = createInitialRemoteControlState();
+
+  function resetRemoteControlState(): void {
+    remoteControlState = createInitialRemoteControlState();
+  }
+
+  function runRemoteControl(command: PinetControlCommand, ctx: ExtensionContext): void {
+    deps.flushDeferredRemoteControlAcks(command);
+
+    const controlCtx = ctx as PinetRuntimeControlContext;
+    if (!(ctx.isIdle?.() ?? true)) {
+      try {
+        controlCtx.abort?.();
+      } catch {
+        /* best effort */
+      }
+    }
+
+    ctx.ui.notify(`Pinet remote control requested: /${command}`, "warning");
+    void (async () => {
+      try {
+        if (command === "reload") {
+          await deps.reloadPinetRuntime(ctx);
+          return;
+        }
+
+        if (typeof controlCtx.shutdown !== "function") {
+          throw new Error("Shutdown is not available in this extension context.");
+        }
+        controlCtx.shutdown();
+      } catch (err) {
+        ctx.ui.notify(`Pinet remote control failed: ${deps.formatError(err)}`, "error");
+      } finally {
+        const next = finishPinetRemoteControl(remoteControlState);
+        remoteControlState = {
+          currentCommand: next.currentCommand,
+          queuedCommand: next.queuedCommand,
+        };
+        if (next.nextCommand) {
+          ctx.ui.notify(
+            `Pinet remote control continuing with queued /${next.nextCommand}`,
+            "warning",
+          );
+          runRemoteControl(next.nextCommand, ctx);
+        }
+      }
+    })();
+  }
+
+  function requestRemoteControl(
+    command: PinetControlCommand,
+    ctx: ExtensionContext,
+  ): PinetRemoteControlRequestResult {
+    const queued = queuePinetRemoteControl(remoteControlState, command);
+    remoteControlState = {
+      currentCommand: queued.currentCommand,
+      queuedCommand: queued.queuedCommand,
+    };
+
+    if (queued.status === "queued") {
+      ctx.ui.notify(`Pinet remote control queued: /${queued.queuedCommand ?? command}`, "warning");
+    } else if (!queued.shouldStartNow) {
+      ctx.ui.notify(
+        `Pinet remote control already scheduled — keeping /${queued.scheduledCommand}`,
+        "warning",
+      );
+    }
+
+    return queued;
+  }
+
+  return {
+    requestRemoteControl,
+    runRemoteControl,
+    resetRemoteControlState,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow Pinet remote-control flow seam from `slack-bridge/index.ts` into `slack-bridge/pinet-remote-control.ts`
- keep the existing broker/follower wiring and reset touchpoints behaviorally identical through `createPinetRemoteControl(deps)`
- add focused coverage for request, run, queue/continue, failure, and reset behavior

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-remote-control.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test