### PR TITLE
fix: hint canvas comment context fetch

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -392,6 +392,47 @@ describe("classifyMessage", () => {
     }
   });
 
+  it("preserves fetchable canvas file references for normal mention events", () => {
+    const evt = {
+      type: "message",
+      user: "U1",
+      text: "<@U_BOT> Alice mentioned you in a comment",
+      channel: "C1",
+      channel_type: "channel",
+      ts: "1.1",
+      files: [
+        {
+          id: "F_CANVAS_1",
+          title: "Launch plan",
+          permalink: "https://example.slack.com/docs/T/F_CANVAS_1",
+        },
+      ],
+    };
+
+    const result = classifyMessage(evt, botId, emptyTracked);
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.isChannelMention).toBe(true);
+      expect(result.text).toBe(
+        [
+          "Alice mentioned you in a comment",
+          "",
+          "Slack message context:",
+          "- Launch plan — id=F_CANVAS_1 — https://example.slack.com/docs/T/F_CANVAS_1",
+        ].join("\n"),
+      );
+      expect(result.metadata).toEqual({
+        slackFiles: [
+          {
+            id: "F_CANVAS_1",
+            title: "Launch plan",
+            permalink: "https://example.slack.com/docs/T/F_CANVAS_1",
+          },
+        ],
+      });
+    }
+  });
+
   it("does not strip mention in tracked threads", () => {
     const tracked = new Set(["1.1"]);
     const evt = {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -490,6 +490,60 @@ describe("formatInboxMessages", () => {
     expect(result).toContain('will: Clicked Slack "Approve" (action_id: review.approve).');
     expect(result).toContain('metadata={"kind":"slack_block_action","actionId":"review.approve"');
   });
+
+  it("includes a compact canvas metadata suffix with a comment-read hint", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "C123",
+        threadTs: "123.456",
+        userId: "U1",
+        text: "Alice mentioned you in a comment",
+        timestamp: "123.789",
+        metadata: {
+          slackFiles: [
+            {
+              id: "F_CANVAS_1",
+              title: "Launch plan",
+              permalink: "https://example.slack.com/docs/T/F_CANVAS_1",
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain("will: Alice mentioned you in a comment");
+    expect(result).toContain('canvas={"canvasId":"F_CANVAS_1"');
+    expect(result).toContain('"title":"Launch plan"');
+    expect(result).toContain('"permalink":"https://example.slack.com/docs/T/F_CANVAS_1"');
+    expect(result).toContain('"toolHint":"slack_canvas_comments_read canvas_id=F_CANVAS_1"');
+  });
+
+  it("keeps generic Slack file metadata out of the canvas-only suffix", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "C123",
+        threadTs: "123.456",
+        userId: "U1",
+        text: "See attached note",
+        timestamp: "123.789",
+        metadata: {
+          slackFiles: [
+            {
+              id: "F123",
+              title: "Incident notes",
+              permalink: "https://files.example/incident.md",
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain("will: See attached note");
+    expect(result).not.toContain("slack_canvas_comments_read");
+    expect(result).not.toContain(" | canvas=");
+  });
 });
 
 describe("isTerminalPinetStandDownMessage", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -190,6 +190,56 @@ export function buildSqliteWalFallbackWarning(
   return `[${component}] SQLite WAL mode not available, using ${getSqliteJournalMode(result)} journal mode fallback`;
 }
 
+function extractSlackCanvasIdFromPermalink(permalink: string | undefined): string | undefined {
+  if (!permalink) return undefined;
+
+  const match = permalink.match(/\/docs\/[^/]+\/(F[^/?#]+)/i);
+  return match?.[1];
+}
+
+function extractInboxCanvasReference(metadata: Record<string, unknown> | null | undefined): {
+  canvasId: string;
+  title?: string;
+  permalink?: string;
+} | null {
+  const slackFiles = Array.isArray(metadata?.slackFiles) ? metadata.slackFiles : [];
+
+  for (const file of slackFiles) {
+    if (!file || typeof file !== "object" || Array.isArray(file)) {
+      continue;
+    }
+
+    const record = asRecord(file);
+    if (!record) {
+      continue;
+    }
+
+    const title = asString(record.title) ?? asString(record.name);
+    const permalink = asString(record.permalink);
+    const prettyType = asString(record.prettyType)?.toLowerCase();
+    const filetype = asString(record.filetype)?.toLowerCase();
+    const mimetype = asString(record.mimetype)?.toLowerCase();
+    const canvasId = asString(record.id) ?? extractSlackCanvasIdFromPermalink(permalink);
+    const looksCanvas =
+      Boolean(permalink && permalink.includes("/docs/")) ||
+      prettyType === "canvas" ||
+      filetype === "canvas" ||
+      Boolean(mimetype?.includes("slack-doc"));
+
+    if (!looksCanvas || !canvasId) {
+      continue;
+    }
+
+    return {
+      canvasId,
+      ...(title ? { title } : {}),
+      ...(permalink ? { permalink } : {}),
+    };
+  }
+
+  return null;
+}
+
 function formatInboxMetadata(metadata: Record<string, unknown> | null | undefined): string {
   if (!metadata || Object.keys(metadata).length === 0) return "";
 
@@ -200,6 +250,16 @@ function formatInboxMetadata(metadata: Record<string, unknown> | null | undefine
       blockId: metadata.blockId ?? null,
       value: metadata.value ?? null,
       parsedValue: metadata.parsedValue ?? null,
+    })}`;
+  }
+
+  const canvasReference = extractInboxCanvasReference(metadata);
+  if (canvasReference) {
+    return ` | canvas=${JSON.stringify({
+      canvasId: canvasReference.canvasId,
+      ...(canvasReference.title ? { title: canvasReference.title } : {}),
+      ...(canvasReference.permalink ? { permalink: canvasReference.permalink } : {}),
+      toolHint: `slack_canvas_comments_read canvas_id=${canvasReference.canvasId}`,
     })}`;
   }
 


### PR DESCRIPTION
## Summary
- add a compact canvas-only inbox metadata suffix when inbound slackFiles contain a canvas reference
- point agents at `slack_canvas_comments_read canvas_id=...` instead of auto-copying canvas body/history
- preserve fetchable canvas references on the normal mention ingress path

## Testing
- `pnpm --dir slack-bridge test -- helpers.test.ts broker/adapters/slack.test.ts`
- `pnpm exec prettier --check slack-bridge/helpers.ts slack-bridge/helpers.test.ts slack-bridge/broker/adapters/slack.test.ts`
- `pnpm --dir slack-bridge exec eslint helpers.ts helpers.test.ts broker/adapters/slack.test.ts`

Closes #337