### PR TITLE
fix(slack-bridge): refresh broker thread owner hints

### DIFF
--- a/slack-bridge/broker-thread-owner-hints.test.ts
+++ b/slack-bridge/broker-thread-owner-hints.test.ts
@@ -17,23 +17,40 @@ function createDeps(overrides: Partial<BrokerThreadOwnerHintsDeps> = {}) {
 }
 
 describe("createBrokerThreadOwnerHints", () => {
-  it("caches resolved broker thread-owner hints per channel/thread pair", async () => {
+  it("re-fetches resolved broker thread-owner hints so ownership changes stay fresh", async () => {
     const { deps, slack } = createDeps({
-      slack: vi.fn(async () => ({
-        ok: true,
-        messages: [
-          {
-            bot_id: "B123",
-            metadata: {
-              event_type: "pi_agent_msg",
-              event_payload: {
-                agent_owner: "owner:crane",
-                agent: "Cobalt Olive Crane",
+      slack: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          messages: [
+            {
+              bot_id: "B123",
+              metadata: {
+                event_type: "pi_agent_msg",
+                event_payload: {
+                  agent_owner: "owner:crane",
+                  agent: "Cobalt Olive Crane",
+                },
               },
             },
-          },
-        ],
-      })),
+          ],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          messages: [
+            {
+              bot_id: "B123",
+              metadata: {
+                event_type: "pi_agent_msg",
+                event_payload: {
+                  agent_owner: "owner:moth",
+                  agent: "Silent Slate Mantis",
+                },
+              },
+            },
+          ],
+        }),
     });
     const brokerThreadOwnerHints = createBrokerThreadOwnerHints(deps);
 
@@ -46,12 +63,18 @@ describe("createBrokerThreadOwnerHints", () => {
     await expect(
       brokerThreadOwnerHints.resolveBrokerThreadOwnerHint("C123", "100.1"),
     ).resolves.toEqual({
-      agentOwner: "owner:crane",
-      agentName: "Cobalt Olive Crane",
+      agentOwner: "owner:moth",
+      agentName: "Silent Slate Mantis",
     });
 
-    expect(slack).toHaveBeenCalledTimes(1);
-    expect(slack).toHaveBeenCalledWith("conversations.replies", "xoxb-test", {
+    expect(slack).toHaveBeenCalledTimes(2);
+    expect(slack).toHaveBeenNthCalledWith(1, "conversations.replies", "xoxb-test", {
+      channel: "C123",
+      ts: "100.1",
+      limit: 200,
+      include_all_metadata: true,
+    });
+    expect(slack).toHaveBeenNthCalledWith(2, "conversations.replies", "xoxb-test", {
       channel: "C123",
       ts: "100.1",
       limit: 200,

--- a/slack-bridge/broker-thread-owner-hints.ts
+++ b/slack-bridge/broker-thread-owner-hints.ts
@@ -1,6 +1,5 @@
 import type { ThreadOwnerHint } from "./broker/router.js";
 import { resolveSlackThreadOwnerHint, type SlackCall } from "./slack-access.js";
-import { TtlCache } from "./ttl-cache.js";
 
 export interface BrokerThreadOwnerHintsDeps {
   slack: SlackCall;
@@ -17,11 +16,6 @@ export interface BrokerThreadOwnerHints {
 export function createBrokerThreadOwnerHints(
   deps: BrokerThreadOwnerHintsDeps,
 ): BrokerThreadOwnerHints {
-  const brokerThreadOwnerHintCache = new TtlCache<string, ThreadOwnerHint>({
-    maxSize: 2000,
-    ttlMs: 60 * 1000,
-  });
-
   async function resolveBrokerThreadOwnerHint(
     channel: string,
     threadTs: string,
@@ -31,7 +25,6 @@ export function createBrokerThreadOwnerHints(
       token: deps.getBotToken(),
       channel,
       threadTs,
-      cache: brokerThreadOwnerHintCache,
     });
   }
 

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -178,7 +178,7 @@ describe("findAgentMention", () => {
 });
 
 describe("extractPiAgentThreadOwnerHint", () => {
-  it("returns the first pi_agent_msg owner hint from thread replies", () => {
+  it("returns the latest pi_agent_msg owner hint from thread replies", () => {
     expect(
       extractPiAgentThreadOwnerHint([
         {
@@ -203,8 +203,8 @@ describe("extractPiAgentThreadOwnerHint", () => {
         },
       ]),
     ).toEqual({
-      agentName: "Pixel Lime Hippo",
-      agentOwner: "owner:hippo",
+      agentName: "Aurora Pearl Cobra",
+      agentOwner: "owner:cobra",
     });
   });
 

--- a/slack-bridge/broker/router.ts
+++ b/slack-bridge/broker/router.ts
@@ -36,7 +36,8 @@ export function findAgentMention(text: string, agents: AgentInfo[]): AgentInfo |
 export function extractPiAgentThreadOwnerHint(
   replies: ReadonlyArray<Record<string, unknown>>,
 ): ThreadOwnerHint | null {
-  for (const message of replies) {
+  for (let index = replies.length - 1; index >= 0; index -= 1) {
+    const message = replies[index];
     if (!message.bot_id) continue;
     const metadata = message.metadata as
       | {


### PR DESCRIPTION
## Summary
- make broker thread-owner extraction prefer the latest `pi_agent_msg` owner hint from Slack replies
- stop reusing stale positive broker thread-owner hints across ownership changes
- keep the change pinned to the narrow broker owner-hint freshness seam for worker-owned Slack follow-ups

## Testing
- pnpm exec vitest run broker/router.test.ts broker-thread-owner-hints.test.ts
- pnpm check
- pnpm test

Refs #346