### PR TITLE
fix(broker): stop exposing ownerStableId in registration conflict (#495)

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -192,6 +192,7 @@ describe("broker integration — client ↔ server ↔ DB", () => {
       }),
     );
     expect(rpcConflictError.data as Record<string, unknown>).not.toHaveProperty("ownerAgentId");
+    expect(rpcConflictError.data as Record<string, unknown>).not.toHaveProperty("ownerStableId");
 
     client2.disconnect();
   });

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -592,6 +592,8 @@ export class BrokerSocketServer {
     if (explicitNameRequest) {
       const conflict = this.db.findAgentNameConflict(finalName, candidateId, stableId);
       if (conflict) {
+        // Do not expose raw ownerStableId on this client-visible payload (#495).
+        // The message + code + requestedName are enough to drive the retry path.
         return rpcError(
           req.id,
           RPC_AGENT_NAME_CONFLICT,
@@ -599,7 +601,6 @@ export class BrokerSocketServer {
           {
             code: "AGENT_NAME_CONFLICT",
             requestedName: finalName,
-            ownerStableId: conflict.stableId,
             retryable: true,
           },
         );


### PR DESCRIPTION
Narrow follow-up slice under #324 after #491, #493, and #496.

## What
Stops serializing raw `ownerStableId` into the `RPC_AGENT_NAME_CONFLICT` (`data`) payload returned by the broker when a client registers with an already-reserved agent name.

## Why
Current `main` still emits the conflicting owner's raw `stableId` on this client-visible path. Nothing in the client actually consumes it — `BrokerClient`'s conflict handler only inspects `code` / message — so it's pure exposure with no functional value. This closes the last narrow client-visible raw-stableId seam called out by the #324 umbrella, per the preflight in #495.

## Scope guardrail
Intentionally narrow:
- keeps message, `code`, `requestedName`, and `retryable` unchanged
- does **not** touch `ownerAgentId` redesign or broader identity/conflict payload work (those live separately under #324)

## Test
Adds one focused assertion to the existing `rejects duplicate explicitly requested agent names with a clear retry path` integration test, mirroring the existing `ownerAgentId` check:

```ts
expect(rpcConflictError.data as Record<string, unknown>).not.toHaveProperty("ownerStableId");
```

## Gates
`pnpm prepush` (lint + typecheck + test across the workspace) passes locally — full turbo green.

Closes #495.
