### PR TITLE
refactor: extract inbox drain runtime (#450)

### DIFF
--- a/slack-bridge/inbox-drain-runtime.test.ts
+++ b/slack-bridge/inbox-drain-runtime.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFollowerDeliveryState } from "./follower-delivery.js";
+import { formatInboxMessages, type InboxMessage } from "./helpers.js";
+import { createInboxDrainRuntime, type InboxDrainRuntimeDeps } from "./inbox-drain-runtime.js";
+
+function createMessage(overrides: Partial<InboxMessage> = {}): InboxMessage {
+  return {
+    channel: "C123",
+    threadTs: "100.1",
+    userId: "U123",
+    text: "hello",
+    timestamp: "100.2",
+    ...overrides,
+  };
+}
+
+function createDeps(overrides: Partial<InboxDrainRuntimeDeps> = {}) {
+  const inbox: InboxMessage[] = [];
+  const sendUserMessage = vi.fn();
+  const updateBadge = vi.fn();
+  const reportStatus = vi.fn(async () => {});
+  const userNames = new Map<string, string>([["U123", "Ada"]]);
+  const deliverTrackedSlackFollowUpMessage = vi.fn(() => true);
+  const flushFollowerDeliveredAcks = vi.fn(async () => {});
+  const markBrokerInboxIdsDelivered = vi.fn();
+  let securityPrompt = "";
+  let brokerRole: "broker" | "follower" | null = null;
+  let followerClient = true;
+  const followerDeliveryState = createFollowerDeliveryState();
+
+  const deps: InboxDrainRuntimeDeps = {
+    sendUserMessage,
+    takeInboxMessages: () => inbox.splice(0, inbox.length),
+    restoreInboxMessages: (messages) => {
+      inbox.push(...messages);
+    },
+    updateBadge,
+    reportStatus,
+    userNames,
+    getSecurityPrompt: () => securityPrompt,
+    deliverTrackedSlackFollowUpMessage,
+    getBrokerRole: () => brokerRole,
+    hasFollowerClient: () => followerClient,
+    flushFollowerDeliveredAcks,
+    markBrokerInboxIdsDelivered,
+    getFollowerDeliveryState: () => followerDeliveryState,
+    ...overrides,
+  };
+
+  const runtime = createInboxDrainRuntime(deps);
+
+  return {
+    runtime,
+    inbox,
+    sendUserMessage,
+    updateBadge,
+    reportStatus,
+    userNames,
+    deliverTrackedSlackFollowUpMessage,
+    flushFollowerDeliveredAcks,
+    markBrokerInboxIdsDelivered,
+    followerDeliveryState,
+    setSecurityPrompt: (value: string) => {
+      securityPrompt = value;
+    },
+    setBrokerRole: (value: "broker" | "follower" | null) => {
+      brokerRole = value;
+    },
+    setFollowerClient: (value: boolean) => {
+      followerClient = value;
+    },
+  };
+}
+
+describe("createInboxDrainRuntime", () => {
+  it("delivers follow-up messages with a plain-send fallback", () => {
+    const { runtime, sendUserMessage } = createDeps();
+    sendUserMessage
+      .mockImplementationOnce(() => {
+        throw new Error("followUp failed");
+      })
+      .mockImplementationOnce(() => undefined);
+
+    expect(runtime.deliverFollowUpMessage("steady note")).toBe(true);
+    expect(sendUserMessage).toHaveBeenNthCalledWith(1, "steady note", { deliverAs: "followUp" });
+    expect(sendUserMessage).toHaveBeenNthCalledWith(2, "steady note");
+  });
+
+  it("returns false when both follow-up delivery attempts fail", () => {
+    const { runtime, sendUserMessage } = createDeps();
+    sendUserMessage.mockImplementation(() => {
+      throw new Error("send failed");
+    });
+
+    expect(runtime.deliverFollowUpMessage("steady note")).toBe(false);
+    expect(sendUserMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("formats pending inbox work, applies security guidance, and flushes follower acks", () => {
+    const {
+      runtime,
+      inbox,
+      updateBadge,
+      reportStatus,
+      userNames,
+      deliverTrackedSlackFollowUpMessage,
+      flushFollowerDeliveredAcks,
+      followerDeliveryState,
+      markBrokerInboxIdsDelivered,
+      setSecurityPrompt,
+      setBrokerRole,
+    } = createDeps();
+    const message = createMessage({ brokerInboxId: 42 });
+    inbox.push(message);
+    setSecurityPrompt("SECURITY FIRST");
+    setBrokerRole("follower");
+
+    runtime.drainInbox();
+
+    expect(updateBadge).toHaveBeenCalledTimes(1);
+    expect(reportStatus).toHaveBeenCalledWith("working");
+    expect(deliverTrackedSlackFollowUpMessage).toHaveBeenCalledWith({
+      prompt: `SECURITY FIRST\n\n${formatInboxMessages([message], userNames)}`,
+      messages: [message],
+    });
+    expect(followerDeliveryState.deliveredAwaitingAckIds.has(42)).toBe(true);
+    expect(flushFollowerDeliveredAcks).toHaveBeenCalledTimes(1);
+    expect(markBrokerInboxIdsDelivered).not.toHaveBeenCalled();
+    expect(inbox).toEqual([]);
+  });
+
+  it("marks broker inbox ids delivered after a successful broker-side drain", () => {
+    const {
+      runtime,
+      inbox,
+      markBrokerInboxIdsDelivered,
+      setBrokerRole,
+      flushFollowerDeliveredAcks,
+    } = createDeps();
+    inbox.push(createMessage({ brokerInboxId: 77 }));
+    setBrokerRole("broker");
+
+    runtime.drainInbox();
+
+    expect(markBrokerInboxIdsDelivered).toHaveBeenCalledWith([77]);
+    expect(flushFollowerDeliveredAcks).not.toHaveBeenCalled();
+  });
+
+  it("requeues pending inbox work when the follow-up delivery is not accepted", () => {
+    const { runtime, inbox, updateBadge, reportStatus, markBrokerInboxIdsDelivered } = createDeps({
+      deliverTrackedSlackFollowUpMessage: vi.fn(() => false),
+    });
+    const message = createMessage({ brokerInboxId: 88 });
+    inbox.push(message);
+
+    runtime.drainInbox();
+
+    expect(reportStatus).toHaveBeenCalledWith("working");
+    expect(updateBadge).toHaveBeenCalledTimes(2);
+    expect(markBrokerInboxIdsDelivered).not.toHaveBeenCalled();
+    expect(inbox).toEqual([message]);
+  });
+
+  it("only flushes follower acks when follower delivery is still live", async () => {
+    const { runtime, flushFollowerDeliveredAcks, setBrokerRole, setFollowerClient } = createDeps();
+
+    await runtime.flushDeliveredFollowerAcks();
+    expect(flushFollowerDeliveredAcks).not.toHaveBeenCalled();
+
+    setBrokerRole("follower");
+    setFollowerClient(false);
+    await runtime.flushDeliveredFollowerAcks();
+    expect(flushFollowerDeliveredAcks).not.toHaveBeenCalled();
+
+    setFollowerClient(true);
+    await runtime.flushDeliveredFollowerAcks();
+    expect(flushFollowerDeliveredAcks).toHaveBeenCalledTimes(1);
+  });
+});

--- a/slack-bridge/inbox-drain-runtime.ts
+++ b/slack-bridge/inbox-drain-runtime.ts
@@ -1,0 +1,101 @@
+import { getBrokerInboxIds } from "./broker-delivery.js";
+import { markFollowerInboxIdsDelivered, type FollowerDeliveryState } from "./follower-delivery.js";
+import { formatInboxMessages, type InboxMessage } from "./helpers.js";
+
+export interface InboxDrainRuntimeDeps {
+  sendUserMessage: (text: string, options?: { deliverAs?: "followUp" }) => void;
+  takeInboxMessages: () => InboxMessage[];
+  restoreInboxMessages: (messages: InboxMessage[]) => void;
+  updateBadge: () => void;
+  reportStatus: (status: "working" | "idle") => Promise<void>;
+  userNames: { get: (key: string) => string | undefined };
+  getSecurityPrompt: () => string;
+  deliverTrackedSlackFollowUpMessage: (options: {
+    prompt: string;
+    messages: Pick<InboxMessage, "threadTs">[];
+  }) => boolean;
+  getBrokerRole: () => "broker" | "follower" | null;
+  hasFollowerClient: () => boolean;
+  flushFollowerDeliveredAcks: () => Promise<void>;
+  markBrokerInboxIdsDelivered: (inboxIds: number[]) => void;
+  getFollowerDeliveryState: () => FollowerDeliveryState;
+}
+
+export interface InboxDrainRuntime {
+  deliverFollowUpMessage: (text: string) => boolean;
+  flushDeliveredFollowerAcks: () => Promise<void>;
+  drainInbox: () => void;
+}
+
+export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrainRuntime {
+  function deliverFollowUpMessage(text: string): boolean {
+    try {
+      deps.sendUserMessage(text, { deliverAs: "followUp" });
+      return true;
+    } catch {
+      try {
+        deps.sendUserMessage(text);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  async function flushDeliveredFollowerAcks(): Promise<void> {
+    if (deps.getBrokerRole() !== "follower" || !deps.hasFollowerClient()) {
+      return;
+    }
+
+    await deps.flushFollowerDeliveredAcks();
+  }
+
+  function drainInbox(): void {
+    const pending = deps.takeInboxMessages();
+    if (pending.length === 0) {
+      return;
+    }
+
+    const brokerInboxIds = getBrokerInboxIds(pending);
+    deps.updateBadge();
+    void deps.reportStatus("working").catch(() => {
+      /* best effort */
+    });
+
+    let prompt = formatInboxMessages(pending, deps.userNames);
+    const securityPrompt = deps.getSecurityPrompt();
+    if (securityPrompt) {
+      prompt = `${securityPrompt}\n\n${prompt}`;
+    }
+
+    if (
+      deps.deliverTrackedSlackFollowUpMessage({
+        prompt,
+        messages: pending,
+      })
+    ) {
+      if (brokerInboxIds.length > 0) {
+        if (deps.getBrokerRole() === "follower") {
+          markFollowerInboxIdsDelivered(deps.getFollowerDeliveryState(), brokerInboxIds);
+          void flushDeliveredFollowerAcks();
+        } else if (deps.getBrokerRole() === "broker") {
+          try {
+            deps.markBrokerInboxIdsDelivered(brokerInboxIds);
+          } catch {
+            /* best effort */
+          }
+        }
+      }
+      return;
+    }
+
+    deps.restoreInboxMessages(pending);
+    deps.updateBadge();
+  }
+
+  return {
+    deliverFollowUpMessage,
+    flushDeliveredFollowerAcks,
+    drainInbox,
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -6,7 +6,6 @@ import {
   type InboxMessage,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
-  formatInboxMessages,
   reloadPinetRuntimeSafely,
   buildPinetOwnerToken,
   resolveAgentIdentity,
@@ -48,11 +47,7 @@ import {
 } from "./single-player-runtime.js";
 import { createBrokerRuntime } from "./broker-runtime.js";
 import { SlackActivityLogger } from "./activity-log.js";
-import {
-  createBrokerDeliveryState,
-  getBrokerInboxIds,
-  queueBrokerInboxIds,
-} from "./broker-delivery.js";
+import { createBrokerDeliveryState, queueBrokerInboxIds } from "./broker-delivery.js";
 import { buildBrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
 import { createPinetAgentStatus } from "./pinet-agent-status.js";
@@ -72,6 +67,7 @@ import { createSessionUiRuntime } from "./session-ui-runtime.js";
 import { createSlackRequestRuntime } from "./slack-request-runtime.js";
 import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
 import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
+import { createInboxDrainRuntime } from "./inbox-drain-runtime.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -190,13 +186,44 @@ export default function (pi: ExtensionAPI) {
 
   const inbox: InboxMessage[] = [];
   const brokerDeliveryState = createBrokerDeliveryState();
+  let drainInboxPort: (() => void) | null = null;
   const sessionUiRuntime = createSessionUiRuntime({
     getAgentName: () => agentName,
     getAgentEmoji: () => agentEmoji,
     getInboxLength: () => inbox.length,
-    drainInbox,
+    drainInbox: () => {
+      drainInboxPort?.();
+    },
   });
   const { updateBadge, setExtStatus, maybeDrainInboxIfIdle } = sessionUiRuntime;
+  let reportAgentStatus: (status: "working" | "idle") => Promise<void> = async () => {};
+  let deliverTrackedSlackFollowUpMessage: (options: {
+    prompt: string;
+    messages: Pick<InboxMessage, "threadTs">[];
+  }) => boolean = () => false;
+  const inboxDrainRuntime = createInboxDrainRuntime({
+    sendUserMessage: (body, options) => {
+      pi.sendUserMessage(body, options);
+    },
+    takeInboxMessages: () => inbox.splice(0, inbox.length),
+    restoreInboxMessages: (messages) => {
+      inbox.push(...messages);
+    },
+    updateBadge,
+    reportStatus: (status) => reportAgentStatus(status),
+    userNames,
+    getSecurityPrompt: () => securityPrompt,
+    deliverTrackedSlackFollowUpMessage: (options) => deliverTrackedSlackFollowUpMessage(options),
+    getBrokerRole: () => brokerRole,
+    hasFollowerClient: () => brokerClient?.client != null,
+    flushFollowerDeliveredAcks: () => followerRuntime.flushDeliveredAcks(),
+    markBrokerInboxIdsDelivered: (inboxIds) => {
+      brokerRuntime.markDelivered(inboxIds);
+    },
+    getFollowerDeliveryState: () => followerDeliveryState,
+  });
+  const { deliverFollowUpMessage, flushDeliveredFollowerAcks, drainInbox } = inboxDrainRuntime;
+  drainInboxPort = drainInbox;
 
   // ─── Helpers ─────────────────────────────────────────
 
@@ -359,6 +386,7 @@ export default function (pi: ExtensionAPI) {
     getExtensionContext: () => sessionUiRuntime.getExtensionContext() ?? undefined,
   });
   const { reportStatus, signalAgentFree } = pinetAgentStatus;
+  reportAgentStatus = reportStatus;
   const pinetMeshSkin = createPinetMeshSkin({
     getBrokerRole: () => brokerRole,
     getActiveBrokerDb,
@@ -1213,20 +1241,6 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Agent status reporting ──────────────────────────
 
-  function deliverFollowUpMessage(text: string): boolean {
-    try {
-      pi.sendUserMessage(text, { deliverAs: "followUp" });
-      return true;
-    } catch {
-      try {
-        pi.sendUserMessage(text);
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-
   const slackToolPolicyRuntime = createSlackToolPolicyRuntime({
     getBrokerRole: () => brokerRole,
     getGuardrails: () => guardrails,
@@ -1235,54 +1249,7 @@ export default function (pi: ExtensionAPI) {
     formatError: msg,
     deliverFollowUpMessage,
   });
-
-  async function flushDeliveredFollowerAcks(): Promise<void> {
-    if (brokerRole !== "follower" || !brokerClient?.client) return;
-    await followerRuntime.flushDeliveredAcks();
-  }
-
-  // Drain inbox: set thinking status, send to agent
-  function drainInbox(): void {
-    if (inbox.length === 0) return;
-
-    const pending = inbox.splice(0, inbox.length);
-    const brokerInboxIds = getBrokerInboxIds(pending);
-    updateBadge();
-    void reportStatus("working").catch(() => {
-      /* best effort */
-    });
-
-    let prompt = formatInboxMessages(pending, userNames);
-
-    // Prepend security guardrails if configured
-    if (securityPrompt) {
-      prompt = securityPrompt + "\n\n" + prompt;
-    }
-
-    if (
-      slackToolPolicyRuntime.deliverTrackedSlackFollowUpMessage({
-        prompt,
-        messages: pending,
-      })
-    ) {
-      if (brokerInboxIds.length > 0) {
-        if (brokerRole === "follower") {
-          markFollowerInboxIdsDelivered(followerDeliveryState, brokerInboxIds);
-          void flushDeliveredFollowerAcks();
-        } else if (brokerRole === "broker") {
-          try {
-            brokerRuntime.markDelivered(brokerInboxIds);
-          } catch {
-            /* best effort */
-          }
-        }
-      }
-      return;
-    }
-
-    inbox.push(...pending);
-    updateBadge();
-  }
+  deliverTrackedSlackFollowUpMessage = slackToolPolicyRuntime.deliverTrackedSlackFollowUpMessage;
 
   pi.on("input", slackToolPolicyRuntime.onInput);
 


### PR DESCRIPTION
## Summary
- extract the inbox drain delivery runtime seam into `slack-bridge/inbox-drain-runtime.ts`
- keep `slack-bridge/index.ts` pinned to inbox ownership and wire existing consumers through the extracted runtime port
- add focused coverage for follow-up delivery fallback, inbox drain formatting/security behavior, broker delivery marking, follower ack flushing, and requeue behavior

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- inbox-drain-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test