### PR TITLE
ci: add repo quality gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,36 @@
+name: Quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run quality checks
+        run: pnpm check
+
+      - name: Run tests
+        run: pnpm test

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install StyLua
+        run: npm install --global @johnnymorganz/stylua-bin@2.0.2
+
       - name: Run quality checks
         run: pnpm check
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,8 +23,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Enable Corepack and provision pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.1 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,17 +16,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-
-      - name: Enable Corepack and provision pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.18.1 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- add a repo-hosted GitHub Actions workflow for pull requests and pushes to `main`
- run the existing repo quality gate unchanged: `pnpm install --frozen-lockfile`, `pnpm check`, and `pnpm test`
- keep local hooks and command ergonomics unchanged

Closes #503

## Testing
- pnpm install --frozen-lockfile
- pnpm check
- pnpm test
- pnpm prepush