### PR TITLE
feat: add slack install topology compatibility plumbing

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -151,9 +151,11 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                       |
 | `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true             |
 | `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                              |
-| `defaultChannel`               | no       | Default channel for the `slack` dispatcher `post_channel` action                                                   |
-| `logChannel`                   | no       | Channel for broker activity logs                                                                                   |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
+| `defaultChannel`               | no       | Default channel for `slack_post_channel` in legacy single-install compatibility mode                                   |
+| `logChannel`                   | no       | Channel for broker activity logs in legacy single-install compatibility mode                                       |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                 |
+| `defaultInstallId`             | no       | When `installs` is configured, selects which install projects into today’s singleton runtime                       |
+| `installs`                     | no       | Explicit Slack install/workspace topology entries; each install can carry scoped tokens and surface targets        |
 | `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |
 | `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                             |
 | `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                        |
@@ -164,17 +166,51 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context      |
 | `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                       |
 
+## Slack topology model (compatibility-first)
+
+Slack/Pinet now has an explicit install/workspace topology model that still preserves today’s single-workspace behavior by default.
+
+### Explicit install topology
+
+```json
+{
+  "slack-bridge": {
+    "defaultInstallId": "primary",
+    "installs": [
+      {
+        "installId": "primary",
+        "workspaceId": "T_PRIMARY",
+        "botToken": "xoxb-primary",
+        "appToken": "xapp-primary",
+        "defaultChannel": "C_PRIMARY_DEFAULT",
+        "logChannel": "C_PRIMARY_LOGS",
+        "controlPlaneCanvasChannel": "C_PRIMARY_OPS",
+        "homeTabEnabled": true
+      }
+    ]
+  }
+}
+```
+
+Compatibility and current limits:
+
+- if `installs` is omitted, the bridge synthesizes **one default compatibility install** from the legacy singleton settings
+- when `installs` is present, the selected `defaultInstallId` projects its `botToken`, `appToken`, `defaultChannel`, `logChannel`, and control-plane/Home targets into today’s singleton runtime
+- a missing or empty Slack `teamId` still stays **unknown** — the bridge does not invent a fake workspace ID
+- this slice defines topology/config plumbing only; live multi-install orchestration lands later in `#550`
+- authorization/enforcement changes stay out of this slice and land later in `#547` / `#548`
+
 ## Scope carrier model (compatibility-first)
 
-Slack/Pinet now threads a first-class runtime `scope` carrier through shared message contracts and runtime metadata.
+Slack/Pinet threads a first-class runtime `scope` carrier through shared message contracts and runtime metadata.
 
-For this first slice:
+For this slice:
 
-- **workspace/install scope** is carried as compatibility-first metadata for Slack
+- **workspace/install scope** is carried as first-class metadata for Slack
 - **instance scope** is also carried as a first-class compatibility carrier
-- today’s single-workspace deployments use one default compatibility scope
-- a missing or empty Slack `teamId` stays **unknown** — the bridge does not invent a fake workspace ID
-- these carriers are metadata only in this slice; enforcement and multi-install behavior land later in `#547` / `#550`
+- compatibility mode uses one default install with install id `default`
+- explicit install topology preserves `workspaceId` + `installId` in runtime metadata without changing routing/orchestration yet
+- these carriers remain metadata/plumbing only in this slice
 
 ## Usage
 
@@ -278,11 +314,12 @@ Startup selection:
 
 ## Scope carriers (compatibility-first)
 
-`slack-bridge` now emits first-class runtime scope carriers in shared transport contracts and agent runtime metadata.
+`slack-bridge` emits first-class runtime scope carriers in shared transport contracts and agent runtime metadata.
 
 - `scope.workspace` models the current Slack install/workspace scope.
 - `scope.instance` models the current broker/runtime instance scope.
-- in the first slice, both stay **compatibility-first**: today’s singleton runtime gets one default compatibility scope
+- in compatibility mode, today’s singleton runtime gets one default install scope with install id `default`
+- with explicit `installs` config, the selected default install preserves `workspaceId` + `installId` in runtime metadata
 - if Slack omits `team_id`, the carrier keeps the workspace id **unknown** instead of inventing a fake one
 - this slice is metadata/plumbing only: it does **not** change routing, enforcement, or multi-install orchestration yet
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -151,9 +151,9 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                       |
 | `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true             |
 | `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                              |
