### PR TITLE
fix: dedupe stable RALPH follow-up alerts

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -2364,10 +2364,22 @@ describe("shouldDeliverRalphLoopFollowUp", () => {
     ).toBe(true);
   });
 
-  it("allows the same signature again after cooldown", () => {
+  it("does not resend the same signature again after cooldown without new evidence", () => {
     expect(
       shouldDeliverRalphLoopFollowUp({
         signature: "ghost agents detected: ghost-1",
+        lastDeliveredSignature: "ghost agents detected: ghost-1",
+        lastDeliveredAt: 10_000,
+        now: 10_000 + DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows a changed signature after cooldown", () => {
+    expect(
+      shouldDeliverRalphLoopFollowUp({
+        signature: "ghost agents detected: ghost-2",
+        lastDeliveredSignature: "ghost agents detected: ghost-1",
         lastDeliveredAt: 10_000,
         now: 10_000 + DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
       }),
@@ -2396,6 +2408,7 @@ describe("shouldDeliverRalphLoopFollowUp", () => {
     expect(
       shouldDeliverRalphLoopFollowUp({
         signature: "ghost agents detected: ghost-1",
+        lastDeliveredSignature: "ghost agents detected: ghost-0",
         lastDeliveredAt: 10_000,
         now: 10_000 + DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS - 1,
       }),
@@ -2416,6 +2429,7 @@ describe("shouldDeliverRalphLoopFollowUp", () => {
     expect(
       shouldDeliverRalphLoopFollowUp({
         signature: "ghost agents detected: ghost-1",
+        lastDeliveredSignature: "ghost agents detected: ghost-1",
         lastDeliveredAt: deliveredAt,
         now: deliveredAt + DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS - 1,
       }),

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1317,6 +1317,7 @@ export function buildRalphLoopStatusMessage(summary: string, cycleStartedAt: str
 
 export interface RalphLoopFollowUpDeliveryOptions {
   signature: string;
+  lastDeliveredSignature?: string;
   lastDeliveredAt?: number;
   now?: number;
   cooldownMs?: number;
@@ -1335,6 +1336,9 @@ export function shouldDeliverRalphLoopFollowUp(options: RalphLoopFollowUpDeliver
     return false;
   }
   if (pending || !idle) {
+    return false;
+  }
+  if (options.lastDeliveredSignature === options.signature) {
     return false;
   }
   if (lastDeliveredAt > 0 && now - lastDeliveredAt < cooldownMs) {

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -43,6 +43,7 @@ export interface RalphLoopState {
   hadOutstandingAnomalies: boolean;
   followUpAt: number;
   followUpPending: boolean;
+  followUpSignature: string;
   taskAssignmentReportSignature: string;
   pendingTaskAssignmentReport: { message: string; signature: string } | null;
 }
@@ -58,6 +59,7 @@ export function createRalphLoopState(): RalphLoopState {
     hadOutstandingAnomalies: false,
     followUpAt: 0,
     followUpPending: false,
+    followUpSignature: "",
     taskAssignmentReportSignature: "",
     pendingTaskAssignmentReport: null,
   };
@@ -76,6 +78,7 @@ export function resetRalphLoopState(state: RalphLoopState): void {
   state.hadOutstandingAnomalies = false;
   state.followUpAt = 0;
   state.followUpPending = false;
+  state.followUpSignature = "";
   state.taskAssignmentReportSignature = "";
   state.pendingTaskAssignmentReport = null;
 }
@@ -331,21 +334,33 @@ export async function runRalphLoopCycle(
       );
     }
 
+    const shouldWarn =
+      ghostRewrite.newGhostIds.length > 0 ||
+      (nonGhostSignature.length > 0 && nonGhostSignature !== state.nonGhostSignature);
+    const shouldInform =
+      ghostRewrite.clearedGhostIds.length > 0 && visibleEvaluation.anomalies.length > 0;
+
     const shouldDeliverFollowUp =
       followUpPrompt != null &&
       shouldDeliverRalphLoopFollowUp({
         signature: visibleSignature,
+        lastDeliveredSignature: state.followUpSignature,
         lastDeliveredAt: state.followUpAt,
         now,
         cooldownMs: DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
         pending: state.followUpPending,
         idle: ctx.isIdle?.() ?? true,
-      });
+      }) &&
+      (shouldWarn || shouldInform);
     if (shouldDeliverFollowUp && followUpPrompt) {
       deps.trySendFollowUp(followUpPrompt, () => {
         state.followUpPending = true;
         state.followUpAt = now;
+        state.followUpSignature = visibleSignature;
       });
+    }
+    if (!hasOutstandingAnomalies) {
+      state.followUpSignature = "";
     }
     if (state.pendingTaskAssignmentReport && (ctx.isIdle?.() ?? true)) {
       const reportToDeliver = state.pendingTaskAssignmentReport;
@@ -354,12 +369,6 @@ export async function runRalphLoopCycle(
         state.pendingTaskAssignmentReport = null;
       });
     }
-
-    const shouldWarn =
-      ghostRewrite.newGhostIds.length > 0 ||
-      (nonGhostSignature.length > 0 && nonGhostSignature !== state.nonGhostSignature);
-    const shouldInform =
-      ghostRewrite.clearedGhostIds.length > 0 && visibleEvaluation.anomalies.length > 0;
     if (shouldWarn) {
       ctx.ui.notify(ralphNotifications.anomalyStatus ?? "RALPH loop anomaly detected", "warning");
     } else if (shouldInform) {


### PR DESCRIPTION
## Summary
- add follow-up signature tracking to the RALPH loop state
- stop re-sending the same anomaly follow-up after cooldown when the evidence picture has not changed
- keep follow-ups for genuinely new or changed evidence, with regression coverage for the helper and loop wiring

## Checks
- pnpm exec vitest run slack-bridge/helpers.test.ts slack-bridge/ralph-loop.test.ts
- pnpm exec tsc --noEmit -p slack-bridge/tsconfig.json
- pnpm exec eslint slack-bridge --ext .ts

## Notes
- scope is intentionally pinned to repeated unchanged follow-up delivery only
- `#341` is already fixed/superseded as written on current `main`
- `#483` was an earlier preflight hypothesis, not the narrowest live seam

Closes #486
