### PR TITLE
fix(slack-bridge): prefer fresh heartbeat for idle alerts

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1900,7 +1900,6 @@ describe("evaluateRalphLoopCycle", () => {
           status: "idle",
           metadata: { role: "worker" },
           lastSeen: "2026-04-01T00:00:00.000Z",
-          lastHeartbeat: "2026-04-01T00:01:55.000Z",
           pendingInboxCount: 2,
           ownedThreadCount: 1,
         },
@@ -1998,7 +1997,6 @@ describe("evaluateRalphLoopCycle", () => {
           status: "idle",
           metadata: { role: "worker" },
           lastSeen: "2026-04-01T00:00:00.000Z",
-          lastHeartbeat: "2026-04-01T00:01:55.000Z",
           pendingInboxCount: 1,
           ownedThreadCount: 1,
         },
@@ -2017,6 +2015,33 @@ describe("evaluateRalphLoopCycle", () => {
       result.anomalies.some((item) => item.includes("Broker Llama idle with assigned work")),
     ).toBe(false);
     expect(result.anomalies).toContain("Busy Fox idle with assigned work (1 inbox, 1 threads)");
+  });
+
+  it("does not nudge healthy idle workers with assigned work when heartbeats are fresh", () => {
+    const result = evaluateRalphLoopCycle(
+      [
+        {
+          emoji: "🦫",
+          name: "Quiet Beaver",
+          id: "quiet-idle",
+          status: "idle",
+          metadata: { role: "worker" },
+          lastSeen: "2026-04-01T00:00:00.000Z",
+          lastHeartbeat: "2026-04-01T00:01:55.000Z",
+          pendingInboxCount: 1,
+          ownedThreadCount: 1,
+        },
+      ],
+      {
+        now: Date.parse("2026-04-01T00:02:00.000Z"),
+        idleWithWorkThresholdMs: 60_000,
+        heartbeatTimeoutMs: 15_000,
+        heartbeatIntervalMs: 5_000,
+      },
+    );
+
+    expect(result.nudgeAgentIds).toEqual([]);
+    expect(result.anomalies).toEqual([]);
   });
 
   it("detects stuck agents when quiet activity crosses the threshold under queue pressure", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1165,8 +1165,15 @@ export function evaluateRalphLoopCycle(
     }
 
     const hasAssignedWork = workload.pendingInboxCount > 0 || workload.ownedThreadCount > 0;
-    const lastSeenMs = parseIsoMs(workload.lastSeen) ?? parseIsoMs(workload.lastHeartbeat);
-    const idleAgeMs = lastSeenMs == null ? null : Math.max(0, nowMs - lastSeenMs);
+    const lastSeenMs = parseIsoMs(workload.lastSeen);
+    const lastHeartbeatMs = parseIsoMs(workload.lastHeartbeat);
+    const lastContactMs =
+      lastSeenMs == null
+        ? lastHeartbeatMs
+        : lastHeartbeatMs == null
+          ? lastSeenMs
+          : Math.max(lastSeenMs, lastHeartbeatMs);
+    const idleAgeMs = lastContactMs == null ? null : Math.max(0, nowMs - lastContactMs);
 
     if (
       hasAssignedWork &&


### PR DESCRIPTION
## Summary
- prefer the freshest worker contact timestamp across `lastSeen` and `lastHeartbeat` when evaluating idle-with-assigned-work alerts
- keep the cut pinned to `slack-bridge/helpers.ts` and `slack-bridge/helpers.test.ts`
- add regression coverage proving healthy idle workers with fresh heartbeats are not nudged

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Fixes #483
