### PR TITLE
refactor: extract session UI runtime (#442)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -73,6 +73,7 @@ import { createPinetRemoteControl } from "./pinet-remote-control.js";
 import { createPinetMeshOps } from "./pinet-mesh-ops.js";
 import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
 import { createSlackToolPolicyRuntime } from "./slack-tool-policy-runtime.js";
+import { createSessionUiRuntime } from "./session-ui-runtime.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -198,54 +199,13 @@ export default function (pi: ExtensionAPI) {
 
   const inbox: InboxMessage[] = [];
   const brokerDeliveryState = createBrokerDeliveryState();
-  const AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS = 1_500;
-  let suppressAutoDrainUntil = 0;
-  let terminalInputUnsubscribe: (() => void) | null = null;
-  let extCtx: ExtensionContext | null = null; // cached for badge updates
-
-  function updateBadge(): void {
-    if (!extCtx?.hasUI) return;
-    const t = extCtx.ui.theme;
-    const n = inbox.length;
-    const label =
-      n > 0
-        ? t.fg("accent", `${agentEmoji} ${agentName} ✦ ${n}`)
-        : t.fg("accent", `${agentEmoji} ${agentName} ✦`);
-    extCtx.ui.setStatus("slack-bridge", label);
-  }
-
-  function notePotentialInterruptInput(data: string): void {
-    if (data !== "\u001b") {
-      return;
-    }
-
-    suppressAutoDrainUntil = Math.max(
-      suppressAutoDrainUntil,
-      Date.now() + AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS,
-    );
-  }
-
-  function shouldSuppressAutomaticInboxDrain(now = Date.now()): boolean {
-    if (suppressAutoDrainUntil === 0) {
-      return false;
-    }
-    if (now >= suppressAutoDrainUntil) {
-      suppressAutoDrainUntil = 0;
-      return false;
-    }
-    return true;
-  }
-
-  function maybeDrainInboxIfIdle(ctx?: ExtensionContext): boolean {
-    if (!(ctx?.isIdle?.() ?? false)) {
-      return false;
-    }
-    if (shouldSuppressAutomaticInboxDrain()) {
-      return false;
-    }
-    drainInbox();
-    return true;
-  }
+  const sessionUiRuntime = createSessionUiRuntime({
+    getAgentName: () => agentName,
+    getAgentEmoji: () => agentEmoji,
+    getInboxLength: () => inbox.length,
+    drainInbox,
+  });
+  const { updateBadge, setExtStatus, maybeDrainInboxIfIdle } = sessionUiRuntime;
 
   // ─── Helpers ─────────────────────────────────────────
 
@@ -305,7 +265,7 @@ export default function (pi: ExtensionAPI) {
     },
     getAgentAliases: () => agentAliases,
     getThreads: () => threads,
-    getExtensionContext: () => extCtx,
+    getExtensionContext: sessionUiRuntime.getExtensionContext,
     persistState,
     updateBadge,
     getGitContext: () => gitContextCache.get(),
@@ -394,7 +354,7 @@ export default function (pi: ExtensionAPI) {
     getInboxLength: () => inbox.length,
     getCurrentRuntimeMode: () => currentRuntimeMode,
     maybeDrainInboxIfIdle,
-    getExtensionContext: () => extCtx ?? undefined,
+    getExtensionContext: () => sessionUiRuntime.getExtensionContext() ?? undefined,
   });
   const { reportStatus, signalAgentFree } = pinetAgentStatus;
   const pinetMeshSkin = createPinetMeshSkin({
@@ -545,27 +505,6 @@ export default function (pi: ExtensionAPI) {
   isSinglePlayerConnected = () => singlePlayerRuntime.isConnected();
 
   // ─── Reconnect / status ─────────────────────────────
-
-  function setExtStatus(
-    ctx: ExtensionContext,
-    state: "ok" | "reconnecting" | "error" | "off",
-  ): void {
-    if (!ctx.hasUI) return;
-    extCtx = ctx;
-    const t = ctx.ui.theme;
-    if (state === "ok") {
-      // delegate to updateBadge so unread count is shown
-      updateBadge();
-      return;
-    }
-    const text =
-      state === "reconnecting"
-        ? t.fg("warning", `${agentEmoji} ${agentName} ⟳`)
-        : state === "error"
-          ? t.fg("error", `${agentEmoji} ${agentName} ✗`)
-          : "";
-    ctx.ui.setStatus("slack-bridge", text);
-  }
 
   // ─── Tools ──────────────────────────────────────────
 
@@ -1217,9 +1156,7 @@ export default function (pi: ExtensionAPI) {
     applyMeshSkin,
     applyLocalAgentIdentity,
     setExtStatus,
-    setExtCtx: (ctx) => {
-      extCtx = ctx;
-    },
+    setExtCtx: sessionUiRuntime.setExtCtx,
   });
 
   async function connectAsFollower(ctx: ExtensionContext): Promise<void> {
@@ -1260,10 +1197,7 @@ export default function (pi: ExtensionAPI) {
     resetTopLevelSlackRequests();
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
-    suppressAutoDrainUntil = 0;
-    terminalInputUnsubscribe?.();
-    terminalInputUnsubscribe = null;
-    extCtx = ctx;
+    sessionUiRuntime.prepareForSessionStart(ctx);
     const sessionHeader = (
       ctx.sessionManager as { getHeader?: () => { parentSession?: string } | null }
     ).getHeader?.();
@@ -1276,18 +1210,6 @@ export default function (pi: ExtensionAPI) {
       stdinIsTTY: process.stdin.isTTY,
       stdoutIsTTY: process.stdout.isTTY,
     });
-    const uiWithTerminalInput = ctx.ui as ExtensionContext["ui"] & {
-      onTerminalInput?: (
-        handler: (data: string) => { consume?: boolean; data?: string } | undefined,
-      ) => () => void;
-    };
-    if (ctx.hasUI && typeof uiWithTerminalInput.onTerminalInput === "function") {
-      terminalInputUnsubscribe = uiWithTerminalInput.onTerminalInput((data: string) => {
-        notePotentialInterruptInput(data);
-        return undefined;
-      });
-    }
-
     // Restore persisted thread state (always restore, even before /pinet)
     restorePersistedRuntimeState(ctx);
 
@@ -1427,9 +1349,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_shutdown", async (_event, ctx) => {
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
-    terminalInputUnsubscribe?.();
-    terminalInputUnsubscribe = null;
-    suppressAutoDrainUntil = 0;
+    sessionUiRuntime.cleanupForSessionShutdown();
     await stopPinetRuntime(ctx, { releaseIdentity: true });
     pinetRegistrationBlocked = false;
   });

--- a/slack-bridge/session-ui-runtime.test.ts
+++ b/slack-bridge/session-ui-runtime.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { createSessionUiRuntime, type SessionUiRuntimeDeps } from "./session-ui-runtime.js";
+
+function createContext(
+  options: {
+    hasUI?: boolean;
+    idle?: boolean;
+    onTerminalInput?: (
+      handler: (data: string) => { consume?: boolean; data?: string } | undefined,
+    ) => () => void;
+  } = {},
+) {
+  const setStatus = vi.fn();
+  const notify = vi.fn();
+  const ctx = {
+    cwd: process.cwd(),
+    hasUI: options.hasUI ?? true,
+    isIdle: () => options.idle ?? true,
+    ui: {
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+      notify,
+      setStatus,
+      ...(options.onTerminalInput ? { onTerminalInput: options.onTerminalInput } : {}),
+    },
+    sessionManager: {
+      getEntries: () => [],
+      getHeader: () => null,
+      getLeafId: () => "leaf-123",
+      getSessionFile: () => "/tmp/session-ui-runtime.json",
+    },
+  } as unknown as ExtensionContext;
+
+  return { ctx, setStatus, notify };
+}
+
+function createDeps(overrides: Partial<SessionUiRuntimeDeps> = {}) {
+  const drainInbox = vi.fn();
+
+  const deps: SessionUiRuntimeDeps = {
+    getAgentName: () => "Cobalt Olive Crane",
+    getAgentEmoji: () => "🦩",
+    getInboxLength: () => 0,
+    drainInbox,
+    ...overrides,
+  };
+
+  return { deps, drainInbox };
+}
+
+describe("createSessionUiRuntime", () => {
+  it("updates the unread badge using the cached extension context", () => {
+    const { deps } = createDeps({
+      getInboxLength: () => 3,
+    });
+    const runtime = createSessionUiRuntime(deps);
+    const { ctx, setStatus } = createContext();
+
+    runtime.setExtCtx(ctx);
+    runtime.updateBadge();
+
+    expect(setStatus).toHaveBeenCalledWith("slack-bridge", "🦩 Cobalt Olive Crane ✦ 3");
+  });
+
+  it("renders reconnecting/error/off states and delegates ok back through the badge", () => {
+    const { deps } = createDeps({
+      getInboxLength: () => 2,
+    });
+    const runtime = createSessionUiRuntime(deps);
+    const { ctx, setStatus } = createContext();
+
+    runtime.setExtStatus(ctx, "reconnecting");
+    runtime.setExtStatus(ctx, "error");
+    runtime.setExtStatus(ctx, "off");
+    runtime.setExtStatus(ctx, "ok");
+
+    expect(setStatus).toHaveBeenNthCalledWith(1, "slack-bridge", "🦩 Cobalt Olive Crane ⟳");
+    expect(setStatus).toHaveBeenNthCalledWith(2, "slack-bridge", "🦩 Cobalt Olive Crane ✗");
+    expect(setStatus).toHaveBeenNthCalledWith(3, "slack-bridge", "");
+    expect(setStatus).toHaveBeenNthCalledWith(4, "slack-bridge", "🦩 Cobalt Olive Crane ✦ 2");
+  });
+
+  it("gates idle inbox draining while Escape suppression is active", () => {
+    const { deps, drainInbox } = createDeps();
+    const runtime = createSessionUiRuntime(deps);
+    const { ctx } = createContext({ idle: true });
+
+    expect(runtime.maybeDrainInboxIfIdle(ctx)).toBe(true);
+    expect(drainInbox).toHaveBeenCalledTimes(1);
+
+    runtime.notePotentialInterruptInput("\u001b");
+    expect(runtime.shouldSuppressAutomaticInboxDrain(Date.now())).toBe(true);
+    expect(runtime.maybeDrainInboxIfIdle(ctx)).toBe(false);
+    expect(drainInbox).toHaveBeenCalledTimes(1);
+
+    expect(runtime.shouldSuppressAutomaticInboxDrain(Date.now() + 1_600)).toBe(false);
+    expect(runtime.maybeDrainInboxIfIdle(ctx)).toBe(true);
+    expect(drainInbox).toHaveBeenCalledTimes(2);
+  });
+
+  it("binds terminal input on session start and cleans it up on shutdown", () => {
+    const unsubscribe = vi.fn();
+    let terminalHandler:
+      | ((data: string) => { consume?: boolean; data?: string } | undefined)
+      | undefined;
+    const onTerminalInput = vi.fn(
+      (handler: (data: string) => { consume?: boolean; data?: string } | undefined) => {
+        terminalHandler = handler;
+        return unsubscribe;
+      },
+    );
+    const { deps, drainInbox } = createDeps();
+    const runtime = createSessionUiRuntime(deps);
+    const { ctx } = createContext({ idle: true, onTerminalInput });
+
+    runtime.prepareForSessionStart(ctx);
+    expect(runtime.getExtensionContext()).toBe(ctx);
+    expect(onTerminalInput).toHaveBeenCalledTimes(1);
+    expect(terminalHandler?.("\u001b")).toBeUndefined();
+    expect(runtime.maybeDrainInboxIfIdle(ctx)).toBe(false);
+    expect(drainInbox).not.toHaveBeenCalled();
+
+    runtime.cleanupForSessionShutdown();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(runtime.shouldSuppressAutomaticInboxDrain(Date.now())).toBe(false);
+    expect(runtime.maybeDrainInboxIfIdle(ctx)).toBe(true);
+    expect(drainInbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes the latest extension context through the explicit setter", () => {
+    const { deps } = createDeps();
+    const runtime = createSessionUiRuntime(deps);
+    const first = createContext().ctx;
+    const second = createContext({ hasUI: false }).ctx;
+
+    runtime.setExtCtx(first);
+    expect(runtime.getExtensionContext()).toBe(first);
+
+    runtime.setExtCtx(second);
+    expect(runtime.getExtensionContext()).toBe(second);
+  });
+});

--- a/slack-bridge/session-ui-runtime.ts
+++ b/slack-bridge/session-ui-runtime.ts
@@ -1,0 +1,138 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+const AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS = 1_500;
+
+export type SessionUiStatusState = "ok" | "reconnecting" | "error" | "off";
+
+export interface SessionUiRuntimeDeps {
+  getAgentName: () => string;
+  getAgentEmoji: () => string;
+  getInboxLength: () => number;
+  drainInbox: () => void;
+}
+
+export interface SessionUiRuntime {
+  getExtensionContext: () => ExtensionContext | null;
+  setExtCtx: (ctx: ExtensionContext) => void;
+  updateBadge: () => void;
+  setExtStatus: (ctx: ExtensionContext, state: SessionUiStatusState) => void;
+  notePotentialInterruptInput: (data: string) => void;
+  shouldSuppressAutomaticInboxDrain: (now?: number) => boolean;
+  maybeDrainInboxIfIdle: (ctx?: ExtensionContext) => boolean;
+  prepareForSessionStart: (ctx: ExtensionContext) => void;
+  cleanupForSessionShutdown: () => void;
+}
+
+type SessionUiWithTerminalInput = ExtensionContext["ui"] & {
+  onTerminalInput?: (
+    handler: (data: string) => { consume?: boolean; data?: string } | undefined,
+  ) => () => void;
+};
+
+export function createSessionUiRuntime(deps: SessionUiRuntimeDeps): SessionUiRuntime {
+  let suppressAutoDrainUntil = 0;
+  let terminalInputUnsubscribe: (() => void) | null = null;
+  let extCtx: ExtensionContext | null = null;
+
+  function getExtensionContext(): ExtensionContext | null {
+    return extCtx;
+  }
+
+  function setExtCtx(ctx: ExtensionContext): void {
+    extCtx = ctx;
+  }
+
+  function updateBadge(): void {
+    if (!extCtx?.hasUI) return;
+    const t = extCtx.ui.theme;
+    const n = deps.getInboxLength();
+    const label =
+      n > 0
+        ? t.fg("accent", `${deps.getAgentEmoji()} ${deps.getAgentName()} ✦ ${n}`)
+        : t.fg("accent", `${deps.getAgentEmoji()} ${deps.getAgentName()} ✦`);
+    extCtx.ui.setStatus("slack-bridge", label);
+  }
+
+  function setExtStatus(ctx: ExtensionContext, state: SessionUiStatusState): void {
+    if (!ctx.hasUI) return;
+    extCtx = ctx;
+    const t = ctx.ui.theme;
+    if (state === "ok") {
+      updateBadge();
+      return;
+    }
+    const text =
+      state === "reconnecting"
+        ? t.fg("warning", `${deps.getAgentEmoji()} ${deps.getAgentName()} ⟳`)
+        : state === "error"
+          ? t.fg("error", `${deps.getAgentEmoji()} ${deps.getAgentName()} ✗`)
+          : "";
+    ctx.ui.setStatus("slack-bridge", text);
+  }
+
+  function notePotentialInterruptInput(data: string): void {
+    if (data !== "\u001b") {
+      return;
+    }
+
+    suppressAutoDrainUntil = Math.max(
+      suppressAutoDrainUntil,
+      Date.now() + AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS,
+    );
+  }
+
+  function shouldSuppressAutomaticInboxDrain(now = Date.now()): boolean {
+    if (suppressAutoDrainUntil === 0) {
+      return false;
+    }
+    if (now >= suppressAutoDrainUntil) {
+      suppressAutoDrainUntil = 0;
+      return false;
+    }
+    return true;
+  }
+
+  function maybeDrainInboxIfIdle(ctx?: ExtensionContext): boolean {
+    if (!(ctx?.isIdle?.() ?? false)) {
+      return false;
+    }
+    if (shouldSuppressAutomaticInboxDrain()) {
+      return false;
+    }
+    deps.drainInbox();
+    return true;
+  }
+
+  function prepareForSessionStart(ctx: ExtensionContext): void {
+    suppressAutoDrainUntil = 0;
+    terminalInputUnsubscribe?.();
+    terminalInputUnsubscribe = null;
+    extCtx = ctx;
+
+    const uiWithTerminalInput = ctx.ui as SessionUiWithTerminalInput;
+    if (ctx.hasUI && typeof uiWithTerminalInput.onTerminalInput === "function") {
+      terminalInputUnsubscribe = uiWithTerminalInput.onTerminalInput((data: string) => {
+        notePotentialInterruptInput(data);
+        return undefined;
+      });
+    }
+  }
+
+  function cleanupForSessionShutdown(): void {
+    terminalInputUnsubscribe?.();
+    terminalInputUnsubscribe = null;
+    suppressAutoDrainUntil = 0;
+  }
+
+  return {
+    getExtensionContext,
+    setExtCtx,
+    updateBadge,
+    setExtStatus,
+    notePotentialInterruptInput,
+    shouldSuppressAutomaticInboxDrain,
+    maybeDrainInboxIfIdle,
+    prepareForSessionStart,
+    cleanupForSessionShutdown,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the session UI/status runtime into `slack-bridge/session-ui-runtime.ts`
- keep badge rendering, status slot updates, Escape-based idle-drain suppression, terminal-input lifecycle wiring, and extension-context ownership behind the new runtime port
- add focused coverage for badge/status rendering, suppression gating, terminal-input binding cleanup, and explicit context wiring

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- session-ui-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test