### PR TITLE
docs: clarify same-host local-power trust boundaries

### DIFF
--- a/browser-playwright/README.md
+++ b/browser-playwright/README.md
@@ -124,6 +124,15 @@ implementation:
 - screenshots saved under `.pi/artifacts/browser-playwright/`
 - explicit storage-state reuse from `.pi/state/browser-playwright/`
 
+## Trust boundary notes
+
+This backend intentionally includes two same-host local-power assumptions:
+
+- **Direct localhost navigation is allowed on purpose.** That is for local app testing on the current host; it is not meant to imply that arbitrary localhost/private-network subrequests are generally trusted.
+- **Stored browser state is trusted auth material.** Any `storageState` file under `.pi/state/browser-playwright/` may contain live cookies, tokens, and local storage data for the current workspace.
+
+Treat both as local operator power, not as generic public-web browsing.
+
 ## Example requests
 
 ### Start a session
@@ -226,7 +235,7 @@ Allowed by default:
 - `http://...`
 - `https://...`
 - public internet targets
-- direct top-level navigation to `localhost`, `127.0.0.1`, and `::1`
+- direct top-level navigation to `localhost`, `127.0.0.1`, and `::1` for intentional same-host local-app testing
 
 Blocked by default:
 
@@ -253,7 +262,7 @@ Saved Playwright login/session state is supported in a narrow, explicit way.
 - reuse one explicitly via the `start` action and `storage_state_name` inside `input_json`
 - the extension never auto-saves browser state on close or shutdown
 
-Treat `.pi/state/browser-playwright/` as secret-bearing auth material.
+Treat `.pi/state/browser-playwright/` as trusted, secret-bearing auth material for the current workspace and host.
 
 ## Artifacts
 

--- a/browser-playwright/helpers.test.ts
+++ b/browser-playwright/helpers.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   assessUrl,
+  buildBrowserTrustBoundaryNotes,
   buildInstallInstructions,
   buildStorageStateFileName,
   findPreferredChromiumExecutable,
@@ -138,6 +139,17 @@ test("buildInstallInstructions is browser-engine aware", () => {
   assert.match(firefox, /firefox browser binaries/);
   assert.match(firefox, /npx playwright install firefox/);
   assert.doesNotMatch(firefox, /host Chrome\/Chromium executable/i);
+});
+
+test("buildBrowserTrustBoundaryNotes calls out localhost and trusted storage-state assumptions", () => {
+  const notes = buildBrowserTrustBoundaryNotes({
+    mountedStorageStatePath: ".pi/state/browser-playwright/example-session.json",
+  });
+
+  assert.equal(notes.length, 3);
+  assert.match(notes[0] ?? "", /localhost navigation is intentionally allowed/i);
+  assert.match(notes[1] ?? "", /trusted, secret-bearing auth material/i);
+  assert.match(notes[2] ?? "", /example-session\.json/);
 });
 
 test("findPreferredChromiumExecutable prefers an explicit env override", async () => {

--- a/browser-playwright/helpers.ts
+++ b/browser-playwright/helpers.ts
@@ -38,6 +38,11 @@ export const STORAGE_STATE_RELATIVE_DIR = ".pi/state/browser-playwright";
 export const DEFAULT_TEXT_LINES = 120;
 export const DEFAULT_TEXT_CHARS = 4_000;
 
+const LOCALHOST_TRUST_BOUNDARY_NOTE =
+  "Direct top-level localhost navigation is intentionally allowed for same-host local-app testing. Localhost/private-network subrequests still stay behind the route guardrails unless a page is already trusted through that direct localhost navigation.";
+const STORAGE_STATE_TRUST_BOUNDARY_NOTE =
+  "Stored browser state files under `.pi/state/browser-playwright/` are treated as trusted, secret-bearing auth material from the current workspace.";
+
 const STORAGE_STATE_NAME_MAX_CHARS = 80;
 const CHROMIUM_PATH_NAMES_POSIX = [
   "google-chrome",
@@ -87,6 +92,20 @@ export function sanitizeStorageStateName(value: string): string {
 
 export function buildStorageStateFileName(value: string): string {
   return `${sanitizeStorageStateName(value)}.json`;
+}
+
+export function buildBrowserTrustBoundaryNotes(options?: {
+  mountedStorageStatePath?: string | null;
+}): string[] {
+  const notes = [LOCALHOST_TRUST_BOUNDARY_NOTE, STORAGE_STATE_TRUST_BOUNDARY_NOTE];
+
+  if (options?.mountedStorageStatePath) {
+    notes.push(
+      `Mounted storage state: \`${options.mountedStorageStatePath}\`. Reuse it only when you intentionally trust those cookies, tokens, and local storage values on this same host.`,
+    );
+  }
+
+  return notes;
 }
 
 export function truncateText(

--- a/browser-playwright/index.ts
+++ b/browser-playwright/index.ts
@@ -18,6 +18,7 @@ import {
   STORAGE_STATE_RELATIVE_DIR,
   truncateText,
   type SupportedBrowserEngine,
+  buildBrowserTrustBoundaryNotes,
 } from "./helpers.ts";
 import { buildAgentBrowserModeResult } from "./agent-browser.ts";
 import {
@@ -791,6 +792,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
           localhost_direct_navigation: true,
           localhost_subrequests_require_trusted_page: true,
         },
+        trust_boundary: buildBrowserTrustBoundaryNotes({
+          mountedStorageStatePath: session.mountedStorageState?.path ?? null,
+        }),
       });
     } catch (error) {
       await browser.close().catch(() => undefined);
@@ -817,6 +821,9 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       network_summary: session.networkSummary,
       recent_console: session.consoleEntries,
       blocked_requests: session.blockedRequests,
+      trust_boundary: buildBrowserTrustBoundaryNotes({
+        mountedStorageStatePath: session.mountedStorageState?.path ?? null,
+      }),
     });
   }
 
