### PR TITLE
fix: surface follower runtime diagnostics

### DIFF
--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -1,10 +1,12 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
+  type FollowerRuntimeDiagnostic,
   type FollowerThreadState,
   type InboxMessage,
   type PinetControlCommand,
   type PinetRemoteControlRequestResult,
   type SlackBridgeSettings,
+  buildFollowerRuntimeDiagnostic,
   buildPinetOwnerToken,
   extractPinetControlCommand,
   extractPinetSkinUpdate,
@@ -74,6 +76,8 @@ export interface FollowerRuntimeDeps {
   runRemoteControl: (command: PinetControlCommand, ctx: ExtensionContext) => void;
   deliverFollowUpMessage: (text: string) => boolean;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
+  getRuntimeDiagnostic: () => FollowerRuntimeDiagnostic | null;
+  setRuntimeDiagnostic: (diagnostic: FollowerRuntimeDiagnostic | null) => void;
   handleTerminalReconnectFailure: (ctx: ExtensionContext, error: Error) => Promise<void> | void;
   formatError: (error: unknown) => string;
   deliveryState: FollowerDeliveryState;
@@ -257,6 +261,9 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
         followerPollRunning = true;
         try {
           const entries = await client.pollInbox();
+          if (deps.getRuntimeDiagnostic()?.kind === "poll_failure") {
+            deps.setRuntimeDiagnostic(null);
+          }
           const newEntries = entries.filter(
             (entry) => !isFollowerInboxIdTracked(deps.deliveryState, entry.inboxId),
           );
@@ -366,8 +373,13 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
             deps.updateBadge();
             deps.maybeDrainInboxIfIdle(ctx);
           }
-        } catch {
-          /* broker may be restarting */
+        } catch (error) {
+          deps.setRuntimeDiagnostic(
+            buildFollowerRuntimeDiagnostic("poll_failure", {
+              detail: deps.formatError(error),
+              connected: client.isConnected(),
+            }),
+          );
         } finally {
           void syncDesiredStatus(deps.getDesiredAgentStatus()).catch(() => {
             /* best effort */
@@ -380,6 +392,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
     try {
       await client.connect();
       await registerFollowerRuntime();
+      deps.setRuntimeDiagnostic(null);
 
       syncedFollowerStatus = "idle";
       clientRef = {
@@ -396,6 +409,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
           return;
         }
         stopPolling();
+        deps.setRuntimeDiagnostic(buildFollowerRuntimeDiagnostic("broker_disconnect"));
         deps.setExtStatus(ctx, "reconnecting");
         const uiUpdate = getFollowerReconnectUiUpdate("disconnect", wasDisconnected);
         wasDisconnected = uiUpdate.nextWasDisconnected;
@@ -411,9 +425,15 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
           }
           try {
             await registerFollowerRuntime();
+            deps.setRuntimeDiagnostic(null);
           } catch (error) {
             console.error(
               `[slack-bridge] follower reconnect registration refresh failed: ${deps.formatError(error)}`,
+            );
+            deps.setRuntimeDiagnostic(
+              buildFollowerRuntimeDiagnostic("registration_refresh_failure", {
+                detail: deps.formatError(error),
+              }),
             );
             const registration = client.getRegisteredIdentity();
             if (registration) {
@@ -442,10 +462,13 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
         if (clientRef?.client !== client) {
           return;
         }
-        void deps.handleTerminalReconnectFailure(
-          ctx,
-          error instanceof Error ? error : new Error(String(error)),
+        const reconnectError = error instanceof Error ? error : new Error(String(error));
+        deps.setRuntimeDiagnostic(
+          buildFollowerRuntimeDiagnostic("reconnect_stopped", {
+            detail: deps.formatError(reconnectError),
+          }),
         );
+        void deps.handleTerminalReconnectFailure(ctx, reconnectError);
       });
 
       await resumeThreadClaims();

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -75,6 +75,9 @@ import {
   syncFollowerInboxEntries,
   resolveFollowerThreadChannel,
   isDirectMessageChannel,
+  buildFollowerRuntimeDiagnostic,
+  formatFollowerRuntimeDiagnosticHealth,
+  formatFollowerRuntimeDiagnosticNextStep,
   getFollowerReconnectUiUpdate,
   agentOwnsThread,
   normalizeOwnedThreads,
@@ -2975,6 +2978,83 @@ describe("resolveFollowerThreadChannel", () => {
       channelId: null,
       changed: false,
     });
+  });
+});
+
+// ─── follower runtime diagnostics ─────────────────────────
+
+describe("buildFollowerRuntimeDiagnostic", () => {
+  it("builds disconnect diagnostics", () => {
+    const diagnostic = buildFollowerRuntimeDiagnostic("broker_disconnect");
+
+    expect(diagnostic).toEqual({
+      kind: "broker_disconnect",
+      state: "reconnecting",
+      reason: "broker disconnected",
+      nextStep: "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+    });
+    expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
+      "reconnecting — broker disconnected",
+    );
+    expect(formatFollowerRuntimeDiagnosticNextStep(diagnostic)).toBe(
+      "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+    );
+  });
+
+  it("builds poll failure diagnostics", () => {
+    const diagnostic = buildFollowerRuntimeDiagnostic("poll_failure", {
+      connected: true,
+      detail: "Request timed out: pollInbox",
+    });
+
+    expect(diagnostic).toEqual({
+      kind: "poll_failure",
+      state: "degraded",
+      reason: "inbox polling failed",
+      detail: "Request timed out: pollInbox",
+      nextStep:
+        "Watch the next poll cycle. If failures continue, inspect the broker and run /pinet-follow.",
+    });
+    expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
+      "degraded — inbox polling failed (Request timed out: pollInbox)",
+    );
+  });
+
+  it("builds registration refresh failure diagnostics", () => {
+    const diagnostic = buildFollowerRuntimeDiagnostic("registration_refresh_failure", {
+      detail: "refresh failed once",
+    });
+
+    expect(diagnostic).toEqual({
+      kind: "registration_refresh_failure",
+      state: "degraded",
+      reason: "registration refresh failed after reconnect",
+      detail: "refresh failed once",
+      nextStep:
+        "Follower kept the last registered identity. If status or ownership looks stale, run /pinet-follow.",
+    });
+    expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
+      "degraded — registration refresh failed after reconnect (refresh failed once)",
+    );
+  });
+
+  it("builds reconnect stopped diagnostics and healthy fallbacks", () => {
+    const diagnostic = buildFollowerRuntimeDiagnostic("reconnect_stopped", {
+      detail: 'Agent name "Reserved Crane" is already reserved.',
+    });
+
+    expect(diagnostic).toEqual({
+      kind: "reconnect_stopped",
+      state: "error",
+      reason: "automatic reconnect stopped",
+      detail: 'Agent name "Reserved Crane" is already reserved.',
+      nextStep: "Fix the reported error, then run /pinet-follow to retry.",
+    });
+    expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
+      'error — automatic reconnect stopped (Agent name "Reserved Crane" is already reserved.)',
+    );
+    expect(formatFollowerRuntimeDiagnosticHealth(null)).toBe("healthy");
+    expect(formatFollowerRuntimeDiagnosticNextStep(null)).toBe("None.");
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1940,6 +1940,90 @@ export async function resolveFollowerThreadChannel(
   }
 }
 
+export type FollowerRuntimeDiagnosticKind =
+  | "broker_disconnect"
+  | "poll_failure"
+  | "registration_refresh_failure"
+  | "reconnect_stopped";
+
+export type FollowerRuntimeDiagnosticState = "reconnecting" | "degraded" | "error";
+
+export interface FollowerRuntimeDiagnostic {
+  kind: FollowerRuntimeDiagnosticKind;
+  state: FollowerRuntimeDiagnosticState;
+  reason: string;
+  nextStep: string;
+  detail?: string;
+}
+
+export function buildFollowerRuntimeDiagnostic(
+  kind: FollowerRuntimeDiagnosticKind,
+  options: {
+    detail?: string | null;
+    connected?: boolean;
+  } = {},
+): FollowerRuntimeDiagnostic {
+  const detail = options.detail?.trim() || undefined;
+
+  if (kind === "broker_disconnect") {
+    return {
+      kind,
+      state: "reconnecting",
+      reason: "broker disconnected",
+      nextStep: "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+      ...(detail ? { detail } : {}),
+    };
+  }
+
+  if (kind === "poll_failure") {
+    const connected = options.connected ?? true;
+    return {
+      kind,
+      state: connected ? "degraded" : "reconnecting",
+      reason: "inbox polling failed",
+      nextStep: connected
+        ? "Watch the next poll cycle. If failures continue, inspect the broker and run /pinet-follow."
+        : "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+      ...(detail ? { detail } : {}),
+    };
+  }
+
+  if (kind === "registration_refresh_failure") {
+    return {
+      kind,
+      state: "degraded",
+      reason: "registration refresh failed after reconnect",
+      nextStep:
+        "Follower kept the last registered identity. If status or ownership looks stale, run /pinet-follow.",
+      ...(detail ? { detail } : {}),
+    };
+  }
+
+  return {
+    kind,
+    state: "error",
+    reason: "automatic reconnect stopped",
+    nextStep: "Fix the reported error, then run /pinet-follow to retry.",
+    ...(detail ? { detail } : {}),
+  };
+}
+
+export function formatFollowerRuntimeDiagnosticHealth(
+  diagnostic: FollowerRuntimeDiagnostic | null,
+): string {
+  if (!diagnostic) {
+    return "healthy";
+  }
+
+  return `${diagnostic.state} — ${diagnostic.reason}${diagnostic.detail ? ` (${diagnostic.detail})` : ""}`;
+}
+
+export function formatFollowerRuntimeDiagnosticNextStep(
+  diagnostic: FollowerRuntimeDiagnostic | null,
+): string {
+  return diagnostic?.nextStep ?? "None.";
+}
+
 export interface FollowerReconnectUiUpdate {
   nextWasDisconnected: boolean;
   notify?: {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2125,7 +2125,10 @@ describe("slack-bridge Pinet reconnect", () => {
 
     notify.mockClear();
     await pinetStatus?.handler("", ctx);
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: disconnected"), "info");
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Connection: disconnected"),
+      "info",
+    );
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("Runtime health: reconnecting — broker disconnected"),
       "info",
@@ -2505,7 +2508,10 @@ describe("slack-bridge Pinet reconnect", () => {
       notify.mockClear();
       await pinetStatus?.handler("", ctx);
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: off"), "info");
-      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: disconnected"), "info");
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("Connection: disconnected"),
+        "info",
+      );
       expect(notify).toHaveBeenCalledWith(
         expect.stringContaining(
           'Runtime health: error — automatic reconnect stopped (Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.)',
@@ -2528,7 +2534,10 @@ describe("slack-bridge Pinet reconnect", () => {
       await pinetStatus?.handler("", ctx);
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: follower"), "info");
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
-      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Runtime health: healthy"), "info");
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("Runtime health: healthy"),
+        "info",
+      );
 
       await sessionShutdown?.({}, ctx);
     } finally {
@@ -2654,7 +2663,10 @@ describe("slack-bridge Pinet reconnect", () => {
 
       notify.mockClear();
       await pinetStatus?.handler("", ctx);
-      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Runtime health: healthy"), "info");
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("Runtime health: healthy"),
+        "info",
+      );
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Next step: None."), "info");
 
       await sessionShutdown?.({}, ctx);

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2017,6 +2017,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
     let disconnectHandler: (() => void) | null = null;
     let reconnectHandler: (() => void) | null = null;
+    let followerConnected = false;
     const registerCalls: Array<{
       name: string;
       emoji: string;
@@ -2024,7 +2025,10 @@ describe("slack-bridge Pinet reconnect", () => {
       stableId?: string;
     }> = [];
 
-    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "connect").mockImplementation(async () => {
+      followerConnected = true;
+    });
+    vi.spyOn(BrokerClient.prototype, "isConnected").mockImplementation(() => followerConnected);
     vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async function (
       this: BrokerClient,
       name: string,
@@ -2088,10 +2092,12 @@ describe("slack-bridge Pinet reconnect", () => {
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
     const follow = commands.get("pinet-follow");
+    const pinetStatus = commands.get("pinet-status");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(follow).toBeDefined();
+    expect(pinetStatus).toBeDefined();
 
     await sessionStart?.({}, ctx);
     await follow?.handler("", ctx);
@@ -2104,10 +2110,33 @@ describe("slack-bridge Pinet reconnect", () => {
       throw new Error("Reconnect handlers were not registered");
     }
 
-    const runDisconnect: () => void = disconnectHandler;
-    const runReconnect: () => void = reconnectHandler;
+    const activeDisconnectHandler: () => void = disconnectHandler;
+    const activeReconnectHandler: () => void = reconnectHandler;
+    const runDisconnect = (): void => {
+      followerConnected = false;
+      activeDisconnectHandler();
+    };
+    const runReconnect = (): void => {
+      followerConnected = true;
+      activeReconnectHandler();
+    };
 
     runDisconnect();
+
+    notify.mockClear();
+    await pinetStatus?.handler("", ctx);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: disconnected"), "info");
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Runtime health: reconnecting — broker disconnected"),
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Next step: Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+      ),
+      "info",
+    );
+
     runReconnect();
 
     await vi.waitFor(() => {
@@ -2119,11 +2148,182 @@ describe("slack-bridge Pinet reconnect", () => {
       role: "worker",
       capabilities: expect.objectContaining({ role: "worker" }),
     });
-    expect(notify).toHaveBeenCalledWith("Pinet broker disconnected — reconnecting...", "warning");
     expect(notify).toHaveBeenCalledWith("Pinet broker reconnected", "info");
+
+    notify.mockClear();
+    await pinetStatus?.handler("", ctx);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Runtime health: healthy"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Next step: None."), "info");
 
     await sessionShutdown?.({}, ctx);
     expect(setStatus).toHaveBeenCalled();
+  });
+
+  it("reports degraded follower diagnostics when reconnect registration refresh fails", async () => {
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let disconnectHandler: (() => void) | null = null;
+    let reconnectHandler: (() => void) | null = null;
+    let followerConnected = false;
+    let registerAttempt = 0;
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockImplementation(async () => {
+      followerConnected = true;
+    });
+    vi.spyOn(BrokerClient.prototype, "isConnected").mockImplementation(() => followerConnected);
+    vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async function (
+      this: BrokerClient,
+      name: string,
+      emoji: string,
+      metadata?: Record<string, unknown>,
+      stableId?: string,
+    ) {
+      registerAttempt += 1;
+      if (registerAttempt === 2) {
+        throw new Error("refresh failed once");
+      }
+
+      const result = {
+        agentId: "worker-1",
+        name,
+        emoji,
+        metadata: metadata ?? null,
+      };
+      (
+        this as unknown as {
+          registeredIdentity: typeof result | null;
+          registrationSnapshot: {
+            name: string;
+            emoji: string;
+            metadata?: Record<string, unknown>;
+            stableId?: string;
+          } | null;
+        }
+      ).registeredIdentity = result;
+      (
+        this as unknown as {
+          registrationSnapshot: {
+            name: string;
+            emoji: string;
+            metadata?: Record<string, unknown>;
+            stableId?: string;
+          } | null;
+        }
+      ).registrationSnapshot = {
+        name,
+        emoji,
+        ...(metadata ? { metadata } : {}),
+        ...(stableId ? { stableId } : {}),
+      };
+      return result;
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation((handler) => {
+      disconnectHandler = handler;
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation((handler) => {
+      reconnectHandler = handler;
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+    const pinetStatus = commands.get("pinet-status");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+    expect(pinetStatus).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await follow?.handler("", ctx);
+
+    expect(registerAttempt).toBe(1);
+    expect(disconnectHandler).toBeTypeOf("function");
+    expect(reconnectHandler).toBeTypeOf("function");
+
+    if (!disconnectHandler || !reconnectHandler) {
+      throw new Error("Reconnect handlers were not registered");
+    }
+
+    notify.mockClear();
+    const activeDisconnectHandler: () => void = disconnectHandler;
+    const activeReconnectHandler: () => void = reconnectHandler;
+    followerConnected = false;
+    activeDisconnectHandler();
+    followerConnected = true;
+    activeReconnectHandler();
+
+    await vi.waitFor(() => {
+      expect(registerAttempt).toBe(2);
+    });
+    await vi.waitFor(() => {
+      expect(notify).toHaveBeenCalledWith("Pinet broker reconnected", "info");
+    });
+
+    notify.mockClear();
+    await pinetStatus?.handler("", ctx);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: follower"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Runtime health: degraded — registration refresh failed after reconnect (refresh failed once)",
+      ),
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Next step: Follower kept the last registered identity. If status or ownership looks stale, run /pinet-follow.",
+      ),
+      "info",
+    );
+
+    await sessionShutdown?.({}, ctx);
   });
 
   it("stops follower reconnect retries after a terminal name conflict and allows a clean retry", async () => {
@@ -2172,6 +2372,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
       let disconnectHandler: (() => void) | null = null;
       let reconnectFailedHandler: ((error: Error) => void) | null = null;
+      let followerConnected = false;
       const registerCalls: Array<{
         name: string;
         emoji: string;
@@ -2179,7 +2380,10 @@ describe("slack-bridge Pinet reconnect", () => {
         stableId?: string;
       }> = [];
 
-      const connect = vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+      const connect = vi.spyOn(BrokerClient.prototype, "connect").mockImplementation(async () => {
+        followerConnected = true;
+      });
+      vi.spyOn(BrokerClient.prototype, "isConnected").mockImplementation(() => followerConnected);
       vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async function (
         this: BrokerClient,
         name: string,
@@ -2248,10 +2452,12 @@ describe("slack-bridge Pinet reconnect", () => {
       const sessionStart = events.get("session_start");
       const sessionShutdown = events.get("session_shutdown");
       const follow = commands.get("pinet-follow");
+      const pinetStatus = commands.get("pinet-status");
 
       expect(sessionStart).toBeDefined();
       expect(sessionShutdown).toBeDefined();
       expect(follow).toBeDefined();
+      expect(pinetStatus).toBeDefined();
 
       await sessionStart?.({}, ctx);
       await follow?.handler("", ctx);
@@ -2265,11 +2471,15 @@ describe("slack-bridge Pinet reconnect", () => {
         throw new Error("Reconnect handlers were not registered");
       }
 
-      const runDisconnect: () => void = disconnectHandler;
-      const runReconnectFailed: (error: Error) => void = reconnectFailedHandler;
+      const activeDisconnectHandler: () => void = disconnectHandler;
+      const activeReconnectFailedHandler: (error: Error) => void = reconnectFailedHandler;
+      const runDisconnect = (): void => {
+        followerConnected = false;
+        activeDisconnectHandler();
+      };
 
       runDisconnect();
-      runReconnectFailed(
+      activeReconnectFailedHandler(
         new Error(
           'Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.',
         ),
@@ -2292,10 +2502,33 @@ describe("slack-bridge Pinet reconnect", () => {
       );
       expect(setStatus).toHaveBeenCalledWith("slack-bridge", expect.stringContaining("✗"));
 
+      notify.mockClear();
+      await pinetStatus?.handler("", ctx);
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: off"), "info");
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: disconnected"), "info");
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Runtime health: error — automatic reconnect stopped (Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.)',
+        ),
+        "info",
+      );
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Next step: Fix the reported error, then run /pinet-follow to retry.",
+        ),
+        "info",
+      );
+
       await follow?.handler("", ctx);
       expect(connect).toHaveBeenCalledTimes(2);
       expect(registerCalls).toHaveLength(2);
       expect(registerCalls[1]?.name).toBe("Reserved Crane");
+
+      notify.mockClear();
+      await pinetStatus?.handler("", ctx);
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: follower"), "info");
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Runtime health: healthy"), "info");
 
       await sessionShutdown?.({}, ctx);
     } finally {
@@ -2304,6 +2537,129 @@ describe("slack-bridge Pinet reconnect", () => {
       } else {
         process.env.PI_NICKNAME = originalNickname;
       }
+    }
+  });
+
+  it("surfaces follower poll failures in pinet-status and clears them after recovery", async () => {
+    vi.useFakeTimers();
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let followerConnected = false;
+    let pollAttempt = 0;
+    vi.spyOn(BrokerClient.prototype, "connect").mockImplementation(async () => {
+      followerConnected = true;
+    });
+    vi.spyOn(BrokerClient.prototype, "isConnected").mockImplementation(() => followerConnected);
+    vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Agent",
+      emoji: "🦙",
+      metadata: { role: "worker", capabilities: { role: "worker" } },
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockImplementation(async () => {
+      pollAttempt += 1;
+      if (pollAttempt === 1) {
+        throw new Error("poll failed once");
+      }
+      return [];
+    });
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+      /* mocked */
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+    const pinetStatus = commands.get("pinet-status");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+    expect(pinetStatus).toBeDefined();
+
+    try {
+      await sessionStart?.({}, ctx);
+      await follow?.handler("", ctx);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(pollAttempt).toBe(1);
+
+      notify.mockClear();
+      await pinetStatus?.handler("", ctx);
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: follower"), "info");
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Runtime health: degraded — inbox polling failed (poll failed once)",
+        ),
+        "info",
+      );
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Next step: Watch the next poll cycle. If failures continue, inspect the broker and run /pinet-follow.",
+        ),
+        "info",
+      );
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(pollAttempt).toBe(2);
+
+      notify.mockClear();
+      await pinetStatus?.handler("", ctx);
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Runtime health: healthy"), "info");
+      expect(notify).toHaveBeenCalledWith(expect.stringContaining("Next step: None."), "info");
+
+      await sessionShutdown?.({}, ctx);
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-metadata.js";
 import {
+  type FollowerRuntimeDiagnostic,
   type InboxMessage,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
@@ -629,6 +630,7 @@ export default function (pi: ExtensionAPI) {
   let currentRuntimeMode: SlackBridgeRuntimeMode = "off";
   let brokerRole: "broker" | "follower" | null = null;
   let brokerClient: BrokerClientRef | null = null;
+  let followerRuntimeDiagnostic: FollowerRuntimeDiagnostic | null = null;
   const followerDeliveryState = createFollowerDeliveryState();
   let desiredAgentStatus: "working" | "idle" = "idle";
   const pinetRegistrationGate = createPinetRegistrationGate();
@@ -1191,6 +1193,10 @@ export default function (pi: ExtensionAPI) {
     runRemoteControl,
     deliverFollowUpMessage,
     setExtStatus,
+    getRuntimeDiagnostic: () => followerRuntimeDiagnostic,
+    setRuntimeDiagnostic: (diagnostic) => {
+      followerRuntimeDiagnostic = diagnostic;
+    },
     handleTerminalReconnectFailure: async (ctx, error) => {
       console.error(`[slack-bridge] follower reconnect failed: ${msg(error)}`);
       await disconnectFollower(ctx, { preserveErrorState: true }).catch(() => {
@@ -1215,7 +1221,7 @@ export default function (pi: ExtensionAPI) {
         currentRuntimeMode === "broker"
           ? brokerRuntime.isConnected()
           : currentRuntimeMode === "follower"
-            ? brokerClient != null
+            ? (brokerClient?.client.isConnected() ?? false)
             : currentRuntimeMode === "single"
               ? singlePlayerRuntime.isConnected()
               : false,
@@ -1228,6 +1234,7 @@ export default function (pi: ExtensionAPI) {
       botUserId: () => botUserId,
       activeSkinTheme: () => activeSkinTheme,
       lastDmChannel: () => lastDmChannel,
+      followerRuntimeDiagnostic: () => followerRuntimeDiagnostic,
       threads: () => threads,
       allowedUsers: () => allowedUsers,
       inboxLength: () => inbox.length,
@@ -1267,6 +1274,7 @@ export default function (pi: ExtensionAPI) {
 
     const clientRef = await followerRuntime.connect(ctx);
     brokerClient = clientRef;
+    followerRuntimeDiagnostic = null;
     brokerRole = "follower";
     pinetEnabled = true;
     desiredAgentStatus = "idle";
@@ -1285,6 +1293,7 @@ export default function (pi: ExtensionAPI) {
     pinetEnabled = false;
     currentRuntimeMode = "off";
     if (!options.preserveErrorState) {
+      followerRuntimeDiagnostic = null;
       setExtStatus(ctx, "off");
     }
 

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -3,7 +3,10 @@ import {
   generateAgentName,
   agentOwnsThread,
   describeSlackUserAccess,
+  formatFollowerRuntimeDiagnosticHealth,
+  formatFollowerRuntimeDiagnosticNextStep,
   resolveAllowAllWorkspaceUsers,
+  type FollowerRuntimeDiagnostic,
   type SlackBridgeSettings,
 } from "./helpers.js";
 import { formatRecentActivityLogEntries, type LoggedActivityLogEntry } from "./activity-log.js";
@@ -29,6 +32,7 @@ export interface PinetCommandsDeps {
   botUserId: () => string | null;
   activeSkinTheme: () => string | null;
   lastDmChannel: () => string | null;
+  followerRuntimeDiagnostic: () => FollowerRuntimeDiagnostic | null;
   threads: () => Map<string, { owner?: string }>;
   allowedUsers: () => Set<string> | null;
   inboxLength: () => number;
@@ -284,6 +288,9 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       const activityLogInfo = s.logChannel
         ? `Activity log: ${s.logChannel} (${s.logLevel ?? "actions"})`
         : "Activity log: disabled";
+      const runtimeDiagnostic = deps.followerRuntimeDiagnostic();
+      const runtimeHealthInfo = `Runtime health: ${formatFollowerRuntimeDiagnosticHealth(runtimeDiagnostic)}`;
+      const runtimeNextStepInfo = `Next step: ${formatFollowerRuntimeDiagnosticNextStep(runtimeDiagnostic)}`;
       const slackToolHealthInfo = `Slack tool health: ${formatSlackScopeDiagnosticsStatus(deps.slackScopeDiagnostics())}`;
       const lbm = deps.lastBrokerMaintenance();
       const brokerHealthInfo =
@@ -324,6 +331,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
           `Agent: ${deps.agentEmoji()} ${deps.agentName()}`,
           `Bot: ${deps.botUserId() ?? "unknown"}`,
           `Connection: ${deps.runtimeConnected() ? "connected" : "disconnected"}`,
+          runtimeHealthInfo,
+          runtimeNextStepInfo,
           `Skin: ${deps.activeSkinTheme() ?? "(legacy/manual)"}`,
           ...(deps.agentPersonality() ? [`Persona: ${deps.agentPersonality()}`] : []),
           `Threads: ${deps.threads().size} (${ownedCount} owned by ${deps.agentName()})`,


### PR DESCRIPTION
## Summary
- add a structured follower runtime diagnostic shape plus status formatters
- preserve follower-side restart/reconnect diagnostics across disconnect, poll failure, registration refresh failure, and terminal reconnect stop
- show truthful follower connection state and runtime guidance in `/pinet-status`

## Testing
- ../../../node_modules/.bin/vitest run helpers.test.ts index.test.ts
- ../../../node_modules/.bin/tsc --noEmit -p tsconfig.json
- ../../../node_modules/.bin/eslint helpers.ts follower-runtime.ts index.ts pinet-commands.ts helpers.test.ts index.test.ts

Refs #404