### PR TITLE
refactor: extract broker runtime accessors (#448)

### DIFF
--- a/slack-bridge/broker-runtime-access.test.ts
+++ b/slack-bridge/broker-runtime-access.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { Broker } from "./broker/index.js";
+import type { BrokerDB } from "./broker/schema.js";
+import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
+
+describe("createBrokerRuntimeAccess", () => {
+  it("reads the active broker, broker db, self id, and Home tab viewers from the runtime getters", () => {
+    const db = { label: "db-1" } as unknown as BrokerDB;
+    const broker = { db } as unknown as Broker;
+    let activeBroker: Broker | null = broker;
+    let selfId: string | null = "broker-1";
+    let homeTabViewerIds = ["U123", "U456"];
+    const access = createBrokerRuntimeAccess({
+      getBroker: () => activeBroker,
+      getSelfId: () => selfId,
+      getHomeTabViewerIds: () => homeTabViewerIds,
+    });
+
+    expect(access.getActiveBroker()).toBe(broker);
+    expect(access.getActiveBrokerDb()).toBe(db);
+    expect(access.getActiveBrokerSelfId()).toBe("broker-1");
+    expect(access.getBrokerControlPlaneHomeTabViewerIds()).toEqual(["U123", "U456"]);
+
+    activeBroker = null;
+    selfId = null;
+    homeTabViewerIds = ["U789"];
+
+    expect(access.getActiveBroker()).toBeNull();
+    expect(access.getActiveBrokerDb()).toBeNull();
+    expect(access.getActiveBrokerSelfId()).toBeNull();
+    expect(access.getBrokerControlPlaneHomeTabViewerIds()).toEqual(["U789"]);
+  });
+
+  it("returns null for the broker db when the active broker is missing", () => {
+    const access = createBrokerRuntimeAccess({
+      getBroker: () => null,
+      getSelfId: () => "broker-2",
+      getHomeTabViewerIds: () => [],
+    });
+
+    expect(access.getActiveBrokerDb()).toBeNull();
+    expect(access.getActiveBrokerSelfId()).toBe("broker-2");
+  });
+});

--- a/slack-bridge/broker-runtime-access.ts
+++ b/slack-bridge/broker-runtime-access.ts
@@ -1,0 +1,40 @@
+import type { Broker } from "./broker/index.js";
+import type { BrokerDB } from "./broker/schema.js";
+
+export interface BrokerRuntimeAccessDeps {
+  getBroker: () => Broker | null;
+  getSelfId: () => string | null;
+  getHomeTabViewerIds: () => string[];
+}
+
+export interface BrokerRuntimeAccess {
+  getActiveBroker: () => Broker | null;
+  getActiveBrokerDb: () => BrokerDB | null;
+  getActiveBrokerSelfId: () => string | null;
+  getBrokerControlPlaneHomeTabViewerIds: () => string[];
+}
+
+export function createBrokerRuntimeAccess(deps: BrokerRuntimeAccessDeps): BrokerRuntimeAccess {
+  function getActiveBroker(): Broker | null {
+    return deps.getBroker();
+  }
+
+  function getActiveBrokerDb(): BrokerDB | null {
+    return (getActiveBroker()?.db as BrokerDB | undefined) ?? null;
+  }
+
+  function getActiveBrokerSelfId(): string | null {
+    return deps.getSelfId();
+  }
+
+  function getBrokerControlPlaneHomeTabViewerIds(): string[] {
+    return deps.getHomeTabViewerIds();
+  }
+
+  return {
+    getActiveBroker,
+    getActiveBrokerDb,
+    getActiveBrokerSelfId,
+    getBrokerControlPlaneHomeTabViewerIds,
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -18,8 +18,6 @@ import {
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
-import type { Broker } from "./broker/index.js";
-import type { BrokerDB } from "./broker/schema.js";
 import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { registerSlackTools } from "./slack-tools.js";
@@ -73,6 +71,7 @@ import { createSlackToolPolicyRuntime } from "./slack-tool-policy-runtime.js";
 import { createSessionUiRuntime } from "./session-ui-runtime.js";
 import { createSlackRequestRuntime } from "./slack-request-runtime.js";
 import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
+import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -328,6 +327,17 @@ export default function (pi: ExtensionAPI) {
     getCurrentBranch: async () => (await probeGitBranch(process.cwd())) ?? null,
     getBrokerHomeTabs: () => brokerRuntime,
   });
+  const brokerRuntimeAccess = createBrokerRuntimeAccess({
+    getBroker: () => brokerRuntime.getBroker(),
+    getSelfId: () => brokerRuntime.getSelfId(),
+    getHomeTabViewerIds: () => brokerRuntime.getHomeTabViewerIds(),
+  });
+  const {
+    getActiveBroker,
+    getActiveBrokerDb,
+    getActiveBrokerSelfId,
+    getBrokerControlPlaneHomeTabViewerIds,
+  } = brokerRuntimeAccess;
   const pinetAgentStatus = createPinetAgentStatus({
     getPinetEnabled: () => pinetEnabled,
     getBrokerRole: () => brokerRole,
@@ -410,7 +420,7 @@ export default function (pi: ExtensionAPI) {
   });
   const { requestRemoteControl, runRemoteControl, resetRemoteControlState } = pinetRemoteControl;
   const pinetActivityFormatting = createPinetActivityFormatting({
-    getActiveBrokerDb: () => (brokerRuntime.getBroker()?.db as BrokerDB | undefined) ?? null,
+    getActiveBrokerDb,
   });
   const { formatTrackedAgent, summarizeTrackedAssignmentStatus } = pinetActivityFormatting;
   const pinetControlPlaneCanvas = createPinetControlPlaneCanvas({
@@ -757,18 +767,6 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
-  function getActiveBroker(): Broker | null {
-    return brokerRuntime.getBroker();
-  }
-
-  function getActiveBrokerDb(): BrokerDB | null {
-    return (getActiveBroker()?.db as BrokerDB | undefined) ?? null;
-  }
-
-  function getActiveBrokerSelfId(): string | null {
-    return brokerRuntime.getSelfId();
-  }
-
   const pinetMeshOps = createPinetMeshOps({
     getPinetEnabled: () => pinetEnabled,
     getBrokerRole: () => brokerRole,
@@ -789,10 +787,6 @@ export default function (pi: ExtensionAPI) {
     listBrokerAgents,
     listFollowerAgents,
   } = pinetMeshOps;
-
-  function getBrokerControlPlaneHomeTabViewerIds(): string[] {
-    return brokerRuntime.getHomeTabViewerIds();
-  }
 
   async function transitionToRuntimeMode(
     ctx: ExtensionContext,


### PR DESCRIPTION
## Summary
- extract the broker runtime accessor port into `slack-bridge/broker-runtime-access.ts`
- keep `index.ts` pinned to wiring already-extracted modules through the new access port without changing broker lifecycle ownership
- add focused coverage for active broker/db/self-id access and Home tab viewer access

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- broker-runtime-access.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test