### PR TITLE
fix: hide stable ids from broker agent lists (#493)

### DIFF
--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -2,6 +2,7 @@ import * as net from "node:net";
 import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
+import type { ClientAgentInfo } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -28,22 +29,7 @@ export interface ThreadInfo {
   updatedAt: string;
 }
 
-export interface AgentInfo {
-  id: string;
-  stableId?: string | null;
-  name: string;
-  emoji: string;
-  pid: number;
-  connectedAt: string;
-  lastSeen: string;
-  lastHeartbeat: string;
-  metadata: Record<string, unknown> | null;
-  status: "working" | "idle";
-  disconnectedAt?: string | null;
-  resumableUntil?: string | null;
-  idleSince?: string | null;
-  lastActivity?: string | null;
-}
+export type AgentInfo = ClientAgentInfo;
 
 export interface ScheduledWakeupInfo {
   id: number;

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -181,19 +181,20 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
-  it("agents.list returns all connected agents", async () => {
-    await client.register("agent-alpha", "🅰️");
+  it("agents.list returns connected agents without exposing raw stableIds", async () => {
+    await client.register("agent-alpha", "🅰️", undefined, "host:session:/tmp/alpha");
 
     const info = server.getConnectInfo();
     if (info.type !== "tcp") throw new Error("Expected TCP");
     const client2 = new BrokerClient({ host: info.host, port: info.port });
     await client2.connect();
-    await client2.register("agent-beta", "🅱️");
+    await client2.register("agent-beta", "🅱️", undefined, "host:session:/tmp/beta");
 
     const agents = await client.listAgents();
     expect(agents.length).toBe(2);
     const names = agents.map((a) => a.name).sort();
     expect(names).toEqual(["agent-alpha", "agent-beta"]);
+    expect(agents.every((agent) => !("stableId" in agent))).toBe(true);
 
     client2.disconnect();
   });

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -9,7 +9,9 @@ import { MessageRouter } from "./router.js";
 import { dispatchDirectAgentMessage } from "./agent-messaging.js";
 import { sendBrokerMessage } from "./message-send.js";
 import type {
+  AgentInfo,
   BrokerMessage,
+  ClientAgentInfo,
   JsonRpcRequest,
   JsonRpcResponse,
   JsonRpcError,
@@ -47,6 +49,12 @@ export type AgentMessageCallback = (
 ) => void;
 
 export type AgentStatusChangeCallback = (agentId: string, status: "working" | "idle") => void;
+
+function toClientAgentInfo(agent: AgentInfo): ClientAgentInfo {
+  const { stableId, ...clientAgent } = agent;
+  void stableId;
+  return clientAgent;
+}
 
 export type AgentRegistrationResolver = (input: {
   agentId: string;
@@ -755,7 +763,9 @@ export class BrokerSocketServer {
   private handleAgentsList(req: JsonRpcRequest): JsonRpcResponse {
     const params = req.params ?? {};
     const includeDisconnected = params.includeDisconnected === true;
-    const agents = includeDisconnected ? this.db.getAllAgents() : this.db.getAgents();
+    const agents = (includeDisconnected ? this.db.getAllAgents() : this.db.getAgents()).map(
+      toClientAgentInfo,
+    );
     return rpcOk(req.id, agents);
   }
 

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -17,6 +17,8 @@ export interface AgentInfo {
   lastActivity?: string | null;
 }
 
+export type ClientAgentInfo = Omit<AgentInfo, "stableId">;
+
 export interface ThreadInfo {
   threadId: string;
   source: string;


### PR DESCRIPTION
## Summary
- add a narrow client-safe projection for `agents.list` at the broker socket boundary
- stop returning raw `stableId` values on that client-visible surface while leaving internal broker uses untouched
- update the client-visible broker `listAgents()` type and focused exposure coverage accordingly

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge test -- broker/integration.test.ts broker/client.test.ts
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm prepush