### PR TITLE
fix: default-deny cross-workspace operator surfaces

### DIFF
--- a/broker-core/agent-messaging.ts
+++ b/broker-core/agent-messaging.ts
@@ -1,4 +1,11 @@
-import type { AgentInfo, BrokerMessage } from "./types.js";
+import {
+  formatRuntimeScopeCarrier,
+  getRuntimeScopeConflicts,
+  parseRuntimeScopeCarrier,
+  type AgentInfo,
+  type BrokerMessage,
+  type RuntimeScopeCarrier,
+} from "./types.js";
 
 interface AgentCapabilities {
   repo?: string;
@@ -27,6 +34,89 @@ function extractAgentCapabilities(
     tools: asStringArray(capabilitiesRecord?.tools),
     tags: asStringArray(capabilitiesRecord?.tags),
   };
+}
+
+function extractAgentScope(agent: Pick<AgentInfo, "metadata">): RuntimeScopeCarrier | null {
+  const record = asRecord(agent.metadata);
+  const capabilitiesRecord = asRecord(record?.capabilities);
+  return parseRuntimeScopeCarrier(capabilitiesRecord?.scope ?? record?.scope);
+}
+
+function parsePinetControlAction(
+  body: string,
+  metadata?: Record<string, unknown>,
+): "reload" | "exit" | null {
+  const metadataAction = asString(metadata?.action);
+  if (
+    metadata?.type === "pinet:control" &&
+    (metadataAction === "reload" || metadataAction === "exit")
+  ) {
+    return metadataAction;
+  }
+
+  const trimmedBody = body.trim();
+  if (trimmedBody === "/reload") return "reload";
+  if (trimmedBody === "/exit") return "exit";
+
+  try {
+    const parsed = JSON.parse(trimmedBody) as Record<string, unknown>;
+    const parsedAction = asString(parsed.action);
+    if (parsed.type === "pinet:control" && (parsedAction === "reload" || parsedAction === "exit")) {
+      return parsedAction;
+    }
+  } catch {
+    /* not json */
+  }
+
+  return null;
+}
+
+function hasExplicitCrossScopeAdminAuthorization(metadata?: Record<string, unknown>): boolean {
+  if (metadata?.allowCrossScopeAdmin === true) {
+    return true;
+  }
+
+  const authorization = asRecord(metadata?.pinetAdminAuthorization);
+  return authorization?.allowCrossScope === true;
+}
+
+function formatScopeConflictDimensions(
+  senderScope: RuntimeScopeCarrier | null,
+  targetScope: RuntimeScopeCarrier | null,
+): string {
+  return getRuntimeScopeConflicts(senderScope, targetScope)
+    .map((conflict) => `${conflict.dimension}.${conflict.field}`)
+    .join(", ");
+}
+
+function assertAdminDispatchScopeAuthorized(input: {
+  sender: AgentInfo | undefined;
+  target: AgentInfo;
+  body: string;
+  metadata?: Record<string, unknown>;
+}): void {
+  const action = parsePinetControlAction(input.body, input.metadata);
+  if (!action || hasExplicitCrossScopeAdminAuthorization(input.metadata)) {
+    return;
+  }
+
+  const senderScope = input.sender ? extractAgentScope(input.sender) : null;
+  const targetScope = extractAgentScope(input.target);
+  const conflicts = getRuntimeScopeConflicts(senderScope, targetScope);
+  if (conflicts.length === 0) {
+    return;
+  }
+
+  const senderName = input.sender?.name ?? input.sender?.id ?? "unknown sender";
+  throw new Error(
+    [
+      `Pinet admin action /${action} from ${senderName} to ${input.target.name} crosses an unauthorized workspace/install or instance boundary.`,
+      `Conflicts: ${formatScopeConflictDimensions(senderScope, targetScope)}.`,
+      `Sender scope: ${formatRuntimeScopeCarrier(senderScope)}.`,
+      `Target scope: ${formatRuntimeScopeCarrier(targetScope)}.`,
+      "Add metadata.pinetAdminAuthorization.allowCrossScope=true to allow this cross-scope admin action explicitly.",
+    ].join(" "),
+  );
 }
 
 function buildAgentCapabilityTags(capabilities: AgentCapabilities): string[] {
@@ -253,10 +343,19 @@ export function dispatchDirectAgentMessage(
   input: DirectAgentDispatchInput,
   onDispatch?: AgentDispatchCallback,
 ): DirectAgentDispatchResult {
-  const target = resolveDirectAgentTarget(storage.getAgents(), input.target);
+  const agents = storage.getAgents();
+  const target = resolveDirectAgentTarget(agents, input.target);
   if (!target) {
     throw new Error(`Agent not found: ${input.target}`);
   }
+
+  const sender = agents.find((agent) => agent.id === input.senderAgentId);
+  assertAdminDispatchScopeAuthorized({
+    sender,
+    target,
+    body: input.body,
+    metadata: input.metadata,
+  });
 
   const resolvedTarget: AgentDispatchTarget = { id: target.id, name: target.name };
   const metadata = buildAgentMessageMetadata(input.senderAgentName, input.metadata);
@@ -287,9 +386,17 @@ export function dispatchBroadcastAgentMessage(
   }
 
   const agents = storage.getAgents();
-  const targets = resolveBroadcastTargets(agents, input.senderAgentId, normalizedChannel).map(
-    (agent) => ({ id: agent.id, name: agent.name }),
-  );
+  const sender = agents.find((agent) => agent.id === input.senderAgentId);
+  const targetAgents = resolveBroadcastTargets(agents, input.senderAgentId, normalizedChannel);
+  for (const target of targetAgents) {
+    assertAdminDispatchScopeAuthorized({
+      sender,
+      target,
+      body: input.body,
+      metadata: input.metadata,
+    });
+  }
+  const targets = targetAgents.map((agent) => ({ id: agent.id, name: agent.name }));
 
   if (targets.length === 0) {
     throw new Error(`No agents subscribed to #${normalizedChannel} other than the sender.`);

--- a/slack-bridge/broker/agent-messaging.test.ts
+++ b/slack-bridge/broker/agent-messaging.test.ts
@@ -31,6 +31,27 @@ function createAgent(
   };
 }
 
+function createScopedMetadata(installId: string, workspaceId: string): Record<string, unknown> {
+  return {
+    capabilities: {
+      repo: "extensions",
+      role: "worker",
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "explicit",
+          installId,
+          workspaceId,
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    },
+  };
+}
+
 function createStorage(agents: AgentInfo[]): AgentMessageStorage & {
   threads: Set<string>;
   inserted: Array<{
@@ -182,6 +203,53 @@ describe("dispatchDirectAgentMessage", () => {
     });
     expect(delivered).toEqual(["target:1:Sender Agent"]);
   });
+
+  it("denies cross-scope admin control messages by default", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("target", "target", createScopedMetadata("secondary", "T_SECONDARY")),
+    ]);
+
+    expect(() =>
+      dispatchDirectAgentMessage(storage, {
+        senderAgentId: "sender",
+        senderAgentName: "Sender Agent",
+        target: "target",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { type: "pinet:control", action: "reload" },
+      }),
+    ).toThrow(/Conflicts: workspace\.workspaceId, workspace\.installId\./);
+  });
+
+  it("allows cross-scope admin control when explicitly authorized in metadata", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("target", "target", createScopedMetadata("secondary", "T_SECONDARY")),
+    ]);
+
+    const result = dispatchDirectAgentMessage(storage, {
+      senderAgentId: "sender",
+      senderAgentName: "Sender Agent",
+      target: "target",
+      body: '{"type":"pinet:control","action":"reload"}',
+      metadata: {
+        type: "pinet:control",
+        action: "reload",
+        pinetAdminAuthorization: { allowCrossScope: true },
+      },
+    });
+
+    expect(result).toEqual({
+      target: { id: "target", name: "target" },
+      messageId: 1,
+      threadId: "a2a:sender:target",
+    });
+    expect(storage.inserted[0]?.metadata).toMatchObject({
+      type: "pinet:control",
+      action: "reload",
+      pinetAdminAuthorization: { allowCrossScope: true },
+    });
+  });
 });
 
 describe("dispatchBroadcastAgentMessage", () => {
@@ -249,5 +317,40 @@ describe("dispatchBroadcastAgentMessage", () => {
         body: "anyone there?",
       }),
     ).toThrow("No agents subscribed to #extensions other than the sender.");
+  });
+
+  it("denies cross-scope admin control broadcasts by default", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("worker-a", "worker-a", createScopedMetadata("primary", "T_PRIMARY")),
+      createAgent("worker-b", "worker-b", {
+        capabilities: {
+          repo: "extensions",
+          role: "worker",
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "explicit",
+              installId: "secondary",
+              workspaceId: "T_SECONDARY",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(() =>
+      dispatchBroadcastAgentMessage(storage, {
+        senderAgentId: "sender",
+        senderAgentName: "Sender Agent",
+        channel: "#extensions",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { type: "pinet:control", action: "reload" },
+      }),
+    ).toThrow(/Pinet admin action \/reload/);
   });
 });

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -568,6 +568,52 @@ describe("resolveSlackTopology", () => {
       },
     });
   });
