### PR TITLE
fix: separate neon-psql read-only query env from injection mode

### DIFF
--- a/neon-psql/README.md
+++ b/neon-psql/README.md
@@ -1,6 +1,14 @@
 # neon-psql
 
-Config-driven tunnel + `psql` + tunnel-aware bash for pi.
+Config-driven Neon tunnel + read-only `psql` inspection for pi.
+
+By default, `neon-psql` is now **safe-first**:
+
+- the `psql` tool and `/psql` command stay available for read-only DB inspection
+- shell env injection is **off** unless you explicitly enable it
+- the Python `sitecustomize.py` asyncpg shim is **off** unless you explicitly enable it
+
+That keeps the default operator story narrow: read-only `psql` inspection is separate from the higher-power mode that copies tunnel credentials into shell/Python subprocesses.
 
 ## Install / configure
 
@@ -31,8 +39,8 @@ Global (`~/.pi/agent/settings.json`):
 {
   "neon-psql": {
     "enabled": true,
-    "injectIntoBash": true,
-    "injectPythonShim": true,
+    "injectIntoBash": false,
+    "injectPythonShim": false,
     "logPath": ".pi/neon-psql-tunnel.log",
     "psqlBin": "/custom/path/to/psql",
     "sourceEnv": {
@@ -41,12 +49,51 @@ Global (`~/.pi/agent/settings.json`):
       "user": "DB_USER",
       "password": "DB_PASSWORD",
       "database": "DB_NAME"
+    },
+    "psqlEnv": {
+      "NEON_TUNNEL_DATABASE_URL": "postgres_url"
     }
   }
 }
 ```
 
 Project-local (`.pi/settings.json`) works too and takes priority over the global settings.
+
+#### Safe default vs higher-power injection mode
+
+**Safe default**
+
+- keep `injectIntoBash: false`
+- keep `injectPythonShim: false`
+- use the `psql` tool and `/psql` command for read-only inspection only
+
+**Higher-power injection mode**
+
+- set `injectIntoBash: true` to copy tunnel env into agent `bash` and user shell commands
+- optionally set `injectPythonShim: true` to prepend the asyncpg shim to `PYTHONPATH`
+- when either injection option is enabled, the extension emits an operator-visible warning and `/psql-tunnel status` shows the elevated mode
+
+Example higher-power mode:
+
+```json
+{
+  "neon-psql": {
+    "enabled": true,
+    "injectIntoBash": true,
+    "injectPythonShim": true,
+    "injectEnv": {
+      "DATABASE_URL": "postgres_url",
+      "DB_HOST": "tunnel_host",
+      "DB_PORT": "tunnel_port",
+      "DB_USER": "source_user",
+      "DB_PASSWORD": "source_password",
+      "DB_NAME": "source_database"
+    }
+  }
+}
+```
+
+`injectPythonShim` is only useful when shell injection is enabled, because the shim is applied through the injected process environment.
 
 #### Legacy config files still supported
 
@@ -82,6 +129,23 @@ cp ~/.pi/agent/extensions/neon-psql/config.example.json ~/.pi/agent/extensions/n
 - optional bash env injection for agent `bash` and user `!` / `!!` commands
 - optional Python `sitecustomize.py` shim for `asyncpg` / SQLAlchemy asyncpg
 - automatic reuse of the sandbox SOCKS proxy when the `sandbox` extension is installed
+
+## Config semantics
+
+- `injectIntoBash` — default `false`; enables higher-power shell env injection
+- `injectPythonShim` — default `false`; enables the asyncpg shim inside injected Python subprocesses
+- `psqlEnv` — narrow env used by the read-only `psql` tool/command path
+- `injectEnv` — broader env used only for shell/Python injection mode
+
+The default `psqlEnv` is intentionally narrow:
+
+```json
+{
+  "NEON_TUNNEL_DATABASE_URL": "postgres_url"
+}
+```
+
+The default `injectEnv` is broader because it is meant for explicit shell/Python opt-in workflows.
 
 ## Common config tokens
 

--- a/neon-psql/config.example.json
+++ b/neon-psql/config.example.json
@@ -1,7 +1,7 @@
 {
   "enabled": true,
-  "injectIntoBash": true,
-  "injectPythonShim": true,
+  "injectIntoBash": false,
+  "injectPythonShim": false,
   "logPath": ".pi/neon-psql-tunnel.log",
   "psqlBin": "/custom/path/to/psql",
   "sourceEnv": {
@@ -10,6 +10,9 @@
     "user": "DB_USER",
     "password": "DB_PASSWORD",
     "database": "DB_NAME"
+  },
+  "psqlEnv": {
+    "NEON_TUNNEL_DATABASE_URL": "postgres_url"
   },
   "injectEnv": {
     "NEON_TUNNEL_DATABASE_URL": "postgres_url",

--- a/neon-psql/helpers.test.ts
+++ b/neon-psql/helpers.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildInjectedValues,
+  buildPsqlEnv,
   deriveEndpoint,
   encodeConnectionUrl,
+  formatInjectionModeSummary,
+  getInjectionModeWarning,
   isReadOnlyQuery,
   mergePathValue,
   needsSsl,
@@ -73,8 +76,31 @@ describe("encodeConnectionUrl", () => {
   });
 });
 
+describe("buildPsqlEnv", () => {
+  it("keeps the read-only psql env narrow by default", () => {
+    const result = buildPsqlEnv(
+      {
+        path: "/tmp/config.json",
+        psqlEnv: {
+          NEON_TUNNEL_DATABASE_URL: "postgres_url",
+        },
+      },
+      state,
+      {
+        pythonShimDir: "/opt/pi/python",
+        env: { PYTHONPATH: "/workspace/site-packages" },
+      },
+    );
+
+    expect(result).toEqual({
+      NEON_TUNNEL_DATABASE_URL:
+        "postgresql://user%40example.com:pa%3Ass%2Fword%3F@127.0.0.1:6543/db%2Fname?sslmode=require&options=endpoint%3Dep-cool-river",
+    });
+  });
+});
+
 describe("buildInjectedValues", () => {
-  it("builds the injected connection env values", () => {
+  it("builds the higher-power injected connection env values", () => {
     const result = buildInjectedValues(
       {
         path: "/tmp/config.json",
@@ -118,6 +144,40 @@ describe("buildInjectedValues", () => {
 
     expect(result.PGSSLMODE).toBe("disable");
     expect(result.PGOPTIONS).toBe("");
+  });
+});
+
+describe("injection mode messaging", () => {
+  it("formats the safe default mode summary", () => {
+    expect(
+      formatInjectionModeSummary({
+        injectIntoBash: false,
+        injectPythonShim: false,
+      }),
+    ).toBe("Mode: read-only psql inspection only (shell/Python injection disabled).");
+    expect(
+      getInjectionModeWarning({
+        path: "/tmp/config.json",
+        injectIntoBash: false,
+        injectPythonShim: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("warns clearly when shell and python injection are explicitly enabled", () => {
+    expect(
+      formatInjectionModeSummary({
+        injectIntoBash: true,
+        injectPythonShim: true,
+      }),
+    ).toContain("higher-power process injection");
+    expect(
+      getInjectionModeWarning({
+        path: "/tmp/config.json",
+        injectIntoBash: true,
+        injectPythonShim: true,
+      }),
+    ).toContain("higher-power shell/Python injection mode is enabled");
   });
 });
 

--- a/neon-psql/helpers.ts
+++ b/neon-psql/helpers.ts
@@ -127,8 +127,10 @@ export function encodeConnectionUrl(
   return `${scheme}://${user}:${password}@127.0.0.1:${port}/${database}${query ? `?${query}` : ""}`;
 }
 
