### PR TITLE
refactor: extract broker thread-owner hints (#431)

### DIFF
--- a/slack-bridge/broker-thread-owner-hints.test.ts
+++ b/slack-bridge/broker-thread-owner-hints.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBrokerThreadOwnerHints,
+  type BrokerThreadOwnerHintsDeps,
+} from "./broker-thread-owner-hints.js";
+
+function createDeps(overrides: Partial<BrokerThreadOwnerHintsDeps> = {}) {
+  const slack = vi.fn(async () => ({ ok: true, messages: [] }));
+
+  const deps: BrokerThreadOwnerHintsDeps = {
+    slack,
+    getBotToken: () => "xoxb-test",
+    ...overrides,
+  };
+
+  return { deps, slack: deps.slack };
+}
+
+describe("createBrokerThreadOwnerHints", () => {
+  it("caches resolved broker thread-owner hints per channel/thread pair", async () => {
+    const { deps, slack } = createDeps({
+      slack: vi.fn(async () => ({
+        ok: true,
+        messages: [
+          {
+            bot_id: "B123",
+            metadata: {
+              event_type: "pi_agent_msg",
+              event_payload: {
+                agent_owner: "owner:crane",
+                agent: "Cobalt Olive Crane",
+              },
+            },
+          },
+        ],
+      })),
+    });
+    const brokerThreadOwnerHints = createBrokerThreadOwnerHints(deps);
+
+    await expect(
+      brokerThreadOwnerHints.resolveBrokerThreadOwnerHint("C123", "100.1"),
+    ).resolves.toEqual({
+      agentOwner: "owner:crane",
+      agentName: "Cobalt Olive Crane",
+    });
+    await expect(
+      brokerThreadOwnerHints.resolveBrokerThreadOwnerHint("C123", "100.1"),
+    ).resolves.toEqual({
+      agentOwner: "owner:crane",
+      agentName: "Cobalt Olive Crane",
+    });
+
+    expect(slack).toHaveBeenCalledTimes(1);
+    expect(slack).toHaveBeenCalledWith("conversations.replies", "xoxb-test", {
+      channel: "C123",
+      ts: "100.1",
+      limit: 200,
+      include_all_metadata: true,
+    });
+  });
+
+  it("does not cache null hints so later lookups can retry Slack", async () => {
+    const { deps, slack } = createDeps({
+      slack: vi.fn(async () => ({ ok: true, messages: [] })),
+    });
+    const brokerThreadOwnerHints = createBrokerThreadOwnerHints(deps);
+
+    await expect(
+      brokerThreadOwnerHints.resolveBrokerThreadOwnerHint("C123", "100.1"),
+    ).resolves.toBeNull();
+    await expect(
+      brokerThreadOwnerHints.resolveBrokerThreadOwnerHint("C123", "100.1"),
+    ).resolves.toBeNull();
+
+    expect(slack).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null for invalid inputs or Slack failures", async () => {
+    const { deps, slack } = createDeps({
+      slack: vi.fn(async (_method, _token, body) => {
+        if (body?.channel === "C_FAIL") {
+          throw new Error("Slack failed");
+        }
+        return { ok: true, messages: [] };
+      }),
+    });
+    const brokerThreadOwnerHints = createBrokerThreadOwnerHints(deps);
+
+    await expect(
+      brokerThreadOwnerHints.resolveBrokerThreadOwnerHint("", "100.1"),
+    ).resolves.toBeNull();
+    await expect(
+      brokerThreadOwnerHints.resolveBrokerThreadOwnerHint("C_FAIL", "100.1"),
+    ).resolves.toBeNull();
+
+    expect(slack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/slack-bridge/broker-thread-owner-hints.ts
+++ b/slack-bridge/broker-thread-owner-hints.ts
@@ -1,0 +1,41 @@
+import type { ThreadOwnerHint } from "./broker/router.js";
+import { resolveSlackThreadOwnerHint, type SlackCall } from "./slack-access.js";
+import { TtlCache } from "./ttl-cache.js";
+
+export interface BrokerThreadOwnerHintsDeps {
+  slack: SlackCall;
+  getBotToken: () => string;
+}
+
+export interface BrokerThreadOwnerHints {
+  resolveBrokerThreadOwnerHint: (
+    channel: string,
+    threadTs: string,
+  ) => Promise<ThreadOwnerHint | null>;
+}
+
+export function createBrokerThreadOwnerHints(
+  deps: BrokerThreadOwnerHintsDeps,
+): BrokerThreadOwnerHints {
+  const brokerThreadOwnerHintCache = new TtlCache<string, ThreadOwnerHint>({
+    maxSize: 2000,
+    ttlMs: 60 * 1000,
+  });
+
+  async function resolveBrokerThreadOwnerHint(
+    channel: string,
+    threadTs: string,
+  ): Promise<ThreadOwnerHint | null> {
+    return resolveSlackThreadOwnerHint({
+      slack: deps.slack,
+      token: deps.getBotToken(),
+      channel,
+      threadTs,
+      cache: brokerThreadOwnerHintCache,
+    });
+  }
+
+  return {
+    resolveBrokerThreadOwnerHint,
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -61,7 +61,6 @@ import {
   formatIMessageMvpReadiness,
 } from "@gugu910/pi-imessage-bridge";
 import {
-  resolveSlackThreadOwnerHint,
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
 } from "./slack-access.js";
@@ -87,6 +86,7 @@ import { buildBrokerControlPlaneDashboardSnapshot } from "./broker/control-plane
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
+import { createBrokerThreadOwnerHints } from "./broker-thread-owner-hints.js";
 import { createPinetActivityFormatting } from "./pinet-activity-formatting.js";
 import { createPinetControlPlaneCanvas } from "./pinet-control-plane-canvas.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
@@ -820,26 +820,11 @@ export default function (pi: ExtensionAPI) {
     return "Pinet is disabled in local subagent sessions to avoid polluting the agent mesh.";
   }
 
-  const brokerThreadOwnerHintCache = new TtlCache<
-    string,
-    { agentOwner?: string; agentName?: string }
-  >({
-    maxSize: 2000,
-    ttlMs: 60 * 1000,
+  const brokerThreadOwnerHints = createBrokerThreadOwnerHints({
+    slack,
+    getBotToken: () => botToken!,
   });
-
-  async function resolveBrokerThreadOwnerHint(
-    channel: string,
-    threadTs: string,
-  ): Promise<{ agentOwner?: string; agentName?: string } | null> {
-    return resolveSlackThreadOwnerHint({
-      slack,
-      token: botToken!,
-      channel,
-      threadTs,
-      cache: brokerThreadOwnerHintCache,
-    });
-  }
+  const { resolveBrokerThreadOwnerHint } = brokerThreadOwnerHints;
 
   const brokerRuntime = createBrokerRuntime({
     getSettings: () => settings,


### PR DESCRIPTION
## Summary
- extract the narrow broker thread-owner hint seam from `slack-bridge/index.ts` into `slack-bridge/broker-thread-owner-hints.ts`
- keep the TTL cache internal to the new module and expose only `resolveBrokerThreadOwnerHint(channel, threadTs)`
- add focused coverage for cached hits, uncached null retries, and graceful invalid-input/error handling

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- broker-thread-owner-hints.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test