### PR TITLE
chore: slim and align current four Pinet tool definitions (#500)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -149,7 +149,7 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------ |
 | `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                                  |
 | `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                       |
-| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true            |
+| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true             |
 | `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                              |
 | `defaultChannel`               | no       | Default channel for `slack_post_channel`                                                                           |
 | `logChannel`                   | no       | Channel for broker activity logs                                                                                   |
@@ -265,12 +265,12 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 ### Multi-agent tools
 
-| Tool             | Description                                           |
-| ---------------- | ----------------------------------------------------- |
-| `pinet_message`  | Send a message to another connected agent             |
-| `pinet_agents`   | List connected agents with status and capabilities    |
-| `pinet_free`     | Signal that this agent is idle and available for work |
-| `pinet_schedule` | Schedule a future wake-up message for this agent      |
+| Tool             | Description                                                                |
+| ---------------- | -------------------------------------------------------------------------- |
+| `pinet_message`  | Send a message to a connected Pinet agent or broker-only broadcast channel |
+| `pinet_agents`   | List connected Pinet agents with status and capabilities                   |
+| `pinet_free`     | Mark this Pinet agent idle/free for new work                               |
+| `pinet_schedule` | Schedule a future wake-up for this Pinet agent                             |
 
 ### Broker commands
 

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -84,10 +84,9 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
   pi.registerTool({
     name: "pinet_message",
     label: "Pinet Message",
-    description:
-      "Send a message to another connected Pinet agent, or from the broker to a broadcast channel.",
+    description: "Send a message to a connected Pinet agent or broker-only broadcast channel.",
     promptSnippet:
-      "Send a message to another connected Pinet agent. When you send a task, sepcify the desired workflow, ideally something like `ack/work/ask/report`: ACK briefly, do the work, report blockers or questions immediately, report the outcome when done. Always reply where the task came from. To trigger remote agent control, send the exact message `/reload` or `/exit`. Broadcast channels like `#all` or `#extensions` are broker-only.",
+      "Send a message to a connected Pinet agent by name or ID, or to a broker-only broadcast channel. Use it to delegate work, reply in a Pinet thread, or send `/reload` / `/exit`; when assigning work, include the expected `ack/work/ask/report` flow.",
     parameters: Type.Object({
       to: Type.String({
         description:
@@ -135,9 +134,8 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
   pi.registerTool({
     name: "pinet_free",
     label: "Pinet Free",
-    description: "Signal that this Pinet agent is idle/free and available for new work.",
-    promptSnippet:
-      "When you have finished all assigned work and already reported the outcome, call this to mark yourself idle/free for new assignments.",
+    description: "Mark this Pinet agent idle/free for new work.",
+    promptSnippet: "Mark this Pinet agent idle/free for new work after you report the outcome.",
     parameters: Type.Object({
       note: Type.Optional(
         Type.String({ description: "Optional short note about what you just finished" }),
@@ -173,9 +171,9 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
   pi.registerTool({
     name: "pinet_schedule",
     label: "Pinet Schedule",
-    description: "Schedule a future wake-up message for the current Pinet agent.",
+    description: "Schedule a future wake-up for this Pinet agent.",
     promptSnippet:
-      "Schedule a future wake-up for yourself via the Pinet broker. Use this instead of busy-waiting when you need to check back later.",
+      "Schedule a future wake-up for this Pinet agent instead of waiting around for the next check-in.",
     parameters: Type.Object({
       delay: Type.Optional(
         Type.String({ description: "Relative delay like 5m, 30s, 1h30m, or 1d" }),
@@ -236,9 +234,9 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
   pi.registerTool({
     name: "pinet_agents",
     label: "Pinet Agents",
-    description: "List Pinet agents, including liveness and capability visibility.",
+    description: "List connected Pinet agents with status and capabilities.",
     promptSnippet:
-      "List connected Pinet agents with liveness and capability info. Use before delegating work to find available agents, or to check health and status of agents you have assigned work to.",
+      "List connected Pinet agents to choose a worker, check status, or route work by repo, branch, role, or tools.",
     parameters: Type.Object({
       repo: Type.Optional(Type.String({ description: "Preferred repo name for routing" })),
       branch: Type.Optional(Type.String({ description: "Preferred branch for routing" })),


### PR DESCRIPTION
## Summary
- slim the current four Pinet tool descriptions and prompt snippets without changing names or behavior
- align the wording in `slack-bridge/pinet-tools.ts` with the existing `/pinet-*` command UX
- update the README tool table so the documented surface matches the lighter in-repo copy

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-tools.test.ts
- pnpm prepush