### PR TITLE
feat: add compatibility scope carriers to runtime metadata

### DIFF
--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -38,7 +38,8 @@
     "build": "node ../scripts/build-package.mjs",
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run *.test.ts"
   },
   "dependencies": {
     "@gugu910/pi-transport-core": "workspace:*"

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -1746,6 +1746,7 @@ export class BrokerDB implements BrokerDBInterface {
       userId: message.userId,
       timestamp: message.timestamp,
       ...(message.isChannelMention ? { isChannelMention: true } : {}),
+      ...(message.scope ? { scope: message.scope } : {}),
     };
     this.insertMessage(
       message.threadId,

--- a/broker-core/tsconfig.json
+++ b/broker-core/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
   "include": ["**/*.ts", "../types/**/*.d.ts"]
 }

--- a/broker-core/types.test.ts
+++ b/broker-core/types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCompatibilityInstanceScope,
+  buildCompatibilityWorkspaceScope,
+  buildRuntimeScopeCarrier,
+  type InboundMessage,
+} from "./types.ts";
+
+describe("broker-core scope carriers", () => {
+  it("re-exports compatibility scope builders from transport-core", () => {
+    const scope = buildRuntimeScopeCarrier({
+      workspace: buildCompatibilityWorkspaceScope({
+        provider: "slack",
+        workspaceId: "T123",
+      }),
+      instance: buildCompatibilityInstanceScope({ compatibilityKey: "default" }),
+    });
+
+    expect(scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        workspaceId: "T123",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+  });
+
+  it("preserves optional runtime scope carriers on inbound messages", () => {
+    const message: InboundMessage = {
+      source: "slack",
+      threadId: "123.456",
+      channel: "C123",
+      userId: "U123",
+      text: "hello",
+      timestamp: "123.456",
+      scope: buildRuntimeScopeCarrier({
+        workspace: buildCompatibilityWorkspaceScope({
+          provider: "slack",
+          workspaceId: "T123",
+        }),
+      }),
+    };
+
+    expect(message.scope?.workspace?.workspaceId).toBe("T123");
+    expect(message.scope?.workspace?.source).toBe("compatibility");
+  });
+});

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -146,15 +146,29 @@ export const RPC_AGENT_STABLE_ID_CONFLICT = -32003;
 
 // ─── Message adapter (canonical transport contracts) ─────
 
+import {
+  buildCompatibilityInstanceScope as _buildCompatibilityInstanceScope,
+  buildCompatibilityWorkspaceScope as _buildCompatibilityWorkspaceScope,
+  buildRuntimeScopeCarrier as _buildRuntimeScopeCarrier,
+} from "@gugu910/pi-transport-core";
 import type {
   InboundMessage as _InboundMessage,
   OutboundMessage as _OutboundMessage,
   MessageAdapter as _MessageAdapter,
+  RuntimeScopeCarrier as _RuntimeScopeCarrier,
+  WorkspaceInstallScopeCarrier as _WorkspaceInstallScopeCarrier,
+  InstanceScopeCarrier as _InstanceScopeCarrier,
 } from "@gugu910/pi-transport-core";
 
 export type InboundMessage = _InboundMessage;
 export type OutboundMessage = _OutboundMessage;
 export type MessageAdapter = _MessageAdapter;
+export type RuntimeScopeCarrier = _RuntimeScopeCarrier;
+export type WorkspaceInstallScopeCarrier = _WorkspaceInstallScopeCarrier;
+export type InstanceScopeCarrier = _InstanceScopeCarrier;
+export const buildCompatibilityWorkspaceScope = _buildCompatibilityWorkspaceScope;
+export const buildCompatibilityInstanceScope = _buildCompatibilityInstanceScope;
+export const buildRuntimeScopeCarrier = _buildRuntimeScopeCarrier;
 
 // ─── BrokerDB interface (subset used by the router) ──────
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -164,6 +164,18 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context      |
 | `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                       |
 
+## Scope carrier model (compatibility-first)
+
+Slack/Pinet now threads a first-class runtime `scope` carrier through shared message contracts and runtime metadata.
+
+For this first slice:
+
+- **workspace/install scope** is carried as compatibility-first metadata for Slack
+- **instance scope** is also carried as a first-class compatibility carrier
+- today’s single-workspace deployments use one default compatibility scope
+- a missing or empty Slack `teamId` stays **unknown** — the bridge does not invent a fake workspace ID
+- these carriers are metadata only in this slice; enforcement and multi-install behavior land later in `#547` / `#550`
+
 ## Usage
 
 Once configured, Pinet appears in Slack's sidebar. Users open it, type a message, and the pi agent responds.
@@ -243,6 +255,16 @@ Startup selection:
 - `autoFollow` is a legacy compatibility alias for `runtimeMode: "follower"` when a broker socket is available.
 - explicit `runtimeMode` wins over the legacy flags.
 - `/pinet-start` and `/pinet-follow` still switch the live session into broker/follower runtimes explicitly.
+
+## Scope carriers (compatibility-first)
+
+`slack-bridge` now emits first-class runtime scope carriers in shared transport contracts and agent runtime metadata.
+
+- `scope.workspace` models the current Slack install/workspace scope.
+- `scope.instance` models the current broker/runtime instance scope.
+- in the first slice, both stay **compatibility-first**: today’s singleton runtime gets one default compatibility scope
+- if Slack omits `team_id`, the carrier keeps the workspace id **unknown** instead of inventing a fake one
+- this slice is metadata/plumbing only: it does **not** change routing, enforcement, or multi-install orchestration yet
 
 ## Pinet (Multi-Agent Mode)
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -148,10 +148,23 @@ describe("extractThreadStarted", () => {
     expect(result?.context).toEqual({
       channelId: "C789",
       teamId: "T001",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          workspaceId: "T001",
+          channelId: "C789",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
     });
   });
 
-  it("defaults teamId to empty string when missing", () => {
+  it("keeps teamId unknown when Slack does not provide one", () => {
     const evt = {
       type: "assistant_thread_started",
       assistant_thread: {
@@ -162,7 +175,21 @@ describe("extractThreadStarted", () => {
       },
     };
     const result = extractThreadStarted(evt);
-    expect(result?.context?.teamId).toBe("");
+    expect(result?.context).toEqual({
+      channelId: "C789",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "C789",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    });
   });
 
   it("omits context when context has no channel_id", () => {
@@ -943,6 +970,18 @@ describe("SlackAdapter", () => {
       userName: "Will",
       text: 'Clicked Slack "Approve" (action_id: review.approve).',
       timestamp: "123.789",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "C123",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
       metadata: {
         kind: "slack_block_action",
         triggerId: "trigger-1",
@@ -1048,6 +1087,18 @@ describe("SlackAdapter", () => {
       userName: "Will",
       text: 'Submitted Slack modal (deploy.confirm) "Deploy approval".',
       timestamp: "V123",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "C123",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
       metadata: {
         kind: "slack_view_submission",
         triggerId: "trigger-1",
@@ -1178,12 +1229,104 @@ describe("SlackAdapter — allowlist filtering", () => {
       userName: "Alice Example",
       text: "hello from Slack",
       timestamp: "1.1",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "D1",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
     });
     await waitForAssertion(() => {
       const endpoints = fetchMock.mock.calls.map(([url]) => String(url));
       expect(endpoints).toContain("https://slack.com/api/users.info");
       expect(endpoints).toContain("https://slack.com/api/reactions.add");
     });
+  });
+
+  it("carries known Slack thread team context into the inbound scope carrier", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as {
+        onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onThreadStarted({
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D1",
+        thread_ts: "1.1",
+        user_id: "U_ALLOWED",
+        context: {
+          channel_id: "C_TEAM",
+          team_id: "T001",
+        },
+      },
+    });
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "hello from scoped Slack",
+      channel: "D1",
+      channel_type: "im",
+      thread_ts: "1.1",
+      ts: "1.2",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "1.1",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "compatibility",
+            compatibilityKey: "default",
+            workspaceId: "T001",
+            channelId: "C_TEAM",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      }),
+    );
   });
 });
 
@@ -1377,6 +1520,18 @@ describe("SlackAdapter — send", () => {
     expect(meta.event_type).toBe("pi_agent_msg");
     expect(meta.event_payload.agent).toBe("TestBot");
     expect(meta.event_payload.emoji).toBe("🤖");
+    expect(meta.event_payload.scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        channelId: "C123",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
   });
 
   it("includes agent_owner in metadata when agentOwnerToken is provided", async () => {
@@ -1403,6 +1558,18 @@ describe("SlackAdapter — send", () => {
     };
     expect(meta.event_payload.agent).toBe("TestBot");
     expect(meta.event_payload.agent_owner).toBe("owner:abcd1234efgh5678");
+    expect(meta.event_payload.scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        channelId: "C123",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
   });
 
   it("includes metadata when only agentOwnerToken is set (no agentName)", async () => {
@@ -1429,6 +1596,18 @@ describe("SlackAdapter — send", () => {
     expect(meta.event_type).toBe("pi_agent_msg");
     expect(meta.event_payload.agent_owner).toBe("owner:abcd1234efgh5678");
     expect(meta.event_payload.agent).toBeUndefined();
+    expect(meta.event_payload.scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        channelId: "C123",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
   });
 
   it("does not include metadata when no agentName or metadata", async () => {
@@ -1735,6 +1914,18 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
         userName: "Alice Example",
         text: "Hello from Slack",
         timestamp: "111.222",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "compatibility",
+            compatibilityKey: "default",
+            channelId: "D123",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
       });
     });
 
@@ -1848,6 +2039,18 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
           "- Incident notes — markdown — snippet — id=F123 — https://files.example/incident.md",
         ].join("\n"),
         timestamp: "111.222",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "compatibility",
+            compatibilityKey: "default",
+            channelId: "D123",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
         metadata: {
           slackSubtype: "file_share",
           slackFiles: [

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -1,5 +1,6 @@
 import {
   addSlackReaction,
+  buildSlackThreadRuntimeScope,
   classifyMessage,
   clearSlackThreadStatus,
   extractAppHomeOpened,
@@ -62,7 +63,7 @@ interface SlackThreadInfo {
   channelId: string;
   threadTs: string;
   userId: string;
-  context?: { channelId: string; teamId: string };
+  context?: ParsedThreadStarted["context"];
 }
 
 export class SlackAdapter implements MessageAdapter {
@@ -152,14 +153,16 @@ export class SlackAdapter implements MessageAdapter {
       text: msg.text,
       thread_ts: msg.threadId,
     };
+    const scope = msg.scope ?? this.resolveScopeForThread(msg.threadId, msg.channel);
 
-    if (msg.agentName ?? msg.agentOwnerToken ?? msg.metadata) {
+    if (msg.agentName ?? msg.agentOwnerToken ?? msg.metadata ?? msg.scope) {
       body.metadata = {
         event_type: "pi_agent_msg",
         event_payload: {
           ...(msg.agentName ? { agent: msg.agentName } : {}),
           ...(msg.agentOwnerToken ? { agent_owner: msg.agentOwnerToken } : {}),
           ...(msg.agentEmoji ? { emoji: msg.agentEmoji } : {}),
+          ...(scope ? { scope } : {}),
           ...msg.metadata,
         },
       };
@@ -189,6 +192,13 @@ export class SlackAdapter implements MessageAdapter {
 
   isConnected(): boolean {
     return this.socketMode?.isConnected() ?? false;
+  }
+
+  private resolveScopeForThread(threadTs: string, channelId: string) {
+    return buildSlackThreadRuntimeScope({
+      channelId,
+      context: this.threads.get(threadTs)?.context ?? null,
+    });
   }
 
   private async onThreadStarted(
@@ -323,6 +333,7 @@ export class SlackAdapter implements MessageAdapter {
           ? reactedMessage.text
           : "(no text)";
 
+      const threadInfo = this.threads.get(threadTs);
       this.inboundHandler?.({
         source: "slack",
         threadId: threadTs,
@@ -340,6 +351,10 @@ export class SlackAdapter implements MessageAdapter {
           reactedMessageAuthor,
         }),
         timestamp: (evt.event_ts as string) ?? item.ts,
+        scope: buildSlackThreadRuntimeScope({
+          channelId: item.channel,
+          context: threadInfo?.context,
+        }),
       });
 
       await this.addReaction(item.channel, item.ts, "white_check_mark");
@@ -380,6 +395,7 @@ export class SlackAdapter implements MessageAdapter {
     const userName = await this.resolveUser(userId);
     if (this.shuttingDown) return;
 
+    const threadInfo = this.threads.get(threadTs);
     this.inboundHandler?.({
       source: "slack",
       threadId: threadTs,
@@ -388,6 +404,10 @@ export class SlackAdapter implements MessageAdapter {
       userName,
       text,
       timestamp: messageTs,
+      scope: buildSlackThreadRuntimeScope({
+        channelId: channel,
+        context: threadInfo?.context,
+      }),
       ...(isChannelMention ? { isChannelMention: true } : {}),
       ...(metadata ? { metadata } : {}),
     });
@@ -420,6 +440,7 @@ export class SlackAdapter implements MessageAdapter {
     const userName = await this.resolveUser(normalized.userId);
     if (this.shuttingDown) return;
 
+    const threadInfo = this.threads.get(normalized.threadTs);
     this.inboundHandler?.({
       source: "slack",
       threadId: normalized.threadTs,
@@ -429,6 +450,10 @@ export class SlackAdapter implements MessageAdapter {
       text: normalized.text,
       timestamp: normalized.timestamp,
       metadata: normalized.metadata,
+      scope: buildSlackThreadRuntimeScope({
+        channelId: normalized.channel,
+        context: threadInfo?.context,
+      }),
     });
   }
 
@@ -442,6 +467,7 @@ export class SlackAdapter implements MessageAdapter {
       userId: "system",
       text: `Bot was added to channel ${event.channel}`,
       timestamp: String(Date.now() / 1000),
+      scope: buildSlackThreadRuntimeScope({ channelId: event.channel }),
     });
   }
 

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -11,6 +11,7 @@ import { startBroker, type Broker } from "./index.js";
 import { runBrokerMaintenancePass } from "./maintenance.js";
 import { BrokerSocketServer } from "./socket-server.js";
 import { buildTaskAssignmentReport } from "../task-assignments.js";
+import { buildSlackCompatibilityScope } from "../helpers.js";
 import type { JsonRpcRequest, JsonRpcResponse } from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -1768,6 +1769,30 @@ describe("BrokerDB", () => {
     expect(inbox[0].message.metadata).toEqual({
       priority: "high",
       tags: ["urgent"],
+    });
+  });
+
+  it("queueMessage preserves first-class scope carriers inside stored metadata without schema changes", () => {
+    db.registerAgent("a1", "Agent", "🔵", 1);
+    db.createThread("t-scope", "slack", "C_SCOPE", "a1");
+
+    const scope = buildSlackCompatibilityScope({ teamId: "T_SCOPE", channelId: "C_SCOPE" });
+    db.queueMessage("a1", {
+      source: "slack",
+      threadId: "t-scope",
+      channel: "C_SCOPE",
+      userId: "U_SCOPE",
+      text: "scoped hello",
+      timestamp: "100.200",
+      scope,
+    });
+
+    const inbox = db.getInbox("a1");
+    expect(inbox[0].message.metadata).toMatchObject({
+      channel: "C_SCOPE",
+      userId: "U_SCOPE",
+      timestamp: "100.200",
+      scope,
     });
   });
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -32,7 +32,10 @@ import {
   buildSqliteWalFallbackWarning,
   formatAgentList,
   shortenPath,
+  buildAgentCapabilityTags,
   buildAgentDisplayInfo,
+  buildSlackCompatibilityScope,
+  extractAgentCapabilities,
   isAgentVisibleInMesh,
   filterAgentsForMeshVisibility,
   rankAgentsForRouting,
@@ -2922,8 +2925,9 @@ describe("syncFollowerInboxEntries", () => {
     expect(result.changed).toBe(false);
   });
 
-  it("preserves structured metadata on synced inbox messages", () => {
+  it("preserves structured metadata and restores first-class scope on synced inbox messages", () => {
     const threads = new Map<string, FollowerThreadState>();
+    const scope = buildSlackCompatibilityScope({ teamId: "T_ACTION", channelId: "C_ACTION" });
     const result = syncFollowerInboxEntries(
       [
         {
@@ -2937,6 +2941,7 @@ describe("syncFollowerInboxEntries", () => {
               channel: "C_ACTION",
               kind: "slack_block_action",
               actionId: "review.approve",
+              scope,
             },
           },
         },
@@ -2949,10 +2954,12 @@ describe("syncFollowerInboxEntries", () => {
     expect(result.inboxMessages[0]).toMatchObject({
       channel: "C_ACTION",
       brokerInboxId: 29,
+      scope,
       metadata: {
         channel: "C_ACTION",
         kind: "slack_block_action",
         actionId: "review.approve",
+        scope,
       },
     });
   });
@@ -3477,5 +3484,54 @@ describe("buildAgentDisplayInfo observability fields", () => {
     expect(info.lastActivity).toBeNull();
     expect(info.idleDuration).toBeNull();
     expect(info.lastActivityAge).toBeNull();
+  });
+});
+
+describe("scope compatibility helpers", () => {
+  it("builds a compatibility scope without inventing a workspace id for an unknown team", () => {
+    expect(
+      buildSlackCompatibilityScope({
+        teamId: "",
+        channelId: "C123",
+      }),
+    ).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        channelId: "C123",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+  });
+
+  it("extracts scoped capabilities and derives scope tags", () => {
+    const capabilities = extractAgentCapabilities({
+      capabilities: {
+        repo: "extensions",
+        role: "worker",
+        scope: buildSlackCompatibilityScope({ teamId: "T123", channelId: "C123" }),
+      },
+    });
+
+    expect(capabilities.scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        workspaceId: "T123",
+        channelId: "C123",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+    expect(buildAgentCapabilityTags(capabilities)).toEqual(
+      expect.arrayContaining(["scope-provider:slack", "scope:default", "workspace:T123"]),
+    );
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import {
+  buildCompatibilityInstanceScope,
+  buildCompatibilityWorkspaceScope,
+  buildRuntimeScopeCarrier,
+  type RuntimeScopeCarrier,
+} from "@gugu910/pi-transport-core";
 import type { ReactionCommandSettings } from "./reaction-triggers.js";
 import { matchesToolPattern } from "./guardrails.js";
 
@@ -47,6 +53,29 @@ export interface ResolvedPinetMeshAuthSettings {
 function normalizeOptionalSetting(value?: string | null): string | null {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function buildSlackCompatibilityScope(
+  options: {
+    teamId?: string | null;
+    channelId?: string | null;
+    installId?: string | null;
+    instanceId?: string | null;
+    instanceName?: string | null;
+  } = {},
+): RuntimeScopeCarrier {
+  return buildRuntimeScopeCarrier({
+    workspace: buildCompatibilityWorkspaceScope({
+      provider: "slack",
+      workspaceId: normalizeOptionalSetting(options.teamId) ?? undefined,
+      installId: normalizeOptionalSetting(options.installId) ?? undefined,
+      channelId: normalizeOptionalSetting(options.channelId) ?? undefined,
+    }),
+    instance: buildCompatibilityInstanceScope({
+      instanceId: normalizeOptionalSetting(options.instanceId) ?? undefined,
+      instanceName: normalizeOptionalSetting(options.instanceName) ?? undefined,
+    }),
+  })!;
 }
 
 export function resolvePinetMeshAuth(
@@ -168,6 +197,7 @@ export interface InboxMessage {
   isChannelMention?: boolean;
   brokerInboxId?: number;
   metadata?: Record<string, unknown> | null;
+  scope?: RuntimeScopeCarrier | null;
 }
 
 export interface SqliteJournalModeResult {
@@ -751,6 +781,7 @@ export interface AgentCapabilities {
   role?: string;
   tools?: string[];
   tags?: string[];
+  scope?: RuntimeScopeCarrier | null;
 }
 
 export type AgentHealth = "healthy" | "stale" | "ghost" | "resumable";
@@ -772,6 +803,7 @@ export interface AgentDisplayInfo {
     skinTheme?: string;
     personality?: string;
     capabilities?: AgentCapabilities | null;
+    scope?: RuntimeScopeCarrier | null;
   } | null;
   lastHeartbeat?: string;
   leaseExpiresAt?: string | null;
@@ -836,6 +868,50 @@ function asStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const strings = value.map(asString).filter((item): item is string => Boolean(item));
   return strings.length > 0 ? strings : undefined;
+}
+
+function extractRuntimeScopeCarrier(value: unknown): RuntimeScopeCarrier | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const workspaceRecord = asRecord(record.workspace);
+  const instanceRecord = asRecord(record.instance);
+  const scope = buildRuntimeScopeCarrier({
+    workspace: workspaceRecord
+      ? {
+          provider: asString(workspaceRecord.provider) ?? "slack",
+          source: asString(workspaceRecord.source) === "explicit" ? "explicit" : "compatibility",
+          ...(asString(workspaceRecord.compatibilityKey)
+            ? { compatibilityKey: asString(workspaceRecord.compatibilityKey) }
+            : {}),
+          ...(asString(workspaceRecord.workspaceId)
+            ? { workspaceId: asString(workspaceRecord.workspaceId) }
+            : {}),
+          ...(asString(workspaceRecord.installId)
+            ? { installId: asString(workspaceRecord.installId) }
+            : {}),
+          ...(asString(workspaceRecord.channelId)
+            ? { channelId: asString(workspaceRecord.channelId) }
+            : {}),
+        }
+      : null,
+    instance: instanceRecord
+      ? {
+          source: asString(instanceRecord.source) === "explicit" ? "explicit" : "compatibility",
+          ...(asString(instanceRecord.compatibilityKey)
+            ? { compatibilityKey: asString(instanceRecord.compatibilityKey) }
+            : {}),
+          ...(asString(instanceRecord.instanceId)
+            ? { instanceId: asString(instanceRecord.instanceId) }
+            : {}),
+          ...(asString(instanceRecord.instanceName)
+            ? { instanceName: asString(instanceRecord.instanceName) }
+            : {}),
+        }
+      : null,
+  });
+
+  return scope ?? null;
 }
 
 function parseIsoMs(value: string | null | undefined): number | null {
@@ -919,6 +995,7 @@ export function extractAgentCapabilities(
     role: asString(capabilitiesRecord?.role) ?? asString(record?.role),
     tools: asStringArray(capabilitiesRecord?.tools),
     tags: asStringArray(capabilitiesRecord?.tags),
+    scope: extractRuntimeScopeCarrier(capabilitiesRecord?.scope ?? record?.scope),
   };
 }
 
@@ -928,6 +1005,21 @@ export function buildAgentCapabilityTags(capabilities: AgentCapabilities): strin
   if (capabilities.role) tags.add(`role:${capabilities.role}`);
   if (capabilities.repo) tags.add(`repo:${capabilities.repo}`);
   if (capabilities.branch) tags.add(`branch:${capabilities.branch}`);
+  if (capabilities.scope?.workspace?.provider) {
+    tags.add(`scope-provider:${capabilities.scope.workspace.provider}`);
+  }
+  if (capabilities.scope?.workspace?.compatibilityKey) {
+    tags.add(`scope:${capabilities.scope.workspace.compatibilityKey}`);
+  }
+  if (capabilities.scope?.workspace?.workspaceId) {
+    tags.add(`workspace:${capabilities.scope.workspace.workspaceId}`);
+  }
+  if (capabilities.scope?.instance?.instanceId) {
+    tags.add(`instance:${capabilities.scope.instance.instanceId}`);
+  }
+  if (capabilities.scope?.instance?.instanceName) {
+    tags.add(`instance-name:${capabilities.scope.instance.instanceName}`);
+  }
   for (const tool of capabilities.tools ?? []) {
     tags.add(`tool:${tool}`);
   }
@@ -1029,6 +1121,7 @@ export function buildAgentDisplayInfo(
           role: asString(metadata.role) ?? capabilities.role,
           skinTheme: asString(metadata.skinTheme),
           personality: asString(metadata.personality),
+          ...(capabilities.scope ? { scope: capabilities.scope } : {}),
           capabilities,
         }
       : null,
@@ -1859,6 +1952,7 @@ export function syncFollowerInboxEntries(
     const threadTs = entry.message.threadId ?? "";
     const channel = typeof meta.channel === "string" ? meta.channel : "";
     const sender = entry.message.sender ?? "";
+    const scope = extractRuntimeScopeCarrier(meta.scope);
 
     if (threadTs && channel) {
       const existing = existingThreads.get(threadTs);
@@ -1900,6 +1994,7 @@ export function syncFollowerInboxEntries(
       timestamp: entry.message.createdAt ?? "",
       brokerInboxId: entry.inboxId,
       metadata: meta,
+      ...(scope ? { scope } : {}),
     };
   });
 
@@ -1944,6 +2039,7 @@ export function syncBrokerInboxEntries(entries: FollowerInboxEntry[]): BrokerInb
       continue;
     }
 
+    const scope = extractRuntimeScopeCarrier(meta.scope);
     inboxMessages.push({
       channel: "",
       threadTs,
@@ -1952,6 +2048,7 @@ export function syncBrokerInboxEntries(entries: FollowerInboxEntry[]): BrokerInb
       timestamp: createdAt,
       brokerInboxId: inboxId,
       metadata: meta,
+      ...(scope ? { scope } : {}),
     });
   }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -707,6 +707,7 @@ export default function (pi: ExtensionAPI) {
             text: routedMessage.text,
             timestamp: routedMessage.timestamp,
             metadata: routedMessage.metadata ?? null,
+            ...(routedMessage.scope ? { scope: routedMessage.scope } : {}),
           });
           updateBadge();
           maybeDrainInboxIfIdle(ctx);

--- a/slack-bridge/runtime-agent-context.test.ts
+++ b/slack-bridge/runtime-agent-context.test.ts
@@ -431,10 +431,32 @@ describe("createRuntimeAgentContext", () => {
       role: "broker",
       skinTheme: "midnight",
       personality: "observant",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
     });
     expect(metadata.capabilities).toMatchObject({
       role: "broker",
       tools: ["build", "git", "lint", "test", "typecheck"],
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
       tags: expect.arrayContaining([
         "role:broker",
         "repo:extensions",

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -8,6 +8,7 @@ import {
   buildIdentityReplyGuidelines,
   buildPinetOwnerToken,
   buildPinetSkinAssignment,
+  buildSlackCompatibilityScope,
   getSlackUserAccessWarning,
   isUserAllowed as checkUserAllowed,
   loadSettings as loadSettingsFromFile,
@@ -330,10 +331,13 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     const { cwd, repo, repoRoot, branch } = gitContext;
     const resolvedRepoRoot = repoRoot ?? cwd;
     const tools = detectProjectTools(resolvedRepoRoot, cwd);
+    const scope = buildSlackCompatibilityScope();
     const tags = [
       `role:${role}`,
       `repo:${repo}`,
       ...(branch ? [`branch:${branch}`] : []),
+      ...(scope.workspace?.provider ? [`scope-provider:${scope.workspace.provider}`] : []),
+      ...(scope.workspace?.compatibilityKey ? [`scope:${scope.workspace.compatibilityKey}`] : []),
       ...tools.map((tool) => `tool:${tool}`),
     ];
 
@@ -344,6 +348,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
       role,
       repo,
       repoRoot,
+      scope,
       ...(deps.getActiveSkinTheme() ? { skinTheme: deps.getActiveSkinTheme() } : {}),
       ...(deps.getAgentPersonality() ? { personality: deps.getAgentPersonality() } : {}),
       capabilities: {
@@ -353,6 +358,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
         role,
         tools,
         tags,
+        scope,
       },
     };
   }

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -291,6 +291,18 @@ describe("single-player-runtime", () => {
       userId: "U_SENDER",
       text: "hello from Slack",
       timestamp: "100.1",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "D123",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
     });
     expect(spies.updateBadge).toHaveBeenCalledTimes(1);
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
@@ -354,6 +366,18 @@ describe("single-player-runtime", () => {
             mode: "snippet",
           },
         ],
+      },
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "D123",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
       },
     });
   });

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -8,6 +8,7 @@ import {
 import type { SlackInteractiveInboxEvent } from "./slack-block-kit.js";
 import type { SlackToolsThreadContextPort } from "./slack-tools.js";
 import {
+  buildSlackThreadRuntimeScope,
   classifyMessage,
   resolveSlackThreadOwnerHint,
   SlackSocketModeClient,
@@ -322,12 +323,17 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       });
 
       ctx.ui.notify(`${reactorName} reacted with :${reactionName}:`, "info");
+      const threadInfo = threads.get(threadTs);
       deps.pushInboxMessage({
         channel: item.channel,
         threadTs,
         userId: user,
         text: reactionMessage,
         timestamp: (evt.event_ts as string) ?? item.ts,
+        scope: buildSlackThreadRuntimeScope({
+          channelId: item.channel,
+          context: threadInfo?.context,
+        }),
       });
       deps.persistState();
       deps.updateBadge();
@@ -390,12 +396,17 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     pending.push({ channel, messageTs });
     deps.getPendingEyes().set(threadTs, pending);
 
+    const threadInfo = threads.get(threadTs);
     deps.pushInboxMessage({
       channel,
       threadTs,
       userId,
       text: messageText,
       timestamp: messageTs,
+      scope: buildSlackThreadRuntimeScope({
+        channelId: channel,
+        context: threadInfo?.context,
+      }),
       ...(isChannelMention && { isChannelMention: true }),
       ...(metadata ? { metadata } : {}),
     });
@@ -448,6 +459,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     if (shuttingDown) return;
     ctx.ui.notify(`${name}: ${normalized.text.slice(0, 100)}`, "info");
 
+    const threadInfo = threads.get(normalized.threadTs);
     deps.pushInboxMessage({
       channel: normalized.channel,
       threadTs: normalized.threadTs,
@@ -455,6 +467,10 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       text: normalized.text,
       timestamp: normalized.timestamp,
       metadata: normalized.metadata,
+      scope: buildSlackThreadRuntimeScope({
+        channelId: normalized.channel,
+        context: threadInfo?.context,
+      }),
     });
     deps.updateBadge();
 

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -1,4 +1,11 @@
-import { isUserAllowed, isChannelId, stripBotMention, isAbortError } from "./helpers.js";
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
+import {
+  buildSlackCompatibilityScope,
+  isUserAllowed,
+  isChannelId,
+  stripBotMention,
+  isAbortError,
+} from "./helpers.js";
 import {
   buildSlackInboundMessageText,
   extractSlackMessageFileMetadata,
@@ -37,7 +44,34 @@ export interface SlackAccessSet<K> {
 
 export interface SlackThreadContext {
   channelId: string;
-  teamId: string;
+  teamId?: string;
+  scope: RuntimeScopeCarrier;
+}
+
+function buildSlackThreadContext(channelId: string, teamId?: string | null): SlackThreadContext {
+  const normalizedTeamId =
+    typeof teamId === "string" && teamId.trim().length > 0 ? teamId.trim() : undefined;
+  return {
+    channelId,
+    ...(normalizedTeamId ? { teamId: normalizedTeamId } : {}),
+    scope: buildSlackCompatibilityScope({
+      teamId: normalizedTeamId,
+      channelId,
+    }),
+  };
+}
+
+export function buildSlackThreadRuntimeScope(input: {
+  channelId?: string | null;
+  context?: SlackThreadContext | null;
+}): RuntimeScopeCarrier {
+  return (
+    input.context?.scope ??
+    buildSlackCompatibilityScope({
+      teamId: input.context?.teamId,
+      channelId: input.context?.channelId ?? input.channelId,
+    })
+  );
 }
 
 export interface ParsedEnvelope {
@@ -114,7 +148,7 @@ export function extractThreadStarted(evt: Record<string, unknown>): ParsedThread
 
   const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
   if (ctx?.channel_id) {
-    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+    result.context = buildSlackThreadContext(ctx.channel_id, ctx.team_id);
   }
 
   return result;
@@ -139,7 +173,7 @@ export function extractThreadContextChanged(
   const result: ParsedThreadContextChanged = { threadTs };
   const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
   if (ctx?.channel_id) {
-    result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
+    result.context = buildSlackThreadContext(ctx.channel_id, ctx.team_id);
   }
 
   return result;

--- a/slack-bridge/slack-runtime-access.test.ts
+++ b/slack-bridge/slack-runtime-access.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
 import { createSlackRuntimeAccess, type SlackRuntimeAccessDeps } from "./slack-runtime-access.js";
+import { buildSlackCompatibilityScope } from "./helpers.js";
 import { TtlCache } from "./ttl-cache.js";
 
 function createDeps(overrides: Partial<SlackRuntimeAccessDeps> = {}) {
@@ -99,7 +100,11 @@ describe("createSlackRuntimeAccess", () => {
       threadTs: "100.1",
       userId: "U123",
       source: "slack",
-      context: { channelId: "C_STALE", teamId: "T1" },
+      context: {
+        channelId: "C_STALE",
+        teamId: "T1",
+        scope: buildSlackCompatibilityScope({ teamId: "T1", channelId: "C_STALE" }),
+      },
     });
     const access = createSlackRuntimeAccess(deps);
 
@@ -110,7 +115,11 @@ describe("createSlackRuntimeAccess", () => {
       threadTs: "100.1",
       userId: "U123",
       source: "slack",
-      context: { channelId: "C_STALE", teamId: "T1" },
+      context: {
+        channelId: "C_STALE",
+        teamId: "T1",
+        scope: buildSlackCompatibilityScope({ teamId: "T1", channelId: "C_STALE" }),
+      },
     });
     expect(persistState).toHaveBeenCalledTimes(1);
   });

--- a/transport-core/index.test.ts
+++ b/transport-core/index.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCompatibilityInstanceScope,
+  buildCompatibilityWorkspaceScope,
+  buildRuntimeScopeCarrier,
+  type InboundMessage,
+} from "./index.ts";
+
+test("buildCompatibilityWorkspaceScope keeps unknown workspace ids unknown while preserving compatibility mode", () => {
+  assert.deepEqual(
+    buildCompatibilityWorkspaceScope({
+      provider: "slack",
+      workspaceId: "",
+      channelId: " C123 ",
+    }),
+    {
+      provider: "slack",
+      source: "compatibility",
+      compatibilityKey: "default",
+      channelId: "C123",
+    },
+  );
+});
+
+test("buildRuntimeScopeCarrier combines workspace and instance compatibility carriers", () => {
+  const scope = buildRuntimeScopeCarrier({
+    workspace: buildCompatibilityWorkspaceScope({
+      provider: "slack",
+      workspaceId: "T123",
+      channelId: "C123",
+    }),
+    instance: buildCompatibilityInstanceScope(),
+  });
+
+  assert.deepEqual(scope, {
+    workspace: {
+      provider: "slack",
+      source: "compatibility",
+      compatibilityKey: "default",
+      workspaceId: "T123",
+      channelId: "C123",
+    },
+    instance: {
+      source: "compatibility",
+      compatibilityKey: "default",
+    },
+  });
+});
+
+test("InboundMessage can carry first-class runtime scope metadata", () => {
+  const message: InboundMessage = {
+    source: "slack",
+    threadId: "123.456",
+    channel: "C123",
+    userId: "U123",
+    text: "hello",
+    timestamp: "123.456",
+    scope: buildRuntimeScopeCarrier({
+      workspace: buildCompatibilityWorkspaceScope({
+        provider: "slack",
+        workspaceId: "T123",
+      }),
+      instance: buildCompatibilityInstanceScope(),
+    }),
+  };
+
+  assert.equal(message.scope?.workspace?.workspaceId, "T123");
+  assert.equal(message.scope?.instance?.compatibilityKey, "default");
+});

--- a/transport-core/index.ts
+++ b/transport-core/index.ts
@@ -1,3 +1,91 @@
+export type RuntimeScopeSource = "explicit" | "compatibility";
+
+export const DEFAULT_COMPATIBILITY_SCOPE_KEY = "default";
+
+export interface WorkspaceInstallScopeCarrier {
+  provider: string;
+  source: RuntimeScopeSource;
+  compatibilityKey?: string;
+  workspaceId?: string;
+  installId?: string;
+  channelId?: string;
+}
+
+export interface InstanceScopeCarrier {
+  source: RuntimeScopeSource;
+  compatibilityKey?: string;
+  instanceId?: string;
+  instanceName?: string;
+}
+
+export interface RuntimeScopeCarrier {
+  workspace?: WorkspaceInstallScopeCarrier;
+  instance?: InstanceScopeCarrier;
+}
+
+function normalizeScopeValue(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function buildCompatibilityWorkspaceScope(options: {
+  provider: string;
+  workspaceId?: string | null;
+  installId?: string | null;
+  channelId?: string | null;
+  compatibilityKey?: string | null;
+}): WorkspaceInstallScopeCarrier {
+  return {
+    provider: options.provider,
+    source: "compatibility",
+    compatibilityKey:
+      normalizeScopeValue(options.compatibilityKey) ?? DEFAULT_COMPATIBILITY_SCOPE_KEY,
+    ...(normalizeScopeValue(options.workspaceId)
+      ? { workspaceId: normalizeScopeValue(options.workspaceId) }
+      : {}),
+    ...(normalizeScopeValue(options.installId)
+      ? { installId: normalizeScopeValue(options.installId) }
+      : {}),
+    ...(normalizeScopeValue(options.channelId)
+      ? { channelId: normalizeScopeValue(options.channelId) }
+      : {}),
+  };
+}
+
+export function buildCompatibilityInstanceScope(
+  options: {
+    instanceId?: string | null;
+    instanceName?: string | null;
+    compatibilityKey?: string | null;
+  } = {},
+): InstanceScopeCarrier {
+  return {
+    source: "compatibility",
+    compatibilityKey:
+      normalizeScopeValue(options.compatibilityKey) ?? DEFAULT_COMPATIBILITY_SCOPE_KEY,
+    ...(normalizeScopeValue(options.instanceId)
+      ? { instanceId: normalizeScopeValue(options.instanceId) }
+      : {}),
+    ...(normalizeScopeValue(options.instanceName)
+      ? { instanceName: normalizeScopeValue(options.instanceName) }
+      : {}),
+  };
+}
+
+export function buildRuntimeScopeCarrier(options: {
+  workspace?: WorkspaceInstallScopeCarrier | null;
+  instance?: InstanceScopeCarrier | null;
+}): RuntimeScopeCarrier | undefined {
+  const scope: RuntimeScopeCarrier = {};
+  if (options.workspace) {
+    scope.workspace = options.workspace;
+  }
+  if (options.instance) {
+    scope.instance = options.instance;
+  }
+  return Object.keys(scope).length > 0 ? scope : undefined;
+}
+
 export interface InboundMessage {
   source: string;
   threadId: string;
@@ -8,6 +96,7 @@ export interface InboundMessage {
   timestamp: string;
   isChannelMention?: boolean;
   metadata?: Record<string, unknown>;
+  scope?: RuntimeScopeCarrier;
 }
 
 export interface OutboundMessage {
@@ -18,6 +107,7 @@ export interface OutboundMessage {
   agentEmoji?: string;
   agentOwnerToken?: string;
   metadata?: Record<string, unknown>;
+  scope?: RuntimeScopeCarrier;
 }
 
 export interface MessageAdapter {

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -28,6 +28,7 @@
     "build": "node ../scripts/build-package.mjs",
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test *.test.ts"
   }
 }

--- a/transport-core/tsconfig.json
+++ b/transport-core/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
   "include": ["**/*.ts", "../types/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- add first-class optional workspace/install + instance scope carriers to transport-neutral message contracts
- thread compatibility-first scope metadata through broker-core and slack-bridge runtime surfaces without changing live behavior
- keep unknown or empty Slack `teamId` unknown instead of inventing a fake workspace id
- add focused tests/docs for compatibility-mode scope propagation

Closes #546.

## Notes
- carrier-only / compatibility-first slice
- no enforcement or deny-path changes
- no multi-install runtime orchestration
- no operator/admin semantics drift
- no schema migration churn beyond reusing existing broker message metadata JSON

## Testing
- `pnpm --filter @gugu910/pi-transport-core lint`
- `pnpm --filter @gugu910/pi-transport-core typecheck`
- `pnpm --filter @gugu910/pi-transport-core test`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`