### PR TITLE
fix: warn when Slack guardrails are effectively empty

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -296,6 +296,7 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 - **User access**: Slack access is default-deny. Set `allowedUsers` for a narrow allowlist, or `allowAllWorkspaceUsers: true` only if you explicitly want workspace-wide access
 - **Tool guardrails**: `security.readOnly`, `security.requireConfirmation`, and `security.blockedTools` are runtime-enforced for Slack-triggered turns, including core tools such as `bash`, `edit`, and `write`
+- **Guardrail posture**: If Slack/Pinet access is enabled for admitted users and `security.readOnly`, `security.blockedTools`, and `security.requireConfirmation` are all effectively empty (`readOnly !== true` and both arrays are absent or empty), the bridge emits a startup/runtime warning and `/pinet-status` shows `Guardrails: empty (warn-first posture; behavior unchanged)`. This is visibility-only: it does **not** auto-enable `readOnly`, block startup, or require an acknowledgement flow.
 - **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` (or `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH`) to require a shared secret; leave them unset to disable shared-secret auth. Configured followers fail closed on missing secret files or older/no-auth brokers rather than silently downgrading.
 
 Find Slack user IDs: click a user's profile → **More** → **Copy member ID**.

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -4,6 +4,9 @@ import {
   isToolBlocked,
   toolNeedsConfirmation,
   buildSecurityPrompt,
+  getEmptyRuntimeGuardrailsWarning,
+  hasEffectivelyEmptyRuntimeGuardrails,
+  formatRuntimeGuardrailsPosture,
   isConfirmationApproval,
   isConfirmationRejection,
   isBrokerForbiddenTool,
@@ -171,6 +174,55 @@ describe("toolNeedsConfirmation", () => {
   it("returns false with empty requireConfirmation array", () => {
     const g: SecurityGuardrails = { requireConfirmation: [] };
     expect(toolNeedsConfirmation("bash", g)).toBe(false);
+  });
+});
+
+// ─── runtime guardrail posture helpers ────────────────────
+
+describe("hasEffectivelyEmptyRuntimeGuardrails", () => {
+  it("treats an empty guardrail config as effectively empty", () => {
+    expect(hasEffectivelyEmptyRuntimeGuardrails({})).toBe(true);
+    expect(hasEffectivelyEmptyRuntimeGuardrails({ readOnly: false })).toBe(true);
+    expect(
+      hasEffectivelyEmptyRuntimeGuardrails({ blockedTools: [], requireConfirmation: [] }),
+    ).toBe(true);
+  });
+
+  it("returns false when readOnly is enabled", () => {
+    expect(hasEffectivelyEmptyRuntimeGuardrails({ readOnly: true })).toBe(false);
+  });
+
+  it("returns false when blocked tools are configured", () => {
+    expect(hasEffectivelyEmptyRuntimeGuardrails({ blockedTools: ["bash"] })).toBe(false);
+  });
+
+  it("returns false when confirmations are configured", () => {
+    expect(hasEffectivelyEmptyRuntimeGuardrails({ requireConfirmation: ["bash"] })).toBe(false);
+  });
+});
+
+describe("formatRuntimeGuardrailsPosture", () => {
+  it("formats the empty guardrail posture", () => {
+    expect(formatRuntimeGuardrailsPosture({})).toBe(
+      "empty (warn-first posture; behavior unchanged)",
+    );
+  });
+
+  it("formats configured guardrails with a concise summary", () => {
+    expect(
+      formatRuntimeGuardrailsPosture({
+        readOnly: true,
+        blockedTools: ["bash"],
+        requireConfirmation: ["edit", "write"],
+      }),
+    ).toBe("configured (readOnly, blockedTools:1, requireConfirmation:2)");
+  });
+});
+
+describe("getEmptyRuntimeGuardrailsWarning", () => {
+  it("returns a warning only when guardrails are effectively empty", () => {
+    expect(getEmptyRuntimeGuardrailsWarning({})).toContain("effectively empty");
+    expect(getEmptyRuntimeGuardrailsWarning({ blockedTools: ["bash"] })).toBeNull();
   });
 });
 

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -98,6 +98,53 @@ export function toolNeedsConfirmation(toolName: string, guardrails: SecurityGuar
  * Returns a clear, structured prompt with active guardrails.
  * Returns empty string if no guardrails are active.
  */
+export function hasEffectivelyEmptyRuntimeGuardrails(
+  guardrails: SecurityGuardrails | null | undefined,
+): boolean {
+  return (
+    guardrails?.readOnly !== true &&
+    (guardrails?.blockedTools?.length ?? 0) === 0 &&
+    (guardrails?.requireConfirmation?.length ?? 0) === 0
+  );
+}
+
+export function formatRuntimeGuardrailsPosture(
+  guardrails: SecurityGuardrails | null | undefined,
+): string {
+  if (hasEffectivelyEmptyRuntimeGuardrails(guardrails)) {
+    return "empty (warn-first posture; behavior unchanged)";
+  }
+
+  const sections: string[] = [];
+  if (guardrails?.readOnly === true) {
+    sections.push("readOnly");
+  }
+  const blockedCount = guardrails?.blockedTools?.length ?? 0;
+  if (blockedCount > 0) {
+    sections.push(`blockedTools:${blockedCount}`);
+  }
+  const confirmationCount = guardrails?.requireConfirmation?.length ?? 0;
+  if (confirmationCount > 0) {
+    sections.push(`requireConfirmation:${confirmationCount}`);
+  }
+
+  return sections.length > 0 ? `configured (${sections.join(", ")})` : "configured";
+}
+
+export function getEmptyRuntimeGuardrailsWarning(
+  guardrails: SecurityGuardrails | null | undefined,
+): string | null {
+  if (!hasEffectivelyEmptyRuntimeGuardrails(guardrails)) {
+    return null;
+  }
+
+  return [
+    "Slack/Pinet access is enabled for admitted users, but runtime guardrails are effectively empty.",
+    "Configure slack-bridge.security.readOnly, security.blockedTools, or security.requireConfirmation if you want runtime restrictions for Slack-triggered turns.",
+    "This warning is visibility-only; current runtime behavior is unchanged.",
+  ].join(" ");
+}
+
 export function buildSecurityPrompt(guardrails: SecurityGuardrails): string {
   const sections: string[] = [];
 
@@ -105,7 +152,7 @@ export function buildSecurityPrompt(guardrails: SecurityGuardrails): string {
   const hasBlocked = (guardrails.blockedTools?.length ?? 0) > 0;
   const hasConfirmation = (guardrails.requireConfirmation?.length ?? 0) > 0;
 
-  if (!hasReadOnly && !hasBlocked && !hasConfirmation) return "";
+  if (hasEffectivelyEmptyRuntimeGuardrails(guardrails)) return "";
 
   sections.push("⚠️ SECURITY GUARDRAILS — Slack-triggered action restrictions:");
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1438,6 +1438,13 @@ describe("slack-bridge top-level shutdown", () => {
       ),
       "warning",
     );
+    expect(
+      notify.mock.calls.some(
+        ([message, level]) =>
+          level === "warning" &&
+          String(message).includes("runtime guardrails are effectively empty"),
+      ),
+    ).toBe(false);
 
     await pinetStatus?.handler("", ctx);
 
@@ -1447,12 +1454,131 @@ describe("slack-bridge top-level shutdown", () => {
       ),
       "info",
     );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Guardrails: empty (warn-first posture; behavior unchanged)"),
+      "info",
+    );
 
     await sessionShutdown?.({}, ctx);
     const firstSocket = FakeWebSocket.instances[0];
     expect(firstSocket).toBeDefined();
     if (!firstSocket) {
       throw new Error("Expected a default-deny single-mode websocket instance");
+    }
+    expect(firstSocket.close).toHaveBeenCalled();
+
+    if (originalAllowedUsersEnv === undefined) {
+      delete process.env.SLACK_ALLOWED_USERS;
+    } else {
+      process.env.SLACK_ALLOWED_USERS = originalAllowedUsersEnv;
+    }
+    if (originalAllowAllEnv === undefined) {
+      delete process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
+    } else {
+      process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS = originalAllowAllEnv;
+    }
+  });
+
+  it("warns when admitted users have effectively empty guardrails and reports the posture in pinet-status", async () => {
+    const originalAllowedUsersEnv = process.env.SLACK_ALLOWED_USERS;
+    const originalAllowAllEnv = process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
+    delete process.env.SLACK_ALLOWED_USERS;
+    delete process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
+
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        "slack-bridge": {
+          runtimeMode: "single",
+          allowedUsers: ["U_SENDER"],
+        },
+      }),
+    );
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "single-empty-guardrails-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-single-empty-guardrails-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStatus = commands.get("pinet-status");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStatus).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await Promise.resolve();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://slack.com/api/apps.connections.open",
+      expect.any(Object),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("runtime guardrails are effectively empty"),
+      "warning",
+    );
+
+    await pinetStatus?.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Guardrails: empty (warn-first posture; behavior unchanged)"),
+      "info",
+    );
+
+    await sessionShutdown?.({}, ctx);
+    const firstSocket = FakeWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+    if (!firstSocket) {
+      throw new Error("Expected a single-mode websocket instance");
     }
     expect(firstSocket.close).toHaveBeenCalled();
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -299,6 +299,7 @@ export default function (pi: ExtensionAPI) {
   const {
     isUserAllowed,
     maybeWarnSlackUserAccess,
+    maybeWarnSlackGuardrailPosture,
     applyLocalAgentIdentity,
     refreshSettings,
     snapshotReloadableRuntime,
@@ -1057,6 +1058,7 @@ export default function (pi: ExtensionAPI) {
   async function connectAsBroker(ctx: ExtensionContext): Promise<void> {
     refreshSettings();
     maybeWarnSlackUserAccess(ctx);
+    maybeWarnSlackGuardrailPosture(ctx);
 
     const {
       botUserId: brokerBotUserId,
@@ -1328,6 +1330,7 @@ export default function (pi: ExtensionAPI) {
     try {
       await transitionToRuntimeMode(ctx, startupMode);
       if (startupMode === "single") {
+        maybeWarnSlackGuardrailPosture(ctx);
         console.log("[slack-bridge] runtime mode: single");
       } else if (startupMode === "follower") {
         console.log("[slack-bridge] runtime mode: follower");

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -10,6 +10,7 @@ import {
   type SlackBridgeSettings,
 } from "./helpers.js";
 import { formatRecentActivityLogEntries, type LoggedActivityLogEntry } from "./activity-log.js";
+import { formatRuntimeGuardrailsPosture } from "./guardrails.js";
 import type { PinetRuntimeControlContext } from "./pinet-remote-control.js";
 import {
   formatSlackScopeDiagnosticsStatus,
@@ -288,6 +289,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       const activityLogInfo = s.logChannel
         ? `Activity log: ${s.logChannel} (${s.logLevel ?? "actions"})`
         : "Activity log: disabled";
+      const guardrailsInfo = `Guardrails: ${formatRuntimeGuardrailsPosture(s.security ?? {})}`;
       const runtimeDiagnostic = deps.followerRuntimeDiagnostic();
       const runtimeHealthInfo = `Runtime health: ${formatFollowerRuntimeDiagnosticHealth(runtimeDiagnostic)}`;
       const runtimeNextStepInfo = `Next step: ${formatFollowerRuntimeDiagnosticNextStep(runtimeDiagnostic)}`;
@@ -338,6 +340,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
           `Threads: ${deps.threads().size} (${ownedCount} owned by ${deps.agentName()})`,
           `DM channel: ${deps.lastDmChannel() ?? "none yet"}`,
           allowlistInfo,
+          guardrailsInfo,
           defaultChInfo,
           activityLogInfo,
           slackToolHealthInfo,

--- a/slack-bridge/runtime-agent-context.test.ts
+++ b/slack-bridge/runtime-agent-context.test.ts
@@ -232,6 +232,44 @@ describe("createRuntimeAgentContext", () => {
     expect(notify).toHaveBeenCalledTimes(2);
   });
 
+  it("warns once when admitted users have effectively empty guardrails and resets when posture changes", () => {
+    const notify = vi.fn();
+    const { deps, state } = createDeps({
+      extensionContext: createContext(undefined, notify),
+      state: {
+        allowedUsers: new Set(["U_OK"]),
+        guardrails: {},
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    runtimeAgentContext.maybeWarnSlackGuardrailPosture(deps.getExtensionContext() ?? undefined);
+    runtimeAgentContext.maybeWarnSlackGuardrailPosture(deps.getExtensionContext() ?? undefined);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("guardrails are effectively empty");
+
+    state.guardrails = { blockedTools: ["bash"] };
+    runtimeAgentContext.maybeWarnSlackGuardrailPosture(deps.getExtensionContext() ?? undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    state.guardrails = {};
+    runtimeAgentContext.maybeWarnSlackGuardrailPosture(deps.getExtensionContext() ?? undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenCalledTimes(2);
+
+    state.allowedUsers = new Set();
+    runtimeAgentContext.maybeWarnSlackGuardrailPosture(deps.getExtensionContext() ?? undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    state.allowedUsers = new Set(["U_OK"]);
+    runtimeAgentContext.maybeWarnSlackGuardrailPosture(deps.getExtensionContext() ?? undefined);
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    expect(notify).toHaveBeenCalledTimes(3);
+  });
+
   it("applies local agent identity updates, normalizes owned threads, and skips redundant writes", () => {
     const { deps, state, threads, agentAliases, persistState, updateBadge } = createDeps({
       threads: new Map([

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -16,7 +16,11 @@ import {
   shortenPath,
   type SlackBridgeSettings,
 } from "./helpers.js";
-import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
+import {
+  buildSecurityPrompt,
+  getEmptyRuntimeGuardrailsWarning,
+  type SecurityGuardrails,
+} from "./guardrails.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
 import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
 
@@ -78,6 +82,7 @@ export interface RuntimeAgentContextDeps {
 export interface RuntimeAgentContext {
   isUserAllowed: (userId: string) => boolean;
   maybeWarnSlackUserAccess: (ctx?: ExtensionContext) => void;
+  maybeWarnSlackGuardrailPosture: (ctx?: ExtensionContext) => void;
   getStableIdForRole: (role: RuntimeAgentRole) => string;
   getIdentitySeedForRole: (role: RuntimeAgentRole, sessionFile?: string) => string;
   getSkinSeed: (preferredSeed?: string) => string;
@@ -115,6 +120,7 @@ export interface RuntimeAgentContext {
 
 export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): RuntimeAgentContext {
   let lastSlackUserAccessWarning = "";
+  let lastSlackGuardrailPostureWarning = "";
   const selfLocation = `${shortenPath(deps.cwd, os.homedir())}@${os.hostname()}`;
 
   function isUserAllowed(userId: string): boolean {
@@ -131,6 +137,29 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
       return;
     }
     lastSlackUserAccessWarning = warning;
+    console.warn(`[slack-bridge] ${warning}`);
+    ctx?.ui.notify(warning, "warning");
+  }
+
+  function maybeWarnSlackGuardrailPosture(ctx?: ExtensionContext): void {
+    const botToken = deps.getBotToken()?.trim();
+    const appToken = deps.getAppToken()?.trim();
+    const allowlist = deps.getAllowedUsers();
+    const hasAdmittedUsers = allowlist === null || allowlist.size > 0;
+    const warning =
+      botToken && appToken && hasAdmittedUsers
+        ? getEmptyRuntimeGuardrailsWarning(deps.getGuardrails())
+        : null;
+
+    if (!warning) {
+      lastSlackGuardrailPostureWarning = "";
+      return;
+    }
+    if (warning === lastSlackGuardrailPostureWarning) {
+      return;
+    }
+
+    lastSlackGuardrailPostureWarning = warning;
     console.warn(`[slack-bridge] ${warning}`);
     ctx?.ui.notify(warning, "warning");
   }
@@ -399,6 +428,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
   return {
     isUserAllowed,
     maybeWarnSlackUserAccess,
+    maybeWarnSlackGuardrailPosture,
     getStableIdForRole,
     getIdentitySeedForRole,
     getSkinSeed,


### PR DESCRIPTION
## Summary
- define one shared predicate for effectively empty Slack runtime guardrails
- add warn-first posture visibility in startup/runtime and `/pinet-status`
- document the operator contract and cover the new posture with focused tests

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test

Closes #558