### PR TITLE
feat(slack-bridge): add slack_delete tool

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -190,6 +190,7 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 | `slack_upload`               | Upload files, snippets, or diffs into Slack                                       |
 | `slack_schedule`             | Schedule a message for later delivery                                             |
 | `slack_post_channel`         | Post to a channel (by name or ID)                                                 |
+| `slack_delete`               | Delete a bot-posted message or an entire thread                                   |
 | `slack_read_channel`         | Read channel history or a thread in a channel                                     |
 | `slack_create_channel`       | Create a new Slack channel                                                        |
 | `slack_project_create`       | Create a project channel + RFC canvas + bot invite in one call                    |

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -95,6 +95,7 @@ describe("isToolBlocked", () => {
   it("classifies Slack mutation tools as write-only", () => {
     expect(WRITE_TOOLS.has("slack_create_channel")).toBe(true);
     expect(WRITE_TOOLS.has("slack_post_channel")).toBe(true);
+    expect(WRITE_TOOLS.has("slack_delete")).toBe(true);
     expect(WRITE_TOOLS.has("slack_upload")).toBe(true);
     expect(WRITE_TOOLS.has("slack_schedule")).toBe(true);
     expect(WRITE_TOOLS.has("slack_pin")).toBe(true);
@@ -107,6 +108,7 @@ describe("isToolBlocked", () => {
     expect(READ_ONLY_TOOLS.has("slack_presence")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack_create_channel")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_post_channel")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_delete")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_upload")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_schedule")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack_pin")).toBe(false);

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -36,6 +36,7 @@ export const WRITE_TOOLS = new Set([
   "memory_init",
   "slack_create_channel",
   "slack_post_channel",
+  "slack_delete",
   "slack_upload",
   "slack_schedule",
   "slack_pin",

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -208,6 +208,7 @@ describe("registerSlackTools", () => {
       null;
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
+    const requireToolPolicy = vi.fn();
 
     registerSlackTools(pi, {
       getBotToken: () => botToken,
@@ -228,7 +229,7 @@ describe("registerSlackTools", () => {
       },
       resolveChannel: async (nameOrId) => `resolved:${nameOrId}`,
       rememberChannel: () => {},
-      requireToolPolicy: () => {},
+      requireToolPolicy,
       registerConfirmationRequest: () => ({ status: "created" }),
       getBotUserId: () => "U_BOT",
     });
@@ -275,6 +276,7 @@ describe("registerSlackTools", () => {
       },
       noteThreadReply,
       clearPendingAttention,
+      requireToolPolicy,
     };
   }
 
@@ -315,7 +317,7 @@ describe("registerSlackTools", () => {
   });
 
   it("deletes a single bot-posted message when confirm=true", async () => {
-    const { slack, tools, setBotToken, setDefaultChannel } = setup();
+    const { slack, tools, setBotToken, setDefaultChannel, requireToolPolicy } = setup();
     setBotToken("xoxb-reloaded");
     setDefaultChannel("ops-alerts");
 
@@ -324,6 +326,11 @@ describe("registerSlackTools", () => {
       confirm: true,
     });
 
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "slack_delete",
+      undefined,
+      "channel=ops-alerts | thread_ts= | ts=123.789 | thread=false",
+    );
     expect(slack).toHaveBeenCalledWith("chat.delete", "xoxb-reloaded", {
       channel: "resolved:ops-alerts",
       ts: "123.789",
@@ -339,7 +346,7 @@ describe("registerSlackTools", () => {
   });
 
   it("requires confirm=true before deleting Slack messages", async () => {
-    const { tools, setDefaultChannel } = setup();
+    const { tools, setDefaultChannel, requireToolPolicy } = setup();
     setDefaultChannel("ops-alerts");
 
     await expect(
@@ -349,6 +356,7 @@ describe("registerSlackTools", () => {
     ).rejects.toThrow(
       "Deleting Slack messages is irreversible. Re-run with confirm=true once you've verified the target.",
     );
+    expect(requireToolPolicy).not.toHaveBeenCalled();
   });
 
   it("uses read-through thread resolution for slack_read", async () => {
@@ -550,7 +558,11 @@ describe("registerSlackTools", () => {
     setConversationsReplies([
       {
         ok: true,
-        messages: [{ ts: "123.456" }, { ts: "123.457" }, { ts: "123.458" }],
+        messages: [
+          { ts: "123.456", user: "U_BOT" },
+          { ts: "123.457", user: "U_BOT" },
+          { ts: "123.458", user: "U_BOT" },
+        ],
         response_metadata: { next_cursor: "" },
       } as SlackResult,
     ]);
@@ -588,18 +600,47 @@ describe("registerSlackTools", () => {
     });
   });
 
-  it("requires the thread root ts when deleting an entire thread", async () => {
-    const { tools, setConversationsReplies } = setup();
+  it("rejects whole-thread deletion when the thread includes other authors", async () => {
+    const { slack, tools, setConversationsReplies } = setup();
     setConversationsReplies([
       {
         ok: true,
-        messages: [{ ts: "123.000" }, { ts: "123.789" }],
+        messages: [
+          { ts: "123.456", user: "U_BOT" },
+          { ts: "123.457", user: "U_HUMAN" },
+        ],
         response_metadata: { next_cursor: "" },
       } as SlackResult,
     ]);
 
     await expect(
       tools.get("slack_delete")!.execute("tool-6c", {
+        channel: "deployments",
+        ts: "123.456",
+        thread: true,
+        confirm: true,
+      }),
+    ).rejects.toThrow(
+      "Cannot delete thread 123.456 because it includes message(s) not posted by the current bot: 123.457. Delete those messages individually instead.",
+    );
+    expect(slack.mock.calls.filter(([method]) => method === "chat.delete")).toHaveLength(0);
+  });
+
+  it("requires the thread root ts when deleting an entire thread", async () => {
+    const { tools, setConversationsReplies } = setup();
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [
+          { ts: "123.000", user: "U_BOT" },
+          { ts: "123.789", user: "U_BOT" },
+        ],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+
+    await expect(
+      tools.get("slack_delete")!.execute("tool-6d", {
         channel: "deployments",
         ts: "123.789",
         thread: true,

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -559,9 +559,27 @@ describe("registerSlackTools", () => {
       {
         ok: true,
         messages: [
-          { ts: "123.456", user: "U_BOT" },
-          { ts: "123.457", user: "U_BOT" },
-          { ts: "123.458", user: "U_BOT" },
+          {
+            ts: "123.456",
+            metadata: {
+              event_type: "pi_agent_msg",
+              event_payload: { agent_owner: "owner:test-token" },
+            },
+          },
+          {
+            ts: "123.457",
+            metadata: {
+              event_type: "pi_agent_msg",
+              event_payload: { agent_owner: "owner:test-token" },
+            },
+          },
+          {
+            ts: "123.458",
+            metadata: {
+              event_type: "pi_agent_msg",
+              event_payload: { agent_owner: "owner:test-token" },
+            },
+          },
         ],
         response_metadata: { next_cursor: "" },
       } as SlackResult,
@@ -578,6 +596,7 @@ describe("registerSlackTools", () => {
       channel: "resolved:deployments",
       ts: "123.456",
       limit: 1000,
+      include_all_metadata: true,
     });
     expect(slack).toHaveBeenNthCalledWith(2, "chat.delete", "xoxb-initial", {
       channel: "resolved:deployments",

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -78,6 +78,16 @@ describe("registerSlackTools", () => {
         } as SlackResult;
       }
 
+      if (method === "chat.delete") {
+        return {
+          ok: true,
+          token,
+          body,
+          channel: typeof body?.channel === "string" ? body.channel : "C123",
+          ts: typeof body?.ts === "string" ? body.ts : "123.456",
+        } as SlackResult;
+      }
+
       if (method === "views.open" || method === "views.push" || method === "views.update") {
         return {
           ok: true,
@@ -304,6 +314,43 @@ describe("registerSlackTools", () => {
     );
   });
 
+  it("deletes a single bot-posted message when confirm=true", async () => {
+    const { slack, tools, setBotToken, setDefaultChannel } = setup();
+    setBotToken("xoxb-reloaded");
+    setDefaultChannel("ops-alerts");
+
+    const response = await tools.get("slack_delete")!.execute("tool-2b", {
+      ts: "123.789",
+      confirm: true,
+    });
+
+    expect(slack).toHaveBeenCalledWith("chat.delete", "xoxb-reloaded", {
+      channel: "resolved:ops-alerts",
+      ts: "123.789",
+    });
+    expect(response.content?.[0]?.text).toContain("Deleted message 123.789");
+    expect(response.details).toMatchObject({
+      channel: "resolved:ops-alerts",
+      ts: "123.789",
+      thread: false,
+      deleted_count: 1,
+      deleted_ts: ["123.789"],
+    });
+  });
+
+  it("requires confirm=true before deleting Slack messages", async () => {
+    const { tools, setDefaultChannel } = setup();
+    setDefaultChannel("ops-alerts");
+
+    await expect(
+      tools.get("slack_delete")!.execute("tool-2c", {
+        ts: "123.789",
+      }),
+    ).rejects.toThrow(
+      "Deleting Slack messages is irreversible. Re-run with confirm=true once you've verified the target.",
+    );
+  });
+
   it("uses read-through thread resolution for slack_read", async () => {
     const { slack, tools, setResolveThreadChannel } = setup();
     setResolveThreadChannel(async (threadTs: string | undefined) => {
@@ -317,6 +364,25 @@ describe("registerSlackTools", () => {
       channel: "C-DB",
       ts: "123.456",
       limit: 20,
+    });
+  });
+
+  it("uses thread channel resolution for slack_delete", async () => {
+    const { slack, tools, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return "C-DB";
+    });
+
+    await tools.get("slack_delete")!.execute("tool-3b", {
+      ts: "123.789",
+      thread_ts: "123.456",
+      confirm: true,
+    });
+
+    expect(slack).toHaveBeenCalledWith("chat.delete", "xoxb-initial", {
+      channel: "C-DB",
+      ts: "123.789",
     });
   });
 
@@ -477,6 +543,69 @@ describe("registerSlackTools", () => {
         post_at: Math.floor(Date.parse("2026-04-02T14:30:00.000Z") / 1000),
       }),
     );
+  });
+
+  it("deletes thread replies before deleting the root message", async () => {
+    const { slack, tools, setConversationsReplies } = setup();
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [{ ts: "123.456" }, { ts: "123.457" }, { ts: "123.458" }],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+
+    const response = await tools.get("slack_delete")!.execute("tool-6b", {
+      channel: "deployments",
+      ts: "123.456",
+      thread: true,
+      confirm: true,
+    });
+
+    expect(slack).toHaveBeenNthCalledWith(1, "conversations.replies", "xoxb-initial", {
+      channel: "resolved:deployments",
+      ts: "123.456",
+      limit: 1000,
+    });
+    expect(slack).toHaveBeenNthCalledWith(2, "chat.delete", "xoxb-initial", {
+      channel: "resolved:deployments",
+      ts: "123.457",
+    });
+    expect(slack).toHaveBeenNthCalledWith(3, "chat.delete", "xoxb-initial", {
+      channel: "resolved:deployments",
+      ts: "123.458",
+    });
+    expect(slack).toHaveBeenNthCalledWith(4, "chat.delete", "xoxb-initial", {
+      channel: "resolved:deployments",
+      ts: "123.456",
+    });
+    expect(response.details).toMatchObject({
+      channel: "resolved:deployments",
+      ts: "123.456",
+      thread: true,
+      deleted_count: 3,
+      deleted_ts: ["123.457", "123.458", "123.456"],
+    });
+  });
+
+  it("requires the thread root ts when deleting an entire thread", async () => {
+    const { tools, setConversationsReplies } = setup();
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [{ ts: "123.000" }, { ts: "123.789" }],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+
+    await expect(
+      tools.get("slack_delete")!.execute("tool-6c", {
+        channel: "deployments",
+        ts: "123.789",
+        thread: true,
+        confirm: true,
+      }),
+    ).rejects.toThrow("When thread=true, ts must be the thread root timestamp.");
   });
 
   it("handles already_pinned gracefully", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -201,6 +201,32 @@ function normalizeSlackBookmarkUrl(url: string): string {
   return parsed.toString();
 }
 
+function isPiAgentSlackMessage(
+  message: Record<string, unknown>,
+  botUserId: string | null,
+): boolean {
+  if (botUserId && message.user === botUserId) {
+    return true;
+  }
+
+  const metadata = message.metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+
+  return (metadata as { event_type?: unknown }).event_type === "pi_agent_msg";
+}
+
+function summarizeSlackDeleteAction(input: {
+  channel?: string;
+  defaultChannel?: string;
+  threadTs?: string;
+  ts: string;
+  thread?: boolean;
+}): string {
+  return `channel=${input.channel ?? input.defaultChannel ?? ""} | thread_ts=${input.threadTs ?? ""} | ts=${input.ts} | thread=${input.thread ?? false}`;
+}
+
 export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDeps): void {
   const {
     getBotToken,
@@ -379,6 +405,15 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     }
     if (threadRootTs !== targetTs) {
       throw new Error("When thread=true, ts must be the thread root timestamp.");
+    }
+
+    const undeletableMessages = messages
+      .filter((message) => !isPiAgentSlackMessage(message, getBotUserId()))
+      .map((message) => (typeof message.ts === "string" ? message.ts : "unknown-ts"));
+    if (undeletableMessages.length > 0) {
+      throw new Error(
+        `Cannot delete thread ${targetTs} because it includes message(s) not posted by the current bot: ${undeletableMessages.join(", ")}. Delete those messages individually instead.`,
+      );
     }
 
     const messageTsList = messages
@@ -1827,17 +1862,23 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       ),
     }),
     async execute(_id, params) {
-      requireToolPolicy(
-        "slack_delete",
-        params.thread_ts,
-        `channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | ts=${params.ts} | thread=${params.thread ?? false} | confirm=${params.confirm ?? false}`,
-      );
-
       if (params.confirm !== true) {
         throw new Error(
           "Deleting Slack messages is irreversible. Re-run with confirm=true once you've verified the target.",
         );
       }
+
+      requireToolPolicy(
+        "slack_delete",
+        params.thread_ts,
+        summarizeSlackDeleteAction({
+          channel: params.channel,
+          defaultChannel: getDefaultChannel(),
+          threadTs: params.thread_ts,
+          ts: params.ts,
+          thread: params.thread,
+        }),
+      );
 
       const deleteThread = params.thread === true;
       const { channelId, messageTsList } = await resolveSlackDeleteTargets({

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -351,6 +351,49 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     return messages;
   }
 
+  async function resolveSlackDeleteTargets(input: {
+    channel?: string;
+    threadTs?: string;
+    ts: string;
+    thread?: boolean;
+  }): Promise<{ channelId: string; messageTsList: string[] }> {
+    const channelId = await resolveSlackTargetChannel(input.threadTs, input.channel);
+    const targetTs = input.ts.trim();
+    if (!targetTs) {
+      throw new Error("ts is required.");
+    }
+
+    if (!input.thread) {
+      return { channelId, messageTsList: [targetTs] };
+    }
+
+    const messages = await fetchSlackThreadMessages(channelId, targetTs);
+    const threadRootTs =
+      messages.length > 0 && typeof messages[0]?.ts === "string"
+        ? (messages[0].ts as string)
+        : undefined;
+    if (!threadRootTs) {
+      throw new Error(
+        `Slack did not return a thread rooted at ${targetTs} in channel ${input.channel ?? channelId}.`,
+      );
+    }
+    if (threadRootTs !== targetTs) {
+      throw new Error("When thread=true, ts must be the thread root timestamp.");
+    }
+
+    const messageTsList = messages
+      .map((message) => (typeof message.ts === "string" ? message.ts : undefined))
+      .filter((messageTs): messageTs is string => messageTs != null && messageTs.length > 0);
+    if (messageTsList.length === 0) {
+      throw new Error(`Slack did not return any deletable messages for thread ${targetTs}.`);
+    }
+
+    return {
+      channelId,
+      messageTsList: [...messageTsList.slice(1), messageTsList[0]],
+    };
+  }
+
   async function buildSlackExportPayload(messages: Record<string, unknown>[]): Promise<{
     mentionNames: Record<string, string>;
     authors: string[];
@@ -1744,6 +1787,93 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           },
         ],
         details: { ts, channel: channelId, blocksCount: params.blocks?.length ?? 0 },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "slack_delete",
+    label: "Slack Delete",
+    description:
+      "Delete a Slack message posted by the bot, or delete an entire thread rooted at a bot-posted message.",
+    promptSnippet:
+      "Delete a bot-posted Slack message. This is destructive — set confirm=true, and prefer explicit approval before deleting whole threads.",
+    parameters: Type.Object({
+      ts: Type.String({
+        description:
+          "Timestamp (ts) of the message to delete. When thread=true, this must be the thread root timestamp.",
+      }),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Channel name or ID. Omit to use the current thread channel, active DM, or defaultChannel.",
+        }),
+      ),
+      thread_ts: Type.Optional(
+        Type.String({
+          description:
+            "Optional thread timestamp used to resolve the current channel when channel is omitted.",
+        }),
+      ),
+      thread: Type.Optional(
+        Type.Boolean({
+          description: "Delete the entire thread rooted at ts (default false).",
+        }),
+      ),
+      confirm: Type.Optional(
+        Type.Boolean({
+          description: "Must be true to confirm this irreversible deletion.",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_delete",
+        params.thread_ts,
+        `channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | ts=${params.ts} | thread=${params.thread ?? false} | confirm=${params.confirm ?? false}`,
+      );
+
+      if (params.confirm !== true) {
+        throw new Error(
+          "Deleting Slack messages is irreversible. Re-run with confirm=true once you've verified the target.",
+        );
+      }
+
+      const deleteThread = params.thread === true;
+      const { channelId, messageTsList } = await resolveSlackDeleteTargets({
+        channel: params.channel,
+        threadTs: params.thread_ts,
+        ts: params.ts,
+        thread: deleteThread,
+      });
+
+      for (const messageTs of messageTsList) {
+        await slack("chat.delete", getBotToken(), {
+          channel: channelId,
+          ts: messageTs,
+        });
+      }
+
+      const targetTs = params.ts.trim();
+      const deletedCount = messageTsList.length;
+      const channelLabel = params.channel ?? channelId;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: deleteThread
+              ? `Deleted thread rooted at ${targetTs} in channel ${channelLabel} (${deletedCount} message${deletedCount === 1 ? "" : "s"}).`
+              : `Deleted message ${targetTs} from channel ${channelLabel}.`,
+          },
+        ],
+        details: {
+          channel: channelId,
+          ts: targetTs,
+          thread: deleteThread,
+          deleted_count: deletedCount,
+          deleted_ts: messageTsList,
+        },
       };
     },
   });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -204,9 +204,11 @@ function normalizeSlackBookmarkUrl(url: string): string {
 function isPiAgentSlackMessage(
   message: Record<string, unknown>,
   botUserId: string | null,
+  agentOwnerToken: string,
 ): boolean {
-  if (botUserId && message.user === botUserId) {
-    return true;
+  const messageUser = typeof message.user === "string" ? message.user : undefined;
+  if (messageUser) {
+    return botUserId != null && messageUser === botUserId;
   }
 
   const metadata = message.metadata;
@@ -214,7 +216,16 @@ function isPiAgentSlackMessage(
     return false;
   }
 
-  return (metadata as { event_type?: unknown }).event_type === "pi_agent_msg";
+  if ((metadata as { event_type?: unknown }).event_type !== "pi_agent_msg") {
+    return false;
+  }
+
+  const eventPayload = (metadata as { event_payload?: unknown }).event_payload;
+  if (!eventPayload || typeof eventPayload !== "object") {
+    return false;
+  }
+
+  return (eventPayload as { agent_owner?: unknown }).agent_owner === agentOwnerToken;
 }
 
 function summarizeSlackDeleteAction(input: {
@@ -350,6 +361,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     threadTs: string,
     oldest?: string,
     latest?: string,
+    includeAllMetadata = false,
   ): Promise<Record<string, unknown>[]> {
     const messages: Record<string, unknown>[] = [];
     let cursor: string | undefined;
@@ -362,6 +374,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         ...(cursor ? { cursor } : {}),
         ...(oldest ? { oldest } : {}),
         ...(latest ? { latest } : {}),
+        ...(includeAllMetadata ? { include_all_metadata: true } : {}),
       });
 
       const batch = Array.isArray(response.messages)
@@ -393,7 +406,13 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       return { channelId, messageTsList: [targetTs] };
     }
 
-    const messages = await fetchSlackThreadMessages(channelId, targetTs);
+    const messages = await fetchSlackThreadMessages(
+      channelId,
+      targetTs,
+      undefined,
+      undefined,
+      true,
+    );
     const threadRootTs =
       messages.length > 0 && typeof messages[0]?.ts === "string"
         ? (messages[0].ts as string)
@@ -408,7 +427,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     }
 
     const undeletableMessages = messages
-      .filter((message) => !isPiAgentSlackMessage(message, getBotUserId()))
+      .filter((message) => !isPiAgentSlackMessage(message, getBotUserId(), getAgentOwnerToken()))
       .map((message) => (typeof message.ts === "string" ? message.ts : "unknown-ts"));
     if (undeletableMessages.length > 0) {
       throw new Error(


### PR DESCRIPTION
## Summary
- add a new `slack_delete` tool for deleting bot-posted Slack messages
- support whole-thread deletion by enumerating replies and deleting replies before the root
- mark the tool as write/destructive in guardrails, document it, and cover the behavior with tests

## Testing
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck

Closes #535