### PR TITLE
fix: preserve inbound Slack file context (#405)

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -274,6 +274,55 @@ describe("classifyMessage", () => {
     }
   });
 
+  it("accepts file_share messages and preserves attachment context", () => {
+    const evt = {
+      type: "message",
+      subtype: "file_share",
+      user: "U1",
+      text: "",
+      channel: "D1",
+      channel_type: "im",
+      ts: "1.1",
+      files: [
+        {
+          id: "F123",
+          title: "incident.md",
+          filetype: "markdown",
+          pretty_type: "Markdown",
+          mode: "snippet",
+          permalink: "https://files.example/F123",
+        },
+      ],
+    };
+    const result = classifyMessage(evt, botId, emptyTracked);
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.isDM).toBe(true);
+      expect(result.text).toBe(
+        [
+          "(Slack message had no plain-text body)",
+          "",
+          "Slack message context:",
+          "- incident.md — Markdown — snippet",
+          "- file_id=F123 | permalink=https://files.example/F123",
+        ].join("\n"),
+      );
+      expect(result.metadata).toEqual({
+        kind: "slack_file_context",
+        files: [
+          {
+            id: "F123",
+            title: "incident.md",
+            prettyType: "Markdown",
+            filetype: "markdown",
+            mode: "snippet",
+            permalink: "https://files.example/F123",
+          },
+        ],
+      });
+    }
+  });
+
   it("accepts messages in tracked threads", () => {
     const tracked = new Set(["100.200"]);
     const evt = {
@@ -632,6 +681,71 @@ describe("SlackAdapter", () => {
     adapter.onInbound(handler);
     // handler is registered (can't easily verify without triggering a message)
     expect(adapter.name).toBe("slack");
+  });
+
+  it("forwards inbound file-share metadata to broker routing", async () => {
+    const adapter = new SlackAdapter(baseConfig);
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    vi.spyOn(
+      adapter as unknown as { resolveUser: (userId: string) => Promise<string> },
+      "resolveUser",
+    ).mockResolvedValue("Alice");
+    vi.spyOn(
+      adapter as unknown as {
+        addReaction: (channel: string, ts: string, emoji: string) => Promise<void>;
+      },
+      "addReaction",
+    ).mockResolvedValue(undefined);
+
+    await (
+      adapter as unknown as {
+        onMessage: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onMessage({
+      type: "message",
+      subtype: "file_share",
+      user: "U_SENDER",
+      text: "",
+      channel: "D123",
+      channel_type: "im",
+      ts: "100.1",
+      files: [
+        {
+          id: "F123",
+          title: "incident.md",
+          pretty_type: "Markdown",
+          filetype: "markdown",
+          mode: "snippet",
+          permalink: "https://files.example/F123",
+        },
+      ],
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        threadId: "100.1",
+        channel: "D123",
+        userId: "U_SENDER",
+        userName: "Alice",
+        metadata: {
+          kind: "slack_file_context",
+          files: [
+            {
+              id: "F123",
+              title: "incident.md",
+              prettyType: "Markdown",
+              filetype: "markdown",
+              mode: "snippet",
+              permalink: "https://files.example/F123",
+            },
+          ],
+        },
+      }),
+    );
   });
 
   it("forwards app_home_opened events to the configured callback", async () => {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -360,7 +360,7 @@ export class SlackAdapter implements MessageAdapter {
     );
     if (!classified.relevant) return;
 
-    const { threadTs, channel, userId, text, isChannelMention, messageTs } = classified;
+    const { threadTs, channel, userId, text, isChannelMention, messageTs, metadata } = classified;
 
     if (!this.threads.has(threadTs)) {
       this.threads.set(threadTs, {
@@ -389,6 +389,7 @@ export class SlackAdapter implements MessageAdapter {
       text,
       timestamp: messageTs,
       ...(isChannelMention ? { isChannelMention: true } : {}),
+      ...(metadata ? { metadata } : {}),
     });
   }
 

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -283,4 +283,67 @@ describe("single-player-runtime", () => {
     expect(spies.updateBadge).toHaveBeenCalledTimes(1);
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
   });
+
+  it("queues Slack file shares with preserved attachment metadata", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const { deps, spies } = createDeps(state);
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      subtype: "file_share",
+      channel: "D123",
+      channel_type: "im",
+      user: "U_SENDER",
+      text: "",
+      ts: "100.2",
+      files: [
+        {
+          id: "F123",
+          title: "incident.md",
+          pretty_type: "Markdown",
+          filetype: "markdown",
+          mode: "snippet",
+          permalink: "https://files.example/F123",
+        },
+      ],
+    });
+
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith({
+      channel: "D123",
+      threadTs: "100.2",
+      userId: "U_SENDER",
+      text: [
+        "(Slack message had no plain-text body)",
+        "",
+        "Slack message context:",
+        "- incident.md — Markdown — snippet",
+        "- file_id=F123 | permalink=https://files.example/F123",
+      ].join("\n"),
+      timestamp: "100.2",
+      metadata: {
+        kind: "slack_file_context",
+        files: [
+          {
+            id: "F123",
+            title: "incident.md",
+            prettyType: "Markdown",
+            filetype: "markdown",
+            mode: "snippet",
+            permalink: "https://files.example/F123",
+          },
+        ],
+      },
+    });
+  });
 });

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -347,7 +347,8 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     const classified = classifyMessage(evt, getCurrentBotUserId(), new Set(threads.keys()));
     if (!classified.relevant) return;
 
-    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
+    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs, metadata } =
+      classified;
 
     if (!threads.has(threadTs)) {
       threads.set(threadTs, { channelId: channel, threadTs, userId, source: "slack" });
@@ -396,6 +397,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       text: messageText,
       timestamp: messageTs,
       ...(isChannelMention && { isChannelMention: true }),
+      ...(metadata ? { metadata } : {}),
     });
     deps.updateBadge();
 

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -5,7 +5,10 @@ import {
   stripBotMention,
   isAbortError,
 } from "./helpers.js";
