### PR TITLE
fix(slack-bridge): detect idle tracked-assignment reply stalls

### DIFF
--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -832,13 +832,7 @@ describe("BrokerDB", () => {
       { senderAgent: "Broker Crane", a2a: true },
     );
 
-    db.recordTaskAssignment(
-      "worker-1",
-      114,
-      "fix/114",
-      "a2a:broker:worker-1",
-      sourceMessage.id,
-    );
+    db.recordTaskAssignment("worker-1", 114, "fix/114", "a2a:broker:worker-1", sourceMessage.id);
 
     expect(db.listTaskAssignmentsAwaitingFirstReply()).toEqual([
       {

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -817,6 +817,83 @@ describe("BrokerDB", () => {
     );
   });
 
+  it("lists active tracked assignments that still have no reply to the original sender", () => {
+    db.registerAgent("broker", "Broker Crane", "🪿", 10);
+    db.registerAgent("worker-1", "Hyper Horse", "🐎", 100);
+
+    db.createThread("a2a:broker:worker-1", "agent", "", "broker");
+    const sourceMessage = db.insertMessage(
+      "a2a:broker:worker-1",
+      "agent",
+      "inbound",
+      "broker",
+      "Please take issue #114",
+      ["worker-1"],
+      { senderAgent: "Broker Crane", a2a: true },
+    );
+
+    db.recordTaskAssignment(
+      "worker-1",
+      114,
+      "fix/114",
+      "a2a:broker:worker-1",
+      sourceMessage.id,
+    );
+
+    expect(db.listTaskAssignmentsAwaitingFirstReply()).toEqual([
+      {
+        id: expect.any(Number),
+        agentId: "worker-1",
+        issueNumber: 114,
+        status: "assigned",
+        sourceMessageId: sourceMessage.id,
+        originalSenderAgentId: "broker",
+      },
+    ]);
+  });
+
+  it("stops tracking once the assignee replies and ignores completed tracked assignments", () => {
+    db.registerAgent("broker", "Broker Crane", "🪿", 10);
+    db.registerAgent("worker-1", "Hyper Horse", "🐎", 100);
+
+    db.createThread("a2a:broker:worker-1", "agent", "", "broker");
+    const sourceMessage = db.insertMessage(
+      "a2a:broker:worker-1",
+      "agent",
+      "inbound",
+      "broker",
+      "Please take issue #114",
+      ["worker-1"],
+      { senderAgent: "Broker Crane", a2a: true },
+    );
+    const tracked = db.recordTaskAssignment(
+      "worker-1",
+      114,
+      "fix/114",
+      "a2a:broker:worker-1",
+      sourceMessage.id,
+    );
+
+    db.updateTaskAssignmentProgress(tracked.id, "pr_merged", 201);
+    expect(db.listTaskAssignmentsAwaitingFirstReply()).toEqual([]);
+
+    db.updateTaskAssignmentProgress(tracked.id, "assigned", null);
+    expect(db.listTaskAssignmentsAwaitingFirstReply()).toHaveLength(1);
+
+    db.createThread("a2a:worker-1:broker", "agent", "", "worker-1");
+    db.insertMessage(
+      "a2a:worker-1:broker",
+      "agent",
+      "inbound",
+      "worker-1",
+      "Working on it",
+      ["broker"],
+      { senderAgent: "Hyper Horse", a2a: true },
+    );
+
+    expect(db.listTaskAssignmentsAwaitingFirstReply()).toEqual([]);
+  });
+
   it("startup reconciliation preserves ownership until reconnect and refreshes the returning identity", () => {
     const dbPath = path.join(dir, "restart.db");
     const firstDb = new BrokerDB(dbPath);

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -89,6 +89,15 @@ interface ScheduledWakeupRow {
   created_at: string;
 }
 
+export interface TaskAssignmentAwaitingReplyInfo {
+  id: number;
+  agentId: string;
+  issueNumber: number;
+  status: TaskAssignmentStatus;
+  sourceMessageId: number;
+  originalSenderAgentId: string;
+}
+
 // ─── Mappers ─────────────────────────────────────────────
 
 interface RalphCycleRow {
@@ -1515,6 +1524,55 @@ export class BrokerDB implements BrokerDBInterface {
       )
       .all() as unknown as TaskAssignmentRow[];
     return rows.map(rowToTaskAssignment);
+  }
+
+  listTaskAssignmentsAwaitingFirstReply(): TaskAssignmentAwaitingReplyInfo[] {
+    const db = this.getDb();
+    const rows = db
+      .prepare(
+        `SELECT
+           ta.id AS id,
+           ta.agent_id AS agent_id,
+           ta.issue_number AS issue_number,
+           ta.status AS status,
+           ta.source_message_id AS source_message_id,
+           source.sender AS original_sender_agent_id
+         FROM task_assignments ta
+         JOIN messages source ON source.id = ta.source_message_id
+         WHERE ta.source_message_id IS NOT NULL
+           AND ta.status IN ('assigned', 'branch_pushed', 'pr_open')
+           AND source.source = 'agent'
+           AND source.direction = 'inbound'
+           AND source.sender != ta.agent_id
+           AND NOT EXISTS (
+             SELECT 1
+             FROM messages reply
+             JOIN inbox reply_inbox ON reply_inbox.message_id = reply.id
+             WHERE reply.source = 'agent'
+               AND reply.direction = 'inbound'
+               AND reply.sender = ta.agent_id
+               AND reply.id > source.id
+               AND reply_inbox.agent_id = source.sender
+           )
+         ORDER BY ta.updated_at DESC, ta.created_at DESC, ta.id DESC`,
+      )
+      .all() as Array<{
+      id: number;
+      agent_id: string;
+      issue_number: number;
+      status: string;
+      source_message_id: number;
+      original_sender_agent_id: string;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      agentId: row.agent_id,
+      issueNumber: row.issue_number,
+      status: row.status as TaskAssignmentStatus,
+      sourceMessageId: row.source_message_id,
+      originalSenderAgentId: row.original_sender_agent_id,
+    }));
   }
 
   updateTaskAssignmentProgress(

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -69,7 +69,7 @@ describe("hydrateRalphLoopReportedGhosts", () => {
 });
 
 describe("applyTrackedAssignmentIdleReplyStalls", () => {
-  it("flags and nudges idle assignees that never replied after a tracked assignment", () => {
+  it("flags and nudges healthy idle assignees that never replied after a tracked assignment", () => {
     const evaluation = {
       ghostAgentIds: [],
       nudgeAgentIds: [],
@@ -81,7 +81,12 @@ describe("applyTrackedAssignmentIdleReplyStalls", () => {
     const pending = applyTrackedAssignmentIdleReplyStalls(
       evaluation,
       [
-        { id: "worker-1", name: "Quiet Otter", status: "idle" },
+        {
+          id: "worker-1",
+          name: "Quiet Otter",
+          status: "idle",
+          lastHeartbeat: "2026-04-20T10:00:15.000Z",
+        },
         { id: "worker-2", name: "Busy Crane", status: "working" },
       ],
       [
@@ -110,12 +115,95 @@ describe("applyTrackedAssignmentIdleReplyStalls", () => {
           originalSenderAgentId: "broker",
         },
       ],
+      { now: Date.parse("2026-04-20T10:00:20.000Z") },
     );
 
     expect(pending).toEqual(new Map([["worker-1", [114, 463]]]));
     expect(evaluation.nudgeAgentIds).toEqual(["worker-1"]);
     expect(evaluation.anomalies).toEqual([
       "Quiet Otter idle after tracked assignments #114, #463 without any agent reply to the original sender",
+    ]);
+  });
+
+  it("ignores idle tracked assignees that are disconnected, resumable, or stale", () => {
+    const evaluation = {
+      ghostAgentIds: [],
+      nudgeAgentIds: [],
+      idleDrainAgentIds: [],
+      stuckAgentIds: [],
+      anomalies: [],
+    };
+
+    const pending = applyTrackedAssignmentIdleReplyStalls(
+      evaluation,
+      [
+        {
+          id: "healthy-worker",
+          name: "Careful Moth",
+          status: "idle",
+          lastHeartbeat: "2026-04-20T10:00:15.000Z",
+        },
+        {
+          id: "ghost-worker",
+          name: "Ghost Goose",
+          status: "idle",
+          disconnectedAt: "2026-04-20T10:00:19.000Z",
+        },
+        {
+          id: "resumable-worker",
+          name: "Resumable Raven",
+          status: "idle",
+          disconnectedAt: "2026-04-20T10:00:19.000Z",
+          resumableUntil: "2026-04-20T10:01:00.000Z",
+        },
+        {
+          id: "stale-worker",
+          name: "Stale Stoat",
+          status: "idle",
+          lastHeartbeat: "2026-04-20T10:00:09.000Z",
+        },
+      ],
+      [
+        {
+          id: 1,
+          agentId: "healthy-worker",
+          issueNumber: 463,
+          status: "assigned",
+          sourceMessageId: 10,
+          originalSenderAgentId: "broker",
+        },
+        {
+          id: 2,
+          agentId: "ghost-worker",
+          issueNumber: 464,
+          status: "assigned",
+          sourceMessageId: 11,
+          originalSenderAgentId: "broker",
+        },
+        {
+          id: 3,
+          agentId: "resumable-worker",
+          issueNumber: 465,
+          status: "assigned",
+          sourceMessageId: 12,
+          originalSenderAgentId: "broker",
+        },
+        {
+          id: 4,
+          agentId: "stale-worker",
+          issueNumber: 466,
+          status: "assigned",
+          sourceMessageId: 13,
+          originalSenderAgentId: "broker",
+        },
+      ],
+      { now: Date.parse("2026-04-20T10:00:20.000Z") },
+    );
+
+    expect(pending).toEqual(new Map([["healthy-worker", [463]]]));
+    expect(evaluation.nudgeAgentIds).toEqual(["healthy-worker"]);
+    expect(evaluation.anomalies).toEqual([
+      "Careful Moth idle after tracked assignment #463 without any agent reply to the original sender",
     ]);
   });
 });

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { createRalphLoopState, hydrateRalphLoopReportedGhosts } from "./ralph-loop.js";
+import {
+  applyTrackedAssignmentIdleReplyStalls,
+  buildTrackedAssignmentReplyNudgeMessage,
+  createRalphLoopState,
+  hydrateRalphLoopReportedGhosts,
+} from "./ralph-loop.js";
 import { rewriteRalphLoopGhostAnomalies } from "./helpers.js";
 
 function buildEvaluation(ghostAgentIds: string[]) {
@@ -60,5 +65,65 @@ describe("hydrateRalphLoopReportedGhosts", () => {
     expect(rewritten.evaluation.anomalies).toEqual(["NEW ghost agents detected: ghost-1"]);
     expect(rewritten.newGhostIds).toEqual(["ghost-1"]);
     expect(rewritten.nextReportedGhostIds).toEqual(["ghost-1"]);
+  });
+});
+
+describe("applyTrackedAssignmentIdleReplyStalls", () => {
+  it("flags and nudges idle assignees that never replied after a tracked assignment", () => {
+    const evaluation = {
+      ghostAgentIds: [],
+      nudgeAgentIds: [],
+      idleDrainAgentIds: [],
+      stuckAgentIds: [],
+      anomalies: [],
+    };
+
+    const pending = applyTrackedAssignmentIdleReplyStalls(
+      evaluation,
+      [
+        { id: "worker-1", name: "Quiet Otter", status: "idle" },
+        { id: "worker-2", name: "Busy Crane", status: "working" },
+      ],
+      [
+        {
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 114,
+          status: "assigned",
+          sourceMessageId: 10,
+          originalSenderAgentId: "broker",
+        },
+        {
+          id: 2,
+          agentId: "worker-1",
+          issueNumber: 463,
+          status: "assigned",
+          sourceMessageId: 11,
+          originalSenderAgentId: "broker",
+        },
+        {
+          id: 3,
+          agentId: "worker-2",
+          issueNumber: 999,
+          status: "assigned",
+          sourceMessageId: 12,
+          originalSenderAgentId: "broker",
+        },
+      ],
+    );
+
+    expect(pending).toEqual(new Map([["worker-1", [114, 463]]]));
+    expect(evaluation.nudgeAgentIds).toEqual(["worker-1"]);
+    expect(evaluation.anomalies).toEqual([
+      "Quiet Otter idle after tracked assignments #114, #463 without any agent reply to the original sender",
+    ]);
+  });
+});
+
+describe("buildTrackedAssignmentReplyNudgeMessage", () => {
+  it("asks the assignee to report outcome or blocker for the tracked issues", () => {
+    expect(buildTrackedAssignmentReplyNudgeMessage([114, 463], "2026-04-20T10:00:00.000Z")).toBe(
+      "RALPH LOOP nudge (2026-04-20T10:00:00.000Z): you are idle after tracked assignments #114, #463 and still have not sent any agent reply to the original sender. Please report outcome or blocker now.",
+    );
   });
 });

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -6,6 +6,7 @@ import {
   type RalphLoopEvaluationResult,
   evaluateRalphLoopCycle,
   rewriteRalphLoopGhostAnomalies,
+  buildAgentDisplayInfo,
   buildRalphLoopNudgeMessage,
   buildRalphLoopAnomalySignature,
   buildRalphLoopCycleNotifications,
@@ -108,18 +109,33 @@ export function buildTrackedAssignmentReplyNudgeMessage(
 
 export function applyTrackedAssignmentIdleReplyStalls(
   evaluation: RalphLoopEvaluationResult,
-  workloads: ReadonlyArray<Pick<RalphLoopAgentWorkload, "id" | "name" | "status">>,
+  workloads: ReadonlyArray<
+    Pick<
+      RalphLoopAgentWorkload,
+      "id" | "name" | "status" | "lastHeartbeat" | "lastSeen" | "disconnectedAt" | "resumableUntil"
+    >
+  >,
   awaitingReplyAssignments: ReadonlyArray<TaskAssignmentAwaitingReplyInfo>,
+  options: Pick<
+    RalphLoopEvaluationOptions,
+    "now" | "heartbeatTimeoutMs" | "heartbeatIntervalMs"
+  > = {},
 ): Map<string, number[]> {
-  const idleWorkloads = new Map(
+  const idleHealthyWorkloads = new Map(
     workloads
-      .filter((workload) => workload.status === "idle")
+      .filter((workload) => {
+        if (workload.status !== "idle" || workload.disconnectedAt != null) {
+          return false;
+        }
+
+        return buildAgentDisplayInfo({ emoji: "", ...workload }, options).health === "healthy";
+      })
       .map((workload) => [workload.id, workload] as const),
   );
   const pendingIssuesByAgent = new Map<string, Set<number>>();
 
   for (const assignment of awaitingReplyAssignments) {
-    if (!idleWorkloads.has(assignment.agentId)) {
+    if (!idleHealthyWorkloads.has(assignment.agentId)) {
       continue;
     }
     const issues = pendingIssuesByAgent.get(assignment.agentId) ?? new Set<number>();
@@ -133,7 +149,7 @@ export function applyTrackedAssignmentIdleReplyStalls(
     if (!evaluation.nudgeAgentIds.includes(agentId)) {
       evaluation.nudgeAgentIds.push(agentId);
     }
-    const agentName = idleWorkloads.get(agentId)?.name ?? agentId;
+    const agentName = idleHealthyWorkloads.get(agentId)?.name ?? agentId;
     evaluation.anomalies.push(buildTrackedAssignmentIdleReplyStallAnomaly(agentName, issueNumbers));
     result.set(agentId, issueNumbers);
   }
@@ -250,6 +266,7 @@ export async function runRalphLoopCycle(
       evaluation,
       workloads,
       db.listTaskAssignmentsAwaitingFirstReply(),
+      evaluationOptions,
     );
 
     const nudgeAgentIds = new Set(evaluation.nudgeAgentIds);

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -1,7 +1,9 @@
 import * as os from "node:os";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
+  type RalphLoopAgentWorkload,
   type RalphLoopEvaluationOptions,
+  type RalphLoopEvaluationResult,
   evaluateRalphLoopCycle,
   rewriteRalphLoopGhostAnomalies,
   buildRalphLoopNudgeMessage,
@@ -28,7 +30,7 @@ import type { ActivityLogEntry, ActivityLogTone } from "./activity-log.js";
 import { probeGitBranch } from "./git-metadata.js";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
 import type { BrokerMaintenanceResult } from "./broker/maintenance.js";
-import type { BrokerDB } from "./broker/schema.js";
+import type { BrokerDB, TaskAssignmentAwaitingReplyInfo } from "./broker/schema.js";
 import type { TaskAssignmentInfo } from "./broker/types.js";
 
 // ─── State ───────────────────────────────────────────────
@@ -81,6 +83,64 @@ export function resetRalphLoopState(state: RalphLoopState): void {
   state.followUpSignature = "";
   state.taskAssignmentReportSignature = "";
   state.pendingTaskAssignmentReport = null;
+}
+
+function formatTrackedAssignmentIssueList(issueNumbers: readonly number[]): string {
+  return issueNumbers.map((issueNumber) => `#${issueNumber}`).join(", ");
+}
+
+function buildTrackedAssignmentIdleReplyStallAnomaly(
+  agentName: string,
+  issueNumbers: readonly number[],
+): string {
+  const label = issueNumbers.length === 1 ? "assignment" : "assignments";
+  return `${agentName} idle after tracked ${label} ${formatTrackedAssignmentIssueList(issueNumbers)} without any agent reply to the original sender`;
+}
+
+export function buildTrackedAssignmentReplyNudgeMessage(
+  issueNumbers: readonly number[],
+  cycleStartedAt?: string,
+): string {
+  const prefix = cycleStartedAt ? `RALPH LOOP nudge (${cycleStartedAt})` : "RALPH LOOP nudge";
+  const label = issueNumbers.length === 1 ? "assignment" : "assignments";
+  return `${prefix}: you are idle after tracked ${label} ${formatTrackedAssignmentIssueList(issueNumbers)} and still have not sent any agent reply to the original sender. Please report outcome or blocker now.`;
+}
+
+export function applyTrackedAssignmentIdleReplyStalls(
+  evaluation: RalphLoopEvaluationResult,
+  workloads: ReadonlyArray<Pick<RalphLoopAgentWorkload, "id" | "name" | "status">>,
+  awaitingReplyAssignments: ReadonlyArray<TaskAssignmentAwaitingReplyInfo>,
+): Map<string, number[]> {
+  const idleWorkloads = new Map(
+    workloads
+      .filter((workload) => workload.status === "idle")
+      .map((workload) => [workload.id, workload] as const),
+  );
+  const pendingIssuesByAgent = new Map<string, Set<number>>();
+
+  for (const assignment of awaitingReplyAssignments) {
+    if (!idleWorkloads.has(assignment.agentId)) {
+      continue;
+    }
+    const issues = pendingIssuesByAgent.get(assignment.agentId) ?? new Set<number>();
+    issues.add(assignment.issueNumber);
+    pendingIssuesByAgent.set(assignment.agentId, issues);
+  }
+
+  const result = new Map<string, number[]>();
+  for (const [agentId, issues] of pendingIssuesByAgent) {
+    const issueNumbers = [...issues].sort((left, right) => left - right);
+    if (!evaluation.nudgeAgentIds.includes(agentId)) {
+      evaluation.nudgeAgentIds.push(agentId);
+    }
+    const agentName = idleWorkloads.get(agentId)?.name ?? agentId;
+    evaluation.anomalies.push(
+      buildTrackedAssignmentIdleReplyStallAnomaly(agentName, issueNumbers),
+    );
+    result.set(agentId, issueNumbers);
+  }
+
+  return result;
 }
 
 // ─── Callbacks ───────────────────────────────────────────
@@ -188,6 +248,11 @@ export async function runRalphLoopCycle(
       brokerAgentId: selfId,
     };
     const evaluation = evaluateRalphLoopCycle(workloads, evaluationOptions);
+    const trackedAssignmentIdleReplyStalls = applyTrackedAssignmentIdleReplyStalls(
+      evaluation,
+      workloads,
+      db.listTaskAssignmentsAwaitingFirstReply(),
+    );
 
     const nudgeAgentIds = new Set(evaluation.nudgeAgentIds);
     for (const workload of workloads) {
@@ -201,13 +266,16 @@ export async function runRalphLoopCycle(
         continue;
       }
 
+      const trackedAssignmentIssues = trackedAssignmentIdleReplyStalls.get(workload.id);
       deps.sendMaintenanceMessage(
         workload.id,
-        buildRalphLoopNudgeMessage(
-          workload.pendingInboxCount,
-          workload.ownedThreadCount,
-          cycleStartedAt,
-        ),
+        trackedAssignmentIssues
+          ? buildTrackedAssignmentReplyNudgeMessage(trackedAssignmentIssues, cycleStartedAt)
+          : buildRalphLoopNudgeMessage(
+              workload.pendingInboxCount,
+              workload.ownedThreadCount,
+              cycleStartedAt,
+            ),
       );
       state.nudges.set(workload.id, now);
     }

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -134,9 +134,7 @@ export function applyTrackedAssignmentIdleReplyStalls(
       evaluation.nudgeAgentIds.push(agentId);
     }
     const agentName = idleWorkloads.get(agentId)?.name ?? agentId;
-    evaluation.anomalies.push(
-      buildTrackedAssignmentIdleReplyStallAnomaly(agentName, issueNumbers),
-    );
+    evaluation.anomalies.push(buildTrackedAssignmentIdleReplyStallAnomaly(agentName, issueNumbers));
     result.set(agentId, issueNumbers);
   }
 


### PR DESCRIPTION
## Summary
- add a broker DB query for tracked task assignments that still have no first agent reply to the original sender
- have RALPH flag idle assignees in that state and send a targeted report-outcome-or-blocker nudge
- keep the slice pinned to tracked assignments only, reusing `task_assignments.sourceMessageId`

## Testing
- tsc --noEmit
- eslint . --ext .ts
- vitest run

Refs #463