@@ -1204,6 +1211,8 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       "Prefer the single browser tool over many browser_* actions.",
       "Set backend=playwright for the working runtime in this environment.",
       "Use backend=agent-browser only when you specifically want that adapter path; capability-aware responses may report it as unavailable in restricted environments.",
+      "Direct top-level localhost navigation is intentionally allowed for same-host local-app testing; treat it as local-power access, not a generic public-web sandbox.",
+      "Only mount storage_state_name files when you intentionally trust that workspace-local auth material on the current host.",
       "Pass action-specific fields through input_json so the public tool surface stays narrow.",
     ],
     parameters: Type.Object({

--- a/browser-playwright/storage-state.ts
+++ b/browser-playwright/storage-state.ts
@@ -102,7 +102,7 @@ export async function loadStoredStorageState(
     const fileName = buildStorageStateFileName(name).replace(/\.json$/i, "");
     if (code === "ENOENT") {
       throw new Error(
-        `Stored browser state \`${fileName}\` was not found in \`${STORAGE_STATE_RELATIVE_DIR}\`. Place a trusted Playwright storageState JSON file there first.`,
+        `Stored browser state \`${fileName}\` was not found in \`${STORAGE_STATE_RELATIVE_DIR}\`. Place a trusted, secret-bearing Playwright storageState JSON file there first.`,
       );
     }
     throw error;
@@ -138,7 +138,7 @@ export async function loadStoredStorageState(
     const code = (error as NodeJS.ErrnoException | undefined)?.code;
     if (code === "ENOENT") {
       throw new Error(
-        `Stored browser state \`${resolvedState.name}\` was not found at \`${resolvedState.relativePath}\`. Place a trusted Playwright storageState JSON file there first.`,
+        `Stored browser state \`${resolvedState.name}\` was not found at \`${resolvedState.relativePath}\`. Place a trusted, secret-bearing Playwright storageState JSON file there first.`,
       );
     }
     if (code === "ELOOP") {

--- a/imessage-bridge/README.md
+++ b/imessage-bridge/README.md
@@ -22,6 +22,17 @@ The current implementation is intentionally narrow:
 
 That means outbound sends can work even when the local Messages database is unavailable, while startup/readiness reporting still makes the history blocker explicit.
 
+## Trust boundary notes
+
+`@gugu910/pi-imessage-bridge` is an intentional **same-host local-power surface**.
+
+- When enabled, outbound sends run through the local Messages app via `/usr/bin/osascript` as the current macOS user.
+- There is no extra approval or policy layer inside this package today; the trust boundary is local operator intent on the same host.
+- The current MVP is still **send-first**, so outbound capability can be ready even when local history access is unavailable.
+- Missing `chat.db` only blocks local history/readiness depth. It does **not** remove the outbound send power when AppleScript remains available.
+
+Treat this as explicit local outbound power, not as a remote-safe transport or a generic policy-enforced messaging surface.
+
 In the current repo bring-up path, enable the adapter with `slack-bridge.imessage.enabled: true` and start the broker runtime with `/pinet-start`.
 
 ## What stays in this package

--- a/imessage-bridge/adapter.test.ts
+++ b/imessage-bridge/adapter.test.ts
@@ -68,7 +68,7 @@ describe("AppleScriptIMessageAdapter", () => {
     expect(runAppleScript).toHaveBeenCalledTimes(1);
   });
 
-  it("fails connect when the host cannot attempt iMessage sends", async () => {
+  it("fails connect when the host cannot attempt iMessage sends and keeps the trust boundary explicit", async () => {
     const adapter = createIMessageAdapter({
       detectEnvironment: () => ({
         platform: "linux",
@@ -84,7 +84,9 @@ describe("AppleScriptIMessageAdapter", () => {
       }),
     });
 
-    await expect(adapter.connect()).rejects.toThrow("iMessage send-first adapter is not ready");
+    await expect(adapter.connect()).rejects.toThrow(
+      /iMessage send-first adapter is not ready.*same-host local-power surface/i,
+    );
   });
 
   it("treats onInbound as a no-op for the send-first adapter", async () => {

--- a/imessage-bridge/adapter.ts
+++ b/imessage-bridge/adapter.ts
@@ -4,7 +4,11 @@ import type {
   OutboundMessage as IMessageAdapterOutboundMessage,
 } from "@gugu910/pi-transport-core";
 import { assertIMessageSendCapability, sendIMessage, type RunAppleScript } from "./send.js";
-import type { DetectIMessageMvpEnvironmentOptions, IMessageMvpEnvironment } from "./mvp.js";
+import {
+  formatIMessageMvpReadiness,
+  type DetectIMessageMvpEnvironmentOptions,
+  type IMessageMvpEnvironment,
+} from "./mvp.js";
 
 export type { IMessageAdapterInboundMessage, IMessageAdapterOutboundMessage };
 
@@ -39,10 +43,7 @@ export class AppleScriptIMessageAdapter implements IMessageAdapter {
         throw new Error(
           [
             "iMessage send-first adapter is not ready.",
-            `platform: ${environment.platform}`,
-            `osascript: ${environment.osascriptAvailable ? "ready" : "missing"} (${environment.osascriptPath})`,
-            `messages-db: ${environment.messagesDbAvailable ? "ready" : "missing"} (${environment.messagesDbPath})`,
-            `mvp blockers: ${environment.blockers.join(", ")}`,
+            ...formatIMessageMvpReadiness(environment),
           ].join(" "),
         );
       }

--- a/imessage-bridge/mvp.test.ts
+++ b/imessage-bridge/mvp.test.ts
@@ -56,7 +56,7 @@ describe("detectIMessageMvpEnvironment", () => {
 });
 
 describe("formatIMessageMvpReadiness", () => {
-  it("calls out send-first readiness when only local history is unavailable", () => {
+  it("calls out send-first readiness and the same-host trust boundary when only local history is unavailable", () => {
     const lines = formatIMessageMvpReadiness(
       detectIMessageMvpEnvironment({
         platform: "darwin",
@@ -67,6 +67,9 @@ describe("formatIMessageMvpReadiness", () => {
 
     expect(lines).toContain("mvp: send-first ready; local history is unavailable");
     expect(lines).toContain("mvp blockers: missing_messages_db");
+    expect(lines).toContain(
+      "trust-boundary: same-host local-power surface; when enabled, outbound sends go through the local Messages app via /usr/bin/osascript as the current macOS user.",
+    );
   });
 
   it("includes blockers in the human-readable summary", () => {

--- a/imessage-bridge/mvp.ts
+++ b/imessage-bridge/mvp.ts
@@ -79,6 +79,7 @@ export function formatIMessageMvpReadiness(environment: IMessageMvpEnvironment):
     `platform: ${environment.platform}`,
     `osascript: ${environment.osascriptAvailable ? "ready" : "missing"} (${environment.osascriptPath})`,
     `messages-db: ${environment.messagesDbAvailable ? "ready" : "missing"} (${environment.messagesDbPath})`,
+    "trust-boundary: same-host local-power surface; when enabled, outbound sends go through the local Messages app via /usr/bin/osascript as the current macOS user.",
   ];
 
   if (environment.readyForLocalMvp) {

--- a/nvim-bridge/README.md
+++ b/nvim-bridge/README.md
@@ -14,6 +14,16 @@ Neovim ↔ pi bridge that sends active editor context (file, viewport, selection
 
 > Important: Neovim and pi must be in the **same git repo and same branch**.
 
+## Trust boundary notes
+
+`nvim-bridge` is a **same-host local-power surface**.
+
+- The Unix socket under `/tmp/pi-nvim/<hash>.sock` assumes local trust between Neovim and the pi process on the same machine.
+- There is **no peer authentication handshake** on that socket today; the main boundary is host-local access plus the repo/branch-derived socket name.
+- The bridge now tightens the socket directory/socket permissions on a best-effort basis, but that is intentionally narrow hardening rather than a transport redesign.
+
+Treat the socket as local editor-control access for the current host, not as a remote-safe transport.
+
 ## Install / configure
 
 ### 1) Link this as a pi extension
@@ -143,6 +153,7 @@ pnpm check
 
 - Lua files are intentionally ignored by Prettier and formatted with StyLua.
 - A local ambient type declaration is provided in `types/pi-coding-agent.d.ts` so `tsc` can run without requiring external SDK types.
+- If `/tmp` or your local machine account is shared more broadly than usual, remember that `nvim-bridge` still relies on same-host trust rather than explicit socket peer auth.
 
 ## License
 

--- a/nvim-bridge/index.ts
+++ b/nvim-bridge/index.ts
@@ -39,13 +39,31 @@ function resolveRepoInfo(cwd: string): RepoInfo | null {
   }
 }
 
+function ensureSocketDirectory(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // Best effort only: same-host trust is the primary boundary here.
+  }
+}
+
+function tightenSocketPermissions(socketPath: string): void {
+  try {
+    fs.chmodSync(socketPath, 0o600);
+  } catch {
+    // Best effort only: keep any hardening here deliberately narrow.
+  }
+}
+
 function computeSocketPath(repoInfo: RepoInfo): string {
   const key = `${repoInfo.repoRoot}:${repoInfo.branch}`;
   const hash = crypto.createHash("sha256").update(key).digest("hex");
   const dir = "/tmp/pi-nvim";
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  ensureSocketDirectory(dir);
   return path.join(dir, `${hash}.sock`);
 }
 
@@ -571,6 +589,10 @@ export default function (pi: ExtensionAPI) {
     });
 
     server.listen(socketPath, () => {
+      const activeSocketPath = socketPath;
+      if (activeSocketPath) {
+        tightenSocketPermissions(activeSocketPath);
+      }
       // Socket is ready, waiting for nvim to connect.
       setBridgeStatus(false);
     });

--- a/nvim-bridge/nvim/lua/pi-nvim/socket.lua
+++ b/nvim-bridge/nvim/lua/pi-nvim/socket.lua
@@ -275,6 +275,8 @@ local function handle_server_message(msg)
 end
 
 --- Connect to the Unix socket.
+--- This socket is intentionally same-host and trust-based; there is no peer
+--- authentication handshake beyond the local socket path and local file permissions.
 function M.connect()
   should_reconnect = true
 


### PR DESCRIPTION
## Summary
- document browser-playwright, nvim-bridge, and imessage-bridge as intentional same-host local-power surfaces
- make localhost direct navigation and trusted storage-state assumptions more legible in browser-playwright
- document the local socket trust boundary in nvim-bridge and keep the only hardening to narrow socket permission tightening
- make send-first outbound power explicit in imessage-bridge readiness and docs

Closes #561.

## Testing
- `pnpm --filter @gugu910/pi-browser-playwright lint`
- `pnpm --filter @gugu910/pi-browser-playwright typecheck`
- `pnpm --filter @gugu910/pi-browser-playwright test`
- `pnpm --filter @gugu910/pi-nvim-bridge lint`
- `pnpm --filter @gugu910/pi-nvim-bridge typecheck`
- `pnpm --filter @gugu910/pi-nvim-bridge test`
- `pnpm --filter @gugu910/pi-imessage-bridge lint`
- `pnpm --filter @gugu910/pi-imessage-bridge typecheck`
- `pnpm --filter @gugu910/pi-imessage-bridge test`