### PR TITLE
refactor: codify send-only iMessage adapter contract (#476)

### DIFF
--- a/imessage-bridge/adapter.test.ts
+++ b/imessage-bridge/adapter.test.ts
@@ -86,4 +86,32 @@ describe("AppleScriptIMessageAdapter", () => {
 
     await expect(adapter.connect()).rejects.toThrow("iMessage send-first adapter is not ready");
   });
+
+  it("treats onInbound as a no-op for the send-first adapter", async () => {
+    const runAppleScript = vi.fn(async () => ({ stdout: "sent", stderr: "" }));
+    const handler = vi.fn();
+    const adapter = createIMessageAdapter({
+      runAppleScript,
+      detectEnvironment: () => ({
+        platform: "darwin",
+        homeDir: "/Users/goose",
+        messagesDbPath: "/Users/goose/Library/Messages/chat.db",
+        osascriptPath: APPLESCRIPT_BINARY_PATH,
+        osascriptAvailable: true,
+        messagesDbAvailable: false,
+        canAttemptSend: true,
+        canAttemptHistoryRead: false,
+        readyForLocalMvp: false,
+        blockers: ["missing_messages_db"],
+      }),
+    });
+
+    adapter.onInbound(handler);
+    await adapter.connect();
+    await adapter.send({ threadId: "imessage:alice", channel: "chat:alice", text: "hi" });
+    await adapter.disconnect();
+
+    expect(runAppleScript).toHaveBeenCalledTimes(1);
+    expect(handler).not.toHaveBeenCalled();
+  });
 });

--- a/imessage-bridge/adapter.ts
+++ b/imessage-bridge/adapter.ts
@@ -23,7 +23,6 @@ export class AppleScriptIMessageAdapter implements IMessageAdapter {
   readonly name = "imessage" as const;
 
   private readonly options: IMessageAdapterOptions;
-  private inboundHandler: ((msg: IMessageAdapterInboundMessage) => void) | null = null;
 
   constructor(options: IMessageAdapterOptions = {}) {
     this.options = options;
@@ -54,11 +53,13 @@ export class AppleScriptIMessageAdapter implements IMessageAdapter {
   }
 
   async disconnect(): Promise<void> {
-    this.inboundHandler = null;
+    // The current send-first adapter does not hold inbound subscriptions or
+    // long-lived connection state beyond the shared MessageAdapter surface.
   }
 
-  onInbound(handler: (msg: IMessageAdapterInboundMessage) => void): void {
-    this.inboundHandler = handler;
+  onInbound(_handler: (msg: IMessageAdapterInboundMessage) => void): void {
+    // The shared MessageAdapter contract requires an inbound hook, but the
+    // current iMessage adapter is send-only and intentionally ignores it.
   }
 
   async send(msg: IMessageAdapterOutboundMessage): Promise<void> {


### PR DESCRIPTION
## Summary
- remove dead inbound handler state from the send-first iMessage adapter
- keep the shared MessageAdapter surface unchanged and document `onInbound(...)` as an explicit no-op for this adapter
- add narrow test coverage that the send-first adapter still sends normally after `onInbound(...)` is called

## Testing
- pnpm --dir .worktrees/refactor-476-send-only-imessage-contract --filter @gugu910/pi-imessage-bridge test
- pnpm --dir .worktrees/refactor-476-send-only-imessage-contract --filter @gugu910/pi-imessage-bridge lint
- pnpm --dir .worktrees/refactor-476-send-only-imessage-contract --filter @gugu910/pi-imessage-bridge typecheck
- pnpm --dir .worktrees/refactor-476-send-only-imessage-contract exec tsc --noEmit --noUnusedLocals --noUnusedParameters -p imessage-bridge/tsconfig.json