### PR TITLE
fix: forbid non-loopback raw TCP broker endpoints

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -124,6 +124,17 @@ describe("BrokerClient — construction", () => {
     const client = new BrokerClient({ host: "127.0.0.1", port: 9999 });
     expect(client.isConnected()).toBe(false);
   });
+
+  it("allows loopback TCP connect opts", () => {
+    expect(() => new BrokerClient({ host: "localhost", port: 9999 })).not.toThrow();
+    expect(() => new BrokerClient({ host: "127.0.0.42", port: 9999 })).not.toThrow();
+    expect(() => new BrokerClient({ host: "::1", port: 9999 })).not.toThrow();
+  });
+
+  it("rejects non-loopback TCP connect opts", () => {
+    expect(() => new BrokerClient({ host: "0.0.0.0", port: 9999 })).toThrow(/loopback-only/i);
+    expect(() => new BrokerClient({ host: "192.168.1.25", port: 9999 })).toThrow(/loopback-only/i);
+  });
 });
 
 describe("BrokerClient — connect / disconnect", () => {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -1,6 +1,7 @@
 import * as net from "node:net";
 import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
+import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
 import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
@@ -226,6 +227,7 @@ export class BrokerClient {
     if ("path" in opts) {
       this.connectOpts = { path: opts.path };
     } else {
+      assertLoopbackTcpHost(opts.host, "broker client connect target");
       this.connectOpts = { host: opts.host, port: opts.port };
     }
 

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1862,6 +1862,19 @@ describe("BrokerSocketServer", () => {
     client.destroy();
   });
 
+  it("allows loopback raw TCP listen targets and rejects non-loopback ones", () => {
+    expect(
+      () => new BrokerSocketServer(db, { type: "tcp", host: "localhost", port: 0 }),
+    ).not.toThrow();
+    expect(() => new BrokerSocketServer(db, { type: "tcp", host: "::1", port: 0 })).not.toThrow();
+    expect(() => new BrokerSocketServer(db, { type: "tcp", host: "0.0.0.0", port: 0 })).toThrow(
+      /loopback-only/i,
+    );
+    expect(
+      () => new BrokerSocketServer(db, { type: "tcp", host: "192.168.1.25", port: 0 }),
+    ).toThrow(/loopback-only/i);
+  });
+
   it("register returns agentId", async () => {
     const client = await connectClient(getInfo());
     const res = await client.call("register", { name: "TestBot", emoji: "🤖" });
@@ -2219,6 +2232,23 @@ describe("startBroker leader lock", () => {
 
     const broker = await launch({ lockPath });
     expect(broker.lock.isLeader()).toBe(true);
+  });
+
+  it("rejects non-loopback raw TCP listen targets before creating broker artifacts", async () => {
+    const lockPath = path.join(dir, "broker.lock");
+    const meshSecretPath = path.join(dir, "pinet.secret");
+
+    await expect(
+      startBroker({
+        dbPath: path.join(dir, "blocked.db"),
+        listenTarget: { type: "tcp", host: "0.0.0.0", port: 0 },
+        lockPath,
+        meshSecretPath,
+      }),
+    ).rejects.toThrow(/loopback-only/i);
+
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(meshSecretPath)).toBe(false);
   });
 
   it("starts without creating a mesh secret when none is configured", async () => {

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -3,6 +3,7 @@ import { BrokerDB } from "./schema.js";
 import { loadOrCreateMeshSecret } from "./auth.js";
 import { BrokerSocketServer } from "./socket-server.js";
 import type { ListenTarget } from "./socket-server.js";
+import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
 import { LeaderLock } from "./leader.js";
 import { getDefaultSocketPath } from "./paths.js";
 import type { MessageAdapter } from "./types.js";
@@ -57,6 +58,15 @@ export interface Broker {
  * Throws if another broker process already holds the lock.
  */
 export async function startBroker(options: BrokerOptions = {}): Promise<Broker> {
+  // Resolve listen target: explicit target > socketPath > default
+  const target: ListenTarget = options.listenTarget ?? {
+    type: "unix" as const,
+    path: options.socketPath ?? getDefaultSocketPath(),
+  };
+  if (target.type === "tcp") {
+    assertLoopbackTcpHost(target.host, "broker listen target");
+  }
+
   // ── Leader lock: prevent split-brain (issue #119) ────
   const lock = new LeaderLock(options.lockPath);
   if (!lock.tryAcquire()) {
@@ -72,12 +82,6 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
     lock.release();
     throw err;
   }
-
-  // Resolve listen target: explicit target > socketPath > default
-  const target: ListenTarget = options.listenTarget ?? {
-    type: "unix" as const,
-    path: options.socketPath ?? getDefaultSocketPath(),
-  };
 
   // Clean up stale socket file (Unix only)
   if (target.type === "unix") {

--- a/slack-bridge/broker/raw-tcp-loopback.ts
+++ b/slack-bridge/broker/raw-tcp-loopback.ts
@@ -1,0 +1,53 @@
+import * as net from "node:net";
+
+function normalizeTcpHost(host: string): string {
+  const trimmed = host.trim();
+  const unwrapped =
+    trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
+  return unwrapped.toLowerCase().replace(/\.$/, "");
+}
+
+function isLoopbackIpv4Host(host: string): boolean {
+  if (net.isIP(host) !== 4) {
+    return false;
+  }
+
+  const octets = host.split(".");
+  if (octets.length !== 4) {
+    return false;
+  }
+
+  return (
+    octets[0] === "127" &&
+    octets.every((octet) => {
+      if (!/^\d+$/.test(octet)) {
+        return false;
+      }
+      const value = Number(octet);
+      return value >= 0 && value <= 255;
+    })
+  );
+}
+
+export function isLoopbackTcpHost(host: string): boolean {
+  const normalized = normalizeTcpHost(host);
+  if (normalized === "localhost" || normalized === "::1") {
+    return true;
+  }
+
+  if (normalized.startsWith("::ffff:")) {
+    return isLoopbackTcpHost(normalized.slice("::ffff:".length));
+  }
+
+  return isLoopbackIpv4Host(normalized);
+}
+
+export function assertLoopbackTcpHost(host: string, targetDescription: string): void {
+  if (isLoopbackTcpHost(host)) {
+    return;
+  }
+
+  throw new Error(
+    `Refusing ${targetDescription} on non-loopback raw TCP host "${host}". Raw TCP broker endpoints are limited to loopback-only hosts until a secure remote transport exists.`,
+  );
+}

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -8,6 +8,7 @@ import { DEFAULT_SOCKET_PATH } from "./paths.js";
 import { MessageRouter } from "./router.js";
 import { dispatchDirectAgentMessage } from "./agent-messaging.js";
 import { sendBrokerMessage } from "./message-send.js";
+import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
 import type {
   BrokerMessage,
   JsonRpcRequest,
@@ -174,6 +175,9 @@ export class BrokerSocketServer {
       this.target = target;
     } else {
       this.target = { type: "unix", path: DEFAULT_SOCKET_PATH };
+    }
+    if (this.target.type === "tcp") {
+      assertLoopbackTcpHost(this.target.host, "broker listen target");
     }
   }
 


### PR DESCRIPTION
## Summary
- forbid non-loopback raw TCP broker listen targets before broker artifacts are created
- reject non-loopback raw TCP client connect targets while preserving unix sockets and loopback TCP flows
- add focused allow/block boundary coverage for broker listen and client connect paths

Closes #498

## Testing
- pnpm --filter @gugu910/pi-slack-bridge test -- broker/client.test.ts broker/helpers.test.ts
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm prepush