### PR TITLE
fix: surface pinet outbound counts in agent listings (#462)

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -196,7 +196,7 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
-  it("agents.list returns connected agents without exposing raw stableIds", async () => {
+  it("agents.list returns connected agents with outbound counts without exposing raw stableIds", async () => {
     await client.register("agent-alpha", "🅰️", undefined, "host:session:/tmp/alpha");
 
     const info = server.getConnectInfo();
@@ -205,11 +205,16 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     await client2.connect();
     await client2.register("agent-beta", "🅱️", undefined, "host:session:/tmp/beta");
 
+    const messageId = await client.sendAgentMessage("agent-beta", "handover ready");
+    expect(messageId).toBeGreaterThan(0);
+
     const agents = await client.listAgents();
     expect(agents.length).toBe(2);
     const names = agents.map((a) => a.name).sort();
     expect(names).toEqual(["agent-alpha", "agent-beta"]);
     expect(agents.every((agent) => !("stableId" in agent))).toBe(true);
+    expect(agents.find((agent) => agent.name === "agent-alpha")?.outboundCount).toBe(1);
+    expect(agents.find((agent) => agent.name === "agent-beta")?.outboundCount).toBe(0);
 
     client2.disconnect();
   });

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -746,12 +746,34 @@ export class BrokerDB implements BrokerDBInterface {
     return row ? rowToAgent(row) : null;
   }
 
+  private getCurrentSessionOutboundCount(agentId: string, connectedAt: string): number {
+    const db = this.getDb();
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS count
+         FROM messages
+         WHERE sender = ?
+           AND source = 'agent'
+           AND created_at >= ?`,
+      )
+      .get(agentId, connectedAt) as { count: number } | undefined;
+    return Number(row?.count ?? 0);
+  }
+
+  private rowToAgentWithCurrentSessionOutboundCount(row: AgentRow): AgentInfo {
+    const agent = rowToAgent(row);
+    return {
+      ...agent,
+      outboundCount: this.getCurrentSessionOutboundCount(agent.id, agent.connectedAt),
+    };
+  }
+
   getAgents(): AgentInfo[] {
     const db = this.getDb();
     const rows = db
       .prepare("SELECT * FROM agents WHERE disconnected_at IS NULL ORDER BY connected_at ASC")
       .all() as unknown as AgentRow[];
-    return rows.map(rowToAgent);
+    return rows.map((row) => this.rowToAgentWithCurrentSessionOutboundCount(row));
   }
 
   getAllAgents(): AgentInfo[] {
@@ -762,7 +784,7 @@ export class BrokerDB implements BrokerDBInterface {
          ORDER BY CASE WHEN disconnected_at IS NULL THEN 0 ELSE 1 END, connected_at ASC`,
       )
       .all() as unknown as AgentRow[];
-    return rows.map(rowToAgent);
+    return rows.map((row) => this.rowToAgentWithCurrentSessionOutboundCount(row));
   }
 
   getSetting<T = unknown>(key: string): T | null {

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -15,6 +15,7 @@ export interface AgentInfo {
   resumableUntil?: string | null;
   idleSince?: string | null;
   lastActivity?: string | null;
+  outboundCount?: number;
 }
 
 export type ClientAgentInfo = Omit<AgentInfo, "stableId">;

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -725,6 +725,7 @@ export interface AgentDisplayInfo {
   lastActivity?: string | null;
   idleDuration?: string | null;
   lastActivityAge?: string | null;
+  outboundCount?: number | null;
   capabilityTags?: string[];
   routingScore?: number;
   routingReasons?: string[];
@@ -743,6 +744,7 @@ export interface AgentVisibilityInput {
   resumableUntil?: string | null;
   idleSince?: string | null;
   lastActivity?: string | null;
+  outboundCount?: number | null;
 }
 
 export interface AgentVisibilityOptions {
@@ -982,6 +984,7 @@ export function buildAgentDisplayInfo(
     lastActivity: agent.lastActivity ?? null,
     idleDuration: formatAge(idleDurationMs),
     lastActivityAge: formatAge(lastActivityAgeMs),
+    outboundCount: agent.outboundCount ?? null,
     capabilityTags,
   };
 }
@@ -2115,6 +2118,10 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
           activityInfo,
         ].filter((item): item is string => Boolean(item));
         line += `\n   ${summary.join(" · ")}`;
+      }
+
+      if (a.outboundCount != null) {
+        line += `\n   outbound: ${a.outboundCount} this session`;
       }
 
       const tags = (a.capabilityTags ?? []).slice(0, 6);

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -40,6 +40,7 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
       stableId: "stable-worker-1",
       name: "Worker One",
       emoji: "🦊",
+      outboundCount: 3,
     }),
     makeAgent({
       id: "worker-2",
@@ -159,6 +160,7 @@ function createFollowerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
       lastSeen: "2026-04-15T13:09:30.000Z",
       disconnectedAt: null,
       resumableUntil: null,
+      outboundCount: 2,
     },
   ]);
   const followerClient: PinetMeshOpsFollowerClientPort = {
@@ -306,12 +308,22 @@ describe("createPinetMeshOps", () => {
 
     expect(brokerMeshOps.listBrokerAgents()).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: "worker-1", status: "idle", name: "Worker One" }),
+        expect.objectContaining({
+          id: "worker-1",
+          status: "idle",
+          name: "Worker One",
+          outboundCount: 3,
+        }),
         expect.objectContaining({ id: "worker-2", status: "idle", name: "Worker Two" }),
       ]),
     );
     await expect(followerMeshOps.listFollowerAgents(true)).resolves.toEqual([
-      expect.objectContaining({ id: "worker-2", status: "idle", name: "Worker Two" }),
+      expect.objectContaining({
+        id: "worker-2",
+        status: "idle",
+        name: "Worker Two",
+        outboundCount: 2,
+      }),
     ]);
     expect(follower.listAgents).toHaveBeenCalledWith(true);
   });

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -20,6 +20,7 @@ export interface PinetMeshOpsAgentRecord {
   lastSeen?: string;
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
+  outboundCount?: number;
 }
 
 export interface PinetMeshOpsRecordedAssignment {
@@ -256,6 +257,7 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
       lastSeen: agent.lastSeen,
       disconnectedAt: agent.disconnectedAt,
       resumableUntil: agent.resumableUntil,
+      outboundCount: agent.outboundCount,
     }));
   }
 
