### PR TITLE
feat: orchestrate scoped Slack broker installs

### DIFF
--- a/broker-core/agent-messaging.ts
+++ b/broker-core/agent-messaging.ts
@@ -1,4 +1,11 @@
-import type { AgentInfo, BrokerMessage } from "./types.js";
+import {
+  formatRuntimeScopeCarrier,
+  getRuntimeScopeConflicts,
+  parseRuntimeScopeCarrier,
+  type AgentInfo,
+  type BrokerMessage,
+  type RuntimeScopeCarrier,
+} from "./types.js";
 
 interface AgentCapabilities {
   repo?: string;
@@ -27,6 +34,89 @@ function extractAgentCapabilities(
     tools: asStringArray(capabilitiesRecord?.tools),
     tags: asStringArray(capabilitiesRecord?.tags),
   };
+}
+
+function extractAgentScope(agent: Pick<AgentInfo, "metadata">): RuntimeScopeCarrier | null {
+  const record = asRecord(agent.metadata);
+  const capabilitiesRecord = asRecord(record?.capabilities);
+  return parseRuntimeScopeCarrier(capabilitiesRecord?.scope ?? record?.scope);
+}
+
+function parsePinetControlAction(
+  body: string,
+  metadata?: Record<string, unknown>,
+): "reload" | "exit" | null {
+  const metadataAction = asString(metadata?.action);
+  if (
+    metadata?.type === "pinet:control" &&
+    (metadataAction === "reload" || metadataAction === "exit")
+  ) {
+    return metadataAction;
+  }
+
+  const trimmedBody = body.trim();
+  if (trimmedBody === "/reload") return "reload";
+  if (trimmedBody === "/exit") return "exit";
+
+  try {
+    const parsed = JSON.parse(trimmedBody) as Record<string, unknown>;
+    const parsedAction = asString(parsed.action);
+    if (parsed.type === "pinet:control" && (parsedAction === "reload" || parsedAction === "exit")) {
+      return parsedAction;
+    }
+  } catch {
+    /* not json */
+  }
+
+  return null;
+}
+
+function hasExplicitCrossScopeAdminAuthorization(metadata?: Record<string, unknown>): boolean {
+  if (metadata?.allowCrossScopeAdmin === true) {
+    return true;
+  }
+
+  const authorization = asRecord(metadata?.pinetAdminAuthorization);
+  return authorization?.allowCrossScope === true;
+}
+
+function formatScopeConflictDimensions(
+  senderScope: RuntimeScopeCarrier | null,
+  targetScope: RuntimeScopeCarrier | null,
+): string {
+  return getRuntimeScopeConflicts(senderScope, targetScope)
+    .map((conflict) => `${conflict.dimension}.${conflict.field}`)
+    .join(", ");
+}
+
+function assertAdminDispatchScopeAuthorized(input: {
+  sender: AgentInfo | undefined;
+  target: AgentInfo;
+  body: string;
+  metadata?: Record<string, unknown>;
+}): void {
+  const action = parsePinetControlAction(input.body, input.metadata);
+  if (!action || hasExplicitCrossScopeAdminAuthorization(input.metadata)) {
+    return;
+  }
+
+  const senderScope = input.sender ? extractAgentScope(input.sender) : null;
+  const targetScope = extractAgentScope(input.target);
+  const conflicts = getRuntimeScopeConflicts(senderScope, targetScope);
+  if (conflicts.length === 0) {
+    return;
+  }
+
+  const senderName = input.sender?.name ?? input.sender?.id ?? "unknown sender";
+  throw new Error(
+    [
+      `Pinet admin action /${action} from ${senderName} to ${input.target.name} crosses an unauthorized workspace/install or instance boundary.`,
+      `Conflicts: ${formatScopeConflictDimensions(senderScope, targetScope)}.`,
+      `Sender scope: ${formatRuntimeScopeCarrier(senderScope)}.`,
+      `Target scope: ${formatRuntimeScopeCarrier(targetScope)}.`,
+      "Add metadata.pinetAdminAuthorization.allowCrossScope=true to allow this cross-scope admin action explicitly.",
+    ].join(" "),
+  );
 }
 
 function buildAgentCapabilityTags(capabilities: AgentCapabilities): string[] {
@@ -253,10 +343,19 @@ export function dispatchDirectAgentMessage(
   input: DirectAgentDispatchInput,
   onDispatch?: AgentDispatchCallback,
 ): DirectAgentDispatchResult {
-  const target = resolveDirectAgentTarget(storage.getAgents(), input.target);
+  const agents = storage.getAgents();
+  const target = resolveDirectAgentTarget(agents, input.target);
   if (!target) {
     throw new Error(`Agent not found: ${input.target}`);
   }
+
+  const sender = agents.find((agent) => agent.id === input.senderAgentId);
+  assertAdminDispatchScopeAuthorized({
+    sender,
+    target,
+    body: input.body,
+    metadata: input.metadata,
+  });
 
   const resolvedTarget: AgentDispatchTarget = { id: target.id, name: target.name };
   const metadata = buildAgentMessageMetadata(input.senderAgentName, input.metadata);
@@ -287,9 +386,17 @@ export function dispatchBroadcastAgentMessage(
   }
 
   const agents = storage.getAgents();
-  const targets = resolveBroadcastTargets(agents, input.senderAgentId, normalizedChannel).map(
-    (agent) => ({ id: agent.id, name: agent.name }),
-  );
+  const sender = agents.find((agent) => agent.id === input.senderAgentId);
+  const targetAgents = resolveBroadcastTargets(agents, input.senderAgentId, normalizedChannel);
+  for (const target of targetAgents) {
+    assertAdminDispatchScopeAuthorized({
+      sender,
+      target,
+      body: input.body,
+      metadata: input.metadata,
+    });
+  }
+  const targets = targetAgents.map((agent) => ({ id: agent.id, name: agent.name }));
 
   if (targets.length === 0) {
     throw new Error(`No agents subscribed to #${normalizedChannel} other than the sender.`);

--- a/broker-core/message-send.ts
+++ b/broker-core/message-send.ts
@@ -2,6 +2,7 @@ import type { BrokerMessage, MessageAdapter, OutboundMessage, ThreadInfo } from 
 
 export interface BrokerMessageSenderDb {
   getThread(threadId: string): ThreadInfo | null;
+  getThreadScope?(threadId: string): OutboundMessage["scope"] | null;
   createThread(
     threadId: string,
     source: string,
@@ -35,6 +36,7 @@ export interface SendBrokerMessageInput {
   agentEmoji?: string;
   agentOwnerToken?: string;
   metadata?: Record<string, unknown>;
+  scope?: OutboundMessage["scope"];
 }
 
 export interface SendBrokerMessageResult {
@@ -69,6 +71,8 @@ export async function sendBrokerMessage(
     throw new Error(`No adapter is registered for transport source ${JSON.stringify(source)}.`);
   }
 
+  const resolvedScope = input.scope ?? deps.db.getThreadScope?.(threadId) ?? null;
+
   const outbound: OutboundMessage = {
     threadId,
     channel,
@@ -77,6 +81,7 @@ export async function sendBrokerMessage(
     ...(input.agentEmoji ? { agentEmoji: input.agentEmoji } : {}),
     ...(input.agentOwnerToken ? { agentOwnerToken: input.agentOwnerToken } : {}),
     ...(input.metadata ? { metadata: input.metadata } : {}),
+    ...(resolvedScope ? { scope: resolvedScope } : {}),
   };
   await adapter.send(outbound);
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -151,9 +151,9 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                       |
 | `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true             |
 | `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                              |
-| `defaultChannel`               | no       | Default channel for `slack_post_channel` in legacy single-install compatibility mode                                   |
+| `defaultChannel`               | no       | Default channel for `slack_post_channel` in legacy single-install compatibility mode                               |
 | `logChannel`                   | no       | Channel for broker activity logs in legacy single-install compatibility mode                                       |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                 |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
 | `defaultInstallId`             | no       | When `installs` is configured, selects which install projects into today’s singleton runtime                       |
 | `installs`                     | no       | Explicit Slack install/workspace topology entries; each install can carry scoped tokens and surface targets        |
 | `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |

--- a/slack-bridge/activity-log.test.ts
+++ b/slack-bridge/activity-log.test.ts
@@ -3,6 +3,7 @@ import {
   buildActivityLogBlocks,
   buildActivityLogText,
   formatRecentActivityLogEntries,
+  MultiInstallSlackActivityLogger,
   normalizeActivityLogLevel,
   redactSensitiveText,
   shouldLogActivity,
@@ -186,5 +187,53 @@ describe("SlackActivityLogger", () => {
     expect(slack).toHaveBeenCalledTimes(2);
     expect(logger.getRecentEntries()).toHaveLength(1);
     expect(logger.getRecentEntries()[0]?.title).toBe("Log failure");
+  });
+});
+
+describe("MultiInstallSlackActivityLogger", () => {
+  it("routes scoped entries only to the selected install logger", () => {
+    const primary = {
+      log: vi.fn(),
+      getRecentEntries: vi.fn((): LoggedActivityLogEntry[] => []),
+      clearPending: vi.fn(),
+    };
+    const secondary = {
+      log: vi.fn(),
+      getRecentEntries: vi.fn((): LoggedActivityLogEntry[] => []),
+      clearPending: vi.fn(),
+    };
+    const logger = new MultiInstallSlackActivityLogger(
+      [primary, secondary],
+      primary,
+      (entry, loggers) => (entry.scope ? [loggers[1]!] : loggers),
+    );
+
+    logger.log({
+      kind: "task_assignment",
+      level: "actions",
+      title: "Task assigned",
+      summary: "Scoped to secondary.",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_SECONDARY",
+          installId: "secondary",
+        },
+      },
+    });
+
+    expect(primary.log).not.toHaveBeenCalled();
+    expect(secondary.log).toHaveBeenCalledOnce();
+
+    logger.log({
+      kind: "broker_start",
+      level: "actions",
+      title: "Broker started",
+      summary: "Global event.",
+    });
+
+    expect(primary.log).toHaveBeenCalledOnce();
+    expect(secondary.log).toHaveBeenCalledTimes(2);
   });
 });

--- a/slack-bridge/activity-log.ts
+++ b/slack-bridge/activity-log.ts
@@ -1,3 +1,4 @@
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
 import type { SlackResult } from "./slack-api.js";
 
 export type ActivityLogLevel = "errors" | "actions" | "verbose";
@@ -17,10 +18,17 @@ export interface ActivityLogEntry {
   fields?: ActivityLogField[];
   tone?: ActivityLogTone;
   timestamp?: string;
+  scope?: RuntimeScopeCarrier | null;
 }
 
 export interface LoggedActivityLogEntry extends ActivityLogEntry {
   timestamp: string;
+}
+
+export interface ActivityLoggerPort {
+  log(entry: ActivityLogEntry): void;
+  getRecentEntries(limit?: number): LoggedActivityLogEntry[];
+  clearPending(): void;
 }
 
 interface QueuedActivityLogEntry {
@@ -28,10 +36,20 @@ interface QueuedActivityLogEntry {
   attempts: number;
 }
 
+export interface SlackActivityLoggerSurfaceTarget {
+  botToken?: string;
+  logChannel?: string;
+  logLevel?: string;
+  cacheKey?: string;
+}
+
 export interface SlackActivityLoggerDeps {
   getBotToken: () => string | undefined;
   getLogChannel: () => string | undefined;
   getLogLevel: () => string | undefined;
+  resolveSurfaceTarget?: (
+    scope?: RuntimeScopeCarrier | null,
+  ) => SlackActivityLoggerSurfaceTarget | null;
   getAgentName: () => string;
   getAgentEmoji: () => string;
   resolveChannel: (nameOrId: string) => Promise<string>;
@@ -247,26 +265,27 @@ export function formatRecentActivityLogEntries(
     .join("\n");
 }
 
-export class SlackActivityLogger {
+export class SlackActivityLogger implements ActivityLoggerPort {
   private readonly queue: QueuedActivityLogEntry[] = [];
   private readonly recent: LoggedActivityLogEntry[] = [];
   private readonly maxRecentEntries: number;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private flushRunning = false;
-  private resolvedChannelCache: { raw: string; id: string } | null = null;
-  private dailyThreadCache: { rawChannel: string; dateKey: string; threadTs: string } | null = null;
+  private resolvedChannelCache: { key: string; id: string } | null = null;
+  private dailyThreadCache: { key: string; dateKey: string; threadTs: string } | null = null;
 
   constructor(private readonly deps: SlackActivityLoggerDeps) {
     this.maxRecentEntries = deps.maxRecentEntries ?? DEFAULT_MAX_RECENT_ENTRIES;
   }
 
   log(entry: ActivityLogEntry): void {
-    const rawChannel = this.deps.getLogChannel()?.trim();
+    const target = this.resolveSurfaceTarget(entry.scope);
+    const rawChannel = target.logChannel?.trim();
     if (!rawChannel) {
       return;
     }
 
-    const configuredLevel = normalizeActivityLogLevel(this.deps.getLogLevel());
+    const configuredLevel = normalizeActivityLogLevel(target.logLevel);
     if (!shouldLogActivity(configuredLevel, entry.level)) {
       return;
     }
@@ -335,28 +354,38 @@ export class SlackActivityLogger {
     }
   }
 
-  private async resolveLogChannel(rawChannel: string): Promise<string> {
-    if (this.resolvedChannelCache?.raw === rawChannel) {
+  private resolveSurfaceTarget(
+    scope?: RuntimeScopeCarrier | null,
+  ): SlackActivityLoggerSurfaceTarget {
+    const resolved = this.deps.resolveSurfaceTarget?.(scope) ?? null;
+    const fallbackLogChannel = this.deps.getLogChannel();
+    const fallbackToken = this.deps.getBotToken();
+    return {
+      botToken: resolved?.botToken ?? fallbackToken,
+      logChannel: resolved?.logChannel ?? fallbackLogChannel,
+      logLevel: resolved?.logLevel ?? this.deps.getLogLevel(),
+      cacheKey: resolved?.cacheKey ?? resolved?.logChannel ?? fallbackLogChannel ?? "default",
+    };
+  }
+
+  private async resolveLogChannel(cacheKey: string, rawChannel: string): Promise<string> {
+    if (this.resolvedChannelCache?.key === cacheKey) {
       return this.resolvedChannelCache.id;
     }
 
     const channelId = await this.deps.resolveChannel(rawChannel);
-    this.resolvedChannelCache = { raw: rawChannel, id: channelId };
+    this.resolvedChannelCache = { key: cacheKey, id: channelId };
     return channelId;
   }
 
-  private async ensureDailyThread(rawChannel: string, channelId: string): Promise<string> {
+  private async ensureDailyThread(
+    cacheKey: string,
+    channelId: string,
+    token: string,
+  ): Promise<string> {
     const dateKey = this.getNow().toISOString().slice(0, 10);
-    if (
-      this.dailyThreadCache?.rawChannel === rawChannel &&
-      this.dailyThreadCache.dateKey === dateKey
-    ) {
+    if (this.dailyThreadCache?.key === cacheKey && this.dailyThreadCache.dateKey === dateKey) {
       return this.dailyThreadCache.threadTs;
-    }
-
-    const token = this.deps.getBotToken();
-    if (!token) {
-      throw new Error("Slack bot token unavailable for activity logging.");
     }
 
     const heading = buildActivityLogThreadHeader(
@@ -375,19 +404,21 @@ export class SlackActivityLogger {
       throw new Error("Slack activity log thread creation did not return a ts.");
     }
 
-    this.dailyThreadCache = { rawChannel, dateKey, threadTs };
+    this.dailyThreadCache = { key: cacheKey, dateKey, threadTs };
     return threadTs;
   }
 
   private async postEntry(entry: LoggedActivityLogEntry): Promise<void> {
-    const rawChannel = this.deps.getLogChannel()?.trim();
-    const token = this.deps.getBotToken();
+    const target = this.resolveSurfaceTarget(entry.scope);
+    const rawChannel = target.logChannel?.trim();
+    const token = target.botToken;
     if (!rawChannel || !token) {
       return;
     }
 
-    const channelId = await this.resolveLogChannel(rawChannel);
-    const threadTs = await this.ensureDailyThread(rawChannel, channelId);
+    const cacheKey = `${target.cacheKey}:${rawChannel}`;
+    const channelId = await this.resolveLogChannel(cacheKey, rawChannel);
+    const threadTs = await this.ensureDailyThread(cacheKey, channelId, token);
 
     await this.deps.slack("chat.postMessage", token, {
       channel: channelId,
@@ -395,5 +426,28 @@ export class SlackActivityLogger {
       text: buildActivityLogText(this.deps.getAgentName(), this.deps.getAgentEmoji(), entry),
       blocks: buildActivityLogBlocks(this.deps.getAgentName(), this.deps.getAgentEmoji(), entry),
     });
+  }
+}
+
+export class MultiInstallSlackActivityLogger implements ActivityLoggerPort {
+  constructor(
+    private readonly loggers: ReadonlyArray<ActivityLoggerPort>,
+    private readonly primaryLogger: ActivityLoggerPort | null = loggers[0] ?? null,
+  ) {}
+
+  log(entry: ActivityLogEntry): void {
+    for (const logger of this.loggers) {
+      logger.log(entry);
+    }
+  }
+
+  getRecentEntries(limit = 20): LoggedActivityLogEntry[] {
+    return this.primaryLogger?.getRecentEntries(limit) ?? [];
+  }
+
+  clearPending(): void {
+    for (const logger of this.loggers) {
+      logger.clearPending();
+    }
   }
 }

--- a/slack-bridge/activity-log.ts
+++ b/slack-bridge/activity-log.ts
@@ -429,14 +429,21 @@ export class SlackActivityLogger implements ActivityLoggerPort {
   }
 }
 
+export type MultiInstallActivityLoggerSelector = (
+  entry: ActivityLogEntry,
+  loggers: ReadonlyArray<ActivityLoggerPort>,
+) => ReadonlyArray<ActivityLoggerPort>;
+
 export class MultiInstallSlackActivityLogger implements ActivityLoggerPort {
   constructor(
     private readonly loggers: ReadonlyArray<ActivityLoggerPort>,
     private readonly primaryLogger: ActivityLoggerPort | null = loggers[0] ?? null,
+    private readonly selectLoggers?: MultiInstallActivityLoggerSelector,
   ) {}
 
   log(entry: ActivityLogEntry): void {
-    for (const logger of this.loggers) {
+    const targets = this.selectLoggers?.(entry, this.loggers) ?? this.loggers;
+    for (const logger of targets) {
       logger.log(entry);
     }
   }

--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -1,13 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
 import { createBrokerRuntime, type BrokerRuntimeDeps } from "./broker-runtime.js";
-import type { SlackActivityLogger } from "./activity-log.js";
+import type { ActivityLoggerPort } from "./activity-log.js";
 
 function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDeps {
   return {
     getSettings: () => ({}),
-    getBotToken: () => "xoxb-test",
-    getAppToken: () => "xapp-test",
+    getSlackRuntimeInstalls: () => [
+      {
+        installId: "default",
+        source: "compatibility",
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        homeTabEnabled: true,
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "compatibility",
+            compatibilityKey: "default",
+            installId: "default",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      },
+    ],
+    getDefaultSlackInstallId: () => "default",
     getAllowedUsers: () => null,
     shouldAllowAllWorkspaceUsers: () => false,
     getBrokerStableId: () => "broker-stable-id",
@@ -52,7 +72,7 @@ function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDe
           clearPending: vi.fn(),
           getRecentEntries: vi.fn(() => []),
           log: vi.fn(),
-        }) as unknown as SlackActivityLogger,
+        }) as ActivityLoggerPort,
     ),
     formatTrackedAgent: vi.fn((agentId: string) => agentId),
     summarizeTrackedAssignmentStatus: vi.fn(() => ({

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -4,17 +4,17 @@ import {
   type PinetControlCommand,
   type PinetRemoteControlRequestResult,
   type PinetSkinUpdate,
+  type ResolvedSlackInstallTopology,
   type SlackBridgeSettings,
   buildPinetOwnerToken,
   buildPinetSkinAssignment,
   DEFAULT_PINET_SKIN_THEME,
   resolvePinetMeshAuth,
-  resolveSlackDefaultScope,
   syncBrokerInboxEntries,
 } from "./helpers.js";
 import { startBroker, type Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
-import { SlackAdapter } from "./broker/adapters/slack.js";
+import { SlackTopologyAdapter } from "./broker/adapters/slack-topology.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { MessageRouter } from "./broker/router.js";
 import {
@@ -35,8 +35,8 @@ import type { InboundMessage } from "./broker/types.js";
 import {
   type ActivityLogEntry,
   type ActivityLogTone,
+  type ActivityLoggerPort,
   type LoggedActivityLogEntry,
-  type SlackActivityLogger,
 } from "./activity-log.js";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
 import {
@@ -54,10 +54,16 @@ export interface BrokerRuntimeConnectResult {
   releasedBrokerClaims: number;
 }
 
+export interface BrokerHomeTabViewerRecord {
+  userId: string;
+  installId: string;
+  openedAt: string;
+}
+
 export interface BrokerRuntimeDeps {
   getSettings: () => SlackBridgeSettings;
-  getBotToken: () => string;
-  getAppToken: () => string;
+  getSlackRuntimeInstalls: () => ResolvedSlackInstallTopology[];
+  getDefaultSlackInstallId: () => string;
   getAllowedUsers: () => Set<string> | null;
   shouldAllowAllWorkspaceUsers: () => boolean;
   getBrokerStableId: () => string;
@@ -82,7 +88,10 @@ export interface BrokerRuntimeDeps {
     selfId: string;
     ctx: ExtensionContext;
   }) => Promise<void> | void;
-  onAppHomeOpened: (userId: string, ctx: ExtensionContext) => Promise<void> | void;
+  onAppHomeOpened: (
+    input: { userId: string; installId: string },
+    ctx: ExtensionContext,
+  ) => Promise<void> | void;
   pushInboxMessages: (messages: InboxMessage[]) => void;
   updateBadge: () => void;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
@@ -110,7 +119,7 @@ export interface BrokerRuntimeDeps {
     changedAgentId: string,
     status: "working" | "idle",
   ) => void;
-  createActivityLogger: (onError: (error: unknown) => void) => SlackActivityLogger;
+  createActivityLogger: (onError: (error: unknown) => void) => ActivityLoggerPort;
   formatTrackedAgent: (agentId: string) => string;
   summarizeTrackedAssignmentStatus: (
     status: "assigned" | "branch_pushed" | "pr_open" | "pr_merged" | "pr_closed",
@@ -124,7 +133,7 @@ export interface BrokerRuntimeDeps {
     ctx: ExtensionContext,
     snapshot: BrokerControlPlaneDashboardSnapshot,
     refreshedAt: string,
-    userIds?: string[],
+    viewers?: BrokerHomeTabViewerRecord[],
   ) => Promise<void>;
   buildControlPlaneDashboardSnapshot: (
     input: Record<string, unknown>,
@@ -164,6 +173,7 @@ export interface BrokerRuntime {
   getLastControlPlaneCanvasError: () => string | null;
   setLastControlPlaneCanvasError: (value: string | null) => void;
   getHomeTabViewerIds: () => string[];
+  getHomeTabViewers: () => BrokerHomeTabViewerRecord[];
   getLastHomeTabSnapshot: () => BrokerControlPlaneDashboardSnapshot | null;
   setLastHomeTabSnapshot: (snapshot: BrokerControlPlaneDashboardSnapshot | null) => void;
   getLastHomeTabRefreshAt: () => string | null;
@@ -174,6 +184,7 @@ export interface BrokerRuntime {
     userId: string,
     ctx: ExtensionContext,
     openedAt?: string,
+    installId?: string,
   ) => Promise<boolean>;
 }
 
@@ -193,14 +204,14 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
   let brokerScheduledWakeupRunning = false;
   let lastBrokerMaintenance: BrokerMaintenanceResult | null = null;
   let lastBrokerMaintenanceSignature = "";
-  let activityLogger: SlackActivityLogger | null = null;
+  let activityLogger: ActivityLoggerPort | null = null;
   let activityLogContext: ExtensionContext | null = null;
   let lastActivityLogFailureAt = 0;
   let brokerControlPlaneCanvasRuntimeId: string | null = null;
   let brokerControlPlaneCanvasRuntimeChannelId: string | null = null;
   let lastBrokerControlPlaneCanvasRefreshAt: string | null = null;
   let lastBrokerControlPlaneCanvasError: string | null = null;
-  const brokerControlPlaneHomeTabViewers = new TtlCache<string, { openedAt: string }>({
+  const brokerControlPlaneHomeTabViewers = new TtlCache<string, BrokerHomeTabViewerRecord>({
     maxSize: 100,
     ttlMs: 12 * 60 * 60 * 1000,
   });
@@ -228,7 +239,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     );
   }
 
-  function ensureActivityLogger(): SlackActivityLogger {
+  function ensureActivityLogger(): ActivityLoggerPort {
     if (activityLogger) {
       return activityLogger;
     }
@@ -477,13 +488,15 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     userId: string,
     ctx: ExtensionContext,
     openedAt: string = new Date().toISOString(),
+    installId: string = deps.getDefaultSlackInstallId(),
   ): Promise<boolean> {
     if (!activeBroker) {
       return false;
     }
 
     activityLogContext = ctx;
-    brokerControlPlaneHomeTabViewers.set(userId, { openedAt });
+    const viewerKey = `${installId}:${userId}`;
+    brokerControlPlaneHomeTabViewers.set(viewerKey, { userId, installId, openedAt });
 
     try {
       const snapshot =
@@ -492,7 +505,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
       if (!snapshot) {
         return false;
       }
-      await deps.refreshHomeTabs(ctx, snapshot, openedAt, [userId]);
+      await deps.refreshHomeTabs(ctx, snapshot, openedAt, [{ userId, installId, openedAt }]);
       return true;
     } catch (error) {
       const homeTabMessage = `Pinet Home tab publish failed: ${deps.formatError(error)}`;
@@ -536,24 +549,52 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
       const settings = deps.getSettings();
       const meshAuth = resolvePinetMeshAuth(settings);
       const allowedUsers = deps.getAllowedUsers();
+      const runtimeInstalls = deps.getSlackRuntimeInstalls();
+      const defaultInstallId = deps.getDefaultSlackInstallId();
       const broker = await startBroker({
         ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
         ...(meshAuth.meshSecretPath ? { meshSecretPath: meshAuth.meshSecretPath } : {}),
       });
-      const adapter = new SlackAdapter({
-        botToken: deps.getBotToken(),
-        appToken: deps.getAppToken(),
+      const adapter = new SlackTopologyAdapter({
+        installs: runtimeInstalls,
+        defaultInstallId,
+        resolveInstallForScope: (scope) => {
+          const installId = normalizeOptionalSetting(scope?.workspace?.installId);
+          if (installId) {
+            return runtimeInstalls.find((install) => install.installId === installId) ?? null;
+          }
+
+          const workspaceId = normalizeOptionalSetting(scope?.workspace?.workspaceId);
+          if (workspaceId) {
+            const matches = runtimeInstalls.filter(
+              (install) => install.workspaceId === workspaceId,
+            );
+            if (matches.length > 0) {
+              return (
+                matches.find((install) => install.installId === defaultInstallId) ??
+                matches[0] ??
+                null
+              );
+            }
+            return null;
+          }
+
+          return (
+            runtimeInstalls.find((install) => install.installId === defaultInstallId) ??
+            runtimeInstalls[0] ??
+            null
+          );
+        },
         allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
         allowAllWorkspaceUsers: deps.shouldAllowAllWorkspaceUsers(),
         suggestedPrompts: settings.suggestedPrompts,
         reactionCommands: settings.reactionCommands,
-        getDefaultScope: () => resolveSlackDefaultScope(deps.getSettings(), process.env),
         isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
         rememberKnownThread: (threadTs: string, channelId: string) => {
           broker.db.updateThread(threadTs, { source: "slack", channel: channelId });
         },
-        onAppHomeOpened: async ({ userId }) => {
-          await deps.onAppHomeOpened(userId, ctx);
+        onAppHomeOpened: async ({ userId, installId }) => {
+          await deps.onAppHomeOpened({ userId, installId }, ctx);
         },
       });
       let selfId: string | null = null;
@@ -807,7 +848,15 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     },
 
     getHomeTabViewerIds(): string[] {
-      return [...brokerControlPlaneHomeTabViewers.entries()].map(([userId]) => userId);
+      return [
+        ...new Set(
+          [...brokerControlPlaneHomeTabViewers.entries()].map(([, viewer]) => viewer.userId),
+        ),
+      ];
+    },
+
+    getHomeTabViewers(): BrokerHomeTabViewerRecord[] {
+      return [...brokerControlPlaneHomeTabViewers.entries()].map(([, viewer]) => ({ ...viewer }));
     },
 
     getLastHomeTabSnapshot(): BrokerControlPlaneDashboardSnapshot | null {
@@ -838,8 +887,9 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
       userId: string,
       ctx: ExtensionContext,
       openedAt = new Date().toISOString(),
+      installId = deps.getDefaultSlackInstallId(),
     ): Promise<boolean> {
-      return publishCurrentHomeTabSafely(userId, ctx, openedAt);
+      return publishCurrentHomeTabSafely(userId, ctx, openedAt, installId);
     },
   };
 }

--- a/slack-bridge/broker-thread-owner-hints.test.ts
+++ b/slack-bridge/broker-thread-owner-hints.test.ts
@@ -9,7 +9,7 @@ function createDeps(overrides: Partial<BrokerThreadOwnerHintsDeps> = {}) {
 
   const deps: BrokerThreadOwnerHintsDeps = {
     slack,
-    getBotToken: () => "xoxb-test",
+    resolveBotToken: () => "xoxb-test",
     ...overrides,
   };
 

--- a/slack-bridge/broker-thread-owner-hints.ts
+++ b/slack-bridge/broker-thread-owner-hints.ts
@@ -1,15 +1,17 @@
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
 import type { ThreadOwnerHint } from "./broker/router.js";
 import { resolveSlackThreadOwnerHint, type SlackCall } from "./slack-access.js";
 
 export interface BrokerThreadOwnerHintsDeps {
   slack: SlackCall;
-  getBotToken: () => string;
+  resolveBotToken: (scope: RuntimeScopeCarrier | null | undefined) => string | null;
 }
 
 export interface BrokerThreadOwnerHints {
   resolveBrokerThreadOwnerHint: (
     channel: string,
     threadTs: string,
+    scope?: RuntimeScopeCarrier | null,
   ) => Promise<ThreadOwnerHint | null>;
 }
 
@@ -19,10 +21,16 @@ export function createBrokerThreadOwnerHints(
   async function resolveBrokerThreadOwnerHint(
     channel: string,
     threadTs: string,
+    scope?: RuntimeScopeCarrier | null,
   ): Promise<ThreadOwnerHint | null> {
+    const token = deps.resolveBotToken(scope ?? null);
+    if (!token) {
+      return null;
+    }
+
     return resolveSlackThreadOwnerHint({
       slack: deps.slack,
-      token: deps.getBotToken(),
+      token,
       channel,
       threadTs,
     });

--- a/slack-bridge/broker/adapters/slack-topology.test.ts
+++ b/slack-bridge/broker/adapters/slack-topology.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedSlackInstallTopology } from "../../helpers.js";
+
+const mockState = vi.hoisted(() => ({
+  adapterConfigs: [] as Array<{ installId: string; config: Record<string, unknown> }>,
+  sendCalls: new Map<string, unknown[]>(),
+}));
+
+vi.mock("./slack.js", () => {
+  class FakeSlackAdapter {
+    private readonly installId: string;
+
+    constructor(private readonly config: Record<string, unknown>) {
+      const scope = config.getDefaultScope as
+        | (() => { workspace?: { installId?: string } })
+        | undefined;
+      this.installId = scope?.().workspace?.installId ?? "unknown";
+      mockState.adapterConfigs.push({ installId: this.installId, config });
+      mockState.sendCalls.set(this.installId, []);
+    }
+
+    async connect(): Promise<void> {}
+
+    async disconnect(): Promise<void> {}
+
+    onInbound(): void {}
+
+    async send(message: unknown): Promise<void> {
+      mockState.sendCalls.get(this.installId)?.push(message);
+    }
+
+    getBotUserId(): string {
+      return `B_${this.installId}`;
+    }
+
+    isConnected(): boolean {
+      return true;
+    }
+  }
+
+  return {
+    SlackAdapter: FakeSlackAdapter,
+  };
+});
+
+import { SlackTopologyAdapter } from "./slack-topology.js";
+
+describe("SlackTopologyAdapter", () => {
+  beforeEach(() => {
+    mockState.adapterConfigs.length = 0;
+    mockState.sendCalls.clear();
+  });
+
+  it("connects one Slack adapter per runtime install and routes outbound scope to the matching install", async () => {
+    const installs = [
+      {
+        installId: "primary",
+        source: "explicit",
+        workspaceId: "T_PRIMARY",
+        botToken: "xoxb-primary",
+        appToken: "xapp-primary",
+        homeTabEnabled: true,
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_PRIMARY",
+            installId: "primary",
+          },
+        },
+      },
+      {
+        installId: "secondary",
+        source: "explicit",
+        workspaceId: "T_SECONDARY",
+        botToken: "xoxb-secondary",
+        appToken: "xapp-secondary",
+        homeTabEnabled: true,
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_SECONDARY",
+            installId: "secondary",
+          },
+        },
+      },
+    ] satisfies ReadonlyArray<ResolvedSlackInstallTopology>;
+    const adapter = new SlackTopologyAdapter({
+      installs,
+      defaultInstallId: "primary",
+      resolveInstallForScope: (scope) =>
+        installs.find((install) => install.installId === scope?.workspace?.installId) ??
+        installs[0] ??
+        null,
+    });
+
+    await adapter.connect();
+    await adapter.send({
+      threadId: "100.1",
+      channel: "C_SECONDARY",
+      text: "hello secondary",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_SECONDARY",
+          installId: "secondary",
+        },
+      },
+    });
+    await adapter.send({
+      threadId: "100.2",
+      channel: "C_PRIMARY",
+      text: "hello default",
+    });
+
+    expect(mockState.adapterConfigs.map((entry) => entry.installId)).toEqual([
+      "primary",
+      "secondary",
+    ]);
+    expect(mockState.sendCalls.get("secondary")).toEqual([
+      {
+        threadId: "100.1",
+        channel: "C_SECONDARY",
+        text: "hello secondary",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "explicit",
+            workspaceId: "T_SECONDARY",
+            installId: "secondary",
+          },
+        },
+      },
+    ]);
+    expect(mockState.sendCalls.get("primary")).toEqual([
+      {
+        threadId: "100.2",
+        channel: "C_PRIMARY",
+        text: "hello default",
+        scope: installs[0]?.scope,
+      },
+    ]);
+    expect(adapter.getBotUserId()).toBe("B_primary");
+  });
+});

--- a/slack-bridge/broker/adapters/slack-topology.ts
+++ b/slack-bridge/broker/adapters/slack-topology.ts
@@ -1,0 +1,121 @@
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
+import type { ResolvedSlackInstallTopology } from "../../helpers.js";
+import type { ParsedAppHomeOpened } from "../../slack-access.js";
+import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
+import { SlackAdapter, type SlackAdapterConfig } from "./slack.js";
+
+export interface ScopedAppHomeOpenedEvent extends ParsedAppHomeOpened {
+  installId: string;
+  scope: RuntimeScopeCarrier;
+}
+
+export interface SlackTopologyAdapterConfig {
+  installs: ReadonlyArray<ResolvedSlackInstallTopology>;
+  defaultInstallId: string;
+  resolveInstallForScope: (
+    scope: RuntimeScopeCarrier | null | undefined,
+  ) => ResolvedSlackInstallTopology | null;
+  allowedUsers?: SlackAdapterConfig["allowedUsers"];
+  allowAllWorkspaceUsers?: SlackAdapterConfig["allowAllWorkspaceUsers"];
+  suggestedPrompts?: SlackAdapterConfig["suggestedPrompts"];
+  reactionCommands?: SlackAdapterConfig["reactionCommands"];
+  isKnownThread?: SlackAdapterConfig["isKnownThread"];
+  rememberKnownThread?: SlackAdapterConfig["rememberKnownThread"];
+  onAppHomeOpened?: (event: ScopedAppHomeOpenedEvent) => Promise<void> | void;
+}
+
+export class SlackTopologyAdapter implements MessageAdapter {
+  readonly name = "slack";
+
+  private readonly config: SlackTopologyAdapterConfig;
+  private readonly adapters = new Map<string, SlackAdapter>();
+  private inboundHandler: ((msg: InboundMessage) => void) | null = null;
+
+  constructor(config: SlackTopologyAdapterConfig) {
+    this.config = config;
+  }
+
+  async connect(): Promise<void> {
+    if (this.config.installs.length === 0) {
+      throw new Error("No runtime-capable Slack installs are configured for broker mode.");
+    }
+
+    const started: SlackAdapter[] = [];
+    try {
+      for (const install of this.config.installs) {
+        if (!install.botToken || !install.appToken) {
+          continue;
+        }
+
+        const adapter = new SlackAdapter({
+          botToken: install.botToken,
+          appToken: install.appToken,
+          allowedUsers: this.config.allowedUsers,
+          allowAllWorkspaceUsers: this.config.allowAllWorkspaceUsers,
+          suggestedPrompts: this.config.suggestedPrompts,
+          reactionCommands: this.config.reactionCommands,
+          getDefaultScope: () => install.scope,
+          isKnownThread: this.config.isKnownThread,
+          rememberKnownThread: this.config.rememberKnownThread,
+          onAppHomeOpened: async (event) => {
+            await this.config.onAppHomeOpened?.({
+              ...event,
+              installId: install.installId,
+              scope: install.scope,
+            });
+          },
+        });
+        adapter.onInbound((message) => {
+          this.inboundHandler?.(message);
+        });
+        await adapter.connect();
+        this.adapters.set(install.installId, adapter);
+        started.push(adapter);
+      }
+    } catch (error) {
+      await Promise.allSettled(started.map((adapter) => adapter.disconnect()));
+      this.adapters.clear();
+      throw error;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    const adapters = [...this.adapters.values()];
+    this.adapters.clear();
+    await Promise.allSettled(adapters.map((adapter) => adapter.disconnect()));
+  }
+
+  onInbound(handler: (msg: InboundMessage) => void): void {
+    this.inboundHandler = handler;
+  }
+
+  async send(msg: OutboundMessage): Promise<void> {
+    const selectedInstall = this.config.resolveInstallForScope(msg.scope ?? null);
+    const fallbackInstall =
+      this.config.installs.find((install) => install.installId === this.config.defaultInstallId) ??
+      this.config.installs[0] ??
+      null;
+    const install = selectedInstall ?? (msg.scope ? null : fallbackInstall);
+    if (!install) {
+      throw new Error("No Slack install is authorized for the outbound message scope.");
+    }
+
+    const adapter = this.adapters.get(install.installId);
+    if (!adapter) {
+      throw new Error(`Slack install ${JSON.stringify(install.installId)} is not connected.`);
+    }
+
+    await adapter.send({
+      ...msg,
+      ...(msg.scope ? {} : { scope: install.scope }),
+    });
+  }
+
+  getBotUserId(): string | null {
+    return this.adapters.get(this.config.defaultInstallId)?.getBotUserId() ?? null;
+  }
+
+  isConnected(): boolean {
+    return [...this.adapters.values()].some((adapter) => adapter.isConnected());
+  }
+}

--- a/slack-bridge/broker/agent-messaging.test.ts
+++ b/slack-bridge/broker/agent-messaging.test.ts
@@ -31,6 +31,27 @@ function createAgent(
   };
 }
 
+function createScopedMetadata(installId: string, workspaceId: string): Record<string, unknown> {
+  return {
+    capabilities: {
+      repo: "extensions",
+      role: "worker",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          installId,
+          workspaceId,
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    },
+  };
+}
+
 function createStorage(agents: AgentInfo[]): AgentMessageStorage & {
   threads: Set<string>;
   inserted: Array<{
@@ -182,6 +203,53 @@ describe("dispatchDirectAgentMessage", () => {
     });
     expect(delivered).toEqual(["target:1:Sender Agent"]);
   });
+
+  it("denies cross-scope admin control messages by default", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("target", "target", createScopedMetadata("secondary", "T_SECONDARY")),
+    ]);
+
+    expect(() =>
+      dispatchDirectAgentMessage(storage, {
+        senderAgentId: "sender",
+        senderAgentName: "Sender Agent",
+        target: "target",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { type: "pinet:control", action: "reload" },
+      }),
+    ).toThrow(/Conflicts: workspace\.workspaceId, workspace\.installId\./);
+  });
+
+  it("allows cross-scope admin control when explicitly authorized in metadata", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("target", "target", createScopedMetadata("secondary", "T_SECONDARY")),
+    ]);
+
+    const result = dispatchDirectAgentMessage(storage, {
+      senderAgentId: "sender",
+      senderAgentName: "Sender Agent",
+      target: "target",
+      body: '{"type":"pinet:control","action":"reload"}',
+      metadata: {
+        type: "pinet:control",
+        action: "reload",
+        pinetAdminAuthorization: { allowCrossScope: true },
+      },
+    });
+
+    expect(result).toEqual({
+      target: { id: "target", name: "target" },
+      messageId: 1,
+      threadId: "a2a:sender:target",
+    });
+    expect(storage.inserted[0]?.metadata).toMatchObject({
+      type: "pinet:control",
+      action: "reload",
+      pinetAdminAuthorization: { allowCrossScope: true },
+    });
+  });
 });
 
 describe("dispatchBroadcastAgentMessage", () => {
@@ -249,5 +317,40 @@ describe("dispatchBroadcastAgentMessage", () => {
         body: "anyone there?",
       }),
     ).toThrow("No agents subscribed to #extensions other than the sender.");
+  });
+
+  it("denies cross-scope admin control broadcasts by default", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("worker-a", "worker-a", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("worker-b", "worker-b", {
+        capabilities: {
+          repo: "extensions",
+          role: "worker",
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "explicit",
+              installId: "secondary",
+              workspaceId: "T_SECONDARY",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(() =>
+      dispatchBroadcastAgentMessage(storage, {
+        senderAgentId: "sender",
+        senderAgentName: "Sender Agent",
+        channel: "#extensions",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { type: "pinet:control", action: "reload" },
+      }),
+    ).toThrow(/Pinet admin action \/reload/);
   });
 });

--- a/slack-bridge/broker/message-send.test.ts
+++ b/slack-bridge/broker/message-send.test.ts
@@ -1,15 +1,21 @@
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
 import { describe, expect, it, vi } from "vitest";
 import { sendBrokerMessage } from "./message-send.js";
 import type { BrokerMessage, ThreadInfo } from "./types.js";
 
 function createFakeDb() {
   const threads = new Map<string, ThreadInfo>();
+  const threadScopes = new Map<string, RuntimeScopeCarrier>();
   let nextMessageId = 1;
 
   return {
     threads,
+    threadScopes,
     getThread(threadId: string) {
       return threads.get(threadId) ?? null;
+    },
+    getThreadScope(threadId: string) {
+      return threadScopes.get(threadId) ?? null;
     },
     createThread(threadId: string, source: string, channel: string, ownerAgent: string | null) {
       const now = new Date().toISOString();
@@ -113,6 +119,46 @@ describe("sendBrokerMessage", () => {
       threadId: "imessage:chat:bob",
       channel: "chat:bob",
       text: "follow-up",
+    });
+  });
+
+  it("threads stored scope carriers into outbound adapter sends", async () => {
+    const db = createFakeDb();
+    db.createThread("slack:100.1", "slack", "C123", "agent-1");
+    db.threadScopes.set("slack:100.1", {
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_PRIMARY",
+        installId: "primary",
+      },
+    });
+    const send = vi.fn(async () => undefined);
+
+    await sendBrokerMessage(
+      {
+        db,
+        adapters: [{ name: "slack", send }],
+      },
+      {
+        threadId: "slack:100.1",
+        body: "scoped follow-up",
+        senderAgentId: "agent-1",
+      },
+    );
+
+    expect(send).toHaveBeenCalledWith({
+      threadId: "slack:100.1",
+      channel: "C123",
+      text: "scoped follow-up",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+          installId: "primary",
+        },
+      },
     });
   });
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -5,7 +5,10 @@ import * as os from "node:os";
 import {
   loadSettings,
   resolveSlackDefaultScope,
+  resolveSlackInstallForScope,
+  resolveSlackRuntimeInstalls,
   resolveSlackRuntimeSettings,
+  resolveSlackSurfaceInstalls,
   resolveSlackTopology,
   resolvePinetMeshAuth,
   resolveAllowAllWorkspaceUsers,
@@ -596,6 +599,99 @@ describe("resolveSlackTopology", () => {
         },
       },
     });
+  });
+});
+
+describe("resolveSlack install selection helpers", () => {
+  it("selects installs by install id or workspace id from scope carriers", () => {
+    const topology = resolveSlackTopology(
+      {
+        defaultInstallId: "primary",
+        installs: [
+          {
+            installId: "primary",
+            workspaceId: "T_PRIMARY",
+            botToken: "xoxb-primary",
+            appToken: "xapp-primary",
+          },
+          {
+            installId: "secondary",
+            workspaceId: "T_SECONDARY",
+            botToken: "xoxb-secondary",
+            appToken: "xapp-secondary",
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(
+      resolveSlackInstallForScope(topology, {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          installId: "secondary",
+          workspaceId: "T_SECONDARY",
+        },
+      }),
+    ).toMatchObject({ installId: "secondary" });
+    expect(
+      resolveSlackInstallForScope(topology, {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          workspaceId: "T_PRIMARY",
+        },
+      }),
+    ).toMatchObject({ installId: "primary" });
+    expect(resolveSlackInstallForScope(topology, null)).toMatchObject({ installId: "primary" });
+    expect(
+      resolveSlackInstallForScope(topology, {
+        workspace: {
+          provider: "imessage",
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      }),
+    ).toBeNull();
+    expect(
+      resolveSlackInstallForScope(topology, {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          installId: "missing",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("filters runtime-capable installs separately from broker surface installs", () => {
+    const settings = {
+      defaultInstallId: "primary",
+      installs: [
+        {
+          installId: "primary",
+          workspaceId: "T_PRIMARY",
+          botToken: "xoxb-primary",
+          appToken: "xapp-primary",
+          logChannel: "C_PRIMARY_LOGS",
+        },
+        {
+          installId: "secondary",
+          workspaceId: "T_SECONDARY",
+          botToken: "xoxb-secondary",
+          logChannel: "C_SECONDARY_LOGS",
+        },
+      ],
+    };
+
+    expect(resolveSlackRuntimeInstalls(settings, {}).map((install) => install.installId)).toEqual([
+      "primary",
+    ]);
+    expect(resolveSlackSurfaceInstalls(settings, {}).map((install) => install.installId)).toEqual([
+      "primary",
+      "secondary",
+    ]);
   });
 });
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -600,6 +600,52 @@ describe("resolveSlackTopology", () => {
       },
     });
   });
+
+  it("defaults privileged broker surfaces to the default install unless a secondary install opts in", () => {
+    const topology = resolveSlackTopology(
+      {
+        defaultInstallId: "primary",
+        installs: [
+          {
+            installId: "primary",
+            workspaceId: "T_PRIMARY",
+            botToken: "xoxb-primary",
+            appToken: "xapp-primary",
+          },
+          {
+            installId: "secondary",
+            workspaceId: "T_SECONDARY",
+            botToken: "xoxb-secondary",
+            appToken: "xapp-secondary",
+          },
+          {
+            installId: "operator-opt-in",
+            workspaceId: "T_OPERATOR",
+            botToken: "xoxb-operator",
+            appToken: "xapp-operator",
+            homeTabEnabled: true,
+            controlPlaneCanvasEnabled: true,
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(topology.installs.find((install) => install.installId === "primary")).toMatchObject({
+      homeTabEnabled: true,
+      controlPlaneCanvasEnabled: true,
+    });
+    expect(topology.installs.find((install) => install.installId === "secondary")).toMatchObject({
+      homeTabEnabled: false,
+      controlPlaneCanvasEnabled: false,
+    });
+    expect(
+      topology.installs.find((install) => install.installId === "operator-opt-in"),
+    ).toMatchObject({
+      homeTabEnabled: true,
+      controlPlaneCanvasEnabled: true,
+    });
+  });
 });
 
 describe("resolveSlack install selection helpers", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -232,6 +232,22 @@ function normalizeSlackInstallId(install: SlackInstallTopologySettings, index: n
   );
 }
 
+function applyExplicitOperatorSurfaceDefaults(
+  install: ResolvedSlackInstallTopology,
+  rawInstall: SlackInstallTopologySettings,
+  isDefaultInstall: boolean,
+): ResolvedSlackInstallTopology {
+  return {
+    ...install,
+    controlPlaneCanvasEnabled:
+      typeof rawInstall.controlPlaneCanvasEnabled === "boolean"
+        ? rawInstall.controlPlaneCanvasEnabled
+        : isDefaultInstall,
+    homeTabEnabled:
+      typeof rawInstall.homeTabEnabled === "boolean" ? rawInstall.homeTabEnabled : isDefaultInstall,
+  };
+}
+
 function validateExplicitSlackInstalls(
   installs: ReadonlyArray<ResolvedSlackInstallTopology>,
   configuredDefaultInstallId: string | null,
@@ -251,7 +267,6 @@ function validateExplicitSlackInstalls(
     );
   }
 }
-
 function resolveCompatibilityInstall(
   settings: SlackBridgeSettings,
   env = process.env,
@@ -350,9 +365,7 @@ function resolveExplicitInstall(
       ? { logChannel: normalizeOptionalSetting(install.logChannel) ?? undefined }
       : {}),
     ...(install.logLevel ? { logLevel: install.logLevel } : {}),
-    ...(typeof install.controlPlaneCanvasEnabled === "boolean"
-      ? { controlPlaneCanvasEnabled: install.controlPlaneCanvasEnabled }
-      : {}),
+    controlPlaneCanvasEnabled: install.controlPlaneCanvasEnabled ?? false,
     ...(normalizeOptionalSetting(install.controlPlaneCanvasId)
       ? {
           controlPlaneCanvasId: normalizeOptionalSetting(install.controlPlaneCanvasId) ?? undefined,
@@ -370,7 +383,7 @@ function resolveExplicitInstall(
             normalizeOptionalSetting(install.controlPlaneCanvasTitle) ?? undefined,
         }
       : {}),
-    homeTabEnabled: install.homeTabEnabled ?? true,
+    homeTabEnabled: install.homeTabEnabled ?? false,
     scope: buildSlackScope({
       source: "explicit",
       workspaceId,
@@ -399,12 +412,23 @@ export function resolveSlackTopology(
   const installs = explicitInstalls.map((install, index) => resolveExplicitInstall(install, index));
   const configuredDefaultInstallId = normalizeOptionalSetting(settings.defaultInstallId);
   validateExplicitSlackInstalls(installs, configuredDefaultInstallId);
-  const defaultInstall =
+  const unresolvedDefaultInstall =
     installs.find((install) => install.installId === configuredDefaultInstallId) ?? installs[0]!;
+  const installsWithOperatorSurfaceDefaults = installs.map((install, index) =>
+    applyExplicitOperatorSurfaceDefaults(
+      install,
+      explicitInstalls[index]!,
+      install.installId === unresolvedDefaultInstall.installId,
+    ),
+  );
+  const defaultInstall =
+    installsWithOperatorSurfaceDefaults.find(
+      (install) => install.installId === unresolvedDefaultInstall.installId,
+    ) ?? installsWithOperatorSurfaceDefaults[0]!;
 
   return {
-    mode: installs.length === 1 ? "explicit-single" : "explicit-multi",
-    installs,
+    mode: installsWithOperatorSurfaceDefaults.length === 1 ? "explicit-single" : "explicit-multi",
+    installs: installsWithOperatorSurfaceDefaults,
     defaultInstallId: defaultInstall.installId,
     defaultInstall,
   };

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -418,6 +418,61 @@ export function summarizeSlackTopology(topology: ResolvedSlackTopology): SlackTo
   };
 }
 
+export function resolveSlackRuntimeInstalls(
+  settings: SlackBridgeSettings,
+  env = process.env,
+): ResolvedSlackInstallTopology[] {
+  return resolveSlackTopology(settings, env).installs.filter(
+    (
+      install,
+    ): install is ResolvedSlackInstallTopology & {
+      botToken: string;
+      appToken: string;
+    } => typeof install.botToken === "string" && typeof install.appToken === "string",
+  );
+}
+
+export function resolveSlackSurfaceInstalls(
+  settings: SlackBridgeSettings,
+  env = process.env,
+): ResolvedSlackInstallTopology[] {
+  return resolveSlackTopology(settings, env).installs.filter(
+    (
+      install,
+    ): install is ResolvedSlackInstallTopology & {
+      botToken: string;
+    } => typeof install.botToken === "string",
+  );
+}
+
+export function resolveSlackInstallForScope(
+  topology: ResolvedSlackTopology,
+  scope: RuntimeScopeCarrier | null | undefined,
+): ResolvedSlackInstallTopology | null {
+  const provider = normalizeOptionalSetting(scope?.workspace?.provider);
+  if (provider && provider !== "slack") {
+    return null;
+  }
+
+  const installId = normalizeOptionalSetting(scope?.workspace?.installId);
+  if (installId) {
+    return topology.installs.find((install) => install.installId === installId) ?? null;
+  }
+
+  const workspaceId = normalizeOptionalSetting(scope?.workspace?.workspaceId);
+  if (workspaceId) {
+    const matches = topology.installs.filter((install) => install.workspaceId === workspaceId);
+    if (matches.length > 0) {
+      return (
+        matches.find((install) => install.installId === topology.defaultInstallId) ?? matches[0]!
+      );
+    }
+    return null;
+  }
+
+  return topology.defaultInstall;
+}
+
 export function resolveSlackDefaultScope(
   settings: SlackBridgeSettings,
   env = process.env,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1039,6 +1039,13 @@ export default function (pi: ExtensionAPI) {
       },
       getDefaultChannel: () => settings.defaultChannel,
       getDefaultScope: () => resolveSlackDefaultScope(settings, process.env),
+      resolveInstallIdForScope: (scope) =>
+        slackTopologyRuntime.resolveInstallForScope(scope)?.installId ?? null,
+      getBotTokenForInstall: (installId) => slackTopologyRuntime.getBotToken(installId),
+      getDefaultChannelForInstall: (installId) =>
+        slackTopologyRuntime.getDefaultChannel(installId) ?? undefined,
+      resolveChannelForInstall: (installId, nameOrId) =>
+        slackTopologyRuntime.resolveChannel(installId, nameOrId),
       getSecurityPrompt: () => securityPrompt,
       inbox,
       slack,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -759,33 +759,45 @@ export default function (pi: ExtensionAPI) {
       const installs = slackTopologyRuntime
         .getSurfaceInstalls()
         .filter((install) => install.botToken && install.logChannel);
-      const loggers = installs.map(
-        (install) =>
-          new SlackActivityLogger({
-            getBotToken: () => install.botToken,
-            getLogChannel: () => install.logChannel,
-            getLogLevel: () => install.logLevel,
-            getAgentName: () => agentName,
-            getAgentEmoji: () => agentEmoji,
-            resolveChannel: async (channelInput) => {
-              const channelId = await slackTopologyRuntime.resolveChannel(
-                install.installId,
-                channelInput,
+      const loggerEntries = installs.map((install) => ({
+        installId: install.installId,
+        logger: new SlackActivityLogger({
+          getBotToken: () => install.botToken,
+          getLogChannel: () => install.logChannel,
+          getLogLevel: () => install.logLevel,
+          getAgentName: () => agentName,
+          getAgentEmoji: () => agentEmoji,
+          resolveChannel: async (channelInput) => {
+            const channelId = await slackTopologyRuntime.resolveChannel(
+              install.installId,
+              channelInput,
+            );
+            if (!channelId) {
+              throw new Error(
+                `Unable to resolve Slack activity log channel ${JSON.stringify(channelInput)} for install ${install.installId}.`,
               );
-              if (!channelId) {
-                throw new Error(
-                  `Unable to resolve Slack activity log channel ${JSON.stringify(channelInput)} for install ${install.installId}.`,
-                );
-              }
-              return channelId;
-            },
-            slack,
-            onError,
-          }),
-      );
+            }
+            return channelId;
+          },
+          slack,
+          onError,
+        }),
+      }));
+      const loggers = loggerEntries.map((entry) => entry.logger);
       return loggers.length <= 1
         ? (loggers[0] ?? new MultiInstallSlackActivityLogger([]))
-        : new MultiInstallSlackActivityLogger(loggers, loggers[0]);
+        : new MultiInstallSlackActivityLogger(loggers, loggers[0], (entry) => {
+            if (!entry.scope) {
+              return loggers;
+            }
+            const scopedInstallId = slackTopologyRuntime.resolveInstallForScope(
+              entry.scope,
+            )?.installId;
+            const scopedLogger = loggerEntries.find(
+              (loggerEntry) => loggerEntry.installId === scopedInstallId,
+            )?.logger;
+            return scopedLogger ? [scopedLogger] : [];
+          });
     },
     formatTrackedAgent,
     summarizeTrackedAssignmentStatus,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -35,6 +35,7 @@ import {
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
 } from "./slack-access.js";
+import { createSlackTopologyRuntime } from "./slack-topology-runtime.js";
 import {
   createFollowerDeliveryState,
   markFollowerInboxIdsDelivered,
@@ -47,7 +48,7 @@ import {
   type SinglePlayerThreadInfo,
 } from "./single-player-runtime.js";
 import { createBrokerRuntime } from "./broker-runtime.js";
-import { SlackActivityLogger } from "./activity-log.js";
+import { MultiInstallSlackActivityLogger, SlackActivityLogger } from "./activity-log.js";
 import { createBrokerDeliveryState, queueBrokerInboxIds } from "./broker-delivery.js";
 import { buildBrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
 import { createPinetHomeTabs } from "./pinet-home-tabs.js";
@@ -93,6 +94,11 @@ export default function (pi: ExtensionAPI) {
 
   const slackRequestRuntime = createSlackRequestRuntime();
   const { slack } = slackRequestRuntime;
+  const slackTopologyRuntime = createSlackTopologyRuntime({
+    slack,
+    getSettings: () => settings,
+    env: process.env,
+  });
 
   // allowedUsers / allowAllWorkspaceUsers: settings.json takes priority, env vars as fallback
   let allowedUsers = buildAllowlist(
@@ -405,7 +411,9 @@ export default function (pi: ExtensionAPI) {
   } = slackRuntimeAccess;
   const pinetHomeTabs = createPinetHomeTabs({
     slack,
-    getBotToken: () => botToken,
+    getBotToken: (installId) => slackTopologyRuntime.getBotToken(installId),
+    getDefaultInstallId: () => slackTopologyRuntime.getDefaultInstallId(),
+    isHomeTabEnabled: (installId) => slackTopologyRuntime.isHomeTabEnabled(installId),
     formatError: msg,
     getAgentName: () => agentName,
     getAgentEmoji: () => agentEmoji,
@@ -415,7 +423,7 @@ export default function (pi: ExtensionAPI) {
     isSinglePlayerConnected: () => isSinglePlayerConnected(),
     getActiveThreads: () => threads.size,
     getPendingInboxCount: () => inbox.length,
-    getDefaultChannel: () => settings.defaultChannel ?? null,
+    getDefaultChannel: (installId) => slackTopologyRuntime.getDefaultChannel(installId),
     getCurrentBranch: async () => (await probeGitBranch(process.cwd())) ?? null,
     getBrokerHomeTabs: () => brokerRuntime,
   });
@@ -540,17 +548,17 @@ export default function (pi: ExtensionAPI) {
   });
   const { formatTrackedAgent, summarizeTrackedAssignmentStatus } = pinetActivityFormatting;
   const pinetControlPlaneCanvas = createPinetControlPlaneCanvas({
-    getSettings: () => settings,
-    getBotToken: () => botToken,
+    getSlackSurfaceInstalls: () => slackTopologyRuntime.getSurfaceInstalls(),
+    getDefaultSlackInstallId: () => slackTopologyRuntime.getDefaultInstallId(),
     slack,
-    resolveChannel,
+    resolveChannel: async (installId, channelInput) =>
+      await slackTopologyRuntime.resolveChannel(installId, channelInput),
     persistState,
     getActiveBrokerDb,
     getActiveBrokerSelfId,
     heartbeatTimerActive: () => brokerRuntime.heartbeatTimerActive(),
     maintenanceTimerActive: () => brokerRuntime.maintenanceTimerActive(),
     getLastMaintenance: () => brokerRuntime.getLastMaintenance(),
-    isBrokerControlPlaneCanvasEnabled: () => brokerRuntime.isBrokerControlPlaneCanvasEnabled(),
     getControlPlaneCanvasRuntimeId: () => brokerRuntime.getControlPlaneCanvasRuntimeId(),
     getControlPlaneCanvasRuntimeChannelId: () =>
       brokerRuntime.getControlPlaneCanvasRuntimeChannelId(),
@@ -643,14 +651,17 @@ export default function (pi: ExtensionAPI) {
 
   const brokerThreadOwnerHints = createBrokerThreadOwnerHints({
     slack,
-    getBotToken: () => botToken!,
+    resolveBotToken: (scope) =>
+      slackTopologyRuntime.getBotToken(
+        slackTopologyRuntime.resolveInstallForScope(scope)?.installId ?? null,
+      ) ?? null,
   });
   const { resolveBrokerThreadOwnerHint } = brokerThreadOwnerHints;
 
   const brokerRuntime = createBrokerRuntime({
     getSettings: () => settings,
-    getBotToken: () => botToken!,
-    getAppToken: () => appToken!,
+    getSlackRuntimeInstalls: () => slackTopologyRuntime.getRuntimeInstalls(),
+    getDefaultSlackInstallId: () => slackTopologyRuntime.getDefaultInstallId(),
     getAllowedUsers: () => allowedUsers,
     shouldAllowAllWorkspaceUsers: () =>
       resolveAllowAllWorkspaceUsers(settings, process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS),
@@ -675,7 +686,7 @@ export default function (pi: ExtensionAPI) {
       try {
         const ownerHint =
           message.source === "slack" && message.threadId && message.channel
-            ? await resolveBrokerThreadOwnerHint(message.channel, message.threadId)
+            ? await resolveBrokerThreadOwnerHint(message.channel, message.threadId, message.scope)
             : null;
         const routedMessage =
           ownerHint && (ownerHint.agentOwner || ownerHint.agentName)
@@ -722,8 +733,13 @@ export default function (pi: ExtensionAPI) {
         console.error(`[slack-bridge] broker inbound routing failed: ${msg(err)}`);
       }
     },
-    onAppHomeOpened: async (userId, ctx) => {
-      await pinetHomeTabs.publishCurrentPinetHomeTabSafely(userId, ctx, new Date().toISOString());
+    onAppHomeOpened: async ({ userId, installId }, ctx) => {
+      await pinetHomeTabs.publishCurrentPinetHomeTabSafely(
+        userId,
+        ctx,
+        new Date().toISOString(),
+        installId,
+      );
     },
     pushInboxMessages: (messages) => {
       inbox.push(...messages);
@@ -739,17 +755,38 @@ export default function (pi: ExtensionAPI) {
     },
     formatError: msg,
     deliveryState: brokerDeliveryState,
-    createActivityLogger: (onError) =>
-      new SlackActivityLogger({
-        getBotToken: () => botToken,
-        getLogChannel: () => settings.logChannel,
-        getLogLevel: () => settings.logLevel,
-        getAgentName: () => agentName,
-        getAgentEmoji: () => agentEmoji,
-        resolveChannel,
-        slack,
-        onError,
-      }),
+    createActivityLogger: (onError) => {
+      const installs = slackTopologyRuntime
+        .getSurfaceInstalls()
+        .filter((install) => install.botToken && install.logChannel);
+      const loggers = installs.map(
+        (install) =>
+          new SlackActivityLogger({
+            getBotToken: () => install.botToken,
+            getLogChannel: () => install.logChannel,
+            getLogLevel: () => install.logLevel,
+            getAgentName: () => agentName,
+            getAgentEmoji: () => agentEmoji,
+            resolveChannel: async (channelInput) => {
+              const channelId = await slackTopologyRuntime.resolveChannel(
+                install.installId,
+                channelInput,
+              );
+              if (!channelId) {
+                throw new Error(
+                  `Unable to resolve Slack activity log channel ${JSON.stringify(channelInput)} for install ${install.installId}.`,
+                );
+              }
+              return channelId;
+            },
+            slack,
+            onError,
+          }),
+      );
+      return loggers.length <= 1
+        ? (loggers[0] ?? new MultiInstallSlackActivityLogger([]))
+        : new MultiInstallSlackActivityLogger(loggers, loggers[0]);
+    },
     formatTrackedAgent,
     summarizeTrackedAssignmentStatus,
     sendMaintenanceMessage: (targetAgentId, body) => {
@@ -764,8 +801,8 @@ export default function (pi: ExtensionAPI) {
         input as Parameters<typeof refreshBrokerControlPlaneCanvasDashboard>[1],
       );
     },
-    refreshHomeTabs: async (ctx, snapshot, refreshedAt, userIds) => {
-      await pinetHomeTabs.refreshBrokerControlPlaneHomeTabs(ctx, snapshot, refreshedAt, userIds);
+    refreshHomeTabs: async (ctx, snapshot, refreshedAt, viewers) => {
+      await pinetHomeTabs.refreshBrokerControlPlaneHomeTabs(ctx, snapshot, refreshedAt, viewers);
     },
     buildControlPlaneDashboardSnapshot: (input) =>
       buildBrokerControlPlaneDashboardSnapshot(

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -178,7 +178,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   });
 
   pi.registerCommand("pinet-reload", {
-    description: "Tell a connected Pinet agent to reload itself",
+    description:
+      "Tell a connected Pinet agent to reload itself (same workspace/install or instance by default)",
     handler: async (args, ctx) => {
       const target = args.trim();
       if (!target) {
@@ -196,7 +197,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   });
 
   pi.registerCommand("pinet-exit", {
-    description: "Tell a connected Pinet agent to exit gracefully",
+    description:
+      "Tell a connected Pinet agent to exit gracefully (same workspace/install or instance by default)",
     handler: async (args, ctx) => {
       const target = args.trim();
       if (!target) {

--- a/slack-bridge/pinet-control-plane-canvas.test.ts
+++ b/slack-bridge/pinet-control-plane-canvas.test.ts
@@ -414,7 +414,7 @@ describe("createPinetControlPlaneCanvas", () => {
     );
   });
 
-  it("refreshes canvases for every configured surface install", async () => {
+  it("skips non-default installs unless broker canvas access is explicitly enabled", async () => {
     const { deps, slack, resolveChannel } = createDeps({
       slack: vi.fn(async (method: string) => {
         if (method === "conversations.canvases.create") {
@@ -447,6 +447,71 @@ describe("createPinetControlPlaneCanvas", () => {
           source: "explicit",
           workspaceId: "T_SECONDARY",
           botToken: "xoxb-secondary",
+          controlPlaneCanvasChannel: "ops-secondary",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "explicit",
+              workspaceId: "T_SECONDARY",
+              installId: "secondary",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+      ],
+    });
+    const canvas = createPinetControlPlaneCanvas(deps);
+    const { ctx } = createContext();
+
+    await canvas.refreshBrokerControlPlaneCanvasDashboard(ctx, createRefreshInput());
+
+    expect(resolveChannel).toHaveBeenCalledWith("default", "ops-control");
+    expect(resolveChannel).not.toHaveBeenCalledWith("secondary", "ops-secondary");
+    expect(slack).not.toHaveBeenCalledWith(
+      "conversations.canvases.create",
+      "xoxb-secondary",
+      expect.anything(),
+    );
+  });
+
+  it("refreshes canvases for every configured surface install that explicitly opts in", async () => {
+    const { deps, slack, resolveChannel } = createDeps({
+      slack: vi.fn(async (method: string) => {
+        if (method === "conversations.canvases.create") {
+          return { ok: true, canvas_id: "FNEWCANVAS" };
+        }
+        return { ok: true };
+      }),
+      getSlackSurfaceInstalls: () => [
+        {
+          installId: "default",
+          source: "compatibility",
+          botToken: "xoxb-default",
+          controlPlaneCanvasChannel: "ops-control",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "compatibility",
+              compatibilityKey: "default",
+              installId: "default",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+        {
+          installId: "secondary",
+          source: "explicit",
+          workspaceId: "T_SECONDARY",
+          botToken: "xoxb-secondary",
+          controlPlaneCanvasEnabled: true,
           controlPlaneCanvasChannel: "ops-secondary",
           homeTabEnabled: true,
           scope: {

--- a/slack-bridge/pinet-control-plane-canvas.test.ts
+++ b/slack-bridge/pinet-control-plane-canvas.test.ts
@@ -156,12 +156,33 @@ function createDeps(overrides: Partial<PinetControlPlaneCanvasDeps> = {}) {
   };
 
   const slack = vi.fn(async () => ({ ok: true }));
-  const resolveChannel = vi.fn(async () => "C123CANVAS");
+  const resolveChannel = vi.fn(async (_installId: string, _channelInput: string) => "C123CANVAS");
   const persistState = vi.fn();
 
   const deps: PinetControlPlaneCanvasDeps = {
-    getSettings: () => ({}),
-    getBotToken: () => "xoxb-test",
+    getSlackSurfaceInstalls: () => [
+      {
+        installId: "default",
+        source: "compatibility",
+        botToken: "xoxb-test",
+        controlPlaneCanvasChannel: "ops-control",
+        controlPlaneCanvasTitle: "Broker Canvas",
+        homeTabEnabled: true,
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "compatibility",
+            compatibilityKey: "default",
+            installId: "default",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      },
+    ],
+    getDefaultSlackInstallId: () => "default",
     slack,
     resolveChannel,
     persistState,
@@ -177,7 +198,6 @@ function createDeps(overrides: Partial<PinetControlPlaneCanvasDeps> = {}) {
       pendingBacklogCount: 3,
       anomalies: [],
     }),
-    isBrokerControlPlaneCanvasEnabled: () => true,
     getControlPlaneCanvasRuntimeId: () => runtimeCanvasId,
     getControlPlaneCanvasRuntimeChannelId: () => runtimeChannelId,
     restoreControlPlaneCanvasRuntimeState: vi.fn((input) => {
@@ -213,13 +233,31 @@ describe("createPinetControlPlaneCanvas", () => {
     vi.mocked(probeGitBranch).mockResolvedValue("main");
   });
 
-  it("normalizes explicit canvas settings and falls back to runtime/default values", () => {
+  it("reads canvas settings from the default surface install and falls back to runtime ids", () => {
     const { deps } = createDeps({
-      getSettings: () => ({
-        controlPlaneCanvasId: "  FEXPLICIT  ",
-        controlPlaneCanvasChannel: "  ops-control  ",
-        controlPlaneCanvasTitle: "  Mesh Control Plane  ",
-      }),
+      getSlackSurfaceInstalls: () => [
+        {
+          installId: "default",
+          source: "compatibility",
+          botToken: "xoxb-test",
+          controlPlaneCanvasId: "  FEXPLICIT  ",
+          controlPlaneCanvasChannel: "  ops-control  ",
+          controlPlaneCanvasTitle: "  Mesh Control Plane  ",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "compatibility",
+              compatibilityKey: "default",
+              installId: "default",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+      ],
       getControlPlaneCanvasRuntimeId: () => "FRUNTIME",
     });
     const canvas = createPinetControlPlaneCanvas(deps);
@@ -231,7 +269,27 @@ describe("createPinetControlPlaneCanvas", () => {
 
     const fallback = createPinetControlPlaneCanvas(
       createDeps({
-        getSettings: () => ({ defaultChannel: "  broker-ops  " }),
+        getSlackSurfaceInstalls: () => [
+          {
+            installId: "default",
+            source: "compatibility",
+            botToken: "xoxb-test",
+            defaultChannel: "  broker-ops  ",
+            homeTabEnabled: true,
+            scope: {
+              workspace: {
+                provider: "slack",
+                source: "compatibility",
+                compatibilityKey: "default",
+                installId: "default",
+              },
+              instance: {
+                source: "compatibility",
+                compatibilityKey: "default",
+              },
+            },
+          },
+        ],
         getControlPlaneCanvasRuntimeId: () => "FRUNTIME",
       }).deps,
     );
@@ -271,9 +329,28 @@ describe("createPinetControlPlaneCanvas", () => {
     expect(snapshot?.recentCycles).toHaveLength(1);
   });
 
-  it("warns once when no canvas destination is configured", async () => {
+  it("warns once when the default install has no canvas destination", async () => {
     const { deps, getLastError } = createDeps({
-      getSettings: () => ({}),
+      getSlackSurfaceInstalls: () => [
+        {
+          installId: "default",
+          source: "compatibility",
+          botToken: "xoxb-test",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "compatibility",
+              compatibilityKey: "default",
+              installId: "default",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+      ],
       getControlPlaneCanvasRuntimeId: () => null,
     });
     const canvas = createPinetControlPlaneCanvas(deps);
@@ -304,10 +381,6 @@ describe("createPinetControlPlaneCanvas", () => {
       getLastRefreshAt,
       getLastError,
     } = createDeps({
-      getSettings: () => ({
-        controlPlaneCanvasChannel: "ops-control",
-        controlPlaneCanvasTitle: "Broker Canvas",
-      }),
       slack: vi.fn(async (method: string) => {
         if (method === "conversations.canvases.create") {
           return { ok: true, canvas_id: "FNEWCANVAS" };
@@ -320,7 +393,7 @@ describe("createPinetControlPlaneCanvas", () => {
 
     await canvas.refreshBrokerControlPlaneCanvasDashboard(ctx, createRefreshInput());
 
-    expect(resolveChannel).toHaveBeenCalledWith("ops-control");
+    expect(resolveChannel).toHaveBeenCalledWith("default", "ops-control");
     expect(slack).toHaveBeenCalledWith(
       "conversations.canvases.create",
       "xoxb-test",
@@ -338,6 +411,70 @@ describe("createPinetControlPlaneCanvas", () => {
     expect(notify).toHaveBeenCalledWith(
       "Pinet broker control plane canvas created: FNEWCANVAS via ops-control",
       "info",
+    );
+  });
+
+  it("refreshes canvases for every configured surface install", async () => {
+    const { deps, slack, resolveChannel } = createDeps({
+      slack: vi.fn(async (method: string) => {
+        if (method === "conversations.canvases.create") {
+          return { ok: true, canvas_id: "FNEWCANVAS" };
+        }
+        return { ok: true };
+      }),
+      getSlackSurfaceInstalls: () => [
+        {
+          installId: "default",
+          source: "compatibility",
+          botToken: "xoxb-default",
+          controlPlaneCanvasChannel: "ops-control",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "compatibility",
+              compatibilityKey: "default",
+              installId: "default",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+        {
+          installId: "secondary",
+          source: "explicit",
+          workspaceId: "T_SECONDARY",
+          botToken: "xoxb-secondary",
+          controlPlaneCanvasChannel: "ops-secondary",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "explicit",
+              workspaceId: "T_SECONDARY",
+              installId: "secondary",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+      ],
+    });
+    const canvas = createPinetControlPlaneCanvas(deps);
+    const { ctx } = createContext();
+
+    await canvas.refreshBrokerControlPlaneCanvasDashboard(ctx, createRefreshInput());
+
+    expect(resolveChannel).toHaveBeenCalledWith("default", "ops-control");
+    expect(resolveChannel).toHaveBeenCalledWith("secondary", "ops-secondary");
+    expect(slack).toHaveBeenCalledWith(
+      "conversations.canvases.create",
+      "xoxb-secondary",
+      expect.objectContaining({ channel_id: "C123CANVAS" }),
     );
   });
 });

--- a/slack-bridge/pinet-control-plane-canvas.ts
+++ b/slack-bridge/pinet-control-plane-canvas.ts
@@ -105,8 +105,14 @@ function getInstallCanvasTitle(install: ResolvedSlackInstallTopology): string {
   return normalizeOptionalSetting(install.controlPlaneCanvasTitle) ?? "Pinet Broker Control Plane";
 }
 
-function isInstallCanvasEnabled(install: ResolvedSlackInstallTopology): boolean {
-  return install.controlPlaneCanvasEnabled ?? true;
+function isInstallCanvasEnabled(
+  install: ResolvedSlackInstallTopology,
+  defaultInstallId: string,
+): boolean {
+  if (typeof install.controlPlaneCanvasEnabled === "boolean") {
+    return install.controlPlaneCanvasEnabled;
+  }
+  return install.installId === defaultInstallId;
 }
 
 export function createPinetControlPlaneCanvas(
@@ -229,13 +235,15 @@ export function createPinetControlPlaneCanvas(
     ctx: ExtensionContext,
     input: PinetControlPlaneCanvasRefreshInput,
   ): Promise<void> {
-    const installs = deps.getSlackSurfaceInstalls().filter(isInstallCanvasEnabled);
+    const defaultInstallId = deps.getDefaultSlackInstallId();
+    const installs = deps
+      .getSlackSurfaceInstalls()
+      .filter((install) => isInstallCanvasEnabled(install, defaultInstallId));
     if (installs.length === 0) {
       deps.setLastControlPlaneCanvasError(null);
       return;
     }
 
-    const defaultInstallId = deps.getDefaultSlackInstallId();
     const snapshot = buildBrokerControlPlaneDashboardSnapshot({
       ...input,
       homedir: os.homedir(),

--- a/slack-bridge/pinet-control-plane-canvas.ts
+++ b/slack-bridge/pinet-control-plane-canvas.ts
@@ -4,10 +4,10 @@ import { probeGitBranch } from "./git-metadata.js";
 import {
   type RalphLoopAgentWorkload,
   type RalphLoopEvaluationOptions,
+  type ResolvedSlackInstallTopology,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
   filterAgentsForMeshVisibility,
   evaluateRalphLoopCycle,
-  type SlackBridgeSettings,
 } from "./helpers.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
@@ -54,17 +54,16 @@ export type PinetControlPlaneCanvasRefreshInput = Omit<
 >;
 
 export interface PinetControlPlaneCanvasDeps {
-  getSettings: () => SlackBridgeSettings;
-  getBotToken: () => string | undefined;
+  getSlackSurfaceInstalls: () => ResolvedSlackInstallTopology[];
+  getDefaultSlackInstallId: () => string;
   slack: RefreshBrokerControlPlaneCanvasInput["slack"];
-  resolveChannel: (channelInput: string) => Promise<string | null>;
+  resolveChannel: (installId: string, channelInput: string) => Promise<string | null>;
   persistState: () => void;
   getActiveBrokerDb: () => PinetControlPlaneCanvasBrokerDbPort | null;
   getActiveBrokerSelfId: () => string | null;
   heartbeatTimerActive: () => boolean;
   maintenanceTimerActive: () => boolean;
   getLastMaintenance: () => BrokerMaintenanceResult | null;
-  isBrokerControlPlaneCanvasEnabled: () => boolean;
   getControlPlaneCanvasRuntimeId: () => string | null;
   getControlPlaneCanvasRuntimeChannelId: () => string | null;
   restoreControlPlaneCanvasRuntimeState: (input: {
@@ -95,11 +94,35 @@ function normalizeOptionalSetting(value?: string | null): string | null {
   return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
+function getInstallCanvasChannel(install: ResolvedSlackInstallTopology): string | null {
+  return (
+    normalizeOptionalSetting(install.controlPlaneCanvasChannel) ??
+    normalizeOptionalSetting(install.defaultChannel)
+  );
+}
+
+function getInstallCanvasTitle(install: ResolvedSlackInstallTopology): string {
+  return normalizeOptionalSetting(install.controlPlaneCanvasTitle) ?? "Pinet Broker Control Plane";
+}
+
+function isInstallCanvasEnabled(install: ResolvedSlackInstallTopology): boolean {
+  return install.controlPlaneCanvasEnabled ?? true;
+}
+
 export function createPinetControlPlaneCanvas(
   deps: PinetControlPlaneCanvasDeps,
 ): PinetControlPlaneCanvas {
+  function getDefaultInstall(): ResolvedSlackInstallTopology | null {
+    const installs = deps.getSlackSurfaceInstalls();
+    return (
+      installs.find((install) => install.installId === deps.getDefaultSlackInstallId()) ??
+      installs[0] ??
+      null
+    );
+  }
+
   function getExplicitBrokerControlPlaneCanvasId(): string | null {
-    return normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasId);
+    return normalizeOptionalSetting(getDefaultInstall()?.controlPlaneCanvasId);
   }
 
   function getConfiguredBrokerControlPlaneCanvasId(): string | null {
@@ -107,17 +130,13 @@ export function createPinetControlPlaneCanvas(
   }
 
   function getConfiguredBrokerControlPlaneCanvasChannel(): string | null {
-    return (
-      normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasChannel) ??
-      normalizeOptionalSetting(deps.getSettings().defaultChannel)
-    );
+    const install = getDefaultInstall();
+    return install ? getInstallCanvasChannel(install) : null;
   }
 
   function getConfiguredBrokerControlPlaneCanvasTitle(): string {
-    return (
-      normalizeOptionalSetting(deps.getSettings().controlPlaneCanvasTitle) ??
-      "Pinet Broker Control Plane"
-    );
+    const install = getDefaultInstall();
+    return install ? getInstallCanvasTitle(install) : "Pinet Broker Control Plane";
   }
 
   async function buildCurrentBrokerControlPlaneDashboardSnapshot(
@@ -210,16 +229,104 @@ export function createPinetControlPlaneCanvas(
     ctx: ExtensionContext,
     input: PinetControlPlaneCanvasRefreshInput,
   ): Promise<void> {
-    const botToken = deps.getBotToken();
-    if (!botToken || !deps.isBrokerControlPlaneCanvasEnabled()) {
+    const installs = deps.getSlackSurfaceInstalls().filter(isInstallCanvasEnabled);
+    if (installs.length === 0) {
       deps.setLastControlPlaneCanvasError(null);
       return;
     }
 
-    const explicitCanvasId = getExplicitBrokerControlPlaneCanvasId();
-    const effectiveCanvasId = getConfiguredBrokerControlPlaneCanvasId();
-    const channelInput = getConfiguredBrokerControlPlaneCanvasChannel();
-    if (!effectiveCanvasId && !channelInput) {
+    const defaultInstallId = deps.getDefaultSlackInstallId();
+    const snapshot = buildBrokerControlPlaneDashboardSnapshot({
+      ...input,
+      homedir: os.homedir(),
+    });
+    const markdown = renderBrokerControlPlaneCanvasMarkdown(snapshot);
+
+    let refreshedInstallCount = 0;
+    const errors: string[] = [];
+    let defaultInstallMissingDestination = false;
+
+    for (const install of installs) {
+      if (!install.botToken) {
+        continue;
+      }
+
+      const explicitCanvasId = normalizeOptionalSetting(install.controlPlaneCanvasId);
+      const channelInput = getInstallCanvasChannel(install);
+      if (!explicitCanvasId && !channelInput) {
+        if (install.installId === defaultInstallId) {
+          defaultInstallMissingDestination = true;
+        }
+        continue;
+      }
+
+      try {
+        const channelId =
+          explicitCanvasId || !channelInput
+            ? null
+            : await deps.resolveChannel(install.installId, channelInput);
+        if (!explicitCanvasId && channelInput && !channelId) {
+          throw new Error(
+            `Unable to resolve Slack channel ${JSON.stringify(channelInput)} for install ${install.installId}.`,
+          );
+        }
+
+        const runtimeCanvasId =
+          install.installId === defaultInstallId ? deps.getControlPlaneCanvasRuntimeId() : null;
+        const runtimeChannelId =
+          install.installId === defaultInstallId
+            ? deps.getControlPlaneCanvasRuntimeChannelId()
+            : null;
+        const reusableRuntimeCanvasId =
+          install.installId === defaultInstallId &&
+          !explicitCanvasId &&
+          runtimeCanvasId &&
+          (!channelId || runtimeChannelId === channelId)
+            ? runtimeCanvasId
+            : null;
+        const result = await refreshBrokerControlPlaneCanvas({
+          slack: deps.slack,
+          token: install.botToken,
+          markdown,
+          canvasId: explicitCanvasId ?? reusableRuntimeCanvasId,
+          channelId,
+          title: getInstallCanvasTitle(install),
+        });
+
+        if (install.installId === defaultInstallId) {
+          if (!explicitCanvasId) {
+            deps.restoreControlPlaneCanvasRuntimeState({
+              canvasId: result.canvasId,
+              channelId,
+            });
+          }
+          if (
+            !explicitCanvasId &&
+            (result.canvasId !== runtimeCanvasId || channelId !== runtimeChannelId)
+          ) {
+            deps.persistState();
+            const destination = channelInput ? ` via ${channelInput}` : "";
+            const action = result.created
+              ? "created"
+              : result.reusedExistingChannelCanvas
+                ? "attached"
+                : "updated";
+            ctx.ui.notify(
+              `Pinet broker control plane canvas ${action}: ${result.canvasId}${destination}`,
+              "info",
+            );
+          }
+        }
+
+        refreshedInstallCount += 1;
+      } catch (error) {
+        errors.push(
+          `install ${install.installId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    if (refreshedInstallCount === 0 && defaultInstallMissingDestination) {
       const warning =
         "Pinet broker control plane canvas skipped: set slack-bridge.controlPlaneCanvasChannel, defaultChannel, or controlPlaneCanvasId.";
       if (deps.getLastControlPlaneCanvasError() !== warning) {
@@ -229,53 +336,17 @@ export function createPinetControlPlaneCanvas(
       return;
     }
 
-    const snapshot = buildBrokerControlPlaneDashboardSnapshot({
-      ...input,
-      homedir: os.homedir(),
-    });
-    const markdown = renderBrokerControlPlaneCanvasMarkdown(snapshot);
-    const channelId =
-      explicitCanvasId || !channelInput ? null : await deps.resolveChannel(channelInput);
-    const runtimeCanvasId = deps.getControlPlaneCanvasRuntimeId();
-    const runtimeChannelId = deps.getControlPlaneCanvasRuntimeChannelId();
-    const reusableRuntimeCanvasId =
-      !explicitCanvasId && runtimeCanvasId && (!channelId || runtimeChannelId === channelId)
-        ? runtimeCanvasId
-        : null;
-    const result = await refreshBrokerControlPlaneCanvas({
-      slack: deps.slack,
-      token: botToken,
-      markdown,
-      canvasId: explicitCanvasId ?? reusableRuntimeCanvasId,
-      channelId,
-      title: getConfiguredBrokerControlPlaneCanvasTitle(),
-    });
-
-    if (!explicitCanvasId) {
-      deps.restoreControlPlaneCanvasRuntimeState({
-        canvasId: result.canvasId,
-        channelId,
-      });
+    if (refreshedInstallCount > 0) {
+      deps.setLastControlPlaneCanvasRefreshAt(input.cycleStartedAt);
     }
-    deps.setLastControlPlaneCanvasRefreshAt(input.cycleStartedAt);
+
+    if (errors.length > 0) {
+      const message = `Pinet broker control plane canvas failed: ${errors.join("; ")}`;
+      deps.setLastControlPlaneCanvasError(message);
+      throw new Error(message);
+    }
+
     deps.setLastControlPlaneCanvasError(null);
-
-    if (
-      !explicitCanvasId &&
-      (result.canvasId !== runtimeCanvasId || channelId !== runtimeChannelId)
-    ) {
-      deps.persistState();
-      const destination = channelInput ? ` via ${channelInput}` : "";
-      const action = result.created
-        ? "created"
-        : result.reusedExistingChannelCanvas
-          ? "attached"
-          : "updated";
-      ctx.ui.notify(
-        `Pinet broker control plane canvas ${action}: ${result.canvasId}${destination}`,
-        "info",
-      );
-    }
   }
 
   return {

--- a/slack-bridge/pinet-home-tabs.test.ts
+++ b/slack-bridge/pinet-home-tabs.test.ts
@@ -14,6 +14,7 @@ function createBrokerHomeTabs(): PinetHomeTabsBrokerPort {
     isConnected: vi.fn(() => false),
     publishCurrentHomeTabSafely: vi.fn(async () => false),
     getHomeTabViewerIds: vi.fn(() => []),
+    getHomeTabViewers: vi.fn(() => []),
     getLastHomeTabError: vi.fn(() => lastHomeTabError),
     setLastHomeTabSnapshot: vi.fn(),
     setLastHomeTabRefreshAt: vi.fn(),
@@ -100,6 +101,8 @@ function createDeps(overrides: Partial<PinetHomeTabsDeps> = {}) {
   const deps: PinetHomeTabsDeps = {
     slack,
     getBotToken: () => "xoxb-test",
+    getDefaultInstallId: () => "default",
+    isHomeTabEnabled: () => true,
     formatError: (error: unknown) => (error instanceof Error ? error.message : String(error)),
     getAgentName: () => "Cobalt Olive Crane",
     getAgentEmoji: () => "🦩",
@@ -121,7 +124,10 @@ function createDeps(overrides: Partial<PinetHomeTabsDeps> = {}) {
 describe("createPinetHomeTabs", () => {
   it("refreshes broker control-plane home tabs and stores the latest snapshot state", async () => {
     const brokerHomeTabs = createBrokerHomeTabs();
-    brokerHomeTabs.getHomeTabViewerIds = vi.fn(() => ["U123", "U456"]);
+    brokerHomeTabs.getHomeTabViewers = vi.fn(() => [
+      { userId: "U123", installId: "default" },
+      { userId: "U456", installId: "default" },
+    ]);
     const { deps, slack } = createDeps({
       getBrokerHomeTabs: () => brokerHomeTabs,
     });
@@ -162,12 +168,13 @@ describe("createPinetHomeTabs", () => {
     const homeTabs = createPinetHomeTabs(deps);
     const { ctx } = createContext();
 
-    await homeTabs.publishCurrentPinetHomeTab("U123", ctx, "2026-04-15T00:00:00.000Z");
+    await homeTabs.publishCurrentPinetHomeTab("U123", ctx, "2026-04-15T00:00:00.000Z", "default");
 
     expect(brokerHomeTabs.publishCurrentHomeTabSafely).toHaveBeenCalledWith(
       "U123",
       ctx,
       "2026-04-15T00:00:00.000Z",
+      "default",
     );
     expect(slack).not.toHaveBeenCalled();
   });
@@ -207,6 +214,18 @@ describe("createPinetHomeTabs", () => {
     expect(JSON.stringify(body)).toContain("main");
     expect(JSON.stringify(body)).toContain("Pending inbox");
     expect(brokerHomeTabs.setLastHomeTabError).toHaveBeenCalledWith(null);
+  });
+
+  it("skips publishes for installs with Home tabs disabled", async () => {
+    const { deps, slack } = createDeps({
+      isHomeTabEnabled: (installId) => installId !== "secondary",
+    });
+    const homeTabs = createPinetHomeTabs(deps);
+    const { ctx } = createContext();
+
+    await homeTabs.publishCurrentPinetHomeTab("U123", ctx, undefined, "secondary");
+
+    expect(slack).not.toHaveBeenCalled();
   });
 
   it("reports Home tab publish failures safely", async () => {

--- a/slack-bridge/pinet-home-tabs.ts
+++ b/slack-bridge/pinet-home-tabs.ts
@@ -9,14 +9,21 @@ import {
 } from "./home-tab.js";
 import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
+export interface PinetHomeTabViewerRecord {
+  userId: string;
+  installId: string;
+}
+
 export interface PinetHomeTabsBrokerPort {
   isConnected: () => boolean;
   publishCurrentHomeTabSafely: (
     userId: string,
     ctx: ExtensionContext,
     openedAt?: string,
+    installId?: string,
   ) => Promise<boolean>;
   getHomeTabViewerIds: () => string[];
+  getHomeTabViewers: () => PinetHomeTabViewerRecord[];
   getLastHomeTabError: () => string | null;
   setLastHomeTabSnapshot: (snapshot: BrokerControlPlaneDashboardSnapshot | null) => void;
   setLastHomeTabRefreshAt: (value: string | null) => void;
@@ -25,7 +32,9 @@ export interface PinetHomeTabsBrokerPort {
 
 export interface PinetHomeTabsDeps {
   slack: PublishSlackHomeTabInput["slack"];
-  getBotToken: () => string | undefined;
+  getBotToken: (installId?: string | null) => string | undefined;
+  getDefaultInstallId: () => string | null | undefined;
+  isHomeTabEnabled: (installId?: string | null) => boolean;
   formatError: (error: unknown) => string;
   getAgentName: () => string;
   getAgentEmoji: () => string;
@@ -35,7 +44,7 @@ export interface PinetHomeTabsDeps {
   isSinglePlayerConnected: () => boolean;
   getActiveThreads: () => number;
   getPendingInboxCount: () => number;
-  getDefaultChannel: () => string | null | undefined;
+  getDefaultChannel: (installId?: string | null) => string | null | undefined;
   getBrokerHomeTabs: () => PinetHomeTabsBrokerPort;
   getCurrentBranch?: () => Promise<string | null>;
 }
@@ -45,18 +54,20 @@ export interface PinetHomeTabs {
     ctx: ExtensionContext,
     snapshot: BrokerControlPlaneDashboardSnapshot,
     refreshedAt: string,
-    userIds?: string[],
+    viewers?: PinetHomeTabViewerRecord[],
   ) => Promise<void>;
   reportHomeTabPublishFailure: (ctx: ExtensionContext, err: unknown) => void;
   publishCurrentPinetHomeTab: (
     userId: string,
     ctx: ExtensionContext,
     openedAt?: string,
+    installId?: string,
   ) => Promise<void>;
   publishCurrentPinetHomeTabSafely: (
     userId: string,
     ctx: ExtensionContext,
     openedAt?: string,
+    installId?: string,
   ) => Promise<void>;
 }
 
@@ -96,10 +107,9 @@ export function createPinetHomeTabs(deps: PinetHomeTabsDeps): PinetHomeTabs {
     ctx: ExtensionContext,
     snapshot: BrokerControlPlaneDashboardSnapshot,
     refreshedAt: string,
-    userIds: string[] = deps.getBrokerHomeTabs().getHomeTabViewerIds(),
+    viewers: PinetHomeTabViewerRecord[] = deps.getBrokerHomeTabs().getHomeTabViewers(),
   ): Promise<void> {
-    const botToken = deps.getBotToken();
-    if (!botToken || userIds.length === 0) {
+    if (viewers.length === 0) {
       return;
     }
 
@@ -107,12 +117,21 @@ export function createPinetHomeTabs(deps: PinetHomeTabsDeps): PinetHomeTabs {
     brokerHomeTabs.setLastHomeTabSnapshot(snapshot);
     let hadError = false;
 
-    for (const userId of userIds) {
+    for (const viewer of viewers) {
+      if (!deps.isHomeTabEnabled(viewer.installId)) {
+        continue;
+      }
+
+      const botToken = deps.getBotToken(viewer.installId);
+      if (!botToken) {
+        continue;
+      }
+
       try {
         await publishSlackHomeTab({
           slack: deps.slack,
           token: botToken,
-          userId,
+          userId: viewer.userId,
           view: renderBrokerControlPlaneHomeTabView(snapshot),
         });
       } catch (err) {
@@ -131,17 +150,22 @@ export function createPinetHomeTabs(deps: PinetHomeTabsDeps): PinetHomeTabs {
     userId: string,
     ctx: ExtensionContext,
     openedAt: string = new Date().toISOString(),
+    installId: string = deps.getDefaultInstallId() ?? "default",
   ): Promise<void> {
-    const botToken = deps.getBotToken();
-    if (!botToken) {
+    if (!deps.isHomeTabEnabled(installId)) {
       return;
     }
 
     const brokerHomeTabs = deps.getBrokerHomeTabs();
     if (brokerHomeTabs.isConnected() && deps.getBrokerRole() === "broker") {
-      if (await brokerHomeTabs.publishCurrentHomeTabSafely(userId, ctx, openedAt)) {
+      if (await brokerHomeTabs.publishCurrentHomeTabSafely(userId, ctx, openedAt, installId)) {
         return;
       }
+    }
+
+    const botToken = deps.getBotToken(installId);
+    if (!botToken) {
+      return;
     }
 
     const currentBranch = deps.getCurrentBranch
@@ -159,7 +183,7 @@ export function createPinetHomeTabs(deps: PinetHomeTabsDeps): PinetHomeTabs {
         activeThreads: deps.getActiveThreads(),
         pendingInbox: deps.getPendingInboxCount(),
         currentBranch,
-        defaultChannel: deps.getDefaultChannel() ?? null,
+        defaultChannel: deps.getDefaultChannel(installId) ?? null,
       }),
     });
     brokerHomeTabs.setLastHomeTabError(null);
@@ -169,9 +193,10 @@ export function createPinetHomeTabs(deps: PinetHomeTabsDeps): PinetHomeTabs {
     userId: string,
     ctx: ExtensionContext,
     openedAt: string = new Date().toISOString(),
+    installId?: string,
   ): Promise<void> {
     try {
-      await publishCurrentPinetHomeTab(userId, ctx, openedAt);
+      await publishCurrentPinetHomeTab(userId, ctx, openedAt, installId);
     } catch (err) {
       reportHomeTabPublishFailure(ctx, err);
     }

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -87,7 +87,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     label: "Pinet Message",
     description: "Send a message to a connected Pinet agent or broker-only broadcast channel.",
     promptSnippet:
-      "Send a message to a connected Pinet agent by name/ID, or to a broker-only broadcast channel. Use repo-scoped channels such as #extensions for repo-specific issue/policy broadcasts; do not use #all for repo-specific announcements. When assigning work, include the expected ack/work/ask/report flow.",
+      "Send a message to a connected Pinet agent by name or ID, or to a broker-only broadcast channel. Use it to delegate work, reply in a Pinet thread, or send `/reload` / `/exit`; admin control stays same-scope by default, so cross-workspace/install or cross-instance control needs explicit authorization metadata. Use repo-scoped channels such as #extensions for repo-specific issue/policy broadcasts; avoid #all for repo-specific announcements. Include the expected `ack/work/ask/report` flow when assigning work.",
     parameters: Type.Object({
       to: Type.String({
         description:

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -87,7 +87,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     label: "Pinet Message",
     description: "Send a message to a connected Pinet agent or broker-only broadcast channel.",
     promptSnippet:
-      "Send a message to a connected Pinet agent by name or ID, or to a broker-only broadcast channel. Use it to delegate work, reply in a Pinet thread, or send `/reload` / `/exit`; admin control stays same-scope by default, so cross-workspace/install or cross-instance control needs explicit authorization metadata. Use repo-scoped channels such as #extensions for repo-specific issue/policy broadcasts; avoid #all for repo-specific announcements. Include the expected `ack/work/ask/report` flow when assigning work.",
+      "Send a message to a connected Pinet agent by name or ID, or to a broker-only broadcast channel. Use it to delegate work, reply in a Pinet thread, or send `/reload` / `/exit`; admin control stays same-scope by default, so cross-workspace/install or cross-instance control needs explicit authorization metadata. Use repo-scoped channels such as #extensions for repo-specific issue/policy broadcasts; do not use #all for repo-specific announcements. Include the expected `ack/work/ask/report` flow when assigning work.",
     parameters: Type.Object({
       to: Type.String({
         description:

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -505,6 +505,58 @@ describe("registerSlackTools", () => {
     );
   });
 
+  it("rejects non-default scoped Slack actions instead of falling back to the default bot token", async () => {
+    const {
+      slack,
+      tools,
+      setGetBotTokenForInstall,
+      setResolveThreadChannel,
+      setResolveThreadScope,
+    } = setup();
+    setResolveThreadChannel(async () => "C_SECONDARY");
+    setResolveThreadScope(async () => ({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_SECONDARY",
+        installId: "secondary",
+      },
+    }));
+    setGetBotTokenForInstall((installId) =>
+      installId === "secondary" ? undefined : "xoxb-initial",
+    );
+
+    await expect(
+      tools.get("slack_send")!.execute("tool-2c-scoped-token", {
+        thread_ts: "200.3",
+        text: "must not leak to default install",
+      }),
+    ).rejects.toThrow(/scoped to install "secondary" but that install has no bot token/i);
+    expect(slack.mock.calls.filter(([method]) => method === "chat.postMessage")).toHaveLength(0);
+  });
+
+  it("rejects non-default scoped channel misses instead of falling back to default channel resolution", async () => {
+    const { slack, tools, setResolveChannelForInstall, setResolveThreadScope } = setup();
+    setResolveThreadScope(async () => ({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_SECONDARY",
+        installId: "secondary",
+      },
+    }));
+    setResolveChannelForInstall(async () => null);
+
+    await expect(
+      tools.get("slack_post_channel")!.execute("tool-2d-scoped-channel", {
+        channel: "ops-alerts",
+        thread_ts: "200.4",
+        text: "must not resolve in default install",
+      }),
+    ).rejects.toThrow(/could not be resolved for scoped install "secondary"/i);
+    expect(slack.mock.calls.filter(([method]) => method === "chat.postMessage")).toHaveLength(0);
+  });
+
   it("deletes a single bot-posted message when confirm=true", async () => {
     const { slack, tools, setBotToken, setDefaultChannel, requireToolPolicy } = setup();
     setBotToken("xoxb-reloaded");

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -234,6 +234,21 @@ describe("registerSlackTools", () => {
     let resolveThreadScope: (
       threadTs: string | undefined,
     ) => Promise<RuntimeScopeCarrier | null> = async () => null;
+    let resolveInstallIdForScope: (
+      scope: RuntimeScopeCarrier | null | undefined,
+    ) => string | null = (scope) => scope?.workspace?.installId ?? null;
+    let getBotTokenForInstall: (installId: string | null | undefined) => string | undefined = (
+      installId,
+    ) => (installId === "secondary" ? "xoxb-secondary" : botToken);
+    let getDefaultChannelForInstall: (
+      installId: string | null | undefined,
+    ) => string | undefined = (installId) =>
+      installId === "secondary" ? "secondary-alerts" : defaultChannel;
+    let resolveChannelForInstall: (
+      installId: string | null | undefined,
+      nameOrId: string,
+    ) => Promise<string | null> = async (installId, nameOrId) =>
+      installId ? `resolved:${installId}:${nameOrId}` : null;
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
     const requireToolPolicy = vi.fn();
@@ -253,6 +268,11 @@ describe("registerSlackTools", () => {
           compatibilityKey: "default",
         },
       }),
+      resolveInstallIdForScope: (scope) => resolveInstallIdForScope(scope),
+      getBotTokenForInstall: (installId) => getBotTokenForInstall(installId),
+      getDefaultChannelForInstall: (installId) => getDefaultChannelForInstall(installId),
+      resolveChannelForInstall: (installId, nameOrId) =>
+        resolveChannelForInstall(installId, nameOrId),
       getSecurityPrompt: () => securityPrompt,
       inbox,
       slack,
@@ -358,6 +378,26 @@ describe("registerSlackTools", () => {
       ) => {
         resolveThreadScope = fn;
       },
+      setResolveInstallIdForScope: (
+        fn: (scope: RuntimeScopeCarrier | null | undefined) => string | null,
+      ) => {
+        resolveInstallIdForScope = fn;
+      },
+      setGetBotTokenForInstall: (
+        fn: (installId: string | null | undefined) => string | undefined,
+      ) => {
+        getBotTokenForInstall = fn;
+      },
+      setGetDefaultChannelForInstall: (
+        fn: (installId: string | null | undefined) => string | undefined,
+      ) => {
+        getDefaultChannelForInstall = fn;
+      },
+      setResolveChannelForInstall: (
+        fn: (installId: string | null | undefined, nameOrId: string) => Promise<string | null>,
+      ) => {
+        resolveChannelForInstall = fn;
+      },
       noteThreadReply,
       clearPendingAttention,
       requireToolPolicy,
@@ -396,6 +436,62 @@ describe("registerSlackTools", () => {
       expect.objectContaining({
         channel: "resolved:ops-alerts",
         text: "hello from reloaded config",
+      }),
+    );
+  });
+
+  it("uses the scoped install token when slack_send replies in a tracked thread", async () => {
+    const { slack, tools, setResolveThreadChannel, setResolveThreadScope } = setup();
+    setResolveThreadChannel(async () => "C_SECONDARY");
+    setResolveThreadScope(async () => ({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_SECONDARY",
+        installId: "secondary",
+      },
+    }));
+
+    await tools.get("slack_send")!.execute("tool-2a", {
+      thread_ts: "200.1",
+      text: "hello secondary",
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "chat.postMessage",
+      "xoxb-secondary",
+      expect.objectContaining({
+        channel: "C_SECONDARY",
+        thread_ts: "200.1",
+        text: "hello secondary",
+      }),
+    );
+  });
+
+  it("uses the scoped default channel when slack_post_channel omits channel inside a tracked thread", async () => {
+    const { slack, tools, setResolveThreadScope, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async () => null);
+    setResolveThreadScope(async () => ({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_SECONDARY",
+        installId: "secondary",
+      },
+    }));
+
+    await tools.get("slack_post_channel")!.execute("tool-2b", {
+      thread_ts: "200.2",
+      text: "post in scoped default channel",
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "chat.postMessage",
+      "xoxb-secondary",
+      expect.objectContaining({
+        channel: "resolved:secondary:secondary-alerts",
+        thread_ts: "200.2",
+        text: "post in scoped default channel",
       }),
     );
   });
@@ -460,7 +556,7 @@ describe("registerSlackTools", () => {
   });
 
   it("rejects thread-scoped Slack tool actions when the tracked thread scope is unauthorized", async () => {
-    const { tools, setResolveThreadScope } = setup();
+    const { tools, setResolveThreadScope, setResolveInstallIdForScope } = setup();
     setResolveThreadScope(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return {
@@ -476,6 +572,8 @@ describe("registerSlackTools", () => {
         },
       };
     });
+
+    setResolveInstallIdForScope(() => null);
 
     await expect(
       tools.get("slack_read")!.execute("tool-3-scope", { thread_ts: "123.456" }),

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -189,6 +189,15 @@ describe("registerSlackTools", () => {
         );
       }
 
+      if (method === "auth.test") {
+        return {
+          ok: true,
+          token,
+          body,
+          user_id: token === "xoxb-secondary" ? "U_SECONDARY_BOT" : "U_BOT",
+        } as SlackResult;
+      }
+
       if (method === "users.list") {
         return usersListResponse;
       }
@@ -850,6 +859,59 @@ describe("registerSlackTools", () => {
     expect(slack.mock.calls.filter(([method]) => method === "chat.delete")).toHaveLength(0);
   });
 
+  it("deletes secondary-install bot threads using the scoped bot identity", async () => {
+    const {
+      slack,
+      tools,
+      setConversationsReplies,
+      setResolveThreadChannel,
+      setResolveThreadScope,
+    } = setup();
+    setResolveThreadChannel(async () => "C_SECONDARY");
+    setResolveThreadScope(async () => ({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_SECONDARY",
+        installId: "secondary",
+      },
+    }));
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [
+          { ts: "200.100", user: "U_SECONDARY_BOT" },
+          { ts: "200.101", user: "U_SECONDARY_BOT" },
+        ],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+
+    const response = await tools.get("slack_delete")!.execute("tool-6c-secondary", {
+      thread_ts: "200.100",
+      ts: "200.100",
+      thread: true,
+      confirm: true,
+    });
+
+    expect(slack).toHaveBeenCalledWith("auth.test", "xoxb-secondary");
+    expect(slack).toHaveBeenCalledWith("chat.delete", "xoxb-secondary", {
+      channel: "C_SECONDARY",
+      ts: "200.101",
+    });
+    expect(slack).toHaveBeenCalledWith("chat.delete", "xoxb-secondary", {
+      channel: "C_SECONDARY",
+      ts: "200.100",
+    });
+    expect(response.details).toMatchObject({
+      channel: "C_SECONDARY",
+      ts: "200.100",
+      thread: true,
+      deleted_count: 2,
+      deleted_ts: ["200.101", "200.100"],
+    });
+  });
+
   it("requires the thread root ts when deleting an entire thread", async () => {
     const { tools, setConversationsReplies } = setup();
     setConversationsReplies([
@@ -1230,6 +1292,71 @@ describe("registerSlackTools", () => {
       thread_ts: "123.456",
       view_id: "V123",
     });
+  });
+
+  it("uses the scoped install token for modal actions in tracked threads", async () => {
+    const { slack, tools, setResolveThreadChannel, setResolveThreadScope } = setup();
+    setResolveThreadChannel(async () => "C_SECONDARY");
+    setResolveThreadScope(async () => ({
+      workspace: {
+        provider: "slack",
+        source: "explicit",
+        workspaceId: "T_SECONDARY",
+        installId: "secondary",
+      },
+    }));
+
+    await tools.get("slack_modal_open")!.execute("tool-19b", {
+      trigger_id: "trigger-open",
+      thread_ts: "200.3",
+      view: {
+        type: "modal",
+        title: { type: "plain_text", text: "Open" },
+        submit: { type: "plain_text", text: "Go" },
+        close: { type: "plain_text", text: "Cancel" },
+        blocks: [],
+      },
+    });
+
+    await tools.get("slack_modal_push")!.execute("tool-19c", {
+      trigger_id: "trigger-push",
+      thread_ts: "200.3",
+      view: {
+        type: "modal",
+        title: { type: "plain_text", text: "Push" },
+        submit: { type: "plain_text", text: "Next" },
+        close: { type: "plain_text", text: "Cancel" },
+        blocks: [],
+      },
+    });
+
+    await tools.get("slack_modal_update")!.execute("tool-19d", {
+      external_id: "modal-secondary",
+      thread_ts: "200.3",
+      view: {
+        type: "modal",
+        title: { type: "plain_text", text: "Update" },
+        submit: { type: "plain_text", text: "Save" },
+        close: { type: "plain_text", text: "Cancel" },
+        blocks: [],
+      },
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "views.open",
+      "xoxb-secondary",
+      expect.objectContaining({ trigger_id: "trigger-open" }),
+    );
+    expect(slack).toHaveBeenCalledWith(
+      "views.push",
+      "xoxb-secondary",
+      expect.objectContaining({ trigger_id: "trigger-push" }),
+    );
+    expect(slack).toHaveBeenCalledWith(
+      "views.update",
+      "xoxb-secondary",
+      expect.objectContaining({ external_id: "modal-secondary" }),
+    );
   });
 
   it("updates a modal by view_id", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -51,6 +51,13 @@ export interface RegisterSlackToolsDeps {
   getBotToken: () => string;
   getDefaultChannel: () => string | undefined;
   getDefaultScope: () => RuntimeScopeCarrier;
+  resolveInstallIdForScope?: (scope: RuntimeScopeCarrier | null | undefined) => string | null;
+  getBotTokenForInstall?: (installId: string | null | undefined) => string | undefined;
+  getDefaultChannelForInstall?: (installId: string | null | undefined) => string | undefined;
+  resolveChannelForInstall?: (
+    installId: string | null | undefined,
+    nameOrId: string,
+  ) => Promise<string | null>;
   getSecurityPrompt: () => string;
   inbox: InboxMessage[];
   slack: (method: string, token: string, body?: Record<string, unknown>) => Promise<SlackResult>;
@@ -499,6 +506,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     getBotToken,
     getDefaultChannel,
     getDefaultScope,
+    resolveInstallIdForScope,
+    getBotTokenForInstall,
+    getDefaultChannelForInstall,
+    resolveChannelForInstall,
     getSecurityPrompt,
     inbox,
     slack,
@@ -516,17 +527,52 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     getBotUserId,
   } = deps;
 
-  async function resolveTrackedThreadChannel(threadTs: string | undefined): Promise<string | null> {
-    const threadScope = await threadContext.resolveThreadScope(threadTs);
-    const scopeError = getSlackScopeAuthorizationError({
-      actualScope: threadScope,
-      expectedScope: getDefaultScope(),
-      target: threadTs ? `thread ${threadTs}` : undefined,
-    });
-    if (scopeError) {
-      throw new Error(scopeError);
+  async function resolveScopedInstallContext(threadTs?: string): Promise<{
+    scope: RuntimeScopeCarrier | null;
+    installId: string | null;
+    token: string;
+    defaultChannel: string | undefined;
+  }> {
+    const scope = threadTs ? await threadContext.resolveThreadScope(threadTs) : null;
+    const installId = resolveInstallIdForScope?.(scope ?? null) ?? null;
+    if (threadTs && scope && resolveInstallIdForScope && !installId) {
+      const scopeError = getSlackScopeAuthorizationError({
+        actualScope: scope,
+        expectedScope: getDefaultScope(),
+        target: `thread ${threadTs}`,
+      });
+      throw new Error(
+        scopeError ?? `Slack thread ${threadTs} scope is not mapped to a configured install.`,
+      );
     }
 
+    return {
+      scope,
+      installId,
+      token: getBotTokenForInstall?.(installId) ?? getBotToken(),
+      defaultChannel: getDefaultChannelForInstall?.(installId) ?? getDefaultChannel(),
+    };
+  }
+
+  async function resolveSlackToken(threadTs?: string): Promise<string> {
+    return (await resolveScopedInstallContext(threadTs)).token;
+  }
+
+  async function resolveScopedChannelId(nameOrId: string, threadTs?: string): Promise<string> {
+    const { installId } = await resolveScopedInstallContext(threadTs);
+    const scopedChannel = await resolveChannelForInstall?.(installId, nameOrId);
+    if (scopedChannel) {
+      rememberChannel(nameOrId, scopedChannel);
+      return scopedChannel;
+    }
+    return resolveChannel(nameOrId);
+  }
+
+  async function resolveTrackedThreadChannel(threadTs: string | undefined): Promise<string | null> {
+    if (!threadTs) {
+      return null;
+    }
+    await resolveScopedInstallContext(threadTs);
     return threadContext.resolveThreadChannel(threadTs);
   }
 
@@ -682,8 +728,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       throw new Error("Provide either canvas_id or channel.");
     }
 
-    const channelId = await resolveChannel(channelInput);
-    const info = await slack("conversations.info", getBotToken(), { channel: channelId });
+    const channelId = await resolveScopedChannelId(channelInput);
+    const info = await slack("conversations.info", await resolveSlackToken(), {
+      channel: channelId,
+    });
     const resolvedCanvasId = extractSlackChannelCanvasId(info);
     if (!resolvedCanvasId) {
       throw new Error(
@@ -700,7 +748,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
   async function assertCanvasCommentsTargetIsCanvas(canvasId: string): Promise<void> {
     try {
-      await slack("canvases.sections.lookup", getBotToken(), {
+      await slack("canvases.sections.lookup", await resolveSlackToken(), {
         canvas_id: canvasId,
         criteria: { section_types: ["any_header"] },
       });
@@ -764,7 +812,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     let cursor: string | undefined;
 
     do {
-      const response = await slack("conversations.replies", getBotToken(), {
+      const response = await slack("conversations.replies", await resolveSlackToken(threadTs), {
         channel: channelId,
         ts: threadTs,
         limit: 1000,
@@ -1427,7 +1475,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       }
       if (params.thread_ts) body.thread_ts = params.thread_ts;
 
-      const response = await slack("chat.postMessage", getBotToken(), body);
+      const response = await slack(
+        "chat.postMessage",
+        await resolveSlackToken(params.thread_ts),
+        body,
+      );
       const ts = (response.message as { ts: string }).ts;
       const actualTs = params.thread_ts ?? ts;
 
@@ -1495,7 +1547,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       const reactionName = normalizeReactionName(params.emoji);
       const channelId = await resolveReactionChannel(params.thread_ts, params.channel);
 
-      await slack("reactions.add", getBotToken(), {
+      await slack("reactions.add", await resolveSlackToken(params.thread_ts), {
         channel: channelId,
         timestamp: targetTimestamp,
         name: reactionName,
@@ -1576,7 +1628,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         channelId,
         threadTs: params.thread_ts,
         slack,
-        token: getBotToken(),
+        token: await resolveSlackToken(params.thread_ts),
       });
 
       if (params.thread_ts) {
@@ -1637,11 +1689,15 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         throw new Error("Unknown thread.");
       }
 
-      const response = await slack("conversations.replies", getBotToken(), {
-        channel,
-        ts: params.thread_ts,
-        limit: params.limit ?? 20,
-      });
+      const response = await slack(
+        "conversations.replies",
+        await resolveSlackToken(params.thread_ts),
+        {
+          channel,
+          ts: params.thread_ts,
+          limit: params.limit ?? 20,
+        },
+      );
 
       const messages = response.messages as Record<string, unknown>[];
       const lines: string[] = [];
@@ -2003,11 +2059,14 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       );
 
       const resolvedThreadChannel = await resolveTrackedThreadChannel(params.thread_ts);
-      const channelInput = params.channel ?? getDefaultChannel();
-      let channelId = params.channel ? await resolveChannel(params.channel) : resolvedThreadChannel;
+      const { defaultChannel } = await resolveScopedInstallContext(params.thread_ts);
+      const channelInput = params.channel ?? defaultChannel;
+      let channelId = params.channel
+        ? await resolveScopedChannelId(params.channel, params.thread_ts)
+        : resolvedThreadChannel;
 
       if (!channelId && channelInput) {
-        channelId = await resolveChannel(channelInput);
+        channelId = await resolveScopedChannelId(channelInput, params.thread_ts);
       }
       if (!channelId) {
         throw new Error("No channel specified and no defaultChannel configured in settings.json.");
@@ -2026,7 +2085,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       }
       if (params.thread_ts) body.thread_ts = params.thread_ts;
 
-      const response = await slack("chat.postMessage", getBotToken(), body);
+      const response = await slack(
+        "chat.postMessage",
+        await resolveSlackToken(params.thread_ts),
+        body,
+      );
       const ts = (response.message as { ts: string }).ts;
       const actualTs = params.thread_ts ?? ts;
 
@@ -2110,7 +2173,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       });
 
       for (const messageTs of messageTsList) {
-        await slack("chat.delete", getBotToken(), {
+        await slack("chat.delete", await resolveSlackToken(params.thread_ts), {
           channel: channelId,
           ts: messageTs,
         });
@@ -2179,7 +2242,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       const body = { channel: channelId, timestamp: messageTs };
 
       try {
-        await slack(method, getBotToken(), body);
+        await slack(method, await resolveSlackToken(params.thread_ts), body);
       } catch (err) {
         if (action === "pin" && isSlackMethodError(err, "pins.add", "already_pinned")) {
           return {
@@ -2276,7 +2339,9 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       const channelLabel = params.channel ?? channelId;
 
       if (action === "list") {
-        const response = await slack("bookmarks.list", getBotToken(), { channel_id: channelId });
+        const response = await slack("bookmarks.list", await resolveSlackToken(params.thread_ts), {
+          channel_id: channelId,
+        });
         const bookmarks = Array.isArray(response.bookmarks)
           ? (response.bookmarks as Array<Record<string, unknown>>)
           : [];
@@ -2313,7 +2378,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
         const link = normalizeSlackBookmarkUrl(params.url ?? "");
         const emoji = params.emoji?.trim();
-        const response = await slack("bookmarks.add", getBotToken(), {
+        const response = await slack("bookmarks.add", await resolveSlackToken(params.thread_ts), {
           channel_id: channelId,
           title,
           type: "link",
@@ -2350,7 +2415,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       }
 
       try {
-        await slack("bookmarks.remove", getBotToken(), {
+        await slack("bookmarks.remove", await resolveSlackToken(params.thread_ts), {
           channel_id: channelId,
           bookmark_id: bookmarkId,
         });
@@ -2432,7 +2497,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         body.thread_ts = params.thread_ts;
       }
 
-      const response = await slack("chat.scheduleMessage", getBotToken(), body);
+      const response = await slack(
+        "chat.scheduleMessage",
+        await resolveSlackToken(params.thread_ts),
+        body,
+      );
       const scheduledMessageId =
         typeof response.scheduled_message_id === "string"
           ? response.scheduled_message_id
@@ -2477,16 +2546,20 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         `channel=${params.channel} | thread_ts=${params.thread_ts ?? ""} | limit=${params.limit ?? 20}`,
       );
 
-      const channelId = await resolveChannel(params.channel);
+      const channelId = await resolveScopedChannelId(params.channel, params.thread_ts);
       const limit = params.limit ?? 20;
 
       let messages: Record<string, unknown>[];
       if (params.thread_ts) {
-        const response = await slack("conversations.replies", getBotToken(), {
-          channel: channelId,
-          ts: params.thread_ts,
-          limit,
-        });
+        const response = await slack(
+          "conversations.replies",
+          await resolveSlackToken(params.thread_ts),
+          {
+            channel: channelId,
+            ts: params.thread_ts,
+            limit,
+          },
+        );
         messages = response.messages as Record<string, unknown>[];
       } else {
         const response = await slack("conversations.history", getBotToken(), {
@@ -2875,7 +2948,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         };
       }
 
-      await slack("chat.postMessage", getBotToken(), {
+      await slack("chat.postMessage", await resolveSlackToken(params.thread_ts), {
         channel: channelId,
         thread_ts: params.thread_ts,
         text: confirmMessage,

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -527,11 +527,20 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     getBotUserId,
   } = deps;
 
+  function isNonDefaultScopedInstall(
+    scope: RuntimeScopeCarrier | null,
+    installId: string | null,
+  ): boolean {
+    const defaultInstallId = getDefaultScope().workspace?.installId ?? null;
+    return Boolean(scope && installId && defaultInstallId && installId !== defaultInstallId);
+  }
+
   async function resolveScopedInstallContext(threadTs?: string): Promise<{
     scope: RuntimeScopeCarrier | null;
     installId: string | null;
     token: string;
     defaultChannel: string | undefined;
+    strictScopedInstall: boolean;
   }> {
     const scope = threadTs ? await threadContext.resolveThreadScope(threadTs) : null;
     const installId = resolveInstallIdForScope?.(scope ?? null) ?? null;
@@ -546,11 +555,23 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       );
     }
 
+    const strictScopedInstall = isNonDefaultScopedInstall(scope, installId);
+    const scopedToken = getBotTokenForInstall?.(installId);
+    if (strictScopedInstall && !scopedToken) {
+      throw new Error(
+        `Slack thread ${threadTs} is scoped to install ${JSON.stringify(installId)} but that install has no bot token configured.`,
+      );
+    }
+
+    const scopedDefaultChannel = getDefaultChannelForInstall?.(installId);
     return {
       scope,
       installId,
-      token: getBotTokenForInstall?.(installId) ?? getBotToken(),
-      defaultChannel: getDefaultChannelForInstall?.(installId) ?? getDefaultChannel(),
+      token: scopedToken ?? getBotToken(),
+      defaultChannel: strictScopedInstall
+        ? scopedDefaultChannel
+        : (scopedDefaultChannel ?? getDefaultChannel()),
+      strictScopedInstall,
     };
   }
 
@@ -584,11 +605,16 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
   }
 
   async function resolveScopedChannelId(nameOrId: string, threadTs?: string): Promise<string> {
-    const { installId } = await resolveScopedInstallContext(threadTs);
+    const { installId, strictScopedInstall } = await resolveScopedInstallContext(threadTs);
     const scopedChannel = await resolveChannelForInstall?.(installId, nameOrId);
     if (scopedChannel) {
       rememberChannel(nameOrId, scopedChannel);
       return scopedChannel;
+    }
+    if (strictScopedInstall) {
+      throw new Error(
+        `Slack channel ${JSON.stringify(nameOrId)} could not be resolved for scoped install ${JSON.stringify(installId)}.`,
+      );
     }
     return resolveChannel(nameOrId);
   }

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -554,8 +554,33 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     };
   }
 
+  const botUserIdCache = new TtlCache<string, string | null>({
+    maxSize: 16,
+    ttlMs: 60 * 60 * 1000,
+  });
+
   async function resolveSlackToken(threadTs?: string): Promise<string> {
     return (await resolveScopedInstallContext(threadTs)).token;
+  }
+
+  async function resolveSlackBotUserId(threadTs?: string): Promise<string | null> {
+    const token = await resolveSlackToken(threadTs);
+    const cachedBotUserId = botUserIdCache.get(token);
+    if (cachedBotUserId !== undefined) {
+      return cachedBotUserId;
+    }
+
+    const defaultBotToken = getBotToken();
+    const knownBotUserId = getBotUserId();
+    if (knownBotUserId && token === defaultBotToken) {
+      botUserIdCache.set(token, knownBotUserId);
+      return knownBotUserId;
+    }
+
+    const response = await slack("auth.test", token);
+    const botUserId = typeof response.user_id === "string" ? response.user_id : null;
+    botUserIdCache.set(token, botUserId);
+    return botUserId;
   }
 
   async function resolveScopedChannelId(nameOrId: string, threadTs?: string): Promise<string> {
@@ -871,8 +896,9 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       throw new Error("When thread=true, ts must be the thread root timestamp.");
     }
 
+    const botUserId = await resolveSlackBotUserId(input.threadTs);
     const undeletableMessages = messages
-      .filter((message) => !isPiAgentSlackMessage(message, getBotUserId(), getAgentOwnerToken()))
+      .filter((message) => !isPiAgentSlackMessage(message, botUserId, getAgentOwnerToken()))
       .map((message) => (typeof message.ts === "string" ? message.ts : "unknown-ts"));
     if (undeletableMessages.length > 0) {
       throw new Error(
@@ -1283,7 +1309,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
       try {
         const view = await buildSlackModalView(params.view, params.thread_ts);
-        const response = await slack("views.open", getBotToken(), {
+        const response = await slack("views.open", await resolveSlackToken(params.thread_ts), {
           trigger_id: params.trigger_id,
           view,
         });
@@ -1335,7 +1361,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
       try {
         const view = await buildSlackModalView(params.view, params.thread_ts);
-        const response = await slack("views.push", getBotToken(), {
+        const response = await slack("views.push", await resolveSlackToken(params.thread_ts), {
           trigger_id: params.trigger_id,
           view,
         });
@@ -1397,7 +1423,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
       try {
         const view = await buildSlackModalView(params.view, params.thread_ts);
-        const response = await slack("views.update", getBotToken(), {
+        const response = await slack("views.update", await resolveSlackToken(params.thread_ts), {
           ...(params.view_id ? { view_id: params.view_id } : {}),
           ...(params.external_id ? { external_id: params.external_id } : {}),
           ...(params.hash ? { hash: params.hash } : {}),

--- a/slack-bridge/slack-topology-runtime.ts
+++ b/slack-bridge/slack-topology-runtime.ts
@@ -1,0 +1,175 @@
+import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
+import {
+  resolveSlackInstallForScope,
+  resolveSlackTopology,
+  type ResolvedSlackInstallTopology,
+  type ResolvedSlackTopology,
+  type SlackBridgeSettings,
+} from "./helpers.js";
+import { resolveSlackChannelId, type SlackCall } from "./slack-access.js";
+import { TtlCache } from "./ttl-cache.js";
+
+export interface SlackTopologyRuntimeDeps {
+  slack: SlackCall;
+  getSettings: () => SlackBridgeSettings;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface SlackTopologyRuntime {
+  getTopology: () => ResolvedSlackTopology;
+  getDefaultInstall: () => ResolvedSlackInstallTopology;
+  getDefaultInstallId: () => string;
+  getInstall: (installId?: string | null) => ResolvedSlackInstallTopology | null;
+  getRuntimeInstalls: () => ResolvedSlackInstallTopology[];
+  getSurfaceInstalls: () => ResolvedSlackInstallTopology[];
+  resolveInstallForScope: (
+    scope: RuntimeScopeCarrier | null | undefined,
+  ) => ResolvedSlackInstallTopology | null;
+  getBotToken: (installId?: string | null) => string | undefined;
+  getAppToken: (installId?: string | null) => string | undefined;
+  getDefaultChannel: (installId?: string | null) => string | null;
+  getLogChannel: (installId?: string | null) => string | null;
+  isHomeTabEnabled: (installId?: string | null) => boolean;
+  resolveChannel: (
+    installId: string | null | undefined,
+    nameOrId: string,
+  ) => Promise<string | null>;
+}
+
+function normalizeOptionalSetting(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function orderInstalls(
+  installs: ResolvedSlackInstallTopology[],
+  defaultInstallId: string,
+): ResolvedSlackInstallTopology[] {
+  return [...installs].sort((left, right) => {
+    const leftIsDefault = left.installId === defaultInstallId ? 0 : 1;
+    const rightIsDefault = right.installId === defaultInstallId ? 0 : 1;
+    return leftIsDefault - rightIsDefault;
+  });
+}
+
+export function createSlackTopologyRuntime(deps: SlackTopologyRuntimeDeps): SlackTopologyRuntime {
+  const env = deps.env ?? process.env;
+  const channelCaches = new Map<string, TtlCache<string, string>>();
+
+  function getTopology(): ResolvedSlackTopology {
+    return resolveSlackTopology(deps.getSettings(), env);
+  }
+
+  function getDefaultInstall(): ResolvedSlackInstallTopology {
+    return getTopology().defaultInstall;
+  }
+
+  function getDefaultInstallId(): string {
+    return getTopology().defaultInstallId;
+  }
+
+  function getInstall(installId?: string | null): ResolvedSlackInstallTopology | null {
+    const topology = getTopology();
+    const normalizedInstallId = normalizeOptionalSetting(installId);
+    if (!normalizedInstallId) {
+      return topology.defaultInstall;
+    }
+    return topology.installs.find((install) => install.installId === normalizedInstallId) ?? null;
+  }
+
+  function getRuntimeInstalls(): ResolvedSlackInstallTopology[] {
+    const topology = getTopology();
+    return orderInstalls(
+      topology.installs.filter(
+        (
+          install,
+        ): install is ResolvedSlackInstallTopology & {
+          botToken: string;
+          appToken: string;
+        } => typeof install.botToken === "string" && typeof install.appToken === "string",
+      ),
+      topology.defaultInstallId,
+    );
+  }
+
+  function getSurfaceInstalls(): ResolvedSlackInstallTopology[] {
+    const topology = getTopology();
+    return orderInstalls(
+      topology.installs.filter(
+        (
+          install,
+        ): install is ResolvedSlackInstallTopology & {
+          botToken: string;
+        } => typeof install.botToken === "string",
+      ),
+      topology.defaultInstallId,
+    );
+  }
+
+  function resolveInstallForScope(
+    scope: RuntimeScopeCarrier | null | undefined,
+  ): ResolvedSlackInstallTopology | null {
+    return resolveSlackInstallForScope(getTopology(), scope);
+  }
+
+  function getBotToken(installId?: string | null): string | undefined {
+    return getInstall(installId)?.botToken;
+  }
+
+  function getAppToken(installId?: string | null): string | undefined {
+    return getInstall(installId)?.appToken;
+  }
+
+  function getDefaultChannel(installId?: string | null): string | null {
+    return normalizeOptionalSetting(getInstall(installId)?.defaultChannel);
+  }
+
+  function getLogChannel(installId?: string | null): string | null {
+    return normalizeOptionalSetting(getInstall(installId)?.logChannel);
+  }
+
+  function isHomeTabEnabled(installId?: string | null): boolean {
+    return getInstall(installId)?.homeTabEnabled ?? false;
+  }
+
+  async function resolveChannel(
+    installId: string | null | undefined,
+    nameOrId: string,
+  ): Promise<string | null> {
+    const install = getInstall(installId);
+    const token = install?.botToken;
+    const normalizedNameOrId = normalizeOptionalSetting(nameOrId);
+    if (!install || !token || !normalizedNameOrId) {
+      return null;
+    }
+
+    let cache = channelCaches.get(install.installId);
+    if (!cache) {
+      cache = new TtlCache<string, string>({ maxSize: 200, ttlMs: 30 * 60 * 1000 });
+      channelCaches.set(install.installId, cache);
+    }
+
+    return resolveSlackChannelId({
+      slack: deps.slack,
+      token,
+      nameOrId: normalizedNameOrId,
+      cache,
+    });
+  }
+
+  return {
+    getTopology,
+    getDefaultInstall,
+    getDefaultInstallId,
+    getInstall,
+    getRuntimeInstalls,
+    getSurfaceInstalls,
+    resolveInstallForScope,
+    getBotToken,
+    getAppToken,
+    getDefaultChannel,
+    getLogChannel,
+    isHomeTabEnabled,
+    resolveChannel,
+  };
+}


### PR DESCRIPTION
## Summary
- add runtime helpers to resolve active Slack installs, surface-capable installs, and install selection from runtime scope
- introduce topology-aware Slack broker/runtime adapters so broker surfaces can route through the right install while preserving the default single-install path
- scope broker-facing Slack surfaces and tool surfaces by install, including activity log, Home tab, control-plane canvas, and Slack tools

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test