### PR TITLE
refactor: extract Slack tool-policy runtime (#440)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -18,17 +18,7 @@ import {
   resolveAllowAllWorkspaceUsers,
   trackBrokerInboundThread,
 } from "./helpers.js";
-import {
-  buildSecurityPrompt,
-  isBrokerForbiddenTool,
-  type SecurityGuardrails,
-} from "./guardrails.js";
-import { evaluateSlackOriginCoreToolPolicy } from "./core-tool-guardrails.js";
-import {
-  consumePendingSlackToolPolicyTurn,
-  deliverTrackedSlackFollowUpMessage,
-  type PendingSlackToolPolicyTurn,
-} from "./slack-turn-guardrails.js";
+import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
 import type { Broker } from "./broker/index.js";
@@ -82,6 +72,7 @@ import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
 import { createPinetRemoteControl } from "./pinet-remote-control.js";
 import { createPinetMeshOps } from "./pinet-mesh-ops.js";
 import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
+import { createSlackToolPolicyRuntime } from "./slack-tool-policy-runtime.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -211,9 +202,6 @@ export default function (pi: ExtensionAPI) {
   let suppressAutoDrainUntil = 0;
   let terminalInputUnsubscribe: (() => void) | null = null;
   let extCtx: ExtensionContext | null = null; // cached for badge updates
