### PR TITLE
fix(slack-bridge): preserve continued Slack thread association

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseSocketFrame,
   extractThreadStarted,
+  extractThreadContextChanged,
   extractAppHomeOpened,
   classifyMessage,
   parseMemberJoinedChannel,
@@ -177,6 +178,33 @@ describe("extractThreadStarted", () => {
     };
     const result = extractThreadStarted(evt);
     expect(result?.context).toBeUndefined();
+  });
+});
+
+describe("extractThreadContextChanged", () => {
+  it("extracts channel and user identity when Slack reports a continued thread context", () => {
+    expect(
+      extractThreadContextChanged({
+        type: "assistant_thread_context_changed",
+        assistant_thread: {
+          channel_id: "C123",
+          thread_ts: "222.333",
+          user_id: "U456",
+          context: {
+            channel_id: "C789",
+            team_id: "T001",
+          },
+        },
+      }),
+    ).toEqual({
+      channelId: "C123",
+      threadTs: "222.333",
+      userId: "U456",
+      context: {
+        channelId: "C789",
+        teamId: "T001",
+      },
+    });
   });
 });
 
@@ -1184,6 +1212,89 @@ describe("SlackAdapter — allowlist filtering", () => {
       expect(endpoints).toContain("https://slack.com/api/users.info");
       expect(endpoints).toContain("https://slack.com/api/reactions.add");
     });
+  });
+
+  it("treats an unknown continued thread with a pi_agent owner hint as relevant inbound work", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.replies")) {
+        expect(parsedBody.channel).toBe("C_THREAD");
+        expect(parsedBody.ts).toBe("200.2");
+        expect(String(parsedBody.limit)).toBe("200");
+        expect(String(parsedBody.include_all_metadata)).toBe("true");
+        return mockSlackResponse({
+          messages: [
+            {
+              ts: "200.1",
+              thread_ts: "200.2",
+              bot_id: "B_BOT",
+              metadata: {
+                event_type: "pi_agent_msg",
+                event_payload: {
+                  agent: "Cobalt Olive Crane",
+                  agent_owner: "owner:crane",
+                },
+              },
+            },
+          ],
+        });
+      }
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "C_THREAD", timestamp: "200.3", name: "eyes" });
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "continuing here after Slack split the thread",
+      channel: "C_THREAD",
+      channel_type: "channel",
+      thread_ts: "200.2",
+      ts: "200.3",
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      source: "slack",
+      threadId: "200.2",
+      channel: "C_THREAD",
+      userId: "U_ALLOWED",
+      userName: "Alice Example",
+      text: "continuing here after Slack split the thread",
+      timestamp: "200.3",
+      metadata: {
+        threadOwnerAgentOwner: "owner:crane",
+        threadOwnerAgentName: "Cobalt Olive Crane",
+      },
+    });
+    expect(adapter.getTrackedThreadIds()).toEqual(new Set(["200.2"]));
   });
 });
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -1,6 +1,6 @@
 import {
   addSlackReaction,
-  classifyMessage,
+  classifyMessageWithThreadOwnerHintFallback,
   clearSlackThreadStatus,
   extractAppHomeOpened,
   extractThreadContextChanged,
@@ -8,6 +8,7 @@ import {
   fetchSlackMessageByTs,
   isSlackUserAllowed,
   removeSlackReaction,
+  resolveSlackThreadOwnerHint,
   resolveSlackUserName,
   setSlackSuggestedPrompts,
   SlackSocketModeClient,
@@ -37,6 +38,7 @@ import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js
 export {
   classifyMessage,
   extractAppHomeOpened,
+  extractThreadContextChanged,
   extractThreadStarted,
   parseMemberJoinedChannel,
   parseSocketFrame,
@@ -225,9 +227,34 @@ export class SlackAdapter implements MessageAdapter {
     if (!parsed) return;
 
     const existing = this.threads.get(parsed.threadTs);
-    if (!existing || !parsed.context) return;
+    if (!existing) {
+      if (!parsed.channelId) return;
+      const info: SlackThreadInfo = {
+        channelId: parsed.channelId,
+        threadTs: parsed.threadTs,
+        userId: parsed.userId ?? "",
+      };
+      if (parsed.context) {
+        info.context = parsed.context;
+      }
+      this.threads.set(parsed.threadTs, info);
+      try {
+        this.config.rememberKnownThread?.(parsed.threadTs, parsed.channelId);
+      } catch {
+        /* best effort — DB cache sync must not break Slack event handling */
+      }
+      return;
+    }
 
-    existing.context = parsed.context;
+    if (parsed.channelId) {
+      existing.channelId = parsed.channelId;
+    }
+    if (parsed.userId) {
+      existing.userId = parsed.userId;
+    }
+    if (parsed.context) {
+      existing.context = parsed.context;
+    }
   }
 
   private async onAppHomeOpened(
@@ -307,6 +334,13 @@ export class SlackAdapter implements MessageAdapter {
         }
       }
 
+      const threadOwnerHint = await resolveSlackThreadOwnerHint({
+        slack: this.callSlack.bind(this),
+        token: this.config.botToken,
+        channel: item.channel,
+        threadTs,
+      });
+
       const reactorName = await this.resolveUser(userId);
       if (this.shuttingDown) return;
       const reactedMessageAuthorId =
@@ -340,6 +374,18 @@ export class SlackAdapter implements MessageAdapter {
           reactedMessageAuthor,
         }),
         timestamp: (evt.event_ts as string) ?? item.ts,
+        ...(threadOwnerHint?.agentOwner || threadOwnerHint?.agentName
+          ? {
+              metadata: {
+                ...(threadOwnerHint.agentOwner
+                  ? { threadOwnerAgentOwner: threadOwnerHint.agentOwner }
+                  : {}),
+                ...(threadOwnerHint.agentName
+                  ? { threadOwnerAgentName: threadOwnerHint.agentName }
+                  : {}),
+              },
+            }
+          : {}),
       });
 
       await this.addReaction(item.channel, item.ts, "white_check_mark");
