### PR TITLE
chore: restore pnpm check green

### DIFF
--- a/.pi/extensions/browser-playwright/helpers.ts
+++ b/.pi/extensions/browser-playwright/helpers.ts
@@ -78,7 +78,10 @@ export function sanitizeLabel(value: string | undefined): string {
 }
 
 export function sanitizeStorageStateName(value: string): string {
-  const base = value.trim().toLowerCase().replace(/\.json$/i, "");
+  const base = value
+    .trim()
+    .toLowerCase()
+    .replace(/\.json$/i, "");
   const cleaned = base.replace(/[^a-z0-9_-]+/g, "-").replace(/^[-_]+|[-_]+$/g, "");
   if (!/[a-z0-9]/.test(cleaned)) {
     throw new Error("Storage state names must contain at least one letter or number.");
@@ -133,7 +136,9 @@ export function buildInstallInstructions(
           "The extension prefers a host Chrome/Chromium executable when one is available.",
           "If no compatible host browser is found, install Playwright Chromium:",
         ]
-      : [`Install the browser-playwright extension dependencies and ${browserEngine} browser binaries:`];
+      : [
+          `Install the browser-playwright extension dependencies and ${browserEngine} browser binaries:`,
+        ];
 
   return [
     reason,
@@ -177,8 +182,7 @@ function chromiumExecutableCandidates(
       : null,
   );
 
-  const pathNames =
-    platform === "win32" ? CHROMIUM_PATH_NAMES_WINDOWS : CHROMIUM_PATH_NAMES_POSIX;
+  const pathNames = platform === "win32" ? CHROMIUM_PATH_NAMES_WINDOWS : CHROMIUM_PATH_NAMES_POSIX;
   for (const entry of pathEntries(env.PATH)) {
     for (const executableName of pathNames) {
       push({
@@ -200,7 +204,10 @@ function chromiumExecutableCandidates(
       "/Applications/Chromium.app/Contents/MacOS/Chromium",
       home ? join(home, "Applications/Google Chrome.app/Contents/MacOS/Google Chrome") : "",
       home
-        ? join(home, "Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing")
+        ? join(
+            home,
+            "Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+          )
         : "",
       home ? join(home, "Applications/Chromium.app/Contents/MacOS/Chromium") : "",
     ]) {
@@ -224,13 +231,9 @@ function chromiumExecutableCandidates(
     for (const candidatePath of [
       localAppData ? join(localAppData, "Google", "Chrome", "Application", "chrome.exe") : "",
       programFiles ? join(programFiles, "Google", "Chrome", "Application", "chrome.exe") : "",
-      programFilesX86
-        ? join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe")
-        : "",
+      programFilesX86 ? join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe") : "",
       programFiles ? join(programFiles, "Chromium", "Application", "chrome.exe") : "",
-      programFilesX86
-        ? join(programFilesX86, "Chromium", "Application", "chrome.exe")
-        : "",
+      programFilesX86 ? join(programFilesX86, "Chromium", "Application", "chrome.exe") : "",
     ]) {
       push(candidatePath ? { path: candidatePath, source: "system" } : null);
     }
@@ -242,11 +245,7 @@ function chromiumExecutableCandidates(
 export async function findPreferredChromiumExecutable(
   options: ChromiumExecutableLookupOptions = {},
 ): Promise<ChromiumExecutableCandidate | null> {
-  const {
-    env = process.env,
-    platform = process.platform,
-    accessImpl = access,
-  } = options;
+  const { env = process.env, platform = process.platform, accessImpl = access } = options;
 
   for (const candidate of chromiumExecutableCandidates(env, platform)) {
     try {
@@ -271,9 +270,7 @@ export function safeRequestPageId<PageLike>(
   }
 }
 
-export function isPlaywrightStorageState(
-  value: unknown,
-): value is PlaywrightStorageStateLike {
+export function isPlaywrightStorageState(value: unknown): value is PlaywrightStorageStateLike {
   if (value == null || typeof value !== "object") {
     return false;
   }

--- a/.pi/extensions/browser-playwright/index.ts
+++ b/.pi/extensions/browser-playwright/index.ts
@@ -699,7 +699,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
           const request: Request = route.request();
           session.networkSummary.total_requests += 1;
           const pageId = safeRequestPageId(request, (page) => session.pageIds.get(page) ?? null);
-          const pageRecord = pageId ? session.pages.get(pageId) ?? null : null;
+          const pageRecord = pageId ? (session.pages.get(pageId) ?? null) : null;
           const decision = assessUrl(
             request.url(),
             resolveRouteSecurityOptions(getSecurityOptions(), {

--- a/.pi/extensions/browser-playwright/storage-state.test.ts
+++ b/.pi/extensions/browser-playwright/storage-state.test.ts
@@ -24,10 +24,15 @@ test("resolveStorageStateFile keeps saved state under the workspace-local browse
   const resolved = await resolveStorageStateFile(" GitHub Login ", { workspaceRoot: workspace });
 
   assert.equal(resolved.name, "github-login");
-  assert.match(resolved.relativePath, /^\.pi[\\/]state[\\/]browser-playwright[\\/]github-login\.json$/);
+  assert.match(
+    resolved.relativePath,
+    /^\.pi[\\/]state[\\/]browser-playwright[\\/]github-login\.json$/,
+  );
   assert.match(
     resolved.absolutePath,
-    new RegExp(`\\${path.sep}\\.pi\\${path.sep}state\\${path.sep}browser-playwright\\${path.sep}github-login\\.json$`),
+    new RegExp(
+      `\\${path.sep}\\.pi\\${path.sep}state\\${path.sep}browser-playwright\\${path.sep}github-login\\.json$`,
+    ),
   );
 });
 
@@ -39,7 +44,11 @@ test("loadStoredStorageState reuses a trusted saved storageState file", async ()
     origins: [{ origin: "https://example.com", localStorage: [{ name: "theme", value: "dark" }] }],
   };
   await mkdir(targetDir, { recursive: true });
-  await writeFile(path.join(targetDir, "example-session.json"), `${JSON.stringify(storageState, null, 2)}\n`, "utf8");
+  await writeFile(
+    path.join(targetDir, "example-session.json"),
+    `${JSON.stringify(storageState, null, 2)}\n`,
+    "utf8",
+  );
 
   const loaded = await loadStoredStorageState("Example Session", { workspaceRoot: workspace });
   assert.deepEqual(loaded.summary, {
@@ -80,7 +89,11 @@ test("loadStoredStorageState rejects symlinked saved state files", async () => {
   const targetDir = path.join(workspace, ".pi", "state", "browser-playwright");
   const outside = await makeTempDir("browser-storage-outside-file-");
   await mkdir(targetDir, { recursive: true });
-  await writeFile(path.join(outside, "secret.json"), JSON.stringify({ cookies: [], origins: [] }), "utf8");
+  await writeFile(
+    path.join(outside, "secret.json"),
+    JSON.stringify({ cookies: [], origins: [] }),
+    "utf8",
+  );
   await symlink(path.join(outside, "secret.json"), path.join(targetDir, "linked.json"));
 
   await assert.rejects(
@@ -101,13 +114,17 @@ test("loadStoredStorageState rejects a symlink swap just before open", async () 
 
   await assert.rejects(
     () =>
-      loadStoredStorageState("swap", { workspaceRoot: workspace }, {
-        openImpl: async (filePath, flags) => {
-          await rm(filePath, { force: true });
-          await symlink(outsideFile, filePath);
-          return open(filePath, flags);
+      loadStoredStorageState(
+        "swap",
+        { workspaceRoot: workspace },
+        {
+          openImpl: async (filePath, flags) => {
+            await rm(filePath, { force: true });
+            await symlink(outsideFile, filePath);
+            return open(filePath, flags);
+          },
         },
-      }),
+      ),
     /must not use symlinks/i,
   );
 });

--- a/.pi/extensions/browser-playwright/storage-state.ts
+++ b/.pi/extensions/browser-playwright/storage-state.ts
@@ -114,7 +114,9 @@ export async function loadStoredStorageState(
     handle = await openImpl(resolvedState.absolutePath, constants.O_RDONLY | constants.O_NOFOLLOW);
     const stats = await handle.stat();
     if (!stats.isFile()) {
-      throw new Error(`Stored browser state must be a regular file: \`${resolvedState.relativePath}\`.`);
+      throw new Error(
+        `Stored browser state must be a regular file: \`${resolvedState.relativePath}\`.`,
+      );
     }
 
     const parsed = JSON.parse(await handle.readFile({ encoding: "utf8" }));

--- a/imessage-bridge/adapter.test.ts
+++ b/imessage-bridge/adapter.test.ts
@@ -9,9 +9,7 @@ import {
 
 describe("iMessage send helpers", () => {
   it("builds a stable default thread id from the recipient", () => {
-    expect(getDefaultIMessageThreadId("Alice@Example.com")).toBe(
-      "imessage:alice@example.com",
-    );
+    expect(getDefaultIMessageThreadId("Alice@Example.com")).toBe("imessage:alice@example.com");
   });
 
   it("builds the AppleScript lines for an argv-driven send", () => {
@@ -20,9 +18,9 @@ describe("iMessage send helpers", () => {
       "set recipientHandle to item 1 of argv",
       "set messageBody to item 2 of argv",
       'tell application "Messages"',
-      'set targetService to 1st service whose service type = iMessage',
-      'set targetBuddy to buddy recipientHandle of targetService',
-      'send messageBody to targetBuddy',
+      "set targetService to 1st service whose service type = iMessage",
+      "set targetBuddy to buddy recipientHandle of targetService",
+      "send messageBody to targetBuddy",
       "end tell",
       "end run",
     ]);

--- a/imessage-bridge/adapter.ts
+++ b/imessage-bridge/adapter.ts
@@ -3,11 +3,7 @@ import type {
   MessageAdapter,
   OutboundMessage as IMessageAdapterOutboundMessage,
 } from "@gugu910/pi-transport-core";
-import {
-  assertIMessageSendCapability,
-  sendIMessage,
-  type RunAppleScript,
-} from "./send.js";
+import { assertIMessageSendCapability, sendIMessage, type RunAppleScript } from "./send.js";
 import type { DetectIMessageMvpEnvironmentOptions, IMessageMvpEnvironment } from "./mvp.js";
 
 export type { IMessageAdapterInboundMessage, IMessageAdapterOutboundMessage };
@@ -16,9 +12,7 @@ export interface IMessageAdapterOptions {
   osascriptPath?: string;
   runAppleScript?: RunAppleScript;
   detectEnvironmentOptions?: DetectIMessageMvpEnvironmentOptions;
-  detectEnvironment?: (
-    options?: DetectIMessageMvpEnvironmentOptions,
-  ) => IMessageMvpEnvironment;
+  detectEnvironment?: (options?: DetectIMessageMvpEnvironmentOptions) => IMessageMvpEnvironment;
 }
 
 export interface IMessageAdapter extends MessageAdapter {

--- a/imessage-bridge/send.ts
+++ b/imessage-bridge/send.ts
@@ -46,12 +46,12 @@ export function getDefaultIMessageThreadId(recipient: string): string {
 export function buildIMessageSendAppleScript(): string[] {
   return [
     "on run argv",
-    'set recipientHandle to item 1 of argv',
-    'set messageBody to item 2 of argv',
+    "set recipientHandle to item 1 of argv",
+    "set messageBody to item 2 of argv",
     'tell application "Messages"',
-    'set targetService to 1st service whose service type = iMessage',
-    'set targetBuddy to buddy recipientHandle of targetService',
-    'send messageBody to targetBuddy',
+    "set targetService to 1st service whose service type = iMessage",
+    "set targetBuddy to buddy recipientHandle of targetService",
+    "send messageBody to targetBuddy",
     "end tell",
     "end run",
   ];

--- a/openai-execution-shaping/README.md
+++ b/openai-execution-shaping/README.md
@@ -121,7 +121,7 @@ This package is intentionally constrained by the current Pi extension/runtime se
 ### What still needs Pi core support for a cleaner implementation
 
 - treating plan-only / commentary-only turns as **core incomplete-turn retries** instead of post-hoc follow-up turns
-- detecting and handling **one-action-then-narrative** patterns *inside* the agent loop rather than only after `agent_end`
+- detecting and handling **one-action-then-narrative** patterns _inside_ the agent loop rather than only after `agent_end`
 - surfacing richer lifecycle states like `blocked` / `paused` / `abandoned`
 - provider/model-specific prompt overlays integrated at the core prompt builder layer
 

--- a/openai-execution-shaping/config.ts
+++ b/openai-execution-shaping/config.ts
@@ -49,7 +49,9 @@ function parseJsonFile(filePath: string): unknown | null {
   }
 }
 
-function readSettingsConfig(settingsPath: string): { path: string; raw: OpenAIExecutionShapingConfig } | null {
+function readSettingsConfig(
+  settingsPath: string,
+): { path: string; raw: OpenAIExecutionShapingConfig } | null {
   if (!fs.existsSync(settingsPath)) return null;
   const parsed = parseJsonFile(settingsPath);
   if (!parsed || typeof parsed !== "object") return null;
@@ -112,9 +114,7 @@ export function resolveConfig(
   };
 }
 
-export function loadConfig(
-  options: LoadConfigOptions = {},
-): ResolvedOpenAIExecutionShapingConfig {
+export function loadConfig(options: LoadConfigOptions = {}): ResolvedOpenAIExecutionShapingConfig {
   const cwd = options.cwd ?? process.cwd();
   const agentDir = options.agentDir ?? join(os.homedir(), ".pi", "agent");
   const env = options.env ?? process.env;

--- a/openai-execution-shaping/helpers.test.ts
+++ b/openai-execution-shaping/helpers.test.ts
@@ -50,13 +50,15 @@ describe("target model matching", () => {
 
   it("matches targeted OpenAI GPT-5 models", () => {
     expect(isTargetModel({ provider: "openai", id: "gpt-5.4" }, enabledConfig)).toBe(true);
-    expect(isTargetModel({ provider: "openai-codex", id: "openai-codex/gpt-5.4" }, enabledConfig)).toBe(
-      true,
-    );
+    expect(
+      isTargetModel({ provider: "openai-codex", id: "openai-codex/gpt-5.4" }, enabledConfig),
+    ).toBe(true);
   });
 
   it("does not match non-target providers or models", () => {
-    expect(isTargetModel({ provider: "anthropic", id: "claude-sonnet-4-5" }, enabledConfig)).toBe(false);
+    expect(isTargetModel({ provider: "anthropic", id: "claude-sonnet-4-5" }, enabledConfig)).toBe(
+      false,
+    );
     expect(isTargetModel({ provider: "openai", id: "gpt-4.1" }, enabledConfig)).toBe(false);
   });
 
@@ -86,7 +88,12 @@ describe("assistant drift detection", () => {
       message: {
         role: "assistant",
         stopReason: "stop",
-        content: [{ type: "text", text: "I'll inspect the repository structure and then update the files." }],
+        content: [
+          {
+            type: "text",
+            text: "I'll inspect the repository structure and then update the files.",
+          },
+        ],
       },
       toolResultCount: 0,
       usedAutoContinueTurns: 0,
@@ -121,7 +128,12 @@ describe("assistant drift detection", () => {
       message: {
         role: "assistant",
         stopReason: "stop",
-        content: [{ type: "text", text: "I'll inspect the repository structure and then update the files." }],
+        content: [
+          {
+            type: "text",
+            text: "I'll inspect the repository structure and then update the files.",
+          },
+        ],
       },
       toolResultCount: 1,
       usedAutoContinueTurns: 0,
@@ -161,7 +173,12 @@ describe("assistant drift detection", () => {
       message: {
         role: "assistant",
         stopReason: "stop",
-        content: [{ type: "text", text: "I'll inspect the repository structure and then update the files." }],
+        content: [
+          {
+            type: "text",
+            text: "I'll inspect the repository structure and then update the files.",
+          },
+        ],
       },
       toolResultCount: 0,
       usedAutoContinueTurns: 1,

--- a/openai-execution-shaping/helpers.ts
+++ b/openai-execution-shaping/helpers.ts
@@ -68,7 +68,10 @@ export function buildAutoContinueMessage(): string {
   ].join(" ");
 }
 
-export function normalizeModelId(modelId: string | undefined, provider: string | undefined): string {
+export function normalizeModelId(
+  modelId: string | undefined,
+  provider: string | undefined,
+): string {
   if (!modelId) return "";
   const trimmed = modelId.trim();
   if (!trimmed) return "";
@@ -114,9 +117,7 @@ export function countAssistantToolCalls(message: AssistantMessageLike | undefine
   return message.content.filter((block) => block?.type === "toolCall").length;
 }
 
-export function classifyContinuationNeed(
-  input: ContinuationDecisionInput,
-): ContinuationDecision {
+export function classifyContinuationNeed(input: ContinuationDecisionInput): ContinuationDecision {
   const { message, toolResultCount, usedAutoContinueTurns, maxAutoContinueTurns } = input;
 
   if (!message || message.role !== "assistant") {

--- a/openai-execution-shaping/index.ts
+++ b/openai-execution-shaping/index.ts
@@ -119,7 +119,11 @@ export default function openAIExecutionShapingExtension(pi: ExtensionAPI) {
   pi.on("agent_end", async (event, ctx) => {
     const extensionCtx = ctx as CompatibleExtensionContext;
     const config = loadRuntimeConfig(ctx.cwd);
-    if (!config.enabled || !config.autoContinueEnabled || !isTargetModel(extensionCtx.model, config)) {
+    if (
+      !config.enabled ||
+      !config.autoContinueEnabled ||
+      !isTargetModel(extensionCtx.model, config)
+    ) {
       return;
     }
 

--- a/plans/420-broker-daemon-prd.md
+++ b/plans/420-broker-daemon-prd.md
@@ -167,20 +167,20 @@ The daemon is a supervisor/control-plane process that starts and talks to a sepa
 
 ## Comparison table
 
-| Dimension | Pi SDK in daemon | External pi over RPC |
-|---|---|---|
-| Process model | Single long-lived daemon process hosts broker infra and pi session together | Two long-lived processes: daemon + pi child/service |
-| Lifecycle control | Strong — one owner controls session creation, replacement, shutdown, subscriptions | Indirect — daemon must coordinate with external pi lifecycle and reconnect semantics |
-| Extension reuse | Strong — broker can bind the same extensions/resources directly in-process | Medium — reuse depends on what RPC exposes and how extension-side events map across the boundary |
-| Startup complexity | Lower for first implementation | Higher — requires bootstrapping and supervising a second process |
-| Failure isolation | Lower — broker infra and broker reasoning can crash together | Higher — daemon and pi process can fail independently |
-| Observability | Easier unified logs/events in one process | Better hard isolation, but split logs/metrics and cross-process correlation |
-| Backpressure / event streaming | Direct function and event calls | Must be modeled over transport; more framing work |
-| Resource usage | Lower process overhead | Higher process overhead |
-| Upgrade / version skew | Simpler — single dependency graph | Harder — daemon and pi RPC contract can drift |
-| Broker connectivity ownership | Clear — daemon owns Slack + broker session | Risk of ambiguous ownership if daemon and pi child split responsibilities poorly |
-| Fit for long-lived control plane | Strong | Acceptable, but only if strict ownership and supervision are designed up front |
-| Time-to-first-usable daemon | Faster | Slower |
+| Dimension                        | Pi SDK in daemon                                                                   | External pi over RPC                                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Process model                    | Single long-lived daemon process hosts broker infra and pi session together        | Two long-lived processes: daemon + pi child/service                                              |
+| Lifecycle control                | Strong — one owner controls session creation, replacement, shutdown, subscriptions | Indirect — daemon must coordinate with external pi lifecycle and reconnect semantics             |
+| Extension reuse                  | Strong — broker can bind the same extensions/resources directly in-process         | Medium — reuse depends on what RPC exposes and how extension-side events map across the boundary |
+| Startup complexity               | Lower for first implementation                                                     | Higher — requires bootstrapping and supervising a second process                                 |
+| Failure isolation                | Lower — broker infra and broker reasoning can crash together                       | Higher — daemon and pi process can fail independently                                            |
+| Observability                    | Easier unified logs/events in one process                                          | Better hard isolation, but split logs/metrics and cross-process correlation                      |
+| Backpressure / event streaming   | Direct function and event calls                                                    | Must be modeled over transport; more framing work                                                |
+| Resource usage                   | Lower process overhead                                                             | Higher process overhead                                                                          |
+| Upgrade / version skew           | Simpler — single dependency graph                                                  | Harder — daemon and pi RPC contract can drift                                                    |
+| Broker connectivity ownership    | Clear — daemon owns Slack + broker session                                         | Risk of ambiguous ownership if daemon and pi child split responsibilities poorly                 |
+| Fit for long-lived control plane | Strong                                                                             | Acceptable, but only if strict ownership and supervision are designed up front                   |
+| Time-to-first-usable daemon      | Faster                                                                             | Slower                                                                                           |
 
 ## Explicit tradeoffs
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,8 @@ importers:
         specifier: ^0.34.49
         version: 0.34.49
 
+  openai-execution-shaping: {}
+
   slack-api:
     dependencies:
       "@slack/web-api":

--- a/slack-bridge/broker/adapters/types.ts
+++ b/slack-bridge/broker/adapters/types.ts
@@ -1,5 +1,1 @@
-export type {
-  InboundMessage,
-  OutboundMessage,
-  MessageAdapter,
-} from "@gugu910/pi-transport-core";
+export type { InboundMessage, OutboundMessage, MessageAdapter } from "@gugu910/pi-transport-core";

--- a/slack-bridge/broker/message-send.ts
+++ b/slack-bridge/broker/message-send.ts
@@ -2,7 +2,12 @@ import type { BrokerMessage, MessageAdapter, OutboundMessage, ThreadInfo } from 
 
 export interface BrokerMessageSenderDb {
   getThread(threadId: string): ThreadInfo | null;
-  createThread(threadId: string, source: string, channel: string, ownerAgent: string | null): ThreadInfo;
+  createThread(
+    threadId: string,
+    source: string,
+    channel: string,
+    ownerAgent: string | null,
+  ): ThreadInfo;
   updateThread(threadId: string, updates: Partial<ThreadInfo>): void;
   insertMessage(
     threadId: string,

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  createRalphLoopState,
-  hydrateRalphLoopReportedGhosts,
-} from "./ralph-loop.js";
+import { createRalphLoopState, hydrateRalphLoopReportedGhosts } from "./ralph-loop.js";
 import { rewriteRalphLoopGhostAnomalies } from "./helpers.js";
 
 function buildEvaluation(ghostAgentIds: string[]) {


### PR DESCRIPTION
## Summary
- apply formatting-only cleanup to the inherited drift currently blocking `pnpm check` on `main`
- keep the slice pinned to formatter output without changing CI commands or local hooks
- restore the repo so `pnpm check` is green and #503 can resume unchanged

Closes #504

## Testing
- pnpm install --frozen-lockfile
- pnpm check
- pnpm test
- pnpm prepush