### PR TITLE
fix: guard delivery-claiming pinet_free notes (#462)

### DIFF
--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -108,7 +108,62 @@ describe("registerPinetTools", () => {
     });
   });
 
-  it("formats pinet_free responses with note and queued inbox count", async () => {
+  it("rejects delivery-claiming pinet_free notes with no verified outbound sends", async () => {
+    const signalAgentFree = vi.fn(async () => ({
+      queuedInboxCount: 0,
+      drainedQueuedInbox: false,
+    }));
+    const deps = createDeps({ signalAgentFree });
+    const tools = registerWithDeps(deps);
+
+    await expect(
+      tools.get("pinet_free")?.execute("tool-call-2", {
+        note: "Delivered final report to Goose",
+      }),
+    ).rejects.toThrow(
+      "pinet_free note claims delivery, but no verified outbound pinet_message was sent since the last free/reset.",
+    );
+    expect(signalAgentFree).not.toHaveBeenCalled();
+  });
+
+  it("allows delivery-claiming pinet_free notes after a verified pinet_message and resets the window", async () => {
+    const signalAgentFree = vi.fn(async () => ({
+      queuedInboxCount: 0,
+      drainedQueuedInbox: false,
+    }));
+    const sendPinetAgentMessage = vi.fn(async (target: string) => ({ messageId: 17, target }));
+    const deps = createDeps({ signalAgentFree, sendPinetAgentMessage });
+    const tools = registerWithDeps(deps);
+
+    await tools.get("pinet_message")?.execute("tool-call-2a", {
+      to: "Goose",
+      message: "Final report body",
+    });
+
+    const result = (await tools.get("pinet_free")?.execute("tool-call-2b", {
+      note: "Delivered final report to Goose",
+    })) as {
+      content: Array<{ text: string }>;
+      details: { status: string; note: string | null; queuedInboxCount: number };
+    };
+
+    expect(sendPinetAgentMessage).toHaveBeenCalledWith("Goose", "Final report body");
+    expect(signalAgentFree).toHaveBeenCalledTimes(1);
+    expect(result.content[0]?.text).toBe(
+      "Marked this Pinet agent idle/free for new work. Note: Delivered final report to Goose.",
+    );
+
+    await expect(
+      tools.get("pinet_free")?.execute("tool-call-2c", {
+        note: "Sent final report to Goose",
+      }),
+    ).rejects.toThrow(
+      "pinet_free note claims delivery, but no verified outbound pinet_message was sent since the last free/reset.",
+    );
+    expect(signalAgentFree).toHaveBeenCalledTimes(1);
+  });
+
+  it("formats non-delivery pinet_free responses with note and queued inbox count", async () => {
     const signalAgentFree = vi.fn(async () => ({
       queuedInboxCount: 2,
       drainedQueuedInbox: false,
@@ -116,7 +171,7 @@ describe("registerPinetTools", () => {
     const deps = createDeps({ signalAgentFree });
     const tools = registerWithDeps(deps);
 
-    const result = (await tools.get("pinet_free")?.execute("tool-call-2", {
+    const result = (await tools.get("pinet_free")?.execute("tool-call-2d", {
       note: "wrapped up #395",
     })) as {
       content: Array<{ text: string }>;

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -80,7 +80,28 @@ function buildPinetAgentsHintText(hint: PinetAgentsRoutingHint): string {
     .join(" · ")}`;
 }
 
+const DELIVERY_CLAIM_PATTERNS = [
+  /\bdelivered\b/i,
+  /\bsent\b/i,
+  /\breported\b/i,
+  /\bfinal report\b/i,
+  /\bhand(?:ed)?\s+off\b/i,
+];
+
+function noteClaimsDelivery(note: string): boolean {
+  return DELIVERY_CLAIM_PATTERNS.some((pattern) => pattern.test(note));
+}
+
 export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDeps): void {
+  let verifiedOutboundMessagesSinceFree = 0;
+
+  function recordVerifiedOutboundMessage(count = 1): void {
+    verifiedOutboundMessagesSinceFree += count;
+  }
+
+  function resetVerifiedOutboundMessageWindow(): void {
+    verifiedOutboundMessagesSinceFree = 0;
+  }
   pi.registerTool({
     name: "pinet_message",
     label: "Pinet Message",
@@ -103,6 +124,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
 
       if (deps.brokerRole() === "broker" && isBroadcastChannelTarget(params.to)) {
         const result = deps.sendPinetBroadcastMessage(params.to, params.message);
+        recordVerifiedOutboundMessage(result.messageIds.length);
         const preview = result.recipients.slice(0, 5).join(", ");
         const suffix = result.recipients.length > 5 ? ", …" : "";
 
@@ -122,6 +144,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       }
 
       const result = await deps.sendPinetAgentMessage(params.to, params.message);
+      recordVerifiedOutboundMessage();
       return {
         content: [
           { type: "text", text: `Message sent to ${result.target} (id: ${result.messageId}).` },
@@ -145,7 +168,14 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       deps.requireToolPolicy("pinet_free", undefined, `note=${params.note ?? ""}`);
 
       const note = typeof params.note === "string" ? params.note.trim() : "";
+      if (note && noteClaimsDelivery(note) && verifiedOutboundMessagesSinceFree === 0) {
+        throw new Error(
+          "pinet_free note claims delivery, but no verified outbound pinet_message was sent since the last free/reset. Send the report with pinet_message first, or use a non-delivery note.",
+        );
+      }
+
       const result = await deps.signalAgentFree(undefined, { requirePinet: true });
+      resetVerifiedOutboundMessageWindow();
       const inboxSuffix =
         result.queuedInboxCount > 0
           ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`


### PR DESCRIPTION
## Summary
- track verified outbound `pinet_message` sends inside the package-local Pinet tool runtime
- reject delivery-claiming `pinet_free` notes when no verified outbound send happened since the last free/reset
- reset the verified outbound window after a successful free and cover the narrow guard behavior with focused tests

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- pinet-tools.test.ts
- pnpm prepush