### PR TITLE
fix: detect live Slack scope drift before tool failures (#479)

### DIFF
--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -178,7 +178,11 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionShutdown?.({}, ctx);
 
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(
+      fetchSpy.mock.calls.some(
+        (call) => String(call.at(0)) === "https://slack.com/api/conversations.create",
+      ),
+    ).toBe(true);
     expect(notify).not.toHaveBeenCalled();
     expect(setStatus).toHaveBeenCalledTimes(2);
   });
@@ -348,8 +352,11 @@ describe("slack-bridge top-level shutdown", () => {
     expect(response).toMatchObject({
       details: { id: "C123", name: "reload-test" },
     });
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://slack.com/api/conversations.create");
+    expect(
+      fetchSpy.mock.calls.some(
+        (call) => String(call.at(0)) === "https://slack.com/api/conversations.create",
+      ),
+    ).toBe(true);
 
     await sessionShutdown?.({}, ctx);
     expect(notify).not.toHaveBeenCalledWith(
@@ -1219,7 +1226,145 @@ describe("slack-bridge top-level shutdown", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
 
     await sessionShutdown?.({}, ctx);
-    expect(FakeWebSocket.instances[0]?.close).toHaveBeenCalled();
+    const firstSocket = FakeWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+    if (!firstSocket) {
+      throw new Error("Expected a single-mode websocket instance");
+    }
+    expect(firstSocket.close).toHaveBeenCalled();
+  });
+
+  it("warns and reports status when live Slack scope drift is detected at startup", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-scope-drift-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-scope-drift-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(async (input) => {
+      const url = String(input);
+      if (url === "https://slack.com/api/apps.connections.open") {
+        return new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/files.info") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "missing_scope", needed: "files:read" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url === "https://slack.com/api/files.completeUploadExternal") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "missing_scope", needed: "files:write" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url === "https://slack.com/api/bookmarks.list") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "missing_scope", needed: "bookmarks:read" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url === "https://slack.com/api/bookmarks.remove") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "missing_scope", needed: "bookmarks:write" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url === "https://slack.com/api/pins.add") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "missing_scope", needed: "pins:write" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch url: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStatus = commands.get("pinet-status");
+
+    await sessionStart?.({}, ctx);
+    await vi.waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Slack scope drift detected: missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write.",
+        ),
+        "warning",
+      );
+    });
+    await pinetStatus?.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Slack scope drift detected: missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write.",
+      ),
+      "warning",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Slack tool health: scope drift — missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write",
+      ),
+      "info",
+    );
+
+    await sessionShutdown?.({}, ctx);
   });
 
   it("transitions from single runtime mode to broker mode without leaving the direct Slack socket open", async () => {
@@ -1326,9 +1471,18 @@ describe("slack-bridge top-level shutdown", () => {
 
     await pinetStart?.handler("", ctx);
 
-    expect(FakeWebSocket.instances[0]?.close).toHaveBeenCalled();
+    const firstSocket = FakeWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+    if (!firstSocket) {
+      throw new Error("Expected a single-mode websocket instance");
+    }
+    expect(firstSocket.close).toHaveBeenCalled();
     expect(brokerModule.startBroker).toHaveBeenCalledTimes(1);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(
+      fetchSpy.mock.calls.some(
+        (call) => String(call.at(0)) === "https://slack.com/api/apps.connections.open",
+      ),
+    ).toBe(true);
 
     await sessionShutdown?.({}, ctx);
   });
@@ -1754,13 +1908,21 @@ describe("slack-bridge top-level shutdown", () => {
     try {
       const startup = sessionStart?.({}, ctx);
       await Promise.resolve();
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(
+        fetchSpy.mock.calls.some(
+          (call) => String(call.at(0)) === "https://slack.com/api/apps.connections.open",
+        ),
+      ).toBe(true);
 
       await pinetStart?.handler("", ctx);
       await startup;
 
       await vi.advanceTimersByTimeAsync(5_001);
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(
+        fetchSpy.mock.calls.some(
+          (call) => String(call.at(0)) === "https://slack.com/api/apps.connections.open",
+        ),
+      ).toBe(true);
       expect(brokerModule.startBroker).toHaveBeenCalledTimes(1);
 
       await sessionShutdown?.({}, ctx);

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1320,6 +1320,15 @@ describe("slack-bridge top-level shutdown", () => {
           },
         );
       }
+      if (url === "https://slack.com/api/pins.list") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "missing_scope", needed: "pins:read" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
       if (url === "https://slack.com/api/pins.add") {
         return new Response(
           JSON.stringify({ ok: false, error: "missing_scope", needed: "pins:write" }),
@@ -1344,7 +1353,7 @@ describe("slack-bridge top-level shutdown", () => {
     await vi.waitFor(() => {
       expect(notify).toHaveBeenCalledWith(
         expect.stringContaining(
-          "Slack scope drift detected: missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write.",
+          "Slack scope drift detected: missing bookmarks:read, bookmarks:write, files:read, files:write, pins:read, pins:write.",
         ),
         "warning",
       );
@@ -1353,13 +1362,13 @@ describe("slack-bridge top-level shutdown", () => {
 
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Slack scope drift detected: missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write.",
+        "Slack scope drift detected: missing bookmarks:read, bookmarks:write, files:read, files:write, pins:read, pins:write.",
       ),
       "warning",
     );
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Slack tool health: scope drift — missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write",
+        "Slack tool health: scope drift — missing bookmarks:read, bookmarks:write, files:read, files:write, pins:read, pins:write",
       ),
       "info",
     );

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -71,6 +71,12 @@ import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
 } from "./runtime-mode.js";
+import {
+  buildSlackScopeDriftWarning,
+  createPendingSlackScopeDiagnostics,
+  createUncheckedSlackScopeDiagnostics,
+  detectSlackScopeDiagnostics,
+} from "./slack-scope-diagnostics.js";
 
 // Settings and helpers imported from ./helpers.js
 
@@ -109,6 +115,9 @@ export default function (pi: ExtensionAPI) {
   let securityPrompt = buildSecurityPrompt(guardrails);
 
   let botUserId: string | null = null;
+  let slackScopeDiagnostics = createUncheckedSlackScopeDiagnostics();
+  let slackScopeDiagnosticsRefresh: Promise<void> | null = null;
+  let lastSlackScopeDriftWarning = "";
 
   const threads = new Map<string, SinglePlayerThreadInfo>();
   const pendingEyes = new Map<string, SinglePlayerPendingAttentionEntry[]>(); // thread_ts → message ts list // thread_ts values showing "is thinking…"
@@ -298,6 +307,59 @@ export default function (pi: ExtensionAPI) {
     buildSkinMetadata,
     applyRegistrationIdentity,
   } = runtimeAgentContext;
+
+  async function refreshSlackScopeDiagnostics(ctx?: ExtensionContext): Promise<void> {
+    if (!botToken) {
+      slackScopeDiagnostics = createUncheckedSlackScopeDiagnostics();
+      lastSlackScopeDriftWarning = "";
+      return;
+    }
+
+    slackScopeDiagnostics = createPendingSlackScopeDiagnostics();
+    const diagnostics = await detectSlackScopeDiagnostics({ token: botToken });
+    slackScopeDiagnostics = diagnostics;
+
+    const warning = buildSlackScopeDriftWarning(diagnostics);
+    if (!warning) {
+      lastSlackScopeDriftWarning = "";
+      return;
+    }
+
+    if (warning === lastSlackScopeDriftWarning) {
+      return;
+    }
+
+    lastSlackScopeDriftWarning = warning;
+    console.warn(`[slack-bridge] ${warning}`);
+    ctx?.ui.notify(warning, "warning");
+  }
+
+  async function ensureSlackScopeDiagnostics(ctx?: ExtensionContext): Promise<void> {
+    if (slackScopeDiagnosticsRefresh) {
+      await slackScopeDiagnosticsRefresh;
+      return;
+    }
+
+    slackScopeDiagnosticsRefresh = refreshSlackScopeDiagnostics(ctx)
+      .catch((error) => {
+        slackScopeDiagnostics = {
+          status: "unavailable",
+          checkedAt: new Date().toISOString(),
+          summary: `unavailable (${msg(error)})`,
+          surfaces: [],
+          missingScopes: [],
+          results: [],
+          error: msg(error),
+        };
+        lastSlackScopeDriftWarning = "";
+      })
+      .finally(() => {
+        slackScopeDiagnosticsRefresh = null;
+      });
+
+    await slackScopeDiagnosticsRefresh;
+  }
+
   const agentPromptGuidance = createAgentPromptGuidance({
     getIdentityGuidelines: runtimeAgentContext.getIdentityGuidelines,
     getAgentName: () => agentName,
@@ -839,15 +901,18 @@ export default function (pi: ExtensionAPI) {
       setExtStatus(ctx, "reconnecting");
       await singlePlayerRuntime.connect(ctx);
       botUserId = singlePlayerRuntime.getBotUserId() ?? botUserId;
+      void ensureSlackScopeDiagnostics(ctx);
       return;
     }
 
     if (mode === "broker") {
       await connectAsBroker(ctx);
+      void ensureSlackScopeDiagnostics(ctx);
       return;
     }
 
     await connectAsFollower(ctx);
+    void ensureSlackScopeDiagnostics(ctx);
   }
 
   async function stopPinetRuntime(
@@ -1167,6 +1232,7 @@ export default function (pi: ExtensionAPI) {
       allowedUsers: () => allowedUsers,
       inboxLength: () => inbox.length,
       recentActivityLogEntries: (limit) => brokerRuntime.getRecentActivityEntries(limit),
+      slackScopeDiagnostics: () => slackScopeDiagnostics,
       settings: () => settings,
       lastBrokerMaintenance: () => brokerRuntime.getLastMaintenance(),
       isBrokerControlPlaneCanvasEnabled: () => brokerRuntime.isBrokerControlPlaneCanvasEnabled(),

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -8,6 +8,10 @@ import {
 } from "./helpers.js";
 import { formatRecentActivityLogEntries, type LoggedActivityLogEntry } from "./activity-log.js";
 import type { PinetRuntimeControlContext } from "./pinet-remote-control.js";
+import {
+  formatSlackScopeDiagnosticsStatus,
+  type SlackScopeDiagnostics,
+} from "./slack-scope-diagnostics.js";
 import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 export interface PinetCommandsDeps {
@@ -29,6 +33,7 @@ export interface PinetCommandsDeps {
   allowedUsers: () => Set<string> | null;
   inboxLength: () => number;
   recentActivityLogEntries: (limit: number) => ReadonlyArray<LoggedActivityLogEntry>;
+  slackScopeDiagnostics: () => SlackScopeDiagnostics;
   settings: () => SlackBridgeSettings;
   lastBrokerMaintenance: () => {
     pendingBacklogCount: number;
@@ -279,6 +284,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       const activityLogInfo = s.logChannel
         ? `Activity log: ${s.logChannel} (${s.logLevel ?? "actions"})`
         : "Activity log: disabled";
+      const slackToolHealthInfo = `Slack tool health: ${formatSlackScopeDiagnosticsStatus(deps.slackScopeDiagnostics())}`;
       const lbm = deps.lastBrokerMaintenance();
       const brokerHealthInfo =
         mode === "broker" && lbm
@@ -325,6 +331,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
           allowlistInfo,
           defaultChInfo,
           activityLogInfo,
+          slackToolHealthInfo,
           ...brokerHealthInfo,
           ...brokerCanvasInfo,
         ].join("\n"),

--- a/slack-bridge/slack-scope-diagnostics.test.ts
+++ b/slack-bridge/slack-scope-diagnostics.test.ts
@@ -41,6 +41,9 @@ describe("slack scope diagnostics", () => {
       if (url.endsWith("/bookmarks.remove")) {
         return slackJson({ ok: false, error: "missing_scope", needed: "bookmarks:write" });
       }
+      if (url.endsWith("/pins.list")) {
+        return slackJson({ ok: false, error: "missing_scope", needed: "pins:read" });
+      }
       if (url.endsWith("/pins.add")) {
         return slackJson({ ok: false, error: "missing_scope", needed: "pins:write" });
       }
@@ -61,12 +64,13 @@ describe("slack scope diagnostics", () => {
         "bookmarks:write",
         "files:read",
         "files:write",
+        "pins:read",
         "pins:write",
       ],
       surfaces: ["bookmarks", "files", "pins"],
     });
     expect(formatSlackScopeDiagnosticsStatus(diagnostics)).toBe(
-      "scope drift — missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write",
+      "scope drift — missing bookmarks:read, bookmarks:write, files:read, files:write, pins:read, pins:write",
     );
     expect(buildSlackScopeDriftWarning(diagnostics)).toContain(
       "Affected Slack surfaces: bookmarks, files, pins.",
@@ -87,6 +91,9 @@ describe("slack scope diagnostics", () => {
       }
       if (url.endsWith("/bookmarks.remove")) {
         return slackJson({ ok: false, error: "not_found" });
+      }
+      if (url.endsWith("/pins.list")) {
+        return slackJson({ ok: false, error: "channel_not_found" });
       }
       if (url.endsWith("/pins.add")) {
         return slackJson({ ok: false, error: "channel_not_found" });

--- a/slack-bridge/slack-scope-diagnostics.test.ts
+++ b/slack-bridge/slack-scope-diagnostics.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSlackScopeDriftWarning,
+  createPendingSlackScopeDiagnostics,
+  createUncheckedSlackScopeDiagnostics,
+  detectSlackScopeDiagnostics,
+  formatSlackScopeDiagnosticsStatus,
+} from "./slack-scope-diagnostics.js";
+
+function slackJson(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("slack scope diagnostics", () => {
+  it("starts unchecked or pending before a live probe runs", () => {
+    expect(createUncheckedSlackScopeDiagnostics()).toMatchObject({
+      status: "not_checked",
+      summary: "not checked",
+    });
+    expect(createPendingSlackScopeDiagnostics()).toMatchObject({
+      status: "pending",
+      summary: "pending",
+    });
+  });
+
+  it("reports drift when Slack returns missing_scope for file/bookmark/pin probes", async () => {
+    const fetchImpl = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/files.info")) {
+        return slackJson({ ok: false, error: "missing_scope", needed: "files:read" });
+      }
+      if (url.endsWith("/files.completeUploadExternal")) {
+        return slackJson({ ok: false, error: "missing_scope", needed: "files:write" });
+      }
+      if (url.endsWith("/bookmarks.list")) {
+        return slackJson({ ok: false, error: "missing_scope", needed: "bookmarks:read" });
+      }
+      if (url.endsWith("/bookmarks.remove")) {
+        return slackJson({ ok: false, error: "missing_scope", needed: "bookmarks:write" });
+      }
+      if (url.endsWith("/pins.add")) {
+        return slackJson({ ok: false, error: "missing_scope", needed: "pins:write" });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const diagnostics = await detectSlackScopeDiagnostics({
+      token: "xoxb-test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => "2026-04-14T00:00:00.000Z",
+    });
+
+    expect(diagnostics).toMatchObject({
+      status: "drift",
+      checkedAt: "2026-04-14T00:00:00.000Z",
+      missingScopes: [
+        "bookmarks:read",
+        "bookmarks:write",
+        "files:read",
+        "files:write",
+        "pins:write",
+      ],
+      surfaces: ["bookmarks", "files", "pins"],
+    });
+    expect(formatSlackScopeDiagnosticsStatus(diagnostics)).toBe(
+      "scope drift — missing bookmarks:read, bookmarks:write, files:read, files:write, pins:write",
+    );
+    expect(buildSlackScopeDriftWarning(diagnostics)).toContain(
+      "Affected Slack surfaces: bookmarks, files, pins.",
+    );
+  });
+
+  it("treats benign not-found style probe errors as healthy", async () => {
+    const fetchImpl = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/files.info")) {
+        return slackJson({ ok: false, error: "file_not_found" });
+      }
+      if (url.endsWith("/files.completeUploadExternal")) {
+        return slackJson({ ok: false, error: "file_not_found" });
+      }
+      if (url.endsWith("/bookmarks.list")) {
+        return slackJson({ ok: false, error: "channel_not_found" });
+      }
+      if (url.endsWith("/bookmarks.remove")) {
+        return slackJson({ ok: false, error: "not_found" });
+      }
+      if (url.endsWith("/pins.add")) {
+        return slackJson({ ok: false, error: "channel_not_found" });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const diagnostics = await detectSlackScopeDiagnostics({
+      token: "xoxb-test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(diagnostics.status).toBe("healthy");
+    expect(diagnostics.summary).toBe("healthy");
+    expect(buildSlackScopeDriftWarning(diagnostics)).toBeNull();
+  });
+
+  it("surfaces unavailable diagnostics when probes fail for non-scope reasons", async () => {
+    const fetchImpl = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/files.info")) {
+        return slackJson({ ok: false, error: "invalid_auth" });
+      }
+      return slackJson({ ok: true });
+    });
+
+    const diagnostics = await detectSlackScopeDiagnostics({
+      token: "xoxb-test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(diagnostics.status).toBe("unavailable");
+    expect(diagnostics.summary).toContain("files.info: invalid_auth");
+  });
+});

--- a/slack-bridge/slack-scope-diagnostics.ts
+++ b/slack-bridge/slack-scope-diagnostics.ts
@@ -82,6 +82,14 @@ const SCOPE_DRIFT_PROBES: readonly SlackScopeProbe[] = [
     okErrors: ["channel_not_found", "not_found", "invalid_arguments"],
   },
   {
+    key: "pins_read",
+    surface: "pins",
+    method: "pins.list",
+    body: { channel: "C0000000000" },
+    expectedScopes: ["pins:read"],
+    okErrors: ["channel_not_found", "invalid_arguments"],
+  },
+  {
     key: "pins_write",
     surface: "pins",
     method: "pins.add",

--- a/slack-bridge/slack-scope-diagnostics.ts
+++ b/slack-bridge/slack-scope-diagnostics.ts
@@ -1,0 +1,310 @@
+import { buildSlackRequest } from "./helpers.js";
+import type { SlackResult } from "./slack-api.js";
+
+interface SlackScopeProbe {
+  key: string;
+  surface: "files" | "bookmarks" | "pins";
+  method: string;
+  body: Record<string, unknown>;
+  expectedScopes: string[];
+  okErrors: string[];
+}
+
+export type SlackScopeDiagnosticsStatus =
+  | "not_checked"
+  | "pending"
+  | "healthy"
+  | "drift"
+  | "unavailable";
+
+export interface SlackScopeProbeResult {
+  key: string;
+  surface: "files" | "bookmarks" | "pins";
+  method: string;
+  expectedScopes: string[];
+  status: "ok" | "missing" | "unavailable";
+  missingScopes: string[];
+  error?: string;
+  neededScopes?: string[];
+  providedScopes?: string[];
+}
+
+export interface SlackScopeDiagnostics {
+  status: SlackScopeDiagnosticsStatus;
+  checkedAt: string | null;
+  summary: string;
+  surfaces: Array<"files" | "bookmarks" | "pins">;
+  missingScopes: string[];
+  results: SlackScopeProbeResult[];
+  error?: string;
+}
+
+export interface DetectSlackScopeDiagnosticsOptions {
+  token: string;
+  fetchImpl?: typeof fetch;
+  now?: () => string;
+}
+
+const SCOPE_DRIFT_PROBES: readonly SlackScopeProbe[] = [
+  {
+    key: "files_read",
+    surface: "files",
+    method: "files.info",
+    body: { file: "F0000000000" },
+    expectedScopes: ["files:read"],
+    okErrors: ["file_not_found", "invalid_arguments", "channel_canvas_deleted"],
+  },
+  {
+    key: "files_write",
+    surface: "files",
+    method: "files.completeUploadExternal",
+    body: {
+      files: [{ id: "F0000000000", title: "scope-drift-probe" }],
+      channel_id: "C0000000000",
+    },
+    expectedScopes: ["files:write"],
+    okErrors: ["file_not_found", "channel_not_found", "invalid_arguments"],
+  },
+  {
+    key: "bookmarks_read",
+    surface: "bookmarks",
+    method: "bookmarks.list",
+    body: { channel_id: "C0000000000" },
+    expectedScopes: ["bookmarks:read"],
+    okErrors: ["channel_not_found", "invalid_arguments"],
+  },
+  {
+    key: "bookmarks_write",
+    surface: "bookmarks",
+    method: "bookmarks.remove",
+    body: { channel_id: "C0000000000", bookmark_id: "Bk0000000000" },
+    expectedScopes: ["bookmarks:write"],
+    okErrors: ["channel_not_found", "not_found", "invalid_arguments"],
+  },
+  {
+    key: "pins_write",
+    surface: "pins",
+    method: "pins.add",
+    body: { channel: "C0000000000", timestamp: "0" },
+    expectedScopes: ["pins:write"],
+    okErrors: [
+      "channel_not_found",
+      "message_not_found",
+      "file_not_found",
+      "no_item",
+      "invalid_arguments",
+    ],
+  },
+];
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort();
+}
+
+function normalizeScopeList(raw: unknown): string[] {
+  if (typeof raw !== "string") {
+    return [];
+  }
+
+  return uniqueSorted(
+    raw
+      .split(/[\s,]+/)
+      .map((scope) => scope.trim())
+      .filter(Boolean),
+  );
+}
+
+function summarizeUnavailableErrors(results: SlackScopeProbeResult[]): string | undefined {
+  const errors = uniqueSorted(
+    results
+      .filter((result) => result.status === "unavailable")
+      .map((result) => `${result.method}: ${result.error ?? "unknown"}`),
+  );
+  return errors[0];
+}
+
+function formatScopeList(scopes: string[]): string {
+  return scopes.join(", ");
+}
+
+async function readSlackProbeResult(response: Response): Promise<SlackResult> {
+  try {
+    return (await response.json()) as SlackResult;
+  } catch {
+    return { ok: false, error: `http_${response.status}` };
+  }
+}
+
+async function runSlackScopeProbe(
+  probe: SlackScopeProbe,
+  token: string,
+  fetchImpl: typeof fetch,
+): Promise<SlackScopeProbeResult> {
+  const { url, init } = buildSlackRequest(probe.method, token, probe.body);
+
+  try {
+    const response = await fetchImpl(url, init);
+    if (response.status === 429) {
+      return {
+        key: probe.key,
+        surface: probe.surface,
+        method: probe.method,
+        expectedScopes: probe.expectedScopes,
+        status: "unavailable",
+        missingScopes: [],
+        error: "rate_limited",
+      };
+    }
+
+    const payload = await readSlackProbeResult(response);
+    if (payload.ok) {
+      return {
+        key: probe.key,
+        surface: probe.surface,
+        method: probe.method,
+        expectedScopes: probe.expectedScopes,
+        status: "ok",
+        missingScopes: [],
+      };
+    }
+
+    const error = typeof payload.error === "string" ? payload.error : `http_${response.status}`;
+    if (probe.okErrors.includes(error)) {
+      return {
+        key: probe.key,
+        surface: probe.surface,
+        method: probe.method,
+        expectedScopes: probe.expectedScopes,
+        status: "ok",
+        missingScopes: [],
+      };
+    }
+
+    if (error === "missing_scope" || error === "not_allowed_token_type") {
+      const neededScopes = normalizeScopeList(payload.needed);
+      const providedScopes = normalizeScopeList(payload.provided);
+      return {
+        key: probe.key,
+        surface: probe.surface,
+        method: probe.method,
+        expectedScopes: probe.expectedScopes,
+        status: "missing",
+        missingScopes: neededScopes.length > 0 ? neededScopes : probe.expectedScopes,
+        error,
+        ...(neededScopes.length > 0 ? { neededScopes } : {}),
+        ...(providedScopes.length > 0 ? { providedScopes } : {}),
+      };
+    }
+
+    return {
+      key: probe.key,
+      surface: probe.surface,
+      method: probe.method,
+      expectedScopes: probe.expectedScopes,
+      status: "unavailable",
+      missingScopes: [],
+      error,
+    };
+  } catch (error) {
+    return {
+      key: probe.key,
+      surface: probe.surface,
+      method: probe.method,
+      expectedScopes: probe.expectedScopes,
+      status: "unavailable",
+      missingScopes: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function createUncheckedSlackScopeDiagnostics(): SlackScopeDiagnostics {
+  return {
+    status: "not_checked",
+    checkedAt: null,
+    summary: "not checked",
+    surfaces: [],
+    missingScopes: [],
+    results: [],
+  };
+}
+
+export function createPendingSlackScopeDiagnostics(): SlackScopeDiagnostics {
+  return {
+    status: "pending",
+    checkedAt: null,
+    summary: "pending",
+    surfaces: [],
+    missingScopes: [],
+    results: [],
+  };
+}
+
+export async function detectSlackScopeDiagnostics(
+  options: DetectSlackScopeDiagnosticsOptions,
+): Promise<SlackScopeDiagnostics> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => new Date().toISOString());
+  const checkedAt = now();
+  const results = await Promise.all(
+    SCOPE_DRIFT_PROBES.map((probe) => runSlackScopeProbe(probe, options.token, fetchImpl)),
+  );
+
+  const missingScopes = uniqueSorted(
+    results.flatMap((result) => (result.status === "missing" ? result.missingScopes : [])),
+  );
+  const surfaces = uniqueSorted(
+    results.flatMap((result) => (result.status === "missing" ? [result.surface] : [])),
+  ) as Array<"files" | "bookmarks" | "pins">;
+
+  if (missingScopes.length > 0) {
+    return {
+      status: "drift",
+      checkedAt,
+      summary: `scope drift — missing ${formatScopeList(missingScopes)}`,
+      surfaces,
+      missingScopes,
+      results,
+    };
+  }
+
+  const unavailableError = summarizeUnavailableErrors(results);
+  if (unavailableError) {
+    return {
+      status: "unavailable",
+      checkedAt,
+      summary: `unavailable (${unavailableError})`,
+      surfaces: [],
+      missingScopes: [],
+      results,
+      error: unavailableError,
+    };
+  }
+
+  return {
+    status: "healthy",
+    checkedAt,
+    summary: "healthy",
+    surfaces: [],
+    missingScopes: [],
+    results,
+  };
+}
+
+export function formatSlackScopeDiagnosticsStatus(diagnostics: SlackScopeDiagnostics): string {
+  return diagnostics.summary;
+}
+
+export function buildSlackScopeDriftWarning(diagnostics: SlackScopeDiagnostics): string | null {
+  if (diagnostics.status !== "drift" || diagnostics.missingScopes.length === 0) {
+    return null;
+  }
+
+  const surfaceSummary =
+    diagnostics.surfaces.length > 0 ? diagnostics.surfaces.join(", ") : "files";
+  return [
+    `Slack scope drift detected: missing ${formatScopeList(diagnostics.missingScopes)}.`,
+    `Affected Slack surfaces: ${surfaceSummary}.`,
+    "Reinstall or reapply the current slack-bridge manifest scopes in Slack, then restart the bridge.",
+  ].join(" ");
+}


### PR DESCRIPTION
## Summary
- add a narrow Slack scope-drift diagnostic probe for the live file/bookmark/pin surfaces
- surface operator-visible warnings when required Slack scopes drift from repo expectations
- report Slack tool health in `/pinet-status` so operators can confirm drift before runtime tool failures

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge test -- slack-scope-diagnostics.test.ts index.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm prepush`
