### PR TITLE
refactor: extract agent event runtime (#454)

### DIFF
--- a/slack-bridge/agent-event-runtime.test.ts
+++ b/slack-bridge/agent-event-runtime.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createAgentEventRuntime, type AgentEventRuntimeDeps } from "./agent-event-runtime.js";
+
+function createDeps(overrides: Partial<AgentEventRuntimeDeps> = {}) {
+  const deliverFollowUpMessage = vi.fn(() => true);
+  const requireToolPolicy = vi.fn();
+  const beforeAgentStart = vi.fn(async (event: { systemPrompt: string }) => ({
+    systemPrompt: event.systemPrompt + "\nextra guidance",
+  }));
+  const onCompletionAgentEnd = vi.fn(async () => {});
+  const setDeliverTrackedSlackFollowUpMessage = vi.fn();
+
+  const deps: AgentEventRuntimeDeps = {
+    getBrokerRole: () => null,
+    getGuardrails: () => ({}),
+    requireToolPolicy,
+    formatAction: (action) => `<${action}>`,
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    deliverFollowUpMessage,
+    beforeAgentStart,
+    onCompletionAgentEnd,
+    setDeliverTrackedSlackFollowUpMessage,
+    ...overrides,
+  };
+
+  return {
+    deps,
+    deliverFollowUpMessage,
+    requireToolPolicy,
+    beforeAgentStart,
+    onCompletionAgentEnd,
+    setDeliverTrackedSlackFollowUpMessage,
+  };
+}
+
+function createPi() {
+  const registrations: Array<{ eventName: string; handler: (...args: unknown[]) => unknown }> = [];
+  const pi = {
+    on: vi.fn((eventName: string, handler: (...args: unknown[]) => unknown) => {
+      registrations.push({ eventName, handler });
+    }),
+  } as Pick<ExtensionAPI, "on">;
+
+  return { pi, registrations };
+}
+
+describe("createAgentEventRuntime", () => {
+  it("registers the pinned agent event wiring in order and preserves agent_end ordering", () => {
+    const { deps, beforeAgentStart, onCompletionAgentEnd } = createDeps();
+    const runtime = createAgentEventRuntime(deps);
+    const { pi, registrations } = createPi();
+
+    runtime.register(pi);
+
+    expect(registrations.map(({ eventName }) => eventName)).toEqual([
+      "input",
+      "turn_start",
+      "turn_end",
+      "agent_end",
+      "tool_call",
+      "before_agent_start",
+      "agent_end",
+    ]);
+
+    const agentEndHandlers = registrations.filter(({ eventName }) => eventName === "agent_end");
+    expect(agentEndHandlers).toHaveLength(2);
+    expect(agentEndHandlers[0]?.handler).not.toBe(onCompletionAgentEnd);
+    expect(agentEndHandlers[1]?.handler).toBe(onCompletionAgentEnd);
+    expect(registrations[5]?.handler).toBe(beforeAgentStart);
+  });
+
+  it("hands off tracked Slack follow-up delivery from the created tool-policy runtime", async () => {
+    const {
+      deps,
+      deliverFollowUpMessage,
+      requireToolPolicy,
+      setDeliverTrackedSlackFollowUpMessage,
+    } = createDeps({
+      getGuardrails: () => ({ requireConfirmation: ["read"] }),
+    });
+    const runtime = createAgentEventRuntime(deps);
+    const { pi, registrations } = createPi();
+
+    runtime.register(pi);
+
+    expect(setDeliverTrackedSlackFollowUpMessage).toHaveBeenCalledTimes(1);
+    const deliverTrackedSlackFollowUpMessage = setDeliverTrackedSlackFollowUpMessage.mock
+      .calls[0]?.[0] as
+      | ((options: { prompt: string; messages: Array<{ threadTs?: string }> }) => boolean)
+      | undefined;
+    expect(deliverTrackedSlackFollowUpMessage).toBeTypeOf("function");
+
+    expect(
+      deliverTrackedSlackFollowUpMessage?.({
+        prompt: "guarded slack prompt",
+        messages: [{ threadTs: "100.1" }],
+      }),
+    ).toBe(true);
+    expect(deliverFollowUpMessage).toHaveBeenCalledWith("guarded slack prompt");
+
+    const onInput = registrations.find(({ eventName }) => eventName === "input")?.handler as
+      | ((event: { source?: string; text: string }) => Promise<void>)
+      | undefined;
+    const onTurnStart = registrations.find(({ eventName }) => eventName === "turn_start")
+      ?.handler as (() => Promise<void>) | undefined;
+    const onToolCall = registrations.find(({ eventName }) => eventName === "tool_call")?.handler as
+      | ((event: { toolName: string; input: Record<string, unknown> }) => Promise<unknown>)
+      | undefined;
+
+    await onInput?.({ source: "extension", text: "guarded slack prompt" });
+    await onTurnStart?.();
+
+    await expect(
+      onToolCall?.({
+        toolName: "read",
+        input: { path: "plans/454.md" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "read",
+      "100.1",
+      "path=plans/454.md | offset= | limit=",
+    );
+  });
+});

--- a/slack-bridge/agent-event-runtime.ts
+++ b/slack-bridge/agent-event-runtime.ts
@@ -1,0 +1,49 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { AgentCompletionRuntime } from "./agent-completion-runtime.js";
+import type { AgentPromptGuidance } from "./agent-prompt-guidance.js";
+import {
+  createSlackToolPolicyRuntime,
+  type SlackToolPolicyRuntime,
+  type SlackToolPolicyRuntimeDeps,
+} from "./slack-tool-policy-runtime.js";
+
+export interface AgentEventRuntimeDeps extends SlackToolPolicyRuntimeDeps {
+  beforeAgentStart: AgentPromptGuidance["beforeAgentStart"];
+  onCompletionAgentEnd: AgentCompletionRuntime["onAgentEnd"];
+  setDeliverTrackedSlackFollowUpMessage: (
+    deliver: SlackToolPolicyRuntime["deliverTrackedSlackFollowUpMessage"],
+  ) => void;
+}
+
+export interface AgentEventRuntime {
+  register: (pi: Pick<ExtensionAPI, "on">) => void;
+}
+
+export function createAgentEventRuntime(deps: AgentEventRuntimeDeps): AgentEventRuntime {
+  const slackToolPolicyRuntime = createSlackToolPolicyRuntime({
+    getBrokerRole: deps.getBrokerRole,
+    getGuardrails: deps.getGuardrails,
+    requireToolPolicy: deps.requireToolPolicy,
+    formatAction: deps.formatAction,
+    formatError: deps.formatError,
+    deliverFollowUpMessage: deps.deliverFollowUpMessage,
+  });
+
+  deps.setDeliverTrackedSlackFollowUpMessage(
+    slackToolPolicyRuntime.deliverTrackedSlackFollowUpMessage,
+  );
+
+  function register(pi: Pick<ExtensionAPI, "on">): void {
+    pi.on("input", slackToolPolicyRuntime.onInput);
+    pi.on("turn_start", slackToolPolicyRuntime.onTurnStart);
+    pi.on("turn_end", slackToolPolicyRuntime.onTurnEnd);
+    pi.on("agent_end", slackToolPolicyRuntime.onAgentEnd);
+    pi.on("tool_call", slackToolPolicyRuntime.onToolCall);
+    pi.on("before_agent_start", deps.beforeAgentStart);
+    pi.on("agent_end", deps.onCompletionAgentEnd);
+  }
+
+  return {
+    register,
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -62,7 +62,7 @@ import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
 import { createPinetRemoteControl } from "./pinet-remote-control.js";
 import { createPinetMeshOps } from "./pinet-mesh-ops.js";
 import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
-import { createSlackToolPolicyRuntime } from "./slack-tool-policy-runtime.js";
+import { createAgentEventRuntime } from "./agent-event-runtime.js";
 import { createSessionUiRuntime } from "./session-ui-runtime.js";
 import { createSlackRequestRuntime } from "./slack-request-runtime.js";
 import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
@@ -395,6 +395,19 @@ export default function (pi: ExtensionAPI) {
     },
     signalAgentFree: (ctx) => signalAgentFree(ctx),
     formatError: msg,
+  });
+  const agentEventRuntime = createAgentEventRuntime({
+    getBrokerRole: () => brokerRole,
+    getGuardrails: () => guardrails,
+    requireToolPolicy,
+    formatAction: formatConfirmationAction,
+    formatError: msg,
+    deliverFollowUpMessage,
+    beforeAgentStart: agentPromptGuidance.beforeAgentStart,
+    onCompletionAgentEnd: agentCompletionRuntime.onAgentEnd,
+    setDeliverTrackedSlackFollowUpMessage: (deliver) => {
+      deliverTrackedSlackFollowUpMessage = deliver;
+    },
   });
   const pinetMeshSkin = createPinetMeshSkin({
     getBrokerRole: () => brokerRole,
@@ -1248,35 +1261,9 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  // ─── Agent status reporting ──────────────────────────
+  // ─── Agent event wiring ──────────────────────────────
 
-  const slackToolPolicyRuntime = createSlackToolPolicyRuntime({
-    getBrokerRole: () => brokerRole,
-    getGuardrails: () => guardrails,
-    requireToolPolicy,
-    formatAction: formatConfirmationAction,
-    formatError: msg,
-    deliverFollowUpMessage,
-  });
-  deliverTrackedSlackFollowUpMessage = slackToolPolicyRuntime.deliverTrackedSlackFollowUpMessage;
-
-  pi.on("input", slackToolPolicyRuntime.onInput);
-
-  pi.on("turn_start", slackToolPolicyRuntime.onTurnStart);
-
-  pi.on("turn_end", slackToolPolicyRuntime.onTurnEnd);
-
-  pi.on("agent_end", slackToolPolicyRuntime.onAgentEnd);
-
-  // Hard-block forbidden tools when broker role is active.
-  // Also hard-enforce Slack-origin guardrails for core built-in tools.
-  pi.on("tool_call", slackToolPolicyRuntime.onToolCall);
-
-  // Inject dynamic identity guidance every turn so reload/session restore keeps prompts in sync.
-  pi.on("before_agent_start", agentPromptGuidance.beforeAgentStart);
-
-  // When agent finishes: clear thinking status, mark free, and auto-drain inbox
-  pi.on("agent_end", agentCompletionRuntime.onAgentEnd);
+  agentEventRuntime.register(pi);
 
   pi.on("session_shutdown", async (_event, ctx) => {
     resetRemoteControlState();


### PR DESCRIPTION
## Summary
- extract the narrow agent-event wiring seam into `slack-bridge/agent-event-runtime.ts`
- keep `slack-bridge/index.ts` pinned to session start/shutdown and runtime lifecycle ownership while delegating the moved agent-facing Pi event registrations through the extracted runtime
- add focused coverage for handler ordering and follow-up delivery handoff

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- agent-event-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test