### PR TITLE
docs: record broker prompt layering precedence

### DIFF
--- a/plans/475-broker-prompt-layering.md
+++ b/plans/475-broker-prompt-layering.md
@@ -1,0 +1,75 @@
+# #475 — broker prompt layering on `main`
+
+This note records the current repo-level source of truth for broker prompt layering.
+It documents what `main` does today. It does **not** propose new prompt semantics.
+
+## Current repo truth
+
+### Project-level prompt files
+
+Current `main` has:
+
+- no project `.pi/SYSTEM.md`
+- no project `.pi/APPEND_SYSTEM.md`
+
+So this repo does **not** replace Pi's base system prompt at the project level, and it does **not** append a project-scoped system prompt fragment through those files.
+
+### Root context files
+
+Current `main` does have root context files:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+
+Per Pi's documented loading model:
+
+- project `.pi/SYSTEM.md` would replace the default system prompt
+- project `.pi/APPEND_SYSTEM.md` would append to it
+- `AGENTS.md` / `CLAUDE.md` are loaded as context files
+- `before_agent_start` can modify the current turn's effective system prompt
+
+At repo scope, that means broker turns in this repo inherit Pi's upstream effective prompt first — i.e. the prompt Pi has already assembled before `slack-bridge` runs, including the upstream base prompt selection plus root `AGENTS.md` / `CLAUDE.md` context that Pi loaded for the repo.
+
+## `slack-bridge` broker append layer
+
+`slack-bridge/agent-prompt-guidance.ts` does not replace the incoming prompt. It appends to `event.systemPrompt` in `before_agent_start`:
+
+```ts
+return {
+  systemPrompt: event.systemPrompt + "\n\n" + buildPromptGuidelines().join("\n"),
+};
+```
+
+For broker turns, the append order is:
+
+1. identity guidance (`buildIdentityReplyGuidelines()` via `getIdentityGuidelines()`)
+2. personality guidance (`buildAgentPersonalityGuidelines()`)
+3. reaction guidance (`buildReactionPromptGuidelines()`)
+4. optional skin guidance (`buildPinetSkinPromptGuideline()`) when a skin theme/personality is active
+5. broker guidance (`buildBrokerPromptGuidelines()`)
+6. broker tool guardrails (`buildBrokerToolGuardrailsPrompt()`)
+
+Collapsed to the narrow broker-specific layers for this issue, the order is:
+
+1. identity / personality / reaction
+2. broker guidance
+3. broker tool guardrails
+
+## What this issue verifies
+
+The narrow regression slice for #475 is:
+
+- document this repo-level prompt layering truth in this file
+- keep broker prompt semantics unchanged
+- add one root-runtime integration test proving that an incoming sentinel `systemPrompt` survives as the prefix, with the broker guidance layers appended after it
+
+## Evidence in repo
+
+- `slack-bridge/agent-prompt-guidance.ts`
+- `slack-bridge/agent-prompt-guidance.test.ts`
+- `slack-bridge/index.test.ts`
+
+## Upstream Pi references
+
+- `README.md` — context files and `.pi/SYSTEM.md` / `APPEND_SYSTEM.md`
+- `docs/extensions.md` — `before_agent_start` can replace or extend the current turn system prompt

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -718,6 +718,129 @@ describe("slack-bridge top-level shutdown", () => {
     expect(brokerRuntimes[1]?.stop).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves the incoming system prompt prefix when broker guidance is appended at root runtime", async () => {
+    const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "broker-prompt-layering-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-broker-prompt-layering-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation((db) => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: db.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    const startBrokerSpy = vi.spyOn(brokerModule, "startBroker").mockImplementation(async () => {
+      const db = new BrokerDB(dbPath);
+      db.initialize();
+      const server = {
+        setAgentRegistrationResolver: vi.fn(),
+        onAgentMessage: vi.fn(),
+        onAgentStatusChange: vi.fn(),
+      };
+      const stop = vi.fn(async () => {
+        db.close();
+      });
+      return {
+        db,
+        server,
+        lock: {
+          isLeader: () => true,
+          release: vi.fn(),
+        },
+        adapters: [],
+        addAdapter: vi.fn(),
+        stop,
+      } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
+    });
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStart = commands.get("pinet-start");
+    const beforeAgentStart = events.get("before_agent_start") as
+      | ((
+          event: { systemPrompt: string },
+          ctx: ExtensionContext,
+        ) => Promise<{ systemPrompt: string }>)
+      | undefined;
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStart).toBeDefined();
+    expect(beforeAgentStart).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await pinetStart?.handler("", ctx);
+    expect(startBrokerSpy).toHaveBeenCalledTimes(1);
+
+    const sentinelSystemPrompt = "SENTINEL ROOT PROMPT";
+    const result = await beforeAgentStart?.({ systemPrompt: sentinelSystemPrompt }, ctx);
+    const nextPrompt = result?.systemPrompt ?? "";
+
+    expect(nextPrompt.startsWith(`${sentinelSystemPrompt}\n\n`)).toBe(true);
+    expect(nextPrompt).toContain("First message in a new thread:");
+    expect(nextPrompt).toContain("COMMUNICATION STYLE:");
+    expect(nextPrompt).toContain("Reaction-triggered requests may appear");
+    expect(nextPrompt).toContain("the Pinet BROKER. Your ONLY role is coordination");
+    expect(nextPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(nextPrompt.indexOf("First message in a new thread:")).toBeGreaterThan(
+      nextPrompt.indexOf(sentinelSystemPrompt),
+    );
+    expect(nextPrompt.indexOf("COMMUNICATION STYLE:")).toBeGreaterThan(
+      nextPrompt.indexOf("First message in a new thread:"),
+    );
+    expect(nextPrompt.indexOf("Reaction-triggered requests may appear")).toBeGreaterThan(
+      nextPrompt.indexOf("COMMUNICATION STYLE:"),
+    );
+    expect(nextPrompt.indexOf("the Pinet BROKER. Your ONLY role is coordination")).toBeGreaterThan(
+      nextPrompt.indexOf("Reaction-triggered requests may appear"),
+    );
+    expect(nextPrompt.indexOf("🚫 BROKER TOOL RESTRICTION:")).toBeGreaterThan(
+      nextPrompt.indexOf("the Pinet BROKER. Your ONLY role is coordination"),
+    );
+
+    await sessionShutdown?.({}, ctx);
+  });
+
   it("sends an iMessage through the broker adapter when enabled", async () => {
     const settingsPath = path.join(testHome, ".pi", "agent", "settings.json");
     fs.writeFileSync(


### PR DESCRIPTION
## Summary
- add a repo source-of-truth note for current broker prompt layering on main
- document that broker turns inherit Pi's upstream prompt/context and then get broker guidance appended in before_agent_start
- add a root-runtime integration test proving an incoming sentinel systemPrompt stays as the prefix with broker layers appended after it

## Testing
- pnpm --dir slack-bridge test -- index.test.ts agent-prompt-guidance.test.ts

Refs #475