### PR TITLE
feat: enforce scoped slack authorization boundaries

### DIFF
--- a/broker-core/router.ts
+++ b/broker-core/router.ts
@@ -1,4 +1,13 @@
-import type { AgentInfo, BrokerDBInterface, InboundMessage, RoutingDecision } from "./types.js";
+import {
+  formatRuntimeScopeCarrier,
+  getRuntimeScopeConflicts,
+  parseRuntimeScopeCarrier,
+  type AgentInfo,
+  type BrokerDBInterface,
+  type InboundMessage,
+  type RoutingDecision,
+  type RuntimeScopeCarrier,
+} from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -15,6 +24,49 @@ function buildPinetOwnerToken(stableId: string): string {
   const primary = hashString(stableId).toString(16).padStart(8, "0");
   const secondary = hashString(`${stableId}:owner`).toString(16).padStart(8, "0");
   return `owner:${primary}${secondary}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function extractAgentScope(agent: AgentInfo): RuntimeScopeCarrier | null {
+  const metadata = asRecord(agent.metadata);
+  const capabilities = asRecord(metadata?.capabilities);
+  return parseRuntimeScopeCarrier(capabilities?.scope ?? metadata?.scope);
+}
+
+function buildScopeRejectReason(
+  prefix: string,
+  actual: RuntimeScopeCarrier | null | undefined,
+  expected: RuntimeScopeCarrier | null | undefined,
+): string {
+  const conflicts = getRuntimeScopeConflicts(actual, expected);
+  if (conflicts.length === 0) {
+    return prefix;
+  }
+
+  return `${prefix}: ${conflicts.map((conflict) => `${conflict.dimension}.${conflict.field}`).join(", ")} (actual ${formatRuntimeScopeCarrier(actual)}; expected ${formatRuntimeScopeCarrier(expected)})`;
+}
+
+function getAgentScopeRejection(
+  msg: InboundMessage,
+  agent: AgentInfo,
+  scope: RuntimeScopeCarrier | null | undefined,
+): RoutingDecision | null {
+  const agentScope = extractAgentScope(agent);
+  if (getRuntimeScopeConflicts(scope, agentScope).length === 0) {
+    return null;
+  }
+
+  return {
+    action: "reject",
+    reason: buildScopeRejectReason(
+      `Inbound message scope is not authorized for agent ${agent.name}`,
+      scope,
+      agentScope,
+    ),
+  };
 }
 
 export interface ThreadOwnerHint {
@@ -251,10 +303,28 @@ export class MessageRouter {
 
     const agents = this.db.getAgents();
     let thread = this.db.getThread(msg.threadId);
+    const threadScope = thread ? this.db.getThreadScope(msg.threadId) : null;
+    const authorizationScope = msg.scope ?? threadScope;
     const explicitDirective = findExplicitThreadDirective(msg.text, agents);
+
+    if (threadScope && getRuntimeScopeConflicts(msg.scope ?? null, threadScope).length > 0) {
+      return {
+        action: "reject",
+        reason: buildScopeRejectReason(
+          `Inbound message scope is outside the existing thread authorization for ${msg.threadId}`,
+          msg.scope ?? null,
+          threadScope,
+        ),
+      };
+    }
 
     if (explicitDirective) {
       if (thread) {
+        const rejection = getAgentScopeRejection(msg, explicitDirective.agent, authorizationScope);
+        if (rejection) {
+          return rejection;
+        }
+
         if (explicitDirective.kind === "retarget") {
           this.db.updateThread(msg.threadId, {
             ownerAgent: explicitDirective.agent.id,
@@ -271,6 +341,11 @@ export class MessageRouter {
       if (thread.ownerBinding === "explicit") {
         const explicitOwner = resolveRoutableThreadOwner(this.db, thread.ownerAgent);
         if (explicitOwner) {
+          const rejection = getAgentScopeRejection(msg, explicitOwner, authorizationScope);
+          if (rejection) {
+            return rejection;
+          }
+
           if (thread.ownerAgent !== explicitOwner.id) {
             this.db.updateThread(msg.threadId, { ownerAgent: explicitOwner.id });
           }
@@ -289,6 +364,11 @@ export class MessageRouter {
 
       const hintedOwner = resolveAgentFromThreadOwnerHint(msg.metadata, agents);
       if (hintedOwner && isRoutableOwner(hintedOwner)) {
+        const rejection = getAgentScopeRejection(msg, hintedOwner, authorizationScope);
+        if (rejection) {
+          return rejection;
+        }
+
         if (thread.ownerAgent !== hintedOwner.id) {
           this.db.updateThread(msg.threadId, { ownerAgent: hintedOwner.id, channel: msg.channel });
         }
@@ -298,6 +378,11 @@ export class MessageRouter {
       if (thread.ownerAgent) {
         const owner = resolveRoutableThreadOwner(this.db, thread.ownerAgent);
         if (owner) {
+          const rejection = getAgentScopeRejection(msg, owner, authorizationScope);
+          if (rejection) {
+            return rejection;
+          }
+
           if (thread.ownerAgent !== owner.id) {
             this.db.updateThread(msg.threadId, { ownerAgent: owner.id });
           }
@@ -313,6 +398,11 @@ export class MessageRouter {
 
       const mentioned = findAgentMention(msg.text, agents);
       if (mentioned) {
+        const rejection = getAgentScopeRejection(msg, mentioned, authorizationScope);
+        if (rejection) {
+          return rejection;
+        }
+
         const claimed = this.db.claimThread(msg.threadId, mentioned.id, msg.source, msg.channel);
         if (claimed) {
           return { action: "deliver", agentId: mentioned.id };
@@ -321,6 +411,14 @@ export class MessageRouter {
         const claimedThread = this.db.getThread(msg.threadId);
         const claimedOwner = resolveRoutableThreadOwner(this.db, claimedThread?.ownerAgent ?? null);
         if (claimedOwner) {
+          const claimedOwnerRejection = getAgentScopeRejection(
+            msg,
+            claimedOwner,
+            authorizationScope,
+          );
+          if (claimedOwnerRejection) {
+            return claimedOwnerRejection;
+          }
           return { action: "deliver", agentId: claimedOwner.id };
         }
       }
@@ -333,12 +431,21 @@ export class MessageRouter {
     if (assignment) {
       const assigned = agents.find((agent) => agent.id === assignment.agentId);
       if (assigned) {
+        const rejection = getAgentScopeRejection(msg, assigned, authorizationScope);
+        if (rejection) {
+          return rejection;
+        }
         return { action: "deliver", agentId: assigned.id };
       }
     }
 
     const mentioned = findAgentMention(msg.text, agents);
     if (mentioned) {
+      const rejection = getAgentScopeRejection(msg, mentioned, authorizationScope);
+      if (rejection) {
+        return rejection;
+      }
+
       const claimed = this.db.claimThread(msg.threadId, mentioned.id, msg.source, msg.channel);
       if (claimed) {
         return { action: "deliver", agentId: mentioned.id };
@@ -347,6 +454,10 @@ export class MessageRouter {
       const claimedThread = this.db.getThread(msg.threadId);
       const claimedOwner = resolveRoutableThreadOwner(this.db, claimedThread?.ownerAgent ?? null);
       if (claimedOwner) {
+        const claimedOwnerRejection = getAgentScopeRejection(msg, claimedOwner, authorizationScope);
+        if (claimedOwnerRejection) {
+          return claimedOwnerRejection;
+        }
         return { action: "deliver", agentId: claimedOwner.id };
       }
     }

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getDefaultDbPath } from "./paths.js";
+import { parseRuntimeScopeCarrier, type RuntimeScopeCarrier } from "./types.js";
 import type {
   AgentInfo,
   ThreadInfo,
@@ -1134,6 +1135,36 @@ export class BrokerDB implements BrokerDBInterface {
 
   getAllowedUsers(): Set<string> | null {
     return this.allowedUsers === null ? null : new Set(this.allowedUsers);
+  }
+
+  getThreadScope(threadId: string): RuntimeScopeCarrier | null {
+    const db = this.getDb();
+    const rows = db
+      .prepare(
+        `SELECT metadata FROM messages
+         WHERE thread_id = ?
+           AND metadata IS NOT NULL
+         ORDER BY id DESC`,
+      )
+      .all(threadId) as Array<{ metadata: string | null }>;
+
+    for (const row of rows) {
+      if (!row.metadata) {
+        continue;
+      }
+
+      try {
+        const metadata = JSON.parse(row.metadata) as Record<string, unknown>;
+        const scope = parseRuntimeScopeCarrier(metadata.scope);
+        if (scope) {
+          return scope;
+        }
+      } catch {
+        // Ignore malformed historical metadata rows.
+      }
+    }
+
+    return null;
   }
 
   getChannelAssignment(_channel: string): ChannelAssignment | null {

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -150,6 +150,10 @@ import {
   buildCompatibilityInstanceScope as _buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope as _buildCompatibilityWorkspaceScope,
   buildRuntimeScopeCarrier as _buildRuntimeScopeCarrier,
+  formatRuntimeScopeCarrier as _formatRuntimeScopeCarrier,
+  getRuntimeScopeConflicts as _getRuntimeScopeConflicts,
+  isRuntimeScopeAuthorized as _isRuntimeScopeAuthorized,
+  parseRuntimeScopeCarrier as _parseRuntimeScopeCarrier,
 } from "@gugu910/pi-transport-core";
 import type {
   InboundMessage as _InboundMessage,
@@ -158,6 +162,8 @@ import type {
   RuntimeScopeCarrier as _RuntimeScopeCarrier,
   WorkspaceInstallScopeCarrier as _WorkspaceInstallScopeCarrier,
   InstanceScopeCarrier as _InstanceScopeCarrier,
+  RuntimeScopeConflict as _RuntimeScopeConflict,
+  RuntimeScopeDimension as _RuntimeScopeDimension,
 } from "@gugu910/pi-transport-core";
 
 export type InboundMessage = _InboundMessage;
@@ -166,9 +172,15 @@ export type MessageAdapter = _MessageAdapter;
 export type RuntimeScopeCarrier = _RuntimeScopeCarrier;
 export type WorkspaceInstallScopeCarrier = _WorkspaceInstallScopeCarrier;
 export type InstanceScopeCarrier = _InstanceScopeCarrier;
+export type RuntimeScopeConflict = _RuntimeScopeConflict;
+export type RuntimeScopeDimension = _RuntimeScopeDimension;
 export const buildCompatibilityWorkspaceScope = _buildCompatibilityWorkspaceScope;
 export const buildCompatibilityInstanceScope = _buildCompatibilityInstanceScope;
 export const buildRuntimeScopeCarrier = _buildRuntimeScopeCarrier;
+export const parseRuntimeScopeCarrier = _parseRuntimeScopeCarrier;
+export const getRuntimeScopeConflicts = _getRuntimeScopeConflicts;
+export const isRuntimeScopeAuthorized = _isRuntimeScopeAuthorized;
+export const formatRuntimeScopeCarrier = _formatRuntimeScopeCarrier;
 
 // ─── BrokerDB interface (subset used by the router) ──────
 
@@ -185,6 +197,7 @@ export interface BrokerDBInterface {
    * - empty Set => default-deny / allow nobody
    */
   getAllowedUsers(): Set<string> | null;
+  getThreadScope(threadId: string): RuntimeScopeCarrier | null;
 
   createThread(thread: ThreadInfo): void;
   updateThread(threadId: string, updates: Partial<ThreadInfo>): void;

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -151,9 +151,9 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                       |
 | `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true             |
 | `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                              |
-| `defaultChannel`               | no       | Default channel for `slack_post_channel` in legacy single-install compatibility mode                                   |
+| `defaultChannel`               | no       | Default channel for `slack_post_channel` in legacy single-install compatibility mode                               |
 | `logChannel`                   | no       | Channel for broker activity logs in legacy single-install compatibility mode                                       |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                 |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
 | `defaultInstallId`             | no       | When `installs` is configured, selects which install projects into today’s singleton runtime                       |
 | `installs`                     | no       | Explicit Slack install/workspace topology entries; each install can carry scoped tokens and surface targets        |
 | `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -280,6 +280,7 @@ describe("extractThreadStarted", () => {
         provider: "slack",
         source: "compatibility",
         compatibilityKey: "default",
+        installId: "primary",
         workspaceId: "T_SECONDARY",
         channelId: "C789",
       },

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1328,6 +1328,77 @@ describe("SlackAdapter — allowlist filtering", () => {
       }),
     );
   });
