### PR TITLE
docs: document browser-playwright as supported sandbox path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ interactive browsing and screenshots.
 
 ## Extensions
 
-| Package                                     | Description                                                                |
-| ------------------------------------------- | -------------------------------------------------------------------------- |
-| [`transport-core`](transport-core/)         | Transport-neutral message contracts shared across transport packages       |
-| [`browser-playwright`](browser-playwright/) | Single-tool browser extension with a Playwright local backend              |
-| [`slack-bridge`](slack-bridge/)             | Slack assistant app (Pinet) — broker mesh, inbox, canvases, deploy tooling |
-| [`slack-api`](slack-api/)                   | Typed Slack Web API client + CLI generated from OpenAPI                    |
-| [`imessage-bridge`](imessage-bridge/)       | macOS/iMessage send-first transport package + readiness helpers            |
-| [`nvim-bridge`](nvim-bridge/)               | Neovim editor context sync + PiComms persistent comments                   |
-| [`neon-psql`](neon-psql/)                   | Config-driven Neon tunnel + `psql` tool                                    |
-| [`types`](types/)                           | Shared ambient type declarations                                           |
+| Package                                     | Description                                                                     |
+| ------------------------------------------- | ------------------------------------------------------------------------------- |
+| [`transport-core`](transport-core/)         | Transport-neutral message contracts shared across transport packages            |
+| [`browser-playwright`](browser-playwright/) | Supported Anthropic-sandbox browsing path; Playwright-first single browser tool |
+| [`slack-bridge`](slack-bridge/)             | Slack assistant app (Pinet) — broker mesh, inbox, canvases, deploy tooling      |
+| [`slack-api`](slack-api/)                   | Typed Slack Web API client + CLI generated from OpenAPI                         |
+| [`imessage-bridge`](imessage-bridge/)       | macOS/iMessage send-first transport package + readiness helpers                 |
+| [`nvim-bridge`](nvim-bridge/)               | Neovim editor context sync + PiComms persistent comments                        |
+| [`neon-psql`](neon-psql/)                   | Config-driven Neon tunnel + `psql` tool                                         |
+| [`types`](types/)                           | Shared ambient type declarations                                                |
 
 ## Current state snapshot
 
@@ -33,8 +33,10 @@ interactive browsing and screenshots.
   for pushing `slack-bridge/manifest.yaml` via the Slack App Manifest API.
 - **Browser automation** — the repo now carries a dedicated
   [`browser-playwright`](browser-playwright/README.md)
