### PR TITLE
refactor: extract Pinet control-plane canvas orchestration (#427)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -5,9 +5,6 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-metadata.js";
 import {
   type InboxMessage,
-  type RalphLoopAgentWorkload,
-  type RalphLoopEvaluationResult,
-  type RalphLoopEvaluationOptions,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
   getSlackUserAccessWarning,
@@ -18,9 +15,6 @@ import {
   reloadPinetRuntimeSafely,
   callSlackAPI,
   createAbortableOperationTracker,
-  filterAgentsForMeshVisibility,
-  evaluateRalphLoopCycle,
-  DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
   buildPinetOwnerToken,
   resolveAgentIdentity,
   resolvePersistedAgentIdentity,
@@ -53,9 +47,7 @@ import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { buildReactionPromptGuidelines, resolveReactionCommands } from "./reaction-triggers.js";
 import type { Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
-import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
-import { type BrokerMaintenanceResult } from "./broker/maintenance.js";
-import { DEFAULT_SOCKET_PATH, HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { registerSlackTools } from "./slack-tools.js";
 import { registerPinetCommands } from "./pinet-commands.js";
@@ -85,27 +77,18 @@ import {
   type SinglePlayerThreadInfo,
 } from "./single-player-runtime.js";
 import { createBrokerRuntime } from "./broker-runtime.js";
-import {
-  normalizeTrackedTaskAssignments,
-  resolveTaskAssignments,
-  type ResolvedTaskAssignment,
-} from "./task-assignments.js";
 import { SlackActivityLogger } from "./activity-log.js";
 import {
   createBrokerDeliveryState,
   getBrokerInboxIds,
   queueBrokerInboxIds,
 } from "./broker-delivery.js";
-import {
-  buildBrokerControlPlaneDashboardSnapshot,
-  refreshBrokerControlPlaneCanvas,
-  renderBrokerControlPlaneCanvasMarkdown,
-  type BrokerControlPlaneDashboardSnapshot,
-} from "./broker/control-plane-canvas.js";
+import { buildBrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
 import { createPinetActivityFormatting } from "./pinet-activity-formatting.js";
+import { createPinetControlPlaneCanvas } from "./pinet-control-plane-canvas.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
 import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
 import { createPinetRemoteControl } from "./pinet-remote-control.js";
@@ -181,29 +164,6 @@ export default function (pi: ExtensionAPI) {
   function normalizeOptionalSetting(value?: string | null): string | null {
     const trimmed = value?.trim();
     return trimmed && trimmed.length > 0 ? trimmed : null;
-  }
-
-  function getExplicitBrokerControlPlaneCanvasId(): string | null {
-    return normalizeOptionalSetting(settings.controlPlaneCanvasId);
-  }
-
-  function getConfiguredBrokerControlPlaneCanvasId(): string | null {
-    return (
-      getExplicitBrokerControlPlaneCanvasId() ?? brokerRuntime.getControlPlaneCanvasRuntimeId()
-    );
-  }
-
-  function getConfiguredBrokerControlPlaneCanvasChannel(): string | null {
-    return (
-      normalizeOptionalSetting(settings.controlPlaneCanvasChannel) ??
-      normalizeOptionalSetting(settings.defaultChannel)
-    );
-  }
-
-  function getConfiguredBrokerControlPlaneCanvasTitle(): string {
-    return (
-      normalizeOptionalSetting(settings.controlPlaneCanvasTitle) ?? "Pinet Broker Control Plane"
-    );
   }
 
   interface ReloadableRuntimeSnapshot {
@@ -708,6 +668,36 @@ export default function (pi: ExtensionAPI) {
     getActiveBrokerDb: () => (brokerRuntime.getBroker()?.db as BrokerDB | undefined) ?? null,
   });
   const { formatTrackedAgent, summarizeTrackedAssignmentStatus } = pinetActivityFormatting;
+  const pinetControlPlaneCanvas = createPinetControlPlaneCanvas({
+    getSettings: () => settings,
+    getBotToken: () => botToken,
+    slack,
+    resolveChannel,
+    persistState,
+    getActiveBrokerDb,
+    getActiveBrokerSelfId,
+    heartbeatTimerActive: () => brokerRuntime.heartbeatTimerActive(),
+    maintenanceTimerActive: () => brokerRuntime.maintenanceTimerActive(),
+    getLastMaintenance: () => brokerRuntime.getLastMaintenance(),
+    isBrokerControlPlaneCanvasEnabled: () => brokerRuntime.isBrokerControlPlaneCanvasEnabled(),
+    getControlPlaneCanvasRuntimeId: () => brokerRuntime.getControlPlaneCanvasRuntimeId(),
+    getControlPlaneCanvasRuntimeChannelId: () =>
+      brokerRuntime.getControlPlaneCanvasRuntimeChannelId(),
+    restoreControlPlaneCanvasRuntimeState: (input) => {
+      brokerRuntime.restoreControlPlaneCanvasRuntimeState(input);
+    },
+    setLastControlPlaneCanvasRefreshAt: (value) => {
+      brokerRuntime.setLastControlPlaneCanvasRefreshAt(value);
+    },
+    getLastControlPlaneCanvasError: () => brokerRuntime.getLastControlPlaneCanvasError(),
+    setLastControlPlaneCanvasError: (value) => {
+      brokerRuntime.setLastControlPlaneCanvasError(value);
+    },
+  });
+  const {
+    buildCurrentBrokerControlPlaneDashboardSnapshot,
+    refreshBrokerControlPlaneCanvasDashboard,
+  } = pinetControlPlaneCanvas;
 
   // ─── Socket Mode (native WebSocket) ─────────────────
 
@@ -1097,192 +1087,6 @@ export default function (pi: ExtensionAPI) {
 
   function getBrokerControlPlaneHomeTabViewerIds(): string[] {
     return brokerRuntime.getHomeTabViewerIds();
-  }
-
-  async function buildCurrentBrokerControlPlaneDashboardSnapshot(
-    cycleStartedAt: string = new Date().toISOString(),
-  ): Promise<BrokerControlPlaneDashboardSnapshot | null> {
-    const db = getActiveBrokerDb();
-    if (!db) {
-      return null;
-    }
-
-    const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
-    const nowMs = Date.now();
-    const recentGhostWindowMs = DEFAULT_HEARTBEAT_TIMEOUT_MS * 2;
-    const workloads = filterAgentsForMeshVisibility(db.getAllAgents(), {
-      now: nowMs,
-      includeGhosts: true,
-      recentDisconnectWindowMs: recentGhostWindowMs,
-    }).map((agent) => ({
-      ...agent,
-      pendingInboxCount: db.getPendingInboxCount(agent.id),
-      ownedThreadCount: db.getOwnedThreadCount(agent.id),
-    }));
-    const pendingBacklogCount = db.getBacklogCount("pending");
-    const evaluationOptions: RalphLoopEvaluationOptions = {
-      now: nowMs,
-      heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
-      heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
-      stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
-      pendingBacklogCount,
-      currentBranch,
-      brokerHeartbeatActive: brokerRuntime.heartbeatTimerActive(),
-      brokerMaintenanceActive: brokerRuntime.maintenanceTimerActive(),
-      brokerAgentId: getActiveBrokerSelfId() ?? undefined,
-    };
-    const evaluation = evaluateRalphLoopCycle(workloads, evaluationOptions);
-
-    const rawTrackedAssignments = db.listTaskAssignments();
-    const trackedAssignmentSourceIds = [
-      ...new Set(
-        rawTrackedAssignments
-          .map((assignment) => assignment.sourceMessageId)
-          .filter((messageId): messageId is number => messageId != null),
-      ),
-    ];
-    const trackedAssignments = normalizeTrackedTaskAssignments(
-      rawTrackedAssignments,
-      new Map(
-        db
-          .getMessagesByIds(trackedAssignmentSourceIds)
-          .map((message) => [message.id, message.body]),
-      ),
-    );
-    let projectedAssignments: ResolvedTaskAssignment[] = [];
-    if (trackedAssignments.length > 0) {
-      const resolvedAssignments = await resolveTaskAssignments(trackedAssignments, process.cwd());
-      projectedAssignments = resolvedAssignments.map((assignment) => ({
-        ...assignment,
-        status: assignment.nextStatus,
-        prNumber: assignment.nextPrNumber,
-      }));
-    }
-
-    const recentRalphCycles = db.getRecentRalphCycles(5).map((cycle) => ({
-      startedAt: cycle.startedAt,
-      completedAt: cycle.completedAt,
-      durationMs: cycle.durationMs,
-      ghostAgentIds: cycle.ghostAgentIds,
-      stuckAgentIds: cycle.stuckAgentIds,
-      anomalies: cycle.anomalies,
-      followUpDelivered: cycle.followUpDelivered,
-      agentCount: cycle.agentCount,
-      backlogCount: cycle.backlogCount,
-    }));
-
-    return buildBrokerControlPlaneDashboardSnapshot({
-      workloads,
-      evaluation,
-      evaluationOptions,
-      maintenance: brokerRuntime.getLastMaintenance(),
-      assignments: projectedAssignments,
-      recentCycles: recentRalphCycles,
-      cycleStartedAt,
-      cycleDurationMs: 0,
-      currentBranch,
-      homedir: os.homedir(),
-    });
-  }
-
-  async function refreshBrokerControlPlaneCanvasDashboard(
-    ctx: ExtensionContext,
-    input: {
-      workloads: RalphLoopAgentWorkload[];
-      evaluation: RalphLoopEvaluationResult;
-      evaluationOptions: RalphLoopEvaluationOptions;
-      maintenance: BrokerMaintenanceResult | null;
-      assignments: ResolvedTaskAssignment[];
-      recentCycles: Array<{
-        startedAt: string;
-        completedAt: string | null;
-        durationMs: number | null;
-        ghostAgentIds: string[];
-        stuckAgentIds: string[];
-        anomalies: string[];
-        followUpDelivered: boolean;
-        agentCount: number;
-        backlogCount: number;
-      }>;
-      cycleStartedAt: string;
-      cycleDurationMs: number;
-      currentBranch: string | null;
-    },
-  ): Promise<void> {
-    if (!botToken || !brokerRuntime.isBrokerControlPlaneCanvasEnabled()) {
-      brokerRuntime.setLastControlPlaneCanvasError(null);
-      return;
-    }
-
-    const explicitCanvasId = getExplicitBrokerControlPlaneCanvasId();
-    const effectiveCanvasId = getConfiguredBrokerControlPlaneCanvasId();
-    const channelInput = getConfiguredBrokerControlPlaneCanvasChannel();
-    if (!effectiveCanvasId && !channelInput) {
-      const warning =
-        "Pinet broker control plane canvas skipped: set slack-bridge.controlPlaneCanvasChannel, defaultChannel, or controlPlaneCanvasId.";
-      if (brokerRuntime.getLastControlPlaneCanvasError() !== warning) {
-        ctx.ui.notify(warning, "warning");
-      }
-      brokerRuntime.setLastControlPlaneCanvasError(warning);
-      return;
-    }
-
-    const snapshot = buildBrokerControlPlaneDashboardSnapshot({
-      workloads: input.workloads,
-      evaluation: input.evaluation,
-      evaluationOptions: input.evaluationOptions,
-      maintenance: input.maintenance,
-      assignments: input.assignments,
-      recentCycles: input.recentCycles,
-      cycleStartedAt: input.cycleStartedAt,
-      cycleDurationMs: input.cycleDurationMs,
-      currentBranch: input.currentBranch,
-      homedir: os.homedir(),
-    });
-    const markdown = renderBrokerControlPlaneCanvasMarkdown(snapshot);
-    const channelId = explicitCanvasId || !channelInput ? null : await resolveChannel(channelInput);
-    const reusableRuntimeCanvasId =
-      !explicitCanvasId &&
-      brokerRuntime.getControlPlaneCanvasRuntimeId() &&
-      (!channelId || brokerRuntime.getControlPlaneCanvasRuntimeChannelId() === channelId)
-        ? brokerRuntime.getControlPlaneCanvasRuntimeId()
-        : null;
-    const previousRuntimeId = brokerRuntime.getControlPlaneCanvasRuntimeId();
-    const previousRuntimeChannelId = brokerRuntime.getControlPlaneCanvasRuntimeChannelId();
-    const result = await refreshBrokerControlPlaneCanvas({
-      slack,
-      token: botToken,
-      markdown,
-      canvasId: explicitCanvasId ?? reusableRuntimeCanvasId,
-      channelId,
-      title: getConfiguredBrokerControlPlaneCanvasTitle(),
-    });
-
-    if (!explicitCanvasId) {
-      brokerRuntime.restoreControlPlaneCanvasRuntimeState({
-        canvasId: result.canvasId,
-        channelId,
-      });
-    }
-    brokerRuntime.setLastControlPlaneCanvasRefreshAt(input.cycleStartedAt);
-    brokerRuntime.setLastControlPlaneCanvasError(null);
-
-    if (
-      !explicitCanvasId &&
-      (result.canvasId !== previousRuntimeId || channelId !== previousRuntimeChannelId)
-    ) {
-      persistState();
-      const destination = channelInput ? ` via ${channelInput}` : "";
-      const action = result.created
-        ? "created"
-        : result.reusedExistingChannelCanvas
-          ? "attached"
-          : "updated";
-      ctx.ui.notify(
-        `Pinet broker control plane canvas ${action}: ${result.canvasId}${destination}`,
-        "info",
-      );
-    }
   }
 
   async function transitionToRuntimeMode(

--- a/slack-bridge/pinet-control-plane-canvas.test.ts
+++ b/slack-bridge/pinet-control-plane-canvas.test.ts
@@ -1,0 +1,343 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { probeGitBranch } from "./git-metadata.js";
+import {
+  createPinetControlPlaneCanvas,
+  type PinetControlPlaneCanvasBrokerDbPort,
+  type PinetControlPlaneCanvasDeps,
+  type PinetControlPlaneCanvasRefreshInput,
+} from "./pinet-control-plane-canvas.js";
+
+vi.mock("./git-metadata.js", () => ({
+  probeGitBranch: vi.fn(async () => "main"),
+}));
+
+function createContext() {
+  const notify = vi.fn();
+  const ctx = {
+    ui: {
+      notify,
+    },
+  } as unknown as ExtensionContext;
+
+  return { ctx, notify };
+}
+
+function createRefreshInput(
+  overrides: Partial<PinetControlPlaneCanvasRefreshInput> = {},
+): PinetControlPlaneCanvasRefreshInput {
+  return {
+    workloads: [
+      {
+        id: "broker-1",
+        name: "Broker Otter",
+        emoji: "🦦",
+        status: "working",
+        lastHeartbeat: "2026-04-15T00:00:10.000Z",
+        pendingInboxCount: 0,
+        ownedThreadCount: 0,
+        metadata: {
+          role: "broker",
+          capabilities: { role: "broker" },
+          branch: "main",
+          worktreeKind: "main",
+        },
+      },
+      {
+        id: "worker-1",
+        name: "Worker Crane",
+        emoji: "🦩",
+        status: "working",
+        lastHeartbeat: "2026-04-15T00:00:12.000Z",
+        lastActivity: "2026-04-15T00:00:12.000Z",
+        pendingInboxCount: 1,
+        ownedThreadCount: 2,
+        metadata: {
+          role: "worker",
+          capabilities: { role: "worker" },
+          branch: "feat/control-plane-canvas",
+          repoRoot: "/Users/alice/src/extensions",
+          worktreePath: "/Users/alice/src/extensions/.worktrees/feat-control-plane-canvas",
+          worktreeKind: "linked",
+        },
+      },
+    ],
+    evaluation: {
+      ghostAgentIds: [],
+      nudgeAgentIds: [],
+      idleDrainAgentIds: [],
+      stuckAgentIds: [],
+      anomalies: [],
+    },
+    evaluationOptions: {
+      now: Date.parse("2026-04-15T00:00:15.000Z"),
+      heartbeatTimeoutMs: 15_000,
+      heartbeatIntervalMs: 5_000,
+      brokerAgentId: "broker-1",
+      pendingBacklogCount: 3,
+      currentBranch: "main",
+    },
+    maintenance: {
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 1,
+      nudgedAgentIds: [],
+      pendingBacklogCount: 3,
+      anomalies: [],
+    },
+    assignments: [],
+    recentCycles: [],
+    cycleStartedAt: "2026-04-15T00:00:00.000Z",
+    cycleDurationMs: 2500,
+    currentBranch: "main",
+    ...overrides,
+  };
+}
+
+function createDeps(overrides: Partial<PinetControlPlaneCanvasDeps> = {}) {
+  let runtimeCanvasId: string | null = null;
+  let runtimeChannelId: string | null = null;
+  let lastControlPlaneCanvasRefreshAt: string | null = null;
+  let lastControlPlaneCanvasError: string | null = null;
+
+  const db: PinetControlPlaneCanvasBrokerDbPort = {
+    getAllAgents: () => {
+      const now = new Date().toISOString();
+      return [
+        {
+          id: "broker-1",
+          name: "Broker Otter",
+          emoji: "🦦",
+          status: "working",
+          lastHeartbeat: now,
+          metadata: {
+            role: "broker",
+            capabilities: { role: "broker" },
+            branch: "main",
+            worktreeKind: "main",
+          },
+        },
+        {
+          id: "worker-1",
+          name: "Worker Crane",
+          emoji: "🦩",
+          status: "working",
+          lastHeartbeat: now,
+          lastActivity: now,
+          metadata: {
+            role: "worker",
+            capabilities: { role: "worker" },
+            branch: "feat/control-plane-canvas",
+            repoRoot: "/Users/alice/src/extensions",
+            worktreePath: "/Users/alice/src/extensions/.worktrees/feat-control-plane-canvas",
+            worktreeKind: "linked",
+          },
+        },
+      ];
+    },
+    getPendingInboxCount: (agentId) => (agentId === "worker-1" ? 1 : 0),
+    getOwnedThreadCount: (agentId) => (agentId === "worker-1" ? 2 : 0),
+    getBacklogCount: () => 3,
+    listTaskAssignments: () => [],
+    getMessagesByIds: () => [],
+    getRecentRalphCycles: () => [
+      {
+        startedAt: "2026-04-15T00:00:00.000Z",
+        completedAt: "2026-04-15T00:00:02.500Z",
+        durationMs: 2500,
+        ghostAgentIds: [],
+        stuckAgentIds: [],
+        anomalies: [],
+        followUpDelivered: true,
+        agentCount: 2,
+        backlogCount: 3,
+      },
+    ],
+  };
+
+  const slack = vi.fn(async () => ({ ok: true }));
+  const resolveChannel = vi.fn(async () => "C123CANVAS");
+  const persistState = vi.fn();
+
+  const deps: PinetControlPlaneCanvasDeps = {
+    getSettings: () => ({}),
+    getBotToken: () => "xoxb-test",
+    slack,
+    resolveChannel,
+    persistState,
+    getActiveBrokerDb: () => db,
+    getActiveBrokerSelfId: () => "broker-1",
+    heartbeatTimerActive: () => true,
+    maintenanceTimerActive: () => true,
+    getLastMaintenance: () => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 1,
+      nudgedAgentIds: [],
+      pendingBacklogCount: 3,
+      anomalies: [],
+    }),
+    isBrokerControlPlaneCanvasEnabled: () => true,
+    getControlPlaneCanvasRuntimeId: () => runtimeCanvasId,
+    getControlPlaneCanvasRuntimeChannelId: () => runtimeChannelId,
+    restoreControlPlaneCanvasRuntimeState: vi.fn((input) => {
+      runtimeCanvasId = input.canvasId;
+      runtimeChannelId = input.channelId;
+    }),
+    setLastControlPlaneCanvasRefreshAt: vi.fn((value: string | null) => {
+      lastControlPlaneCanvasRefreshAt = value;
+    }),
+    getLastControlPlaneCanvasError: () => lastControlPlaneCanvasError,
+    setLastControlPlaneCanvasError: vi.fn((value: string | null) => {
+      lastControlPlaneCanvasError = value;
+    }),
+    ...overrides,
+  };
+
+  return {
+    deps,
+    db,
+    slack: deps.slack,
+    resolveChannel: deps.resolveChannel,
+    persistState: deps.persistState,
+    getRuntimeCanvasId: () => runtimeCanvasId,
+    getRuntimeChannelId: () => runtimeChannelId,
+    getLastRefreshAt: () => lastControlPlaneCanvasRefreshAt,
+    getLastError: () => lastControlPlaneCanvasError,
+  };
+}
+
+describe("createPinetControlPlaneCanvas", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(probeGitBranch).mockResolvedValue("main");
+  });
+
+  it("normalizes explicit canvas settings and falls back to runtime/default values", () => {
+    const { deps } = createDeps({
+      getSettings: () => ({
+        controlPlaneCanvasId: "  FEXPLICIT  ",
+        controlPlaneCanvasChannel: "  ops-control  ",
+        controlPlaneCanvasTitle: "  Mesh Control Plane  ",
+      }),
+      getControlPlaneCanvasRuntimeId: () => "FRUNTIME",
+    });
+    const canvas = createPinetControlPlaneCanvas(deps);
+
+    expect(canvas.getExplicitBrokerControlPlaneCanvasId()).toBe("FEXPLICIT");
+    expect(canvas.getConfiguredBrokerControlPlaneCanvasId()).toBe("FEXPLICIT");
+    expect(canvas.getConfiguredBrokerControlPlaneCanvasChannel()).toBe("ops-control");
+    expect(canvas.getConfiguredBrokerControlPlaneCanvasTitle()).toBe("Mesh Control Plane");
+
+    const fallback = createPinetControlPlaneCanvas(
+      createDeps({
+        getSettings: () => ({ defaultChannel: "  broker-ops  " }),
+        getControlPlaneCanvasRuntimeId: () => "FRUNTIME",
+      }).deps,
+    );
+
+    expect(fallback.getExplicitBrokerControlPlaneCanvasId()).toBeNull();
+    expect(fallback.getConfiguredBrokerControlPlaneCanvasId()).toBe("FRUNTIME");
+    expect(fallback.getConfiguredBrokerControlPlaneCanvasChannel()).toBe("broker-ops");
+    expect(fallback.getConfiguredBrokerControlPlaneCanvasTitle()).toBe(
+      "Pinet Broker Control Plane",
+    );
+  });
+
+  it("returns null when no active broker db is available", async () => {
+    const { deps } = createDeps({
+      getActiveBrokerDb: () => null,
+    });
+    const canvas = createPinetControlPlaneCanvas(deps);
+
+    await expect(canvas.buildCurrentBrokerControlPlaneDashboardSnapshot()).resolves.toBeNull();
+  });
+
+  it("builds the current broker control-plane dashboard snapshot from broker state", async () => {
+    const { deps } = createDeps();
+    const canvas = createPinetControlPlaneCanvas(deps);
+
+    const snapshot = await canvas.buildCurrentBrokerControlPlaneDashboardSnapshot(
+      "2026-04-15T00:00:00.000Z",
+    );
+
+    expect(probeGitBranch).toHaveBeenCalledWith(process.cwd());
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.currentBranch).toBe("main");
+    expect(snapshot?.liveAgents).toBe(2);
+    expect(snapshot?.workerCount).toBe(1);
+    expect(snapshot?.pendingBacklogCount).toBe(3);
+    expect(snapshot?.roster[0]?.label).toContain("Broker Otter");
+    expect(snapshot?.recentCycles).toHaveLength(1);
+  });
+
+  it("warns once when no canvas destination is configured", async () => {
+    const { deps, getLastError } = createDeps({
+      getSettings: () => ({}),
+      getControlPlaneCanvasRuntimeId: () => null,
+    });
+    const canvas = createPinetControlPlaneCanvas(deps);
+    const { ctx, notify } = createContext();
+    const input = createRefreshInput();
+
+    await canvas.refreshBrokerControlPlaneCanvasDashboard(ctx, input);
+    await canvas.refreshBrokerControlPlaneCanvasDashboard(ctx, input);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet broker control plane canvas skipped: set slack-bridge.controlPlaneCanvasChannel, defaultChannel, or controlPlaneCanvasId.",
+      "warning",
+    );
+    expect(getLastError()).toBe(
+      "Pinet broker control plane canvas skipped: set slack-bridge.controlPlaneCanvasChannel, defaultChannel, or controlPlaneCanvasId.",
+    );
+  });
+
+  it("refreshes the broker control-plane canvas, persists runtime ids, and notifies on creation", async () => {
+    const {
+      deps,
+      slack,
+      resolveChannel,
+      persistState,
+      getRuntimeCanvasId,
+      getRuntimeChannelId,
+      getLastRefreshAt,
+      getLastError,
+    } = createDeps({
+      getSettings: () => ({
+        controlPlaneCanvasChannel: "ops-control",
+        controlPlaneCanvasTitle: "Broker Canvas",
+      }),
+      slack: vi.fn(async (method: string) => {
+        if (method === "conversations.canvases.create") {
+          return { ok: true, canvas_id: "FNEWCANVAS" };
+        }
+        return { ok: true };
+      }),
+    });
+    const canvas = createPinetControlPlaneCanvas(deps);
+    const { ctx, notify } = createContext();
+
+    await canvas.refreshBrokerControlPlaneCanvasDashboard(ctx, createRefreshInput());
+
+    expect(resolveChannel).toHaveBeenCalledWith("ops-control");
+    expect(slack).toHaveBeenCalledWith(
+      "conversations.canvases.create",
+      "xoxb-test",
+      expect.objectContaining({ channel_id: "C123CANVAS", title: "Broker Canvas" }),
+    );
+    expect(deps.restoreControlPlaneCanvasRuntimeState).toHaveBeenCalledWith({
+      canvasId: "FNEWCANVAS",
+      channelId: "C123CANVAS",
+    });
+    expect(persistState).toHaveBeenCalledTimes(1);
+    expect(getRuntimeCanvasId()).toBe("FNEWCANVAS");
+    expect(getRuntimeChannelId()).toBe("C123CANVAS");
+    expect(getLastRefreshAt()).toBe("2026-04-15T00:00:00.000Z");
+    expect(getLastError()).toBeNull();
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet broker control plane canvas created: FNEWCANVAS via ops-control",
+      "info",
+    );
+  });
+});

--- a/slack-bridge/pinet-control-plane-canvas.ts
+++ b/slack-bridge/pinet-control-plane-canvas.ts
@@ -1,0 +1,289 @@
+import * as os from "node:os";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { probeGitBranch } from "./git-metadata.js";
+import {
+  type RalphLoopAgentWorkload,
+  type RalphLoopEvaluationOptions,
+  DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+  filterAgentsForMeshVisibility,
+  evaluateRalphLoopCycle,
+  type SlackBridgeSettings,
+} from "./helpers.js";
+import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
+import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import type { BrokerMaintenanceResult } from "./broker/maintenance.js";
+import type { TaskAssignmentInfo } from "./broker/types.js";
+import {
+  buildBrokerControlPlaneDashboardSnapshot,
+  refreshBrokerControlPlaneCanvas,
+  renderBrokerControlPlaneCanvasMarkdown,
+  type BrokerControlPlaneDashboardSnapshot,
+  type BrokerControlPlaneRecentCycle,
+  type BuildBrokerControlPlaneDashboardSnapshotInput,
+  type RefreshBrokerControlPlaneCanvasInput,
+} from "./broker/control-plane-canvas.js";
+import {
+  normalizeTrackedTaskAssignments,
+  resolveTaskAssignments,
+  type ResolvedTaskAssignment,
+} from "./task-assignments.js";
+
+export type PinetControlPlaneCanvasAgentRecord = Omit<
+  RalphLoopAgentWorkload,
+  "pendingInboxCount" | "ownedThreadCount"
+>;
+
+export interface PinetControlPlaneCanvasMessageRecord {
+  id: number;
+  body: string;
+}
+
+export interface PinetControlPlaneCanvasBrokerDbPort {
+  getAllAgents: () => PinetControlPlaneCanvasAgentRecord[];
+  getPendingInboxCount: (agentId: string) => number;
+  getOwnedThreadCount: (agentId: string) => number;
+  getBacklogCount: (status: "pending") => number;
+  listTaskAssignments: () => TaskAssignmentInfo[];
+  getMessagesByIds: (ids: number[]) => PinetControlPlaneCanvasMessageRecord[];
+  getRecentRalphCycles: (limit: number) => BrokerControlPlaneRecentCycle[];
+}
+
+export type PinetControlPlaneCanvasRefreshInput = Omit<
+  BuildBrokerControlPlaneDashboardSnapshotInput,
+  "homedir"
+>;
+
+export interface PinetControlPlaneCanvasDeps {
+  getSettings: () => SlackBridgeSettings;
+  getBotToken: () => string | undefined;
+  slack: RefreshBrokerControlPlaneCanvasInput["slack"];
+  resolveChannel: (channelInput: string) => Promise<string | null>;
+  persistState: () => void;
+  getActiveBrokerDb: () => PinetControlPlaneCanvasBrokerDbPort | null;
+  getActiveBrokerSelfId: () => string | null;
+  heartbeatTimerActive: () => boolean;
+  maintenanceTimerActive: () => boolean;
+  getLastMaintenance: () => BrokerMaintenanceResult | null;
+  isBrokerControlPlaneCanvasEnabled: () => boolean;
+  getControlPlaneCanvasRuntimeId: () => string | null;
+  getControlPlaneCanvasRuntimeChannelId: () => string | null;
+  restoreControlPlaneCanvasRuntimeState: (input: {
+    canvasId: string | null;
+    channelId: string | null;
+  }) => void;
+  setLastControlPlaneCanvasRefreshAt: (value: string | null) => void;
+  getLastControlPlaneCanvasError: () => string | null;
+  setLastControlPlaneCanvasError: (value: string | null) => void;
+}
+
+export interface PinetControlPlaneCanvas {
+  getExplicitBrokerControlPlaneCanvasId: () => string | null;
+  getConfiguredBrokerControlPlaneCanvasId: () => string | null;
+  getConfiguredBrokerControlPlaneCanvasChannel: () => string | null;
+  getConfiguredBrokerControlPlaneCanvasTitle: () => string;
+  buildCurrentBrokerControlPlaneDashboardSnapshot: (
+    cycleStartedAt?: string,
+  ) => Promise<BrokerControlPlaneDashboardSnapshot | null>;
+  refreshBrokerControlPlaneCanvasDashboard: (
+    ctx: ExtensionContext,
+    input: PinetControlPlaneCanvasRefreshInput,
+  ) => Promise<void>;
+}
+
+function normalizeOptionalSetting(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function createPinetControlPlaneCanvas(
+  deps: PinetControlPlaneCanvasDeps,
+): PinetControlPlaneCanvas {
+  function getExplicitBrokerControlPlaneCanvasId(): string | null {
+    return normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasId);
+  }
+
+  function getConfiguredBrokerControlPlaneCanvasId(): string | null {
+    return getExplicitBrokerControlPlaneCanvasId() ?? deps.getControlPlaneCanvasRuntimeId();
+  }
+
+  function getConfiguredBrokerControlPlaneCanvasChannel(): string | null {
+    return (
+      normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasChannel) ??
+      normalizeOptionalSetting(deps.getSettings().defaultChannel)
+    );
+  }
+
+  function getConfiguredBrokerControlPlaneCanvasTitle(): string {
+    return (
+      normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasTitle) ??
+      "Pinet Broker Control Plane"
+    );
+  }
+
+  async function buildCurrentBrokerControlPlaneDashboardSnapshot(
+    cycleStartedAt: string = new Date().toISOString(),
+  ): Promise<BrokerControlPlaneDashboardSnapshot | null> {
+    const db = deps.getActiveBrokerDb();
+    if (!db) {
+      return null;
+    }
+
+    const currentBranch = (await probeGitBranch(process.cwd())) ?? null;
+    const nowMs = Date.now();
+    const recentGhostWindowMs = DEFAULT_HEARTBEAT_TIMEOUT_MS * 2;
+    const workloads = filterAgentsForMeshVisibility(db.getAllAgents(), {
+      now: nowMs,
+      includeGhosts: true,
+      recentDisconnectWindowMs: recentGhostWindowMs,
+    }).map((agent) => ({
+      ...agent,
+      pendingInboxCount: db.getPendingInboxCount(agent.id),
+      ownedThreadCount: db.getOwnedThreadCount(agent.id),
+    }));
+    const pendingBacklogCount = db.getBacklogCount("pending");
+    const evaluationOptions: RalphLoopEvaluationOptions = {
+      now: nowMs,
+      heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
+      heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+      stuckWorkingThresholdMs: DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
+      pendingBacklogCount,
+      currentBranch,
+      brokerHeartbeatActive: deps.heartbeatTimerActive(),
+      brokerMaintenanceActive: deps.maintenanceTimerActive(),
+      brokerAgentId: deps.getActiveBrokerSelfId() ?? undefined,
+    };
+    const evaluation = evaluateRalphLoopCycle(workloads, evaluationOptions);
+
+    const rawTrackedAssignments = db.listTaskAssignments();
+    const trackedAssignmentSourceIds = [
+      ...new Set(
+        rawTrackedAssignments
+          .map((assignment) => assignment.sourceMessageId)
+          .filter((messageId): messageId is number => messageId != null),
+      ),
+    ];
+    const trackedAssignments = normalizeTrackedTaskAssignments(
+      rawTrackedAssignments,
+      new Map(
+        db
+          .getMessagesByIds(trackedAssignmentSourceIds)
+          .map((message) => [message.id, message.body]),
+      ),
+    );
+    let projectedAssignments: ResolvedTaskAssignment[] = [];
+    if (trackedAssignments.length > 0) {
+      const resolvedAssignments = await resolveTaskAssignments(trackedAssignments, process.cwd());
+      projectedAssignments = resolvedAssignments.map((assignment) => ({
+        ...assignment,
+        status: assignment.nextStatus,
+        prNumber: assignment.nextPrNumber,
+      }));
+    }
+
+    const recentRalphCycles = db.getRecentRalphCycles(5).map((cycle) => ({
+      startedAt: cycle.startedAt,
+      completedAt: cycle.completedAt,
+      durationMs: cycle.durationMs,
+      ghostAgentIds: cycle.ghostAgentIds,
+      stuckAgentIds: cycle.stuckAgentIds,
+      anomalies: cycle.anomalies,
+      followUpDelivered: cycle.followUpDelivered,
+      agentCount: cycle.agentCount,
+      backlogCount: cycle.backlogCount,
+    }));
+
+    return buildBrokerControlPlaneDashboardSnapshot({
+      workloads,
+      evaluation,
+      evaluationOptions,
+      maintenance: deps.getLastMaintenance(),
+      assignments: projectedAssignments,
+      recentCycles: recentRalphCycles,
+      cycleStartedAt,
+      cycleDurationMs: 0,
+      currentBranch,
+      homedir: os.homedir(),
+    });
+  }
+
+  async function refreshBrokerControlPlaneCanvasDashboard(
+    ctx: ExtensionContext,
+    input: PinetControlPlaneCanvasRefreshInput,
+  ): Promise<void> {
+    const botToken = deps.getBotToken();
+    if (!botToken || !deps.isBrokerControlPlaneCanvasEnabled()) {
+      deps.setLastControlPlaneCanvasError(null);
+      return;
+    }
+
+    const explicitCanvasId = getExplicitBrokerControlPlaneCanvasId();
+    const effectiveCanvasId = getConfiguredBrokerControlPlaneCanvasId();
+    const channelInput = getConfiguredBrokerControlPlaneCanvasChannel();
+    if (!effectiveCanvasId && !channelInput) {
+      const warning =
+        "Pinet broker control plane canvas skipped: set slack-bridge.controlPlaneCanvasChannel, defaultChannel, or controlPlaneCanvasId.";
+      if (deps.getLastControlPlaneCanvasError() !== warning) {
+        ctx.ui.notify(warning, "warning");
+      }
+      deps.setLastControlPlaneCanvasError(warning);
+      return;
+    }
+
+    const snapshot = buildBrokerControlPlaneDashboardSnapshot({
+      ...input,
+      homedir: os.homedir(),
+    });
+    const markdown = renderBrokerControlPlaneCanvasMarkdown(snapshot);
+    const channelId =
+      explicitCanvasId || !channelInput ? null : await deps.resolveChannel(channelInput);
+    const runtimeCanvasId = deps.getControlPlaneCanvasRuntimeId();
+    const runtimeChannelId = deps.getControlPlaneCanvasRuntimeChannelId();
+    const reusableRuntimeCanvasId =
+      !explicitCanvasId && runtimeCanvasId && (!channelId || runtimeChannelId === channelId)
+        ? runtimeCanvasId
+        : null;
+    const result = await refreshBrokerControlPlaneCanvas({
+      slack: deps.slack,
+      token: botToken,
+      markdown,
+      canvasId: explicitCanvasId ?? reusableRuntimeCanvasId,
+      channelId,
+      title: getConfiguredBrokerControlPlaneCanvasTitle(),
+    });
+
+    if (!explicitCanvasId) {
+      deps.restoreControlPlaneCanvasRuntimeState({
+        canvasId: result.canvasId,
+        channelId,
+      });
+    }
+    deps.setLastControlPlaneCanvasRefreshAt(input.cycleStartedAt);
+    deps.setLastControlPlaneCanvasError(null);
+
+    if (
+      !explicitCanvasId &&
+      (result.canvasId !== runtimeCanvasId || channelId !== runtimeChannelId)
+    ) {
+      deps.persistState();
+      const destination = channelInput ? ` via ${channelInput}` : "";
+      const action = result.created
+        ? "created"
+        : result.reusedExistingChannelCanvas
+          ? "attached"
+          : "updated";
+      ctx.ui.notify(
+        `Pinet broker control plane canvas ${action}: ${result.canvasId}${destination}`,
+        "info",
+      );
+    }
+  }
+
+  return {
+    getExplicitBrokerControlPlaneCanvasId,
+    getConfiguredBrokerControlPlaneCanvasId,
+    getConfiguredBrokerControlPlaneCanvasChannel,
+    getConfiguredBrokerControlPlaneCanvasTitle,
+    buildCurrentBrokerControlPlaneDashboardSnapshot,
+    refreshBrokerControlPlaneCanvasDashboard,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the broker-only control-plane canvas orchestration seam from `slack-bridge/index.ts` into `slack-bridge/pinet-control-plane-canvas.ts`
- keep the pure dashboard snapshot/render/Slack canvas helpers in `slack-bridge/broker/control-plane-canvas.ts`
- add focused coverage for config resolution, snapshot assembly, missing-destination warnings, and canvas refresh orchestration

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-control-plane-canvas.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test