### PR TITLE
test(slack-bridge): cover default-deny slack access regressions

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1033,41 +1033,116 @@ describe("SlackAdapter", () => {
 // ─── SlackAdapter — allowlist filtering ──────────────────
 
 describe("SlackAdapter — allowlist filtering", () => {
-  it("filters unauthorized users via classifyMessage + isUserAllowed flow", async () => {
-    // This tests the integration: classifyMessage marks message as relevant,
-    // but the adapter's onMessage checks the allowlist before emitting
-    const evt = {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn<typeof fetch>();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockSlackResponse(data: Record<string, unknown> = {}) {
+    return new Response(JSON.stringify({ ok: true, ...data }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("blocks inbound DM events by default when no allowlist is configured", async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error("default-deny path should not call Slack APIs");
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
       type: "message",
-      user: "U_UNAUTHORIZED",
-      text: "hello",
+      user: "U_BLOCKED",
+      text: "hello from Slack",
       channel: "D1",
       channel_type: "im",
       ts: "1.1",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adapter.getTrackedThreadIds()).toEqual(new Set(["1.1"]));
+  });
+
+  it("admits inbound DM events when allowAllWorkspaceUsers is explicitly enabled", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "D1", timestamp: "1.1", name: "eyes" });
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
     };
-    // classifyMessage sees it as relevant (it's a DM)
-    const result = classifyMessage(evt, "U_BOT", new Set());
-    expect(result.relevant).toBe(true);
+    adapterPort.botUserId = "U_BOT";
 
-    // But the adapter with an allowlist would filter it out
-    // (We test the helper directly since the adapter's onMessage is private)
-    const { isUserAllowed, buildAllowlist } = await import("../../helpers.js");
-    const allowlist = buildAllowlist({ allowedUsers: ["U_AUTHORIZED"] }, undefined);
-    expect(isUserAllowed(allowlist, "U_UNAUTHORIZED")).toBe(false);
-    expect(isUserAllowed(allowlist, "U_AUTHORIZED")).toBe(true);
-  });
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "hello from Slack",
+      channel: "D1",
+      channel_type: "im",
+      ts: "1.1",
+    });
 
-  it("rejects all users by default when no allowlist is configured", async () => {
-    const { isUserAllowed, buildAllowlist } = await import("../../helpers.js");
-    const allowlist = buildAllowlist({}, undefined, undefined);
-    expect(allowlist).toEqual(new Set());
-    expect(isUserAllowed(allowlist, "U_ANYONE")).toBe(false);
-  });
-
-  it("still supports explicit allow-all mode", async () => {
-    const { isUserAllowed, buildAllowlist } = await import("../../helpers.js");
-    const allowlist = buildAllowlist({ allowAllWorkspaceUsers: true }, undefined, undefined);
-    expect(allowlist).toBeNull();
-    expect(isUserAllowed(allowlist, "U_ANYONE")).toBe(true);
+    expect(handler).toHaveBeenCalledWith({
+      source: "slack",
+      threadId: "1.1",
+      channel: "D1",
+      userId: "U_ALLOWED",
+      userName: "Alice Example",
+      text: "hello from Slack",
+      timestamp: "1.1",
+    });
+    await waitForAssertion(() => {
+      const endpoints = fetchMock.mock.calls.map(([url]) => String(url));
+      expect(endpoints).toContain("https://slack.com/api/users.info");
+      expect(endpoints).toContain("https://slack.com/api/reactions.add");
+    });
   });
 });
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1234,6 +1234,115 @@ describe("slack-bridge top-level shutdown", () => {
     expect(firstSocket.close).toHaveBeenCalled();
   });
 
+  it("warns on default-deny Slack access at startup and reports it in pinet-status", async () => {
+    const originalAllowedUsersEnv = process.env.SLACK_ALLOWED_USERS;
+    const originalAllowAllEnv = process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
+    delete process.env.SLACK_ALLOWED_USERS;
+    delete process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
+
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-default-deny-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-default-deny-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStatus = commands.get("pinet-status");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStatus).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://slack.com/api/apps.connections.open",
+      expect.any(Object),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Slack access is default-deny because no allowedUsers are configured."),
+      "warning",
+    );
+
+    await pinetStatus?.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Allowed users: none (default deny; set allowedUsers or allowAllWorkspaceUsers: true)",
+      ),
+      "info",
+    );
+
+    await sessionShutdown?.({}, ctx);
+    const firstSocket = FakeWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+    if (!firstSocket) {
+      throw new Error("Expected a default-deny single-mode websocket instance");
+    }
+    expect(firstSocket.close).toHaveBeenCalled();
+
+    if (originalAllowedUsersEnv === undefined) {
+      delete process.env.SLACK_ALLOWED_USERS;
+    } else {
+      process.env.SLACK_ALLOWED_USERS = originalAllowedUsersEnv;
+    }
+    if (originalAllowAllEnv === undefined) {
+      delete process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
+    } else {
+      process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS = originalAllowAllEnv;
+    }
+  });
+
   it("warns and reports status when live Slack scope drift is detected at startup", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1310,7 +1310,9 @@ describe("slack-bridge top-level shutdown", () => {
     );
     expect(FakeWebSocket.instances).toHaveLength(1);
     expect(notify).toHaveBeenCalledWith(
-      expect.stringContaining("Slack access is default-deny because no allowedUsers are configured."),
+      expect.stringContaining(
+        "Slack access is default-deny because no allowedUsers are configured.",
+      ),
       "warning",
     );
 


### PR DESCRIPTION
## Summary
- add a top-level startup/status regression for the default-deny Slack trust boundary
- replace helper-only Slack adapter allowlist checks with real inbound event-path tests
- keep the cut pinned to `slack-bridge/index.test.ts` and `slack-bridge/broker/adapters/slack.test.ts`

## Testing
- ../../../node_modules/.bin/eslint index.test.ts broker/adapters/slack.test.ts
- ../../../node_modules/.bin/vitest run index.test.ts broker/adapters/slack.test.ts

Closes #323