### PR TITLE
refactor: extract top-level Slack request runtime (#444)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -8,8 +8,6 @@ import {
   buildAllowlist,
   formatInboxMessages,
   reloadPinetRuntimeSafely,
-  callSlackAPI,
-  createAbortableOperationTracker,
   buildPinetOwnerToken,
   resolveAgentIdentity,
   resolveBrokerStableId,
@@ -74,6 +72,7 @@ import { createPinetMeshOps } from "./pinet-mesh-ops.js";
 import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
 import { createSlackToolPolicyRuntime } from "./slack-tool-policy-runtime.js";
 import { createSessionUiRuntime } from "./session-ui-runtime.js";
+import { createSlackRequestRuntime } from "./slack-request-runtime.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -89,15 +88,8 @@ export default function (pi: ExtensionAPI) {
 
   if (!botToken || !appToken) return;
 
-  let slackRequests = createAbortableOperationTracker();
-
-  function resetTopLevelSlackRequests(): void {
-    slackRequests = createAbortableOperationTracker();
-  }
-
-  async function slack(method: string, token: string, body?: Record<string, unknown>) {
-    return slackRequests.run((signal) => callSlackAPI(method, token, body, { signal }));
-  }
+  const slackRequestRuntime = createSlackRequestRuntime();
+  const { slack } = slackRequestRuntime;
 
   // allowedUsers / allowAllWorkspaceUsers: settings.json takes priority, env vars as fallback
   let allowedUsers = buildAllowlist(
@@ -459,7 +451,7 @@ export default function (pi: ExtensionAPI) {
     getBotToken: () => botToken!,
     getAppToken: () => appToken!,
     dedup: processedSlackSocketDeliveries,
-    abortSlackRequests: () => slackRequests.abortAndWait(),
+    abortSlackRequests: slackRequestRuntime.abortAndWait,
     isSingleRuntimeActive: () => currentRuntimeMode === "single",
     setExtStatus,
     formatError: msg,
@@ -821,7 +813,7 @@ export default function (pi: ExtensionAPI) {
       await stopPinetRuntime(ctx, { releaseIdentity: true });
       // Runtime transitions keep the extension alive in-process, so restore a
       // fresh top-level Slack request tracker after tearing the prior runtime down.
-      resetTopLevelSlackRequests();
+      slackRequestRuntime.reset();
       singlePlayerRuntime.resetShutdownState();
     }
 
@@ -899,7 +891,7 @@ export default function (pi: ExtensionAPI) {
         // fresh top-level Slack request tracker after aborting the previous
         // generation. This preserves shutdown abort semantics without leaving
         // top-level Slack tools permanently stuck in "shutdown in progress".
-        resetTopLevelSlackRequests();
+        slackRequestRuntime.reset();
         singlePlayerRuntime.resetShutdownState();
         setExtStatus(ctx, "reconnecting");
       },
@@ -1194,7 +1186,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     singlePlayerRuntime.resetShutdownState();
-    resetTopLevelSlackRequests();
+    slackRequestRuntime.reset();
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
     sessionUiRuntime.prepareForSessionStart(ctx);

--- a/slack-bridge/slack-request-runtime.test.ts
+++ b/slack-bridge/slack-request-runtime.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackRequestRuntime } from "./slack-request-runtime.js";
+
+const slackApiState = vi.hoisted(() => ({
+  callSlackApi: vi.fn(),
+}));
+
+vi.mock("./slack-api.js", () => ({
+  callSlackApi: slackApiState.callSlackApi,
+}));
+
+function createAbortError(message = "aborted"): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+describe("createSlackRequestRuntime", () => {
+  beforeEach(() => {
+    slackApiState.callSlackApi.mockReset();
+  });
+
+  it("passes top-level Slack calls through the tracked runtime signal", async () => {
+    slackApiState.callSlackApi.mockResolvedValue({ ok: true, channel: { id: "C123" } });
+    const runtime = createSlackRequestRuntime();
+
+    await expect(
+      runtime.slack("conversations.create", "xoxb-test", { name: "request-runtime" }),
+    ).resolves.toEqual({ ok: true, channel: { id: "C123" } });
+
+    expect(slackApiState.callSlackApi).toHaveBeenCalledWith(
+      "conversations.create",
+      "xoxb-test",
+      { name: "request-runtime" },
+      { signal: expect.any(AbortSignal) },
+    );
+    const options = slackApiState.callSlackApi.mock.calls[0]?.[3] as
+      | { signal?: AbortSignal }
+      | undefined;
+    expect(options?.signal?.aborted).toBe(false);
+  });
+
+  it("aborts in-flight requests and keeps the current generation shut down until reset", async () => {
+    slackApiState.callSlackApi.mockImplementation(
+      async (
+        _method: string,
+        _token: string,
+        _body?: Record<string, unknown>,
+        options?: { signal?: AbortSignal },
+      ) =>
+        new Promise((_resolve, reject) => {
+          const rejectAbort = () => reject(createAbortError());
+          if (options?.signal?.aborted) {
+            rejectAbort();
+            return;
+          }
+          options?.signal?.addEventListener("abort", rejectAbort, { once: true });
+        }),
+    );
+    const runtime = createSlackRequestRuntime();
+
+    const pending = runtime.slack("conversations.list", "xoxb-test");
+    await runtime.abortAndWait();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError", message: "aborted" });
+    await expect(runtime.slack("conversations.info", "xoxb-test")).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Operation rejected: shutdown in progress",
+    });
+  });
+
+  it("restores top-level Slack calls after reset", async () => {
+    slackApiState.callSlackApi.mockResolvedValue({ ok: true, ts: "123.456" });
+    const runtime = createSlackRequestRuntime();
+
+    await runtime.abortAndWait();
+    runtime.reset();
+
+    await expect(
+      runtime.slack("chat.postMessage", "xoxb-test", { channel: "C123", text: "hi" }),
+    ).resolves.toEqual({ ok: true, ts: "123.456" });
+    expect(slackApiState.callSlackApi).toHaveBeenCalledTimes(1);
+  });
+});

--- a/slack-bridge/slack-request-runtime.ts
+++ b/slack-bridge/slack-request-runtime.ts
@@ -1,0 +1,36 @@
+import { createAbortableOperationTracker } from "./helpers.js";
+import { callSlackApi, type SlackResult } from "./slack-api.js";
+
+export type SlackRequestCall = (
+  method: string,
+  token: string,
+  body?: Record<string, unknown>,
+) => Promise<SlackResult>;
+
+export interface SlackRequestRuntime {
+  slack: SlackRequestCall;
+  reset: () => void;
+  abortAndWait: () => Promise<void>;
+}
+
+export function createSlackRequestRuntime(): SlackRequestRuntime {
+  let slackRequests = createAbortableOperationTracker();
+
+  const slack: SlackRequestCall = async (method, token, body) => {
+    return slackRequests.run((signal) => callSlackApi(method, token, body, { signal }));
+  };
+
+  function reset(): void {
+    slackRequests = createAbortableOperationTracker();
+  }
+
+  async function abortAndWait(): Promise<void> {
+    await slackRequests.abortAndWait();
+  }
+
+  return {
+    slack,
+    reset,
+    abortAndWait,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the top-level Slack request tracker into `slack-bridge/slack-request-runtime.ts`
- keep `index.ts` pinned to wiring the new runtime into single-mode startup, runtime transitions, and reload reset hooks only
- add focused runtime coverage for tracked Slack calls, abort/reset behavior, and post-reset recovery

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- slack-request-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test