@@ -352,12 +398,14 @@ export class SlackAdapter implements MessageAdapter {
   private async onMessage(evt: Record<string, unknown>): Promise<void> {
     if (this.shuttingDown) return;
 
-    const classified = classifyMessage(
+    const classified = await classifyMessageWithThreadOwnerHintFallback({
       evt,
-      this.botUserId,
-      this.getTrackedThreadIds(),
-      this.config.isKnownThread,
-    );
+      botUserId: this.botUserId,
+      trackedThreadIds: this.getTrackedThreadIds(),
+      slack: this.callSlack.bind(this),
+      token: this.config.botToken,
+      isKnownThread: this.config.isKnownThread,
+    });
     if (!classified.relevant) return;
 
     const { threadTs, channel, userId, text, isChannelMention, messageTs, metadata } = classified;

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -296,6 +296,73 @@ describe("single-player-runtime", () => {
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
   });
 
+  it("accepts an unknown continued thread when Slack replies reveal a prior pi_agent owner hint", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const { deps, spies } = createDeps(state, {
+      slack: vi.fn(async (method: string) =>
+        method === "conversations.replies"
+          ? {
+              ok: true,
+              messages: [
+                {
+                  ts: "200.1",
+                  thread_ts: "200.2",
+                  bot_id: "B_BOT",
+                  metadata: {
+                    event_type: "pi_agent_msg",
+                    event_payload: {
+                      agent: "Cobalt Olive Crane",
+                      agent_owner: "owner:crane",
+                    },
+                  },
+                },
+              ],
+            }
+          : { ok: true },
+      ),
+    });
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      channel: "C_THREAD",
+      channel_type: "channel",
+      thread_ts: "200.2",
+      user: "U_SENDER",
+      text: "continuing here after Slack split the thread",
+      ts: "200.3",
+    });
+
+    expect(state.threads.get("200.2")).toMatchObject({
+      channelId: "C_THREAD",
+      threadTs: "200.2",
+      userId: "U_SENDER",
+      source: "slack",
+    });
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith({
+      channel: "C_THREAD",
+      threadTs: "200.2",
+      userId: "U_SENDER",
+      text: "continuing here after Slack split the thread",
+      timestamp: "200.3",
+      metadata: {
+        threadOwnerAgentOwner: "owner:crane",
+        threadOwnerAgentName: "Cobalt Olive Crane",
+      },
+    });
+    expect(spies.addReaction).toHaveBeenCalledWith("C_THREAD", "200.3", "eyes");
+  });
+
   it("preserves file-share metadata on inbound Slack messages", async () => {
     const state: TestState = {
       threads: new Map(),

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -8,7 +8,7 @@ import {
 import type { SlackInteractiveInboxEvent } from "./slack-block-kit.js";
 import type { SlackToolsThreadContextPort } from "./slack-tools.js";
 import {
-  classifyMessage,
+  classifyMessageWithThreadOwnerHintFallback,
   resolveSlackThreadOwnerHint,
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
@@ -220,10 +220,30 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
   function onContextChanged(event: ParsedThreadContextChanged): void {
     if (shuttingDown) return;
 
-    const existing = deps.getThreads().get(event.threadTs);
-    if (!existing || !event.context) return;
+    const threads = deps.getThreads();
+    const existing = threads.get(event.threadTs);
+    if (!existing) {
+      if (!event.channelId) return;
+      threads.set(event.threadTs, {
+        channelId: event.channelId,
+        threadTs: event.threadTs,
+        userId: event.userId ?? "",
+        source: "slack",
+        ...(event.context ? { context: event.context } : {}),
+      });
+      deps.persistState();
+      return;
+    }
 
-    existing.context = event.context;
+    if (event.channelId) {
+      existing.channelId = event.channelId;
+    }
+    if (event.userId) {
+      existing.userId = event.userId;
+    }
+    if (event.context) {
+      existing.context = event.context;
+    }
     deps.persistState();
   }
 
@@ -344,7 +364,13 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     if (shuttingDown) return;
 
     const threads = deps.getThreads();
-    const classified = classifyMessage(evt, getCurrentBotUserId(), new Set(threads.keys()));
+    const classified = await classifyMessageWithThreadOwnerHintFallback({
+      evt,
+      botUserId: getCurrentBotUserId(),
+      trackedThreadIds: new Set(threads.keys()),
+      slack: deps.slack,
+      token: deps.getBotToken(),
+    });
     if (!classified.relevant) return;
 
     const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs, metadata } =

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -122,6 +122,8 @@ export function extractThreadStarted(evt: Record<string, unknown>): ParsedThread
 
 export interface ParsedThreadContextChanged {
   threadTs: string;
+  channelId?: string;
+  userId?: string;
   context?: SlackThreadContext;
 }
 
@@ -136,7 +138,13 @@ export function extractThreadContextChanged(
     return null;
   }
 
-  const result: ParsedThreadContextChanged = { threadTs };
+  const result: ParsedThreadContextChanged = {
+    threadTs,
+    ...(typeof t.channel_id === "string" && t.channel_id.length > 0
+      ? { channelId: t.channel_id }
+      : {}),
+    ...(typeof t.user_id === "string" && t.user_id.length > 0 ? { userId: t.user_id } : {}),
+  };
   const ctx = t.context as { channel_id?: string; team_id?: string } | undefined;
   if (ctx?.channel_id) {
     result.context = { channelId: ctx.channel_id, teamId: ctx.team_id ?? "" };
@@ -181,6 +189,25 @@ export type MessageClassification =
       metadata?: Record<string, unknown>;
     };
 
+function buildSlackMessageClassificationMetadata(
+  evt: Record<string, unknown>,
+  options: { threadOwnerHint?: ThreadOwnerHint | null } = {},
+): Record<string, unknown> {
+  const subtype = typeof evt.subtype === "string" ? evt.subtype : undefined;
+  const slackFiles = extractSlackMessageFileMetadata(evt.files);
+
+  return {
+    ...(subtype ? { slackSubtype: subtype } : {}),
+    ...(slackFiles.length > 0 ? { slackFiles } : {}),
+    ...(options.threadOwnerHint?.agentOwner
+      ? { threadOwnerAgentOwner: options.threadOwnerHint.agentOwner }
+      : {}),
+    ...(options.threadOwnerHint?.agentName
+      ? { threadOwnerAgentName: options.threadOwnerHint.agentName }
+      : {}),
+  };
+}
+
 /**
  * Classify an incoming Slack message event. Determines whether the
  * message is relevant (DM, known thread, or bot mention) and
@@ -211,11 +238,7 @@ export function classifyMessage(
   const effectiveTs = threadTs ?? (evt.ts as string);
   const isChannelMention = isMention && !isDM && !isKnown;
   const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
-  const slackFiles = extractSlackMessageFileMetadata(evt.files);
-  const metadata: Record<string, unknown> = {
-    ...(subtype ? { slackSubtype: subtype } : {}),
-    ...(slackFiles.length > 0 ? { slackFiles } : {}),
-  };
+  const metadata = buildSlackMessageClassificationMetadata(evt);
 
   return {
     relevant: true,
@@ -226,6 +249,65 @@ export function classifyMessage(
     isDM,
     isChannelMention,
     messageTs: (evt.ts as string) ?? effectiveTs,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+}
+
+export async function classifyMessageWithThreadOwnerHintFallback(input: {
+  evt: Record<string, unknown>;
+  botUserId: string | null;
+  trackedThreadIds: Set<string>;
+  slack: SlackCall;
+  token: string;
+  isKnownThread?: (threadTs: string) => boolean;
+}): Promise<MessageClassification> {
+  const classified = classifyMessage(
+    input.evt,
+    input.botUserId,
+    input.trackedThreadIds,
+    input.isKnownThread,
+  );
+  if (classified.relevant) {
+    return classified;
+  }
+
+  const subtype = typeof input.evt.subtype === "string" ? input.evt.subtype : undefined;
+  const allowsSubtype = subtype === undefined || subtype === "file_share";
+  if (!allowsSubtype || input.evt.bot_id) {
+    return classified;
+  }
+
+  const threadTs = typeof input.evt.thread_ts === "string" ? input.evt.thread_ts : null;
+  const channel = typeof input.evt.channel === "string" ? input.evt.channel : null;
+  const userId = typeof input.evt.user === "string" ? input.evt.user : null;
+  const channelType = typeof input.evt.channel_type === "string" ? input.evt.channel_type : null;
+  if (!threadTs || !channel || !userId || channelType === "im") {
+    return classified;
+  }
+
+  const hint = await resolveSlackThreadOwnerHint({
+    slack: input.slack,
+    token: input.token,
+    channel,
+    threadTs,
+  });
+  if (!hint) {
+    return classified;
+  }
+
+  const metadata = buildSlackMessageClassificationMetadata(input.evt, {
+    threadOwnerHint: hint,
+  });
+
+  return {
+    relevant: true,
+    threadTs,
+    channel,
+    userId,
+    text: buildSlackInboundMessageText((input.evt.text as string) ?? "", input.evt),
+    isDM: false,
+    isChannelMention: false,
+    messageTs: (input.evt.ts as string) ?? threadTs,
     ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- preserve continued Slack thread association when Slack thread replies arrive on an unknown continuation thread
- recover prior pi-agent owner hints from Slack thread history before dropping unknown threaded replies
- seed continued thread tracking from `assistant_thread_context_changed` when Slack reports a fresh thread context
- add broker + single-player regression coverage for continued-thread routing

Closes #575.

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
