### PR TITLE
refactor: extract persisted runtime state (#433)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -17,7 +17,6 @@ import {
   createAbortableOperationTracker,
   buildPinetOwnerToken,
   resolveAgentIdentity,
-  resolvePersistedAgentIdentity,
   resolveRuntimeAgentIdentity,
   resolveBrokerStableId,
   shortenPath,
@@ -87,6 +86,7 @@ import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
 import { createBrokerThreadOwnerHints } from "./broker-thread-owner-hints.js";
+import { createPersistedRuntimeState } from "./persisted-runtime-state.js";
 import { createPinetActivityFormatting } from "./pinet-activity-formatting.js";
 import { createPinetControlPlaneCanvas } from "./pinet-control-plane-canvas.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
@@ -160,11 +160,6 @@ export default function (pi: ExtensionAPI) {
   // Security guardrails
   let guardrails: SecurityGuardrails = settings.security ?? {};
   let securityPrompt = buildSecurityPrompt(guardrails);
-
-  function normalizeOptionalSetting(value?: string | null): string | null {
-    const trimmed = value?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : null;
-  }
 
   interface ReloadableRuntimeSnapshot {
     settings: typeof settings;
@@ -443,42 +438,53 @@ export default function (pi: ExtensionAPI) {
 
   // ─── State persistence ──────────────────────────────
 
-  let persistTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function persistStateNow(): void {
-    persistTimer = null;
-    try {
-      pi.appendEntry("slack-bridge-state", {
-        threads: Array.from(threads.entries()),
-        lastDmChannel,
-        userNames: Array.from(userNames.entries()),
-        agentName,
-        agentEmoji,
-        agentStableId,
-        brokerStableId,
-        lastPinetRole: brokerRole === "broker" ? "broker" : "worker",
-        activeSkinTheme,
-        agentPersonality,
-        agentAliases: [...agentAliases],
-        brokerControlPlaneCanvasId: brokerRuntime.getControlPlaneCanvasRuntimeId(),
-        brokerControlPlaneCanvasChannelId: brokerRuntime.getControlPlaneCanvasRuntimeChannelId(),
-      });
-    } catch (err) {
-      console.error(`[slack-bridge] persistState failed: ${msg(err)}`);
-    }
-  }
-
-  function persistState(): void {
-    if (persistTimer) clearTimeout(persistTimer);
-    persistTimer = setTimeout(persistStateNow, 1_000);
-  }
-
-  function flushPersist(): void {
-    if (persistTimer) {
-      clearTimeout(persistTimer);
-      persistStateNow();
-    }
-  }
+  const persistedRuntimeState = createPersistedRuntimeState({
+    pi,
+    threads,
+    userNames,
+    getLastDmChannel: () => lastDmChannel,
+    setLastDmChannel: (channelId) => {
+      lastDmChannel = channelId;
+    },
+    getAgentName: () => agentName,
+    setAgentName: (name) => {
+      agentName = name;
+    },
+    getAgentEmoji: () => agentEmoji,
+    setAgentEmoji: (emoji) => {
+      agentEmoji = emoji;
+    },
+    getAgentStableId: () => agentStableId,
+    setAgentStableId: (stableId) => {
+      agentStableId = stableId;
+    },
+    getBrokerStableId: () => brokerStableId,
+    setBrokerStableId: (stableId) => {
+      brokerStableId = stableId;
+    },
+    getBrokerRole: () => brokerRole,
+    getActiveSkinTheme: () => activeSkinTheme,
+    setActiveSkinTheme: (theme) => {
+      activeSkinTheme = theme;
+    },
+    getAgentPersonality: () => agentPersonality,
+    setAgentPersonality: (personality) => {
+      agentPersonality = personality;
+    },
+    agentAliases,
+    setAgentOwnerToken: (ownerToken) => {
+      agentOwnerToken = ownerToken;
+    },
+    getSettings: () => settings,
+    getControlPlaneCanvasRuntimeId: () => brokerRuntime.getControlPlaneCanvasRuntimeId(),
+    getControlPlaneCanvasRuntimeChannelId: () =>
+      brokerRuntime.getControlPlaneCanvasRuntimeChannelId(),
+    restoreControlPlaneCanvasRuntimeState: (input) => {
+      brokerRuntime.restoreControlPlaneCanvasRuntimeState(input);
+    },
+    formatError: msg,
+  });
+  const { persistState, flushPersist, restorePersistedRuntimeState } = persistedRuntimeState;
 
   // ─── Inbox queue ────────────────────────────────────
 
@@ -1496,89 +1502,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     // Restore persisted thread state (always restore, even before /pinet)
-    interface PersistedState {
-      threads?: [string, SinglePlayerThreadInfo][];
-      lastDmChannel?: string | null;
-      userNames?: [string, string][];
-      agentName?: string;
-      agentEmoji?: string;
-      agentStableId?: string;
-      brokerStableId?: string;
-      lastPinetRole?: "broker" | "worker";
-      activeSkinTheme?: string | null;
-      agentPersonality?: string | null;
-      agentAliases?: string[];
-      brokerControlPlaneCanvasId?: string | null;
-      brokerControlPlaneCanvasChannelId?: string | null;
-    }
-    try {
-      let savedState: PersistedState | null = null;
-      for (const entry of ctx.sessionManager.getEntries()) {
-        if (entry.type === "custom" && entry.customType === "slack-bridge-state") {
-          savedState = entry.data as PersistedState;
-        }
-      }
-
-      const restoredRole = savedState?.lastPinetRole === "broker" ? "broker" : "worker";
-      agentStableId = resolveAgentStableId(
-        savedState?.agentStableId,
-        ctx.sessionManager.getSessionFile(),
-        os.hostname(),
-        ctx.cwd,
-        ctx.sessionManager.getLeafId(),
-      );
-      brokerStableId = resolveBrokerStableId(savedState?.brokerStableId, os.hostname(), ctx.cwd);
-      agentOwnerToken = buildPinetOwnerToken(getStableIdForRole(restoredRole));
-      const identitySeed = getIdentitySeedForRole(
-        restoredRole,
-        ctx.sessionManager.getSessionFile() ?? undefined,
-      );
-      activeSkinTheme = savedState?.activeSkinTheme ?? null;
-      agentPersonality = savedState?.agentPersonality ?? null;
-      agentAliases.clear();
-      for (const alias of savedState?.agentAliases ?? []) {
-        if (alias) {
-          agentAliases.add(alias);
-        }
-      }
-      const restoredIdentity = resolvePersistedAgentIdentity(
-        settings,
-        savedState?.agentName,
-        savedState?.agentEmoji,
-        process.env.PI_NICKNAME,
-        identitySeed,
-        restoredRole,
-      );
-      agentName = restoredIdentity.name;
-      agentEmoji = restoredIdentity.emoji;
-
-      if (savedState) {
-        if (savedState.threads) {
-          for (const [k, v] of savedState.threads) {
-            if (!threads.has(k)) threads.set(k, v);
-          }
-        }
-        if (savedState.lastDmChannel && !lastDmChannel) {
-          lastDmChannel = savedState.lastDmChannel;
-        }
-        if (savedState.userNames) {
-          for (const [k, v] of savedState.userNames) {
-            if (!userNames.has(k)) userNames.set(k, v);
-          }
-        }
-        brokerRuntime.restoreControlPlaneCanvasRuntimeState({
-          canvasId:
-            normalizeOptionalSetting(savedState.brokerControlPlaneCanvasId) ??
-            brokerRuntime.getControlPlaneCanvasRuntimeId(),
-          channelId:
-            normalizeOptionalSetting(savedState.brokerControlPlaneCanvasChannelId) ??
-            brokerRuntime.getControlPlaneCanvasRuntimeChannelId(),
-        });
-      }
-      persistStateNow();
-    } catch (err) {
-      console.error(`[slack-bridge] restore failed: ${msg(err)}`);
-    }
+    restorePersistedRuntimeState(ctx);
 
     if (pinetRegistrationBlocked) {
       console.log("[slack-bridge] detected local subagent context; skipping Pinet registration");

--- a/slack-bridge/persisted-runtime-state.test.ts
+++ b/slack-bridge/persisted-runtime-state.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { buildPinetOwnerToken } from "./helpers.js";
+import {
+  createPersistedRuntimeState,
+  type PersistedRuntimeStateDeps,
+  type PersistedState,
+} from "./persisted-runtime-state.js";
+import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
+
+interface MutableRuntimeState {
+  lastDmChannel: string | null;
+  agentName: string;
+  agentEmoji: string;
+  agentStableId: string;
+  brokerStableId: string;
+  brokerRole: "broker" | "follower" | null;
+  activeSkinTheme: string | null;
+  agentPersonality: string | null;
+  agentOwnerToken: string;
+  controlPlaneCanvasId: string | null;
+  controlPlaneCanvasChannelId: string | null;
+}
+
+function createDeps(
+  overrides: {
+    state?: Partial<MutableRuntimeState>;
+    threads?: Map<string, SinglePlayerThreadInfo>;
+    userNames?: Map<string, string>;
+    agentAliases?: Set<string>;
+    settings?: PersistedRuntimeStateDeps["getSettings"];
+    formatError?: PersistedRuntimeStateDeps["formatError"];
+  } = {},
+) {
+  const state: MutableRuntimeState = {
+    lastDmChannel: "D_CURRENT",
+    agentName: "Cobalt Olive Crane",
+    agentEmoji: "🦩",
+    agentStableId: "agent-stable-current",
+    brokerStableId: "broker-stable-current",
+    brokerRole: null,
+    activeSkinTheme: "cobalt",
+    agentPersonality: "steady",
+    agentOwnerToken: "owner:current",
+    controlPlaneCanvasId: "CANVAS_CURRENT",
+    controlPlaneCanvasChannelId: "C_CURRENT",
+    ...overrides.state,
+  };
+  const threads =
+    overrides.threads ??
+    new Map<string, SinglePlayerThreadInfo>([
+      [
+        "100.1",
+        {
+          channelId: "D_CURRENT",
+          threadTs: "100.1",
+          userId: "U_CURRENT",
+          owner: "owner:current",
+        },
+      ],
+    ]);
+  const userNames = overrides.userNames ?? new Map<string, string>([["U_CURRENT", "Current User"]]);
+  const agentAliases = overrides.agentAliases ?? new Set<string>(["Current Alias"]);
+  const appendEntry = vi.fn<(customType: string, data?: unknown) => void>();
+  const restoreControlPlaneCanvasRuntimeState = vi.fn(
+    ({ canvasId, channelId }: { canvasId: string | null; channelId: string | null }) => {
+      state.controlPlaneCanvasId = canvasId;
+      state.controlPlaneCanvasChannelId = channelId;
+    },
+  );
+
+  const deps: PersistedRuntimeStateDeps = {
+    pi: {
+      appendEntry: (customType, data) => {
+        appendEntry(customType, data);
+      },
+    },
+    threads,
+    userNames,
+    getLastDmChannel: () => state.lastDmChannel,
+    setLastDmChannel: (channelId) => {
+      state.lastDmChannel = channelId;
+    },
+    getAgentName: () => state.agentName,
+    setAgentName: (name) => {
+      state.agentName = name;
+    },
+    getAgentEmoji: () => state.agentEmoji,
+    setAgentEmoji: (emoji) => {
+      state.agentEmoji = emoji;
+    },
+    getAgentStableId: () => state.agentStableId,
+    setAgentStableId: (stableId) => {
+      state.agentStableId = stableId;
+    },
+    getBrokerStableId: () => state.brokerStableId,
+    setBrokerStableId: (stableId) => {
+      state.brokerStableId = stableId;
+    },
+    getBrokerRole: () => state.brokerRole,
+    getActiveSkinTheme: () => state.activeSkinTheme,
+    setActiveSkinTheme: (theme) => {
+      state.activeSkinTheme = theme;
+    },
+    getAgentPersonality: () => state.agentPersonality,
+    setAgentPersonality: (personality) => {
+      state.agentPersonality = personality;
+    },
+    agentAliases,
+    setAgentOwnerToken: (ownerToken) => {
+      state.agentOwnerToken = ownerToken;
+    },
+    getSettings: overrides.settings ?? (() => ({})),
+    getControlPlaneCanvasRuntimeId: () => state.controlPlaneCanvasId,
+    getControlPlaneCanvasRuntimeChannelId: () => state.controlPlaneCanvasChannelId,
+    restoreControlPlaneCanvasRuntimeState,
+    formatError:
+      overrides.formatError ??
+      ((error) => (error instanceof Error ? error.message : String(error))),
+  };
+
+  return {
+    deps,
+    state,
+    threads,
+    userNames,
+    agentAliases,
+    appendEntry,
+    restoreControlPlaneCanvasRuntimeState,
+  };
+}
+
+function createContext(
+  entries: Array<{ type: string; customType: string; data: PersistedState }> = [],
+): ExtensionContext {
+  return {
+    cwd: "/tmp/project",
+    hasUI: true,
+    isIdle: () => true,
+    ui: {
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+    },
+    sessionManager: {
+      getEntries: () => entries,
+      getHeader: () => null,
+      getLeafId: () => "leaf-123",
+      getSessionFile: () => "/tmp/session.json",
+    },
+  } as unknown as ExtensionContext;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("createPersistedRuntimeState", () => {
+  it("persists the current runtime snapshot immediately", () => {
+    const { deps, appendEntry } = createDeps({
+      state: {
+        brokerRole: "broker",
+        activeSkinTheme: "oceanic",
+        agentPersonality: "calm",
+        controlPlaneCanvasId: "CANVAS_RUNTIME",
+        controlPlaneCanvasChannelId: "C_RUNTIME",
+      },
+      threads: new Map([
+        [
+          "200.1",
+          {
+            channelId: "D200",
+            threadTs: "200.1",
+            userId: "U200",
+            owner: "owner:200",
+          },
+        ],
+      ]),
+      userNames: new Map([["U200", "River User"]]),
+      agentAliases: new Set(["Cobalt", "Crane"]),
+    });
+    const persistedRuntimeState = createPersistedRuntimeState(deps);
+
+    persistedRuntimeState.persistStateNow();
+
+    expect(appendEntry).toHaveBeenCalledTimes(1);
+    expect(appendEntry).toHaveBeenCalledWith("slack-bridge-state", {
+      threads: [
+        [
+          "200.1",
+          {
+            channelId: "D200",
+            threadTs: "200.1",
+            userId: "U200",
+            owner: "owner:200",
+          },
+        ],
+      ],
+      lastDmChannel: "D_CURRENT",
+      userNames: [["U200", "River User"]],
+      agentName: "Cobalt Olive Crane",
+      agentEmoji: "🦩",
+      agentStableId: "agent-stable-current",
+      brokerStableId: "broker-stable-current",
+      lastPinetRole: "broker",
+      activeSkinTheme: "oceanic",
+      agentPersonality: "calm",
+      agentAliases: ["Cobalt", "Crane"],
+      brokerControlPlaneCanvasId: "CANVAS_RUNTIME",
+      brokerControlPlaneCanvasChannelId: "C_RUNTIME",
+    });
+  });
+
+  it("debounces scheduled persistence and flushes only the latest snapshot", () => {
+    vi.useFakeTimers();
+
+    const { deps, state, appendEntry } = createDeps();
+    const persistedRuntimeState = createPersistedRuntimeState(deps);
+
+    persistedRuntimeState.persistState();
+    state.agentName = "First Rename";
+    persistedRuntimeState.persistState();
+    state.agentName = "Final Rename";
+
+    vi.advanceTimersByTime(999);
+    expect(appendEntry).not.toHaveBeenCalled();
+
+    persistedRuntimeState.flushPersist();
+    expect(appendEntry).toHaveBeenCalledTimes(1);
+    expect(appendEntry).toHaveBeenLastCalledWith(
+      "slack-bridge-state",
+      expect.objectContaining({ agentName: "Final Rename" }),
+    );
+
+    vi.advanceTimersByTime(5_000);
+    expect(appendEntry).toHaveBeenCalledTimes(1);
+
+    persistedRuntimeState.flushPersist();
+    expect(appendEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores persisted runtime state, preserves existing live data, and re-persists normalized state", () => {
+    const {
+      deps,
+      state,
+      threads,
+      userNames,
+      agentAliases,
+      appendEntry,
+      restoreControlPlaneCanvasRuntimeState,
+    } = createDeps({
+      state: {
+        lastDmChannel: "D_EXISTING",
+        agentName: "Current Crane",
+        agentEmoji: "🪿",
+        agentStableId: "agent-stable-live",
+        brokerStableId: "broker-stable-live",
+        agentOwnerToken: "owner:live",
+        activeSkinTheme: null,
+        agentPersonality: null,
+        controlPlaneCanvasId: "CANVAS_FALLBACK",
+        controlPlaneCanvasChannelId: "C_FALLBACK",
+      },
+    });
+    const persistedRuntimeState = createPersistedRuntimeState(deps);
+    const savedState: PersistedState = {
+      threads: [
+        [
+          "100.1",
+          {
+            channelId: "D_SAVED",
+            threadTs: "100.1",
+            userId: "U_SAVED",
+            owner: "owner:saved-ignored",
+          },
+        ],
+        [
+          "200.1",
+          {
+            channelId: "D_200",
+            threadTs: "200.1",
+            userId: "U_200",
+            owner: "owner:200",
+          },
+        ],
+      ],
+      lastDmChannel: "D_SAVED",
+      userNames: [
+        ["U_CURRENT", "Saved Name Ignored"],
+        ["U_200", "Saved User"],
+      ],
+      agentName: "Saved Crane",
+      agentEmoji: "🦩",
+      agentStableId: "agent-stable-saved",
+      brokerStableId: "broker-stable-saved",
+      lastPinetRole: "broker",
+      activeSkinTheme: "midnight",
+      agentPersonality: "observant",
+      agentAliases: ["Saved Alias", "Night Crane"],
+      brokerControlPlaneCanvasId: "  CANVAS_SAVED  ",
+      brokerControlPlaneCanvasChannelId: "   ",
+    };
+
+    persistedRuntimeState.restorePersistedRuntimeState(
+      createContext([
+        { type: "custom", customType: "other-state", data: {} as PersistedState },
+        { type: "custom", customType: "slack-bridge-state", data: savedState },
+      ]),
+    );
+
+    expect(state.agentName).toBe("Saved Crane");
+    expect(state.agentEmoji).toBe("🦩");
+    expect(state.agentStableId).toBe("agent-stable-saved");
+    expect(state.brokerStableId).toBe("broker-stable-saved");
+    expect(state.agentOwnerToken).toBe(buildPinetOwnerToken("broker-stable-saved"));
+    expect(state.activeSkinTheme).toBe("midnight");
+    expect(state.agentPersonality).toBe("observant");
+    expect([...agentAliases]).toEqual(["Saved Alias", "Night Crane"]);
+
+    expect(threads.get("100.1")?.owner).toBe("owner:current");
+    expect(threads.get("200.1")).toEqual({
+      channelId: "D_200",
+      threadTs: "200.1",
+      userId: "U_200",
+      owner: "owner:200",
+    });
+    expect(state.lastDmChannel).toBe("D_EXISTING");
+    expect(userNames.get("U_CURRENT")).toBe("Current User");
+    expect(userNames.get("U_200")).toBe("Saved User");
+
+    expect(restoreControlPlaneCanvasRuntimeState).toHaveBeenCalledWith({
+      canvasId: "CANVAS_SAVED",
+      channelId: "C_FALLBACK",
+    });
+    expect(state.controlPlaneCanvasId).toBe("CANVAS_SAVED");
+    expect(state.controlPlaneCanvasChannelId).toBe("C_FALLBACK");
+
+    expect(appendEntry).toHaveBeenCalledTimes(1);
+    expect(appendEntry).toHaveBeenLastCalledWith("slack-bridge-state", {
+      threads: [
+        [
+          "100.1",
+          {
+            channelId: "D_CURRENT",
+            threadTs: "100.1",
+            userId: "U_CURRENT",
+            owner: "owner:current",
+          },
+        ],
+        [
+          "200.1",
+          {
+            channelId: "D_200",
+            threadTs: "200.1",
+            userId: "U_200",
+            owner: "owner:200",
+          },
+        ],
+      ],
+      lastDmChannel: "D_EXISTING",
+      userNames: [
+        ["U_CURRENT", "Current User"],
+        ["U_200", "Saved User"],
+      ],
+      agentName: "Saved Crane",
+      agentEmoji: "🦩",
+      agentStableId: "agent-stable-saved",
+      brokerStableId: "broker-stable-saved",
+      lastPinetRole: "worker",
+      activeSkinTheme: "midnight",
+      agentPersonality: "observant",
+      agentAliases: ["Saved Alias", "Night Crane"],
+      brokerControlPlaneCanvasId: "CANVAS_SAVED",
+      brokerControlPlaneCanvasChannelId: "C_FALLBACK",
+    });
+  });
+});

--- a/slack-bridge/persisted-runtime-state.ts
+++ b/slack-bridge/persisted-runtime-state.ts
@@ -1,0 +1,210 @@
+import * as os from "node:os";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  buildPinetOwnerToken,
+  resolveAgentStableId,
+  resolveBrokerStableId,
+  resolvePersistedAgentIdentity,
+  type SlackBridgeSettings,
+} from "./helpers.js";
+import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
+
+export interface PersistedState {
+  threads?: [string, SinglePlayerThreadInfo][];
+  lastDmChannel?: string | null;
+  userNames?: [string, string][];
+  agentName?: string;
+  agentEmoji?: string;
+  agentStableId?: string;
+  brokerStableId?: string;
+  lastPinetRole?: "broker" | "worker";
+  activeSkinTheme?: string | null;
+  agentPersonality?: string | null;
+  agentAliases?: string[];
+  brokerControlPlaneCanvasId?: string | null;
+  brokerControlPlaneCanvasChannelId?: string | null;
+}
+
+export interface PersistedRuntimeStateStringCache {
+  entries: () => Iterable<[string, string]>;
+  has: (key: string) => boolean;
+  set: (key: string, value: string) => void;
+}
+
+export interface PersistedRuntimeStateDeps {
+  pi: Pick<ExtensionAPI, "appendEntry">;
+  threads: Map<string, SinglePlayerThreadInfo>;
+  userNames: PersistedRuntimeStateStringCache;
+  getLastDmChannel: () => string | null;
+  setLastDmChannel: (channelId: string | null) => void;
+  getAgentName: () => string;
+  setAgentName: (name: string) => void;
+  getAgentEmoji: () => string;
+  setAgentEmoji: (emoji: string) => void;
+  getAgentStableId: () => string;
+  setAgentStableId: (stableId: string) => void;
+  getBrokerStableId: () => string;
+  setBrokerStableId: (stableId: string) => void;
+  getBrokerRole: () => "broker" | "follower" | null;
+  getActiveSkinTheme: () => string | null;
+  setActiveSkinTheme: (theme: string | null) => void;
+  getAgentPersonality: () => string | null;
+  setAgentPersonality: (personality: string | null) => void;
+  agentAliases: Set<string>;
+  setAgentOwnerToken: (ownerToken: string) => void;
+  getSettings: () => SlackBridgeSettings;
+  getControlPlaneCanvasRuntimeId: () => string | null;
+  getControlPlaneCanvasRuntimeChannelId: () => string | null;
+  restoreControlPlaneCanvasRuntimeState: (input: {
+    canvasId: string | null;
+    channelId: string | null;
+  }) => void;
+  formatError: (error: unknown) => string;
+}
+
+export interface PersistedRuntimeStateManager {
+  persistStateNow: () => void;
+  persistState: () => void;
+  flushPersist: () => void;
+  restorePersistedRuntimeState: (ctx: ExtensionContext) => void;
+}
+
+function normalizeOptionalSetting(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function createPersistedRuntimeState(
+  deps: PersistedRuntimeStateDeps,
+): PersistedRuntimeStateManager {
+  let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function persistStateNow(): void {
+    persistTimer = null;
+    try {
+      deps.pi.appendEntry("slack-bridge-state", {
+        threads: Array.from(deps.threads.entries()),
+        lastDmChannel: deps.getLastDmChannel(),
+        userNames: Array.from(deps.userNames.entries()),
+        agentName: deps.getAgentName(),
+        agentEmoji: deps.getAgentEmoji(),
+        agentStableId: deps.getAgentStableId(),
+        brokerStableId: deps.getBrokerStableId(),
+        lastPinetRole: deps.getBrokerRole() === "broker" ? "broker" : "worker",
+        activeSkinTheme: deps.getActiveSkinTheme(),
+        agentPersonality: deps.getAgentPersonality(),
+        agentAliases: [...deps.agentAliases],
+        brokerControlPlaneCanvasId: deps.getControlPlaneCanvasRuntimeId(),
+        brokerControlPlaneCanvasChannelId: deps.getControlPlaneCanvasRuntimeChannelId(),
+      } satisfies PersistedState);
+    } catch (error) {
+      console.error(`[slack-bridge] persistState failed: ${deps.formatError(error)}`);
+    }
+  }
+
+  function persistState(): void {
+    if (persistTimer) {
+      clearTimeout(persistTimer);
+    }
+    persistTimer = setTimeout(persistStateNow, 1_000);
+  }
+
+  function flushPersist(): void {
+    if (!persistTimer) {
+      return;
+    }
+    clearTimeout(persistTimer);
+    persistStateNow();
+  }
+
+  function restorePersistedRuntimeState(ctx: ExtensionContext): void {
+    try {
+      let savedState: PersistedState | null = null;
+      for (const entry of ctx.sessionManager.getEntries()) {
+        if (entry.type === "custom" && entry.customType === "slack-bridge-state") {
+          savedState = entry.data as PersistedState;
+        }
+      }
+
+      const restoredRole = savedState?.lastPinetRole === "broker" ? "broker" : "worker";
+      const agentStableId = resolveAgentStableId(
+        savedState?.agentStableId,
+        ctx.sessionManager.getSessionFile(),
+        os.hostname(),
+        ctx.cwd,
+        ctx.sessionManager.getLeafId(),
+      );
+      const brokerStableId = resolveBrokerStableId(
+        savedState?.brokerStableId,
+        os.hostname(),
+        ctx.cwd,
+      );
+      deps.setAgentStableId(agentStableId);
+      deps.setBrokerStableId(brokerStableId);
+      deps.setAgentOwnerToken(
+        buildPinetOwnerToken(restoredRole === "broker" ? brokerStableId : agentStableId),
+      );
+      const identitySeed =
+        restoredRole === "broker"
+          ? brokerStableId
+          : (ctx.sessionManager.getSessionFile() ?? agentStableId);
+      deps.setActiveSkinTheme(savedState?.activeSkinTheme ?? null);
+      deps.setAgentPersonality(savedState?.agentPersonality ?? null);
+      deps.agentAliases.clear();
+      for (const alias of savedState?.agentAliases ?? []) {
+        if (alias) {
+          deps.agentAliases.add(alias);
+        }
+      }
+      const restoredIdentity = resolvePersistedAgentIdentity(
+        deps.getSettings(),
+        savedState?.agentName,
+        savedState?.agentEmoji,
+        process.env.PI_NICKNAME,
+        identitySeed,
+        restoredRole,
+      );
+      deps.setAgentName(restoredIdentity.name);
+      deps.setAgentEmoji(restoredIdentity.emoji);
+
+      if (savedState) {
+        if (savedState.threads) {
+          for (const [threadTs, info] of savedState.threads) {
+            if (!deps.threads.has(threadTs)) {
+              deps.threads.set(threadTs, info);
+            }
+          }
+        }
+        if (savedState.lastDmChannel && !deps.getLastDmChannel()) {
+          deps.setLastDmChannel(savedState.lastDmChannel);
+        }
+        if (savedState.userNames) {
+          for (const [userId, userName] of savedState.userNames) {
+            if (!deps.userNames.has(userId)) {
+              deps.userNames.set(userId, userName);
+            }
+          }
+        }
+        deps.restoreControlPlaneCanvasRuntimeState({
+          canvasId:
+            normalizeOptionalSetting(savedState.brokerControlPlaneCanvasId) ??
+            deps.getControlPlaneCanvasRuntimeId(),
+          channelId:
+            normalizeOptionalSetting(savedState.brokerControlPlaneCanvasChannelId) ??
+            deps.getControlPlaneCanvasRuntimeChannelId(),
+        });
+      }
+
+      persistStateNow();
+    } catch (error) {
+      console.error(`[slack-bridge] restore failed: ${deps.formatError(error)}`);
+    }
+  }
+
+  return {
+    persistStateNow,
+    persistState,
+    flushPersist,
+    restorePersistedRuntimeState,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the persisted runtime-state seam from `slack-bridge/index.ts` into `slack-bridge/persisted-runtime-state.ts`
- keep the `slack-bridge-state` persist/restore contract behaviorally identical while moving session-start restoration into the new helper
- add focused coverage for immediate persistence, debounced flush behavior, and normalized restore/repersist flow

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- persisted-runtime-state.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test