+
+  it("does not emit inbound messages for thread contexts that are outside the configured runtime scope", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/chat.postMessage")) {
+        return mockSlackResponse({ message: { ts: "1.3" } });
+      }
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as {
+        onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onThreadStarted({
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D1",
+        thread_ts: "1.9",
+        user_id: "U_ALLOWED",
+        context: {
+          channel_id: "C_TEAM",
+          team_id: "T_SECONDARY",
+        },
+      },
+    });
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "hello from the wrong install",
+      channel: "D1",
+      channel_type: "im",
+      thread_ts: "1.9",
+      ts: "1.10",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    await waitForAssertion(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://slack.com/api/chat.postMessage",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
 });
 
 // ─── SlackAdapter — send (mocked fetch) ─────────────────

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1329,6 +1329,199 @@ describe("SlackAdapter — allowlist filtering", () => {
     );
   });
 
+  it("uses the configured default scope when parsing raw thread-started events", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+      return mockSlackResponse();
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as {
+        onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onThreadStarted({
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D1",
+        thread_ts: "1.11",
+        user_id: "U_ALLOWED",
+        context: {
+          channel_id: "C_TEAM",
+          team_id: "T_PRIMARY",
+        },
+      },
+    });
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "hello from the selected install",
+      channel: "D1",
+      channel_type: "im",
+      thread_ts: "1.11",
+      ts: "1.12",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "1.11",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_PRIMARY",
+            installId: "primary",
+            channelId: "C_TEAM",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      }),
+    );
+  });
+
+  it("uses the configured default scope when parsing raw thread-context-changed events", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+      return mockSlackResponse();
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as {
+        onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onThreadStarted({
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D1",
+        thread_ts: "1.13",
+        user_id: "U_ALLOWED",
+      },
+    });
+
+    (
+      adapter as unknown as {
+        onContextChanged: (evt: Record<string, unknown>) => void;
+      }
+    ).onContextChanged({
+      type: "assistant_thread_context_changed",
+      assistant_thread: {
+        thread_ts: "1.13",
+        context: {
+          channel_id: "C_UPDATED",
+          team_id: "T_PRIMARY",
+        },
+      },
+    });
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "hello after context changed",
+      channel: "D1",
+      channel_type: "im",
+      thread_ts: "1.13",
+      ts: "1.14",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "1.13",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_PRIMARY",
+            installId: "primary",
+            channelId: "C_UPDATED",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      }),
+    );
+  });
+
   it("does not emit inbound messages for thread contexts that are outside the configured runtime scope", async () => {
     fetchMock.mockImplementation(async (input) => {
       const url = String(input);

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -205,6 +205,90 @@ describe("extractThreadStarted", () => {
     const result = extractThreadStarted(evt);
     expect(result?.context).toBeUndefined();
   });
+
+  it("applies explicit default scope for explicit installs when context includes channel", () => {
+    const evt = {
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D123",
+        thread_ts: "111.222",
+        user_id: "U456",
+        context: {
+          channel_id: "C789",
+          team_id: "T_PRIMARY",
+        },
+      },
+    };
+
+    const result = extractThreadStarted(evt, {
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_PRIMARY",
+        installId: "primary",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+
+    expect(result?.context?.scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_PRIMARY",
+        installId: "primary",
+        channelId: "C789",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+  });
+
+  it("falls back to compatibility scope when explicit default scope drifts", () => {
+    const evt = {
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D123",
+        thread_ts: "111.222",
+        user_id: "U456",
+        context: {
+          channel_id: "C789",
+          team_id: "T_SECONDARY",
+        },
+      },
+    };
+
+    const result = extractThreadStarted(evt, {
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_PRIMARY",
+        installId: "primary",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+
+    expect(result?.context?.scope).toEqual({
+      workspace: {
+        provider: "slack",
+        source: "compatibility",
+        compatibilityKey: "default",
+        workspaceId: "T_SECONDARY",
+        channelId: "C789",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    });
+  });
 });
 
 describe("extractAppHomeOpened", () => {
@@ -1512,6 +1596,93 @@ describe("SlackAdapter — allowlist filtering", () => {
             workspaceId: "T_PRIMARY",
             installId: "primary",
             channelId: "C_UPDATED",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      }),
+    );
+  });
+
+  it("defaults raw thread-started events to the configured explicit default scope", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+      return mockSlackResponse();
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as {
+        onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+      }
+    ).onThreadStarted({
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D1",
+        thread_ts: "1.21",
+        user_id: "U_ALLOWED",
+      },
+    });
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "hello from the selected install",
+      channel: "D1",
+      channel_type: "im",
+      thread_ts: "1.21",
+      ts: "1.22",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "1.21",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_PRIMARY",
+            installId: "primary",
+            channelId: "D1",
           },
           instance: {
             source: "compatibility",

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -7,6 +7,7 @@ import {
   extractThreadContextChanged,
   extractThreadStarted,
   fetchSlackMessageByTs,
+  getSlackScopeAuthorizationError,
   isSlackUserAllowed,
   removeSlackReaction,
   resolveSlackUserName,
@@ -204,6 +205,28 @@ export class SlackAdapter implements MessageAdapter {
     });
   }
 
+  private getThreadScopeAuthorizationError(threadTs: string): string | null {
+    return getSlackScopeAuthorizationError({
+      actualScope: this.threads.get(threadTs)?.context?.scope ?? null,
+      expectedScope: this.config.getDefaultScope?.() ?? null,
+      target: `thread ${threadTs}`,
+    });
+  }
+
+  private async denyUnauthorizedThreadScope(channel: string, threadTs: string): Promise<void> {
+    const scopeError = this.getThreadScopeAuthorizationError(threadTs);
+    if (!scopeError) {
+      return;
+    }
+
+    console.warn(`[slack-adapter] ${scopeError}`);
+    await this.callSlack("chat.postMessage", this.config.botToken, {
+      channel,
+      thread_ts: threadTs,
+      text: "Sorry, this Slack workspace/install or instance is not authorized for this runtime. Please contact an admin if you need access.",
+    });
+  }
+
   private async onThreadStarted(
     event: ParsedThreadStarted | Record<string, unknown>,
   ): Promise<void> {
@@ -223,6 +246,13 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     this.threads.set(info.threadTs, info);
+
+    const scopeError = this.getThreadScopeAuthorizationError(info.threadTs);
+    if (scopeError) {
+      console.warn(`[slack-adapter] ${scopeError}`);
+      return;
+    }
+
     try {
       this.config.rememberKnownThread?.(info.threadTs, info.channelId);
     } catch {
@@ -241,6 +271,10 @@ export class SlackAdapter implements MessageAdapter {
     if (!existing || !parsed.context) return;
 
     existing.context = parsed.context;
+    const scopeError = this.getThreadScopeAuthorizationError(parsed.threadTs);
+    if (scopeError) {
+      console.warn(`[slack-adapter] ${scopeError}`);
+    }
   }
 
   private async onAppHomeOpened(
@@ -336,6 +370,12 @@ export class SlackAdapter implements MessageAdapter {
           ? reactedMessage.text
           : "(no text)";
 
+      const scopeError = this.getThreadScopeAuthorizationError(threadTs);
+      if (scopeError) {
+        console.warn(`[slack-adapter] ${scopeError}`);
+        return;
+      }
+
       const threadInfo = this.threads.get(threadTs);
       this.inboundHandler?.({
         source: "slack",
@@ -391,6 +431,12 @@ export class SlackAdapter implements MessageAdapter {
 
     if (!isSlackUserAllowed(this.allowlist, userId)) return;
 
+    const scopeError = this.getThreadScopeAuthorizationError(threadTs);
+    if (scopeError) {
+      await this.denyUnauthorizedThreadScope(channel, threadTs);
+      return;
+    }
+
     void this.addReaction(channel, messageTs, "eyes");
     const pending = this.pendingEyes.get(threadTs) ?? [];
     pending.push({ channel, messageTs });
@@ -441,6 +487,12 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     if (!isSlackUserAllowed(this.allowlist, normalized.userId)) return;
+
+    const scopeError = this.getThreadScopeAuthorizationError(normalized.threadTs);
+    if (scopeError) {
+      await this.denyUnauthorizedThreadScope(normalized.channel, normalized.threadTs);
+      return;
+    }
 
     const userName = await this.resolveUser(normalized.userId);
     if (this.shuttingDown) return;

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -206,9 +206,15 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   private getThreadScopeAuthorizationError(threadTs: string): string | null {
+    const thread = this.threads.get(threadTs);
+    const defaultScope = this.config.getDefaultScope?.() ?? null;
     return getSlackScopeAuthorizationError({
-      actualScope: this.threads.get(threadTs)?.context?.scope ?? null,
-      expectedScope: this.config.getDefaultScope?.() ?? null,
+      actualScope: buildSlackThreadRuntimeScope({
+        channelId: thread?.channelId,
+        context: thread?.context,
+        defaultScope,
+      }),
+      expectedScope: defaultScope,
       target: `thread ${threadTs}`,
     });
   }

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -232,7 +232,9 @@ export class SlackAdapter implements MessageAdapter {
   ): Promise<void> {
     if (this.shuttingDown) return;
 
-    const parsed = isParsedThreadStarted(event) ? event : extractThreadStarted(event);
+    const parsed = isParsedThreadStarted(event)
+      ? event
+      : extractThreadStarted(event, this.config.getDefaultScope?.() ?? null);
     if (!parsed) return;
 
     const info: SlackThreadInfo = {
@@ -264,7 +266,9 @@ export class SlackAdapter implements MessageAdapter {
   private onContextChanged(event: ParsedThreadContextChanged | Record<string, unknown>): void {
     if (this.shuttingDown) return;
 
-    const parsed = isParsedThreadContextChanged(event) ? event : extractThreadContextChanged(event);
+    const parsed = isParsedThreadContextChanged(event)
+      ? event
+      : extractThreadContextChanged(event, this.config.getDefaultScope?.() ?? null);
     if (!parsed) return;
 
     const existing = this.threads.get(parsed.threadTs);

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -5,18 +5,21 @@ import {
   findAgentMention,
   findExplicitThreadDirective,
 } from "./router.js";
-import type {
-  AgentInfo,
-  BrokerDBInterface,
-  ChannelAssignment,
-  InboundMessage,
-  ThreadInfo,
+import {
+  buildRuntimeScopeCarrier,
+  type AgentInfo,
+  type BrokerDBInterface,
+  type ChannelAssignment,
+  type InboundMessage,
+  type RuntimeScopeCarrier,
+  type ThreadInfo,
 } from "./types.js";
 
 // ─── In-memory BrokerDBInterface stub ─────────────────────────────
 
 class StubBrokerDBInterface implements BrokerDBInterface {
   threads = new Map<string, ThreadInfo>();
+  threadScopes = new Map<string, RuntimeScopeCarrier>();
   agents: AgentInfo[] = [];
   channelAssignments = new Map<string, ChannelAssignment>();
   allowedUsers: Set<string> | null = null;
@@ -44,6 +47,10 @@ class StubBrokerDBInterface implements BrokerDBInterface {
 
   getAllowedUsers(): Set<string> | null {
     return this.allowedUsers;
+  }
+
+  getThreadScope(threadId: string): RuntimeScopeCarrier | null {
+    return this.threadScopes.get(threadId) ?? null;
   }
 
   createThread(thread: ThreadInfo): void {
@@ -130,6 +137,24 @@ function makeMessage(overrides?: Partial<InboundMessage>): InboundMessage {
     timestamp: "1700000000.000000",
     ...overrides,
   };
+}
+
+function makeScope(
+  overrides?: Partial<NonNullable<RuntimeScopeCarrier["workspace"]>>,
+): RuntimeScopeCarrier {
+  return buildRuntimeScopeCarrier({
+    workspace: {
+      provider: "slack",
+      source: "explicit",
+      workspaceId: "T_PRIMARY",
+      installId: "primary",
+      ...overrides,
+    },
+    instance: {
+      source: "compatibility",
+      compatibilityKey: "default",
+    },
+  })!;
 }
 
 // ─── Tests ───────────────────────────────────────────────
@@ -380,6 +405,68 @@ describe("MessageRouter — route", () => {
     const decision = router.route(makeMessage({ userId: "U001" }));
 
     expect(decision).toEqual({ action: "deliver", agentId: "a1" });
+  });
+
+  it("rejects known-thread messages that conflict with the stored thread scope", () => {
+    const agent = makeAgent({ id: "a1", name: "ScopedBot", metadata: { scope: makeScope() } });
+    db.agents = [agent];
+    db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: "a1" }));
+    db.threadScopes.set("t-100", makeScope());
+
+    const decision = router.route(
+      makeMessage({
+        threadId: "t-100",
+        scope: makeScope({ workspaceId: "T_SECONDARY", installId: "secondary" }),
+      }),
+    );
+
+    expect(decision.action).toBe("reject");
+    expect(decision).toMatchObject({
+      reason: expect.stringContaining("existing thread authorization"),
+    });
+  });
+
+  it("rejects thread-owner delivery when the agent scope does not match the inbound scope", () => {
+    const owner = makeAgent({
+      id: "a1",
+      name: "ScopedBot",
+      metadata: { scope: makeScope() },
+    });
+    db.agents = [owner];
+    db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: "a1" }));
+
+    const decision = router.route(
+      makeMessage({
+        threadId: "t-100",
+        scope: makeScope({ workspaceId: "T_SECONDARY", installId: "secondary" }),
+      }),
+    );
+
+    expect(decision.action).toBe("reject");
+    expect(decision).toMatchObject({
+      reason: expect.stringContaining("not authorized for agent ScopedBot"),
+    });
+  });
+
+  it("rejects channel assignment routing when the assigned agent is out of scope", () => {
+    const agent = makeAgent({
+      id: "a2",
+      name: "ChannelBot",
+      metadata: { scope: makeScope() },
+    });
+    db.agents = [agent];
+    db.channelAssignments.set("C001", { channel: "C001", agentId: "a2" });
+
+    const decision = router.route(
+      makeMessage({
+        scope: makeScope({ workspaceId: "T_SECONDARY", installId: "secondary" }),
+      }),
+    );
+
+    expect(decision.action).toBe("reject");
+    expect(decision).toMatchObject({
+      reason: expect.stringContaining("not authorized for agent ChannelBot"),
+    });
   });
 
   it("thread ownership takes priority over channel assignment", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -213,7 +213,7 @@ export function buildSlackThreadScope(
     workspace: buildSlackWorkspaceScope({
       source,
       workspaceId: liveWorkspaceId ?? workspace?.workspaceId,
-      installId: source === "explicit" ? workspace?.installId : undefined,
+      installId: workspace?.installId,
       channelId: normalizeOptionalSetting(options.channelId) ?? workspace?.channelId,
       compatibilityKey:
         source === "compatibility"

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1956,6 +1956,26 @@ describe("slack-bridge top-level shutdown", () => {
     };
     socket.emitEvent("message", {
       data: JSON.stringify({
+        envelope_id: "env-0",
+        type: "events_api",
+        payload: {
+          event: {
+            type: "assistant_thread_started",
+            assistant_thread: {
+              channel_id: "D123",
+              thread_ts: "100.1",
+              user_id: "U_SENDER",
+              context: {
+                channel_id: "D123",
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    socket.emitEvent("message", {
+      data: JSON.stringify({
         envelope_id: "env-1",
         type: "events_api",
         payload: {
@@ -1972,7 +1992,9 @@ describe("slack-bridge top-level shutdown", () => {
     });
 
     await vi.waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith("https://slack.com/api/users.info", expect.any(Object));
+      expect(
+        fetchSpy.mock.calls.some(([input]) => String(input).includes("conversations.replies")),
+      ).toBe(true);
     });
     expect(sendUserMessage).not.toHaveBeenCalled();
 
@@ -2095,6 +2117,26 @@ describe("slack-bridge top-level shutdown", () => {
     };
     socket.emitEvent("message", {
       data: JSON.stringify({
+        envelope_id: "env-0",
+        type: "events_api",
+        payload: {
+          event: {
+            type: "assistant_thread_started",
+            assistant_thread: {
+              channel_id: "D123",
+              thread_ts: "100.1",
+              user_id: "U_SENDER",
+              context: {
+                channel_id: "D123",
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    socket.emitEvent("message", {
+      data: JSON.stringify({
         envelope_id: "env-1",
         type: "events_api",
         payload: {
@@ -2111,7 +2153,9 @@ describe("slack-bridge top-level shutdown", () => {
     });
 
     await vi.waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith("https://slack.com/api/users.info", expect.any(Object));
+      expect(
+        fetchSpy.mock.calls.some(([input]) => String(input).includes("conversations.replies")),
+      ).toBe(true);
     });
 
     socket.emitEvent("message", {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1001,6 +1001,7 @@ export default function (pi: ExtensionAPI) {
         return botToken;
       },
       getDefaultChannel: () => settings.defaultChannel,
+      getDefaultScope: () => resolveSlackDefaultScope(settings, process.env),
       getSecurityPrompt: () => securityPrompt,
       inbox,
       slack,

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -379,6 +379,135 @@ describe("single-player-runtime", () => {
     });
   });
 
+  it("does not start local prompt handling for threads whose Slack context conflicts with the runtime scope", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const { deps, spies } = createDeps(state, {
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onThreadStarted?.({
+      channelId: "D123",
+      threadTs: "101.9",
+      userId: "U_SENDER",
+      context: {
+        channelId: "C999",
+        teamId: "T_SECONDARY",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_SECONDARY",
+            installId: "secondary",
+            channelId: "C999",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      },
+    });
+
+    expect(spies.setSuggestedPrompts).not.toHaveBeenCalled();
+    expect(state.lastDmChannel).toBeNull();
+    expect(state.threads.get("101.9")?.context?.scope.workspace?.installId).toBe("secondary");
+  });
+
+  it("rejects inbound Slack messages when the tracked thread context is out of scope", async () => {
+    const state: TestState = {
+      threads: new Map([
+        [
+          "101.9",
+          {
+            channelId: "D123",
+            threadTs: "101.9",
+            userId: "U_SENDER",
+            source: "slack",
+            context: {
+              channelId: "C999",
+              teamId: "T_SECONDARY",
+              scope: {
+                workspace: {
+                  provider: "slack",
+                  source: "explicit",
+                  workspaceId: "T_SECONDARY",
+                  installId: "secondary",
+                  channelId: "C999",
+                },
+                instance: {
+                  source: "compatibility",
+                  compatibilityKey: "default",
+                },
+              },
+            },
+          },
+        ],
+      ]),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const { deps, spies } = createDeps(state, {
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    });
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      channel: "D123",
+      channel_type: "im",
+      user: "U_SENDER",
+      text: "out of scope hello",
+      ts: "101.10",
+      thread_ts: "101.9",
+    });
+
+    expect(spies.pushInboxMessage).not.toHaveBeenCalled();
+    expect(spies.slack).toHaveBeenCalledWith("chat.postMessage", "xoxb-test", {
+      channel: "D123",
+      thread_ts: "101.9",
+      text: "Sorry, this Slack workspace/install or instance is not authorized for this runtime. Please contact an admin if you need access.",
+    });
+  });
+
   it("preserves file-share metadata on inbound Slack messages", async () => {
     const state: TestState = {
       threads: new Map(),

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -202,9 +202,14 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
 
   function getThreadScopeAuthorizationError(threadTs: string): string | null {
     const thread = deps.getThreads().get(threadTs);
+    const expectedScope = deps.getDefaultScope();
     return getSlackScopeAuthorizationError({
-      actualScope: thread?.context?.scope ?? null,
-      expectedScope: deps.getDefaultScope(),
+      actualScope: buildSlackThreadRuntimeScope({
+        channelId: thread?.channelId,
+        context: thread?.context,
+        defaultScope: expectedScope,
+      }),
+      expectedScope,
       target: `thread ${threadTs}`,
     });
   }

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -11,6 +11,7 @@ import type { SlackToolsThreadContextPort } from "./slack-tools.js";
 import {
   buildSlackThreadRuntimeScope,
   classifyMessage,
+  getSlackScopeAuthorizationError,
   resolveSlackThreadOwnerHint,
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
@@ -199,6 +200,29 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     return "continue";
   }
 
+  function getThreadScopeAuthorizationError(threadTs: string): string | null {
+    const thread = deps.getThreads().get(threadTs);
+    return getSlackScopeAuthorizationError({
+      actualScope: thread?.context?.scope ?? null,
+      expectedScope: deps.getDefaultScope(),
+      target: `thread ${threadTs}`,
+    });
+  }
+
+  async function denyUnauthorizedThreadScope(channel: string, threadTs: string): Promise<void> {
+    const scopeError = getThreadScopeAuthorizationError(threadTs);
+    if (!scopeError) {
+      return;
+    }
+
+    console.warn(`[slack-bridge] ${scopeError}`);
+    await deps.slack("chat.postMessage", deps.getBotToken(), {
+      channel,
+      thread_ts: threadTs,
+      text: "Sorry, this Slack workspace/install or instance is not authorized for this runtime. Please contact an admin if you need access.",
+    });
+  }
+
   async function onThreadStarted(event: ParsedThreadStarted): Promise<void> {
     if (shuttingDown) return;
 
@@ -214,9 +238,15 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     }
 
     deps.getThreads().set(info.threadTs, info);
-    deps.setLastDmChannel(info.channelId);
     deps.persistState();
 
+    const scopeError = getThreadScopeAuthorizationError(info.threadTs);
+    if (scopeError) {
+      console.warn(`[slack-bridge] ${scopeError}`);
+      return;
+    }
+
+    deps.setLastDmChannel(info.channelId);
     await deps.setSuggestedPrompts(info.channelId, info.threadTs);
   }
 
@@ -228,6 +258,11 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
 
     existing.context = event.context;
     deps.persistState();
+
+    const scopeError = getThreadScopeAuthorizationError(event.threadTs);
+    if (scopeError) {
+      console.warn(`[slack-bridge] ${scopeError}`);
+    }
   }
 
   async function onAppHomeOpened(event: ParsedAppHomeOpened, ctx: ExtensionContext): Promise<void> {
@@ -325,6 +360,12 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       });
 
       ctx.ui.notify(`${reactorName} reacted with :${reactionName}:`, "info");
+      const scopeError = getThreadScopeAuthorizationError(threadTs);
+      if (scopeError) {
+        console.warn(`[slack-bridge] ${scopeError}`);
+        return;
+      }
+
       const threadInfo = threads.get(threadTs);
       deps.pushInboxMessage({
         channel: item.channel,
@@ -374,6 +415,12 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         thread_ts: threadTs,
         text: "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
       });
+      return;
+    }
+
+    const scopeError = getThreadScopeAuthorizationError(threadTs);
+    if (scopeError) {
+      await denyUnauthorizedThreadScope(channel, threadTs);
       return;
     }
 
@@ -454,6 +501,12 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       return;
     }
 
+    const scopeError = getThreadScopeAuthorizationError(normalized.threadTs);
+    if (scopeError) {
+      await denyUnauthorizedThreadScope(normalized.channel, normalized.threadTs);
+      return;
+    }
+
     if (normalized.channel.startsWith("D")) {
       deps.setLastDmChannel(normalized.channel);
     }
@@ -484,6 +537,20 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
 
   const threadContextPort: SlackToolsThreadContextPort = {
     resolveThreadChannel: (threadTs) => deps.resolveThreadChannel(threadTs),
+    resolveThreadScope: async (threadTs) => {
+      if (!threadTs) {
+        return null;
+      }
+      const thread = deps.getThreads().get(threadTs);
+      if (!thread) {
+        return null;
+      }
+      return buildSlackThreadRuntimeScope({
+        channelId: thread.channelId,
+        context: thread.context,
+        defaultScope: deps.getDefaultScope(),
+      });
+    },
     noteThreadReply: (threadTs, channelId) => {
       trackOwnedThread(threadTs, channelId, "slack");
       deps.claimOwnedThread(threadTs, channelId, "slack");

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -1,4 +1,8 @@
-import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
+import {
+  formatRuntimeScopeCarrier,
+  getRuntimeScopeConflicts,
+  type RuntimeScopeCarrier,
+} from "@gugu910/pi-transport-core";
 import {
   buildSlackThreadScope,
   isUserAllowed,
@@ -79,6 +83,25 @@ export function buildSlackThreadRuntimeScope(input: {
       channelId: input.context?.channelId ?? input.channelId,
     })
   );
+}
+
+export function getSlackScopeAuthorizationError(input: {
+  actualScope?: RuntimeScopeCarrier | null;
+  expectedScope?: RuntimeScopeCarrier | null;
+  target?: string;
+}): string | null {
+  const conflicts = getRuntimeScopeConflicts(input.actualScope, input.expectedScope);
+  if (conflicts.length === 0) {
+    return null;
+  }
+
+  const targetLabel = input.target ? `${input.target} ` : "";
+  return [
+    `Slack ${targetLabel}scope is outside the authorized workspace/install or instance boundary for this runtime.`,
+    `Conflicts: ${conflicts.map((conflict) => `${conflict.dimension}.${conflict.field}`).join(", ")}.`,
+    `Actual: ${formatRuntimeScopeCarrier(input.actualScope)}.`,
+    `Expected: ${formatRuntimeScopeCarrier(input.expectedScope)}.`,
+  ].join(" ");
 }
 
 export interface ParsedEnvelope {

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerSlackTools } from "./slack-tools.js";
 import type { InboxMessage } from "./helpers.js";
@@ -230,6 +231,9 @@ describe("registerSlackTools", () => {
 
     let resolveThreadChannel: (threadTs: string | undefined) => Promise<string | null> = async () =>
       null;
+    let resolveThreadScope: (
+      threadTs: string | undefined,
+    ) => Promise<RuntimeScopeCarrier | null> = async () => null;
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
     const requireToolPolicy = vi.fn();
@@ -237,6 +241,18 @@ describe("registerSlackTools", () => {
     registerSlackTools(pi, {
       getBotToken: () => botToken,
       getDefaultChannel: () => defaultChannel,
+      getDefaultScope: () => ({
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
       getSecurityPrompt: () => securityPrompt,
       inbox,
       slack,
@@ -248,6 +264,7 @@ describe("registerSlackTools", () => {
       resolveUser: async (userId) => resolveUser(userId),
       threadContext: {
         resolveThreadChannel: (threadTs) => resolveThreadChannel(threadTs),
+        resolveThreadScope: (threadTs) => resolveThreadScope(threadTs),
         noteThreadReply,
         clearPendingAttention,
       },
@@ -335,6 +352,11 @@ describe("registerSlackTools", () => {
       },
       setResolveThreadChannel: (fn: (threadTs: string | undefined) => Promise<string | null>) => {
         resolveThreadChannel = fn;
+      },
+      setResolveThreadScope: (
+        fn: (threadTs: string | undefined) => Promise<RuntimeScopeCarrier | null>,
+      ) => {
+        resolveThreadScope = fn;
       },
       noteThreadReply,
       clearPendingAttention,
@@ -435,6 +457,29 @@ describe("registerSlackTools", () => {
       ts: "123.456",
       limit: 20,
     });
+  });
+
+  it("rejects thread-scoped Slack tool actions when the tracked thread scope is unauthorized", async () => {
+    const { tools, setResolveThreadScope } = setup();
+    setResolveThreadScope(async (threadTs: string | undefined) => {
+      expect(threadTs).toBe("123.456");
+      return {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_SECONDARY",
+          installId: "secondary",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      };
+    });
+
+    await expect(
+      tools.get("slack_read")!.execute("tool-3-scope", { thread_ts: "123.456" }),
+    ).rejects.toThrow(/authorized workspace\/install or instance boundary for this runtime/i);
   });
 
   it("uses thread channel resolution for slack_delete", async () => {

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -229,11 +229,23 @@ describe("registerSlackTools", () => {
       } as SlackResult;
     });
 
+    const defaultScope: RuntimeScopeCarrier = {
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_PRIMARY",
+        installId: "primary",
+      },
+      instance: {
+        source: "compatibility",
+        compatibilityKey: "default",
+      },
+    };
     let resolveThreadChannel: (threadTs: string | undefined) => Promise<string | null> = async () =>
       null;
     let resolveThreadScope: (
       threadTs: string | undefined,
-    ) => Promise<RuntimeScopeCarrier | null> = async () => null;
+    ) => Promise<RuntimeScopeCarrier | null> = async () => defaultScope;
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
     const requireToolPolicy = vi.fn();
@@ -241,18 +253,8 @@ describe("registerSlackTools", () => {
     registerSlackTools(pi, {
       getBotToken: () => botToken,
       getDefaultChannel: () => defaultChannel,
-      getDefaultScope: () => ({
-        workspace: {
-          provider: "slack",
-          source: "explicit",
-          workspaceId: "T_PRIMARY",
-          installId: "primary",
-        },
-        instance: {
-          source: "compatibility",
-          compatibilityKey: "default",
-        },
-      }),
+      getDefaultScope: () => defaultScope,
+
       getSecurityPrompt: () => securityPrompt,
       inbox,
       slack,

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { InboxMessage } from "./helpers.js";
@@ -36,10 +37,12 @@ import {
 import { normalizeReactionName } from "./reaction-triggers.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
+import { getSlackScopeAuthorizationError } from "./slack-access.js";
 import { TtlCache } from "./ttl-cache.js";
 
 export interface SlackToolsThreadContextPort {
   resolveThreadChannel: (threadTs: string | undefined) => Promise<string | null>;
+  resolveThreadScope: (threadTs: string | undefined) => Promise<RuntimeScopeCarrier | null>;
   noteThreadReply: (threadTs: string, channelId: string) => void;
   clearPendingAttention: (threadTs: string) => void;
 }
@@ -47,6 +50,7 @@ export interface SlackToolsThreadContextPort {
 export interface RegisterSlackToolsDeps {
   getBotToken: () => string;
   getDefaultChannel: () => string | undefined;
+  getDefaultScope: () => RuntimeScopeCarrier;
   getSecurityPrompt: () => string;
   inbox: InboxMessage[];
   slack: (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>;
@@ -494,6 +498,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
   const {
     getBotToken,
     getDefaultChannel,
+    getDefaultScope,
     getSecurityPrompt,
     inbox,
     slack,
@@ -512,6 +517,16 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
   } = deps;
 
   async function resolveTrackedThreadChannel(threadTs: string | undefined): Promise<string | null> {
+    const threadScope = await threadContext.resolveThreadScope(threadTs);
+    const scopeError = getSlackScopeAuthorizationError({
+      actualScope: threadScope,
+      expectedScope: getDefaultScope(),
+      target: threadTs ? `thread ${threadTs}` : undefined,
+    });
+    if (scopeError) {
+      throw new Error(scopeError);
+    }
+
     return threadContext.resolveThreadChannel(threadTs);
   }
 

--- a/transport-core/index.test.ts
+++ b/transport-core/index.test.ts
@@ -4,6 +4,10 @@ import {
   buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope,
   buildRuntimeScopeCarrier,
+  formatRuntimeScopeCarrier,
+  getRuntimeScopeConflicts,
+  isRuntimeScopeAuthorized,
+  parseRuntimeScopeCarrier,
   type InboundMessage,
 } from "./index.ts";
 
@@ -67,4 +71,92 @@ test("InboundMessage can carry first-class runtime scope metadata", () => {
 
   assert.equal(message.scope?.workspace?.workspaceId, "T123");
   assert.equal(message.scope?.instance?.compatibilityKey, "default");
+});
+
+test("parseRuntimeScopeCarrier reconstructs runtime scope carriers from plain metadata", () => {
+  const scope = parseRuntimeScopeCarrier({
+    workspace: {
+      provider: "slack",
+      source: "explicit",
+      workspaceId: "T123",
+      installId: "primary",
+      channelId: "C123",
+    },
+    instance: {
+      source: "compatibility",
+      compatibilityKey: "default",
+    },
+  });
+
+  assert.deepEqual(scope, {
+    workspace: {
+      provider: "slack",
+      source: "explicit",
+      workspaceId: "T123",
+      installId: "primary",
+      channelId: "C123",
+    },
+    instance: {
+      source: "compatibility",
+      compatibilityKey: "default",
+    },
+  });
+});
+
+test("runtime scope authorization rejects conflicting workspace and instance boundaries", () => {
+  const expected = buildRuntimeScopeCarrier({
+    workspace: {
+      provider: "slack",
+      source: "explicit",
+      workspaceId: "T_PRIMARY",
+      installId: "primary",
+    },
+    instance: {
+      source: "explicit",
+      instanceId: "broker-a",
+      instanceName: "Broker A",
+    },
+  });
+  const actual = buildRuntimeScopeCarrier({
+    workspace: {
+      provider: "slack",
+      source: "explicit",
+      workspaceId: "T_SECONDARY",
+      installId: "secondary",
+    },
+    instance: {
+      source: "explicit",
+      instanceId: "broker-b",
+      instanceName: "Broker B",
+    },
+  });
+
+  assert.equal(isRuntimeScopeAuthorized(actual, expected), false);
+  assert.deepEqual(getRuntimeScopeConflicts(actual, expected), [
+    {
+      dimension: "workspace",
+      field: "workspaceId",
+      expected: "T_PRIMARY",
+      actual: "T_SECONDARY",
+    },
+    {
+      dimension: "workspace",
+      field: "installId",
+      expected: "primary",
+      actual: "secondary",
+    },
+    {
+      dimension: "instance",
+      field: "instanceId",
+      expected: "broker-a",
+      actual: "broker-b",
+    },
+    {
+      dimension: "instance",
+      field: "instanceName",
+      expected: "Broker A",
+      actual: "Broker B",
+    },
+  ]);
+  assert.match(formatRuntimeScopeCarrier(actual), /workspace\.installId=secondary/);
 });

--- a/transport-core/index.test.ts
+++ b/transport-core/index.test.ts
@@ -160,3 +160,39 @@ test("runtime scope authorization rejects conflicting workspace and instance bou
   ]);
   assert.match(formatRuntimeScopeCarrier(actual), /workspace\.installId=secondary/);
 });
+
+test("runtime scope authorization rejects missing actual workspace or instance scopes", () => {
+  const expected = buildRuntimeScopeCarrier({
+    workspace: {
+      provider: "slack",
+      source: "explicit",
+      workspaceId: "T_PRIMARY",
+      installId: "primary",
+    },
+    instance: {
+      source: "explicit",
+      instanceId: "broker-a",
+      instanceName: "Broker A",
+    },
+  });
+
+  assert.equal(isRuntimeScopeAuthorized(undefined, expected), false);
+  assert.equal(isRuntimeScopeAuthorized({}, expected), false);
+
+  const conflicts = getRuntimeScopeConflicts(undefined, expected);
+  assert.ok(conflicts.length > 0);
+  assert.deepEqual(conflicts.slice(0, 2), [
+    {
+      dimension: "workspace",
+      field: "provider",
+      expected: "slack",
+      actual: "unscoped",
+    },
+    {
+      dimension: "workspace",
+      field: "source",
+      expected: "explicit",
+      actual: "unscoped",
+    },
+  ]);
+});

--- a/transport-core/index.ts
+++ b/transport-core/index.ts
@@ -43,11 +43,26 @@ function pushScopeConflict(
   expected: string | undefined,
   actual: string | undefined,
 ): void {
-  if (!expected || !actual || expected === actual) {
+  if (!expected) {
     return;
   }
 
-  conflicts.push({ dimension, field, expected, actual });
+  const resolvedExpected = expected;
+  if (!actual) {
+    conflicts.push({
+      dimension,
+      field,
+      expected: resolvedExpected,
+      actual: "unscoped",
+    });
+    return;
+  }
+
+  if (expected === actual) {
+    return;
+  }
+
+  conflicts.push({ dimension, field, expected: resolvedExpected, actual });
 }
 
 export function buildCompatibilityWorkspaceScope(options: {

--- a/transport-core/index.ts
+++ b/transport-core/index.ts
@@ -28,6 +28,28 @@ function normalizeScopeValue(value: string | null | undefined): string | undefin
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function asScopeSource(value: unknown): RuntimeScopeSource {
+  return value === "explicit" ? "explicit" : "compatibility";
+}
+
+function pushScopeConflict(
+  conflicts: RuntimeScopeConflict[],
+  dimension: RuntimeScopeDimension,
+  field: string,
+  expected: string | undefined,
+  actual: string | undefined,
+): void {
+  if (!expected || !actual || expected === actual) {
+    return;
+  }
+
+  conflicts.push({ dimension, field, expected, actual });
+}
+
 export function buildCompatibilityWorkspaceScope(options: {
   provider: string;
   workspaceId?: string | null;
@@ -84,6 +106,250 @@ export function buildRuntimeScopeCarrier(options: {
     scope.instance = options.instance;
   }
   return Object.keys(scope).length > 0 ? scope : undefined;
+}
+
+export type RuntimeScopeDimension = "workspace" | "instance";
+
+export interface RuntimeScopeConflict {
+  dimension: RuntimeScopeDimension;
+  field: string;
+  expected: string;
+  actual: string;
+}
+
+export function parseRuntimeScopeCarrier(value: unknown): RuntimeScopeCarrier | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const workspaceRecord = asRecord(record.workspace);
+  const instanceRecord = asRecord(record.instance);
+  const scope = buildRuntimeScopeCarrier({
+    workspace: workspaceRecord
+      ? {
+          provider: normalizeScopeValue(String(workspaceRecord.provider ?? "slack")) ?? "slack",
+          source: asScopeSource(workspaceRecord.source),
+          ...(normalizeScopeValue(
+            typeof workspaceRecord.compatibilityKey === "string"
+              ? workspaceRecord.compatibilityKey
+              : undefined,
+          )
+            ? {
+                compatibilityKey: normalizeScopeValue(
+                  typeof workspaceRecord.compatibilityKey === "string"
+                    ? workspaceRecord.compatibilityKey
+                    : undefined,
+                ),
+              }
+            : {}),
+          ...(normalizeScopeValue(
+            typeof workspaceRecord.workspaceId === "string"
+              ? workspaceRecord.workspaceId
+              : undefined,
+          )
+            ? {
+                workspaceId: normalizeScopeValue(
+                  typeof workspaceRecord.workspaceId === "string"
+                    ? workspaceRecord.workspaceId
+                    : undefined,
+                ),
+              }
+            : {}),
+          ...(normalizeScopeValue(
+            typeof workspaceRecord.installId === "string" ? workspaceRecord.installId : undefined,
+          )
+            ? {
+                installId: normalizeScopeValue(
+                  typeof workspaceRecord.installId === "string"
+                    ? workspaceRecord.installId
+                    : undefined,
+                ),
+              }
+            : {}),
+          ...(normalizeScopeValue(
+            typeof workspaceRecord.channelId === "string" ? workspaceRecord.channelId : undefined,
+          )
+            ? {
+                channelId: normalizeScopeValue(
+                  typeof workspaceRecord.channelId === "string"
+                    ? workspaceRecord.channelId
+                    : undefined,
+                ),
+              }
+            : {}),
+        }
+      : null,
+    instance: instanceRecord
+      ? {
+          source: asScopeSource(instanceRecord.source),
+          ...(normalizeScopeValue(
+            typeof instanceRecord.compatibilityKey === "string"
+              ? instanceRecord.compatibilityKey
+              : undefined,
+          )
+            ? {
+                compatibilityKey: normalizeScopeValue(
+                  typeof instanceRecord.compatibilityKey === "string"
+                    ? instanceRecord.compatibilityKey
+                    : undefined,
+                ),
+              }
+            : {}),
+          ...(normalizeScopeValue(
+            typeof instanceRecord.instanceId === "string" ? instanceRecord.instanceId : undefined,
+          )
+            ? {
+                instanceId: normalizeScopeValue(
+                  typeof instanceRecord.instanceId === "string"
+                    ? instanceRecord.instanceId
+                    : undefined,
+                ),
+              }
+            : {}),
+          ...(normalizeScopeValue(
+            typeof instanceRecord.instanceName === "string"
+              ? instanceRecord.instanceName
+              : undefined,
+          )
+            ? {
+                instanceName: normalizeScopeValue(
+                  typeof instanceRecord.instanceName === "string"
+                    ? instanceRecord.instanceName
+                    : undefined,
+                ),
+              }
+            : {}),
+        }
+      : null,
+  });
+
+  return scope ?? null;
+}
+
+export function getRuntimeScopeConflicts(
+  actual: RuntimeScopeCarrier | null | undefined,
+  expected: RuntimeScopeCarrier | null | undefined,
+  dimensions: RuntimeScopeDimension[] = ["workspace", "instance"],
+): RuntimeScopeConflict[] {
+  const conflicts: RuntimeScopeConflict[] = [];
+
+  if (dimensions.includes("workspace")) {
+    pushScopeConflict(
+      conflicts,
+      "workspace",
+      "provider",
+      expected?.workspace?.provider,
+      actual?.workspace?.provider,
+    );
+    pushScopeConflict(
+      conflicts,
+      "workspace",
+      "source",
+      expected?.workspace?.source,
+      actual?.workspace?.source,
+    );
+    pushScopeConflict(
+      conflicts,
+      "workspace",
+      "compatibilityKey",
+      expected?.workspace?.compatibilityKey,
+      actual?.workspace?.compatibilityKey,
+    );
+    pushScopeConflict(
+      conflicts,
+      "workspace",
+      "workspaceId",
+      expected?.workspace?.workspaceId,
+      actual?.workspace?.workspaceId,
+    );
+    pushScopeConflict(
+      conflicts,
+      "workspace",
+      "installId",
+      expected?.workspace?.installId,
+      actual?.workspace?.installId,
+    );
+  }
+
+  if (dimensions.includes("instance")) {
+    pushScopeConflict(
+      conflicts,
+      "instance",
+      "source",
+      expected?.instance?.source,
+      actual?.instance?.source,
+    );
+    pushScopeConflict(
+      conflicts,
+      "instance",
+      "compatibilityKey",
+      expected?.instance?.compatibilityKey,
+      actual?.instance?.compatibilityKey,
+    );
+    pushScopeConflict(
+      conflicts,
+      "instance",
+      "instanceId",
+      expected?.instance?.instanceId,
+      actual?.instance?.instanceId,
+    );
+    pushScopeConflict(
+      conflicts,
+      "instance",
+      "instanceName",
+      expected?.instance?.instanceName,
+      actual?.instance?.instanceName,
+    );
+  }
+
+  return conflicts;
+}
+
+export function isRuntimeScopeAuthorized(
+  actual: RuntimeScopeCarrier | null | undefined,
+  expected: RuntimeScopeCarrier | null | undefined,
+  dimensions: RuntimeScopeDimension[] = ["workspace", "instance"],
+): boolean {
+  return getRuntimeScopeConflicts(actual, expected, dimensions).length === 0;
+}
+
+export function formatRuntimeScopeCarrier(scope: RuntimeScopeCarrier | null | undefined): string {
+  if (!scope?.workspace && !scope?.instance) {
+    return "unscoped";
+  }
+
+  const parts: string[] = [];
+  if (scope.workspace) {
+    parts.push(`workspace.provider=${scope.workspace.provider}`);
+    parts.push(`workspace.source=${scope.workspace.source}`);
+    if (scope.workspace.compatibilityKey) {
+      parts.push(`workspace.compatibilityKey=${scope.workspace.compatibilityKey}`);
+    }
+    if (scope.workspace.workspaceId) {
+      parts.push(`workspace.workspaceId=${scope.workspace.workspaceId}`);
+    }
+    if (scope.workspace.installId) {
+      parts.push(`workspace.installId=${scope.workspace.installId}`);
+    }
+    if (scope.workspace.channelId) {
+      parts.push(`workspace.channelId=${scope.workspace.channelId}`);
+    }
+  }
+  if (scope.instance) {
+    parts.push(`instance.source=${scope.instance.source}`);
+    if (scope.instance.compatibilityKey) {
+      parts.push(`instance.compatibilityKey=${scope.instance.compatibilityKey}`);
+    }
+    if (scope.instance.instanceId) {
+      parts.push(`instance.instanceId=${scope.instance.instanceId}`);
+    }
+    if (scope.instance.instanceName) {
+      parts.push(`instance.instanceName=${scope.instance.instanceName}`);
+    }
+  }
+
+  return parts.join(", ");
 }
 
 export interface InboundMessage {


### PR DESCRIPTION
## Summary
- add shared runtime-scope authorization helpers and use them to detect workspace/install + instance boundary conflicts
- enforce scoped authorization across Slack ingress, broker routing, and thread-scoped Slack tool actions using the existing #546/#549 carriers
- add focused coverage for cross-scope rejection in transport-core, broker routing, single-player ingress, broker adapter ingress, and Slack tools

Closes #547.

## Notes
- stacked on `#567` / `feat/issue-549-multi-workspace-topology`
- generic scoped enforcement only
- no `#548` privileged operator/admin semantics
- no `#550` orchestration/runtime-topology work
- no stable-ID / owner-token redesign
- no broker schema migration churn; thread scope reads reuse existing message metadata

## Testing
- `pnpm --filter @gugu910/pi-transport-core lint`
- `pnpm --filter @gugu910/pi-transport-core typecheck`
- `pnpm --filter @gugu910/pi-transport-core test`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`