### PR TITLE
fix(slack-bridge): verify pinet_free delivery claims

### DIFF
--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -900,6 +900,43 @@ export class BrokerDB implements BrokerDBInterface {
     }
   }
 
+  getTaskAssignmentThreadIdsForAgent(agentId: string): string[] {
+    const db = this.getDb();
+    const rows = db
+      .prepare(
+        `SELECT DISTINCT thread_id
+         FROM task_assignments
+         WHERE agent_id = ?`,
+      )
+      .all(agentId) as Array<{ thread_id: string }>;
+
+    return rows
+      .map((row) => row.thread_id)
+      .filter(
+        (threadId): threadId is string => typeof threadId === "string" && threadId.length > 0,
+      );
+  }
+
+  countOutboundMessagesForAgentThreads(agentId: string, threadIds: string[]): number {
+    if (threadIds.length === 0) {
+      return 0;
+    }
+
+    const db = this.getDb();
+    const placeholders = threadIds.map(() => "?").join(", ");
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS count
+         FROM messages
+         WHERE sender = ?
+           AND direction = 'outbound'
+           AND thread_id IN (${placeholders})`,
+      )
+      .get(agentId, ...threadIds) as { count: number };
+
+    return Number(row.count ?? 0);
+  }
+
   updateAgentIdentity(
     id: string,
     identity: { name: string; emoji: string; metadata?: Record<string, unknown> | null },

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -43,6 +43,7 @@ import {
   buildRalphLoopCycleNotifications,
   buildRalphLoopFollowUpMessage,
   buildRalphLoopStatusMessage,
+  containsDeliveryClaimLanguage,
   shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -489,6 +490,19 @@ describe("formatInboxMessages", () => {
     const result = formatInboxMessages(msgs, names);
     expect(result).toContain('will: Clicked Slack "Approve" (action_id: review.approve).');
     expect(result).toContain('metadata={"kind":"slack_block_action","actionId":"review.approve"');
+  });
+});
+
+describe("containsDeliveryClaimLanguage", () => {
+  it("detects delivery-like self-reports in free notes", () => {
+    expect(containsDeliveryClaimLanguage("delivered report")).toBe(true);
+    expect(containsDeliveryClaimLanguage("reported back to broker")).toBe(true);
+    expect(containsDeliveryClaimLanguage("shared results")).toBe(true);
+  });
+
+  it("ignores neutral completion notes", () => {
+    expect(containsDeliveryClaimLanguage("wrapped up #462")).toBe(false);
+    expect(containsDeliveryClaimLanguage("waiting for more work")).toBe(false);
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1315,6 +1315,13 @@ export function buildRalphLoopStatusMessage(summary: string, cycleStartedAt: str
   return `RALPH loop (${cycleStartedAt}): ${summary}`;
 }
 
+const DELIVERY_CLAIM_NOTE_REGEX =
+  /\b(deliver(?:ed|y|ing)?|reported|replied|sent|posted|shared|submitted|returned|responded)\b/i;
+
+export function containsDeliveryClaimLanguage(note: string): boolean {
+  return DELIVERY_CLAIM_NOTE_REGEX.test(note);
+}
+
 export interface RalphLoopFollowUpDeliveryOptions {
   signature: string;
   lastDeliveredSignature?: string;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -13,6 +13,7 @@ import {
   resolveAgentStableId,
   resolveAllowAllWorkspaceUsers,
   trackBrokerInboundThread,
+  containsDeliveryClaimLanguage,
 } from "./helpers.js";
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
@@ -444,6 +445,24 @@ export default function (pi: ExtensionAPI) {
     getCurrentRuntimeMode: () => currentRuntimeMode,
     maybeDrainInboxIfIdle,
     getExtensionContext: () => sessionUiRuntime.getExtensionContext() ?? undefined,
+    noteClaimsDelivery: (note) => containsDeliveryClaimLanguage(note),
+    logSuspiciousDeliveryClaim: ({ note, trackedThreadCount, outboundCount }) => {
+      const selfId = getActiveBrokerSelfId();
+      brokerRuntime.logActivity({
+        kind: "suspicious_delivery_claim",
+        level: "actions",
+        title: "Unverified delivery claim in pinet_free note",
+        summary: `${agentEmoji} ${agentName} claimed delivery in pinet_free without broker-observed outbound evidence.`,
+        details: [
+          `Note: ${note}`,
+          `Tracked assignment threads: ${trackedThreadCount}`,
+          `Broker-observed outbound messages on tracked threads: ${outboundCount}`,
+          "Broker did not verify a matching outbound report, so the claim should be treated as suspicious.",
+        ],
+        fields: selfId ? [{ label: "Agent", value: formatTrackedAgent(selfId) }] : undefined,
+        tone: "warning",
+      });
+    },
   });
   const { reportStatus, signalAgentFree } = pinetAgentStatus;
   reportAgentStatus = reportStatus;

--- a/slack-bridge/pinet-agent-status.test.ts
+++ b/slack-bridge/pinet-agent-status.test.ts
@@ -18,8 +18,17 @@ function createDeps(overrides: Partial<PinetAgentStatusDeps> = {}) {
   const syncFollowerDesiredStatus = vi.fn(async () => undefined);
   const runBrokerMaintenance = vi.fn();
   const maybeDrainInboxIfIdle = vi.fn(() => true);
+  const getTaskAssignmentThreadIdsForAgent = vi.fn<() => string[]>(() => []);
+  const countOutboundMessagesForAgentThreads = vi.fn<
+    (agentId: string, threadIds: string[]) => number
+  >(() => 0);
+  const noteClaimsDelivery = vi.fn<(note: string) => boolean>(() => false);
+  const logSuspiciousDeliveryClaim =
+    vi.fn<(details: { note: string; trackedThreadCount: number; outboundCount: number }) => void>();
   const brokerDb: PinetAgentStatusBrokerDbPort = {
     updateAgentStatus,
+    getTaskAssignmentThreadIdsForAgent,
+    countOutboundMessagesForAgentThreads,
   };
 
   const deps: PinetAgentStatusDeps = {
@@ -38,6 +47,8 @@ function createDeps(overrides: Partial<PinetAgentStatusDeps> = {}) {
     getCurrentRuntimeMode: () => "off",
     maybeDrainInboxIfIdle,
     getExtensionContext: () => ctx,
+    noteClaimsDelivery,
+    logSuspiciousDeliveryClaim,
     ...overrides,
   };
 
@@ -48,6 +59,10 @@ function createDeps(overrides: Partial<PinetAgentStatusDeps> = {}) {
     syncFollowerDesiredStatus,
     runBrokerMaintenance,
     maybeDrainInboxIfIdle,
+    getTaskAssignmentThreadIdsForAgent,
+    countOutboundMessagesForAgentThreads,
+    noteClaimsDelivery,
+    logSuspiciousDeliveryClaim,
     getDesiredAgentStatus: () => desiredAgentStatus,
   };
 }
@@ -126,5 +141,53 @@ describe("createPinetAgentStatus", () => {
     await expect(
       pinetAgentStatus.signalAgentFree(undefined, { requirePinet: true }),
     ).rejects.toThrow("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+  });
+
+  it("flags delivery-claim notes without broker-observed outbound evidence", async () => {
+    const {
+      deps,
+      getTaskAssignmentThreadIdsForAgent,
+      countOutboundMessagesForAgentThreads,
+      noteClaimsDelivery,
+      logSuspiciousDeliveryClaim,
+    } = createDeps({
+      getBrokerRole: () => "broker",
+    });
+    noteClaimsDelivery.mockReturnValue(true);
+    getTaskAssignmentThreadIdsForAgent.mockReturnValue(["a2a:broker:worker"] as string[]);
+    countOutboundMessagesForAgentThreads.mockReturnValue(0);
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await pinetAgentStatus.signalAgentFree(undefined, { note: "delivered report" });
+
+    expect(getTaskAssignmentThreadIdsForAgent).toHaveBeenCalledWith("agent-1");
+    expect(countOutboundMessagesForAgentThreads).toHaveBeenCalledWith("agent-1", [
+      "a2a:broker:worker",
+    ]);
+    expect(logSuspiciousDeliveryClaim).toHaveBeenCalledWith({
+      note: "delivered report",
+      trackedThreadCount: 1,
+      outboundCount: 0,
+    });
+  });
+
+  it("does not flag delivery-claim notes once the broker observed an outbound report", async () => {
+    const {
+      deps,
+      getTaskAssignmentThreadIdsForAgent,
+      countOutboundMessagesForAgentThreads,
+      noteClaimsDelivery,
+      logSuspiciousDeliveryClaim,
+    } = createDeps({
+      getBrokerRole: () => "broker",
+    });
+    noteClaimsDelivery.mockReturnValue(true);
+    getTaskAssignmentThreadIdsForAgent.mockReturnValue(["a2a:broker:worker"] as string[]);
+    countOutboundMessagesForAgentThreads.mockReturnValue(1);
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await pinetAgentStatus.signalAgentFree(undefined, { note: "reported back" });
+
+    expect(logSuspiciousDeliveryClaim).not.toHaveBeenCalled();
   });
 });

--- a/slack-bridge/pinet-agent-status.ts
+++ b/slack-bridge/pinet-agent-status.ts
@@ -5,6 +5,8 @@ export type PinetAgentStatusValue = "working" | "idle";
 
 export interface PinetAgentStatusBrokerDbPort {
   updateAgentStatus: (agentId: string, status: PinetAgentStatusValue) => void;
+  getTaskAssignmentThreadIdsForAgent: (agentId: string) => string[];
+  countOutboundMessagesForAgentThreads: (agentId: string, threadIds: string[]) => number;
 }
 
 export interface PinetAgentStatusDeps {
@@ -24,6 +26,12 @@ export interface PinetAgentStatusDeps {
   getCurrentRuntimeMode: () => SlackBridgeRuntimeMode;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
   getExtensionContext: () => ExtensionContext | undefined;
+  noteClaimsDelivery: (note: string) => boolean;
+  logSuspiciousDeliveryClaim: (details: {
+    note: string;
+    trackedThreadCount: number;
+    outboundCount: number;
+  }) => void;
 }
 
 export interface PinetAgentStatus {
@@ -31,7 +39,7 @@ export interface PinetAgentStatus {
   reportStatus: (status: PinetAgentStatusValue) => Promise<void>;
   signalAgentFree: (
     ctx?: ExtensionContext,
-    options?: { requirePinet?: boolean },
+    options?: { requirePinet?: boolean; note?: string },
   ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
 }
 
@@ -64,18 +72,35 @@ export function createPinetAgentStatus(deps: PinetAgentStatusDeps): PinetAgentSt
 
   async function signalAgentFree(
     ctx?: ExtensionContext,
-    options: { requirePinet?: boolean } = {},
+    options: { requirePinet?: boolean; note?: string } = {},
   ): Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }> {
     const pinetEnabled = deps.getPinetEnabled();
     if (!pinetEnabled && options.requirePinet) {
       throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
     }
 
+    const note = typeof options.note === "string" ? options.note.trim() : "";
     const maintenanceCtx = ctx ?? deps.getExtensionContext() ?? undefined;
     if (pinetEnabled) {
       await reportStatus("idle");
       if (deps.getBrokerRole() === "broker" && maintenanceCtx) {
         deps.runBrokerMaintenance(maintenanceCtx);
+      }
+    }
+
+    if (note && deps.noteClaimsDelivery(note)) {
+      const db = deps.getActiveBrokerDb();
+      const selfId = deps.getActiveBrokerSelfId();
+      if (db && selfId) {
+        const trackedThreadIds = db.getTaskAssignmentThreadIdsForAgent(selfId);
+        const outboundCount = db.countOutboundMessagesForAgentThreads(selfId, trackedThreadIds);
+        if (outboundCount === 0) {
+          deps.logSuspiciousDeliveryClaim({
+            note,
+            trackedThreadCount: trackedThreadIds.length,
+            outboundCount,
+          });
+        }
       }
     }
 

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -123,7 +123,10 @@ describe("registerPinetTools", () => {
       details: { status: string; note: string | null; queuedInboxCount: number };
     };
 
-    expect(signalAgentFree).toHaveBeenCalledWith(undefined, { requirePinet: true });
+    expect(signalAgentFree).toHaveBeenCalledWith(undefined, {
+      requirePinet: true,
+      note: "wrapped up #395",
+    });
     expect(result.content[0]?.text).toBe(
       "Marked this Pinet agent idle/free for new work. Note: wrapped up #395. 2 queued inbox items remain.",
     );

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -145,7 +145,10 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       deps.requireToolPolicy("pinet_free", undefined, `note=${params.note ?? ""}`);
 
       const note = typeof params.note === "string" ? params.note.trim() : "";
-      const result = await deps.signalAgentFree(undefined, { requirePinet: true });
+      const result = await deps.signalAgentFree(undefined, {
+        requirePinet: true,
+        ...(note ? { note } : {}),
+      });
       const inboxSuffix =
         result.queuedInboxCount > 0
           ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`


### PR DESCRIPTION
## Summary
- verify delivery-like `pinet_free` notes against broker-observed outbound messages on tracked assignment threads
- treat self-reported delivery claims as untrusted when the broker has no outbound evidence
- log a warning activity entry instead of quietly trusting zero-outbound delivery claims

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run pinet-agent-status.test.ts pinet-tools.test.ts helpers.test.ts`

Fixes #462
