### PR TITLE
refactor: extract tracked agent activity formatting (#425)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -90,7 +90,7 @@ import {
   resolveTaskAssignments,
   type ResolvedTaskAssignment,
 } from "./task-assignments.js";
-import { SlackActivityLogger, type ActivityLogTone } from "./activity-log.js";
+import { SlackActivityLogger } from "./activity-log.js";
 import {
   createBrokerDeliveryState,
   getBrokerInboxIds,
@@ -105,6 +105,7 @@ import {
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
+import { createPinetActivityFormatting } from "./pinet-activity-formatting.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
 import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
 import { createPinetRemoteControl } from "./pinet-remote-control.js";
@@ -703,49 +704,10 @@ export default function (pi: ExtensionAPI) {
     formatError: msg,
   });
   const { requestRemoteControl, runRemoteControl, resetRemoteControlState } = pinetRemoteControl;
-
-  function formatTrackedAgent(agentId: string): string {
-    const agent = brokerRuntime.getBroker()?.db.getAgentById(agentId);
-    if (!agent) {
-      return agentId;
-    }
-    return `${agent.emoji} ${agent.name}`.trim();
-  }
-
-  function summarizeTrackedAssignmentStatus(
-    status: "assigned" | "branch_pushed" | "pr_open" | "pr_merged" | "pr_closed",
-    prNumber: number | null,
-    branch: string | null,
-  ): { summary: string; tone: ActivityLogTone } {
-    switch (status) {
-      case "pr_merged":
-        return {
-          summary: `PR #${prNumber ?? "?"} merged`,
-          tone: "success",
-        };
-      case "pr_open":
-        return {
-          summary: `PR #${prNumber ?? "?"} opened for review`,
-          tone: "success",
-        };
-      case "pr_closed":
-        return {
-          summary: `PR #${prNumber ?? "?"} closed without merge`,
-          tone: "warning",
-        };
-      case "branch_pushed":
-        return {
-          summary: `commits pushed on ${branch ?? "tracked branch"}`,
-          tone: "info",
-        };
-      case "assigned":
-      default:
-        return {
-          summary: "assigned",
-          tone: "info",
-        };
-    }
-  }
+  const pinetActivityFormatting = createPinetActivityFormatting({
+    getActiveBrokerDb: () => (brokerRuntime.getBroker()?.db as BrokerDB | undefined) ?? null,
+  });
+  const { formatTrackedAgent, summarizeTrackedAssignmentStatus } = pinetActivityFormatting;
 
   // ─── Socket Mode (native WebSocket) ─────────────────
 

--- a/slack-bridge/pinet-activity-formatting.test.ts
+++ b/slack-bridge/pinet-activity-formatting.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  createPinetActivityFormatting,
+  type PinetActivityFormattingAgentRecord,
+  type PinetActivityFormattingBrokerDbPort,
+  type PinetActivityFormattingDeps,
+} from "./pinet-activity-formatting.js";
+
+function createDeps(overrides: Partial<PinetActivityFormattingDeps> = {}) {
+  const agents = new Map<string, PinetActivityFormattingAgentRecord>([
+    ["worker-1", { emoji: "🦩", name: "Cobalt Olive Crane" }],
+    ["worker-2", { emoji: "", name: "Quiet Otter" }],
+  ]);
+
+  const db: PinetActivityFormattingBrokerDbPort = {
+    getAgentById: (agentId) => agents.get(agentId) ?? null,
+  };
+
+  const deps: PinetActivityFormattingDeps = {
+    getActiveBrokerDb: () => db,
+    ...overrides,
+  };
+
+  return { deps };
+}
+
+describe("createPinetActivityFormatting", () => {
+  it("formats tracked agents from the active broker db and falls back to the id", () => {
+    const { deps } = createDeps();
+    const pinetActivityFormatting = createPinetActivityFormatting(deps);
+
+    expect(pinetActivityFormatting.formatTrackedAgent("worker-1")).toBe("🦩 Cobalt Olive Crane");
+    expect(pinetActivityFormatting.formatTrackedAgent("worker-2")).toBe("Quiet Otter");
+    expect(pinetActivityFormatting.formatTrackedAgent("missing-worker")).toBe("missing-worker");
+  });
+
+  it("falls back to the id when no broker db is active", () => {
+    const { deps } = createDeps({
+      getActiveBrokerDb: () => null,
+    });
+    const pinetActivityFormatting = createPinetActivityFormatting(deps);
+
+    expect(pinetActivityFormatting.formatTrackedAgent("worker-1")).toBe("worker-1");
+  });
+
+  it("summarizes PR lifecycle statuses", () => {
+    const { deps } = createDeps();
+    const pinetActivityFormatting = createPinetActivityFormatting(deps);
+
+    expect(pinetActivityFormatting.summarizeTrackedAssignmentStatus("pr_open", 423, null)).toEqual({
+      summary: "PR #423 opened for review",
+      tone: "success",
+    });
+    expect(
+      pinetActivityFormatting.summarizeTrackedAssignmentStatus("pr_merged", 423, null),
+    ).toEqual({
+      summary: "PR #423 merged",
+      tone: "success",
+    });
+    expect(
+      pinetActivityFormatting.summarizeTrackedAssignmentStatus("pr_closed", 423, null),
+    ).toEqual({
+      summary: "PR #423 closed without merge",
+      tone: "warning",
+    });
+  });
+
+  it("summarizes branch pushes with a branch or fallback label", () => {
+    const { deps } = createDeps();
+    const pinetActivityFormatting = createPinetActivityFormatting(deps);
+
+    expect(
+      pinetActivityFormatting.summarizeTrackedAssignmentStatus(
+        "branch_pushed",
+        null,
+        "feat/narrow-seam",
+      ),
+    ).toEqual({
+      summary: "commits pushed on feat/narrow-seam",
+      tone: "info",
+    });
+    expect(
+      pinetActivityFormatting.summarizeTrackedAssignmentStatus("branch_pushed", null, null),
+    ).toEqual({
+      summary: "commits pushed on tracked branch",
+      tone: "info",
+    });
+  });
+
+  it("defaults assigned activity to an info summary", () => {
+    const { deps } = createDeps();
+    const pinetActivityFormatting = createPinetActivityFormatting(deps);
+
+    expect(
+      pinetActivityFormatting.summarizeTrackedAssignmentStatus("assigned", 123, "branch"),
+    ).toEqual({
+      summary: "assigned",
+      tone: "info",
+    });
+  });
+});

