### PR TITLE
chore: remove dead wrapper helpers and tracked residue (#478)

### DIFF
--- a/.nvimlog
+++ b/.nvimlog
@@ -1,6 +1,0 @@
-WRN 2026-03-18T13:59:37.448 ?.9457     server_start:193: Failed to start server: operation not permitted: /tmp/claude/nvim.guglielmoporcellini/jGjtyQ/nvim.9457.0
-WRN 2026-03-18T14:00:58.078 ?.12758    server_start:193: Failed to start server: operation not permitted: /tmp/claude/nvim.guglielmoporcellini/MIyvTw/nvim.12758.0
-WRN 2026-03-18T17:15:27.848 ?.75043    server_start:193: Failed to start server: operation not permitted: /tmp/claude/nvim.guglielmoporcellini/VQPseS/nvim.75043.0
-WRN 2026-03-18T17:25:49.603 ?.95825    server_start:193: Failed to start server: operation not permitted: /tmp/claude/nvim.guglielmoporcellini/OJUsMQ/nvim.95825.0
-WRN 2026-03-18T17:28:36.733 ?.3387     server_start:193: Failed to start server: operation not permitted: /tmp/claude/nvim.guglielmoporcellini/D9cSZ2/nvim.3387.0
-WRN 2026-04-01T17:12:02.619 ?.26445    server_start:193: Failed to start server: operation not permitted: /tmp/claude/nvim.guglielmoporcellini/u7CSKJ/nvim.26445.0

--- a/.pi/extensions/browser-playwright/helpers.ts
+++ b/.pi/extensions/browser-playwright/helpers.ts
@@ -60,10 +60,6 @@ function envFlagFrom(env: NodeJS.ProcessEnv, name: string): boolean {
   return raw != null && /^(1|true|yes|on)$/i.test(raw.trim());
 }
 
-export function envFlag(name: string, env: NodeJS.ProcessEnv = process.env): boolean {
-  return envFlagFrom(env, name);
-}
-
 export function resolveSecurityOptions(env: NodeJS.ProcessEnv = process.env): SecurityOptions {
   return {
     allowLocalhost: envFlagFrom(env, "BROWSER_ALLOW_LOCALHOST"),

--- a/slack-bridge/broker/agent-messaging.ts
+++ b/slack-bridge/broker/agent-messaging.ts
@@ -117,7 +117,6 @@ function buildAgentMessageMetadata(
 function deliverAgentMessage(
   storage: AgentMessageStorage,
   senderAgentId: string,
-  senderAgentName: string,
   target: AgentDispatchTarget,
   body: string,
   metadata: Record<string, unknown>,
@@ -225,7 +224,6 @@ export function dispatchDirectAgentMessage(
   const { threadId, messageId } = deliverAgentMessage(
     storage,
     input.senderAgentId,
-    input.senderAgentName,
     resolvedTarget,
     input.body,
     metadata,
@@ -272,7 +270,6 @@ export function dispatchBroadcastAgentMessage(
     const delivery = deliverAgentMessage(
       storage,
       input.senderAgentId,
-      input.senderAgentName,
       target,
       input.body,
       metadata,

--- a/slack-bridge/canvases.ts
+++ b/slack-bridge/canvases.ts
@@ -340,8 +340,3 @@ export function extractSlackCanvasCommentsPage(
     ...(nextCursor ? { nextCursor } : {}),
   };
 }
-
-export function extractExistingChannelCanvasId(response: Record<string, unknown>): string | null {
-  const canvasId = extractSlackChannelCanvasId(response);
-  return canvasId;
-}

--- a/slack-bridge/scheduled-wakeups.ts
+++ b/slack-bridge/scheduled-wakeups.ts
@@ -76,15 +76,3 @@ export function resolveScheduledWakeupFireAt(
 export function buildScheduledWakeupThreadId(agentId: string): string {
   return `wakeup:${agentId}`;
 }
-
-export function buildScheduledWakeupMetadata(
-  wakeupId: number,
-  fireAt: string,
-): Record<string, unknown> {
-  return {
-    senderAgent: "Pinet Scheduler",
-    scheduledWakeup: true,
-    wakeupId,
-    fireAt,
-  };
-}

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -1,10 +1,4 @@
-import {
-  buildAllowlist,
-  isUserAllowed,
-  isChannelId,
-  stripBotMention,
-  isAbortError,
-} from "./helpers.js";
+import { isUserAllowed, isChannelId, stripBotMention, isAbortError } from "./helpers.js";
 import {
   buildSlackInboundMessageText,
   extractSlackMessageFileMetadata,
@@ -52,13 +46,6 @@ export interface ParsedEnvelope {
   dedupKey?: string;
   event?: Record<string, unknown>;
   interactivePayload?: Record<string, unknown>;
-}
-
-export function buildSlackUserAllowlist(
-  allowedUsers?: string[],
-  envAllowedUsers?: string,
-): Set<string> | null {
-  return buildAllowlist({ allowedUsers }, envAllowedUsers);
 }
 
 export function isSlackUserAllowed(allowlist: Set<string> | null, userId: string): boolean {

--- a/slack-bridge/slack-block-kit.ts
+++ b/slack-bridge/slack-block-kit.ts
@@ -507,15 +507,3 @@ export function normalizeSlackViewSubmissionPayload(
     },
   };
 }
-
-export function normalizeSlackInteractivePayload(
-  payload: Record<string, unknown>,
-): SlackInteractiveInboxEvent | null {
-  if (payload.type === "block_actions") {
-    return normalizeSlackBlockActionPayload(payload);
-  }
-  if (payload.type === "view_submission") {
-    return normalizeSlackViewSubmissionPayload(payload);
-  }
-  return null;
-}


### PR DESCRIPTION
## Summary
- remove tracked `.nvimlog` residue from the repo
- delete the named dead thin-wrapper helpers with zero in-repo call sites
- drop the unused internal `senderAgentName` parameter from `deliverAgentMessage()`

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm exec vitest run broker/agent-messaging.test.ts canvases.test.ts scheduled-wakeups.test.ts slack-block-kit.test.ts` (from `slack-bridge/`)
- `cd .pi/extensions/browser-playwright && npm install && npm run check && npm test`
- `pnpm prepush`