### PR TITLE
docs: clarify fresh worktree bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ are skipped on re-runs.
 
 - NEVER work directly on `main` or checkout feature branches in the main repo directory.
 - ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>` and `cd` into it before making changes.
+- In a fresh worktree, run `pnpm install --frozen-lockfile` before `pnpm lint`, `pnpm typecheck`, `pnpm test`, or `pnpm prepush`. Dependency bootstrap is per checkout/worktree, not a one-time repo setup step.
+- If the lane touches `.pi/extensions/browser-playwright`, also run `cd .pi/extensions/browser-playwright && npm install` in that worktree.
 - If you are already in a worktree, stay there. Do not `cd` back to the main checkout.
 - When your PR is merged, clean up: `git worktree remove .worktrees/<name>` from the main checkout.
 - NEVER run `git checkout <branch>` or `git switch <branch>` in the main repo checkout. It must always be on `main`.

--- a/README.md
+++ b/README.md
@@ -84,11 +84,30 @@ can coordinate and execute most of the work itself.
 ## Quick start
 
 ```bash
-# Install dependencies
+# Install dependencies in this checkout
 pnpm install
 
 # Run all checks
 pnpm lint && pnpm typecheck && pnpm test
+```
+
+### Fresh worktree bootstrap
+
+For a fresh git worktree, bootstrap dependencies in that checkout before
+running `pnpm lint`, `pnpm typecheck`, `pnpm test`, or `pnpm prepush`:
+
+```bash
+git worktree add .worktrees/<name> -b <branch>
+cd .worktrees/<name>
+pnpm install --frozen-lockfile
+```
+
+Dependency bootstrap is per checkout/worktree, not a one-time repo setup step.
+If the lane touches `.pi/extensions/browser-playwright`, also run:
+
+```bash
+cd .pi/extensions/browser-playwright
+npm install
 ```
 
 ## Local extension development


### PR DESCRIPTION
## Summary
- clarify that fresh git worktrees need `pnpm install --frozen-lockfile` before repo-level checks
- note that dependency bootstrap is per checkout/worktree, not a one-time repo setup step
- document the conditional `.pi/extensions/browser-playwright` local `npm install` step for lanes that touch it

## Testing
- ../../node_modules/.bin/prettier --check CLAUDE.md README.md
- git diff --check
- manual confirmation that the new bootstrap guidance now appears before repo-level `pnpm lint` / `pnpm test` guidance in `README.md` and in the worktree rules in `CLAUDE.md` / `AGENTS.md`

Closes #334