### PR TITLE
refactor: extract agent completion runtime (#452)

### DIFF
--- a/slack-bridge/agent-completion-runtime.test.ts
+++ b/slack-bridge/agent-completion-runtime.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  createAgentCompletionRuntime,
+  type AgentCompletionRuntimeDeps,
+} from "./agent-completion-runtime.js";
+
+function createContext() {
+  const notify = vi.fn();
+  const ctx = {
+    cwd: process.cwd(),
+    hasUI: true,
+    isIdle: () => true,
+    ui: {
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+      notify,
+      setStatus: vi.fn(),
+    },
+    sessionManager: {
+      getEntries: () => [],
+      getHeader: () => null,
+      getLeafId: () => "leaf-123",
+      getSessionFile: () => "/tmp/agent-completion-runtime.json",
+    },
+  } as unknown as ExtensionContext;
+
+  return { ctx, notify };
+}
+
+function createDeps(overrides: Partial<AgentCompletionRuntimeDeps> = {}) {
+  const threads = new Map<string, { channelId: string }>();
+  const clearThreadStatus = vi.fn(async () => {});
+  const clearFollowUpPending = vi.fn();
+  const signalAgentFree = vi.fn(async () => ({ queuedInboxCount: 0, drainedQueuedInbox: false }));
+
+  const deps: AgentCompletionRuntimeDeps = {
+    getThreads: () => threads,
+    clearThreadStatus,
+    clearFollowUpPending,
+    signalAgentFree,
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    ...overrides,
+  };
+
+  return {
+    deps,
+    threads,
+    clearThreadStatus,
+    clearFollowUpPending,
+  };
+}
+
+describe("createAgentCompletionRuntime", () => {
+  it("clears tracked thread status, clears follow-up pending, and frees the agent", async () => {
+    const signalAgentFree = vi.fn(async () => ({ queuedInboxCount: 0, drainedQueuedInbox: false }));
+    const { deps, threads, clearThreadStatus, clearFollowUpPending } = createDeps({
+      signalAgentFree,
+    });
+    const runtime = createAgentCompletionRuntime(deps);
+    const { ctx, notify } = createContext();
+
+    threads.set("100.1", { channelId: "D100" });
+    threads.set("200.2", { channelId: "D200" });
+    runtime.trackThinkingThread("100.1");
+    runtime.trackThinkingThread("missing.3");
+    runtime.trackThinkingThread("200.2");
+
+    await runtime.onAgentEnd({}, ctx);
+
+    expect(clearThreadStatus).toHaveBeenNthCalledWith(1, "D100", "100.1");
+    expect(clearThreadStatus).toHaveBeenNthCalledWith(2, "D200", "200.2");
+    expect(clearFollowUpPending).toHaveBeenCalledTimes(1);
+    expect(signalAgentFree).toHaveBeenCalledWith(ctx);
+    expect(clearFollowUpPending.mock.invocationCallOrder[0]).toBeLessThan(
+      signalAgentFree.mock.invocationCallOrder[0] ?? Infinity,
+    );
+    expect(notify).not.toHaveBeenCalled();
+
+    await runtime.onAgentEnd({}, ctx);
+    expect(clearThreadStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("warns when auto-free fails after clearing tracked cleanup state", async () => {
+    const error = new Error("status sync failed once");
+    const signalAgentFree = vi.fn(async () => {
+      throw error;
+    });
+    const { deps, threads, clearThreadStatus, clearFollowUpPending } = createDeps({
+      signalAgentFree,
+    });
+    const runtime = createAgentCompletionRuntime(deps);
+    const { ctx, notify } = createContext();
+
+    threads.set("100.1", { channelId: "D100" });
+    runtime.trackThinkingThread("100.1");
+
+    await runtime.onAgentEnd({}, ctx);
+
+    expect(clearThreadStatus).toHaveBeenCalledWith("D100", "100.1");
+    expect(clearFollowUpPending).toHaveBeenCalledTimes(1);
+    expect(signalAgentFree).toHaveBeenCalledWith(ctx);
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet auto-free failed: status sync failed once",
+      "warning",
+    );
+
+    await runtime.onAgentEnd({}, ctx);
+    expect(clearThreadStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/slack-bridge/agent-completion-runtime.ts
+++ b/slack-bridge/agent-completion-runtime.ts
@@ -1,0 +1,50 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+interface AgentCompletionThreadState {
+  channelId: string;
+}
+
+export interface AgentCompletionRuntimeDeps {
+  getThreads: () => Map<string, AgentCompletionThreadState>;
+  clearThreadStatus: (channelId: string, threadTs: string) => Promise<void>;
+  clearFollowUpPending: () => void;
+  signalAgentFree: (ctx: ExtensionContext) => Promise<unknown>;
+  formatError: (error: unknown) => string;
+}
+
+export interface AgentCompletionRuntime {
+  trackThinkingThread: (threadTs: string) => void;
+  onAgentEnd: (_event: unknown, ctx: ExtensionContext) => Promise<void>;
+}
+
+export function createAgentCompletionRuntime(
+  deps: AgentCompletionRuntimeDeps,
+): AgentCompletionRuntime {
+  const thinking = new Set<string>();
+
+  function trackThinkingThread(threadTs: string): void {
+    thinking.add(threadTs);
+  }
+
+  async function onAgentEnd(_event: unknown, ctx: ExtensionContext): Promise<void> {
+    for (const threadTs of thinking) {
+      const thread = deps.getThreads().get(threadTs);
+      if (thread) {
+        await deps.clearThreadStatus(thread.channelId, threadTs);
+      }
+    }
+    thinking.clear();
+    deps.clearFollowUpPending();
+
+    try {
+      await deps.signalAgentFree(ctx);
+    } catch (err) {
+      ctx.ui.notify(`Pinet auto-free failed: ${deps.formatError(err)}`, "warning");
+    }
+  }
+
+  return {
+    trackThinkingThread,
+    onAgentEnd,
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -68,6 +68,7 @@ import { createSlackRequestRuntime } from "./slack-request-runtime.js";
 import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
 import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
 import { createInboxDrainRuntime } from "./inbox-drain-runtime.js";
+import { createAgentCompletionRuntime } from "./agent-completion-runtime.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -112,7 +113,6 @@ export default function (pi: ExtensionAPI) {
   let botUserId: string | null = null;
 
   const threads = new Map<string, SinglePlayerThreadInfo>();
-  const thinking = new Set<string>();
   const pendingEyes = new Map<string, SinglePlayerPendingAttentionEntry[]>(); // thread_ts → message ts list // thread_ts values showing "is thinking…"
   const userNames = new TtlCache<string, string>({ maxSize: 2000, ttlMs: 60 * 60 * 1000 });
   let lastDmChannel: string | null = null;
@@ -387,6 +387,15 @@ export default function (pi: ExtensionAPI) {
   });
   const { reportStatus, signalAgentFree } = pinetAgentStatus;
   reportAgentStatus = reportStatus;
+  const agentCompletionRuntime = createAgentCompletionRuntime({
+    getThreads: () => threads,
+    clearThreadStatus,
+    clearFollowUpPending: () => {
+      brokerRuntime.clearFollowUpPending();
+    },
+    signalAgentFree: (ctx) => signalAgentFree(ctx),
+    formatError: msg,
+  });
   const pinetMeshSkin = createPinetMeshSkin({
     getBrokerRole: () => brokerRole,
     getActiveBrokerDb,
@@ -1267,20 +1276,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("before_agent_start", agentPromptGuidance.beforeAgentStart);
 
   // When agent finishes: clear thinking status, mark free, and auto-drain inbox
-  pi.on("agent_end", async (_event, ctx) => {
-    for (const ts of thinking) {
-      const thread = threads.get(ts);
-      if (thread) await clearThreadStatus(thread.channelId, ts);
-    }
-    thinking.clear();
-    brokerRuntime.clearFollowUpPending();
-
-    try {
-      await signalAgentFree(ctx);
-    } catch (err) {
-      ctx.ui.notify(`Pinet auto-free failed: ${msg(err)}`, "warning");
-    }
-  });
+  pi.on("agent_end", agentCompletionRuntime.onAgentEnd);
 
   pi.on("session_shutdown", async (_event, ctx) => {
     resetRemoteControlState();


### PR DESCRIPTION
## Summary
- extract the agent-end cleanup seam into `slack-bridge/agent-completion-runtime.ts`
- keep `slack-bridge/index.ts` pinned to existing runtime ownership while wiring the final agent-end cleanup through the extracted runtime port
- add focused coverage for tracked thread cleanup, broker follow-up pending reset, and auto-free warning behavior

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- agent-completion-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test