### PR TITLE
feat: prototype OpenAI execution-shaping Pi extension

### DIFF
--- a/openai-execution-shaping/LICENSE
+++ b/openai-execution-shaping/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openai-execution-shaping/README.md
+++ b/openai-execution-shaping/README.md
@@ -1,0 +1,139 @@
+# @gugu910/pi-openai-execution-shaping
+
+Experimental Pi extension that prototypes a **narrow, extension-only** version of the missing OpenClaw-style execution shaping for **OpenAI / OpenAI Codex GPT-5** models.
+
+## What this prototype does
+
+When explicitly enabled, the extension:
+
+- targets only configured `openai` / `openai-codex` GPT-5-family models
+- appends a stronger **execution-biased overlay** for those models
+- detects some **plan-only / commentary-only** endings with no tool progress
+- injects a **hidden follow-up user-equivalent nudge** to keep the model acting
+
+This is intentionally a **prototype extension**, not a Pi core rewrite.
+
+## What it does not do
+
+This package does **not** reimplement Pi core behavior such as:
+
+- provider transport changes
+- tool-schema normalization
+- low-level OpenAI replay handling
+- native incomplete-turn retry semantics inside the core agent loop
+- explicit `working` / `paused` / `blocked` / `abandoned` run-state surfacing
+
+Those either already landed upstream in Pi, or would require upstream SDK/core seams beyond a clean extension prototype.
+
+## Configuration
+
+The extension is **disabled by default**. Enable it explicitly in either:
+
+- project-local `.pi/settings.json`, or
+- global `~/.pi/agent/settings.json`
+
+under the `"openai-execution-shaping"` key.
+
+### Minimal example
+
+```json
+{
+  "openai-execution-shaping": {
+    "enabled": true
+  }
+}
+```
+
+### Full example
+
+```json
+{
+  "openai-execution-shaping": {
+    "enabled": true,
+    "providers": ["openai", "openai-codex"],
+    "modelRegex": "^gpt-5",
+    "promptOverlay": {
+      "enabled": true
+    },
+    "autoContinue": {
+      "enabled": true,
+      "maxTurns": 1
+    },
+    "debug": false
+  }
+}
+```
+
+### Config fields
+
+- `enabled` — master switch; must be `true` to do anything
+- `providers` — provider ids to target; defaults to `openai` and `openai-codex`
+- `modelRegex` — case-insensitive regex matched against the normalized model id; defaults to `^gpt-5`
+- `promptOverlay.enabled` — append the execution-bias overlay during `before_agent_start`; default `true`
+- `autoContinue.enabled` — send the hidden continuation nudge after detected commentary-only drift; default `true`
+- `autoContinue.maxTurns` — bounded number of extension follow-up turns per user prompt; default `1`, clamped to `0..5`
+- `debug` — show lightweight TUI notifications when the extension auto-continues
+
+## Status command
+
+The extension registers:
+
+- `/openai-execution-shaping-status`
+
+It reports whether the extension is enabled, whether the current model is targeted, the loaded config source, and the current continuation counter.
+
+## How the prototype works
+
+### 1) Prompt overlay
+
+On `before_agent_start`, targeted models receive extra instructions that bias them toward:
+
+- acting first when the next step is clear
+- treating commentary-only turns as incomplete
+- continuing through multi-step work until complete or genuinely blocked
+- avoiding unnecessary permission asks after a single exploratory step
+
+### 2) Bounded auto-continue
+
+On `agent_end`, the extension looks for a narrow class of likely drift:
+
+- final assistant turn
+- `stopReason === "stop"`
+- **no tool results** for the prompt
+- no assistant tool calls in the final message
+- text that looks like future-intent / approval-handoff commentary
+- no obvious completion language or genuine blocker question
+
+When that pattern matches, the extension injects a **hidden custom message** with `triggerTurn: true`.
+
+That custom message participates in LLM context as a user-equivalent steer, but stays hidden from the TUI (`display: false`).
+
+## Known limitations
+
+This package is intentionally constrained by the current Pi extension/runtime seams.
+
+### What the extension can do cleanly
+
+- add model-targeted prompt shaping
+- inspect completed turns and issue bounded hidden follow-up nudges
+- keep the experiment opt-in and tightly scoped to OpenAI/Codex GPT-5 models
+
+### What still needs Pi core support for a cleaner implementation
+
+- treating plan-only / commentary-only turns as **core incomplete-turn retries** instead of post-hoc follow-up turns
+- detecting and handling **one-action-then-narrative** patterns *inside* the agent loop rather than only after `agent_end`
+- surfacing richer lifecycle states like `blocked` / `paused` / `abandoned`
+- provider/model-specific prompt overlays integrated at the core prompt builder layer
+
+So this prototype should be read as:
+
+> the narrowest extension-only slice that demonstrates the behavior-shaping idea without upstream Pi core changes.
+
+## Development
+
+```bash
+pnpm --filter @gugu910/pi-openai-execution-shaping lint
+pnpm --filter @gugu910/pi-openai-execution-shaping typecheck
+pnpm --filter @gugu910/pi-openai-execution-shaping test
+pnpm --filter @gugu910/pi-openai-execution-shaping build
+```