@@ -276,6 +278,7 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
       lastSeen: agent.lastSeen,
       disconnectedAt: agent.disconnectedAt,
       resumableUntil: agent.resumableUntil,
+      outboundCount: agent.outboundCount,
     }));
   }
 

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -158,11 +158,11 @@ describe("registerPinetTools", () => {
     expect(result.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
   });
 
-  it("renders broker pinet_agents output with routing hints", async () => {
+  it("renders broker pinet_agents output with routing hints and outbound counts", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
 
-    const listBrokerAgents = vi.fn(() => [makeAgent()]);
+    const listBrokerAgents = vi.fn(() => [makeAgent({ outboundCount: 3 })]);
     const deps = createDeps({ listBrokerAgents });
     const tools = registerWithDeps(deps);
 
@@ -180,6 +180,7 @@ describe("registerPinetTools", () => {
       "Agent routing hints: repo=extensions · tools=read,edit · task=review #395",
     );
     expect(result.content[0]?.text).toContain("Golden Chalk Rabbit");
+    expect(result.content[0]?.text).toContain("outbound: 3 this session");
     expect(result.details.hint).toEqual({
       repo: "extensions",
       branch: undefined,

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -24,6 +24,7 @@ export interface PinetToolsAgentRecord {
   lastSeen?: string;
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
+  outboundCount?: number;
 }
 
 export interface RegisterPinetToolsDeps {


### PR DESCRIPTION
## Summary
- derive current-session outbound counts for agents from the existing broker-verified agent message record path
- thread the outbound count through the broker/client agents.list projection and pinet mesh listing path
- render the diagnostic count in `pinet_agents` with focused broker + mesh + display coverage

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test -- broker/integration.test.ts pinet-mesh-ops.test.ts pinet-tools.test.ts
- pnpm prepush