### PR TITLE
refactor: extract reloadable runtime agent context (#436)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1,33 +1,25 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
-import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-metadata.js";
 import {
   type InboxMessage,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
-  getSlackUserAccessWarning,
-  isUserAllowed as checkUserAllowed,
   formatInboxMessages,
-  buildPinetSkinAssignment,
   buildPinetSkinPromptGuideline,
   reloadPinetRuntimeSafely,
   callSlackAPI,
   createAbortableOperationTracker,
   buildPinetOwnerToken,
   resolveAgentIdentity,
-  resolveRuntimeAgentIdentity,
   resolveBrokerStableId,
-  shortenPath,
-  buildIdentityReplyGuidelines,
   buildAgentPersonalityGuidelines,
   buildBrokerPromptGuidelines,
   buildWorkerPromptGuidelines,
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
   resolveAllowAllWorkspaceUsers,
-  normalizeOwnedThreads,
   trackBrokerInboundThread,
 } from "./helpers.js";
 import {
@@ -87,6 +79,7 @@ import { createPinetAgentStatus } from "./pinet-agent-status.js";
 import { createPinetMeshSkin } from "./pinet-skin.js";
 import { createBrokerThreadOwnerHints } from "./broker-thread-owner-hints.js";
 import { createPersistedRuntimeState } from "./persisted-runtime-state.js";
+import { createRuntimeAgentContext } from "./runtime-agent-context.js";
 import { createPinetActivityFormatting } from "./pinet-activity-formatting.js";
 import { createPinetControlPlaneCanvas } from "./pinet-control-plane-canvas.js";
 import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js";
@@ -126,26 +119,6 @@ export default function (pi: ExtensionAPI) {
   );
   let reactionCommands = resolveReactionCommands(settings.reactionCommands);
 
-  function isUserAllowed(userId: string): boolean {
-    return checkUserAllowed(allowedUsers, userId);
-  }
-
-  let lastSlackUserAccessWarning = "";
-
-  function maybeWarnSlackUserAccess(ctx?: ExtensionContext): void {
-    const warning = getSlackUserAccessWarning(allowedUsers);
-    if (!warning) {
-      lastSlackUserAccessWarning = "";
-      return;
-    }
-    if (warning === lastSlackUserAccessWarning) {
-      return;
-    }
-    lastSlackUserAccessWarning = warning;
-    console.warn(`[slack-bridge] ${warning}`);
-    ctx?.ui.notify(warning, "warning");
-  }
-
   const initialIdentity = resolveAgentIdentity(settings, process.env.PI_NICKNAME, process.cwd());
   let agentName = initialIdentity.name;
   let agentEmoji = initialIdentity.emoji;
@@ -160,258 +133,6 @@ export default function (pi: ExtensionAPI) {
   // Security guardrails
   let guardrails: SecurityGuardrails = settings.security ?? {};
   let securityPrompt = buildSecurityPrompt(guardrails);
-
-  interface ReloadableRuntimeSnapshot {
-    settings: typeof settings;
-    botToken: string | undefined;
-    appToken: string | undefined;
-    allowedUsers: Set<string> | null;
-    guardrails: SecurityGuardrails;
-    reactionCommands: Map<string, { action: string; prompt: string }>;
-    securityPrompt: string;
-    agentName: string;
-    agentEmoji: string;
-    activeSkinTheme: string | null;
-    agentPersonality: string | null;
-    agentAliases: string[];
-  }
-
-  function getStableIdForRole(role: "broker" | "worker"): string {
-    return role === "broker" ? brokerStableId : agentStableId;
-  }
-
-  function getIdentitySeedForRole(
-    role: "broker" | "worker",
-    sessionFile = extCtx?.sessionManager.getSessionFile() ?? undefined,
-  ): string {
-    return role === "broker" ? brokerStableId : (sessionFile ?? agentStableId);
-  }
-
-  function getSkinSeed(preferredSeed?: string): string {
-    return (
-      preferredSeed?.trim() || getStableIdForRole(brokerRole === "broker" ? "broker" : "worker")
-    );
-  }
-
-  function rememberAgentAlias(name: string | undefined): void {
-    const trimmed = name?.trim();
-    if (!trimmed || trimmed === agentName) return;
-    agentAliases.add(trimmed);
-    while (agentAliases.size > 24) {
-      const oldest = agentAliases.values().next().value;
-      if (!oldest) break;
-      agentAliases.delete(oldest);
-    }
-  }
-
-  function resolveSkinAssignment(
-    role: "broker" | "worker",
-    seed = getSkinSeed(),
-  ): { name: string; emoji: string; personality: string } | null {
-    if (!activeSkinTheme) return null;
-    const assignment = buildPinetSkinAssignment({ theme: activeSkinTheme, role, seed });
-    return {
-      name: assignment.name,
-      emoji: assignment.emoji,
-      personality: assignment.personality,
-    };
-  }
-
-  function applyLocalAgentIdentity(
-    nextName: string,
-    nextEmoji: string,
-    nextPersonality: string | null,
-  ): void {
-    const previousName = agentName;
-    if (
-      agentName === nextName &&
-      agentEmoji === nextEmoji &&
-      (agentPersonality ?? null) === (nextPersonality ?? null)
-    ) {
-      return;
-    }
-
-    agentName = nextName;
-    agentEmoji = nextEmoji;
-    agentPersonality = nextPersonality ?? null;
-    rememberAgentAlias(previousName);
-    normalizeOwnedThreads(threads.values(), agentName, agentOwnerToken, agentAliases);
-    persistState();
-    updateBadge();
-  }
-
-  function refreshSettings(): void {
-    settings = loadSettingsFromFile();
-    botToken = settings.botToken ?? process.env.SLACK_BOT_TOKEN;
-    appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
-    allowedUsers = buildAllowlist(
-      settings,
-      process.env.SLACK_ALLOWED_USERS,
-      process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
-    );
-    guardrails = settings.security ?? {};
-    reactionCommands = resolveReactionCommands(settings.reactionCommands);
-    securityPrompt = buildSecurityPrompt(guardrails);
-    const role = brokerRole === "broker" ? "broker" : "worker";
-    const identitySeed = getIdentitySeedForRole(role);
-    const skinIdentity = resolveSkinAssignment(role, identitySeed);
-    if (skinIdentity) {
-      agentName = skinIdentity.name;
-      agentEmoji = skinIdentity.emoji;
-      agentPersonality = skinIdentity.personality;
-      return;
-    }
-    const refreshedIdentity = resolveRuntimeAgentIdentity(
-      { name: agentName, emoji: agentEmoji },
-      settings,
-      process.env.PI_NICKNAME,
-      identitySeed,
-      role,
-    );
-    agentName = refreshedIdentity.name;
-    agentEmoji = refreshedIdentity.emoji;
-    agentPersonality = null;
-  }
-
-  function snapshotReloadableRuntime(): ReloadableRuntimeSnapshot {
-    return {
-      settings: structuredClone(settings),
-      botToken,
-      appToken,
-      allowedUsers: allowedUsers ? new Set(allowedUsers) : null,
-      guardrails: structuredClone(guardrails),
-      reactionCommands: new Map(reactionCommands),
-      securityPrompt,
-      agentName,
-      agentEmoji,
-      activeSkinTheme,
-      agentPersonality,
-      agentAliases: [...agentAliases],
-    };
-  }
-
-  function restoreReloadableRuntime(snapshot: ReloadableRuntimeSnapshot): void {
-    settings = structuredClone(snapshot.settings);
-    botToken = snapshot.botToken;
-    appToken = snapshot.appToken;
-    allowedUsers = snapshot.allowedUsers ? new Set(snapshot.allowedUsers) : null;
-    guardrails = structuredClone(snapshot.guardrails);
-    reactionCommands = new Map(snapshot.reactionCommands);
-    securityPrompt = snapshot.securityPrompt;
-    agentName = snapshot.agentName;
-    agentEmoji = snapshot.agentEmoji;
-    activeSkinTheme = snapshot.activeSkinTheme;
-    agentPersonality = snapshot.agentPersonality;
-    agentOwnerToken = buildPinetOwnerToken(
-      getStableIdForRole(brokerRole === "broker" ? "broker" : "worker"),
-    );
-    agentAliases.clear();
-    for (const alias of snapshot.agentAliases) {
-      if (alias && alias !== agentName) {
-        agentAliases.add(alias);
-      }
-    }
-  }
-
-  function detectProjectTools(repoRoot: string, cwd: string): string[] {
-    const tools = new Set<string>();
-
-    for (const candidate of [path.join(cwd, "package.json"), path.join(repoRoot, "package.json")]) {
-      try {
-        if (!fs.existsSync(candidate)) continue;
-        const parsed = JSON.parse(fs.readFileSync(candidate, "utf-8")) as {
-          scripts?: Record<string, string>;
-        };
-        const scripts = parsed.scripts ?? {};
-        if (scripts.test) tools.add("test");
-        if (scripts.lint) tools.add("lint");
-        if (scripts.typecheck) tools.add("typecheck");
-        if (scripts.build) tools.add("build");
-      } catch {
-        // Ignore unreadable package.json files.
-      }
-    }
-
-    tools.add("git");
-    return [...tools].sort();
-  }
-
-  const gitContextCache = createGitContextCache(() => probeGitContext(process.cwd()));
-
-  async function getAgentMetadata(
-    role: "broker" | "worker" = "worker",
-  ): Promise<Record<string, unknown>> {
-    const gitContext = await gitContextCache.get();
-    const { cwd, repo, repoRoot, branch } = gitContext;
-    const resolvedRepoRoot = repoRoot ?? cwd;
-    const tools = detectProjectTools(resolvedRepoRoot, cwd);
-    const tags = [
-      `role:${role}`,
-      `repo:${repo}`,
-      ...(branch ? [`branch:${branch}`] : []),
-      ...tools.map((tool) => `tool:${tool}`),
-    ];
-
-    return {
-      cwd,
-      branch,
-      host: os.hostname(),
-      role,
-      repo,
-      repoRoot,
-      ...(activeSkinTheme ? { skinTheme: activeSkinTheme } : {}),
-      ...(agentPersonality ? { personality: agentPersonality } : {}),
-      capabilities: {
-        repo,
-        repoRoot,
-        branch,
-        role,
-        tools,
-        tags,
-      },
-    };
-  }
-
-  function asStringValue(value: unknown): string | undefined {
-    return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-  }
-
-  function getMeshRoleFromMetadata(
-    metadata: Record<string, unknown> | undefined,
-    fallback: "broker" | "worker" = "worker",
-  ): "broker" | "worker" {
-    return asStringValue(metadata?.role) === "broker" ? "broker" : fallback;
-  }
-
-  function buildSkinMetadata(
-    metadata: Record<string, unknown> | undefined,
-    personality: string,
-  ): Record<string, unknown> {
-    return {
-      ...(metadata ?? {}),
-      ...(activeSkinTheme ? { skinTheme: activeSkinTheme } : {}),
-      personality,
-    };
-  }
-
-  const selfLocation = `${shortenPath(process.cwd(), os.homedir())}@${os.hostname()}`;
-
-  function getIdentityGuidelines(): [string, string, string] {
-    return buildIdentityReplyGuidelines(agentEmoji, agentName, selfLocation);
-  }
-
-  function applyRegistrationIdentity(registration: {
-    name: string;
-    emoji: string;
-    metadata?: Record<string, unknown> | null;
-  }): void {
-    activeSkinTheme = asStringValue(registration.metadata?.skinTheme) ?? null;
-    applyLocalAgentIdentity(
-      registration.name,
-      registration.emoji,
-      asStringValue(registration.metadata?.personality) ?? null,
-    );
-  }
 
   let botUserId: string | null = null;
 
@@ -543,6 +264,81 @@ export default function (pi: ExtensionAPI) {
   }
 
   // ─── Helpers ─────────────────────────────────────────
+
+  const gitContextCache = createGitContextCache(() => probeGitContext(process.cwd()));
+  const runtimeAgentContext = createRuntimeAgentContext({
+    cwd: process.cwd(),
+    getSettings: () => settings,
+    setSettings: (nextSettings) => {
+      settings = nextSettings;
+    },
+    getBotToken: () => botToken,
+    setBotToken: (token) => {
+      botToken = token;
+    },
+    getAppToken: () => appToken,
+    setAppToken: (token) => {
+      appToken = token;
+    },
+    getAllowedUsers: () => allowedUsers,
+    setAllowedUsers: (users) => {
+      allowedUsers = users;
+    },
+    getGuardrails: () => guardrails,
+    setGuardrails: (nextGuardrails) => {
+      guardrails = nextGuardrails;
+    },
+    getReactionCommands: () => reactionCommands,
+    setReactionCommands: (commands) => {
+      reactionCommands = commands;
+    },
+    getSecurityPrompt: () => securityPrompt,
+    setSecurityPrompt: (prompt) => {
+      securityPrompt = prompt;
+    },
+    getAgentName: () => agentName,
+    setAgentName: (name) => {
+      agentName = name;
+    },
+    getAgentEmoji: () => agentEmoji,
+    setAgentEmoji: (emoji) => {
+      agentEmoji = emoji;
+    },
+    getAgentStableId: () => agentStableId,
+    getBrokerStableId: () => brokerStableId,
+    getBrokerRole: () => brokerRole,
+    getAgentOwnerToken: () => agentOwnerToken,
+    setAgentOwnerToken: (ownerToken) => {
+      agentOwnerToken = ownerToken;
+    },
+    getActiveSkinTheme: () => activeSkinTheme,
+    setActiveSkinTheme: (theme) => {
+      activeSkinTheme = theme;
+    },
+    getAgentPersonality: () => agentPersonality,
+    setAgentPersonality: (personality) => {
+      agentPersonality = personality;
+    },
+    getAgentAliases: () => agentAliases,
+    getThreads: () => threads,
+    getExtensionContext: () => extCtx,
+    persistState,
+    updateBadge,
+    getGitContext: () => gitContextCache.get(),
+  });
+  const {
+    isUserAllowed,
+    maybeWarnSlackUserAccess,
+    applyLocalAgentIdentity,
+    refreshSettings,
+    snapshotReloadableRuntime,
+    restoreReloadableRuntime,
+    getAgentMetadata,
+    getMeshRoleFromMetadata,
+    buildSkinMetadata,
+    getIdentityGuidelines,
+    applyRegistrationIdentity,
+  } = runtimeAgentContext;
 
   let isSinglePlayerShuttingDown = () => false;
   let isSinglePlayerConnected = () => false;

--- a/slack-bridge/runtime-agent-context.test.ts
+++ b/slack-bridge/runtime-agent-context.test.ts
@@ -1,0 +1,503 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  buildPinetOwnerToken,
+  buildPinetSkinAssignment,
+  type SlackBridgeSettings,
+} from "./helpers.js";
+import {
+  createRuntimeAgentContext,
+  type ReactionCommandMap,
+  type RuntimeAgentContextDeps,
+} from "./runtime-agent-context.js";
+import type { SecurityGuardrails } from "./guardrails.js";
+import type { GitContext } from "./git-metadata.js";
+import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
+
+interface MutableRuntimeAgentState {
+  settings: SlackBridgeSettings;
+  botToken: string | undefined;
+  appToken: string | undefined;
+  allowedUsers: Set<string> | null;
+  guardrails: SecurityGuardrails;
+  reactionCommands: ReactionCommandMap;
+  securityPrompt: string;
+  agentName: string;
+  agentEmoji: string;
+  agentStableId: string;
+  brokerStableId: string;
+  brokerRole: "broker" | "follower" | null;
+  agentOwnerToken: string;
+  activeSkinTheme: string | null;
+  agentPersonality: string | null;
+}
+
+function createContext(
+  sessionFile = "/tmp/runtime-agent-context-session.json",
+  notify = vi.fn(),
+): ExtensionContext {
+  return {
+    cwd: process.cwd(),
+    hasUI: true,
+    isIdle: () => true,
+    ui: {
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+      notify,
+      setStatus: vi.fn(),
+    },
+    sessionManager: {
+      getEntries: () => [],
+      getHeader: () => null,
+      getLeafId: () => "leaf-123",
+      getSessionFile: () => sessionFile,
+    },
+  } as unknown as ExtensionContext;
+}
+
+function createDeps(
+  overrides: {
+    cwd?: string;
+    state?: Partial<MutableRuntimeAgentState>;
+    threads?: Map<string, SinglePlayerThreadInfo>;
+    agentAliases?: Set<string>;
+    extensionContext?: ExtensionContext | null;
+    gitContext?: GitContext;
+  } = {},
+) {
+  const cwd = overrides.cwd ?? process.cwd();
+  const state: MutableRuntimeAgentState = {
+    settings: {},
+    botToken: "xoxb-test",
+    appToken: "xapp-test",
+    allowedUsers: null,
+    guardrails: {},
+    reactionCommands: new Map(),
+    securityPrompt: "",
+    agentName: "Cobalt Olive Crane",
+    agentEmoji: "🦩",
+    agentStableId: "agent-stable-current",
+    brokerStableId: "broker-stable-current",
+    brokerRole: null,
+    agentOwnerToken: buildPinetOwnerToken("agent-stable-current"),
+    activeSkinTheme: null,
+    agentPersonality: null,
+    ...overrides.state,
+  };
+  const threads =
+    overrides.threads ??
+    new Map<string, SinglePlayerThreadInfo>([
+      [
+        "100.1",
+        {
+          channelId: "D100",
+          threadTs: "100.1",
+          userId: "U100",
+          owner: "Cobalt Olive Crane",
+        },
+      ],
+    ]);
+  const agentAliases = overrides.agentAliases ?? new Set<string>();
+  const extensionContext = overrides.extensionContext ?? createContext();
+  const gitContext: GitContext = overrides.gitContext ?? {
+    cwd,
+    repo: path.basename(cwd),
+    repoRoot: cwd,
+    branch: "main",
+  };
+  const persistState = vi.fn();
+  const updateBadge = vi.fn();
+
+  const deps: RuntimeAgentContextDeps = {
+    cwd,
+    getSettings: () => state.settings,
+    setSettings: (settings) => {
+      state.settings = settings;
+    },
+    getBotToken: () => state.botToken,
+    setBotToken: (token) => {
+      state.botToken = token;
+    },
+    getAppToken: () => state.appToken,
+    setAppToken: (token) => {
+      state.appToken = token;
+    },
+    getAllowedUsers: () => state.allowedUsers,
+    setAllowedUsers: (users) => {
+      state.allowedUsers = users;
+    },
+    getGuardrails: () => state.guardrails,
+    setGuardrails: (guardrails) => {
+      state.guardrails = guardrails;
+    },
+    getReactionCommands: () => state.reactionCommands,
+    setReactionCommands: (commands) => {
+      state.reactionCommands = commands;
+    },
+    getSecurityPrompt: () => state.securityPrompt,
+    setSecurityPrompt: (prompt) => {
+      state.securityPrompt = prompt;
+    },
+    getAgentName: () => state.agentName,
+    setAgentName: (name) => {
+      state.agentName = name;
+    },
+    getAgentEmoji: () => state.agentEmoji,
+    setAgentEmoji: (emoji) => {
+      state.agentEmoji = emoji;
+    },
+    getAgentStableId: () => state.agentStableId,
+    getBrokerStableId: () => state.brokerStableId,
+    getBrokerRole: () => state.brokerRole,
+    getAgentOwnerToken: () => state.agentOwnerToken,
+    setAgentOwnerToken: (ownerToken) => {
+      state.agentOwnerToken = ownerToken;
+    },
+    getActiveSkinTheme: () => state.activeSkinTheme,
+    setActiveSkinTheme: (theme) => {
+      state.activeSkinTheme = theme;
+    },
+    getAgentPersonality: () => state.agentPersonality,
+    setAgentPersonality: (personality) => {
+      state.agentPersonality = personality;
+    },
+    getAgentAliases: () => agentAliases,
+    getThreads: () => threads,
+    getExtensionContext: () => extensionContext,
+    persistState,
+    updateBadge,
+    getGitContext: async () => gitContext,
+  };
+
+  return {
+    deps,
+    state,
+    threads,
+    agentAliases,
+    extensionContext,
+    persistState,
+    updateBadge,
+  };
+}
+
+describe("createRuntimeAgentContext", () => {
+  const originalHome = process.env.HOME;
+  let testHome: string;
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-agent-context-home-"));
+    process.env.HOME = testHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("warns once per distinct Slack access warning and resets after access is configured", () => {
+    const notify = vi.fn();
+    const { deps, state } = createDeps({
+      extensionContext: createContext(undefined, notify),
+      state: { allowedUsers: new Set() },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(runtimeAgentContext.isUserAllowed("U_OK")).toBe(false);
+
+    runtimeAgentContext.maybeWarnSlackUserAccess(deps.getExtensionContext() ?? undefined);
+    runtimeAgentContext.maybeWarnSlackUserAccess(deps.getExtensionContext() ?? undefined);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("default-deny");
+
+    state.allowedUsers = new Set(["U_OK"]);
+    runtimeAgentContext.maybeWarnSlackUserAccess(deps.getExtensionContext() ?? undefined);
+    expect(runtimeAgentContext.isUserAllowed("U_OK")).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    state.allowedUsers = new Set();
+    runtimeAgentContext.maybeWarnSlackUserAccess(deps.getExtensionContext() ?? undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies local agent identity updates, normalizes owned threads, and skips redundant writes", () => {
+    const { deps, state, threads, agentAliases, persistState, updateBadge } = createDeps({
+      threads: new Map([
+        [
+          "100.1",
+          {
+            channelId: "D100",
+            threadTs: "100.1",
+            userId: "U100",
+            owner: "Cobalt Olive Crane",
+          },
+        ],
+        [
+          "200.1",
+          {
+            channelId: "D200",
+            threadTs: "200.1",
+            userId: "U200",
+            owner: "someone-else",
+          },
+        ],
+      ]),
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    runtimeAgentContext.applyLocalAgentIdentity("Obsidian Coral Goose", "🪿", "observant");
+
+    expect(state.agentName).toBe("Obsidian Coral Goose");
+    expect(state.agentEmoji).toBe("🪿");
+    expect(state.agentPersonality).toBe("observant");
+    expect([...agentAliases]).toEqual(["Cobalt Olive Crane"]);
+    expect(threads.get("100.1")?.owner).toBe(state.agentOwnerToken);
+    expect(threads.get("200.1")?.owner).toBe("someone-else");
+    expect(persistState).toHaveBeenCalledTimes(1);
+    expect(updateBadge).toHaveBeenCalledTimes(1);
+
+    runtimeAgentContext.applyLocalAgentIdentity("Obsidian Coral Goose", "🪿", "observant");
+    expect(persistState).toHaveBeenCalledTimes(1);
+    expect(updateBadge).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes settings and prefers the active skin identity when a theme is set", () => {
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "slack-bridge": {
+          botToken: "xoxb-updated",
+          appToken: "xapp-updated",
+          allowedUsers: ["U_ALLOWED"],
+          security: { blockedTools: ["bash"] },
+          reactionCommands: {
+            "👀": { action: "inspect", prompt: "Inspect closely" },
+          },
+          agentName: "Ignored By Skin",
+          agentEmoji: "❌",
+        },
+      }),
+    );
+
+    const sessionFile = "/tmp/runtime-agent-context-session.json";
+    const { deps, state } = createDeps({
+      extensionContext: createContext(sessionFile),
+      state: {
+        activeSkinTheme: "cyberpunk neon",
+        agentName: "Current Name",
+        agentEmoji: "🙂",
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    runtimeAgentContext.refreshSettings();
+
+    const expectedSkin = buildPinetSkinAssignment({
+      theme: "cyberpunk neon",
+      role: "worker",
+      seed: sessionFile,
+    });
+
+    expect(state.settings.allowedUsers).toEqual(["U_ALLOWED"]);
+    expect(state.botToken).toBe("xoxb-updated");
+    expect(state.appToken).toBe("xapp-updated");
+    expect(state.allowedUsers).toEqual(new Set(["U_ALLOWED"]));
+    expect(state.guardrails).toEqual({ blockedTools: ["bash"] });
+    expect(state.reactionCommands.get("eyes")).toEqual({
+      action: "inspect",
+      prompt: "Inspect closely",
+    });
+    expect(state.securityPrompt).toContain("bash");
+    expect(state.agentName).toBe(expectedSkin.name);
+    expect(state.agentEmoji).toBe(expectedSkin.emoji);
+    expect(state.agentPersonality).toBe(expectedSkin.personality);
+  });
+
+  it("snapshots and restores reloadable runtime state with cloned collections and role-aware owner tokens", () => {
+    const { deps, state, agentAliases } = createDeps({
+      state: {
+        settings: { allowedUsers: ["U_SAVED"], logLevel: "verbose" },
+        botToken: "xoxb-saved",
+        appToken: "xapp-saved",
+        allowedUsers: new Set(["U_SAVED"]),
+        guardrails: { blockedTools: ["bash"] },
+        reactionCommands: new Map([["eyes", { action: "review", prompt: "Review this" }]]),
+        securityPrompt: "saved prompt",
+        agentName: "Saved Crane",
+        agentEmoji: "🦩",
+        brokerRole: "broker",
+        agentOwnerToken: "owner:stale",
+        activeSkinTheme: "midnight",
+        agentPersonality: "steady",
+      },
+      agentAliases: new Set(["Saved Alias", "Saved Crane"]),
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    const snapshot = runtimeAgentContext.snapshotReloadableRuntime();
+
+    state.settings = { allowedUsers: ["U_MUTATED"] };
+    state.botToken = "xoxb-mutated";
+    state.appToken = undefined;
+    state.allowedUsers = new Set(["U_MUTATED"]);
+    state.guardrails = { blockedTools: ["edit"] };
+    state.reactionCommands = new Map([["bug", { action: "file-issue", prompt: "Bug" }]]);
+    state.securityPrompt = "mutated prompt";
+    state.agentName = "Mutated Goose";
+    state.agentEmoji = "🪿";
+    state.activeSkinTheme = null;
+    state.agentPersonality = null;
+    agentAliases.clear();
+    agentAliases.add("Mutated Alias");
+
+    runtimeAgentContext.restoreReloadableRuntime(snapshot);
+
+    expect(state.settings).toEqual({ allowedUsers: ["U_SAVED"], logLevel: "verbose" });
+    expect(state.botToken).toBe("xoxb-saved");
+    expect(state.appToken).toBe("xapp-saved");
+    expect(state.allowedUsers).toEqual(new Set(["U_SAVED"]));
+    expect(state.allowedUsers).not.toBe(snapshot.allowedUsers);
+    expect(state.guardrails).toEqual({ blockedTools: ["bash"] });
+    expect(state.guardrails).not.toBe(snapshot.guardrails);
+    expect(state.reactionCommands).toEqual(
+      new Map([["eyes", { action: "review", prompt: "Review this" }]]),
+    );
+    expect(state.reactionCommands).not.toBe(snapshot.reactionCommands);
+    expect(state.securityPrompt).toBe("saved prompt");
+    expect(state.agentName).toBe("Saved Crane");
+    expect(state.agentEmoji).toBe("🦩");
+    expect(state.activeSkinTheme).toBe("midnight");
+    expect(state.agentPersonality).toBe("steady");
+    expect(state.agentOwnerToken).toBe(buildPinetOwnerToken(state.brokerStableId));
+    expect([...agentAliases]).toEqual(["Saved Alias"]);
+  });
+
+  it("detects project tools and includes repo, branch, and skin metadata in agent metadata", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-agent-context-repo-"));
+    const workerDir = path.join(repoRoot, "packages", "worker");
+    fs.mkdirSync(workerDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({ scripts: { lint: "eslint .", build: "tsc -b" } }),
+    );
+    fs.writeFileSync(
+      path.join(workerDir, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run", typecheck: "tsc --noEmit" } }),
+    );
+
+    const { deps } = createDeps({
+      cwd: workerDir,
+      state: {
+        activeSkinTheme: "midnight",
+        agentPersonality: "observant",
+      },
+      gitContext: {
+        cwd: workerDir,
+        repo: "extensions",
+        repoRoot,
+        branch: "feat/runtime-agent-context",
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    expect(runtimeAgentContext.detectProjectTools(repoRoot, workerDir)).toEqual([
+      "build",
+      "git",
+      "lint",
+      "test",
+      "typecheck",
+    ]);
+
+    const metadata = await runtimeAgentContext.getAgentMetadata("broker");
+
+    expect(metadata).toMatchObject({
+      cwd: workerDir,
+      repo: "extensions",
+      repoRoot,
+      branch: "feat/runtime-agent-context",
+      role: "broker",
+      skinTheme: "midnight",
+      personality: "observant",
+    });
+    expect(metadata.capabilities).toMatchObject({
+      role: "broker",
+      tools: ["build", "git", "lint", "test", "typecheck"],
+      tags: expect.arrayContaining([
+        "role:broker",
+        "repo:extensions",
+        "branch:feat/runtime-agent-context",
+        "tool:build",
+        "tool:git",
+        "tool:lint",
+        "tool:test",
+        "tool:typecheck",
+      ]),
+    });
+
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("applies registration identity and exposes metadata/id helper behavior", () => {
+    const { deps, state, agentAliases, persistState, updateBadge } = createDeps({
+      state: {
+        activeSkinTheme: "dawn",
+      },
+      agentAliases: new Set(["Current Alias"]),
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    expect(runtimeAgentContext.getStableIdForRole("worker")).toBe("agent-stable-current");
+    expect(runtimeAgentContext.getStableIdForRole("broker")).toBe("broker-stable-current");
+    expect(runtimeAgentContext.getIdentitySeedForRole("worker", "/tmp/explicit-session.json")).toBe(
+      "/tmp/explicit-session.json",
+    );
+    expect(runtimeAgentContext.getIdentitySeedForRole("broker")).toBe("broker-stable-current");
+    expect(runtimeAgentContext.getSkinSeed("  preferred-seed  ")).toBe("preferred-seed");
+    expect(runtimeAgentContext.asStringValue("  hello  ")).toBe("hello");
+    expect(runtimeAgentContext.asStringValue("   ")).toBeUndefined();
+    expect(runtimeAgentContext.getMeshRoleFromMetadata({ role: "broker" }, "worker")).toBe(
+      "broker",
+    );
+    expect(runtimeAgentContext.getMeshRoleFromMetadata(undefined, "worker")).toBe("worker");
+    expect(runtimeAgentContext.buildSkinMetadata({ role: "worker" }, "careful")).toEqual({
+      role: "worker",
+      skinTheme: "dawn",
+      personality: "careful",
+    });
+
+    runtimeAgentContext.applyRegistrationIdentity({
+      name: "Obsidian Coral Goose",
+      emoji: "🪿",
+      metadata: {
+        skinTheme: "  midnight  ",
+        personality: "  observant  ",
+      },
+    });
+
+    expect(state.activeSkinTheme).toBe("midnight");
+    expect(state.agentName).toBe("Obsidian Coral Goose");
+    expect(state.agentEmoji).toBe("🪿");
+    expect(state.agentPersonality).toBe("observant");
+    expect([...agentAliases]).toContain("Cobalt Olive Crane");
+    expect(persistState).toHaveBeenCalledTimes(1);
+    expect(updateBadge).toHaveBeenCalledTimes(1);
+
+    const guidelines = runtimeAgentContext.getIdentityGuidelines();
+    expect(guidelines).toHaveLength(3);
+    expect(guidelines.join("\n")).toContain("Obsidian Coral Goose");
+    expect(guidelines.join("\n")).toContain("🪿");
+  });
+});

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -1,0 +1,419 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { GitContext } from "./git-metadata.js";
+import {
+  buildAllowlist,
+  buildIdentityReplyGuidelines,
+  buildPinetOwnerToken,
+  buildPinetSkinAssignment,
+  getSlackUserAccessWarning,
+  isUserAllowed as checkUserAllowed,
+  loadSettings as loadSettingsFromFile,
+  normalizeOwnedThreads,
+  resolveRuntimeAgentIdentity,
+  shortenPath,
+  type SlackBridgeSettings,
+} from "./helpers.js";
+import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
+import { resolveReactionCommands } from "./reaction-triggers.js";
+import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
+
+export type RuntimeAgentRole = "broker" | "worker";
+export type ReactionCommandMap = Map<string, { action: string; prompt: string }>;
+
+export interface ReloadableRuntimeSnapshot {
+  settings: SlackBridgeSettings;
+  botToken: string | undefined;
+  appToken: string | undefined;
+  allowedUsers: Set<string> | null;
+  guardrails: SecurityGuardrails;
+  reactionCommands: ReactionCommandMap;
+  securityPrompt: string;
+  agentName: string;
+  agentEmoji: string;
+  activeSkinTheme: string | null;
+  agentPersonality: string | null;
+  agentAliases: string[];
+}
+
+export interface RuntimeAgentContextDeps {
+  cwd: string;
+  getSettings: () => SlackBridgeSettings;
+  setSettings: (settings: SlackBridgeSettings) => void;
+  getBotToken: () => string | undefined;
+  setBotToken: (token: string | undefined) => void;
+  getAppToken: () => string | undefined;
+  setAppToken: (token: string | undefined) => void;
+  getAllowedUsers: () => Set<string> | null;
+  setAllowedUsers: (users: Set<string> | null) => void;
+  getGuardrails: () => SecurityGuardrails;
+  setGuardrails: (guardrails: SecurityGuardrails) => void;
+  getReactionCommands: () => ReactionCommandMap;
+  setReactionCommands: (commands: ReactionCommandMap) => void;
+  getSecurityPrompt: () => string;
+  setSecurityPrompt: (prompt: string) => void;
+  getAgentName: () => string;
+  setAgentName: (name: string) => void;
+  getAgentEmoji: () => string;
+  setAgentEmoji: (emoji: string) => void;
+  getAgentStableId: () => string;
+  getBrokerStableId: () => string;
+  getBrokerRole: () => "broker" | "follower" | null;
+  getAgentOwnerToken: () => string;
+  setAgentOwnerToken: (ownerToken: string) => void;
+  getActiveSkinTheme: () => string | null;
+  setActiveSkinTheme: (theme: string | null) => void;
+  getAgentPersonality: () => string | null;
+  setAgentPersonality: (personality: string | null) => void;
+  getAgentAliases: () => Set<string>;
+  getThreads: () => Map<string, SinglePlayerThreadInfo>;
+  getExtensionContext: () => ExtensionContext | null;
+  persistState: () => void;
+  updateBadge: () => void;
+  getGitContext: () => Promise<GitContext>;
+}
+
+export interface RuntimeAgentContext {
+  isUserAllowed: (userId: string) => boolean;
+  maybeWarnSlackUserAccess: (ctx?: ExtensionContext) => void;
+  getStableIdForRole: (role: RuntimeAgentRole) => string;
+  getIdentitySeedForRole: (role: RuntimeAgentRole, sessionFile?: string) => string;
+  getSkinSeed: (preferredSeed?: string) => string;
+  rememberAgentAlias: (name: string | undefined) => void;
+  resolveSkinAssignment: (
+    role: RuntimeAgentRole,
+    seed?: string,
+  ) => { name: string; emoji: string; personality: string } | null;
+  applyLocalAgentIdentity: (
+    nextName: string,
+    nextEmoji: string,
+    nextPersonality: string | null,
+  ) => void;
+  refreshSettings: () => void;
+  snapshotReloadableRuntime: () => ReloadableRuntimeSnapshot;
+  restoreReloadableRuntime: (snapshot: ReloadableRuntimeSnapshot) => void;
+  detectProjectTools: (repoRoot: string, cwd: string) => string[];
+  getAgentMetadata: (role?: RuntimeAgentRole) => Promise<Record<string, unknown>>;
+  asStringValue: (value: unknown) => string | undefined;
+  getMeshRoleFromMetadata: (
+    metadata: Record<string, unknown> | undefined,
+    fallback?: RuntimeAgentRole,
+  ) => RuntimeAgentRole;
+  buildSkinMetadata: (
+    metadata: Record<string, unknown> | undefined,
+    personality: string,
+  ) => Record<string, unknown>;
+  getIdentityGuidelines: () => [string, string, string];
+  applyRegistrationIdentity: (registration: {
+    name: string;
+    emoji: string;
+    metadata?: Record<string, unknown> | null;
+  }) => void;
+}
+
+export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): RuntimeAgentContext {
+  let lastSlackUserAccessWarning = "";
+  const selfLocation = `${shortenPath(deps.cwd, os.homedir())}@${os.hostname()}`;
+
+  function isUserAllowed(userId: string): boolean {
+    return checkUserAllowed(deps.getAllowedUsers(), userId);
+  }
+
+  function maybeWarnSlackUserAccess(ctx?: ExtensionContext): void {
+    const warning = getSlackUserAccessWarning(deps.getAllowedUsers());
+    if (!warning) {
+      lastSlackUserAccessWarning = "";
+      return;
+    }
+    if (warning === lastSlackUserAccessWarning) {
+      return;
+    }
+    lastSlackUserAccessWarning = warning;
+    console.warn(`[slack-bridge] ${warning}`);
+    ctx?.ui.notify(warning, "warning");
+  }
+
+  function getStableIdForRole(role: RuntimeAgentRole): string {
+    return role === "broker" ? deps.getBrokerStableId() : deps.getAgentStableId();
+  }
+
+  function getIdentitySeedForRole(
+    role: RuntimeAgentRole,
+    sessionFile = deps.getExtensionContext()?.sessionManager.getSessionFile() ?? undefined,
+  ): string {
+    return role === "broker" ? deps.getBrokerStableId() : (sessionFile ?? deps.getAgentStableId());
+  }
+
+  function getSkinSeed(preferredSeed?: string): string {
+    return (
+      preferredSeed?.trim() ||
+      getStableIdForRole(deps.getBrokerRole() === "broker" ? "broker" : "worker")
+    );
+  }
+
+  function rememberAgentAlias(name: string | undefined): void {
+    const trimmed = name?.trim();
+    if (!trimmed || trimmed === deps.getAgentName()) {
+      return;
+    }
+
+    const agentAliases = deps.getAgentAliases();
+    agentAliases.add(trimmed);
+    while (agentAliases.size > 24) {
+      const oldest = agentAliases.values().next().value;
+      if (!oldest) {
+        break;
+      }
+      agentAliases.delete(oldest);
+    }
+  }
+
+  function resolveSkinAssignment(
+    role: RuntimeAgentRole,
+    seed = getSkinSeed(),
+  ): { name: string; emoji: string; personality: string } | null {
+    const activeSkinTheme = deps.getActiveSkinTheme();
+    if (!activeSkinTheme) {
+      return null;
+    }
+
+    const assignment = buildPinetSkinAssignment({ theme: activeSkinTheme, role, seed });
+    return {
+      name: assignment.name,
+      emoji: assignment.emoji,
+      personality: assignment.personality,
+    };
+  }
+
+  function applyLocalAgentIdentity(
+    nextName: string,
+    nextEmoji: string,
+    nextPersonality: string | null,
+  ): void {
+    const previousName = deps.getAgentName();
+    if (
+      previousName === nextName &&
+      deps.getAgentEmoji() === nextEmoji &&
+      (deps.getAgentPersonality() ?? null) === (nextPersonality ?? null)
+    ) {
+      return;
+    }
+
+    deps.setAgentName(nextName);
+    deps.setAgentEmoji(nextEmoji);
+    deps.setAgentPersonality(nextPersonality ?? null);
+    rememberAgentAlias(previousName);
+    normalizeOwnedThreads(
+      deps.getThreads().values(),
+      deps.getAgentName(),
+      deps.getAgentOwnerToken(),
+      deps.getAgentAliases(),
+    );
+    deps.persistState();
+    deps.updateBadge();
+  }
+
+  function refreshSettings(): void {
+    const settings = loadSettingsFromFile();
+    deps.setSettings(settings);
+    deps.setBotToken(settings.botToken ?? process.env.SLACK_BOT_TOKEN);
+    deps.setAppToken(settings.appToken ?? process.env.SLACK_APP_TOKEN);
+    deps.setAllowedUsers(
+      buildAllowlist(
+        settings,
+        process.env.SLACK_ALLOWED_USERS,
+        process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+      ),
+    );
+    const guardrails = settings.security ?? {};
+    deps.setGuardrails(guardrails);
+    deps.setReactionCommands(resolveReactionCommands(settings.reactionCommands));
+    deps.setSecurityPrompt(buildSecurityPrompt(guardrails));
+
+    const role = deps.getBrokerRole() === "broker" ? "broker" : "worker";
+    const identitySeed = getIdentitySeedForRole(role);
+    const skinIdentity = resolveSkinAssignment(role, identitySeed);
+    if (skinIdentity) {
+      deps.setAgentName(skinIdentity.name);
+      deps.setAgentEmoji(skinIdentity.emoji);
+      deps.setAgentPersonality(skinIdentity.personality);
+      return;
+    }
+
+    const refreshedIdentity = resolveRuntimeAgentIdentity(
+      { name: deps.getAgentName(), emoji: deps.getAgentEmoji() },
+      settings,
+      process.env.PI_NICKNAME,
+      identitySeed,
+      role,
+    );
+    deps.setAgentName(refreshedIdentity.name);
+    deps.setAgentEmoji(refreshedIdentity.emoji);
+    deps.setAgentPersonality(null);
+  }
+
+  function snapshotReloadableRuntime(): ReloadableRuntimeSnapshot {
+    return {
+      settings: structuredClone(deps.getSettings()),
+      botToken: deps.getBotToken(),
+      appToken: deps.getAppToken(),
+      allowedUsers: deps.getAllowedUsers() ? new Set(deps.getAllowedUsers()) : null,
+      guardrails: structuredClone(deps.getGuardrails()),
+      reactionCommands: new Map(deps.getReactionCommands()),
+      securityPrompt: deps.getSecurityPrompt(),
+      agentName: deps.getAgentName(),
+      agentEmoji: deps.getAgentEmoji(),
+      activeSkinTheme: deps.getActiveSkinTheme(),
+      agentPersonality: deps.getAgentPersonality(),
+      agentAliases: [...deps.getAgentAliases()],
+    };
+  }
+
+  function restoreReloadableRuntime(snapshot: ReloadableRuntimeSnapshot): void {
+    deps.setSettings(structuredClone(snapshot.settings));
+    deps.setBotToken(snapshot.botToken);
+    deps.setAppToken(snapshot.appToken);
+    deps.setAllowedUsers(snapshot.allowedUsers ? new Set(snapshot.allowedUsers) : null);
+    deps.setGuardrails(structuredClone(snapshot.guardrails));
+    deps.setReactionCommands(new Map(snapshot.reactionCommands));
+    deps.setSecurityPrompt(snapshot.securityPrompt);
+    deps.setAgentName(snapshot.agentName);
+    deps.setAgentEmoji(snapshot.agentEmoji);
+    deps.setActiveSkinTheme(snapshot.activeSkinTheme);
+    deps.setAgentPersonality(snapshot.agentPersonality);
+    deps.setAgentOwnerToken(
+      buildPinetOwnerToken(
+        getStableIdForRole(deps.getBrokerRole() === "broker" ? "broker" : "worker"),
+      ),
+    );
+
+    const agentAliases = deps.getAgentAliases();
+    agentAliases.clear();
+    for (const alias of snapshot.agentAliases) {
+      if (alias && alias !== deps.getAgentName()) {
+        agentAliases.add(alias);
+      }
+    }
+  }
+
+  function detectProjectTools(repoRoot: string, cwd: string): string[] {
+    const tools = new Set<string>();
+
+    for (const candidate of [path.join(cwd, "package.json"), path.join(repoRoot, "package.json")]) {
+      try {
+        if (!fs.existsSync(candidate)) {
+          continue;
+        }
+        const parsed = JSON.parse(fs.readFileSync(candidate, "utf-8")) as {
+          scripts?: Record<string, string>;
+        };
+        const scripts = parsed.scripts ?? {};
+        if (scripts.test) tools.add("test");
+        if (scripts.lint) tools.add("lint");
+        if (scripts.typecheck) tools.add("typecheck");
+        if (scripts.build) tools.add("build");
+      } catch {
+        // Ignore unreadable package.json files.
+      }
+    }
+
+    tools.add("git");
+    return [...tools].sort();
+  }
+
+  async function getAgentMetadata(
+    role: RuntimeAgentRole = "worker",
+  ): Promise<Record<string, unknown>> {
+    const gitContext = await deps.getGitContext();
+    const { cwd, repo, repoRoot, branch } = gitContext;
+    const resolvedRepoRoot = repoRoot ?? cwd;
+    const tools = detectProjectTools(resolvedRepoRoot, cwd);
+    const tags = [
+      `role:${role}`,
+      `repo:${repo}`,
+      ...(branch ? [`branch:${branch}`] : []),
+      ...tools.map((tool) => `tool:${tool}`),
+    ];
+
+    return {
+      cwd,
+      branch,
+      host: os.hostname(),
+      role,
+      repo,
+      repoRoot,
+      ...(deps.getActiveSkinTheme() ? { skinTheme: deps.getActiveSkinTheme() } : {}),
+      ...(deps.getAgentPersonality() ? { personality: deps.getAgentPersonality() } : {}),
+      capabilities: {
+        repo,
+        repoRoot,
+        branch,
+        role,
+        tools,
+        tags,
+      },
+    };
+  }
+
+  function asStringValue(value: unknown): string | undefined {
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+  }
+
+  function getMeshRoleFromMetadata(
+    metadata: Record<string, unknown> | undefined,
+    fallback: RuntimeAgentRole = "worker",
+  ): RuntimeAgentRole {
+    return asStringValue(metadata?.role) === "broker" ? "broker" : fallback;
+  }
+
+  function buildSkinMetadata(
+    metadata: Record<string, unknown> | undefined,
+    personality: string,
+  ): Record<string, unknown> {
+    return {
+      ...(metadata ?? {}),
+      ...(deps.getActiveSkinTheme() ? { skinTheme: deps.getActiveSkinTheme() } : {}),
+      personality,
+    };
+  }
+
+  function getIdentityGuidelines(): [string, string, string] {
+    return buildIdentityReplyGuidelines(deps.getAgentEmoji(), deps.getAgentName(), selfLocation);
+  }
+
+  function applyRegistrationIdentity(registration: {
+    name: string;
+    emoji: string;
+    metadata?: Record<string, unknown> | null;
+  }): void {
+    deps.setActiveSkinTheme(asStringValue(registration.metadata?.skinTheme) ?? null);
+    applyLocalAgentIdentity(
+      registration.name,
+      registration.emoji,
+      asStringValue(registration.metadata?.personality) ?? null,
+    );
+  }
+
+  return {
+    isUserAllowed,
+    maybeWarnSlackUserAccess,
+    getStableIdForRole,
+    getIdentitySeedForRole,
+    getSkinSeed,
+    rememberAgentAlias,
+    resolveSkinAssignment,
+    applyLocalAgentIdentity,
+    refreshSettings,
+    snapshotReloadableRuntime,
+    restoreReloadableRuntime,
+    detectProjectTools,
+    getAgentMetadata,
+    asStringValue,
+    getMeshRoleFromMetadata,
+    buildSkinMetadata,
+    getIdentityGuidelines,
+    applyRegistrationIdentity,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the reloadable agent/runtime context seam from `slack-bridge/index.ts` into `slack-bridge/runtime-agent-context.ts`
- keep settings/allowlist/identity/skin/metadata/reload snapshot behavior wired back through the new helper without changing runtime ownership or delivery flow
- add focused coverage for warnings, identity updates, settings refresh, snapshot/restore, metadata shaping, and registration identity handling

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- runtime-agent-context.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test