-| `defaultChannel`               | no       | Default channel for `slack_post_channel` in legacy single-install compatibility mode                                   |
+| `defaultChannel`               | no       | Default channel for `slack_post_channel` in legacy single-install compatibility mode                               |
 | `logChannel`                   | no       | Channel for broker activity logs in legacy single-install compatibility mode                                       |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                 |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
 | `defaultInstallId`             | no       | When `installs` is configured, selects which install projects into today’s singleton runtime                       |
 | `installs`                     | no       | Explicit Slack install/workspace topology entries; each install can carry scoped tokens and surface targets        |
 | `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -9,6 +9,7 @@ import {
   buildPinetSkinAssignment,
   DEFAULT_PINET_SKIN_THEME,
   resolvePinetMeshAuth,
+  resolveSlackDefaultScope,
   syncBrokerInboxEntries,
 } from "./helpers.js";
 import { startBroker, type Broker } from "./broker/index.js";
@@ -546,6 +547,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         allowAllWorkspaceUsers: deps.shouldAllowAllWorkspaceUsers(),
         suggestedPrompts: settings.suggestedPrompts,
         reactionCommands: settings.reactionCommands,
+        getDefaultScope: () => resolveSlackDefaultScope(deps.getSettings(), process.env),
         isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
         rememberKnownThread: (threadTs: string, channelId: string) => {
           broker.db.updateThread(threadTs, { source: "slack", channel: channelId });

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1534,6 +1534,54 @@ describe("SlackAdapter — send", () => {
     });
   });
 
+  it("uses the configured default install scope when metadata is emitted", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+
+    await adapter.send({
+      threadId: "100.200",
+      channel: "C123",
+      text: "Hello",
+      agentName: "TestBot",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const meta = body.metadata as {
+      event_type: string;
+      event_payload: Record<string, unknown>;
+    };
+    expect(meta.event_payload.scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_PRIMARY",
+        installId: "primary",
+        channelId: "C123",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+  });
+
   it("includes agent_owner in metadata when agentOwnerToken is provided", async () => {
     fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -51,6 +51,7 @@ export interface SlackAdapterConfig {
   allowAllWorkspaceUsers?: boolean;
   suggestedPrompts?: { title: string; message: string }[];
   reactionCommands?: ReactionCommandSettings;
+  getDefaultScope?: () => InboundMessage["scope"];
   /** Check whether a thread_ts belongs to a known thread in the broker DB. */
   isKnownThread?: (threadTs: string) => boolean;
   /** Persist thread metadata in the broker DB without claiming ownership. */
@@ -113,6 +114,7 @@ export class SlackAdapter implements MessageAdapter {
       slack: this.callSlack.bind(this),
       botToken: this.config.botToken,
       appToken: this.config.appToken,
+      getDefaultScope: this.config.getDefaultScope,
       dedup: this.processedSocketDeliveries,
       abortAndWait: () => this.slackRequests.abortAndWait(),
       onThreadStarted: (event) => this.onThreadStarted(event),
@@ -198,6 +200,7 @@ export class SlackAdapter implements MessageAdapter {
     return buildSlackThreadRuntimeScope({
       channelId,
       context: this.threads.get(threadTs)?.context ?? null,
+      defaultScope: this.config.getDefaultScope?.() ?? null,
     });
   }
 
@@ -354,6 +357,7 @@ export class SlackAdapter implements MessageAdapter {
         scope: buildSlackThreadRuntimeScope({
           channelId: item.channel,
           context: threadInfo?.context,
+          defaultScope: this.config.getDefaultScope?.() ?? null,
         }),
       });
 
@@ -407,6 +411,7 @@ export class SlackAdapter implements MessageAdapter {
       scope: buildSlackThreadRuntimeScope({
         channelId: channel,
         context: threadInfo?.context,
+        defaultScope: this.config.getDefaultScope?.() ?? null,
       }),
       ...(isChannelMention ? { isChannelMention: true } : {}),
       ...(metadata ? { metadata } : {}),
@@ -453,6 +458,7 @@ export class SlackAdapter implements MessageAdapter {
       scope: buildSlackThreadRuntimeScope({
         channelId: normalized.channel,
         context: threadInfo?.context,
+        defaultScope: this.config.getDefaultScope?.() ?? null,
       }),
     });
   }
@@ -467,7 +473,10 @@ export class SlackAdapter implements MessageAdapter {
       userId: "system",
       text: `Bot was added to channel ${event.channel}`,
       timestamp: String(Date.now() / 1000),
-      scope: buildSlackThreadRuntimeScope({ channelId: event.channel }),
+      scope: buildSlackThreadRuntimeScope({
+        channelId: event.channel,
+        defaultScope: this.config.getDefaultScope?.() ?? null,
+      }),
     });
   }
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -398,11 +398,15 @@ describe("Slack topology helpers", () => {
             {
               installId: "workspace-a",
               workspaceId: "T_WORKSPACE_A",
+              botToken: "xoxb-workspace-a",
+              appToken: "xapp-workspace-a",
               defaultChannel: "C_ALPHA",
             },
             {
               installId: "workspace-b",
               workspaceId: "T_WORKSPACE_B",
+              botToken: "xoxb-workspace-b",
+              appToken: "xapp-workspace-b",
               defaultChannel: "C_BETA",
               logChannel: "C_BETA_LOGS",
             },
@@ -412,9 +416,37 @@ describe("Slack topology helpers", () => {
       ),
     ).toMatchObject({
       defaultInstallId: "workspace-b",
+      botToken: "xoxb-workspace-b",
+      appToken: "xapp-workspace-b",
       defaultChannel: "C_BETA",
       logChannel: "C_BETA_LOGS",
     });
+  });
+
+  it("rejects duplicate normalized explicit install ids", () => {
+    expect(() =>
+      resolveSlackTopology(
+        {
+          installs: [
+            { installId: "primary", workspaceId: "T_PRIMARY" },
+            { installId: " primary ", workspaceId: "T_SECONDARY" },
+          ],
+        },
+        {},
+      ),
+    ).toThrow("Duplicate Slack installId configured: primary");
+  });
+
+  it("rejects an unknown explicit default install id", () => {
+    expect(() =>
+      resolveSlackTopology(
+        {
+          defaultInstallId: "missing-install",
+          installs: [{ installId: "primary", workspaceId: "T_PRIMARY" }],
+        },
+        {},
+      ),
+    ).toThrow("Slack defaultInstallId missing-install does not match any configured install.");
   });
 });
 
@@ -594,6 +626,60 @@ describe("resolveSlackRuntimeSettings", () => {
     expect(settings.logChannel).toBe("C_PRIMARY_LOGS");
     expect(settings.controlPlaneCanvasChannel).toBe("C_PRIMARY_CTRL");
     expect(settings.defaultInstallId).toBe("primary");
+  });
+
+  it("does not fall back to legacy singleton credentials when installs are configured", () => {
+    expect(() =>
+      resolveSlackRuntimeSettings(
+        {
+          defaultInstallId: "workspace-b",
+          botToken: "xoxb-legacy",
+          appToken: "xapp-legacy",
+          defaultChannel: "C_LEGACY",
+          installs: [
+            {
+              installId: "workspace-b",
+              workspaceId: "T_WORKSPACE_B",
+              defaultChannel: "C_BETA",
+            },
+          ],
+        },
+        {
+          ...process.env,
+          SLACK_BOT_TOKEN: "xoxb-env",
+          SLACK_APP_TOKEN: "xapp-env",
+        },
+      ),
+    ).toThrow(
+      "Slack install workspace-b must define both botToken and appToken when installs are configured.",
+    );
+  });
+
+  it("keeps explicit runtime defaults scoped to the selected install", () => {
+    const settings = resolveSlackRuntimeSettings(
+      {
+        defaultInstallId: "workspace-b",
+        defaultChannel: "C_LEGACY",
+        logChannel: "C_LEGACY_LOGS",
+        controlPlaneCanvasChannel: "C_LEGACY_CTRL",
+        installs: [
+          {
+            installId: "workspace-b",
+            workspaceId: "T_WORKSPACE_B",
+            botToken: "xoxb-workspace-b",
+            appToken: "xapp-workspace-b",
+            defaultChannel: "C_BETA",
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(settings.botToken).toBe("xoxb-workspace-b");
+    expect(settings.appToken).toBe("xapp-workspace-b");
+    expect(settings.defaultChannel).toBe("C_BETA");
+    expect(settings.logChannel).toBeUndefined();
+    expect(settings.controlPlaneCanvasChannel).toBeUndefined();
   });
 
   it("retains one-workspace compatibility defaults when installs are omitted", () => {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -4,6 +4,9 @@ import * as path from "node:path";
 import * as os from "node:os";
 import {
   loadSettings,
+  resolveSlackDefaultScope,
+  resolveSlackRuntimeSettings,
+  resolveSlackTopology,
   resolvePinetMeshAuth,
   resolveAllowAllWorkspaceUsers,
   buildAllowlist,
@@ -261,6 +264,158 @@ describe("loadSettings", () => {
     expect(result.controlPlaneCanvasChannel).toBe("ops-control");
     expect(result.controlPlaneCanvasTitle).toBe("Mesh Status");
   });
+
+  it("returns explicit install topology settings", () => {
+    const p = path.join(tmpDir, "settings.json");
+    fs.writeFileSync(
+      p,
+      JSON.stringify({
+        "slack-bridge": {
+          defaultInstallId: "primary",
+          installs: [
+            {
+              installId: "primary",
+              workspaceId: "T_PRIMARY",
+              botToken: "xoxb-primary",
+              appToken: "xapp-primary",
+              defaultChannel: "C_PRIMARY",
+              logChannel: "C_LOGS",
+              controlPlaneCanvasChannel: "C_CTRL",
+              homeTabEnabled: true,
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = loadSettings(p);
+    expect(result.defaultInstallId).toBe("primary");
+    expect(result.installs).toEqual([
+      {
+        installId: "primary",
+        workspaceId: "T_PRIMARY",
+        botToken: "xoxb-primary",
+        appToken: "xapp-primary",
+        defaultChannel: "C_PRIMARY",
+        logChannel: "C_LOGS",
+        controlPlaneCanvasChannel: "C_CTRL",
+        homeTabEnabled: true,
+      },
+    ]);
+  });
+});
+
+describe("Slack topology helpers", () => {
+  it("maps legacy singleton settings into one compatibility install", () => {
+    const topology = resolveSlackTopology(
+      {
+        botToken: " xoxb-legacy ",
+        appToken: " xapp-legacy ",
+        defaultChannel: " C_DEFAULT ",
+        logChannel: " C_LOGS ",
+        controlPlaneCanvasChannel: " C_CONTROL ",
+      },
+      {},
+    );
+
+    expect(topology).toMatchObject({
+      mode: "compatibility-single",
+      defaultInstallId: "default",
+      defaultInstall: {
+        installId: "default",
+        source: "compatibility",
+        defaultChannel: "C_DEFAULT",
+        logChannel: "C_LOGS",
+        controlPlaneCanvasChannel: "C_CONTROL",
+        homeTabEnabled: true,
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "compatibility",
+            compatibilityKey: "default",
+            installId: "default",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      },
+    });
+    expect(resolveSlackDefaultScope({ defaultChannel: "C_DEFAULT" }, {})).toEqual(
+      topology.defaultInstall.scope,
+    );
+  });
+
+  it("keeps explicit install topology distinct and resolves the selected default install", () => {
+    const topology = resolveSlackTopology(
+      {
+        defaultInstallId: "workspace-b",
+        installs: [
+          {
+            installId: "workspace-a",
+            workspaceId: "T_WORKSPACE_A",
+            defaultChannel: "C_ALPHA",
+          },
+          {
+            installId: "workspace-b",
+            workspaceId: "T_WORKSPACE_B",
+            defaultChannel: "C_BETA",
+            logChannel: "C_BETA_LOGS",
+            controlPlaneCanvasChannel: "C_BETA_CONTROL",
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(topology).toMatchObject({
+      mode: "explicit-multi",
+      defaultInstallId: "workspace-b",
+      defaultInstall: {
+        installId: "workspace-b",
+        source: "explicit",
+        workspaceId: "T_WORKSPACE_B",
+        defaultChannel: "C_BETA",
+        logChannel: "C_BETA_LOGS",
+        controlPlaneCanvasChannel: "C_BETA_CONTROL",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_WORKSPACE_B",
+            installId: "workspace-b",
+          },
+        },
+      },
+    });
+
+    expect(
+      resolveSlackRuntimeSettings(
+        {
+          defaultInstallId: "workspace-b",
+          installs: [
+            {
+              installId: "workspace-a",
+              workspaceId: "T_WORKSPACE_A",
+              defaultChannel: "C_ALPHA",
+            },
+            {
+              installId: "workspace-b",
+              workspaceId: "T_WORKSPACE_B",
+              defaultChannel: "C_BETA",
+              logChannel: "C_BETA_LOGS",
+            },
+          ],
+        },
+        {},
+      ),
+    ).toMatchObject({
+      defaultInstallId: "workspace-b",
+      defaultChannel: "C_BETA",
+      logChannel: "C_BETA_LOGS",
+    });
+  });
 });
 
 describe("resolvePinetMeshAuth", () => {
@@ -315,6 +470,160 @@ describe("resolvePinetMeshAuth", () => {
     ).toEqual({
       meshSecret: null,
       meshSecretPath: "/settings/secret",
+    });
+  });
+});
+
+describe("resolveSlackTopology", () => {
+  it("maps singleton settings into one default compatibility install", () => {
+    const topology = resolveSlackTopology(
+      {
+        botToken: "xoxb-single",
+        appToken: "xapp-single",
+        defaultChannel: "C_DEFAULT",
+        logChannel: "C_LOGS",
+        controlPlaneCanvasChannel: "C_CTRL",
+      },
+      {},
+    );
+
+    expect(topology.mode).toBe("compatibility-single");
+    expect(topology.defaultInstallId).toBe("default");
+    expect(topology.installs).toHaveLength(1);
+    expect(topology.defaultInstall).toMatchObject({
+      installId: "default",
+      source: "compatibility",
+      botToken: "xoxb-single",
+      appToken: "xapp-single",
+      defaultChannel: "C_DEFAULT",
+      logChannel: "C_LOGS",
+      controlPlaneCanvasChannel: "C_CTRL",
+      homeTabEnabled: true,
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          installId: "default",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    });
+  });
+
+  it("keeps explicit install topology and selects the configured default install", () => {
+    const topology = resolveSlackTopology(
+      {
+        defaultInstallId: "workspace-b",
+        installs: [
+          {
+            installId: "workspace-a",
+            workspaceId: "T_A",
+            botToken: "xoxb-a",
+            appToken: "xapp-a",
+            defaultChannel: "C_A",
+          },
+          {
+            installId: "workspace-b",
+            workspaceId: "T_B",
+            botToken: "xoxb-b",
+            appToken: "xapp-b",
+            defaultChannel: "C_B",
+            logChannel: "C_B_LOGS",
+            controlPlaneCanvasChannel: "C_B_CTRL",
+            homeTabEnabled: false,
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(topology.mode).toBe("explicit-multi");
+    expect(topology.defaultInstallId).toBe("workspace-b");
+    expect(topology.defaultInstall).toMatchObject({
+      installId: "workspace-b",
+      workspaceId: "T_B",
+      source: "explicit",
+      defaultChannel: "C_B",
+      logChannel: "C_B_LOGS",
+      controlPlaneCanvasChannel: "C_B_CTRL",
+      homeTabEnabled: false,
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_B",
+          installId: "workspace-b",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    });
+  });
+});
+
+describe("resolveSlackRuntimeSettings", () => {
+  it("projects the selected default install into the singleton runtime settings", () => {
+    const settings = resolveSlackRuntimeSettings(
+      {
+        defaultInstallId: "primary",
+        installs: [
+          {
+            installId: "primary",
+            workspaceId: "T_PRIMARY",
+            botToken: "xoxb-primary",
+            appToken: "xapp-primary",
+            defaultChannel: "C_PRIMARY",
+            logChannel: "C_PRIMARY_LOGS",
+            controlPlaneCanvasChannel: "C_PRIMARY_CTRL",
+            homeTabEnabled: true,
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(settings.botToken).toBe("xoxb-primary");
+    expect(settings.appToken).toBe("xapp-primary");
+    expect(settings.defaultChannel).toBe("C_PRIMARY");
+    expect(settings.logChannel).toBe("C_PRIMARY_LOGS");
+    expect(settings.controlPlaneCanvasChannel).toBe("C_PRIMARY_CTRL");
+    expect(settings.defaultInstallId).toBe("primary");
+  });
+
+  it("retains one-workspace compatibility defaults when installs are omitted", () => {
+    const settings = resolveSlackRuntimeSettings(
+      {
+        defaultChannel: "C_LEGACY",
+        logChannel: "C_LOGS",
+      },
+      {
+        ...process.env,
+        SLACK_BOT_TOKEN: "xoxb-env",
+        SLACK_APP_TOKEN: "xapp-env",
+      },
+    );
+
+    expect(settings.botToken).toBe("xoxb-env");
+    expect(settings.appToken).toBe("xapp-env");
+    expect(settings.defaultChannel).toBe("C_LEGACY");
+    expect(settings.logChannel).toBe("C_LOGS");
+    expect(resolveSlackDefaultScope(settings, {})).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        installId: "default",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
     });
   });
 });
@@ -3585,7 +3894,16 @@ describe("scope compatibility helpers", () => {
       capabilities: {
         repo: "extensions",
         role: "worker",
-        scope: buildSlackCompatibilityScope({ teamId: "T123", channelId: "C123" }),
+        scope: buildSlackCompatibilityScope({
+          teamId: "T123",
+          channelId: "C123",
+          installId: "install-primary",
+        }),
+        topology: {
+          mode: "explicit-multi",
+          installCount: 2,
+          defaultInstallId: "install-primary",
+        },
       },
     });
 
@@ -3595,6 +3913,7 @@ describe("scope compatibility helpers", () => {
         source: "compatibility",
         compatibilityKey: "default",
         workspaceId: "T123",
+        installId: "install-primary",
         channelId: "C123",
       },
       instance: {
@@ -3602,8 +3921,21 @@ describe("scope compatibility helpers", () => {
         compatibilityKey: "default",
       },
     });
+    expect(capabilities.topology).toEqual({
+      mode: "explicit-multi",
+      installCount: 2,
+      defaultInstallId: "install-primary",
+    });
     expect(buildAgentCapabilityTags(capabilities)).toEqual(
-      expect.arrayContaining(["scope-provider:slack", "scope:default", "workspace:T123"]),
+      expect.arrayContaining([
+        "scope-provider:slack",
+        "scope:default",
+        "workspace:T123",
+        "install:install-primary",
+        "topology-mode:explicit-multi",
+        "topology-installs:2",
+        "topology-default:install-primary",
+      ]),
     );
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -2,15 +2,35 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+  DEFAULT_COMPATIBILITY_SCOPE_KEY,
   buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope,
   buildRuntimeScopeCarrier,
   type RuntimeScopeCarrier,
+  type RuntimeScopeSource,
+  type WorkspaceInstallScopeCarrier,
 } from "@gugu910/pi-transport-core";
 import type { ReactionCommandSettings } from "./reaction-triggers.js";
 import { matchesToolPattern } from "./guardrails.js";
 
 // ─── Settings ────────────────────────────────────────────
+
+export interface SlackInstallTopologySettings {
+  installId?: string;
+  workspaceId?: string;
+  botToken?: string;
+  appToken?: string;
+  appId?: string;
+  appConfigToken?: string;
+  defaultChannel?: string;
+  logChannel?: string;
+  logLevel?: "errors" | "actions" | "verbose";
+  controlPlaneCanvasEnabled?: boolean;
+  controlPlaneCanvasId?: string;
+  controlPlaneCanvasChannel?: string;
+  controlPlaneCanvasTitle?: string;
+  homeTabEnabled?: boolean;
+}
 
 export interface SlackBridgeSettings {
   botToken?: string;
@@ -22,6 +42,8 @@ export interface SlackBridgeSettings {
   defaultChannel?: string;
   logChannel?: string;
   logLevel?: "errors" | "actions" | "verbose";
+  defaultInstallId?: string;
+  installs?: SlackInstallTopologySettings[];
   suggestedPrompts?: { title: string; message: string }[];
   reactionCommands?: ReactionCommandSettings;
   runtimeMode?: "off" | "single" | "broker" | "follower";
@@ -45,6 +67,40 @@ export interface SlackBridgeSettings {
   };
 }
 
+export interface ResolvedSlackInstallTopology {
+  installId: string;
+  source: RuntimeScopeSource;
+  workspaceId?: string;
+  botToken?: string;
+  appToken?: string;
+  appId?: string;
+  appConfigToken?: string;
+  defaultChannel?: string;
+  logChannel?: string;
+  logLevel?: "errors" | "actions" | "verbose";
+  controlPlaneCanvasEnabled?: boolean;
+  controlPlaneCanvasId?: string;
+  controlPlaneCanvasChannel?: string;
+  controlPlaneCanvasTitle?: string;
+  homeTabEnabled: boolean;
+  scope: RuntimeScopeCarrier;
+}
+
+export type SlackTopologyMode = "compatibility-single" | "explicit-single" | "explicit-multi";
+
+export interface ResolvedSlackTopology {
+  mode: SlackTopologyMode;
+  installs: ResolvedSlackInstallTopology[];
+  defaultInstallId: string;
+  defaultInstall: ResolvedSlackInstallTopology;
+}
+
+export interface SlackTopologySummary {
+  mode: SlackTopologyMode;
+  installCount: number;
+  defaultInstallId: string;
+}
+
 export interface ResolvedPinetMeshAuthSettings {
   meshSecret: string | null;
   meshSecretPath: string | null;
@@ -53,6 +109,68 @@ export interface ResolvedPinetMeshAuthSettings {
 function normalizeOptionalSetting(value?: string | null): string | null {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function buildSlackWorkspaceScope(
+  options: {
+    source?: RuntimeScopeSource;
+    workspaceId?: string | null;
+    installId?: string | null;
+    channelId?: string | null;
+    compatibilityKey?: string | null;
+  } = {},
+): WorkspaceInstallScopeCarrier {
+  const source = options.source === "explicit" ? "explicit" : "compatibility";
+  if (source === "compatibility") {
+    return buildCompatibilityWorkspaceScope({
+      provider: "slack",
+      workspaceId: normalizeOptionalSetting(options.workspaceId) ?? undefined,
+      installId: normalizeOptionalSetting(options.installId) ?? undefined,
+      channelId: normalizeOptionalSetting(options.channelId) ?? undefined,
+      compatibilityKey: normalizeOptionalSetting(options.compatibilityKey) ?? undefined,
+    });
+  }
+
+  return {
+    provider: "slack",
+    source: "explicit",
+    ...(normalizeOptionalSetting(options.workspaceId)
+      ? { workspaceId: normalizeOptionalSetting(options.workspaceId) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(options.installId)
+      ? { installId: normalizeOptionalSetting(options.installId) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(options.channelId)
+      ? { channelId: normalizeOptionalSetting(options.channelId) ?? undefined }
+      : {}),
+  };
+}
+
+export function buildSlackScope(
+  options: {
+    source?: RuntimeScopeSource;
+    teamId?: string | null;
+    workspaceId?: string | null;
+    channelId?: string | null;
+    installId?: string | null;
+    compatibilityKey?: string | null;
+    instanceId?: string | null;
+    instanceName?: string | null;
+  } = {},
+): RuntimeScopeCarrier {
+  return buildRuntimeScopeCarrier({
+    workspace: buildSlackWorkspaceScope({
+      source: options.source,
+      workspaceId: normalizeOptionalSetting(options.workspaceId ?? options.teamId) ?? undefined,
+      installId: normalizeOptionalSetting(options.installId) ?? undefined,
+      channelId: normalizeOptionalSetting(options.channelId) ?? undefined,
+      compatibilityKey: normalizeOptionalSetting(options.compatibilityKey) ?? undefined,
+    }),
+    instance: buildCompatibilityInstanceScope({
+      instanceId: normalizeOptionalSetting(options.instanceId) ?? undefined,
+      instanceName: normalizeOptionalSetting(options.instanceName) ?? undefined,
+    }),
+  })!;
 }
 
 export function buildSlackCompatibilityScope(
@@ -64,18 +182,270 @@ export function buildSlackCompatibilityScope(
     instanceName?: string | null;
   } = {},
 ): RuntimeScopeCarrier {
+  return buildSlackScope({
+    source: "compatibility",
+    teamId: options.teamId,
+    channelId: options.channelId,
+    installId: options.installId,
+    instanceId: options.instanceId,
+    instanceName: options.instanceName,
+  });
+}
+
+export function buildSlackThreadScope(
+  options: {
+    baseScope?: RuntimeScopeCarrier | null;
+    teamId?: string | null;
+    channelId?: string | null;
+  } = {},
+): RuntimeScopeCarrier {
+  const workspace = options.baseScope?.workspace;
+  const source = workspace?.source === "explicit" ? "explicit" : "compatibility";
+
   return buildRuntimeScopeCarrier({
-    workspace: buildCompatibilityWorkspaceScope({
-      provider: "slack",
-      workspaceId: normalizeOptionalSetting(options.teamId) ?? undefined,
-      installId: normalizeOptionalSetting(options.installId) ?? undefined,
-      channelId: normalizeOptionalSetting(options.channelId) ?? undefined,
+    workspace: buildSlackWorkspaceScope({
+      source,
+      workspaceId: normalizeOptionalSetting(options.teamId) ?? workspace?.workspaceId,
+      installId: workspace?.installId,
+      channelId: normalizeOptionalSetting(options.channelId) ?? workspace?.channelId,
+      compatibilityKey:
+        source === "compatibility"
+          ? (workspace?.compatibilityKey ?? DEFAULT_COMPATIBILITY_SCOPE_KEY)
+          : undefined,
     }),
-    instance: buildCompatibilityInstanceScope({
-      instanceId: normalizeOptionalSetting(options.instanceId) ?? undefined,
-      instanceName: normalizeOptionalSetting(options.instanceName) ?? undefined,
-    }),
+    instance: options.baseScope?.instance ?? buildCompatibilityInstanceScope(),
   })!;
+}
+
+function normalizeSlackInstallId(install: SlackInstallTopologySettings, index: number): string {
+  return (
+    normalizeOptionalSetting(install.installId) ??
+    normalizeOptionalSetting(install.workspaceId) ??
+    `install-${index + 1}`
+  );
+}
+
+function resolveCompatibilityInstall(
+  settings: SlackBridgeSettings,
+  env = process.env,
+): ResolvedSlackInstallTopology {
+  return {
+    installId: DEFAULT_COMPATIBILITY_SCOPE_KEY,
+    source: "compatibility",
+    ...((normalizeOptionalSetting(settings.botToken) ??
+    normalizeOptionalSetting(env.SLACK_BOT_TOKEN))
+      ? {
+          botToken:
+            normalizeOptionalSetting(settings.botToken) ??
+            normalizeOptionalSetting(env.SLACK_BOT_TOKEN) ??
+            undefined,
+        }
+      : {}),
+    ...((normalizeOptionalSetting(settings.appToken) ??
+    normalizeOptionalSetting(env.SLACK_APP_TOKEN))
+      ? {
+          appToken:
+            normalizeOptionalSetting(settings.appToken) ??
+            normalizeOptionalSetting(env.SLACK_APP_TOKEN) ??
+            undefined,
+        }
+      : {}),
+    ...(normalizeOptionalSetting(settings.appId)
+      ? { appId: normalizeOptionalSetting(settings.appId) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(settings.appConfigToken)
+      ? { appConfigToken: normalizeOptionalSetting(settings.appConfigToken) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(settings.defaultChannel)
+      ? { defaultChannel: normalizeOptionalSetting(settings.defaultChannel) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(settings.logChannel)
+      ? { logChannel: normalizeOptionalSetting(settings.logChannel) ?? undefined }
+      : {}),
+    ...(settings.logLevel ? { logLevel: settings.logLevel } : {}),
+    ...(typeof settings.controlPlaneCanvasEnabled === "boolean"
+      ? { controlPlaneCanvasEnabled: settings.controlPlaneCanvasEnabled }
+      : {}),
+    ...(normalizeOptionalSetting(settings.controlPlaneCanvasId)
+      ? {
+          controlPlaneCanvasId:
+            normalizeOptionalSetting(settings.controlPlaneCanvasId) ?? undefined,
+        }
+      : {}),
+    ...(normalizeOptionalSetting(settings.controlPlaneCanvasChannel)
+      ? {
+          controlPlaneCanvasChannel:
+            normalizeOptionalSetting(settings.controlPlaneCanvasChannel) ?? undefined,
+        }
+      : {}),
+    ...(normalizeOptionalSetting(settings.controlPlaneCanvasTitle)
+      ? {
+          controlPlaneCanvasTitle:
+            normalizeOptionalSetting(settings.controlPlaneCanvasTitle) ?? undefined,
+        }
+      : {}),
+    homeTabEnabled: true,
+    scope: buildSlackScope({
+      source: "compatibility",
+      installId: DEFAULT_COMPATIBILITY_SCOPE_KEY,
+      compatibilityKey: DEFAULT_COMPATIBILITY_SCOPE_KEY,
+    }),
+  };
+}
+
+function resolveExplicitInstall(
+  install: SlackInstallTopologySettings,
+  index: number,
+): ResolvedSlackInstallTopology {
+  const installId = normalizeSlackInstallId(install, index);
+  const workspaceId = normalizeOptionalSetting(install.workspaceId) ?? undefined;
+
+  return {
+    installId,
+    source: "explicit",
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(normalizeOptionalSetting(install.botToken)
+      ? { botToken: normalizeOptionalSetting(install.botToken) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(install.appToken)
+      ? { appToken: normalizeOptionalSetting(install.appToken) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(install.appId)
+      ? { appId: normalizeOptionalSetting(install.appId) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(install.appConfigToken)
+      ? { appConfigToken: normalizeOptionalSetting(install.appConfigToken) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(install.defaultChannel)
+      ? { defaultChannel: normalizeOptionalSetting(install.defaultChannel) ?? undefined }
+      : {}),
+    ...(normalizeOptionalSetting(install.logChannel)
+      ? { logChannel: normalizeOptionalSetting(install.logChannel) ?? undefined }
+      : {}),
+    ...(install.logLevel ? { logLevel: install.logLevel } : {}),
+    ...(typeof install.controlPlaneCanvasEnabled === "boolean"
+      ? { controlPlaneCanvasEnabled: install.controlPlaneCanvasEnabled }
+      : {}),
+    ...(normalizeOptionalSetting(install.controlPlaneCanvasId)
+      ? {
+          controlPlaneCanvasId: normalizeOptionalSetting(install.controlPlaneCanvasId) ?? undefined,
+        }
+      : {}),
+    ...(normalizeOptionalSetting(install.controlPlaneCanvasChannel)
+      ? {
+          controlPlaneCanvasChannel:
+            normalizeOptionalSetting(install.controlPlaneCanvasChannel) ?? undefined,
+        }
+      : {}),
+    ...(normalizeOptionalSetting(install.controlPlaneCanvasTitle)
+      ? {
+          controlPlaneCanvasTitle:
+            normalizeOptionalSetting(install.controlPlaneCanvasTitle) ?? undefined,
+        }
+      : {}),
+    homeTabEnabled: install.homeTabEnabled ?? true,
+    scope: buildSlackScope({
+      source: "explicit",
+      workspaceId,
+      installId,
+    }),
+  };
+}
+
+export function resolveSlackTopology(
+  settings: SlackBridgeSettings,
+  env = process.env,
+): ResolvedSlackTopology {
+  const explicitInstalls = (settings.installs ?? []).filter(
+    (install) => install && typeof install === "object",
+  );
+  if (explicitInstalls.length === 0) {
+    const defaultInstall = resolveCompatibilityInstall(settings, env);
+    return {
+      mode: "compatibility-single",
+      installs: [defaultInstall],
+      defaultInstallId: defaultInstall.installId,
+      defaultInstall,
+    };
+  }
+
+  const installs = explicitInstalls.map((install, index) => resolveExplicitInstall(install, index));
+  const configuredDefaultInstallId = normalizeOptionalSetting(settings.defaultInstallId);
+  const defaultInstall =
+    installs.find((install) => install.installId === configuredDefaultInstallId) ?? installs[0]!;
+
+  return {
+    mode: installs.length === 1 ? "explicit-single" : "explicit-multi",
+    installs,
+    defaultInstallId: defaultInstall.installId,
+    defaultInstall,
+  };
+}
+
+export function summarizeSlackTopology(topology: ResolvedSlackTopology): SlackTopologySummary {
+  return {
+    mode: topology.mode,
+    installCount: topology.installs.length,
+    defaultInstallId: topology.defaultInstallId,
+  };
+}
+
+export function resolveSlackDefaultScope(
+  settings: SlackBridgeSettings,
+  env = process.env,
+): RuntimeScopeCarrier {
+  return resolveSlackTopology(settings, env).defaultInstall.scope;
+}
+
+export function resolveSlackRuntimeSettings(
+  settings: SlackBridgeSettings,
+  env = process.env,
+): SlackBridgeSettings {
+  const topology = resolveSlackTopology(settings, env);
+  const defaultInstall = topology.defaultInstall;
+
+  return {
+    ...settings,
+    defaultInstallId: topology.defaultInstallId,
+    botToken:
+      defaultInstall.botToken ??
+      normalizeOptionalSetting(settings.botToken) ??
+      normalizeOptionalSetting(env.SLACK_BOT_TOKEN) ??
+      undefined,
+    appToken:
+      defaultInstall.appToken ??
+      normalizeOptionalSetting(settings.appToken) ??
+      normalizeOptionalSetting(env.SLACK_APP_TOKEN) ??
+      undefined,
+    appId: defaultInstall.appId ?? normalizeOptionalSetting(settings.appId) ?? undefined,
+    appConfigToken:
+      defaultInstall.appConfigToken ??
+      normalizeOptionalSetting(settings.appConfigToken) ??
+      undefined,
+    defaultChannel:
+      defaultInstall.defaultChannel ??
+      normalizeOptionalSetting(settings.defaultChannel) ??
+      undefined,
+    logChannel:
+      defaultInstall.logChannel ?? normalizeOptionalSetting(settings.logChannel) ?? undefined,
+    logLevel: defaultInstall.logLevel ?? settings.logLevel,
+    controlPlaneCanvasEnabled:
+      typeof defaultInstall.controlPlaneCanvasEnabled === "boolean"
+        ? defaultInstall.controlPlaneCanvasEnabled
+        : settings.controlPlaneCanvasEnabled,
+    controlPlaneCanvasId:
+      defaultInstall.controlPlaneCanvasId ??
+      normalizeOptionalSetting(settings.controlPlaneCanvasId) ??
+      undefined,
+    controlPlaneCanvasChannel:
+      defaultInstall.controlPlaneCanvasChannel ??
+      normalizeOptionalSetting(settings.controlPlaneCanvasChannel) ??
+      undefined,
+    controlPlaneCanvasTitle:
+      defaultInstall.controlPlaneCanvasTitle ??
+      normalizeOptionalSetting(settings.controlPlaneCanvasTitle) ??
+      undefined,
+  };
 }
 
 export function resolvePinetMeshAuth(
@@ -797,6 +1167,7 @@ export interface AgentCapabilities {
   tools?: string[];
   tags?: string[];
   scope?: RuntimeScopeCarrier | null;
+  topology?: SlackTopologySummary | null;
 }
 
 export type AgentHealth = "healthy" | "stale" | "ghost" | "resumable";
@@ -883,6 +1254,34 @@ function asStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const strings = value.map(asString).filter((item): item is string => Boolean(item));
   return strings.length > 0 ? strings : undefined;
+}
+
+function asSlackTopologyMode(value: unknown): SlackTopologyMode | undefined {
+  return value === "compatibility-single" ||
+    value === "explicit-single" ||
+    value === "explicit-multi"
+    ? value
+    : undefined;
+}
+
+function extractSlackTopologySummary(value: unknown): SlackTopologySummary | null {
+  const record = asRecord(value);
+  const mode = asSlackTopologyMode(record?.mode);
+  if (!record || !mode) {
+    return null;
+  }
+
+  const installCountRaw = record.installCount;
+  const installCount =
+    typeof installCountRaw === "number" && Number.isFinite(installCountRaw)
+      ? Math.max(0, Math.trunc(installCountRaw))
+      : 0;
+
+  return {
+    mode,
+    installCount,
+    defaultInstallId: asString(record.defaultInstallId) ?? DEFAULT_COMPATIBILITY_SCOPE_KEY,
+  };
 }
 
 function extractRuntimeScopeCarrier(value: unknown): RuntimeScopeCarrier | null {
@@ -1011,6 +1410,7 @@ export function extractAgentCapabilities(
     tools: asStringArray(capabilitiesRecord?.tools),
     tags: asStringArray(capabilitiesRecord?.tags),
     scope: extractRuntimeScopeCarrier(capabilitiesRecord?.scope ?? record?.scope),
+    topology: extractSlackTopologySummary(capabilitiesRecord?.topology ?? record?.topology),
   };
 }
 
@@ -1029,11 +1429,19 @@ export function buildAgentCapabilityTags(capabilities: AgentCapabilities): strin
   if (capabilities.scope?.workspace?.workspaceId) {
     tags.add(`workspace:${capabilities.scope.workspace.workspaceId}`);
   }
+  if (capabilities.scope?.workspace?.installId) {
+    tags.add(`install:${capabilities.scope.workspace.installId}`);
+  }
   if (capabilities.scope?.instance?.instanceId) {
     tags.add(`instance:${capabilities.scope.instance.instanceId}`);
   }
   if (capabilities.scope?.instance?.instanceName) {
     tags.add(`instance-name:${capabilities.scope.instance.instanceName}`);
+  }
+  if (capabilities.topology?.mode) {
+    tags.add(`topology-mode:${capabilities.topology.mode}`);
+    tags.add(`topology-installs:${capabilities.topology.installCount}`);
+    tags.add(`topology-default:${capabilities.topology.defaultInstallId}`);
   }
   for (const tool of capabilities.tools ?? []) {
     tags.add(`tool:${tool}`);

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -200,13 +200,20 @@ export function buildSlackThreadScope(
   } = {},
 ): RuntimeScopeCarrier {
   const workspace = options.baseScope?.workspace;
-  const source = workspace?.source === "explicit" ? "explicit" : "compatibility";
+  const baseSource = workspace?.source === "explicit" ? "explicit" : "compatibility";
+  const liveWorkspaceId = normalizeOptionalSetting(options.teamId);
+  const hasExplicitWorkspaceDrift =
+    baseSource === "explicit" &&
+    Boolean(liveWorkspaceId) &&
+    Boolean(workspace?.workspaceId) &&
+    workspace?.workspaceId !== liveWorkspaceId;
+  const source = hasExplicitWorkspaceDrift ? "compatibility" : baseSource;
 
   return buildRuntimeScopeCarrier({
     workspace: buildSlackWorkspaceScope({
       source,
-      workspaceId: normalizeOptionalSetting(options.teamId) ?? workspace?.workspaceId,
-      installId: workspace?.installId,
+      workspaceId: liveWorkspaceId ?? workspace?.workspaceId,
+      installId: source === "explicit" ? workspace?.installId : undefined,
       channelId: normalizeOptionalSetting(options.channelId) ?? workspace?.channelId,
       compatibilityKey:
         source === "compatibility"
@@ -223,6 +230,26 @@ function normalizeSlackInstallId(install: SlackInstallTopologySettings, index: n
     normalizeOptionalSetting(install.workspaceId) ??
     `install-${index + 1}`
   );
+}
+
+function validateExplicitSlackInstalls(
+  installs: ReadonlyArray<ResolvedSlackInstallTopology>,
+  configuredDefaultInstallId: string | null,
+): void {
+  const seenInstallIds = new Set<string>();
+
+  for (const install of installs) {
+    if (seenInstallIds.has(install.installId)) {
+      throw new Error(`Duplicate Slack installId configured: ${install.installId}`);
+    }
+    seenInstallIds.add(install.installId);
+  }
+
+  if (configuredDefaultInstallId && !seenInstallIds.has(configuredDefaultInstallId)) {
+    throw new Error(
+      `Slack defaultInstallId ${configuredDefaultInstallId} does not match any configured install.`,
+    );
+  }
 }
 
 function resolveCompatibilityInstall(
@@ -371,6 +398,7 @@ export function resolveSlackTopology(
 
   const installs = explicitInstalls.map((install, index) => resolveExplicitInstall(install, index));
   const configuredDefaultInstallId = normalizeOptionalSetting(settings.defaultInstallId);
+  validateExplicitSlackInstalls(installs, configuredDefaultInstallId);
   const defaultInstall =
     installs.find((install) => install.installId === configuredDefaultInstallId) ?? installs[0]!;
 
@@ -404,47 +432,74 @@ export function resolveSlackRuntimeSettings(
   const topology = resolveSlackTopology(settings, env);
   const defaultInstall = topology.defaultInstall;
 
+  if (topology.mode === "compatibility-single") {
+    return {
+      ...settings,
+      defaultInstallId: topology.defaultInstallId,
+      botToken:
+        defaultInstall.botToken ??
+        normalizeOptionalSetting(settings.botToken) ??
+        normalizeOptionalSetting(env.SLACK_BOT_TOKEN) ??
+        undefined,
+      appToken:
+        defaultInstall.appToken ??
+        normalizeOptionalSetting(settings.appToken) ??
+        normalizeOptionalSetting(env.SLACK_APP_TOKEN) ??
+        undefined,
+      appId: defaultInstall.appId ?? normalizeOptionalSetting(settings.appId) ?? undefined,
+      appConfigToken:
+        defaultInstall.appConfigToken ??
+        normalizeOptionalSetting(settings.appConfigToken) ??
+        undefined,
+      defaultChannel:
+        defaultInstall.defaultChannel ??
+        normalizeOptionalSetting(settings.defaultChannel) ??
+        undefined,
+      logChannel:
+        defaultInstall.logChannel ?? normalizeOptionalSetting(settings.logChannel) ?? undefined,
+      logLevel: defaultInstall.logLevel ?? settings.logLevel,
+      controlPlaneCanvasEnabled:
+        typeof defaultInstall.controlPlaneCanvasEnabled === "boolean"
+          ? defaultInstall.controlPlaneCanvasEnabled
+          : settings.controlPlaneCanvasEnabled,
+      controlPlaneCanvasId:
+        defaultInstall.controlPlaneCanvasId ??
+        normalizeOptionalSetting(settings.controlPlaneCanvasId) ??
+        undefined,
+      controlPlaneCanvasChannel:
+        defaultInstall.controlPlaneCanvasChannel ??
+        normalizeOptionalSetting(settings.controlPlaneCanvasChannel) ??
+        undefined,
+      controlPlaneCanvasTitle:
+        defaultInstall.controlPlaneCanvasTitle ??
+        normalizeOptionalSetting(settings.controlPlaneCanvasTitle) ??
+        undefined,
+    };
+  }
+
+  if (!defaultInstall.botToken || !defaultInstall.appToken) {
+    throw new Error(
+      `Slack install ${defaultInstall.installId} must define both botToken and appToken when installs are configured.`,
+    );
+  }
+
   return {
     ...settings,
     defaultInstallId: topology.defaultInstallId,
-    botToken:
-      defaultInstall.botToken ??
-      normalizeOptionalSetting(settings.botToken) ??
-      normalizeOptionalSetting(env.SLACK_BOT_TOKEN) ??
-      undefined,
-    appToken:
-      defaultInstall.appToken ??
-      normalizeOptionalSetting(settings.appToken) ??
-      normalizeOptionalSetting(env.SLACK_APP_TOKEN) ??
-      undefined,
-    appId: defaultInstall.appId ?? normalizeOptionalSetting(settings.appId) ?? undefined,
-    appConfigToken:
-      defaultInstall.appConfigToken ??
-      normalizeOptionalSetting(settings.appConfigToken) ??
-      undefined,
-    defaultChannel:
-      defaultInstall.defaultChannel ??
-      normalizeOptionalSetting(settings.defaultChannel) ??
-      undefined,
-    logChannel:
-      defaultInstall.logChannel ?? normalizeOptionalSetting(settings.logChannel) ?? undefined,
+    botToken: defaultInstall.botToken,
+    appToken: defaultInstall.appToken,
+    appId: defaultInstall.appId,
+    appConfigToken: defaultInstall.appConfigToken,
+    defaultChannel: defaultInstall.defaultChannel,
+    logChannel: defaultInstall.logChannel,
     logLevel: defaultInstall.logLevel ?? settings.logLevel,
     controlPlaneCanvasEnabled:
       typeof defaultInstall.controlPlaneCanvasEnabled === "boolean"
         ? defaultInstall.controlPlaneCanvasEnabled
         : settings.controlPlaneCanvasEnabled,
-    controlPlaneCanvasId:
-      defaultInstall.controlPlaneCanvasId ??
-      normalizeOptionalSetting(settings.controlPlaneCanvasId) ??
-      undefined,
-    controlPlaneCanvasChannel:
-      defaultInstall.controlPlaneCanvasChannel ??
-      normalizeOptionalSetting(settings.controlPlaneCanvasChannel) ??
-      undefined,
-    controlPlaneCanvasTitle:
-      defaultInstall.controlPlaneCanvasTitle ??
-      normalizeOptionalSetting(settings.controlPlaneCanvasTitle) ??
-      undefined,
+    controlPlaneCanvasId: defaultInstall.controlPlaneCanvasId,
+    controlPlaneCanvasChannel: defaultInstall.controlPlaneCanvasChannel,
+    controlPlaneCanvasTitle: defaultInstall.controlPlaneCanvasTitle,
   };
 }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -13,6 +13,8 @@ import {
   resolveBrokerStableId,
   resolveAgentStableId,
   resolveAllowAllWorkspaceUsers,
+  resolveSlackDefaultScope,
+  resolveSlackRuntimeSettings,
   trackBrokerInboundThread,
 } from "./helpers.js";
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
@@ -82,10 +84,10 @@ import {
 // Settings and helpers imported from ./helpers.js
 
 export default function (pi: ExtensionAPI) {
-  let settings = loadSettingsFromFile();
+  let settings = resolveSlackRuntimeSettings(loadSettingsFromFile(), process.env);
 
-  let botToken = settings.botToken ?? process.env.SLACK_BOT_TOKEN;
-  let appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
+  let botToken = settings.botToken;
+  let appToken = settings.appToken;
 
   if (!botToken || !appToken) return;
 
@@ -583,6 +585,7 @@ export default function (pi: ExtensionAPI) {
     getAgentAliases: () => agentAliases,
     getAgentOwnerToken: () => agentOwnerToken,
     getBotUserId: () => botUserId,
+    getDefaultScope: () => resolveSlackDefaultScope(settings, process.env),
     getThreads: () => threads,
     getPendingEyes: () => pendingEyes,
     getUnclaimedThreads: () => unclaimedThreads,

--- a/slack-bridge/runtime-agent-context.test.ts
+++ b/slack-bridge/runtime-agent-context.test.ts
@@ -469,11 +469,17 @@ describe("createRuntimeAgentContext", () => {
       role: "broker",
       skinTheme: "midnight",
       personality: "observant",
+      topology: {
+        mode: "compatibility-single",
+        installCount: 1,
+        defaultInstallId: "default",
+      },
       scope: {
         workspace: {
           provider: "slack",
           source: "compatibility",
           compatibilityKey: "default",
+          installId: "default",
         },
         instance: {
           source: "compatibility",
@@ -484,11 +490,17 @@ describe("createRuntimeAgentContext", () => {
     expect(metadata.capabilities).toMatchObject({
       role: "broker",
       tools: ["build", "git", "lint", "test", "typecheck"],
+      topology: {
+        mode: "compatibility-single",
+        installCount: 1,
+        defaultInstallId: "default",
+      },
       scope: {
         workspace: {
           provider: "slack",
           source: "compatibility",
           compatibilityKey: "default",
+          installId: "default",
         },
         instance: {
           source: "compatibility",
@@ -499,6 +511,10 @@ describe("createRuntimeAgentContext", () => {
         "role:broker",
         "repo:extensions",
         "branch:feat/runtime-agent-context",
+        "install:default",
+        "topology-mode:compatibility-single",
+        "topology-installs:1",
+        "topology-default:default",
         "tool:build",
         "tool:git",
         "tool:lint",
@@ -508,6 +524,64 @@ describe("createRuntimeAgentContext", () => {
     });
 
     fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("uses the selected explicit install topology in agent metadata", async () => {
+    const { deps } = createDeps({
+      state: {
+        settings: {
+          defaultInstallId: "primary",
+          installs: [
+            {
+              installId: "primary",
+              workspaceId: "T_PRIMARY",
+              botToken: "xoxb-primary",
+              appToken: "xapp-primary",
+              defaultChannel: "C_PRIMARY",
+            },
+          ],
+        },
+      },
+      gitContext: {
+        cwd: process.cwd(),
+        repo: "extensions",
+        repoRoot: process.cwd(),
+        branch: "feat/runtime-agent-context-topology",
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    const metadata = await runtimeAgentContext.getAgentMetadata("worker");
+
+    expect(metadata).toMatchObject({
+      topology: {
+        mode: "explicit-single",
+        installCount: 1,
+        defaultInstallId: "primary",
+      },
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+      },
+    });
+    expect(metadata.capabilities).toMatchObject({
+      topology: {
+        mode: "explicit-single",
+        installCount: 1,
+        defaultInstallId: "primary",
+      },
+      tags: expect.arrayContaining([
+        "workspace:T_PRIMARY",
+        "install:primary",
+        "topology-mode:explicit-single",
+        "topology-installs:1",
+        "topology-default:primary",
+      ]),
+    });
   });
 
   it("applies registration identity and exposes metadata/id helper behavior", () => {

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -8,12 +8,15 @@ import {
   buildIdentityReplyGuidelines,
   buildPinetOwnerToken,
   buildPinetSkinAssignment,
-  buildSlackCompatibilityScope,
   getSlackUserAccessWarning,
   isUserAllowed as checkUserAllowed,
   loadSettings as loadSettingsFromFile,
   normalizeOwnedThreads,
   resolveRuntimeAgentIdentity,
+  resolveSlackDefaultScope,
+  resolveSlackRuntimeSettings,
+  resolveSlackTopology,
+  summarizeSlackTopology,
   shortenPath,
   type SlackBridgeSettings,
 } from "./helpers.js";
@@ -246,10 +249,10 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
   }
 
   function refreshSettings(): void {
-    const settings = loadSettingsFromFile();
+    const settings = resolveSlackRuntimeSettings(loadSettingsFromFile(), process.env);
     deps.setSettings(settings);
-    deps.setBotToken(settings.botToken ?? process.env.SLACK_BOT_TOKEN);
-    deps.setAppToken(settings.appToken ?? process.env.SLACK_APP_TOKEN);
+    deps.setBotToken(settings.botToken);
+    deps.setAppToken(settings.appToken);
     deps.setAllowedUsers(
       buildAllowlist(
         settings,
@@ -360,13 +363,19 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     const { cwd, repo, repoRoot, branch } = gitContext;
     const resolvedRepoRoot = repoRoot ?? cwd;
     const tools = detectProjectTools(resolvedRepoRoot, cwd);
-    const scope = buildSlackCompatibilityScope();
+    const scope = resolveSlackDefaultScope(deps.getSettings(), process.env);
+    const topology = summarizeSlackTopology(resolveSlackTopology(deps.getSettings(), process.env));
     const tags = [
       `role:${role}`,
       `repo:${repo}`,
       ...(branch ? [`branch:${branch}`] : []),
       ...(scope.workspace?.provider ? [`scope-provider:${scope.workspace.provider}`] : []),
       ...(scope.workspace?.compatibilityKey ? [`scope:${scope.workspace.compatibilityKey}`] : []),
+      ...(scope.workspace?.workspaceId ? [`workspace:${scope.workspace.workspaceId}`] : []),
+      ...(scope.workspace?.installId ? [`install:${scope.workspace.installId}`] : []),
+      `topology-mode:${topology.mode}`,
+      `topology-installs:${topology.installCount}`,
+      `topology-default:${topology.defaultInstallId}`,
       ...tools.map((tool) => `tool:${tool}`),
     ];
 
@@ -378,6 +387,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
       repo,
       repoRoot,
       scope,
+      topology,
       ...(deps.getActiveSkinTheme() ? { skinTheme: deps.getActiveSkinTheme() } : {}),
       ...(deps.getAgentPersonality() ? { personality: deps.getAgentPersonality() } : {}),
       capabilities: {
@@ -388,6 +398,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
         tools,
         tags,
         scope,
+        topology,
       },
     };
   }

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -116,6 +116,17 @@ function createDeps(state: TestState, overrides: Partial<SinglePlayerRuntimeDeps
     getAgentAliases: () => ["Cobalt Olive Crane"],
     getAgentOwnerToken: () => "owner:crane",
     getBotUserId: () => socketState.botUserId,
+    getDefaultScope: () => ({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    }),
     getThreads: () => state.threads,
     getPendingEyes: () => state.pendingEyes,
     getUnclaimedThreads: () => state.unclaimedThreads,
@@ -306,6 +317,66 @@ describe("single-player-runtime", () => {
     });
     expect(spies.updateBadge).toHaveBeenCalledTimes(1);
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
+  });
+
+  it("preserves explicit install scope on inbound Slack messages", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const { deps, spies } = createDeps(state, {
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      channel: "D123",
+      channel_type: "im",
+      user: "U_SENDER",
+      text: "topology hello",
+      ts: "101.1",
+      thread_ts: "101.1",
+    });
+
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith({
+      channel: "D123",
+      threadTs: "101.1",
+      userId: "U_SENDER",
+      text: "topology hello",
+      timestamp: "101.1",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+          channelId: "D123",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    });
   });
 
   it("preserves file-share metadata on inbound Slack messages", async () => {

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -1,3 +1,4 @@
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { agentOwnsThread, type InboxMessage, normalizeOwnedThreads } from "./helpers.js";
 import {
@@ -56,6 +57,7 @@ export interface SinglePlayerRuntimeDeps {
   getAgentAliases: () => Iterable<string>;
   getAgentOwnerToken: () => string;
   getBotUserId: () => string | null;
+  getDefaultScope: () => RuntimeScopeCarrier;
   getThreads: () => Map<string, SinglePlayerThreadState>;
   getPendingEyes: () => Map<string, SinglePlayerPendingAttention[]>;
   getUnclaimedThreads: () => SinglePlayerUnclaimedThreads;
@@ -333,6 +335,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         scope: buildSlackThreadRuntimeScope({
           channelId: item.channel,
           context: threadInfo?.context,
+          defaultScope: deps.getDefaultScope(),
         }),
       });
       deps.persistState();
@@ -406,6 +409,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       scope: buildSlackThreadRuntimeScope({
         channelId: channel,
         context: threadInfo?.context,
+        defaultScope: deps.getDefaultScope(),
       }),
       ...(isChannelMention && { isChannelMention: true }),
       ...(metadata ? { metadata } : {}),
@@ -470,6 +474,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       scope: buildSlackThreadRuntimeScope({
         channelId: normalized.channel,
         context: threadInfo?.context,
+        defaultScope: deps.getDefaultScope(),
       }),
     });
     deps.updateBadge();
@@ -496,6 +501,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         slack: deps.slack,
         botToken: deps.getBotToken(),
         appToken: deps.getAppToken(),
+        getDefaultScope: () => deps.getDefaultScope(),
         resolveBotUserIdOnConnect: false,
         dedup: deps.dedup,
         abortAndWait: deps.abortSlackRequests,

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -1,6 +1,6 @@
 import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
 import {
-  buildSlackCompatibilityScope,
+  buildSlackThreadScope,
   isUserAllowed,
   isChannelId,
   stripBotMention,
@@ -48,13 +48,18 @@ export interface SlackThreadContext {
   scope: RuntimeScopeCarrier;
 }
 
-function buildSlackThreadContext(channelId: string, teamId?: string | null): SlackThreadContext {
+function buildSlackThreadContext(
+  channelId: string,
+  teamId?: string | null,
+  defaultScope?: RuntimeScopeCarrier | null,
+): SlackThreadContext {
   const normalizedTeamId =
     typeof teamId === "string" && teamId.trim().length > 0 ? teamId.trim() : undefined;
   return {
     channelId,
     ...(normalizedTeamId ? { teamId: normalizedTeamId } : {}),
-    scope: buildSlackCompatibilityScope({
+    scope: buildSlackThreadScope({
+      baseScope: defaultScope,
       teamId: normalizedTeamId,
       channelId,
     }),
@@ -64,10 +69,12 @@ function buildSlackThreadContext(channelId: string, teamId?: string | null): Sla
 export function buildSlackThreadRuntimeScope(input: {
   channelId?: string | null;
   context?: SlackThreadContext | null;
+  defaultScope?: RuntimeScopeCarrier | null;
 }): RuntimeScopeCarrier {
   return (
     input.context?.scope ??
-    buildSlackCompatibilityScope({
+    buildSlackThreadScope({
+      baseScope: input.defaultScope,
       teamId: input.context?.teamId,
       channelId: input.context?.channelId ?? input.channelId,
     })
@@ -128,7 +135,10 @@ export interface ParsedThreadStarted {
 /**
  * Extract thread info from an assistant_thread_started event.
  */
-export function extractThreadStarted(evt: Record<string, unknown>): ParsedThreadStarted | null {
+export function extractThreadStarted(
+  evt: Record<string, unknown>,
+  defaultScope?: RuntimeScopeCarrier | null,
+): ParsedThreadStarted | null {
   const t = evt.assistant_thread as Record<string, unknown> | undefined;
   if (!t) return null;
 
@@ -148,7 +158,7 @@ export function extractThreadStarted(evt: Record<string, unknown>): ParsedThread
 
   const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
   if (ctx?.channel_id) {
-    result.context = buildSlackThreadContext(ctx.channel_id, ctx.team_id);
+    result.context = buildSlackThreadContext(ctx.channel_id, ctx.team_id, defaultScope);
   }
 
   return result;
@@ -161,6 +171,7 @@ export interface ParsedThreadContextChanged {
 
 export function extractThreadContextChanged(
   evt: Record<string, unknown>,
+  defaultScope?: RuntimeScopeCarrier | null,
 ): ParsedThreadContextChanged | null {
   const t = evt.assistant_thread as Record<string, unknown> | undefined;
   if (!t) return null;
@@ -173,7 +184,7 @@ export function extractThreadContextChanged(
   const result: ParsedThreadContextChanged = { threadTs };
   const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
   if (ctx?.channel_id) {
-    result.context = buildSlackThreadContext(ctx.channel_id, ctx.team_id);
+    result.context = buildSlackThreadContext(ctx.channel_id, ctx.team_id, defaultScope);
   }
 
   return result;
@@ -496,6 +507,7 @@ export interface SlackSocketModeClientConfig {
   slack: SlackCall;
   botToken: string;
   appToken: string;
+  getDefaultScope?: () => RuntimeScopeCarrier | undefined;
   resolveBotUserIdOnConnect?: boolean;
   reconnectDelayMs?: number;
   dedup?: SlackAccessSet<string>;
@@ -632,14 +644,14 @@ export class SlackSocketModeClient {
       const evt = envelope.event;
       switch (evt.type) {
         case "assistant_thread_started": {
-          const parsed = extractThreadStarted(evt);
+          const parsed = extractThreadStarted(evt, this.config.getDefaultScope?.());
           if (parsed) {
             await this.config.onThreadStarted?.(parsed);
           }
           break;
         }
         case "assistant_thread_context_changed": {
-          const parsed = extractThreadContextChanged(evt);
+          const parsed = extractThreadContextChanged(evt, this.config.getDefaultScope?.());
           if (parsed) {
             await this.config.onThreadContextChanged?.(parsed);
           }


### PR DESCRIPTION
## Summary
- define explicit Slack install/workspace topology settings with a compatibility-first default install model
- project the selected default install into the current singleton runtime without adding multi-install orchestration
- preserve install/workspace scope in runtime metadata, thread scope plumbing, and documentation/tests

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- git push (pre-push ran repo typecheck + test)