### PR TITLE
fix: correct repository.url in 4 package.json files (gugu910 -> gugu91)

### DIFF
--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gugu910/extensions.git",
+    "url": "git+https://github.com/gugu91/extensions.git",
     "directory": "imessage-bridge"
   },
   "publishConfig": {

--- a/neon-psql/package.json
+++ b/neon-psql/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gugu910/extensions.git",
+    "url": "git+https://github.com/gugu91/extensions.git",
     "directory": "neon-psql"
   },
   "publishConfig": {

--- a/nvim-bridge/package.json
+++ b/nvim-bridge/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gugu910/extensions.git",
+    "url": "git+https://github.com/gugu91/extensions.git",
     "directory": "nvim-bridge"
   },
   "publishConfig": {

--- a/slack-api/package.json
+++ b/slack-api/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gugu910/extensions.git",
+    "url": "git+https://github.com/gugu91/extensions.git",
     "directory": "slack-api"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

The `repository.url` field in four `package.json` files points at `github.com/gugu910/extensions.git`, which 404s. The actual GitHub owner is **`gugu91`** (no trailing zero); `gugu910` is the npm scope.

Result: clicking "Repository" on [npmjs.com/package/@gugu910/pi-slack-api](https://www.npmjs.com/package/@gugu910/pi-slack-api) (and the three others below) hits a GitHub 404. `npm repo @gugu910/<pkg>` also fails.

## Changes

One-character fix in four files:

| File | Before | After |
|---|---|---|
| `imessage-bridge/package.json` | `gugu910/extensions.git` | `gugu91/extensions.git` |
| `neon-psql/package.json` | `gugu910/extensions.git` | `gugu91/extensions.git` |
| `nvim-bridge/package.json` | `gugu910/extensions.git` | `gugu91/extensions.git` |
| `slack-api/package.json` | `gugu910/extensions.git` | `gugu91/extensions.git` |

`slack-bridge/package.json` and `transport-core/package.json` already have the correct URL.

## Impact

Purely fixes the stale npm → GitHub link shown on each package's npm page and via `npm repo <pkg>`. No runtime behaviour changes — resolution of `pi install @gugu910/<pkg>` already goes through the npm registry, not `repository.url`.

Next publish of each affected package picks up the corrected metadata.