-export function buildInjectedValues(
-  config: Pick<ResolvedConfig, "injectEnv" | "injectPythonShim" | "path">,
+function buildResolvedEnvValues(
+  envSpecs: Record<string, string>,
+  configPath: string,
+  includePythonShim: boolean,
   state: InjectedValuesState,
   options: BuildInjectedValuesOptions = {},
 ): Record<string, string> {
@@ -175,13 +177,13 @@ export function buildInjectedValues(
     source_user: source.user,
     source_password: source.password,
     source_database: source.database,
-    config_path: config.path,
+    config_path: configPath,
     log_path: state.logPath,
     "1": "1",
   };
 
   const resolved: Record<string, string> = {};
-  for (const [envName, spec] of Object.entries(config.injectEnv)) {
+  for (const [envName, spec] of Object.entries(envSpecs)) {
     if (spec.startsWith("source:")) {
       resolved[envName] = readEnv(spec.slice("source:".length)) ?? "";
       continue;
@@ -189,7 +191,7 @@ export function buildInjectedValues(
     resolved[envName] = tokens[spec] ?? spec;
   }
 
-  if (config.injectPythonShim && options.pythonShimDir) {
+  if (includePythonShim && options.pythonShimDir) {
     resolved.PYTHONPATH = mergePathValue(
       options.pythonShimDir,
       resolved.PYTHONPATH ?? env.PYTHONPATH,
@@ -197,6 +199,66 @@ export function buildInjectedValues(
   }
 
   return resolved;
+}
+
+export function buildPsqlEnv(
+  config: Pick<ResolvedConfig, "path" | "psqlEnv">,
+  state: InjectedValuesState,
+  options: BuildInjectedValuesOptions = {},
+): Record<string, string> {
+  return buildResolvedEnvValues(config.psqlEnv, config.path, false, state, options);
+}
+
+export function buildInjectedValues(
+  config: Pick<ResolvedConfig, "injectEnv" | "injectPythonShim" | "path">,
+  state: InjectedValuesState,
+  options: BuildInjectedValuesOptions = {},
+): Record<string, string> {
+  return buildResolvedEnvValues(
+    config.injectEnv,
+    config.path,
+    config.injectPythonShim,
+    state,
+    options,
+  );
+}
+
+export function hasInjectionEnabled(
+  config: Pick<ResolvedConfig, "injectIntoBash" | "injectPythonShim">,
+): boolean {
+  return config.injectIntoBash || config.injectPythonShim;
+}
+
+export function formatInjectionModeSummary(
+  config: Pick<ResolvedConfig, "injectIntoBash" | "injectPythonShim">,
+): string {
+  if (!hasInjectionEnabled(config)) {
+    return "Mode: read-only psql inspection only (shell/Python injection disabled).";
+  }
+
+  return [
+    "Mode: read-only psql inspection plus higher-power process injection.",
+    `- Bash env injection: ${config.injectIntoBash ? "enabled" : "disabled"}`,
+    `- Python asyncpg shim: ${config.injectPythonShim ? "enabled" : "disabled"}`,
+  ].join("\n");
+}
+
+export function getInjectionModeWarning(
+  config: Pick<ResolvedConfig, "path" | "injectIntoBash" | "injectPythonShim">,
+): string | null {
+  if (!hasInjectionEnabled(config)) {
+    return null;
+  }
+
+  if (config.injectIntoBash && config.injectPythonShim) {
+    return `neon-psql: higher-power shell/Python injection mode is enabled via ${config.path}. Bash and user shell commands will receive tunnel DB env, and Python subprocesses will also receive the asyncpg shim. The psql tool itself remains the safe read-only inspection path.`;
+  }
+
+  if (config.injectIntoBash) {
+    return `neon-psql: higher-power shell injection mode is enabled via ${config.path}. Bash and user shell commands will receive tunnel DB env beyond the safe read-only psql inspection path.`;
+  }
+
+  return `neon-psql: injectPythonShim is enabled in ${config.path}, but it only takes effect when injectIntoBash is also enabled.`;
 }
 
 function readDollarQuoteTag(sql: string, index: number): string | null {

--- a/neon-psql/index.ts
+++ b/neon-psql/index.ts
@@ -18,7 +18,11 @@ import { Type } from "@sinclair/typebox";
 
 import {
   buildInjectedValues as computeInjectedValues,
+  buildPsqlEnv as computePsqlEnv,
   deriveEndpoint,
+  formatInjectionModeSummary,
+  getInjectionModeWarning,
+  hasInjectionEnabled,
   needsSsl,
   type SourceValues,
 } from "./helpers.js";
@@ -72,6 +76,7 @@ let tunnel: TunnelState | null = null;
 let tunnelPromise: Promise<TunnelState> | null = null;
 let injectedEnvBackup = new Map<string, string | undefined>();
 let warnedBashTunnelUnavailable = false;
+let warnedInjectionMode = false;
 let sandboxManagerPromise: Promise<SandboxManagerLike | null> | null = null;
 
 function readRuntimeEnv(envName: string): string | undefined {
@@ -95,7 +100,10 @@ function requireSourceEnv(config: ResolvedConfig): SourceValues {
   };
 }
 
-function buildInjectedValues(config: ResolvedConfig, state: TunnelState): Record<string, string> {
+function buildShellInjectedValues(
+  config: ResolvedConfig,
+  state: TunnelState,
+): Record<string, string> {
   return computeInjectedValues(config, state, {
     env: process.env,
     pythonShimDir: PYTHON_SHIM_DIR,
@@ -103,8 +111,15 @@ function buildInjectedValues(config: ResolvedConfig, state: TunnelState): Record
   });
 }
 
+function buildPsqlEnv(config: ResolvedConfig, state: TunnelState): Record<string, string> {
+  return computePsqlEnv(config, state, {
+    env: process.env,
+    readEnv: readRuntimeEnv,
+  });
+}
+
 function applyInjectedEnvToProcess(config: ResolvedConfig, state: TunnelState): void {
-  for (const [key, value] of Object.entries(buildInjectedValues(config, state))) {
+  for (const [key, value] of Object.entries(buildShellInjectedValues(config, state))) {
     if (!injectedEnvBackup.has(key)) {
       injectedEnvBackup.set(key, process.env[key]);
     }
@@ -342,7 +357,7 @@ async function runPsqlQuery(
 ): Promise<{ text: string; details: PsqlDetails }> {
   return runPsqlQueryWithTunnel(config, query, format, ctx, signal, onUpdate, {
     ensureTunnel,
-    buildInjectedValues,
+    buildPsqlEnv,
     resolvePsqlBin,
     executePsqlQuery,
     truncateOutput: truncateHead,
@@ -357,8 +372,17 @@ function redactValue(key: string, value: string): string {
   return value.replace(/:\/\/([^:@/]+):([^@/]+)@/g, "://$1:***@");
 }
 
-function formatInjectedEnv(config: ResolvedConfig, state: TunnelState): string {
-  const injected = buildInjectedValues(config, state);
+function formatResolvedEnvSection(title: string, envValues: Record<string, string>): string[] {
+  const lines = [title];
+  for (const key of Object.keys(envValues).sort()) {
+    lines.push(`${key}=${redactValue(key, envValues[key])}`);
+  }
+  return lines;
+}
+
+function formatTunnelEnvReport(config: ResolvedConfig, state: TunnelState): string {
+  const psqlEnv = buildPsqlEnv(config, state);
+  const injected = buildShellInjectedValues(config, state);
   const lines = [
     `config: ${config.path}`,
     `source: ${state.source.host}:${state.source.port}/${state.source.database}`,
@@ -366,11 +390,17 @@ function formatInjectedEnv(config: ResolvedConfig, state: TunnelState): string {
     `endpoint: ${state.endpoint || "(none)"}`,
     `log: ${state.logPath}`,
     "",
-    "Injected env:",
+    formatInjectionModeSummary(config),
+    "",
+    ...formatResolvedEnvSection("Read-only psql env:", psqlEnv),
   ];
-  for (const key of Object.keys(injected).sort()) {
-    lines.push(`${key}=${redactValue(key, injected[key])}`);
+
+  if (hasInjectionEnabled(config)) {
+    lines.push("", ...formatResolvedEnvSection("Shell/Python injection env:", injected));
+  } else {
+    lines.push("", "Shell/Python injection env:", "(disabled — safe default)");
   }
+
   return lines.join("\n");
 }
 
@@ -482,13 +512,25 @@ export default function (pi: ExtensionAPI) {
         const action = args.trim() || "status";
         switch (action) {
           case "status": {
+            const tone = hasInjectionEnabled(config) ? "warning" : "info";
             if (!tunnelAlive()) {
-              ctx.ui.notify(`Tunnel is not running (config: ${config.path})`, "info");
+              ctx.ui.notify(
+                [
+                  `Tunnel is not running (config: ${config.path})`,
+                  "",
+                  formatInjectionModeSummary(config),
+                ].join("\n"),
+                tone,
+              );
               return;
             }
             ctx.ui.notify(
-              `Tunnel: 127.0.0.1:${tunnel?.port} -> ${tunnel?.source.host}:${tunnel?.source.port} (${config.path})`,
-              "info",
+              [
+                `Tunnel: 127.0.0.1:${tunnel?.port} -> ${tunnel?.source.host}:${tunnel?.source.port} (${config.path})`,
+                "",
+                formatInjectionModeSummary(config),
+              ].join("\n"),
+              tone,
             );
             return;
           }
@@ -522,7 +564,7 @@ export default function (pi: ExtensionAPI) {
             const state = await ensureTunnel(config, ctx);
             pi.sendMessage({
               customType: "psql-tunnel-env",
-              content: formatInjectedEnv(config, state),
+              content: formatTunnelEnvReport(config, state),
               display: true,
               details: { path: config.path },
             });
@@ -561,6 +603,12 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    const injectionWarning = getInjectionModeWarning(config);
+    if (injectionWarning && ctx.hasUI && !warnedInjectionMode) {
+      ctx.ui.notify(injectionWarning, "warning");
+      warnedInjectionMode = true;
+    }
+
     if (tunnelAlive()) {
       await setTunnelStatus(ctx, `psql tunnel 127.0.0.1:${tunnel?.port}`);
     }

--- a/neon-psql/query-execution.test.ts
+++ b/neon-psql/query-execution.test.ts
@@ -65,9 +65,13 @@ const config: ResolvedConfig = {
     password: "DB_PASSWORD",
     database: "DB_NAME",
   },
-  injectEnv: {
+  psqlEnv: {
     NEON_TUNNEL_DATABASE_URL:
       "postgresql://user%40example.com:super-secret@127.0.0.1:6543/app?sslmode=require",
+  },
+  injectEnv: {
+    DATABASE_URL: "postgresql://user%40example.com:super-secret@127.0.0.1:6543/app?sslmode=require",
+    PYTHONPATH: "/danger-zone",
   },
 };
 
@@ -78,7 +82,7 @@ function makeOptions(overrides: Partial<ExecutePsqlQueryOptions> = {}): ExecuteP
     query: "SELECT 1",
     format: "table",
     state,
-    injectedEnv: config.injectEnv,
+    psqlEnv: config.psqlEnv,
     spawnProcess: vi.fn(() => new FakePsqlProcess()),
     truncateOutput: (text) => ({
       content: text,
@@ -108,7 +112,7 @@ describe("executePsqlQuery", () => {
     expect(spawnProcess).not.toHaveBeenCalled();
   });
 
-  it("spawns psql with the injected connection env and streams partial updates", async () => {
+  it("spawns psql with the narrow psql execution env and streams partial updates", async () => {
     const child = new FakePsqlProcess();
     const spawnProcess = vi.fn(() => child);
     const updates: string[] = [];
@@ -133,7 +137,7 @@ describe("executePsqlQuery", () => {
     expect(spawnProcess).toHaveBeenCalledWith(
       "/custom/bin/psql",
       [
-        config.injectEnv.NEON_TUNNEL_DATABASE_URL,
+        config.psqlEnv.NEON_TUNNEL_DATABASE_URL,
         "-v",
         "ON_ERROR_STOP=1",
         "-P",
@@ -144,7 +148,7 @@ describe("executePsqlQuery", () => {
       ],
       expect.objectContaining({
         env: expect.objectContaining({
-          NEON_TUNNEL_DATABASE_URL: config.injectEnv.NEON_TUNNEL_DATABASE_URL,
+          NEON_TUNNEL_DATABASE_URL: config.psqlEnv.NEON_TUNNEL_DATABASE_URL,
           PGPASSWORD: source.password,
           PGAPPNAME: "pi-extension-psql",
         }),
@@ -173,7 +177,7 @@ describe("executePsqlQuery", () => {
     expect(spawnProcess).toHaveBeenCalledWith(
       "/custom/bin/psql",
       [
-        config.injectEnv.NEON_TUNNEL_DATABASE_URL,
+        config.psqlEnv.NEON_TUNNEL_DATABASE_URL,
         "-v",
         "ON_ERROR_STOP=1",
         "-P",

--- a/neon-psql/query-execution.ts
+++ b/neon-psql/query-execution.ts
@@ -52,7 +52,7 @@ export interface ExecutePsqlQueryOptions {
   query: string;
   format: OutputFormat;
   state: PsqlExecutionState;
-  injectedEnv: Record<string, string>;
+  psqlEnv: Record<string, string>;
   signal?: AbortSignal;
   onUpdate?: (update: PsqlPartialUpdate) => void;
   processEnv?: NodeJS.ProcessEnv;
@@ -89,7 +89,7 @@ export async function executePsqlQuery(
     query,
     format,
     state,
-    injectedEnv,
+    psqlEnv,
     signal,
     onUpdate,
     processEnv = process.env,
@@ -118,7 +118,7 @@ export async function executePsqlQuery(
     );
   }
 
-  const connection = injectedEnv.NEON_TUNNEL_DATABASE_URL;
+  const connection = psqlEnv.NEON_TUNNEL_DATABASE_URL;
   const args = [connection, "-v", "ON_ERROR_STOP=1", "-P", "pager=off"];
   if (format === "csv") args.push("--csv");
   if (format === "tsv") args.push("-A", "-F", "\t");
@@ -152,7 +152,7 @@ export async function executePsqlQuery(
   const child = spawnPsqlProcess(psqlBin, args, {
     env: {
       ...processEnv,
-      ...injectedEnv,
+      ...psqlEnv,
       PGPASSWORD: state.source.password,
       PGAPPNAME: "pi-extension-psql",
     },

--- a/neon-psql/query-runner.test.ts
+++ b/neon-psql/query-runner.test.ts
@@ -16,8 +16,12 @@ const config: ResolvedConfig = {
     password: "DB_PASSWORD",
     database: "DB_NAME",
   },
-  injectEnv: {
+  psqlEnv: {
     NEON_TUNNEL_DATABASE_URL: "postgresql://user:pass@127.0.0.1:6543/app",
+  },
+  injectEnv: {
+    DATABASE_URL: "postgresql://user:pass@127.0.0.1:6543/app",
+    PYTHONPATH: "/danger-zone",
   },
 };
 
@@ -37,14 +41,14 @@ const state: PsqlTunnelState = {
 describe("runPsqlQueryWithTunnel", () => {
   it("rejects mutating queries before trying to start the tunnel", async () => {
     const ensureTunnel = vi.fn();
-    const buildInjectedValues = vi.fn();
+    const buildPsqlEnv = vi.fn();
     const resolvePsqlBin = vi.fn();
     const executePsqlQuery = vi.fn();
 
     await expect(
       runPsqlQueryWithTunnel(config, "DELETE FROM users", "table", {}, undefined, undefined, {
         ensureTunnel,
-        buildInjectedValues,
+        buildPsqlEnv,
         resolvePsqlBin,
         executePsqlQuery,
         truncateOutput: vi.fn(),
@@ -57,14 +61,14 @@ describe("runPsqlQueryWithTunnel", () => {
     );
 
     expect(ensureTunnel).not.toHaveBeenCalled();
-    expect(buildInjectedValues).not.toHaveBeenCalled();
+    expect(buildPsqlEnv).not.toHaveBeenCalled();
     expect(resolvePsqlBin).not.toHaveBeenCalled();
     expect(executePsqlQuery).not.toHaveBeenCalled();
   });
 
   it("starts the tunnel and delegates to executePsqlQuery for read-only queries", async () => {
     const ensureTunnel = vi.fn(async () => state);
-    const buildInjectedValues = vi.fn(() => config.injectEnv);
+    const buildPsqlEnv = vi.fn(() => config.psqlEnv);
     const resolvePsqlBin = vi.fn(() => "/custom/bin/psql");
     const executePsqlQuery = vi.fn(async () => ({
       text: "id,name\n1,Alice",
@@ -100,7 +104,7 @@ describe("runPsqlQueryWithTunnel", () => {
       onUpdate,
       {
         ensureTunnel,
-        buildInjectedValues,
+        buildPsqlEnv,
         resolvePsqlBin,
         executePsqlQuery,
         truncateOutput,
@@ -111,7 +115,7 @@ describe("runPsqlQueryWithTunnel", () => {
     );
 
     expect(ensureTunnel).toHaveBeenCalledWith(config, { hasUI: false });
-    expect(buildInjectedValues).toHaveBeenCalledWith(config, state);
+    expect(buildPsqlEnv).toHaveBeenCalledWith(config, state);
     expect(resolvePsqlBin).toHaveBeenCalledWith({ configuredPath: config.psqlBin });
     expect(executePsqlQuery).toHaveBeenCalledWith({
       psqlBin: "/custom/bin/psql",
@@ -119,7 +123,7 @@ describe("runPsqlQueryWithTunnel", () => {
       query: "SELECT 1",
       format: "table",
       state,
-      injectedEnv: config.injectEnv,
+      psqlEnv: config.psqlEnv,
       signal,
       onUpdate,
       truncateOutput,

--- a/neon-psql/query-runner.ts
+++ b/neon-psql/query-runner.ts
@@ -19,7 +19,7 @@ export interface RunPsqlQueryWithTunnelDependencies<
   TState extends PsqlTunnelState = PsqlTunnelState,
 > {
   ensureTunnel: (config: ResolvedConfig, ctx: TContext) => Promise<TState>;
-  buildInjectedValues: (config: ResolvedConfig, state: TState) => Record<string, string>;
+  buildPsqlEnv: (config: ResolvedConfig, state: TState) => Record<string, string>;
   resolvePsqlBin: (options: { configuredPath?: string }) => string;
   executePsqlQuery: (
     options: ExecutePsqlQueryOptions,
@@ -49,7 +49,7 @@ export async function runPsqlQueryWithTunnel<
   }
 
   const state = await dependencies.ensureTunnel(config, ctx);
-  const injected = dependencies.buildInjectedValues(config, state);
+  const psqlEnv = dependencies.buildPsqlEnv(config, state);
 
   return dependencies.executePsqlQuery({
     psqlBin: dependencies.resolvePsqlBin({ configuredPath: config.psqlBin }),
@@ -57,7 +57,7 @@ export async function runPsqlQueryWithTunnel<
     query,
     format,
     state,
-    injectedEnv: injected,
+    psqlEnv,
     signal,
     onUpdate,
     truncateOutput: dependencies.truncateOutput,

--- a/neon-psql/settings.test.ts
+++ b/neon-psql/settings.test.ts
@@ -25,13 +25,12 @@ describe("loadConfig", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("loads top-level project settings", () => {
+  it("loads top-level project settings with default-off injection and narrow psql env", () => {
     fs.mkdirSync(path.join(cwd, ".pi"), { recursive: true });
     fs.writeFileSync(
       path.join(cwd, ".pi", "settings.json"),
       JSON.stringify({
         "neon-psql": {
-          injectIntoBash: false,
           sourceEnv: { host: "PROJECT_DB_HOST" },
         },
       }),
@@ -42,7 +41,7 @@ describe("loadConfig", () => {
     expect(result).toMatchObject({
       path: path.join(cwd, ".pi", "settings.json") + "#neon-psql",
       injectIntoBash: false,
-      injectPythonShim: true,
+      injectPythonShim: false,
       sourceEnv: {
         host: "PROJECT_DB_HOST",
         port: "DB_PORT",
@@ -50,8 +49,12 @@ describe("loadConfig", () => {
         password: "DB_PASSWORD",
         database: "DB_NAME",
       },
+      psqlEnv: {
+        NEON_TUNNEL_DATABASE_URL: "postgres_url",
+      },
     });
     expect(result?.logPath).toBe(path.join(cwd, ".pi", "neon-psql-tunnel.log"));
+    expect(result?.injectEnv.DATABASE_URL).toBe("postgres_url");
   });
 
   it("prefers project settings over global settings", () => {
@@ -86,18 +89,49 @@ describe("loadConfig", () => {
 
     expect(result).toMatchObject({
       path: path.join(agentDir, "settings.json") + "#neon-psql",
-      injectIntoBash: true,
+      injectIntoBash: false,
       injectPythonShim: false,
     });
     expect(result?.logPath).toBe(path.join(cwd, "logs", "neon.log"));
   });
 
-  it("prefers explicit env config file over settings", () => {
-    const explicitPath = path.join(tmpDir, "explicit.json");
-    fs.writeFileSync(explicitPath, JSON.stringify({ injectIntoBash: false }));
+  it("keeps explicit injection opt-ins and separate psql env overrides", () => {
     fs.writeFileSync(
       path.join(agentDir, "settings.json"),
-      JSON.stringify({ "neon-psql": { injectIntoBash: true } }),
+      JSON.stringify({
+        "neon-psql": {
+          injectIntoBash: true,
+          injectPythonShim: true,
+          psqlEnv: {
+            NEON_TUNNEL_DATABASE_URL: "psql_url",
+          },
+          injectEnv: {
+            DATABASE_URL: "postgres_url",
+            ASYNCPG_DSN: "asyncpg_dsn",
+          },
+        },
+      }),
+    );
+
+    const result = loadConfig({ cwd, agentDir, extensionDir, env: {} });
+
+    expect(result?.injectIntoBash).toBe(true);
+    expect(result?.injectPythonShim).toBe(true);
+    expect(result?.psqlEnv).toEqual({
+      NEON_TUNNEL_DATABASE_URL: "psql_url",
+    });
+    expect(result?.injectEnv).toMatchObject({
+      DATABASE_URL: "postgres_url",
+      ASYNCPG_DSN: "asyncpg_dsn",
+    });
+  });
+
+  it("prefers explicit env config file over settings", () => {
+    const explicitPath = path.join(tmpDir, "explicit.json");
+    fs.writeFileSync(explicitPath, JSON.stringify({ injectIntoBash: true }));
+    fs.writeFileSync(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({ "neon-psql": { injectIntoBash: false } }),
     );
 
     const result = loadConfig({
@@ -108,7 +142,7 @@ describe("loadConfig", () => {
     });
 
     expect(result?.path).toBe(explicitPath);
-    expect(result?.injectIntoBash).toBe(false);
+    expect(result?.injectIntoBash).toBe(true);
   });
 
   it("falls back to legacy config files", () => {

--- a/neon-psql/settings.ts
+++ b/neon-psql/settings.ts
@@ -13,6 +13,10 @@ const DEFAULT_SOURCE_ENV = {
   database: "DB_NAME",
 } as const;
 
+const DEFAULT_PSQL_ENV: Record<string, string> = {
+  NEON_TUNNEL_DATABASE_URL: "postgres_url",
+};
+
 const DEFAULT_INJECT_ENV: Record<string, string> = {
   NEON_TUNNEL_DATABASE_URL: "postgres_url",
   NEON_TUNNEL_SQLALCHEMY_URL: "sqlalchemy_url",
@@ -57,6 +61,7 @@ export interface FileConfig {
   logPath?: string;
   psqlBin?: string;
   sourceEnv?: Partial<SourceEnvConfig>;
+  psqlEnv?: Record<string, string>;
   injectEnv?: Record<string, string>;
 }
 
@@ -67,6 +72,7 @@ export interface ResolvedConfig {
   logPath: string;
   psqlBin?: string;
   sourceEnv: SourceEnvConfig;
+  psqlEnv: Record<string, string>;
   injectEnv: Record<string, string>;
 }
 
@@ -128,8 +134,8 @@ function normalizeConfig(cwd: string, source: RawConfigSource): ResolvedConfig |
 
   return {
     path: source.pathLabel,
-    injectIntoBash: raw.injectIntoBash ?? true,
-    injectPythonShim: raw.injectPythonShim ?? true,
+    injectIntoBash: raw.injectIntoBash ?? false,
+    injectPythonShim: raw.injectPythonShim ?? false,
     logPath: resolveLogPath(cwd, raw.logPath),
     psqlBin: raw.psqlBin?.trim() || undefined,
     sourceEnv: {
@@ -138,6 +144,10 @@ function normalizeConfig(cwd: string, source: RawConfigSource): ResolvedConfig |
       user: raw.sourceEnv?.user ?? DEFAULT_SOURCE_ENV.user,
       password: raw.sourceEnv?.password ?? DEFAULT_SOURCE_ENV.password,
       database: raw.sourceEnv?.database ?? DEFAULT_SOURCE_ENV.database,
+    },
+    psqlEnv: {
+      ...DEFAULT_PSQL_ENV,
+      ...(raw.psqlEnv ?? {}),
     },
     injectEnv: {
       ...DEFAULT_INJECT_ENV,


### PR DESCRIPTION
## Summary
- default `injectIntoBash` and `injectPythonShim` to off unless explicitly enabled
- split the narrow read-only `psql` execution env from the broader shell/Python injection env
- add operator-visible warning and status messaging for higher-power injection mode
- update docs/examples and focused tests for the safe default vs explicit opt-in behavior

Closes #560.

## Testing
- `pnpm --filter @gugu910/pi-neon-psql lint`
- `pnpm --filter @gugu910/pi-neon-psql typecheck`
- `pnpm --filter @gugu910/pi-neon-psql test`