-  const pendingSlackToolPolicyTurns: PendingSlackToolPolicyTurn[] = [];
-  let nextSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
-  let activeSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
 
   function updateBadge(): void {
     if (!extCtx?.hasUI) return;
@@ -1348,6 +1336,15 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  const slackToolPolicyRuntime = createSlackToolPolicyRuntime({
+    getBrokerRole: () => brokerRole,
+    getGuardrails: () => guardrails,
+    requireToolPolicy,
+    formatAction: formatConfirmationAction,
+    formatError: msg,
+    deliverFollowUpMessage,
+  });
+
   async function flushDeliveredFollowerAcks(): Promise<void> {
     if (brokerRole !== "follower" || !brokerClient?.client) return;
     await followerRuntime.flushDeliveredAcks();
@@ -1372,11 +1369,9 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (
-      deliverTrackedSlackFollowUpMessage({
-        queue: pendingSlackToolPolicyTurns,
+      slackToolPolicyRuntime.deliverTrackedSlackFollowUpMessage({
         prompt,
         messages: pending,
-        deliver: deliverFollowUpMessage,
       })
     ) {
       if (brokerInboxIds.length > 0) {
@@ -1398,50 +1393,17 @@ export default function (pi: ExtensionAPI) {
     updateBadge();
   }
 
-  pi.on("input", async (event) => {
-    if (event.source !== "extension") {
-      return;
-    }
+  pi.on("input", slackToolPolicyRuntime.onInput);
 
-    nextSlackToolPolicyTurn = consumePendingSlackToolPolicyTurn(
-      pendingSlackToolPolicyTurns,
-      event.text,
-    );
-  });
+  pi.on("turn_start", slackToolPolicyRuntime.onTurnStart);
 
-  pi.on("turn_start", async () => {
-    activeSlackToolPolicyTurn = nextSlackToolPolicyTurn;
-    nextSlackToolPolicyTurn = null;
-  });
+  pi.on("turn_end", slackToolPolicyRuntime.onTurnEnd);
 
-  pi.on("turn_end", async () => {
-    activeSlackToolPolicyTurn = null;
-  });
-
-  pi.on("agent_end", async () => {
-    activeSlackToolPolicyTurn = null;
-  });
+  pi.on("agent_end", slackToolPolicyRuntime.onAgentEnd);
 
   // Hard-block forbidden tools when broker role is active.
   // Also hard-enforce Slack-origin guardrails for core built-in tools.
-  pi.on("tool_call", async (event) => {
-    if (brokerRole === "broker" && isBrokerForbiddenTool(event.toolName)) {
-      return {
-        block: true,
-        reason: `Tool "${event.toolName}" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.`,
-      };
-    }
-
-    return evaluateSlackOriginCoreToolPolicy({
-      turn: activeSlackToolPolicyTurn,
-      toolName: event.toolName,
-      input: event.input,
-      guardrails,
-      requireToolPolicy,
-      formatAction: formatConfirmationAction,
-      formatError: msg,
-    });
-  });
+  pi.on("tool_call", slackToolPolicyRuntime.onToolCall);
 
   // Inject dynamic identity guidance every turn so reload/session restore keeps prompts in sync.
   pi.on("before_agent_start", agentPromptGuidance.beforeAgentStart);

--- a/slack-bridge/slack-tool-policy-runtime.test.ts
+++ b/slack-bridge/slack-tool-policy-runtime.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSlackToolPolicyRuntime,
+  type SlackToolPolicyRuntimeDeps,
+} from "./slack-tool-policy-runtime.js";
+
+function createDeps(overrides: Partial<SlackToolPolicyRuntimeDeps> = {}) {
+  const deliverFollowUpMessage = vi.fn(() => true);
+  const requireToolPolicy = vi.fn();
+
+  const deps: SlackToolPolicyRuntimeDeps = {
+    getBrokerRole: () => null,
+    getGuardrails: () => ({}),
+    requireToolPolicy,
+    formatAction: (action) => `<${action}>`,
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    deliverFollowUpMessage,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    deliverFollowUpMessage,
+    requireToolPolicy,
+  };
+}
+
+describe("createSlackToolPolicyRuntime", () => {
+  it("tracks a delivered Slack follow-up turn across input and turn lifecycle", async () => {
+    const { deps, deliverFollowUpMessage, requireToolPolicy } = createDeps({
+      getGuardrails: () => ({ requireConfirmation: ["read"] }),
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    expect(
+      runtime.deliverTrackedSlackFollowUpMessage({
+        prompt: "guarded slack prompt",
+        messages: [{ threadTs: "100.1" }],
+      }),
+    ).toBe(true);
+    expect(deliverFollowUpMessage).toHaveBeenCalledWith("guarded slack prompt");
+
+    await runtime.onInput({ source: "extension", text: "guarded slack prompt" });
+    await runtime.onTurnStart();
+
+    await expect(
+      runtime.onToolCall({
+        toolName: "read",
+        input: { path: "plans/440.md" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "read",
+      "100.1",
+      "path=plans/440.md | offset= | limit=",
+    );
+
+    await runtime.onTurnEnd();
+    await expect(
+      runtime.onToolCall({
+        toolName: "read",
+        input: { path: "plans/440.md" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(requireToolPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-extension input and rolls back undelivered turns", async () => {
+    const { deps, requireToolPolicy } = createDeps({
+      getGuardrails: () => ({ requireConfirmation: ["read"] }),
+      deliverFollowUpMessage: vi.fn(() => false),
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    expect(
+      runtime.deliverTrackedSlackFollowUpMessage({
+        prompt: "guarded slack prompt",
+        messages: [{ threadTs: "100.1" }],
+      }),
+    ).toBe(false);
+
+    await runtime.onInput({ source: "user", text: "guarded slack prompt" });
+    await runtime.onInput({ source: "extension", text: "guarded slack prompt" });
+    await runtime.onTurnStart();
+
+    await expect(
+      runtime.onToolCall({
+        toolName: "read",
+        input: { path: "plans/440.md" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(requireToolPolicy).not.toHaveBeenCalled();
+  });
+
+  it("blocks guarded core tools for batched multi-thread Slack turns without a confirmation thread", async () => {
+    const { deps, requireToolPolicy } = createDeps({
+      getGuardrails: () => ({ requireConfirmation: ["read"] }),
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    runtime.deliverTrackedSlackFollowUpMessage({
+      prompt: "batched prompt",
+      messages: [{ threadTs: "100.1" }, { threadTs: "200.2" }, { threadTs: "100.1" }],
+    });
+    await runtime.onInput({ source: "extension", text: "batched prompt" });
+    await runtime.onTurnStart();
+
+    await expect(
+      runtime.onToolCall({
+        toolName: "read",
+        input: { path: "plans/440.md" },
+      }),
+    ).resolves.toEqual({
+      block: true,
+      reason:
+        'Tool "read" requires Slack confirmation for action <path=plans/440.md | offset= | limit=>, but this Slack-triggered turn currently batches 2 threads. Process one Slack thread at a time before using that tool.',
+    });
+    expect(requireToolPolicy).not.toHaveBeenCalled();
+  });
+
+  it("clears the active Slack tool-policy turn on agent_end", async () => {
+    const { deps, requireToolPolicy } = createDeps({
+      getGuardrails: () => ({ requireConfirmation: ["read"] }),
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    runtime.deliverTrackedSlackFollowUpMessage({
+      prompt: "guarded slack prompt",
+      messages: [{ threadTs: "100.1" }],
+    });
+    await runtime.onInput({ source: "extension", text: "guarded slack prompt" });
+    await runtime.onTurnStart();
+    await runtime.onAgentEnd();
+
+    await expect(
+      runtime.onToolCall({
+        toolName: "read",
+        input: { path: "plans/440.md" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(requireToolPolicy).not.toHaveBeenCalled();
+  });
+
+  it("hard-blocks forbidden broker tools before Slack-origin policy checks", async () => {
+    const { deps, requireToolPolicy } = createDeps({
+      getBrokerRole: () => "broker",
+      getGuardrails: () => ({ requireConfirmation: ["edit"] }),
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    await expect(
+      runtime.onToolCall({
+        toolName: "edit",
+        input: { path: "slack-bridge/index.ts", edits: [] },
+      }),
+    ).resolves.toEqual({
+      block: true,
+      reason:
+        'Tool "edit" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.',
+    });
+    expect(requireToolPolicy).not.toHaveBeenCalled();
+  });
+});

--- a/slack-bridge/slack-tool-policy-runtime.ts
+++ b/slack-bridge/slack-tool-policy-runtime.ts
@@ -1,0 +1,107 @@
+import type { InboxMessage } from "./helpers.js";
+import { evaluateSlackOriginCoreToolPolicy } from "./core-tool-guardrails.js";
+import { isBrokerForbiddenTool, type SecurityGuardrails } from "./guardrails.js";
+import {
+  consumePendingSlackToolPolicyTurn,
+  deliverTrackedSlackFollowUpMessage as trackAndDeliverSlackFollowUpMessage,
+  type PendingSlackToolPolicyTurn,
+} from "./slack-turn-guardrails.js";
+
+export interface SlackToolPolicyRuntimeDeps {
+  getBrokerRole: () => "broker" | "follower" | null;
+  getGuardrails: () => SecurityGuardrails;
+  requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
+  formatAction: (action: string) => string;
+  formatError: (error: unknown) => string;
+  deliverFollowUpMessage: (prompt: string) => boolean;
+}
+
+export interface SlackToolPolicyRuntime {
+  deliverTrackedSlackFollowUpMessage: (options: {
+    prompt: string;
+    messages: Pick<InboxMessage, "threadTs">[];
+  }) => boolean;
+  onInput: (event: { source?: string; text: string }) => Promise<void>;
+  onTurnStart: () => Promise<void>;
+  onTurnEnd: () => Promise<void>;
+  onAgentEnd: () => Promise<void>;
+  onToolCall: (event: {
+    toolName: string;
+    input: Record<string, unknown>;
+  }) => Promise<{ block: true; reason: string } | undefined>;
+}
+
+export function createSlackToolPolicyRuntime(
+  deps: SlackToolPolicyRuntimeDeps,
+): SlackToolPolicyRuntime {
+  const pendingSlackToolPolicyTurns: PendingSlackToolPolicyTurn[] = [];
+  let nextSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
+  let activeSlackToolPolicyTurn: PendingSlackToolPolicyTurn | null = null;
+
+  function deliverTrackedSlackFollowUpMessage(options: {
+    prompt: string;
+    messages: Pick<InboxMessage, "threadTs">[];
+  }): boolean {
+    return trackAndDeliverSlackFollowUpMessage({
+      queue: pendingSlackToolPolicyTurns,
+      prompt: options.prompt,
+      messages: options.messages,
+      deliver: deps.deliverFollowUpMessage,
+    });
+  }
+
+  async function onInput(event: { source?: string; text: string }): Promise<void> {
+    if (event.source !== "extension") {
+      return;
+    }
+
+    nextSlackToolPolicyTurn = consumePendingSlackToolPolicyTurn(
+      pendingSlackToolPolicyTurns,
+      event.text,
+    );
+  }
+
+  async function onTurnStart(): Promise<void> {
+    activeSlackToolPolicyTurn = nextSlackToolPolicyTurn;
+    nextSlackToolPolicyTurn = null;
+  }
+
+  async function onTurnEnd(): Promise<void> {
+    activeSlackToolPolicyTurn = null;
+  }
+
+  async function onAgentEnd(): Promise<void> {
+    activeSlackToolPolicyTurn = null;
+  }
+
+  async function onToolCall(event: {
+    toolName: string;
+    input: Record<string, unknown>;
+  }): Promise<{ block: true; reason: string } | undefined> {
+    if (deps.getBrokerRole() === "broker" && isBrokerForbiddenTool(event.toolName)) {
+      return {
+        block: true,
+        reason: `Tool "${event.toolName}" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.`,
+      };
+    }
+
+    return evaluateSlackOriginCoreToolPolicy({
+      turn: activeSlackToolPolicyTurn,
+      toolName: event.toolName,
+      input: event.input,
+      guardrails: deps.getGuardrails(),
+      requireToolPolicy: deps.requireToolPolicy,
+      formatAction: deps.formatAction,
+      formatError: deps.formatError,
+    });
+  }
+
+  return {
+    deliverTrackedSlackFollowUpMessage,
+    onInput,
+    onTurnStart,
+    onTurnEnd,
+    onAgentEnd,
+    onToolCall,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the Slack-origin tool-policy turn runtime into `slack-bridge/slack-tool-policy-runtime.ts`
- keep queue state, tracked follow-up delivery, turn lifecycle handoff, and guarded tool enforcement behind the new runtime seam
- add focused coverage for tracked delivery, rollback, batched-thread blocking, agent-end clearing, and broker forbidden-tool blocking

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- slack-tool-policy-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test