### PR TITLE
refactor: extract tool registration runtime (#456)

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -19,10 +19,8 @@ import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
 import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
-import { registerSlackTools } from "./slack-tools.js";
 import { registerPinetCommands } from "./pinet-commands.js";
-import { registerPinetTools } from "./pinet-tools.js";
-import { registerIMessageTools } from "./imessage-tools.js";
+import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
 import { createSlackRuntimeAccess } from "./slack-runtime-access.js";
 import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
 import {
@@ -558,33 +556,6 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Reconnect / status ─────────────────────────────
 
-  // ─── Tools ──────────────────────────────────────────
-
-  registerSlackTools(pi, {
-    getBotToken: () => {
-      if (!botToken) {
-        throw new Error("Slack bot token is not configured.");
-      }
-      return botToken;
-    },
-    getDefaultChannel: () => settings.defaultChannel,
-    getSecurityPrompt: () => securityPrompt,
-    inbox,
-    slack,
-    getAgentName: () => agentName,
-    getAgentEmoji: () => agentEmoji,
-    getAgentOwnerToken: () => agentOwnerToken,
-    getLastDmChannel: () => lastDmChannel,
-    updateBadge,
-    resolveUser,
-    threadContext: singlePlayerRuntime.getThreadContextPort(),
-    resolveChannel,
-    rememberChannel,
-    requireToolPolicy,
-    getBotUserId: () => botUserId,
-    registerConfirmationRequest,
-  });
-
   // ─── Agent-to-agent messaging tools ──────────────────
 
   // These are registered unconditionally but only work when pinet is active.
@@ -945,45 +916,74 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
-  registerPinetTools(pi, {
-    pinetEnabled: () => pinetEnabled,
-    brokerRole: () => brokerRole,
-    requireToolPolicy,
-    sendPinetAgentMessage,
-    sendPinetBroadcastMessage,
-    signalAgentFree,
-    scheduleBrokerWakeup,
-    scheduleFollowerWakeup,
-    listBrokerAgents,
-    listFollowerAgents,
+  // ─── Tools ──────────────────────────────────────────
+
+  const toolRegistrationRuntime = createToolRegistrationRuntime({
+    slackTools: {
+      getBotToken: () => {
+        if (!botToken) {
+          throw new Error("Slack bot token is not configured.");
+        }
+        return botToken;
+      },
+      getDefaultChannel: () => settings.defaultChannel,
+      getSecurityPrompt: () => securityPrompt,
+      inbox,
+      slack,
+      getAgentName: () => agentName,
+      getAgentEmoji: () => agentEmoji,
+      getAgentOwnerToken: () => agentOwnerToken,
+      getLastDmChannel: () => lastDmChannel,
+      updateBadge,
+      resolveUser,
+      threadContext: singlePlayerRuntime.getThreadContextPort(),
+      resolveChannel,
+      rememberChannel,
+      requireToolPolicy,
+      getBotUserId: () => botUserId,
+      registerConfirmationRequest,
+    },
+    pinetTools: {
+      pinetEnabled: () => pinetEnabled,
+      brokerRole: () => brokerRole,
+      requireToolPolicy,
+      sendPinetAgentMessage,
+      sendPinetBroadcastMessage,
+      signalAgentFree,
+      scheduleBrokerWakeup,
+      scheduleFollowerWakeup,
+      listBrokerAgents,
+      listFollowerAgents,
+    },
+    iMessageTools: {
+      pinetEnabled: () => pinetEnabled,
+      brokerRole: () => brokerRole,
+      requireToolPolicy,
+      getActiveBroker,
+      getActiveBrokerSelfId,
+      sendFollowerIMessage: async (input) => {
+        if (!brokerClient?.client) {
+          throw new Error("Pinet is in an unexpected state.");
+        }
+
+        const result = await brokerClient.client.sendMessage(input);
+        return {
+          adapter: result.adapter,
+          messageId: result.messageId,
+        };
+      },
+      getAgentIdentity: () => ({
+        name: agentName,
+        emoji: agentEmoji,
+        ownerToken: agentOwnerToken,
+      }),
+      trackOwnedThread: (threadId, channel, source) => {
+        singlePlayerRuntime.trackOwnedThread(threadId, channel, source);
+      },
+    },
   });
 
-  registerIMessageTools(pi, {
-    pinetEnabled: () => pinetEnabled,
-    brokerRole: () => brokerRole,
-    requireToolPolicy,
-    getActiveBroker,
-    getActiveBrokerSelfId,
-    sendFollowerIMessage: async (input) => {
-      if (!brokerClient?.client) {
-        throw new Error("Pinet is in an unexpected state.");
-      }
-
-      const result = await brokerClient.client.sendMessage(input);
-      return {
-        adapter: result.adapter,
-        messageId: result.messageId,
-      };
-    },
-    getAgentIdentity: () => ({
-      name: agentName,
-      emoji: agentEmoji,
-      ownerToken: agentOwnerToken,
-    }),
-    trackOwnedThread: (threadId, channel, source) => {
-      singlePlayerRuntime.trackOwnedThread(threadId, channel, source);
-    },
-  });
+  toolRegistrationRuntime.register(pi);
 
   // ─── Commands ───────────────────────────────────────
 

--- a/slack-bridge/tool-registration-runtime.test.ts
+++ b/slack-bridge/tool-registration-runtime.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { RegisterIMessageToolsDeps } from "./imessage-tools.js";
+import type { RegisterPinetToolsDeps } from "./pinet-tools.js";
+import type { RegisterSlackToolsDeps } from "./slack-tools.js";
+import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
+
+const registrationState = vi.hoisted(() => ({
+  registerSlackTools: vi.fn(),
+  registerPinetTools: vi.fn(),
+  registerIMessageTools: vi.fn(),
+}));
+
+vi.mock("./slack-tools.js", () => ({
+  registerSlackTools: registrationState.registerSlackTools,
+}));
+
+vi.mock("./pinet-tools.js", () => ({
+  registerPinetTools: registrationState.registerPinetTools,
+}));
+
+vi.mock("./imessage-tools.js", () => ({
+  registerIMessageTools: registrationState.registerIMessageTools,
+}));
+
+describe("createToolRegistrationRuntime", () => {
+  beforeEach(() => {
+    registrationState.registerSlackTools.mockReset();
+    registrationState.registerPinetTools.mockReset();
+    registrationState.registerIMessageTools.mockReset();
+  });
+
+  it("registers the pinned tool wiring in order with the provided deps", () => {
+    const pi = { registerTool: vi.fn() } as unknown as ExtensionAPI;
+    const slackTools = {} as RegisterSlackToolsDeps;
+    const pinetTools = {} as RegisterPinetToolsDeps;
+    const iMessageTools = {} as RegisterIMessageToolsDeps;
+    const runtime = createToolRegistrationRuntime({
+      slackTools,
+      pinetTools,
+      iMessageTools,
+    });
+
+    runtime.register(pi);
+
+    expect(registrationState.registerSlackTools).toHaveBeenCalledTimes(1);
+    expect(registrationState.registerSlackTools).toHaveBeenCalledWith(pi, slackTools);
+    expect(registrationState.registerPinetTools).toHaveBeenCalledTimes(1);
+    expect(registrationState.registerPinetTools).toHaveBeenCalledWith(pi, pinetTools);
+    expect(registrationState.registerIMessageTools).toHaveBeenCalledTimes(1);
+    expect(registrationState.registerIMessageTools).toHaveBeenCalledWith(pi, iMessageTools);
+
+    expect(registrationState.registerSlackTools.mock.invocationCallOrder[0]).toBeLessThan(
+      registrationState.registerPinetTools.mock.invocationCallOrder[0] ?? Infinity,
+    );
+    expect(registrationState.registerPinetTools.mock.invocationCallOrder[0]).toBeLessThan(
+      registrationState.registerIMessageTools.mock.invocationCallOrder[0] ?? Infinity,
+    );
+  });
+});

--- a/slack-bridge/tool-registration-runtime.ts
+++ b/slack-bridge/tool-registration-runtime.ts
@@ -1,0 +1,28 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerIMessageTools, type RegisterIMessageToolsDeps } from "./imessage-tools.js";
+import { registerPinetTools, type RegisterPinetToolsDeps } from "./pinet-tools.js";
+import { registerSlackTools, type RegisterSlackToolsDeps } from "./slack-tools.js";
+
+export interface ToolRegistrationRuntimeDeps {
+  slackTools: RegisterSlackToolsDeps;
+  pinetTools: RegisterPinetToolsDeps;
+  iMessageTools: RegisterIMessageToolsDeps;
+}
+
+export interface ToolRegistrationRuntime {
+  register: (pi: ExtensionAPI) => void;
+}
+
+export function createToolRegistrationRuntime(
+  deps: ToolRegistrationRuntimeDeps,
+): ToolRegistrationRuntime {
+  function register(pi: ExtensionAPI): void {
+    registerSlackTools(pi, deps.slackTools);
+    registerPinetTools(pi, deps.pinetTools);
+    registerIMessageTools(pi, deps.iMessageTools);
+  }
+
+  return {
+    register,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the narrow tool-registration wiring seam into `slack-bridge/tool-registration-runtime.ts`
- keep `slack-bridge/index.ts` pinned to command registration, session wiring, and runtime lifecycle ownership while delegating only the three moved tool registration call sites through the extracted runtime
- add focused coverage for registration ordering and dependency handoff

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- tool-registration-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm lint
- pnpm typecheck
- pnpm test