### PR TITLE
refactor: extract agent prompt guidance (#438)

### DIFF
--- a/slack-bridge/agent-prompt-guidance.test.ts
+++ b/slack-bridge/agent-prompt-guidance.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAgentPromptGuidance,
+  type AgentPromptGuidanceDeps,
+} from "./agent-prompt-guidance.js";
+
+function createDeps(overrides: Partial<AgentPromptGuidanceDeps> = {}): AgentPromptGuidanceDeps {
+  return {
+    getIdentityGuidelines: () => ["IDENTITY 1", "IDENTITY 2", "IDENTITY 3"],
+    getAgentName: () => "Cobalt Olive Crane",
+    getAgentEmoji: () => "🦩",
+    getActiveSkinTheme: () => null,
+    getAgentPersonality: () => null,
+    getBrokerRole: () => null,
+    ...overrides,
+  };
+}
+
+describe("createAgentPromptGuidance", () => {
+  it("appends identity, personality, and reaction guidance for non-mesh sessions", async () => {
+    const getIdentityGuidelines = vi.fn(() => ["IDENTITY 1", "IDENTITY 2", "IDENTITY 3"]);
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getIdentityGuidelines,
+      }),
+    );
+
+    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+
+    expect(getIdentityGuidelines).toHaveBeenCalledTimes(1);
+    expect(result.systemPrompt).toContain("BASE\n\nIDENTITY 1\nIDENTITY 2\nIDENTITY 3");
+    expect(result.systemPrompt).toContain("COMMUNICATION STYLE:");
+    expect(result.systemPrompt).toContain("For `Cobalt Olive Crane`, aim for a");
+    expect(result.systemPrompt).toContain("Reaction-triggered requests may appear");
+    expect(result.systemPrompt).not.toContain("PINET SKIN (");
+    expect(result.systemPrompt).not.toContain("Pinet BROKER");
+    expect(result.systemPrompt).not.toContain("TASK WORKFLOW:");
+    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
+      result.systemPrompt.indexOf("COMMUNICATION STYLE:"),
+    );
+    expect(result.systemPrompt.indexOf("COMMUNICATION STYLE:")).toBeLessThan(
+      result.systemPrompt.indexOf("Reaction-triggered requests may appear"),
+    );
+  });
+
+  it("includes the skin guideline only when both theme and personality are available", async () => {
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getActiveSkinTheme: () => "ocean-mist",
+        getAgentPersonality: () => "steady, elegant, observant",
+      }),
+    );
+
+    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+
+    expect(result.systemPrompt).toContain("PINET SKIN (");
+    expect(result.systemPrompt).toContain("steady, elegant, observant");
+  });
+
+  it("adds broker-specific prompt guidance and tool guardrails for the broker role", async () => {
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getBrokerRole: () => "broker",
+      }),
+    );
+
+    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+
+    expect(result.systemPrompt).toContain("You are 🦩 Cobalt Olive Crane, the Pinet BROKER.");
+    expect(result.systemPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(result.systemPrompt).not.toContain("TASK WORKFLOW:");
+  });
+
+  it("adds worker workflow guidance for follower runtimes", async () => {
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getBrokerRole: () => "follower",
+      }),
+    );
+
+    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+
+    expect(result.systemPrompt).toContain(
+      "TASK WORKFLOW: When you receive work, follow these steps:",
+    );
+    expect(result.systemPrompt).toContain("REPLY TOOL RULES:");
+    expect(result.systemPrompt).not.toContain("Pinet BROKER");
+    expect(result.systemPrompt).not.toContain("🚫 BROKER TOOL RESTRICTION:");
+  });
+});

