### PR TITLE
refactor: extract Pinet registration gate (#446)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -12,7 +12,6 @@ import {
   resolveAgentIdentity,
   resolveBrokerStableId,
   resolveAgentStableId,
-  isLikelyLocalSubagentContext,
   resolveAllowAllWorkspaceUsers,
   trackBrokerInboundThread,
 } from "./helpers.js";
@@ -73,6 +72,7 @@ import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
 import { createSlackToolPolicyRuntime } from "./slack-tool-policy-runtime.js";
 import { createSessionUiRuntime } from "./session-ui-runtime.js";
 import { createSlackRequestRuntime } from "./slack-request-runtime.js";
+import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -535,14 +535,10 @@ export default function (pi: ExtensionAPI) {
   let pinetEnabled = false;
   let currentRuntimeMode: SlackBridgeRuntimeMode = "off";
   let brokerRole: "broker" | "follower" | null = null;
-  let pinetRegistrationBlocked = false;
   let brokerClient: BrokerClientRef | null = null;
   const followerDeliveryState = createFollowerDeliveryState();
   let desiredAgentStatus: "working" | "idle" = "idle";
-
-  function getPinetRegistrationBlockReason(): string {
-    return "Pinet is disabled in local subagent sessions to avoid polluting the agent mesh.";
-  }
+  const pinetRegistrationGate = createPinetRegistrationGate();
 
   const brokerThreadOwnerHints = createBrokerThreadOwnerHints({
     slack,
@@ -1103,7 +1099,7 @@ export default function (pi: ExtensionAPI) {
 
   registerPinetCommands(pi, {
     pinetEnabled: () => pinetEnabled,
-    pinetRegistrationBlocked: () => pinetRegistrationBlocked,
+    pinetRegistrationBlocked: pinetRegistrationGate.isBlocked,
     runtimeMode: () => currentRuntimeMode,
     runtimeConnected: () =>
       currentRuntimeMode === "broker"
@@ -1138,7 +1134,7 @@ export default function (pi: ExtensionAPI) {
     getBrokerControlPlaneHomeTabViewerIds,
     lastBrokerControlPlaneHomeTabRefreshAt: () => brokerRuntime.getLastHomeTabRefreshAt(),
     lastBrokerControlPlaneHomeTabError: () => brokerRuntime.getLastHomeTabError(),
-    getPinetRegistrationBlockReason,
+    getPinetRegistrationBlockReason: pinetRegistrationGate.getBlockReason,
     connectAsBroker: (ctx) => transitionToRuntimeMode(ctx, "broker"),
     connectAsFollower: (ctx) => transitionToRuntimeMode(ctx, "follower"),
     reloadPinetRuntime,
@@ -1152,9 +1148,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   async function connectAsFollower(ctx: ExtensionContext): Promise<void> {
-    if (pinetRegistrationBlocked) {
-      throw new Error(getPinetRegistrationBlockReason());
-    }
+    pinetRegistrationGate.assertCanRegister();
 
     const clientRef = await followerRuntime.connect(ctx);
     brokerClient = clientRef;
@@ -1190,18 +1184,7 @@ export default function (pi: ExtensionAPI) {
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
     sessionUiRuntime.prepareForSessionStart(ctx);
-    const sessionHeader = (
-      ctx.sessionManager as { getHeader?: () => { parentSession?: string } | null }
-    ).getHeader?.();
-    pinetRegistrationBlocked = isLikelyLocalSubagentContext({
-      sessionHeader,
-      sessionFile: ctx.sessionManager.getSessionFile(),
-      leafId: ctx.sessionManager.getLeafId(),
-      argv: process.argv.slice(2),
-      hasUI: ctx.hasUI,
-      stdinIsTTY: process.stdin.isTTY,
-      stdoutIsTTY: process.stdout.isTTY,
-    });
+    const pinetRegistrationBlocked = pinetRegistrationGate.evaluateSessionStart(ctx);
     // Restore persisted thread state (always restore, even before /pinet)
     restorePersistedRuntimeState(ctx);
 
@@ -1343,7 +1326,7 @@ export default function (pi: ExtensionAPI) {
     resetPendingRemoteControlAcks();
     sessionUiRuntime.cleanupForSessionShutdown();
     await stopPinetRuntime(ctx, { releaseIdentity: true });
-    pinetRegistrationBlocked = false;
+    pinetRegistrationGate.reset();
   });
 }
 

--- a/slack-bridge/pinet-registration-gate.test.ts
+++ b/slack-bridge/pinet-registration-gate.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
+
+function createContext(
+  options: {
+    hasUI?: boolean;
+    sessionFile?: string;
+    leafId?: string;
+    parentSession?: string;
+  } = {},
+): ExtensionContext {
+  return {
+    cwd: process.cwd(),
+    hasUI: options.hasUI ?? true,
+    ui: {
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+      notify: () => undefined,
+      setStatus: () => undefined,
+    },
+    sessionManager: {
+      getEntries: () => [],
+      getHeader: () =>
+        options.parentSession === undefined ? null : { parentSession: options.parentSession },
+      getLeafId: () => options.leafId ?? "leaf-123",
+      getSessionFile: () => options.sessionFile,
+    },
+  } as unknown as ExtensionContext;
+}
+
+describe("createPinetRegistrationGate", () => {
+  it("starts unblocked and allows registration for normal interactive sessions", () => {
+    const gate = createPinetRegistrationGate({
+      getArgv: () => [],
+      getStdinIsTTY: () => true,
+      getStdoutIsTTY: () => true,
+    });
+    const ctx = createContext({ hasUI: true, sessionFile: "/tmp/session.json", leafId: "leaf-1" });
+
+    expect(gate.isBlocked()).toBe(false);
+    expect(gate.evaluateSessionStart(ctx)).toBe(false);
+    expect(gate.isBlocked()).toBe(false);
+    expect(() => gate.assertCanRegister()).not.toThrow();
+  });
+
+  it("blocks likely local subagent sessions and reports the registration reason", () => {
+    const gate = createPinetRegistrationGate({
+      getArgv: () => ["--mode", "json"],
+      getStdinIsTTY: () => false,
+      getStdoutIsTTY: () => false,
+    });
+    const ctx = createContext({ hasUI: false, sessionFile: undefined, leafId: "leaf-ephemeral" });
+
+    expect(gate.evaluateSessionStart(ctx)).toBe(true);
+    expect(gate.isBlocked()).toBe(true);
+    expect(gate.getBlockReason()).toBe(
+      "Pinet is disabled in local subagent sessions to avoid polluting the agent mesh.",
+    );
+    expect(() => gate.assertCanRegister()).toThrow(gate.getBlockReason());
+  });
+
+  it("uses the session header parentSession signal when evaluating the block state", () => {
+    const gate = createPinetRegistrationGate({
+      getArgv: () => [],
+      getStdinIsTTY: () => true,
+      getStdoutIsTTY: () => true,
+    });
+    const ctx = createContext({
+      hasUI: true,
+      sessionFile: "/tmp/session.json",
+      leafId: "leaf-2",
+      parentSession: "parent-session-id",
+    });
+
+    expect(gate.evaluateSessionStart(ctx)).toBe(true);
+    expect(gate.isBlocked()).toBe(true);
+  });
+
+  it("resets the blocked state on shutdown", () => {
+    const gate = createPinetRegistrationGate({
+      getArgv: () => ["--mode", "json"],
+      getStdinIsTTY: () => false,
+      getStdoutIsTTY: () => false,
+    });
+    const blockedCtx = createContext({
+      hasUI: false,
+      sessionFile: undefined,
+      leafId: "leaf-ephemeral",
+    });
+    const normalCtx = createContext({
+      hasUI: true,
+      sessionFile: "/tmp/session.json",
+      leafId: "leaf-3",
+    });
+
+    expect(gate.evaluateSessionStart(blockedCtx)).toBe(true);
+    gate.reset();
+
+    expect(gate.isBlocked()).toBe(false);
+    expect(() => gate.assertCanRegister()).not.toThrow();
+    expect(gate.evaluateSessionStart(normalCtx)).toBe(false);
+  });
+});

--- a/slack-bridge/pinet-registration-gate.ts
+++ b/slack-bridge/pinet-registration-gate.ts
@@ -1,0 +1,73 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { isLikelyLocalSubagentContext } from "./helpers.js";
+
+const PINET_REGISTRATION_BLOCK_REASON =
+  "Pinet is disabled in local subagent sessions to avoid polluting the agent mesh.";
+
+type SessionHeaderAccessor = ExtensionContext["sessionManager"] & {
+  getHeader?: () => { parentSession?: string } | null;
+};
+
+export interface PinetRegistrationGateDeps {
+  getArgv?: () => string[];
+  getStdinIsTTY?: () => boolean | undefined;
+  getStdoutIsTTY?: () => boolean | undefined;
+}
+
+export interface PinetRegistrationGate {
+  isBlocked: () => boolean;
+  getBlockReason: () => string;
+  evaluateSessionStart: (ctx: ExtensionContext) => boolean;
+  assertCanRegister: () => void;
+  reset: () => void;
+}
+
+export function createPinetRegistrationGate(
+  deps: PinetRegistrationGateDeps = {},
+): PinetRegistrationGate {
+  const getArgv = deps.getArgv ?? (() => process.argv.slice(2));
+  const getStdinIsTTY = deps.getStdinIsTTY ?? (() => process.stdin.isTTY);
+  const getStdoutIsTTY = deps.getStdoutIsTTY ?? (() => process.stdout.isTTY);
+
+  let pinetRegistrationBlocked = false;
+
+  function isBlocked(): boolean {
+    return pinetRegistrationBlocked;
+  }
+
+  function getBlockReason(): string {
+    return PINET_REGISTRATION_BLOCK_REASON;
+  }
+
+  function evaluateSessionStart(ctx: ExtensionContext): boolean {
+    const sessionHeader = (ctx.sessionManager as SessionHeaderAccessor).getHeader?.();
+    pinetRegistrationBlocked = isLikelyLocalSubagentContext({
+      sessionHeader,
+      sessionFile: ctx.sessionManager.getSessionFile(),
+      leafId: ctx.sessionManager.getLeafId(),
+      argv: getArgv(),
+      hasUI: ctx.hasUI,
+      stdinIsTTY: getStdinIsTTY(),
+      stdoutIsTTY: getStdoutIsTTY(),
+    });
+    return pinetRegistrationBlocked;
+  }
+
+  function assertCanRegister(): void {
+    if (pinetRegistrationBlocked) {
+      throw new Error(getBlockReason());
+    }
+  }
+
+  function reset(): void {
+    pinetRegistrationBlocked = false;
+  }
+
+  return {
+    isBlocked,
+    getBlockReason,
+    evaluateSessionStart,
+    assertCanRegister,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the Pinet registration-block gate into `slack-bridge/pinet-registration-gate.ts`
- keep `index.ts` pinned to wiring the gate into session start, follower precondition checks, command guards, and shutdown reset only
- add focused coverage for blocked-state evaluation, reason reporting, session-header detection, and shutdown reset behavior

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-registration-gate.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test