### PR TITLE
fix: preserve inbound Slack file context (#405)

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -212,7 +212,7 @@ describe("classifyMessage", () => {
   const botId = "U_BOT";
   const emptyTracked = new Set<string>();
 
-  it("rejects messages with subtype", () => {
+  it("rejects unrelated message subtypes", () => {
     const evt = {
       type: "message",
       subtype: "channel_join",
@@ -224,6 +224,47 @@ describe("classifyMessage", () => {
     expect(classifyMessage(evt, botId, emptyTracked)).toEqual({
       relevant: false,
     });
+  });
+
+  it("accepts file_share subtype messages and preserves fetchable file metadata", () => {
+    const evt = {
+      type: "message",
+      subtype: "file_share",
+      user: "U1",
+      text: "",
+      channel: "D1",
+      channel_type: "im",
+      ts: "1.1",
+      files: [
+        {
+          id: "F123",
+          title: "Incident notes",
+          filetype: "markdown",
+          mode: "snippet",
+          permalink: "https://files.example/incident.md",
+          url_private_download: "https://files.example/download/F123",
+        },
+      ],
+    };
+
+    const result = classifyMessage(evt, botId, emptyTracked);
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.text).toContain("Incident notes — markdown — snippet — id=F123");
+      expect(result.metadata).toEqual({
+        slackSubtype: "file_share",
+        slackFiles: [
+          {
+            id: "F123",
+            title: "Incident notes",
+            filetype: "markdown",
+            permalink: "https://files.example/incident.md",
+            urlPrivate: "https://files.example/download/F123",
+            mode: "snippet",
+          },
+        ],
+      });
+    }
   });
 
   it("rejects messages from bots", () => {
@@ -1600,6 +1641,112 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     expect(endpoints).toContain("https://slack.com/api/chat.postMessage");
     expect(endpoints).toContain("https://slack.com/api/reactions.remove");
     expect(endpoints).toContain("https://slack.com/api/assistant.threads.setStatus");
+
+    await adapter.disconnect();
+  });
+
+  it("emits structured file metadata for inbound file_share messages", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      const ok = (data: Record<string, unknown>) =>
+        new Response(JSON.stringify({ ok: true, ...data }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+
+      if (url.endsWith("/auth.test")) {
+        return ok({ user_id: "U_BOT" });
+      }
+      if (url.endsWith("/apps.connections.open")) {
+        return ok({ url: "wss://slack.test/socket" });
+      }
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U123");
+        return ok({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "D123", timestamp: "111.222", name: "eyes" });
+        return ok({});
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await adapter.connect();
+
+    const ws = FakeWebSocket.instances[0]!;
+    ws.emit("message", {
+      data: JSON.stringify({
+        envelope_id: "env-2",
+        type: "events_api",
+        payload: {
+          event_id: "Ev-2",
+          event: {
+            type: "message",
+            subtype: "file_share",
+            user: "U123",
+            text: "",
+            channel: "D123",
+            channel_type: "im",
+            ts: "111.222",
+            files: [
+              {
+                id: "F123",
+                title: "Incident notes",
+                filetype: "markdown",
+                mode: "snippet",
+                permalink: "https://files.example/incident.md",
+                url_private_download: "https://files.example/download/F123",
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    await waitForAssertion(() => {
+      expect(ws.sent).toContain(JSON.stringify({ envelope_id: "env-2" }));
+      expect(handler).toHaveBeenCalledWith({
+        source: "slack",
+        threadId: "111.222",
+        channel: "D123",
+        userId: "U123",
+        userName: "Alice Example",
+        text: [
+          "(Slack message had no plain-text body)",
+          "",
+          "Slack message context:",
+          "- Incident notes — markdown — snippet — id=F123 — https://files.example/incident.md",
+        ].join("\n"),
+        timestamp: "111.222",
+        metadata: {
+          slackSubtype: "file_share",
+          slackFiles: [
+            {
+              id: "F123",
+              title: "Incident notes",
+              filetype: "markdown",
+              permalink: "https://files.example/incident.md",
+              urlPrivate: "https://files.example/download/F123",
+              mode: "snippet",
+            },
+          ],
+        },
+      });
+    });
 
     await adapter.disconnect();
   });

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -360,7 +360,7 @@ export class SlackAdapter implements MessageAdapter {
     );
     if (!classified.relevant) return;
 
-    const { threadTs, channel, userId, text, isChannelMention, messageTs } = classified;
+    const { threadTs, channel, userId, text, isChannelMention, messageTs, metadata } = classified;
 
     if (!this.threads.has(threadTs)) {
       this.threads.set(threadTs, {
@@ -389,6 +389,7 @@ export class SlackAdapter implements MessageAdapter {
       text,
       timestamp: messageTs,
       ...(isChannelMention ? { isChannelMention: true } : {}),
+      ...(metadata ? { metadata } : {}),
     });
   }
 

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -53,7 +53,12 @@ type TestState = {
   threads: Map<string, SinglePlayerThreadState>;
   pendingEyes: Map<string, SinglePlayerPendingAttention[]>;
   unclaimedThreads: Set<string>;
-  inbox: Array<{ text: string; channel: string; threadTs: string }>;
+  inbox: Array<{
+    text: string;
+    channel: string;
+    threadTs: string;
+    metadata?: Record<string, unknown>;
+  }>;
   lastDmChannel: string | null;
 };
 
@@ -71,9 +76,16 @@ function createContext(notify = vi.fn()): ExtensionContext {
 }
 
 function createDeps(state: TestState, overrides: Partial<SinglePlayerRuntimeDeps> = {}) {
-  const pushInboxMessage = vi.fn((message: { text: string; channel: string; threadTs: string }) => {
-    state.inbox.push(message);
-  });
+  const pushInboxMessage = vi.fn(
+    (message: {
+      text: string;
+      channel: string;
+      threadTs: string;
+      metadata?: Record<string, unknown>;
+    }) => {
+      state.inbox.push(message);
+    },
+  );
   const persistState = vi.fn();
   const updateBadge = vi.fn();
   const maybeDrainInboxIfIdle = vi.fn(() => true);
@@ -282,5 +294,67 @@ describe("single-player-runtime", () => {
     });
     expect(spies.updateBadge).toHaveBeenCalledTimes(1);
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
+  });
+
+  it("preserves file-share metadata on inbound Slack messages", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const { deps, spies } = createDeps(state);
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      subtype: "file_share",
+      channel: "D123",
+      channel_type: "im",
+      user: "U_SENDER",
+      text: "",
+      ts: "100.1",
+      files: [
+        {
+          id: "F123",
+          title: "Incident notes",
+          filetype: "markdown",
+          mode: "snippet",
+          permalink: "https://files.example/incident.md",
+          url_private_download: "https://files.example/download/F123",
+        },
+      ],
+    });
+
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith({
+      channel: "D123",
+      threadTs: "100.1",
+      userId: "U_SENDER",
+      text: [
+        "(Slack message had no plain-text body)",
+        "",
+        "Slack message context:",
+        "- Incident notes — markdown — snippet — id=F123 — https://files.example/incident.md",
+      ].join("\n"),
+      timestamp: "100.1",
+      metadata: {
+        slackSubtype: "file_share",
+        slackFiles: [
+          {
+            id: "F123",
+            title: "Incident notes",
+            filetype: "markdown",
+            permalink: "https://files.example/incident.md",
+            urlPrivate: "https://files.example/download/F123",
+            mode: "snippet",
+          },
+        ],
+      },
+    });
   });
 });

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -347,7 +347,8 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     const classified = classifyMessage(evt, getCurrentBotUserId(), new Set(threads.keys()));
     if (!classified.relevant) return;
 
-    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs } = classified;
+    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs, metadata } =
+      classified;
 
     if (!threads.has(threadTs)) {
       threads.set(threadTs, { channelId: channel, threadTs, userId, source: "slack" });
@@ -396,6 +397,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       text: messageText,
       timestamp: messageTs,
       ...(isChannelMention && { isChannelMention: true }),
+      ...(metadata ? { metadata } : {}),
     });
     deps.updateBadge();
 

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -5,7 +5,10 @@ import {
   stripBotMention,
   isAbortError,
 } from "./helpers.js";
-import { buildSlackInboundMessageText } from "./slack-message-context.js";
+import {
+  buildSlackInboundMessageText,
+  extractSlackMessageFileMetadata,
+} from "./slack-message-context.js";
 import {
   extractSlackInteractivePayloadFromEnvelope,
   normalizeSlackBlockActionPayload,
@@ -188,6 +191,7 @@ export type MessageClassification =
       isDM: boolean;
       isChannelMention: boolean;
       messageTs: string;
+      metadata?: Record<string, unknown>;
     };
 
 /**
@@ -201,7 +205,9 @@ export function classifyMessage(
   trackedThreadIds: Set<string>,
   isKnownThread?: (threadTs: string) => boolean,
 ): MessageClassification {
-  if (evt.subtype || evt.bot_id) return { relevant: false };
+  const subtype = typeof evt.subtype === "string" ? evt.subtype : undefined;
+  const allowsSubtype = subtype === undefined || subtype === "file_share";
+  if (!allowsSubtype || evt.bot_id) return { relevant: false };
 
   const text = (evt.text as string) ?? "";
   const user = evt.user as string;
@@ -218,6 +224,11 @@ export function classifyMessage(
   const effectiveTs = threadTs ?? (evt.ts as string);
   const isChannelMention = isMention && !isDM && !isKnown;
   const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
+  const slackFiles = extractSlackMessageFileMetadata(evt.files);
+  const metadata: Record<string, unknown> = {
+    ...(subtype ? { slackSubtype: subtype } : {}),
+    ...(slackFiles.length > 0 ? { slackFiles } : {}),
+  };
 
   return {
     relevant: true,
@@ -228,6 +239,7 @@ export function classifyMessage(
     isDM,
     isChannelMention,
     messageTs: (evt.ts as string) ?? effectiveTs,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
   };
 }
 

--- a/slack-bridge/slack-message-context.test.ts
+++ b/slack-bridge/slack-message-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildSlackInboundMessageText,
   extractSlackMessageContextLines,
+  extractSlackMessageFileMetadata,
 } from "./slack-message-context.js";
 
 describe("slack message context extraction", () => {
@@ -90,6 +91,56 @@ describe("slack message context extraction", () => {
 
     expect(extractSlackMessageContextLines(evt, "review")).toEqual([
       "Please review the rollout checklist",
+    ]);
+  });
+
+  it("extracts fetchable Slack file metadata for later follow-up", () => {
+    const files = [
+      {
+        id: "F123",
+        name: "incident.md",
+        title: "Incident notes",
+        mimetype: "text/markdown",
+        filetype: "markdown",
+        pretty_type: "Markdown",
+        permalink: "https://files.example/incident.md",
+        url_private_download: "https://files.example/download/F123",
+        mode: "snippet",
+        size: 128,
+      },
+    ] satisfies unknown[];
+
+    expect(extractSlackMessageFileMetadata(files)).toEqual([
+      {
+        id: "F123",
+        name: "incident.md",
+        title: "Incident notes",
+        mimetype: "text/markdown",
+        filetype: "markdown",
+        prettyType: "Markdown",
+        permalink: "https://files.example/incident.md",
+        urlPrivate: "https://files.example/download/F123",
+        mode: "snippet",
+        size: 128,
+      },
+    ]);
+  });
+
+  it("keeps file-share context lines fetchable instead of title-only", () => {
+    const evt = {
+      files: [
+        {
+          id: "F123",
+          title: "Incident notes",
+          filetype: "markdown",
+          mode: "snippet",
+          permalink: "https://files.example/incident.md",
+        },
+      ],
+    } satisfies Record<string, unknown>;
+
+    expect(extractSlackMessageContextLines(evt, "")).toEqual([
+      "Incident notes — markdown — snippet — id=F123 — https://files.example/incident.md",
     ]);
   });
 

--- a/slack-bridge/slack-message-context.ts
+++ b/slack-bridge/slack-message-context.ts
@@ -140,15 +140,62 @@ function extractAttachmentContextLines(attachments: unknown): string[] {
   return lines;
 }
 
+export interface SlackMessageFileMetadata {
+  id?: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  filetype?: string;
+  prettyType?: string;
+  permalink?: string;
+  urlPrivate?: string;
+  mode?: string;
+  size?: number;
+}
+
+export function extractSlackMessageFileMetadata(files: unknown): SlackMessageFileMetadata[] {
+  const extracted: SlackMessageFileMetadata[] = [];
+
+  for (const file of asRecordArray(files)) {
+    const metadata: SlackMessageFileMetadata = {
+      ...(asString(file.id) ? { id: asString(file.id) ?? undefined } : {}),
+      ...(asString(file.name) ? { name: asString(file.name) ?? undefined } : {}),
+      ...(asString(file.title) ? { title: asString(file.title) ?? undefined } : {}),
+      ...(asString(file.mimetype) ? { mimetype: asString(file.mimetype) ?? undefined } : {}),
+      ...(asString(file.filetype) ? { filetype: asString(file.filetype) ?? undefined } : {}),
+      ...(asString(file.pretty_type)
+        ? { prettyType: asString(file.pretty_type) ?? undefined }
+        : {}),
+      ...(asString(file.permalink) ? { permalink: asString(file.permalink) ?? undefined } : {}),
+      ...(asString(file.url_private_download)
+        ? { urlPrivate: asString(file.url_private_download) ?? undefined }
+        : asString(file.url_private)
+          ? { urlPrivate: asString(file.url_private) ?? undefined }
+          : {}),
+      ...(asString(file.mode) ? { mode: asString(file.mode) ?? undefined } : {}),
+      ...(typeof file.size === "number" ? { size: file.size } : {}),
+    };
+
+    if (Object.keys(metadata).length === 0) continue;
+    extracted.push(metadata);
+  }
+
+  return extracted;
+}
+
 function extractFileContextLines(files: unknown): string[] {
   const lines: string[] = [];
 
-  for (const file of asRecordArray(files)) {
-    const title = asString(file.title) ?? asString(file.name);
-    const prettyType = asString(file.pretty_type) ?? asString(file.filetype);
-    const mode = asString(file.mode);
-
-    const parts = [title, prettyType, mode].filter((part): part is string => Boolean(part));
+  for (const file of extractSlackMessageFileMetadata(files)) {
+    const title = file.title ?? file.name;
+    const prettyType = file.prettyType ?? file.filetype ?? file.mimetype;
+    const parts = [
+      title,
+      prettyType,
+      file.mode,
+      file.id ? `id=${file.id}` : null,
+      file.permalink ?? file.urlPrivate ?? null,
+    ].filter((part): part is string => Boolean(part));
     if (parts.length === 0) continue;
 
     pushContextLine(lines, parts.join(" — "));


### PR DESCRIPTION
## Summary
- allow inbound `message.file_share` events through the existing Slack ingress classification instead of dropping them with all other message subtypes
- preserve fetchable Slack file metadata on inbound messages for both broker and single-player runtimes
- upgrade compact Slack file context text so agents can see file ids and permalinks instead of title-only summaries

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- slack-message-context.test.ts broker/adapters/slack.test.ts single-player-runtime.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test