--- a/slack-bridge/agent-prompt-guidance.ts
+++ b/slack-bridge/agent-prompt-guidance.ts
@@ -1,0 +1,63 @@
+import {
+  buildAgentPersonalityGuidelines,
+  buildBrokerPromptGuidelines,
+  buildPinetSkinPromptGuideline,
+  buildWorkerPromptGuidelines,
+} from "./helpers.js";
+import { buildBrokerToolGuardrailsPrompt } from "./guardrails.js";
+import { buildReactionPromptGuidelines } from "./reaction-triggers.js";
+
+export interface BeforeAgentStartEvent {
+  systemPrompt: string;
+}
+
+export interface AgentPromptGuidanceDeps {
+  getIdentityGuidelines: () => string[];
+  getAgentName: () => string;
+  getAgentEmoji: () => string;
+  getActiveSkinTheme: () => string | null;
+  getAgentPersonality: () => string | null;
+  getBrokerRole: () => "broker" | "follower" | null;
+}
+
+export interface AgentPromptGuidance {
+  beforeAgentStart: (event: BeforeAgentStartEvent) => Promise<{ systemPrompt: string }>;
+}
+
+export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentPromptGuidance {
+  function buildPromptGuidelines(): string[] {
+    const agentName = deps.getAgentName();
+    const guidelines = [
+      ...deps.getIdentityGuidelines(),
+      ...buildAgentPersonalityGuidelines(agentName),
+      ...buildReactionPromptGuidelines(),
+    ];
+
+    const skinGuideline = buildPinetSkinPromptGuideline(
+      deps.getActiveSkinTheme(),
+      deps.getAgentPersonality(),
+    );
+    if (skinGuideline) {
+      guidelines.push(skinGuideline);
+    }
+
+    if (deps.getBrokerRole() === "broker") {
+      guidelines.push(...buildBrokerPromptGuidelines(deps.getAgentEmoji(), agentName));
+      guidelines.push(buildBrokerToolGuardrailsPrompt());
+    } else if (deps.getBrokerRole() === "follower") {
+      guidelines.push(...buildWorkerPromptGuidelines());
+    }
+
+    return guidelines;
+  }
+
+  async function beforeAgentStart(event: BeforeAgentStartEvent): Promise<{ systemPrompt: string }> {
+    return {
+      systemPrompt: event.systemPrompt + "\n\n" + buildPromptGuidelines().join("\n"),
+    };
+  }
+
+  return {
+    beforeAgentStart,
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -7,16 +7,12 @@ import {
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
   formatInboxMessages,
-  buildPinetSkinPromptGuideline,
   reloadPinetRuntimeSafely,
   callSlackAPI,
   createAbortableOperationTracker,
   buildPinetOwnerToken,
   resolveAgentIdentity,
   resolveBrokerStableId,
-  buildAgentPersonalityGuidelines,
-  buildBrokerPromptGuidelines,
-  buildWorkerPromptGuidelines,
   resolveAgentStableId,
   isLikelyLocalSubagentContext,
   resolveAllowAllWorkspaceUsers,
@@ -25,7 +21,6 @@ import {
 import {
   buildSecurityPrompt,
   isBrokerForbiddenTool,
-  buildBrokerToolGuardrailsPrompt,
   type SecurityGuardrails,
 } from "./guardrails.js";
 import { evaluateSlackOriginCoreToolPolicy } from "./core-tool-guardrails.js";
@@ -35,7 +30,7 @@ import {
   type PendingSlackToolPolicyTurn,
 } from "./slack-turn-guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
-import { buildReactionPromptGuidelines, resolveReactionCommands } from "./reaction-triggers.js";
+import { resolveReactionCommands } from "./reaction-triggers.js";
 import type { Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
@@ -86,6 +81,7 @@ import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js"
 import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
 import { createPinetRemoteControl } from "./pinet-remote-control.js";
 import { createPinetMeshOps } from "./pinet-mesh-ops.js";
+import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -336,9 +332,16 @@ export default function (pi: ExtensionAPI) {
     getAgentMetadata,
     getMeshRoleFromMetadata,
     buildSkinMetadata,
-    getIdentityGuidelines,
     applyRegistrationIdentity,
   } = runtimeAgentContext;
+  const agentPromptGuidance = createAgentPromptGuidance({
+    getIdentityGuidelines: runtimeAgentContext.getIdentityGuidelines,
+    getAgentName: () => agentName,
+    getAgentEmoji: () => agentEmoji,
+    getActiveSkinTheme: () => activeSkinTheme,
+    getAgentPersonality: () => agentPersonality,
+    getBrokerRole: () => brokerRole,
+  });
 
   let isSinglePlayerShuttingDown = () => false;
   let isSinglePlayerConnected = () => false;
@@ -1441,26 +1444,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   // Inject dynamic identity guidance every turn so reload/session restore keeps prompts in sync.
-  pi.on("before_agent_start", async (event) => {
-    const guidelines = [
-      ...getIdentityGuidelines(),
-      ...buildAgentPersonalityGuidelines(agentName),
-      ...buildReactionPromptGuidelines(),
-    ];
-    const skinGuideline = buildPinetSkinPromptGuideline(activeSkinTheme, agentPersonality);
-    if (skinGuideline) {
-      guidelines.push(skinGuideline);
-    }
-    if (brokerRole === "broker") {
-      guidelines.push(...buildBrokerPromptGuidelines(agentEmoji, agentName));
-      guidelines.push(buildBrokerToolGuardrailsPrompt());
-    } else if (brokerRole === "follower") {
-      guidelines.push(...buildWorkerPromptGuidelines());
-    }
-    return {
-      systemPrompt: event.systemPrompt + "\n\n" + guidelines.join("\n"),
-    };
-  });
+  pi.on("before_agent_start", agentPromptGuidance.beforeAgentStart);
 
   // When agent finishes: clear thinking status, mark free, and auto-drain inbox
   pi.on("agent_end", async (_event, ctx) => {


### PR DESCRIPTION
## Summary
- extract the dynamic `before_agent_start` prompt-guidance assembly into `slack-bridge/agent-prompt-guidance.ts`
- keep prompt-builder helpers in place while consuming the existing runtime-agent-context identity port from `index.ts`
- add focused coverage for base, skin, broker, and follower prompt guidance cases

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- agent-prompt-guidance.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test