### PR TITLE
fix: form-encode Slack external upload endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this repository are documented in this file.
 
+## [0.1.4] - 2026-04-23
+
+Pinet v0.1.4 is a focused patch release for `@gugu910/pi-slack-bridge` that fixes Slack external file-upload requests to use the form encoding Slack expects. The runtime behavior change is intentionally narrow: `slack_upload` should stop failing with `invalid_arguments` when it calls `files.getUploadURLExternal` and `files.completeUploadExternal`.
+
+### Version verification
+
+- `pi-extensions` — `0.1.4` (private repo package)
+- `@gugu910/pi-slack-bridge` — `0.1.4`
+- `@gugu910/pi-nvim-bridge` — `0.1.0` (unchanged)
+- `@gugu910/pi-neon-psql` — `0.1.0` (unchanged)
+- `@gugu910/pi-slack-api` — `0.2.0` (unchanged)
+
+### Release highlights
+
+- Form-encodes `files.getUploadURLExternal` and `files.completeUploadExternal` in the shared Slack request helper so Slack file uploads no longer send JSON to endpoints that expect URL-encoded form bodies.
+- Adds focused regression coverage for both external upload methods, including structured payload serialization for the completion request.
+
 ## [0.1.3] - 2026-04-08
 
 Pinet v0.1.3 is a narrow follow-up patch for `@gugu910/pi-slack-bridge` after `0.1.2` was published with real Slack identifiers in the package README settings example. Because published npm tarballs are immutable, this release corrects the npm-visible package surface with scrubbed example placeholders while leaving the runtime behavior unchanged.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -952,6 +952,35 @@ describe("buildSlackRequest", () => {
     expect(init.body).toContain("limit=10");
   });
 
+  it("uses form encoding for Slack external file upload methods", () => {
+    const uploadUrlRequest = buildSlackRequest("files.getUploadURLExternal", "xoxb-tok", {
+      filename: "changes.diff",
+      length: 42,
+      snippet_type: "diff",
+    });
+
+    expect((uploadUrlRequest.init.headers as Record<string, string>)["Content-Type"]).toContain(
+      "application/x-www-form-urlencoded",
+    );
+    expect(uploadUrlRequest.init.body).toContain("filename=changes.diff");
+    expect(uploadUrlRequest.init.body).toContain("length=42");
+    expect(uploadUrlRequest.init.body).toContain("snippet_type=diff");
+
+    const completeUploadRequest = buildSlackRequest("files.completeUploadExternal", "xoxb-tok", {
+      files: [{ id: "F123", title: "Latest diff" }],
+      channel_id: "C123",
+      thread_ts: "171234.5678",
+    });
+
+    expect(
+      (completeUploadRequest.init.headers as Record<string, string>)["Content-Type"],
+    ).toContain("application/x-www-form-urlencoded");
+    expect(completeUploadRequest.init.body).toContain("channel_id=C123");
+    expect(completeUploadRequest.init.body).toContain("thread_ts=171234.5678");
+    const formBody = new URLSearchParams(String(completeUploadRequest.init.body));
+    expect(formBody.get("files")).toBe('[{"id":"F123","title":"Latest diff"}]');
+  });
+
   it("includes auth header", () => {
     const { init } = buildSlackRequest("auth.test", "xoxb-secret");
     expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer xoxb-secret");

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -616,7 +616,22 @@ export const FORM_METHODS = new Set([
   "conversations.replies",
   "conversations.info",
   "apps.connections.open",
+  "files.getUploadURLExternal",
+  "files.completeUploadExternal",
 ]);
+
+function serializeSlackFormValue(value: unknown): string {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
 
 export function buildSlackRequest(
   method: string,
@@ -637,7 +652,7 @@ export function buildSlackRequest(
     } else {
       headers["Content-Type"] = "application/x-www-form-urlencoded";
       serialized = new URLSearchParams(
-        Object.entries(body).map(([k, v]) => [k, String(v)]),
+        Object.entries(body).map(([k, v]) => [k, serializeSlackFormValue(v)]),
       ).toString();
     }
   }

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gugu910/pi-slack-bridge",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Slack assistant integration for pi (Pinet) — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- form-encode Slack external upload endpoints in the shared request builder
- JSON-stringify non-scalar form values so `files.completeUploadExternal` sends a valid `files` payload
- add focused regression coverage for the upload endpoints

## Testing
- pnpm --filter @gugu910/pi-slack-bridge build
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- git push (pre-push ran repo typecheck + test)