### PR TITLE
fix: guard repo tools in Slack runtime (#473)

### DIFF
--- a/slack-bridge/repo-tool-guardrails.test.ts
+++ b/slack-bridge/repo-tool-guardrails.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateSlackOriginRepoToolPolicy,
+  summarizeRepoToolAction,
+} from "./repo-tool-guardrails.js";
+
+describe("repo tool Slack guardrails", () => {
+  it("blocks Slack-triggered repo tools covered by readOnly or blockedTools", () => {
+    const turn = { threadTs: "100.1", threadCount: 1 };
+
+    const commentAddBlocked = evaluateSlackOriginRepoToolPolicy({
+      turn,
+      toolName: "comment_add",
+      input: { comment: "hi" },
+      guardrails: { readOnly: true },
+      requireToolPolicy: () => {
+        throw new Error("should not reach confirmation layer");
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+    expect(commentAddBlocked).toEqual({
+      block: true,
+      reason: 'Tool "comment_add" is blocked by Slack security guardrails.',
+    });
+
+    const psqlBlocked = evaluateSlackOriginRepoToolPolicy({
+      turn,
+      toolName: "psql",
+      input: { query: "select 1" },
+      guardrails: { blockedTools: ["psql"] },
+      requireToolPolicy: () => {
+        throw new Error("should not reach confirmation layer");
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+    expect(psqlBlocked).toEqual({
+      block: true,
+      reason: 'Tool "psql" is blocked by Slack security guardrails.',
+    });
+  });
+
+  it("requires confirmation for Slack-triggered repo tools with a real Slack thread", () => {
+    const result = evaluateSlackOriginRepoToolPolicy({
+      turn: { threadTs: "100.1", threadCount: 1 },
+      toolName: "psql",
+      input: { query: "select *\nfrom users", format: "csv" },
+      guardrails: { requireConfirmation: ["psql"] },
+      requireToolPolicy: (toolName, threadTs, action) => {
+        throw new Error(
+          `Tool "${toolName}" requires confirmation for action ${JSON.stringify(action)}. Call slack_confirm_action in thread ${threadTs} first.`,
+        );
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason:
+        'Tool "psql" requires confirmation for action "format=csv | query=select * from users". Call slack_confirm_action in thread 100.1 first.',
+    });
+  });
+
+  it("refuses confirmation-required repo tools when a Slack batch spans multiple threads", () => {
+    const result = evaluateSlackOriginRepoToolPolicy({
+      turn: { threadTs: undefined, threadCount: 2 },
+      toolName: "open_in_editor",
+      input: { file: "README.md", line: 7 },
+      guardrails: { requireConfirmation: ["open_in_editor"] },
+      requireToolPolicy: () => {
+        throw new Error("should not reach confirmation layer");
+      },
+      formatAction: (action) => JSON.stringify(action),
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason:
+        'Tool "open_in_editor" requires Slack confirmation for action "file=README.md | line=7", but this Slack-triggered turn currently batches 2 threads. Process one Slack thread at a time before using that tool.',
+    });
+  });
+
+  it("does not interfere with non-Slack turns or tools outside the five-tool slice", () => {
+    expect(
+      evaluateSlackOriginRepoToolPolicy({
+        turn: null,
+        toolName: "psql",
+        input: { query: "select 1" },
+        guardrails: { blockedTools: ["psql"] },
+        requireToolPolicy: () => {
+          throw new Error("should not run");
+        },
+        formatAction: (action) => JSON.stringify(action),
+        formatError: (error) => (error instanceof Error ? error.message : String(error)),
+      }),
+    ).toBeUndefined();
+
+    expect(
+      evaluateSlackOriginRepoToolPolicy({
+        turn: { threadTs: "100.1", threadCount: 1 },
+        toolName: "slack_send",
+        input: { text: "hi" },
+        guardrails: { blockedTools: ["slack_send"] },
+        requireToolPolicy: () => {
+          throw new Error("should not run");
+        },
+        formatAction: (action) => JSON.stringify(action),
+        formatError: (error) => (error instanceof Error ? error.message : String(error)),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps repo-tool confirmation summaries compact and deterministic", () => {
+    expect(
+      summarizeRepoToolAction({
+        toolName: "comment_add",
+        input: {
+          thread_id: "global",
+          file: "notes.md",
+          start_line: 3,
+          end_line: 4,
+          comment: "hello",
+        },
+      }),
+    ).toBe("thread_id=global | file=notes.md | start_line=3 | end_line=4 | comment_length=5");
+    expect(
+      summarizeRepoToolAction({
+        toolName: "comment_wipe_all",
+        input: {},
+      }),
+    ).toBe("scope=current_repo");
+  });
+});

--- a/slack-bridge/repo-tool-guardrails.ts
+++ b/slack-bridge/repo-tool-guardrails.ts
@@ -1,0 +1,106 @@
+import { isToolBlocked, toolNeedsConfirmation, type SecurityGuardrails } from "./guardrails.js";
+import type { SlackToolPolicyTurn } from "./core-tool-guardrails.js";
+
+export const GUARDED_REPO_TOOLS = new Set([
+  "open_in_editor",
+  "comment_add",
+  "comment_list",
+  "comment_wipe_all",
+  "psql",
+]);
+
+export function isGuardedRepoTool(toolName: string): boolean {
+  return GUARDED_REPO_TOOLS.has(toolName);
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function clipValue(value: string, maxLength = 120): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+export function summarizeRepoToolAction(event: {
+  toolName: string;
+  input: Record<string, unknown>;
+}): string {
+  const input = event.input;
+
+  switch (event.toolName) {
+    case "open_in_editor":
+      return `file=${String(input.file ?? "")} | line=${String(input.line ?? "")}`;
+    case "comment_add": {
+      const comment = typeof input.comment === "string" ? input.comment : "";
+      return [
+        `thread_id=${String(input.thread_id ?? "")}`,
+        `file=${String(input.file ?? "")}`,
+        `start_line=${String(input.start_line ?? "")}`,
+        `end_line=${String(input.end_line ?? "")}`,
+        `comment_length=${comment.length}`,
+      ].join(" | ");
+    }
+    case "comment_list":
+      return `thread_id=${String(input.thread_id ?? "")} | limit=${String(input.limit ?? "")}`;
+    case "comment_wipe_all":
+      return "scope=current_repo";
+    case "psql": {
+      const query = typeof input.query === "string" ? normalizeWhitespace(input.query) : "";
+      return `format=${String(input.format ?? "table")} | query=${clipValue(query)}`;
+    }
+    default:
+      return JSON.stringify(input);
+  }
+}
+
+export function evaluateSlackOriginRepoToolPolicy(options: {
+  turn: SlackToolPolicyTurn | null;
+  toolName: string;
+  input: Record<string, unknown>;
+  guardrails: SecurityGuardrails;
+  requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
+  formatAction: (action: string) => string;
+  formatError: (error: unknown) => string;
+}): { block: true; reason: string } | undefined {
+  const { turn, toolName, input, guardrails, requireToolPolicy, formatAction, formatError } =
+    options;
+  if (!turn || !isGuardedRepoTool(toolName)) {
+    return undefined;
+  }
+
+  if (isToolBlocked(toolName, guardrails)) {
+    return {
+      block: true,
+      reason: `Tool "${toolName}" is blocked by Slack security guardrails.`,
+    };
+  }
+
+  if (!toolNeedsConfirmation(toolName, guardrails)) {
+    return undefined;
+  }
+
+  const action = summarizeRepoToolAction({ toolName, input });
+  if (!turn.threadTs) {
+    return {
+      block: true,
+      reason:
+        turn.threadCount > 1
+          ? `Tool "${toolName}" requires Slack confirmation for action ${formatAction(action)}, but this Slack-triggered turn currently batches ${turn.threadCount} threads. Process one Slack thread at a time before using that tool.`
+          : `Tool "${toolName}" requires Slack confirmation for action ${formatAction(action)}, but there is no tracked Slack thread available for this turn. Retry from a specific Slack thread and call slack_confirm_action there first.`,
+    };
+  }
+
+  try {
+    requireToolPolicy(toolName, turn.threadTs, action);
+    return undefined;
+  } catch (error) {
+    return {
+      block: true,
+      reason: formatError(error),
+    };
+  }
+}

--- a/slack-bridge/slack-tool-policy-runtime.test.ts
+++ b/slack-bridge/slack-tool-policy-runtime.test.ts
@@ -118,6 +118,57 @@ describe("createSlackToolPolicyRuntime", () => {
     expect(requireToolPolicy).not.toHaveBeenCalled();
   });
 
+  it("routes the five-tool repo slice through the same Slack turn policy gate", async () => {
+    const { deps, requireToolPolicy } = createDeps({
+      getGuardrails: () => ({ requireConfirmation: ["psql"] }),
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    runtime.deliverTrackedSlackFollowUpMessage({
+      prompt: "repo-tool prompt",
+      messages: [{ threadTs: "100.1" }],
+    });
+    await runtime.onInput({ source: "extension", text: "repo-tool prompt" });
+    await runtime.onTurnStart();
+
+    await expect(
+      runtime.onToolCall({
+        toolName: "psql",
+        input: { query: "select *\nfrom agents", format: "csv" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "psql",
+      "100.1",
+      "format=csv | query=select * from agents",
+    );
+  });
+
+  it("hard-blocks write-capable repo tools under Slack readOnly mode", async () => {
+    const { deps, requireToolPolicy } = createDeps({
+      getGuardrails: () => ({ readOnly: true }),
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    runtime.deliverTrackedSlackFollowUpMessage({
+      prompt: "repo-write prompt",
+      messages: [{ threadTs: "100.1" }],
+    });
+    await runtime.onInput({ source: "extension", text: "repo-write prompt" });
+    await runtime.onTurnStart();
+
+    await expect(
+      runtime.onToolCall({
+        toolName: "comment_add",
+        input: { comment: "hello from slack" },
+      }),
+    ).resolves.toEqual({
+      block: true,
+      reason: 'Tool "comment_add" is blocked by Slack security guardrails.',
+    });
+    expect(requireToolPolicy).not.toHaveBeenCalled();
+  });
+
   it("clears the active Slack tool-policy turn on agent_end", async () => {
     const { deps, requireToolPolicy } = createDeps({
       getGuardrails: () => ({ requireConfirmation: ["read"] }),

--- a/slack-bridge/slack-tool-policy-runtime.ts
+++ b/slack-bridge/slack-tool-policy-runtime.ts
@@ -1,5 +1,6 @@
 import type { InboxMessage } from "./helpers.js";
 import { evaluateSlackOriginCoreToolPolicy } from "./core-tool-guardrails.js";
+import { evaluateSlackOriginRepoToolPolicy } from "./repo-tool-guardrails.js";
 import { isBrokerForbiddenTool, type SecurityGuardrails } from "./guardrails.js";
 import {
   consumePendingSlackToolPolicyTurn,
@@ -85,7 +86,20 @@ export function createSlackToolPolicyRuntime(
       };
     }
 
-    return evaluateSlackOriginCoreToolPolicy({
+    const corePolicy = evaluateSlackOriginCoreToolPolicy({
+      turn: activeSlackToolPolicyTurn,
+      toolName: event.toolName,
+      input: event.input,
+      guardrails: deps.getGuardrails(),
+      requireToolPolicy: deps.requireToolPolicy,
+      formatAction: deps.formatAction,
+      formatError: deps.formatError,
+    });
+    if (corePolicy) {
+      return corePolicy;
+    }
+
+    return evaluateSlackOriginRepoToolPolicy({
       turn: activeSlackToolPolicyTurn,
       toolName: event.toolName,
       input: event.input,


### PR DESCRIPTION
## Summary
- add a narrow repo-tool Slack guardrail evaluator for `open_in_editor`, `comment_add`, `comment_list`, `comment_wipe_all`, and `psql`
- route those five tools through the existing Slack runtime `tool_call` gate without changing current policy semantics
- cover the five-tool slice with focused runtime/evaluator tests only

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge test -- core-tool-guardrails.test.ts repo-tool-guardrails.test.ts slack-tool-policy-runtime.test.ts
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm prepush