--- a/openai-execution-shaping/config.ts
+++ b/openai-execution-shaping/config.ts
@@ -1,0 +1,141 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { join } from "node:path";
+
+export const SETTINGS_KEY = "openai-execution-shaping";
+const DEFAULT_PROVIDER_IDS = ["openai", "openai-codex"] as const;
+const DEFAULT_MODEL_REGEX = "^gpt-5";
+const DEFAULT_MAX_AUTO_CONTINUES = 1;
+
+export interface OpenAIExecutionShapingConfig {
+  enabled?: boolean;
+  providers?: string[];
+  modelRegex?: string;
+  promptOverlay?: {
+    enabled?: boolean;
+  };
+  autoContinue?: {
+    enabled?: boolean;
+    maxTurns?: number;
+  };
+  debug?: boolean;
+}
+
+export interface ResolvedOpenAIExecutionShapingConfig {
+  enabled: boolean;
+  providers: string[];
+  modelRegexSource: string;
+  modelRegex: RegExp;
+  promptOverlayEnabled: boolean;
+  autoContinueEnabled: boolean;
+  maxAutoContinueTurns: number;
+  debug: boolean;
+  sourcePath: string | null;
+}
+
+export interface LoadConfigOptions {
+  cwd?: string;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+function parseJsonFile(filePath: string): unknown | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[${SETTINGS_KEY}] Failed to parse config ${filePath}: ${message}`);
+    return null;
+  }
+}
+
+function readSettingsConfig(settingsPath: string): { path: string; raw: OpenAIExecutionShapingConfig } | null {
+  if (!fs.existsSync(settingsPath)) return null;
+  const parsed = parseJsonFile(settingsPath);
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const raw = (parsed as Record<string, unknown>)[SETTINGS_KEY];
+  if (!raw || typeof raw !== "object") return null;
+
+  return {
+    path: `${settingsPath}#${SETTINGS_KEY}`,
+    raw: raw as OpenAIExecutionShapingConfig,
+  };
+}
+
+export function resolveConfig(
+  raw: OpenAIExecutionShapingConfig | null | undefined,
+  sourcePath: string | null = null,
+): ResolvedOpenAIExecutionShapingConfig {
+  const providers = Array.isArray(raw?.providers)
+    ? raw.providers
+        .map((value) => (typeof value === "string" ? value.trim() : ""))
+        .filter((value) => value.length > 0)
+    : [...DEFAULT_PROVIDER_IDS];
+
+  const modelRegexSource =
+    typeof raw?.modelRegex === "string" && raw.modelRegex.trim().length > 0
+      ? raw.modelRegex.trim()
+      : DEFAULT_MODEL_REGEX;
+
+  let modelRegex: RegExp;
+  try {
+    modelRegex = new RegExp(modelRegexSource, "i");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[${SETTINGS_KEY}] Invalid modelRegex ${JSON.stringify(modelRegexSource)} in ${sourcePath ?? "config"}: ${message}`,
+    );
+    modelRegex = new RegExp(DEFAULT_MODEL_REGEX, "i");
+  }
+
+  const maxAutoContinueTurns = Math.max(
+    0,
+    Math.min(
+      5,
+      typeof raw?.autoContinue?.maxTurns === "number" && Number.isFinite(raw.autoContinue.maxTurns)
+        ? Math.floor(raw.autoContinue.maxTurns)
+        : DEFAULT_MAX_AUTO_CONTINUES,
+    ),
+  );
+
+  return {
+    enabled: raw?.enabled === true,
+    providers: providers.length > 0 ? providers : [...DEFAULT_PROVIDER_IDS],
+    modelRegexSource,
+    modelRegex,
+    promptOverlayEnabled: raw?.promptOverlay?.enabled ?? true,
+    autoContinueEnabled: raw?.autoContinue?.enabled ?? true,
+    maxAutoContinueTurns,
+    debug: raw?.debug === true,
+    sourcePath,
+  };
+}
+
+export function loadConfig(
+  options: LoadConfigOptions = {},
+): ResolvedOpenAIExecutionShapingConfig {
+  const cwd = options.cwd ?? process.cwd();
+  const agentDir = options.agentDir ?? join(os.homedir(), ".pi", "agent");
+  const env = options.env ?? process.env;
+
+  const explicitSettingsPath = env.PI_OPENAI_EXECUTION_SHAPING_SETTINGS;
+  if (explicitSettingsPath) {
+    const explicit = readSettingsConfig(explicitSettingsPath);
+    if (explicit) {
+      return resolveConfig(explicit.raw, explicit.path);
+    }
+  }
+
+  const projectSettings = readSettingsConfig(join(cwd, ".pi", "settings.json"));
+  if (projectSettings) {
+    return resolveConfig(projectSettings.raw, projectSettings.path);
+  }
+
+  const globalSettings = readSettingsConfig(join(agentDir, "settings.json"));
+  if (globalSettings) {
+    return resolveConfig(globalSettings.raw, globalSettings.path);
+  }
+
+  return resolveConfig(null, null);
+}

--- a/openai-execution-shaping/eslint.config.mjs
+++ b/openai-execution-shaping/eslint.config.mjs
@@ -1,0 +1,3 @@
+import rootConfig from "../eslint.config.mjs";
+
+export default [...rootConfig];

--- a/openai-execution-shaping/helpers.test.ts
+++ b/openai-execution-shaping/helpers.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { resolveConfig } from "./config.js";
+import {
+  buildAutoContinueMessage,
+  buildExecutionShapingPrompt,
+  classifyContinuationNeed,
+  countAssistantToolCalls,
+  extractAssistantText,
+  isTargetModel,
+  normalizeModelId,
+} from "./helpers.js";
+
+describe("resolveConfig", () => {
+  it("defaults to disabled experimental behavior", () => {
+    const config = resolveConfig(null);
+
+    expect(config.enabled).toBe(false);
+    expect(config.providers).toEqual(["openai", "openai-codex"]);
+    expect(config.modelRegexSource).toBe("^gpt-5");
+    expect(config.promptOverlayEnabled).toBe(true);
+    expect(config.autoContinueEnabled).toBe(true);
+    expect(config.maxAutoContinueTurns).toBe(1);
+  });
+
+  it("normalizes custom config and clamps max auto-continue turns", () => {
+    const config = resolveConfig(
+      {
+        enabled: true,
+        providers: ["openai-codex"],
+        modelRegex: "gpt-5\\.4",
+        autoContinue: { enabled: true, maxTurns: 9 },
+        promptOverlay: { enabled: false },
+        debug: true,
+      },
+      "/tmp/settings.json#openai-execution-shaping",
+    );
+
+    expect(config.enabled).toBe(true);
+    expect(config.providers).toEqual(["openai-codex"]);
+    expect(config.modelRegex.test("gpt-5.4")).toBe(true);
+    expect(config.maxAutoContinueTurns).toBe(5);
+    expect(config.promptOverlayEnabled).toBe(false);
+    expect(config.debug).toBe(true);
+    expect(config.sourcePath).toBe("/tmp/settings.json#openai-execution-shaping");
+  });
+});
+
+describe("target model matching", () => {
+  const enabledConfig = resolveConfig({ enabled: true });
+
+  it("matches targeted OpenAI GPT-5 models", () => {
+    expect(isTargetModel({ provider: "openai", id: "gpt-5.4" }, enabledConfig)).toBe(true);
+    expect(isTargetModel({ provider: "openai-codex", id: "openai-codex/gpt-5.4" }, enabledConfig)).toBe(
+      true,
+    );
+  });
+
+  it("does not match non-target providers or models", () => {
+    expect(isTargetModel({ provider: "anthropic", id: "claude-sonnet-4-5" }, enabledConfig)).toBe(false);
+    expect(isTargetModel({ provider: "openai", id: "gpt-4.1" }, enabledConfig)).toBe(false);
+  });
+
+  it("normalizes provider-prefixed model ids", () => {
+    expect(normalizeModelId("openai/gpt-5.4", "openai")).toBe("gpt-5.4");
+    expect(normalizeModelId("openai-codex:gpt-5.4", "openai-codex")).toBe("gpt-5.4");
+  });
+});
+
+describe("assistant drift detection", () => {
+  it("extracts text and tool calls from assistant messages", () => {
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: "I will inspect the repo first." },
+        { type: "toolCall", text: undefined },
+      ],
+    };
+
+    expect(extractAssistantText(message)).toBe("I will inspect the repo first.");
+    expect(countAssistantToolCalls(message)).toBe(1);
+  });
+
+  it("requests auto-continue for plan-only continuation intent", () => {
+    const decision = classifyContinuationNeed({
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "I'll inspect the repository structure and then update the files." }],
+      },
+      toolResultCount: 0,
+      usedAutoContinueTurns: 0,
+      maxAutoContinueTurns: 1,
+    });
+
+    expect(decision).toEqual({ shouldContinue: true, reason: "continuation-intent" });
+  });
+
+  it("requests auto-continue for approval-handoff drift", () => {
+    const decision = classifyContinuationNeed({
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "I can start by checking the config and the files. Let me know if you'd like me to continue.",
+          },
+        ],
+      },
+      toolResultCount: 0,
+      usedAutoContinueTurns: 0,
+      maxAutoContinueTurns: 1,
+    });
+
+    expect(decision).toEqual({ shouldContinue: true, reason: "approval-handoff" });
+  });
+
+  it("does not auto-continue after tool progress or completion language", () => {
+    const withToolProgress = classifyContinuationNeed({
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "I'll inspect the repository structure and then update the files." }],
+      },
+      toolResultCount: 1,
+      usedAutoContinueTurns: 0,
+      maxAutoContinueTurns: 1,
+    });
+
+    const completed = classifyContinuationNeed({
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Done. I updated the files and verified the fix." }],
+      },
+      toolResultCount: 0,
+      usedAutoContinueTurns: 0,
+      maxAutoContinueTurns: 1,
+    });
+
+    expect(withToolProgress.shouldContinue).toBe(false);
+    expect(withToolProgress.reason).toBe("has-tool-results");
+    expect(completed.shouldContinue).toBe(false);
+    expect(completed.reason).toBe("completion-language");
+  });
+
+  it("does not auto-continue genuine blockers or exhausted budgets", () => {
+    const blocker = classifyContinuationNeed({
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Which file should I edit first?" }],
+      },
+      toolResultCount: 0,
+      usedAutoContinueTurns: 0,
+      maxAutoContinueTurns: 1,
+    });
+
+    const exhausted = classifyContinuationNeed({
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "I'll inspect the repository structure and then update the files." }],
+      },
+      toolResultCount: 0,
+      usedAutoContinueTurns: 1,
+      maxAutoContinueTurns: 1,
+    });
+
+    expect(blocker.shouldContinue).toBe(false);
+    expect(blocker.reason).toBe("blocker-or-clarification");
+    expect(exhausted.shouldContinue).toBe(false);
+    expect(exhausted.reason).toBe("budget-exhausted");
+  });
+});
+
+describe("prompt text", () => {
+  it("builds the execution-shaping overlay and continuation message", () => {
+    const overlay = buildExecutionShapingPrompt();
+    const continueMessage = buildAutoContinueMessage();
+
+    expect(overlay).toContain("Commentary-only turns are incomplete");
+    expect(overlay).toContain("Do not stop after one exploratory step");
+    expect(continueMessage).toContain("Continue.");
+    expect(continueMessage).toContain("Commentary-only replies are incomplete");
+  });
+});

--- a/openai-execution-shaping/helpers.ts
+++ b/openai-execution-shaping/helpers.ts
@@ -1,0 +1,164 @@
+export interface ModelLike {
+  provider?: string;
+  id?: string;
+}
+
+export interface AssistantContentBlockLike {
+  type?: string;
+  text?: string;
+}
+
+export interface AssistantMessageLike {
+  role?: string;
+  stopReason?: string;
+  content?: AssistantContentBlockLike[];
+}
+
+export interface ContinuationDecision {
+  shouldContinue: boolean;
+  reason:
+    | "not-assistant"
+    | "not-stop"
+    | "has-tool-results"
+    | "has-tool-calls"
+    | "budget-exhausted"
+    | "no-text"
+    | "completion-language"
+    | "blocker-or-clarification"
+    | "approval-handoff"
+    | "continuation-intent"
+    | "no-signal";
+}
+
+export interface ContinuationDecisionInput {
+  message: AssistantMessageLike | undefined;
+  toolResultCount: number;
+  usedAutoContinueTurns: number;
+  maxAutoContinueTurns: number;
+}
+
+const CONTINUATION_INTENT =
+  /\b(i(?:'| wi)?ll|let me|i am going to|i'm going to|first[, ]+i(?:'| wi)?ll|next[, ]+i(?:'| wi)?ll|i can start by|i will start by)\b/i;
+const APPROVAL_HANDOFF =
+  /\blet me know if (?:you(?:'d)? like|you want|i should)\b|\bif you(?:'d)? like[, ]+i can\b|\bwant me to\b|\bshould i (?:continue|proceed|go ahead)\b/i;
+const COMPLETION_LANGUAGE =
+  /\b(done|completed|finished|implemented|updated|fixed|added|created|verified|resolved|here(?:'s| is)|i found|i changed|i ran|i verified)\b/i;
+const BLOCKER_OR_CLARIFICATION =
+  /\b(blocked|cannot|can't|unable|don't have|do not have|need (?:the )?(?:path|file|details|clarification|approval|access|permission|decision)|which (?:file|path|one|option)|what (?:file|path|exactly|should)|could you|can you|please provide)\b/i;
+
+export function buildExecutionShapingPrompt(): string {
+  return `## OpenAI GPT-5 Execution Shaping (Experimental Extension)
+
+Use a real tool call or concrete action first when the task is actionable.
+Commentary-only turns are incomplete when tools are available and the next step is clear.
+If the work will take multiple steps, keep going until the task is complete or you hit a real blocker.
+Do prerequisite lookup or discovery before dependent actions.
+Do not stop after one exploratory step to ask for permission unless the next action is genuinely destructive or needs explicit approval.
+Multi-part requests stay incomplete until each requested item is handled or clearly marked blocked.
+Act first, then summarize or verify when that materially helps.`;
+}
+
+export function buildAutoContinueMessage(): string {
+  return [
+    "Continue.",
+    "Take the next concrete action immediately.",
+    "Use tools if the next step is clear.",
+    "Commentary-only replies are incomplete.",
+    "Do not restate the plan or ask for permission unless you hit a real blocker or a genuinely destructive step requires approval.",
+  ].join(" ");
+}
+
+export function normalizeModelId(modelId: string | undefined, provider: string | undefined): string {
+  if (!modelId) return "";
+  const trimmed = modelId.trim();
+  if (!trimmed) return "";
+  const providerPrefix = provider?.trim().toLowerCase();
+  if (!providerPrefix) return trimmed.toLowerCase();
+  return trimmed.replace(new RegExp(`^${providerPrefix}[:/]`, "i"), "").toLowerCase();
+}
+
+export function isTargetModel(
+  model: ModelLike | undefined,
+  config: { providers: string[]; modelRegex: RegExp; enabled: boolean },
+): boolean {
+  if (!config.enabled || !model?.provider || !model.id) {
+    return false;
+  }
+
+  const provider = model.provider.trim().toLowerCase();
+  if (!config.providers.map((value) => value.toLowerCase()).includes(provider)) {
+    return false;
+  }
+
+  return config.modelRegex.test(normalizeModelId(model.id, provider));
+}
+
+export function extractAssistantText(message: AssistantMessageLike | undefined): string {
+  if (!message || message.role !== "assistant" || !Array.isArray(message.content)) {
+    return "";
+  }
+
+  return message.content
+    .filter((block) => block?.type === "text" && typeof block.text === "string")
+    .map((block) => block.text?.trim() ?? "")
+    .filter((text) => text.length > 0)
+    .join("\n\n")
+    .trim();
+}
+
+export function countAssistantToolCalls(message: AssistantMessageLike | undefined): number {
+  if (!message || message.role !== "assistant" || !Array.isArray(message.content)) {
+    return 0;
+  }
+
+  return message.content.filter((block) => block?.type === "toolCall").length;
+}
+
+export function classifyContinuationNeed(
+  input: ContinuationDecisionInput,
+): ContinuationDecision {
+  const { message, toolResultCount, usedAutoContinueTurns, maxAutoContinueTurns } = input;
+
+  if (!message || message.role !== "assistant") {
+    return { shouldContinue: false, reason: "not-assistant" };
+  }
+
+  if (message.stopReason !== "stop") {
+    return { shouldContinue: false, reason: "not-stop" };
+  }
+
+  if (toolResultCount > 0) {
+    return { shouldContinue: false, reason: "has-tool-results" };
+  }
+
+  if (countAssistantToolCalls(message) > 0) {
+    return { shouldContinue: false, reason: "has-tool-calls" };
+  }
+
+  if (usedAutoContinueTurns >= maxAutoContinueTurns) {
+    return { shouldContinue: false, reason: "budget-exhausted" };
+  }
+
+  const text = extractAssistantText(message);
+  if (!text) {
+    return { shouldContinue: false, reason: "no-text" };
+  }
+
+  if (COMPLETION_LANGUAGE.test(text)) {
+    return { shouldContinue: false, reason: "completion-language" };
+  }
+
+  if (BLOCKER_OR_CLARIFICATION.test(text)) {
+    return { shouldContinue: false, reason: "blocker-or-clarification" };
+  }
+
+  if (APPROVAL_HANDOFF.test(text)) {
+    return { shouldContinue: true, reason: "approval-handoff" };
+  }
+
+  if (CONTINUATION_INTENT.test(text)) {
+    return { shouldContinue: true, reason: "continuation-intent" };
+  }
+
+  return { shouldContinue: false, reason: "no-signal" };
+}

--- a/openai-execution-shaping/index.ts
+++ b/openai-execution-shaping/index.ts
@@ -1,0 +1,164 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { loadConfig } from "./config.js";
+import {
+  buildAutoContinueMessage,
+  buildExecutionShapingPrompt,
+  classifyContinuationNeed,
+  isTargetModel,
+  type AssistantMessageLike,
+} from "./helpers.js";
+
+const STATUS_CUSTOM_TYPE = "openai-execution-shaping.status";
+const CONTINUE_CUSTOM_TYPE = "openai-execution-shaping.continue";
+
+interface ModelLike {
+  provider?: string;
+  id?: string;
+}
+
+interface AgentMessageLike extends AssistantMessageLike {
+  role?: string;
+}
+
+interface AgentEndEventLike {
+  messages: AgentMessageLike[];
+}
+
+interface CompatibleExtensionContext extends ExtensionContext {
+  model?: ModelLike;
+  hasPendingMessages?: () => boolean;
+  hasUI?: boolean;
+}
+
+interface CompatibleExtensionAPI extends ExtensionAPI {
+  sendMessage(
+    message: {
+      customType: string;
+      content: string;
+      display: boolean;
+      details?: Record<string, unknown>;
+    },
+    options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+  ): void;
+}
+
+function countToolResults(event: AgentEndEventLike): number {
+  return event.messages.filter((message) => message.role === "toolResult").length;
+}
+
+function findLastAssistantMessage(event: AgentEndEventLike): AssistantMessageLike | undefined {
+  return [...event.messages].reverse().find((message) => message.role === "assistant");
+}
+
+export default function openAIExecutionShapingExtension(pi: ExtensionAPI) {
+  const extensionApi = pi as CompatibleExtensionAPI;
+  let continuationCount = 0;
+
+  function loadRuntimeConfig(cwd: string) {
+    return loadConfig({ cwd });
+  }
+
+  pi.registerCommand("openai-execution-shaping-status", {
+    description: "Show experimental OpenAI execution-shaping status",
+    handler: async (_args, ctx) => {
+      const extensionCtx = ctx as CompatibleExtensionContext;
+      const config = loadRuntimeConfig(ctx.cwd);
+      const targeted = isTargetModel(extensionCtx.model, config);
+      const modelLabel = extensionCtx.model
+        ? `${extensionCtx.model.provider}/${extensionCtx.model.id}`
+        : "none";
+      const source = config.sourcePath ?? "defaults (disabled)";
+      const lines = [
+        "**OpenAI execution shaping (experimental)**",
+        "",
+        `- enabled: ${config.enabled ? "yes" : "no"}`,
+        `- current model: ${modelLabel}`,
+        `- targeted now: ${targeted ? "yes" : "no"}`,
+        `- providers: ${config.providers.join(", ")}`,
+        `- modelRegex: \`${config.modelRegexSource}\``,
+        `- prompt overlay: ${config.promptOverlayEnabled ? "on" : "off"}`,
+        `- auto-continue: ${config.autoContinueEnabled ? `on (max ${config.maxAutoContinueTurns})` : "off"}`,
+        `- source: ${source}`,
+        `- current continuation count: ${continuationCount}`,
+      ];
+
+      extensionApi.sendMessage(
+        {
+          customType: STATUS_CUSTOM_TYPE,
+          content: lines.join("\n"),
+          display: true,
+        },
+        { triggerTurn: false },
+      );
+    },
+  });
+
+  pi.on("session_start", async () => {
+    continuationCount = 0;
+  });
+
+  pi.on("input", async (event) => {
+    if (event.source !== "extension") {
+      continuationCount = 0;
+    }
+    return { action: "continue" } as const;
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    const extensionCtx = ctx as CompatibleExtensionContext;
+    const config = loadRuntimeConfig(ctx.cwd);
+    if (!config.promptOverlayEnabled || !isTargetModel(extensionCtx.model, config)) {
+      return undefined;
+    }
+
+    return {
+      systemPrompt: `${event.systemPrompt}\n\n${buildExecutionShapingPrompt()}`,
+    };
+  });
+
+  pi.on("agent_end", async (event, ctx) => {
+    const extensionCtx = ctx as CompatibleExtensionContext;
+    const config = loadRuntimeConfig(ctx.cwd);
+    if (!config.enabled || !config.autoContinueEnabled || !isTargetModel(extensionCtx.model, config)) {
+      return;
+    }
+
+    if (extensionCtx.hasPendingMessages?.()) {
+      return;
+    }
+
+    const agentEndEvent = event as AgentEndEventLike;
+    const decision = classifyContinuationNeed({
+      message: findLastAssistantMessage(agentEndEvent),
+      toolResultCount: countToolResults(agentEndEvent),
+      usedAutoContinueTurns: continuationCount,
+      maxAutoContinueTurns: config.maxAutoContinueTurns,
+    });
+
+    if (!decision.shouldContinue) {
+      return;
+    }
+
+    continuationCount += 1;
+
+    if (config.debug && extensionCtx.hasUI) {
+      extensionCtx.ui.notify(
+        `OpenAI execution shaping follow-up ${continuationCount}/${config.maxAutoContinueTurns}: ${decision.reason}`,
+        "info",
+      );
+    }
+
+    extensionApi.sendMessage(
+      {
+        customType: CONTINUE_CUSTOM_TYPE,
+        content: buildAutoContinueMessage(),
+        display: false,
+        details: {
+          reason: decision.reason,
+          attempt: continuationCount,
+        },
+      },
+      { triggerTurn: true },
+    );
+  });
+}

