### PR TITLE
fix: hide owner agent ids from registration conflicts (#496)

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -172,11 +172,26 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     const client2 = new BrokerClient({ host: info.host, port: info.port });
     await client2.connect();
 
-    await expect(
-      client2.register("Reserved Crane", "🪿", undefined, "host:session:/tmp/name-2"),
-    ).rejects.toThrow(
+    let conflictError: unknown;
+    try {
+      await client2.register("Reserved Crane", "🪿", undefined, "host:session:/tmp/name-2");
+    } catch (error) {
+      conflictError = error;
+    }
+
+    expect(conflictError).toBeInstanceOf(Error);
+    const rpcConflictError = conflictError as Error & { data?: unknown };
+    expect(rpcConflictError.message).toBe(
       'Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.',
     );
+    expect(rpcConflictError.data).toEqual(
+      expect.objectContaining({
+        code: "AGENT_NAME_CONFLICT",
+        requestedName: "Reserved Crane",
+        retryable: true,
+      }),
+    );
+    expect(rpcConflictError.data as Record<string, unknown>).not.toHaveProperty("ownerAgentId");
 
     client2.disconnect();
   });

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -595,7 +595,6 @@ export class BrokerSocketServer {
           {
             code: "AGENT_NAME_CONFLICT",
             requestedName: finalName,
-            ownerAgentId: conflict.id,
             ownerStableId: conflict.stableId,
             retryable: true,
           },


### PR DESCRIPTION
## Summary
- remove `ownerAgentId` from the client-visible explicit-name registration conflict payload
- keep the existing conflict message, code, `requestedName`, `retryable`, and sibling `ownerStableId` behavior unchanged
- add a focused integration regression that asserts duplicate-name registration errors no longer expose `ownerAgentId`

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- broker/integration.test.ts broker/client.test.ts
- pnpm prepush