-import { buildSlackInboundMessageText } from "./slack-message-context.js";
+import {
+  buildSlackInboundMessageText,
+  extractSlackInboundMessageMetadata,
+} from "./slack-message-context.js";
 import {
   extractSlackInteractivePayloadFromEnvelope,
   normalizeSlackBlockActionPayload,
@@ -188,6 +191,7 @@ export type MessageClassification =
       isDM: boolean;
       isChannelMention: boolean;
       messageTs: string;
+      metadata?: Record<string, unknown>;
     };
 
 /**
@@ -201,7 +205,8 @@ export function classifyMessage(
   trackedThreadIds: Set<string>,
   isKnownThread?: (threadTs: string) => boolean,
 ): MessageClassification {
-  if (evt.subtype || evt.bot_id) return { relevant: false };
+  const subtype = typeof evt.subtype === "string" ? evt.subtype : null;
+  if ((subtype && subtype !== "file_share") || evt.bot_id) return { relevant: false };
 
   const text = (evt.text as string) ?? "";
   const user = evt.user as string;
@@ -218,6 +223,7 @@ export function classifyMessage(
   const effectiveTs = threadTs ?? (evt.ts as string);
   const isChannelMention = isMention && !isDM && !isKnown;
   const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
+  const metadata = extractSlackInboundMessageMetadata(evt);
 
   return {
     relevant: true,
@@ -228,6 +234,7 @@ export function classifyMessage(
     isDM,
     isChannelMention,
     messageTs: (evt.ts as string) ?? effectiveTs,
+    ...(metadata ? { metadata } : {}),
   };
 }
 

--- a/slack-bridge/slack-message-context.test.ts
+++ b/slack-bridge/slack-message-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSlackInboundMessageText,
+  extractSlackInboundMessageMetadata,
   extractSlackMessageContextLines,
 } from "./slack-message-context.js";
 
@@ -91,6 +92,48 @@ describe("slack message context extraction", () => {
     expect(extractSlackMessageContextLines(evt, "review")).toEqual([
       "Please review the rollout checklist",
     ]);
+  });
+
+  it("preserves fetchable file-share context and metadata for inbound Slack files", () => {
+    const evt = {
+      files: [
+        {
+          id: "F123",
+          title: "incident.md",
+          name: "incident.md",
+          pretty_type: "Markdown",
+          filetype: "markdown",
+          mimetype: "text/markdown",
+          mode: "snippet",
+          permalink: "https://files.example/F123",
+          url_private: "https://files.example/private/F123",
+          preview: "# Incident\n- capture timeline",
+        },
+      ],
+    } satisfies Record<string, unknown>;
+
+    expect(extractSlackMessageContextLines(evt, "")).toEqual([
+      "incident.md — Markdown — snippet",
+      "file_id=F123 | permalink=https://files.example/F123",
+      "# Incident - capture timeline",
+    ]);
+    expect(extractSlackInboundMessageMetadata(evt)).toEqual({
+      kind: "slack_file_context",
+      files: [
+        {
+          id: "F123",
+          title: "incident.md",
+          name: "incident.md",
+          prettyType: "Markdown",
+          filetype: "markdown",
+          mimetype: "text/markdown",
+          mode: "snippet",
+          permalink: "https://files.example/F123",
+          urlPrivate: "https://files.example/private/F123",
+          preview: "# Incident\n- capture timeline",
+        },
+      ],
+    });
   });
 
   it("dedupes repeated context lines and limits the attached snippet count", () => {

--- a/slack-bridge/slack-message-context.ts
+++ b/slack-bridge/slack-message-context.ts
@@ -25,11 +25,28 @@ function clipLine(value: string, maxLength = 220): string {
   return `${value.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
-function pushContextLine(lines: string[], rawValue: string | null | undefined): void {
+function pushContextLine(
+  lines: string[],
+  rawValue: string | null | undefined,
+  maxLength = 220,
+): void {
   if (!rawValue) return;
-  const normalized = clipLine(normalizeWhitespace(rawValue));
+  const normalized = clipLine(normalizeWhitespace(rawValue), maxLength);
   if (!normalized) return;
   lines.push(normalized);
+}
+
+export interface SlackInboundFileContext {
+  id?: string;
+  title?: string;
+  name?: string;
+  prettyType?: string;
+  filetype?: string;
+  mimetype?: string;
+  mode?: string;
+  permalink?: string;
+  urlPrivate?: string;
+  preview?: string;
 }
 
 function extractTextObject(value: unknown): string[] {
@@ -140,18 +157,73 @@ function extractAttachmentContextLines(attachments: unknown): string[] {
   return lines;
 }
 
+function extractSlackInboundFiles(files: unknown): SlackInboundFileContext[] {
+  const extracted: SlackInboundFileContext[] = [];
+
+  for (const file of asRecordArray(files)) {
+    const entry: SlackInboundFileContext = {};
+
+    const id = asString(file.id);
+    if (id) entry.id = id;
+
+    const title = asString(file.title);
+    if (title) entry.title = title;
+
+    const name = asString(file.name);
+    if (name) entry.name = name;
+
+    const prettyType = asString(file.pretty_type);
+    if (prettyType) entry.prettyType = prettyType;
+
+    const filetype = asString(file.filetype);
+    if (filetype) entry.filetype = filetype;
+
+    const mimetype = asString(file.mimetype);
+    if (mimetype) entry.mimetype = mimetype;
+
+    const mode = asString(file.mode);
+    if (mode) entry.mode = mode;
+
+    const permalink = asString(file.permalink);
+    if (permalink) entry.permalink = permalink;
+
+    const urlPrivate = asString(file.url_private_download) ?? asString(file.url_private);
+    if (urlPrivate) entry.urlPrivate = urlPrivate;
+
+    const preview = asString(file.preview);
+    if (preview) entry.preview = preview;
+
+    if (Object.keys(entry).length > 0) {
+      extracted.push(entry);
+    }
+  }
+
+  return extracted;
+}
+
+function buildSlackFileSummaryLine(file: SlackInboundFileContext): string | null {
+  const label = file.title ?? file.name ?? null;
+  const type = file.prettyType ?? file.filetype ?? file.mimetype ?? null;
+  const parts = [label, type, file.mode].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(" — ") : null;
+}
+
+function buildSlackFileHandleLine(file: SlackInboundFileContext): string | null {
+  const parts = [
+    file.id ? `file_id=${file.id}` : null,
+    file.permalink ? `permalink=${file.permalink}` : null,
+  ].filter((part): part is string => Boolean(part));
+
+  return parts.length > 0 ? parts.join(" | ") : null;
+}
+
 function extractFileContextLines(files: unknown): string[] {
   const lines: string[] = [];
 
-  for (const file of asRecordArray(files)) {
-    const title = asString(file.title) ?? asString(file.name);
-    const prettyType = asString(file.pretty_type) ?? asString(file.filetype);
-    const mode = asString(file.mode);
-
-    const parts = [title, prettyType, mode].filter((part): part is string => Boolean(part));
-    if (parts.length === 0) continue;
-
-    pushContextLine(lines, parts.join(" — "));
+  for (const file of extractSlackInboundFiles(files)) {
+    pushContextLine(lines, buildSlackFileSummaryLine(file));
+    pushContextLine(lines, buildSlackFileHandleLine(file), 500);
+    pushContextLine(lines, file.preview);
   }
 
   return lines;
@@ -187,6 +259,20 @@ export function extractSlackMessageContextLines(
   ];
 
   return dedupeContextLines(baseText, lines).slice(0, 4);
+}
+
+export function extractSlackInboundMessageMetadata(
+  evt: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const files = extractSlackInboundFiles(evt.files);
+  if (files.length === 0) {
+    return undefined;
+  }
+
+  return {
+    kind: "slack_file_context",
+    files,
+  };
 }
 
 export function buildSlackInboundMessageText(


### PR DESCRIPTION
## Summary
- stop dropping inbound Slack `message.file_share` events during message classification
- preserve inbound Slack file-share context with file ids, permalinks, and previews in normalized message text/metadata
- thread the preserved attachment metadata through both broker and single-player Slack ingress paths

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge test -- slack-message-context.test.ts single-player-runtime.test.ts broker/adapters/slack.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm prepush`