--- a/openai-execution-shaping/package.json
+++ b/openai-execution-shaping/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@gugu910/pi-openai-execution-shaping",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Experimental Pi extension that adds OpenClaw-style execution shaping for OpenAI/Codex GPT-5 models",
+  "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gugu91/extensions.git",
+    "directory": "openai-execution-shaping"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "dist/"
+  ],
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "scripts": {
+    "build": "node ../scripts/build-package.mjs",
+    "prepack": "pnpm run build",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {}
+}

--- a/openai-execution-shaping/tsconfig.json
+++ b/openai-execution-shaping/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["**/*.ts", "../types/**/*.d.ts"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - imessage-bridge
   - nvim-bridge
   - neon-psql
+  - openai-execution-shaping

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -51,6 +51,13 @@ const packageConfigs = {
     vendorDirs: [],
     importRewrites: [],
   },
+  "openai-execution-shaping": {
+    excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
+    excludeFiles: new Set(),
+    excludePrefixes: [],
+    vendorDirs: [],
+    importRewrites: [],
+  },
 };
 
 const config = packageConfigs[packageName];


### PR DESCRIPTION
## Summary
- add a new experimental workspace package `@gugu910/pi-openai-execution-shaping`
- target only configured `openai` / `openai-codex` GPT-5-family models with an execution-biased prompt overlay
- add bounded hidden post-turn continuation nudges for likely plan-only / approval-handoff drift, plus focused tests and README docs

## Checks
- pnpm --filter @gugu910/pi-openai-execution-shaping lint
- pnpm --filter @gugu910/pi-openai-execution-shaping typecheck
- pnpm --filter @gugu910/pi-openai-execution-shaping test
- pnpm --filter @gugu910/pi-openai-execution-shaping build

## Notes
- kept scope extension-only; no Pi core changes
- important seam: the current Pi SDK cleanly supports prompt shaping and post-turn hidden nudges, but not true in-loop incomplete-turn retry / one-action-then-narrative interception inside the core agent loop

Closes #429