--- a/slack-bridge/pinet-activity-formatting.ts
+++ b/slack-bridge/pinet-activity-formatting.ts
@@ -1,0 +1,83 @@
+import type { ActivityLogTone } from "./activity-log.js";
+
+export type PinetTrackedAssignmentStatus =
+  | "assigned"
+  | "branch_pushed"
+  | "pr_open"
+  | "pr_merged"
+  | "pr_closed";
+
+export interface PinetActivityFormattingAgentRecord {
+  emoji: string;
+  name: string;
+}
+
+export interface PinetActivityFormattingBrokerDbPort {
+  getAgentById: (agentId: string) => PinetActivityFormattingAgentRecord | null;
+}
+
+export interface PinetActivityFormattingDeps {
+  getActiveBrokerDb: () => PinetActivityFormattingBrokerDbPort | null;
+}
+
+export interface PinetActivityFormatting {
+  formatTrackedAgent: (agentId: string) => string;
+  summarizeTrackedAssignmentStatus: (
+    status: PinetTrackedAssignmentStatus,
+    prNumber: number | null,
+    branch: string | null,
+  ) => { summary: string; tone: ActivityLogTone };
+}
+
+export function createPinetActivityFormatting(
+  deps: PinetActivityFormattingDeps,
+): PinetActivityFormatting {
+  function formatTrackedAgent(agentId: string): string {
+    const agent = deps.getActiveBrokerDb()?.getAgentById(agentId);
+    if (!agent) {
+      return agentId;
+    }
+
+    return `${agent.emoji} ${agent.name}`.trim();
+  }
+
+  function summarizeTrackedAssignmentStatus(
+    status: PinetTrackedAssignmentStatus,
+    prNumber: number | null,
+    branch: string | null,
+  ): { summary: string; tone: ActivityLogTone } {
+    switch (status) {
+      case "pr_merged":
+        return {
+          summary: `PR #${prNumber ?? "?"} merged`,
+          tone: "success",
+        };
+      case "pr_open":
+        return {
+          summary: `PR #${prNumber ?? "?"} opened for review`,
+          tone: "success",
+        };
+      case "pr_closed":
+        return {
+          summary: `PR #${prNumber ?? "?"} closed without merge`,
+          tone: "warning",
+        };
+      case "branch_pushed":
+        return {
+          summary: `commits pushed on ${branch ?? "tracked branch"}`,
+          tone: "info",
+        };
+      case "assigned":
+      default:
+        return {
+          summary: "assigned",
+          tone: "info",
+        };
+    }
+  }
+
+  return {
+    formatTrackedAgent,
+    summarizeTrackedAssignmentStatus,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow tracked-agent activity formatting seam from `slack-bridge/index.ts` into `slack-bridge/pinet-activity-formatting.ts`
- keep existing broker-runtime and mesh-ops call sites behaviorally identical through `createPinetActivityFormatting(deps)`
- add focused coverage for tracked-agent formatting and tracked-assignment status summaries

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-activity-formatting.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test