### PR TITLE
fix: reject live stableId takeover (#491)

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -283,6 +283,36 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("rejects live stableId takeover and still allows resume after the holder disconnects", async () => {
+    const stableId = "host:session:/tmp/resume-live";
+    const reg1 = await client.register("resume-agent", "🔁", undefined, stableId);
+    await client.claimThread("t-resume-live");
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+
+    await expect(client2.register("takeover-agent", "🪤", undefined, stableId)).rejects.toThrow(
+      `Agent stableId "${stableId}" is already active on another live connection. Wait for that agent to disconnect before retrying.`,
+    );
+    expect(db.getAgents()).toHaveLength(1);
+    expect(db.getThread("t-resume-live")?.ownerAgent).toBe(reg1.agentId);
+
+    client.disconnect();
+    await waitFor(() => db.getAgents().length === 0, 1000);
+
+    const reg2 = await client2.register("different-name", "❌", undefined, stableId);
+    expect(reg2.agentId).toBe(reg1.agentId);
+    expect(reg2.name).toBe("different-name");
+    expect(reg2.emoji).toBe("❌");
+
+    const threads = await client2.listThreads();
+    expect(threads.map((thread) => thread.threadId)).toContain("t-resume-live");
+
+    client2.disconnect();
+  });
+
   it("reconnect with same stableId refreshes identity while preserving thread ownership", async () => {
     const reg1 = await client.register("resume-agent", "🔁", undefined, "host:session:/tmp/resume");
     await client.claimThread("t-resume");

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -23,6 +23,7 @@ import {
   RPC_INTERNAL_ERROR,
   RPC_AUTH_REQUIRED,
   RPC_AGENT_NAME_CONFLICT,
+  RPC_AGENT_STABLE_ID_CONFLICT,
 } from "./types.js";
 
 export type SlackProxyFn = (
@@ -336,6 +337,25 @@ export class BrokerSocketServer {
     }
   }
 
+  private findLiveStableIdConflict(
+    stableId: string,
+    currentSocket: net.Socket,
+  ): { ownerAgentId: string } | null {
+    const existing = this.db.getAgentByStableId(stableId);
+    if (!existing) {
+      return null;
+    }
+
+    for (const [socket, state] of this.connections) {
+      if (socket === currentSocket || state.agentId !== existing.id) {
+        continue;
+      }
+      return { ownerAgentId: existing.id };
+    }
+
+    return null;
+  }
+
   // ─── Connection handling ─────────────────────────────
 
   private onConnection(socket: net.Socket): void {
@@ -521,6 +541,23 @@ export class BrokerSocketServer {
       params.metadata && typeof params.metadata === "object"
         ? (params.metadata as Record<string, unknown>)
         : undefined;
+
+    if (stableId) {
+      const liveStableIdConflict = this.findLiveStableIdConflict(stableId, socket);
+      if (liveStableIdConflict) {
+        return rpcError(
+          req.id,
+          RPC_AGENT_STABLE_ID_CONFLICT,
+          `Agent stableId "${stableId}" is already active on another live connection. Wait for that agent to disconnect before retrying.`,
+          {
+            code: "AGENT_STABLE_ID_CONFLICT",
+            stableId,
+            ownerAgentId: liveStableIdConflict.ownerAgentId,
+            retryable: true,
+          },
+        );
+      }
+    }
 
     const candidateId = state.agentId ?? crypto.randomUUID();
     const resolved = this.agentRegistrationResolver?.({

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -139,6 +139,7 @@ export const RPC_INTERNAL_ERROR = -32603;
 // Server-defined broker auth / registration error codes
 export const RPC_AUTH_REQUIRED = -32001;
 export const RPC_AGENT_NAME_CONFLICT = -32002;
+export const RPC_AGENT_STABLE_ID_CONFLICT = -32003;
 
 // ─── Message adapter (canonical types from adapters) ─────
 


### PR DESCRIPTION
## Summary
- reject broker registration when a supplied `stableId` is already held by a different live socket
- preserve the existing disconnected/resumable reconnect path for the same `stableId`
- add focused broker integration coverage for reject-vs-allowed resume behavior

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- broker/integration.test.ts *(matched the full slack-bridge suite: 68 files / 1078 tests passed)*
- pnpm prepush