+
+  it("defaults privileged broker surfaces to the default install unless a secondary install opts in", () => {
+    const topology = resolveSlackTopology(
+      {
+        defaultInstallId: "primary",
+        installs: [
+          {
+            installId: "primary",
+            workspaceId: "T_PRIMARY",
+            botToken: "xoxb-primary",
+            appToken: "xapp-primary",
+          },
+          {
+            installId: "secondary",
+            workspaceId: "T_SECONDARY",
+            botToken: "xoxb-secondary",
+            appToken: "xapp-secondary",
+          },
+          {
+            installId: "operator-opt-in",
+            workspaceId: "T_OPERATOR",
+            botToken: "xoxb-operator",
+            appToken: "xapp-operator",
+            homeTabEnabled: true,
+            controlPlaneCanvasEnabled: true,
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(topology.installs.find((install) => install.installId === "primary")).toMatchObject({
+      homeTabEnabled: true,
+      controlPlaneCanvasEnabled: true,
+    });
+    expect(topology.installs.find((install) => install.installId === "secondary")).toMatchObject({
+      homeTabEnabled: false,
+      controlPlaneCanvasEnabled: false,
+    });
+    expect(
+      topology.installs.find((install) => install.installId === "operator-opt-in"),
+    ).toMatchObject({
+      homeTabEnabled: true,
+      controlPlaneCanvasEnabled: true,
+    });
+  });
 });
 
 describe("resolveSlack install selection helpers", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -225,6 +225,22 @@ function normalizeSlackInstallId(install: SlackInstallTopologySettings, index: n
   );
 }
 
+function applyExplicitOperatorSurfaceDefaults(
+  install: ResolvedSlackInstallTopology,
+  rawInstall: SlackInstallTopologySettings,
+  isDefaultInstall: boolean,
+): ResolvedSlackInstallTopology {
+  return {
+    ...install,
+    controlPlaneCanvasEnabled:
+      typeof rawInstall.controlPlaneCanvasEnabled === "boolean"
+        ? rawInstall.controlPlaneCanvasEnabled
+        : isDefaultInstall,
+    homeTabEnabled:
+      typeof rawInstall.homeTabEnabled === "boolean" ? rawInstall.homeTabEnabled : isDefaultInstall,
+  };
+}
+
 function resolveCompatibilityInstall(
   settings: SlackBridgeSettings,
   env = process.env,
@@ -323,9 +339,7 @@ function resolveExplicitInstall(
       ? { logChannel: normalizeOptionalSetting(install.logChannel) ?? undefined }
       : {}),
     ...(install.logLevel ? { logLevel: install.logLevel } : {}),
-    ...(typeof install.controlPlaneCanvasEnabled === "boolean"
-      ? { controlPlaneCanvasEnabled: install.controlPlaneCanvasEnabled }
-      : {}),
+    controlPlaneCanvasEnabled: install.controlPlaneCanvasEnabled ?? false,
     ...(normalizeOptionalSetting(install.controlPlaneCanvasId)
       ? {
           controlPlaneCanvasId: normalizeOptionalSetting(install.controlPlaneCanvasId) ?? undefined,
@@ -343,7 +357,7 @@ function resolveExplicitInstall(
             normalizeOptionalSetting(install.controlPlaneCanvasTitle) ?? undefined,
         }
       : {}),
-    homeTabEnabled: install.homeTabEnabled ?? true,
+    homeTabEnabled: install.homeTabEnabled ?? false,
     scope: buildSlackScope({
       source: "explicit",
       workspaceId,
@@ -371,12 +385,23 @@ export function resolveSlackTopology(
 
   const installs = explicitInstalls.map((install, index) => resolveExplicitInstall(install, index));
   const configuredDefaultInstallId = normalizeOptionalSetting(settings.defaultInstallId);
-  const defaultInstall =
+  const unresolvedDefaultInstall =
     installs.find((install) => install.installId === configuredDefaultInstallId) ?? installs[0]!;
+  const installsWithOperatorSurfaceDefaults = installs.map((install, index) =>
+    applyExplicitOperatorSurfaceDefaults(
+      install,
+      explicitInstalls[index]!,
+      install.installId === unresolvedDefaultInstall.installId,
+    ),
+  );
+  const defaultInstall =
+    installsWithOperatorSurfaceDefaults.find(
+      (install) => install.installId === unresolvedDefaultInstall.installId,
+    ) ?? installsWithOperatorSurfaceDefaults[0]!;
 
   return {
-    mode: installs.length === 1 ? "explicit-single" : "explicit-multi",
-    installs,
+    mode: installsWithOperatorSurfaceDefaults.length === 1 ? "explicit-single" : "explicit-multi",
+    installs: installsWithOperatorSurfaceDefaults,
     defaultInstallId: defaultInstall.installId,
     defaultInstall,
   };

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -177,7 +177,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   });
 
   pi.registerCommand("pinet-reload", {
-    description: "Tell a connected Pinet agent to reload itself",
+    description:
+      "Tell a connected Pinet agent to reload itself (same workspace/install or instance by default)",
     handler: async (args, ctx) => {
       const target = args.trim();
       if (!target) {
@@ -195,7 +196,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   });
 
   pi.registerCommand("pinet-exit", {
-    description: "Tell a connected Pinet agent to exit gracefully",
+    description:
+      "Tell a connected Pinet agent to exit gracefully (same workspace/install or instance by default)",
     handler: async (args, ctx) => {
       const target = args.trim();
       if (!target) {

--- a/slack-bridge/pinet-control-plane-canvas.test.ts
+++ b/slack-bridge/pinet-control-plane-canvas.test.ts
@@ -414,7 +414,7 @@ describe("createPinetControlPlaneCanvas", () => {
     );
   });
 
-  it("refreshes canvases for every configured surface install", async () => {
+  it("skips non-default installs unless broker canvas access is explicitly enabled", async () => {
     const { deps, slack, resolveChannel } = createDeps({
       slack: vi.fn(async (method: string) => {
         if (method === "conversations.canvases.create") {
@@ -447,6 +447,71 @@ describe("createPinetControlPlaneCanvas", () => {
           source: "explicit",
           workspaceId: "T_SECONDARY",
           botToken: "xoxb-secondary",
+          controlPlaneCanvasChannel: "ops-secondary",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "explicit",
+              workspaceId: "T_SECONDARY",
+              installId: "secondary",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+      ],
+    });
+    const canvas = createPinetControlPlaneCanvas(deps);
+    const { ctx } = createContext();
+
+    await canvas.refreshBrokerControlPlaneCanvasDashboard(ctx, createRefreshInput());
+
+    expect(resolveChannel).toHaveBeenCalledWith("default", "ops-control");
+    expect(resolveChannel).not.toHaveBeenCalledWith("secondary", "ops-secondary");
+    expect(slack).not.toHaveBeenCalledWith(
+      "conversations.canvases.create",
+      "xoxb-secondary",
+      expect.anything(),
+    );
+  });
+
+  it("refreshes canvases for every configured surface install that explicitly opts in", async () => {
+    const { deps, slack, resolveChannel } = createDeps({
+      slack: vi.fn(async (method: string) => {
+        if (method === "conversations.canvases.create") {
+          return { ok: true, canvas_id: "FNEWCANVAS" };
+        }
+        return { ok: true };
+      }),
+      getSlackSurfaceInstalls: () => [
+        {
+          installId: "default",
+          source: "compatibility",
+          botToken: "xoxb-default",
+          controlPlaneCanvasChannel: "ops-control",
+          homeTabEnabled: true,
+          scope: {
+            workspace: {
+              provider: "slack",
+              source: "compatibility",
+              compatibilityKey: "default",
+              installId: "default",
+            },
+            instance: {
+              source: "compatibility",
+              compatibilityKey: "default",
+            },
+          },
+        },
+        {
+          installId: "secondary",
+          source: "explicit",
+          workspaceId: "T_SECONDARY",
+          botToken: "xoxb-secondary",
+          controlPlaneCanvasEnabled: true,
           controlPlaneCanvasChannel: "ops-secondary",
           homeTabEnabled: true,
           scope: {

--- a/slack-bridge/pinet-control-plane-canvas.ts
+++ b/slack-bridge/pinet-control-plane-canvas.ts
@@ -105,8 +105,14 @@ function getInstallCanvasTitle(install: ResolvedSlackInstallTopology): string {
   return normalizeOptionalSetting(install.controlPlaneCanvasTitle) ?? "Pinet Broker Control Plane";
 }
 
-function isInstallCanvasEnabled(install: ResolvedSlackInstallTopology): boolean {
-  return install.controlPlaneCanvasEnabled ?? true;
+function isInstallCanvasEnabled(
+  install: ResolvedSlackInstallTopology,
+  defaultInstallId: string,
+): boolean {
+  if (typeof install.controlPlaneCanvasEnabled === "boolean") {
+    return install.controlPlaneCanvasEnabled;
+  }
+  return install.installId === defaultInstallId;
 }
 
 export function createPinetControlPlaneCanvas(
@@ -229,13 +235,15 @@ export function createPinetControlPlaneCanvas(
     ctx: ExtensionContext,
     input: PinetControlPlaneCanvasRefreshInput,
   ): Promise<void> {
-    const installs = deps.getSlackSurfaceInstalls().filter(isInstallCanvasEnabled);
+    const defaultInstallId = deps.getDefaultSlackInstallId();
+    const installs = deps
+      .getSlackSurfaceInstalls()
+      .filter((install) => isInstallCanvasEnabled(install, defaultInstallId));
     if (installs.length === 0) {
       deps.setLastControlPlaneCanvasError(null);
       return;
     }
 
-    const defaultInstallId = deps.getDefaultSlackInstallId();
     const snapshot = buildBrokerControlPlaneDashboardSnapshot({
       ...input,
       homedir: os.homedir(),

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -87,7 +87,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     label: "Pinet Message",
     description: "Send a message to a connected Pinet agent or broker-only broadcast channel.",
     promptSnippet:
-      "Send a message to a connected Pinet agent by name or ID, or to a broker-only broadcast channel. Use it to delegate work, reply in a Pinet thread, or send `/reload` / `/exit`; when assigning work, include the expected `ack/work/ask/report` flow.",
+      "Send a message to a connected Pinet agent by name or ID, or to a broker-only broadcast channel. Use it to delegate work, reply in a Pinet thread, or send `/reload` / `/exit`; admin control stays same-scope by default, so cross-workspace/install or cross-instance control needs explicit authorization metadata. When assigning work, include the expected `ack/work/ask/report` flow.",
     parameters: Type.Object({
       to: Type.String({
         description:


### PR DESCRIPTION
## Summary
- default App Home and control-plane canvas operator surfaces to the default Slack install unless a secondary install explicitly opts in via existing per-install flags
- scope broker admin control dispatches for `/reload`, `/exit`, and related control envelopes to the sender's runtime scope by default, with an explicit metadata override for intentional cross-scope admin actions
- add regression coverage for the privileged surface gating and scoped admin dispatch behavior

## Why
- advances #548 with the smallest safe slice while staying inside the existing scoped carrier/topology/enforcement/orchestration ladder
- avoids generic enforcement redesign, stable-id/owner-token redesign, and new schema churn
- keeps the branch stacked on the runtime orchestration work in #570 / `feat/issue-550-runtime-orchestration`

## Validation
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`

## Stack
- base branch / PR: `feat/issue-550-runtime-orchestration` / #570
- follow-up issue: #548