-  workspace package with reusable sessions, multi-tab browsing, request
-  guardrails, and workspace-local screenshot artifacts.
+  workspace package as the supported browsing path in the Anthropic sandbox,
+  with reusable sessions, multi-tab browsing, request guardrails, and
+  workspace-local screenshot artifacts. Local `agent-browser` daemon
+  compatibility is explicitly not a support goal for this path.
 - **Recent wave** — browser-playwright landed alongside the Pinet v0.1.1 prep,
   mesh-secret optionality, auth-mismatch clarification, and refreshed mesh-auth
   docs ([#282](https://github.com/gugu91/extensions/pull/282),
@@ -155,7 +157,7 @@ extensions/
 │   ├── index.ts        #   canonical transport message contracts
 │   └── package.json    #   workspace package
 ├── browser-playwright/ # @gugu910/pi-browser-playwright
-│   ├── index.ts        #   single typed `browser` tool entry point
+│   ├── index.ts        #   Playwright-first single `browser` tool entry point
 │   ├── helpers.ts      #   security defaults + install guidance
 │   └── package.json    #   workspace package + pi manifest
 ├── slack-bridge/       # @gugu910/pi-slack-bridge

--- a/browser-playwright/README.md
+++ b/browser-playwright/README.md
@@ -5,22 +5,25 @@ A Pi browser extension built around **one typed tool only**.
 Instead of exposing a wide `browser_*` family, the extension now exposes a
 single `browser` tool with a shared envelope:
 
-- `backend`
 - `action`
 - `session_id?`
 - `page_id?`
-- `input_json?`
+- `input_json?` — the current stable carrier for action-specific fields
+- `backend?` — an advanced/experimental override that should be omitted for normal use
 
 The extension owns the runtime, process, proxy, socket, and artifact complexity
 behind that one interface.
+
+In the Anthropic sandbox used by this repo, `browser-playwright` is the
+supported local browsing path.
 
 ## Goals
 
 - radically reduce the public browser tool surface
 - keep browser support feeling like one narrow ARC/comment channel
 - keep Playwright as the real working backend
-- add an explicit `agent-browser` adapter slot behind the same contract
-- avoid pretending both backends have identical capabilities in every sandbox
+- keep any future `agent-browser` path hidden behind the same contract instead of treating it as a supported local path
+- avoid pretending different backends have identical capabilities in every sandbox
 
 ## Public tool contract
 
@@ -28,7 +31,6 @@ Tool: `browser`
 
 Parameters:
 
-- `backend` — optional, `playwright` or `agent-browser` (defaults to `playwright`)
 - `action` — typed enum:
   - `start`
   - `info`
@@ -46,6 +48,12 @@ Parameters:
 - `page_id` — optional page/tab handle for actions that target a specific page
 - `input_json` — optional JSON object with action-specific inputs such as `url`,
   `selector`, `value`, `timeout_ms`, `label`, or `full_page`
+  - this is the **current stable** carrier for action-specific fields
+  - the settled cleanup direction is **args-first**, but that contract change has not landed yet
+- `backend` — advanced/experimental override (`playwright` or `agent-browser`)
+  - omit it for normal Anthropic-sandbox use
+  - the default local path is Playwright
+  - `agent-browser` is not a supported local path in this repo
 
 ## Response shape
 
@@ -61,9 +69,16 @@ Every call returns one shared envelope:
 
 This keeps backend differences explicit instead of overpromising parity.
 
+## Supported path in Anthropic sandbox
+
+- Use `browser-playwright` and the single `browser` tool for local browsing in this repo.
+- Omit `backend` for normal use; Playwright is the supported local path.
+- Treat `input_json` as the stable action-input carrier until the planned args-first cleanup lands.
+- Treat `agent-browser` as hidden/experimental only. Local daemon compatibility is a non-goal here.
+
 ## Backend status
 
-### `backend=playwright`
+### Playwright (default local path)
 
 This is the **real working backend** in this extension today.
 
@@ -82,7 +97,7 @@ Supported actions:
 - `tabs`
 - `close`
 
-### `backend=agent-browser`
+### `agent-browser` (experimental / not a supported local path)
 
 This backend is **scaffolded behind the same contract**, but in this sandbox it
 returns a capability-aware blocked/unavailable result instead of pretending the
@@ -99,8 +114,9 @@ Current blocker is specific and technical, not a missing adapter shape:
 
 Truthful posture in this harness:
 
-- `backend=playwright` is the real local backend
-- `backend=agent-browser` stays explicitly unavailable-locally
+- Playwright is the supported local backend
+- `agent-browser` stays explicitly unavailable locally
+- local `agent-browser` daemon compatibility is a non-goal for this repo
 - the only viable future support shape here is **remote/optional executor**
   unless upstream ships a real published embeddable JS SDK
 
@@ -130,7 +146,6 @@ implementation:
 
 ```json
 {
-  "backend": "playwright",
   "action": "start",
   "input_json": "{\"url\":\"https://example.com\"}"
 }
@@ -140,7 +155,6 @@ implementation:
 
 ```json
 {
-  "backend": "playwright",
   "action": "navigate",
   "session_id": "browser_123",
   "input_json": "{\"url\":\"https://example.com/docs\",\"new_tab\":true}"
@@ -151,7 +165,6 @@ implementation:
 
 ```json
 {
-  "backend": "playwright",
   "action": "fill",
   "session_id": "browser_123",
   "page_id": "page_abc",
@@ -163,7 +176,6 @@ implementation:
 
 ```json
 {
-  "backend": "playwright",
   "action": "wait",
   "session_id": "browser_123",
   "input_json": "{\"text\":\"Playwright\",\"timeout_ms\":10000}"
@@ -174,7 +186,6 @@ implementation:
 
 ```json
 {
-  "backend": "playwright",
   "action": "screenshot",
   "session_id": "browser_123",
   "input_json": "{\"label\":\"search-results\",\"full_page\":true}"
@@ -250,7 +261,7 @@ Saved Playwright login/session state is supported in a narrow, explicit way.
 
 - place trusted Playwright `storageState` JSON files under
   `.pi/state/browser-playwright/`
-- reuse one explicitly via the `start` action and `storage_state_name` inside `input_json`
+- reuse one explicitly via the `start` action and `storage_state_name` inside `input_json` (today's stable action-input carrier)
 - the extension never auto-saves browser state on close or shutdown
 
 Treat `.pi/state/browser-playwright/` as secret-bearing auth material.

--- a/browser-playwright/agent-browser.ts
+++ b/browser-playwright/agent-browser.ts
@@ -14,14 +14,14 @@ export function buildAgentBrowserModeResult(request: BrowserToolRequest): {
       status: "blocked",
       available: false,
       reason:
-        "agent-browser is not currently runnable behind this extension in the active sandbox.",
+        "agent-browser is not a supported local browsing path behind this extension in the active sandbox.",
       constraints: {
         packaging:
           "The published `agent-browser` npm package is CLI/bin-oriented and does not expose an importable JS SDK entrypoint for the documented BrowserManager-style API.",
         runtime:
           "The local agent-browser runtime uses a client-daemon architecture. In this Unix sandbox the daemon fails during startup because binding its local session socket returns EPERM (`Failed to bind socket: Operation not permitted`).",
       },
-      hint: "Use backend=playwright in this sandbox. The only truthful future path here is remote/optional executor mode unless upstream ships a real embeddable JS SDK; local embedded agent-browser support should stay unavailable in this harness.",
+      hint: "Use the default browser tool path in this Anthropic sandbox. Playwright is the supported local backend here; any future agent-browser path would need remote/provider-backed execution rather than local daemon compatibility.",
     },
     artifacts: [],
   };

--- a/browser-playwright/index.ts
+++ b/browser-playwright/index.ts
@@ -1197,19 +1197,20 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
     name: "browser",
     label: "Browser",
     description:
-      "Single typed browser tool with backend-aware actions. The extension owns the runtime, proxy, socket, and session complexity behind one narrow interface.",
+      "Playwright-first single browser tool. In this environment, use the browser tool without a backend override; the extension owns the runtime, proxy, socket, and session complexity behind one narrow interface.",
     promptSnippet:
-      "Use the single browser tool with a backend plus typed action enum. Keep browser runtime complexity inside the extension instead of calling a large browser_* tool family.",
+      "Use the single browser tool for browsing in this environment. The supported local path is Playwright; avoid backend overrides unless you are doing explicit experimental work.",
     promptGuidelines: [
       "Prefer the single browser tool over many browser_* actions.",
-      "Set backend=playwright for the working runtime in this environment.",
-      "Use backend=agent-browser only when you specifically want that adapter path; capability-aware responses may report it as unavailable in restricted environments.",
-      "Pass action-specific fields through input_json so the public tool surface stays narrow.",
+      "Omit backend for normal use here; Playwright is the supported local path in this Anthropic sandbox.",
+      "Treat agent-browser as experimental and unavailable locally; daemon compatibility is not a supported path in this repo.",
+      "The settled contract direction is args-first, but today action-specific fields still travel through input_json.",
     ],
     parameters: Type.Object({
       backend: Type.Optional(
         StringEnum(BROWSER_BACKEND_VALUES, {
-          description: "Browser backend. Defaults to playwright.",
+          description:
+            "Advanced/experimental backend override. Omit for the supported local Playwright path.",
         }),
       ),
       action: StringEnum(BROWSER_ACTION_VALUES, {
@@ -1230,7 +1231,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       input_json: Type.Optional(
         Type.String({
           description:
-            "Optional JSON object carrying action-specific inputs such as url, selector, value, timeout_ms, label, or full_page.",
+            "Current compatibility shape for action-specific inputs such as url, selector, value, timeout_ms, label, or full_page. The planned contract direction is args-first.",
         }),
       ),
     }),

--- a/browser-playwright/protocol.ts
+++ b/browser-playwright/protocol.ts
@@ -128,7 +128,7 @@ export function buildCapabilities(backend: BrowserBackend): BrowserCapabilities 
       available: true,
       supported_actions: [...BROWSER_ACTION_VALUES],
       notes: [
-        "Playwright is the real browser backend in this extension.",
+        "Playwright is the supported local browsing path in this Anthropic sandbox.",
         "Artifacts and storage state stay rooted in the active workspace.",
       ],
     };
@@ -141,7 +141,7 @@ export function buildCapabilities(backend: BrowserBackend): BrowserCapabilities 
     notes: [
       "agent-browser is scaffolded behind the same one-tool contract.",
       "Local agent-browser support is unavailable in this harness.",
-      "Truthful future support is remote/optional executor mode unless upstream ships a real embeddable SDK.",
+      "Local daemon compatibility is a non-goal here; any truthful future support is remote/optional executor mode unless upstream ships a real embeddable SDK.",
     ],
   };
 }


### PR DESCRIPTION
## Summary
- document browser-playwright as the supported local browsing path in the Anthropic sandbox
- de-emphasize backend overrides and describe agent-browser as hidden/experimental rather than a supported local path
- align repo/browser docs and prompt-facing copy with the settled Playwright-first single-tool direction

Closes #541

## Checks
- pnpm --dir browser-playwright check
- pnpm format:check