### PR TITLE
refactor: extract command registration wiring (#458)

### DIFF
--- a/slack-bridge/command-registration-runtime.test.ts
+++ b/slack-bridge/command-registration-runtime.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { PinetCommandsDeps } from "./pinet-commands.js";
+import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
+
+const registrationState = vi.hoisted(() => ({
+  registerPinetCommands: vi.fn(),
+}));
+
+vi.mock("./pinet-commands.js", () => ({
+  registerPinetCommands: registrationState.registerPinetCommands,
+}));
+
+describe("createCommandRegistrationRuntime", () => {
+  beforeEach(() => {
+    registrationState.registerPinetCommands.mockReset();
+  });
+
+  it("registers the pinned command wiring with the provided deps", () => {
+    const pi = { registerCommand: vi.fn() } as unknown as ExtensionAPI;
+    const pinetCommands = {} as PinetCommandsDeps;
+    const runtime = createCommandRegistrationRuntime({
+      pinetCommands,
+    });
+
+    runtime.register(pi);
+
+    expect(registrationState.registerPinetCommands).toHaveBeenCalledTimes(1);
+    expect(registrationState.registerPinetCommands).toHaveBeenCalledWith(pi, pinetCommands);
+  });
+});

--- a/slack-bridge/command-registration-runtime.ts
+++ b/slack-bridge/command-registration-runtime.ts
@@ -1,0 +1,22 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { registerPinetCommands, type PinetCommandsDeps } from "./pinet-commands.js";
+
+export interface CommandRegistrationRuntimeDeps {
+  pinetCommands: PinetCommandsDeps;
+}
+
+export interface CommandRegistrationRuntime {
+  register: (pi: ExtensionAPI) => void;
+}
+
+export function createCommandRegistrationRuntime(
+  deps: CommandRegistrationRuntimeDeps,
+): CommandRegistrationRuntime {
+  function register(pi: ExtensionAPI): void {
+    registerPinetCommands(pi, deps.pinetCommands);
+  }
+
+  return {
+    register,
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -19,7 +19,7 @@ import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
 import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
-import { registerPinetCommands } from "./pinet-commands.js";
+import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
 import { createSlackRuntimeAccess } from "./slack-runtime-access.js";
 import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
@@ -1141,55 +1141,60 @@ export default function (pi: ExtensionAPI) {
     deliveryState: followerDeliveryState,
   });
 
-  registerPinetCommands(pi, {
-    pinetEnabled: () => pinetEnabled,
-    pinetRegistrationBlocked: pinetRegistrationGate.isBlocked,
-    runtimeMode: () => currentRuntimeMode,
-    runtimeConnected: () =>
-      currentRuntimeMode === "broker"
-        ? brokerRuntime.isConnected()
-        : currentRuntimeMode === "follower"
-          ? brokerClient != null
-          : currentRuntimeMode === "single"
-            ? singlePlayerRuntime.isConnected()
-            : false,
-    brokerRole: () => brokerRole,
-    agentName: () => agentName,
-    agentEmoji: () => agentEmoji,
-    agentOwnerToken: () => agentOwnerToken,
-    agentPersonality: () => agentPersonality,
-    agentAliases: () => agentAliases,
-    botUserId: () => botUserId,
-    activeSkinTheme: () => activeSkinTheme,
-    lastDmChannel: () => lastDmChannel,
-    threads: () => threads,
-    allowedUsers: () => allowedUsers,
-    inboxLength: () => inbox.length,
-    recentActivityLogEntries: (limit) => brokerRuntime.getRecentActivityEntries(limit),
-    settings: () => settings,
-    lastBrokerMaintenance: () => brokerRuntime.getLastMaintenance(),
-    isBrokerControlPlaneCanvasEnabled: () => brokerRuntime.isBrokerControlPlaneCanvasEnabled(),
-    getConfiguredBrokerControlPlaneCanvasId: () =>
-      brokerRuntime.getConfiguredBrokerControlPlaneCanvasId(),
-    getConfiguredBrokerControlPlaneCanvasChannel: () =>
-      brokerRuntime.getConfiguredBrokerControlPlaneCanvasChannel(),
-    lastBrokerControlPlaneCanvasRefreshAt: () => brokerRuntime.getLastControlPlaneCanvasRefreshAt(),
-    lastBrokerControlPlaneCanvasError: () => brokerRuntime.getLastControlPlaneCanvasError(),
-    getBrokerControlPlaneHomeTabViewerIds,
-    lastBrokerControlPlaneHomeTabRefreshAt: () => brokerRuntime.getLastHomeTabRefreshAt(),
-    lastBrokerControlPlaneHomeTabError: () => brokerRuntime.getLastHomeTabError(),
-    getPinetRegistrationBlockReason: pinetRegistrationGate.getBlockReason,
-    connectAsBroker: (ctx) => transitionToRuntimeMode(ctx, "broker"),
-    connectAsFollower: (ctx) => transitionToRuntimeMode(ctx, "follower"),
-    reloadPinetRuntime,
-    disconnectFollower,
-    sendPinetAgentMessage,
-    signalAgentFree,
-    applyMeshSkin,
-    applyLocalAgentIdentity,
-    setExtStatus,
-    setExtCtx: sessionUiRuntime.setExtCtx,
+  const commandRegistrationRuntime = createCommandRegistrationRuntime({
+    pinetCommands: {
+      pinetEnabled: () => pinetEnabled,
+      pinetRegistrationBlocked: pinetRegistrationGate.isBlocked,
+      runtimeMode: () => currentRuntimeMode,
+      runtimeConnected: () =>
+        currentRuntimeMode === "broker"
+          ? brokerRuntime.isConnected()
+          : currentRuntimeMode === "follower"
+            ? brokerClient != null
+            : currentRuntimeMode === "single"
+              ? singlePlayerRuntime.isConnected()
+              : false,
+      brokerRole: () => brokerRole,
+      agentName: () => agentName,
+      agentEmoji: () => agentEmoji,
+      agentOwnerToken: () => agentOwnerToken,
+      agentPersonality: () => agentPersonality,
+      agentAliases: () => agentAliases,
+      botUserId: () => botUserId,
+      activeSkinTheme: () => activeSkinTheme,
+      lastDmChannel: () => lastDmChannel,
+      threads: () => threads,
+      allowedUsers: () => allowedUsers,
+      inboxLength: () => inbox.length,
+      recentActivityLogEntries: (limit) => brokerRuntime.getRecentActivityEntries(limit),
+      settings: () => settings,
+      lastBrokerMaintenance: () => brokerRuntime.getLastMaintenance(),
+      isBrokerControlPlaneCanvasEnabled: () => brokerRuntime.isBrokerControlPlaneCanvasEnabled(),
+      getConfiguredBrokerControlPlaneCanvasId: () =>
+        brokerRuntime.getConfiguredBrokerControlPlaneCanvasId(),
+      getConfiguredBrokerControlPlaneCanvasChannel: () =>
+        brokerRuntime.getConfiguredBrokerControlPlaneCanvasChannel(),
+      lastBrokerControlPlaneCanvasRefreshAt: () =>
+        brokerRuntime.getLastControlPlaneCanvasRefreshAt(),
+      lastBrokerControlPlaneCanvasError: () => brokerRuntime.getLastControlPlaneCanvasError(),
+      getBrokerControlPlaneHomeTabViewerIds,
+      lastBrokerControlPlaneHomeTabRefreshAt: () => brokerRuntime.getLastHomeTabRefreshAt(),
+      lastBrokerControlPlaneHomeTabError: () => brokerRuntime.getLastHomeTabError(),
+      getPinetRegistrationBlockReason: pinetRegistrationGate.getBlockReason,
+      connectAsBroker: (ctx) => transitionToRuntimeMode(ctx, "broker"),
+      connectAsFollower: (ctx) => transitionToRuntimeMode(ctx, "follower"),
+      reloadPinetRuntime,
+      disconnectFollower,
+      sendPinetAgentMessage,
+      signalAgentFree,
+      applyMeshSkin,
+      applyLocalAgentIdentity,
+      setExtStatus,
+      setExtCtx: sessionUiRuntime.setExtCtx,
+    },
   });
+
+  commandRegistrationRuntime.register(pi);
 
   async function connectAsFollower(ctx: ExtensionContext): Promise<void> {
     pinetRegistrationGate.assertCanRegister();


### PR DESCRIPTION
## Summary
- extract the pinned `registerPinetCommands(pi, { ... })` wiring from `slack-bridge/index.ts` into `slack-bridge/command-registration-runtime.ts`
- keep session lifecycle wiring plus transition/reload/connect-disconnect flow in `slack-bridge/index.ts`
- add focused coverage for the command-registration runtime handoff

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- command-registration-runtime.test.ts
- pnpm prepush
