### PR TITLE
docs(release): document manual npm workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this repository are documented in this file.
 
+## [Unreleased]
+
+### Docs
+
+- Added `docs/releases.md`, a manual release checklist that makes the path from
+  merged fixes on `main` to published npm packages explicit, including focused
+  package verification and `pnpm --filter <package> pack` tarball review.
+- Linked the root README's development workflow to the release checklist so
+  shipping a fix and publishing it are no longer separate tribal-knowledge
+  steps.
+
 ## [0.1.3] - 2026-04-08
 
 Pinet v0.1.3 is a narrow follow-up patch for `@gugu910/pi-slack-bridge` after `0.1.2` was published with real Slack identifiers in the package README settings example. Because published npm tarballs are immutable, this release corrects the npm-visible package surface with scrubbed example placeholders while leaving the runtime behavior unchanged.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ caching.
 | `pnpm format`       | Prettier + Stylua                                               |
 | `pnpm check`        | lint + typecheck + format check                                 |
 
+### Release workflow
+
+Public npm releases are currently **manual by design**. If a fix merged to
+`main` should reach npm users, prepare a small release PR, verify the package
+with `pnpm --filter <package> pack`, then publish from `main`.
+
+See [`docs/releases.md`](docs/releases.md) for the package list, the manual
+release checklist, and the tarball verification policy.
+
 ### Structure
 
 ```
@@ -179,6 +188,8 @@ expectations and the required smoke checklist.
 2. Write tests for any new logic
 3. Run `pnpm lint && pnpm typecheck && pnpm test`
 4. Create a PR — merge to `main`
+5. If the change should reach npm users, follow [`docs/releases.md`](docs/releases.md)
+   to prep and publish the relevant package release from `main`
 
 ## Contributors
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,78 @@
+# Release workflow
+
+This repo ships workspace packages to npm manually after code lands on `main`.
+The goal is simple: merged fixes should have a short, explicit path from GitHub
+into published npm packages.
+
+## Release policy
+
+- Treat every user-facing fix as **unreleased** until the relevant package is
+  published to npm.
+- Keep release prep **small and package-scoped**. Do not batch unrelated fixes
+  just because they landed near each other.
+- Prefer a patch release for bug fixes unless the package surface clearly needs
+  a minor or major bump.
+- Update `CHANGELOG.md` in the same PR that prepares a release.
+- Verify the package tarball locally before publishing.
+- Publish from `main`, not from a stale feature branch.
+
+## Package list
+
+Public workspace packages in this repo:
+
+- `@gugu910/pi-slack-bridge`
+- `@gugu910/pi-nvim-bridge`
+- `@gugu910/pi-neon-psql`
+- `@gugu910/pi-slack-api`
+- `@gugu910/pi-transport-core`
+
+The root `pi-extensions` package is private and is only bumped for repo-level
+tracking when a release note needs to reflect the current published surface.
+
+## Manual release checklist
+
+1. Start from an up-to-date `main` checkout.
+2. Identify the package(s) whose fixes should ship.
+3. Bump only the package version(s) that need a release.
+4. Update `CHANGELOG.md` with:
+   - release date
+   - version verification
+   - the shipped highlights
+   - linked PRs/issues when useful
+5. Run focused verification for each releasing package:
+   - `pnpm --filter <package> lint`
+   - `pnpm --filter <package> typecheck`
+   - `pnpm --filter <package> test` (if the package has tests)
+   - `pnpm --filter <package> pack`
+6. Inspect the tarball contents to confirm the npm surface is correct.
+7. Merge the release-prep PR.
+8. Publish from `main`:
+   - `pnpm --filter <package> publish --access public --no-git-checks`
+9. Tag the release if maintainers want a matching git tag.
+10. Confirm npm shows the new version.
+
+## Pack verification
+
+`pnpm --filter <package> pack` is the minimum pre-publish gate because it checks
+what npm users will actually receive, not just what exists in the repo.
+
+For this repo, a good pack review confirms:
+
+- `dist/` is present and up to date
+- `README.md` and `LICENSE` are included
+- package-specific runtime assets are included (`manifest.yaml`, `nvim/`,
+  Python helpers, CLI bin files, etc.)
+- no local-only or sensitive files leaked into the tarball
+
+## Current gap this workflow closes
+
+Historically, `main` has been ahead of npm, which leaves users installing stale
+packages even after fixes merged. This workflow makes the release path explicit:
+
+- merge the fix
+- prep a small release PR
+- verify the exact npm tarball
+- publish from `main`
+
+That is intentionally manual for now so maintainers do not need to wire npm
+secrets into CI before the release process is clear and repeatable.


### PR DESCRIPTION
## Summary
- add a manual npm release checklist and publish workflow under `docs/releases.md`
- link the main README/development flow to the release checklist
- note the new release workflow in the changelog

## Testing
- `pnpm install`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm --filter @gugu910/pi-slack-bridge pack`

Fixes #364
