### PR TITLE
fix: make pinet-core scaffold merge-safe

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,15 @@ importers:
 
   openai-execution-shaping: {}
 
+  pinet-core:
+    dependencies:
+      "@gugu910/pi-broker-core":
+        specifier: workspace:*
+        version: link:../broker-core
+      "@gugu910/pi-transport-core":
+        specifier: workspace:*
+        version: link:../transport-core
+
   slack-api:
     dependencies:
       "@slack/web-api":

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -23,6 +23,13 @@ const packageConfigs = {
     vendorDirs: [],
     importRewrites: [],
   },
+  "pinet-core": {
+    excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
+    excludeFiles: new Set(),
+    excludePrefixes: [],
+    vendorDirs: [],
+    importRewrites: [],
+  },
   "imessage-bridge": {
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
     excludeFiles: new Set(),


### PR DESCRIPTION
## Context

Stacked follow-up on #540 (`plan: propose slack split boundary`). This keeps the `pinet-core/` scaffold exactly as Bear proposed, but removes the two mechanical traps that made the planning/scaffold branch unsafe to merge.

Source thread: `a2a:d5a6fe32:241d05b6-29e8-453d-a447-29d0e5e56ce1` (Pixel Chalk Dragon → Orbit Emerald Turtle).

## What changed

1. **Sync `pnpm-lock.yaml` for the new workspace package**
   - Add the missing `pinet-core` importer entry
   - Record its workspace deps:
     - `@gugu910/pi-broker-core`
     - `@gugu910/pi-transport-core`

2. **Teach `scripts/build-package.mjs` about `pinet-core`**
   - Add a `pinet-core` config entry mirroring the simple `broker-core` / `transport-core` shape
   - This makes the scaffold's existing `build` / `prepack` scripts valid immediately

## Why this is the minimal safe fix

The review on #540 found exactly two merge blockers:
- `pnpm install --frozen-lockfile` failed because the lockfile had no `pinet-core` importer
- `pinet-core` already declared `build` and `prepack`, but `scripts/build-package.mjs` threw `Unsupported package for build-package.mjs: pinet-core`

This PR fixes only those blockers. It intentionally does **not** widen into:
- tsconfig alias/include work
- naming cleanup in the plan doc
- rollback policy / architecture polish
- scaffold removal

## Verification

Targeted proof that the scaffold is now merge-safe:

- `pnpm install --frozen-lockfile` ✅
- `cd pinet-core && pnpm run build` ✅
- `cd pinet-core && pnpm pack --pack-destination ../.packtmp` ✅ (exercises `prepack` → `build` path)
- `cd broker-core && pnpm run build` ✅ (spot-check existing package still works through the shared build script)

Push also ran the repo pre-push hook successfully:
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅

## Merge plan

Merge this into #540's branch (or cherry-pick commit `2df8fbd`) and the planning/scaffold PR should no longer be blocked on mechanical repo plumbing. No fresh architecture re-scope should be necessary; this is just the smallest safe repair.
