### PR TITLE
fix(slack-bridge): defer queued follow-up delivery until idle

### DIFF
--- a/slack-bridge/inbox-drain-runtime.test.ts
+++ b/slack-bridge/inbox-drain-runtime.test.ts
@@ -26,11 +26,13 @@ function createDeps(overrides: Partial<InboxDrainRuntimeDeps> = {}) {
   let securityPrompt = "";
   let brokerRole: "broker" | "follower" | null = null;
   let followerClient = true;
+  let idle = true;
   const followerDeliveryState = createFollowerDeliveryState();
 
   const deps: InboxDrainRuntimeDeps = {
     sendUserMessage,
-    takeInboxMessages: () => inbox.splice(0, inbox.length),
+    isIdle: () => idle,
+    takeInboxMessages: (maxMessages) => inbox.splice(0, maxMessages ?? inbox.length),
     restoreInboxMessages: (messages) => {
       inbox.push(...messages);
     },
@@ -69,31 +71,38 @@ function createDeps(overrides: Partial<InboxDrainRuntimeDeps> = {}) {
     setFollowerClient: (value: boolean) => {
       followerClient = value;
     },
+    setIdle: (value: boolean) => {
+      idle = value;
+    },
   };
 }
 
 describe("createInboxDrainRuntime", () => {
-  it("delivers follow-up messages with a plain-send fallback", () => {
+  it("delivers held follow-up messages only through the idle prompt path", () => {
     const { runtime, sendUserMessage } = createDeps();
-    sendUserMessage
-      .mockImplementationOnce(() => {
-        throw new Error("followUp failed");
-      })
-      .mockImplementationOnce(() => undefined);
 
     expect(runtime.deliverFollowUpMessage("steady note")).toBe(true);
-    expect(sendUserMessage).toHaveBeenNthCalledWith(1, "steady note", { deliverAs: "followUp" });
-    expect(sendUserMessage).toHaveBeenNthCalledWith(2, "steady note");
+    expect(sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(sendUserMessage).toHaveBeenCalledWith("steady note");
   });
 
-  it("returns false when both follow-up delivery attempts fail", () => {
+  it("does not inject follow-up messages while the agent is active", () => {
+    const { runtime, sendUserMessage, setIdle } = createDeps();
+    setIdle(false);
+
+    expect(runtime.deliverFollowUpMessage("steady note")).toBe(false);
+    expect(sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns false when idle prompt delivery fails", () => {
     const { runtime, sendUserMessage } = createDeps();
     sendUserMessage.mockImplementation(() => {
       throw new Error("send failed");
     });
 
     expect(runtime.deliverFollowUpMessage("steady note")).toBe(false);
-    expect(sendUserMessage).toHaveBeenCalledTimes(2);
+    expect(sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(sendUserMessage).toHaveBeenCalledWith("steady note");
   });
 
   it("formats pending inbox work, applies security guidance, and flushes follower acks", () => {
@@ -146,6 +155,27 @@ describe("createInboxDrainRuntime", () => {
     expect(flushFollowerDeliveredAcks).not.toHaveBeenCalled();
   });
 
+  it("does not drain inbox work while the agent is active", () => {
+    const {
+      runtime,
+      inbox,
+      updateBadge,
+      reportStatus,
+      deliverTrackedSlackFollowUpMessage,
+      setIdle,
+    } = createDeps();
+    const message = createMessage({ brokerInboxId: 87 });
+    inbox.push(message);
+    setIdle(false);
+
+    runtime.drainInbox();
+
+    expect(updateBadge).not.toHaveBeenCalled();
+    expect(reportStatus).not.toHaveBeenCalled();
+    expect(deliverTrackedSlackFollowUpMessage).not.toHaveBeenCalled();
+    expect(inbox).toEqual([message]);
+  });
+
   it("requeues pending inbox work when the follow-up delivery is not accepted", () => {
     const { runtime, inbox, updateBadge, reportStatus, markBrokerInboxIdsDelivered } = createDeps({
       deliverTrackedSlackFollowUpMessage: vi.fn(() => false),
@@ -159,6 +189,24 @@ describe("createInboxDrainRuntime", () => {
     expect(updateBadge).toHaveBeenCalledTimes(2);
     expect(markBrokerInboxIdsDelivered).not.toHaveBeenCalled();
     expect(inbox).toEqual([message]);
+  });
+
+  it("limits each inbox drain batch and preserves remaining messages", () => {
+    const { runtime, inbox, deliverTrackedSlackFollowUpMessage } = createDeps({
+      maxMessagesPerDrain: 2,
+    });
+    const first = createMessage({ text: "first" });
+    const second = createMessage({ text: "second" });
+    const third = createMessage({ text: "third" });
+    inbox.push(first, second, third);
+
+    runtime.drainInbox();
+
+    expect(deliverTrackedSlackFollowUpMessage).toHaveBeenCalledWith({
+      prompt: formatInboxMessages([first, second], new Map<string, string>([["U123", "Ada"]])),
+      messages: [first, second],
+    });
+    expect(inbox).toEqual([third]);
   });
 
   it("only flushes follower acks when follower delivery is still live", async () => {

--- a/slack-bridge/inbox-drain-runtime.ts
+++ b/slack-bridge/inbox-drain-runtime.ts
@@ -2,9 +2,12 @@ import { getBrokerInboxIds } from "./broker-delivery.js";
 import { markFollowerInboxIdsDelivered, type FollowerDeliveryState } from "./follower-delivery.js";
 import { formatInboxMessages, type InboxMessage } from "./helpers.js";
 
+const DEFAULT_MAX_MESSAGES_PER_DRAIN = 5;
+
 export interface InboxDrainRuntimeDeps {
-  sendUserMessage: (text: string, options?: { deliverAs?: "followUp" }) => void;
-  takeInboxMessages: () => InboxMessage[];
+  sendUserMessage: (text: string) => void;
+  isIdle: () => boolean;
+  takeInboxMessages: (maxMessages?: number) => InboxMessage[];
   restoreInboxMessages: (messages: InboxMessage[]) => void;
   updateBadge: () => void;
   reportStatus: (status: "working" | "idle") => Promise<void>;
@@ -19,6 +22,7 @@ export interface InboxDrainRuntimeDeps {
   flushFollowerDeliveredAcks: () => Promise<void>;
   markBrokerInboxIdsDelivered: (inboxIds: number[]) => void;
   getFollowerDeliveryState: () => FollowerDeliveryState;
+  maxMessagesPerDrain?: number;
 }
 
 export interface InboxDrainRuntime {
@@ -29,16 +33,15 @@ export interface InboxDrainRuntime {
 
 export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrainRuntime {
   function deliverFollowUpMessage(text: string): boolean {
+    if (!deps.isIdle()) {
+      return false;
+    }
+
     try {
-      deps.sendUserMessage(text, { deliverAs: "followUp" });
+      deps.sendUserMessage(text);
       return true;
     } catch {
-      try {
-        deps.sendUserMessage(text);
-        return true;
-      } catch {
-        return false;
-      }
+      return false;
     }
   }
 
@@ -51,7 +54,12 @@ export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrain
   }
 
   function drainInbox(): void {
-    const pending = deps.takeInboxMessages();
+    if (!deps.isIdle()) {
+      return;
+    }
+
+    const maxMessages = deps.maxMessagesPerDrain ?? DEFAULT_MAX_MESSAGES_PER_DRAIN;
+    const pending = deps.takeInboxMessages(maxMessages);
     if (pending.length === 0) {
       return;
     }

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1856,7 +1856,6 @@ describe("slack-bridge top-level shutdown", () => {
     await vi.waitFor(() => {
       expect(sendUserMessage).toHaveBeenCalledWith(
         expect.stringContaining("hello from Slack inbox"),
-        { deliverAs: "followUp" },
       );
     });
 
@@ -3518,9 +3517,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
       await vi.advanceTimersByTimeAsync(2_000);
       await vi.waitFor(() => {
-        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"), {
-          deliverAs: "followUp",
-        });
+        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"));
       });
       expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working"]);
 
@@ -3661,9 +3658,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
       await vi.advanceTimersByTimeAsync(2_000);
       await vi.waitFor(() => {
-        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"), {
-          deliverAs: "followUp",
-        });
+        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"));
       });
       expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working"]);
 
@@ -3822,9 +3817,7 @@ describe("slack-bridge Pinet reconnect", () => {
       await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
 
       expect(sendUserMessage).toHaveBeenCalledTimes(1);
-      expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"), {
-        deliverAs: "followUp",
-      });
+      expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"));
 
       await sessionShutdown?.({}, ctx);
       expect(setStatus).toHaveBeenCalled();

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -210,12 +210,13 @@ export default function (pi: ExtensionAPI) {
     messages: Pick<InboxMessage, "threadTs">[];
   }) => boolean = () => false;
   const inboxDrainRuntime = createInboxDrainRuntime({
-    sendUserMessage: (body, options) => {
-      pi.sendUserMessage(body, options);
+    sendUserMessage: (body) => {
+      pi.sendUserMessage(body);
     },
-    takeInboxMessages: () => inbox.splice(0, inbox.length),
+    isIdle: () => sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true,
+    takeInboxMessages: (maxMessages) => inbox.splice(0, maxMessages ?? inbox.length),
     restoreInboxMessages: (messages) => {
-      inbox.push(...messages);
+      inbox.unshift(...messages);
     },
     updateBadge,
     reportStatus: (status) => reportAgentStatus(status),
@@ -497,8 +498,9 @@ export default function (pi: ExtensionAPI) {
   const pinetMaintenanceDelivery = createPinetMaintenanceDelivery({
     getActiveBrokerDb,
     getActiveBrokerSelfId,
-    sendUserMessage: (body, options) => {
-      pi.sendUserMessage(body, options);
+    isIdle: () => sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true,
+    sendUserMessage: (body) => {
+      pi.sendUserMessage(body);
     },
   });
   const { sendBrokerMaintenanceMessage, trySendBrokerFollowUp } = pinetMaintenanceDelivery;
@@ -1345,6 +1347,10 @@ export default function (pi: ExtensionAPI) {
   // ─── Agent event wiring ──────────────────────────────
 
   agentEventRuntime.register(pi);
+
+  pi.on("session_compact", async (_event, ctx) => {
+    maybeDrainInboxIfIdle(ctx);
+  });
 
   pi.on("session_shutdown", async (_event, ctx) => {
     resetRemoteControlState();

--- a/slack-bridge/pinet-maintenance-delivery.test.ts
+++ b/slack-bridge/pinet-maintenance-delivery.test.ts
@@ -8,7 +8,7 @@ import {
 
 function createDeps(overrides: Partial<PinetMaintenanceDeliveryDeps> = {}) {
   const agents = new Map<string, PinetMaintenanceDeliveryAgentRecord>([
-    ["worker-1", { id: "worker-1" }],
+    ["worker-1", { id: "worker-1", name: "Worker Heron", emoji: "🪶" }],
   ]);
   const threads = new Map<string, { id: string }>();
   const createThread = vi.fn((threadId: string) => {
@@ -16,6 +16,7 @@ function createDeps(overrides: Partial<PinetMaintenanceDeliveryDeps> = {}) {
   });
   const insertMessage = vi.fn();
   const sendUserMessage = vi.fn();
+  let idle = true;
 
   const db: PinetMaintenanceDeliveryBrokerDbPort = {
     getAgentById: (agentId) => agents.get(agentId) ?? null,
@@ -27,6 +28,7 @@ function createDeps(overrides: Partial<PinetMaintenanceDeliveryDeps> = {}) {
   const deps: PinetMaintenanceDeliveryDeps = {
     getActiveBrokerDb: () => db,
     getActiveBrokerSelfId: () => "broker-1",
+    isIdle: () => idle,
     sendUserMessage,
     ...overrides,
   };
@@ -39,6 +41,9 @@ function createDeps(overrides: Partial<PinetMaintenanceDeliveryDeps> = {}) {
     createThread,
     insertMessage,
     sendUserMessage,
+    setIdle: (value: boolean) => {
+      idle = value;
+    },
   };
 }
 
@@ -49,25 +54,31 @@ describe("createPinetMaintenanceDelivery", () => {
 
     pinetMaintenanceDelivery.sendBrokerMaintenanceMessage("worker-1", "Heads up");
 
-    expect(createThread).toHaveBeenCalledWith("a2a:broker-1:worker-1", "agent", "", "broker-1");
-    expect(threads.has("a2a:broker-1:worker-1")).toBe(true);
+    expect(createThread).toHaveBeenCalledWith("a2a:broker-1:broker-1", "agent", "", "broker-1");
+    expect(threads.has("a2a:broker-1:broker-1")).toBe(true);
     expect(insertMessage).toHaveBeenCalledWith(
-      "a2a:broker-1:worker-1",
+      "a2a:broker-1:broker-1",
       "agent",
       "outbound",
       "broker-1",
-      "Heads up",
-      ["worker-1"],
+      [
+        "RALPH broker-only maintenance for 🪶 Worker Heron (worker-1):",
+        "",
+        "Original worker-directed maintenance note (not delivered to the worker/follower Pi queue):",
+        "Heads up",
+      ].join("\n"),
+      ["broker-1"],
       {
         kind: "ralph_loop_nudge",
         targetAgentId: "worker-1",
+        brokerOnly: true,
       },
     );
   });
 
-  it("reuses an existing broker thread and skips unknown targets", () => {
+  it("reuses the broker-only maintenance thread and skips unknown targets", () => {
     const { deps, createThread, insertMessage, threads } = createDeps();
-    threads.set("a2a:broker-1:worker-1", { id: "a2a:broker-1:worker-1" });
+    threads.set("a2a:broker-1:broker-1", { id: "a2a:broker-1:broker-1" });
     const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
 
     pinetMaintenanceDelivery.sendBrokerMaintenanceMessage("worker-1", "Follow up");
@@ -76,20 +87,26 @@ describe("createPinetMaintenanceDelivery", () => {
     expect(createThread).not.toHaveBeenCalled();
     expect(insertMessage).toHaveBeenCalledTimes(1);
     expect(insertMessage).toHaveBeenCalledWith(
-      "a2a:broker-1:worker-1",
+      "a2a:broker-1:broker-1",
       "agent",
       "outbound",
       "broker-1",
-      "Follow up",
-      ["worker-1"],
+      [
+        "RALPH broker-only maintenance for 🪶 Worker Heron (worker-1):",
+        "",
+        "Original worker-directed maintenance note (not delivered to the worker/follower Pi queue):",
+        "Follow up",
+      ].join("\n"),
+      ["broker-1"],
       {
         kind: "ralph_loop_nudge",
         targetAgentId: "worker-1",
+        brokerOnly: true,
       },
     );
   });
 
-  it("prefers follow-up delivery and marks the callback as delivered", () => {
+  it("delivers broker follow-ups only through the idle prompt path", () => {
     const { deps, sendUserMessage } = createDeps();
     const onDelivered = vi.fn();
     const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
@@ -97,30 +114,23 @@ describe("createPinetMaintenanceDelivery", () => {
     pinetMaintenanceDelivery.trySendBrokerFollowUp("Maintenance report", onDelivered);
 
     expect(sendUserMessage).toHaveBeenCalledTimes(1);
-    expect(sendUserMessage).toHaveBeenCalledWith("Maintenance report", {
-      deliverAs: "followUp",
-    });
+    expect(sendUserMessage).toHaveBeenCalledWith("Maintenance report");
     expect(onDelivered).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to plain delivery when follow-up delivery throws", () => {
-    const { deps, sendUserMessage } = createDeps();
-    sendUserMessage.mockImplementationOnce(() => {
-      throw new Error("followUp failed");
-    });
+  it("does not mark broker follow-ups delivered while the agent is active", () => {
+    const { deps, sendUserMessage, setIdle } = createDeps();
     const onDelivered = vi.fn();
     const pinetMaintenanceDelivery = createPinetMaintenanceDelivery(deps);
+    setIdle(false);
 
     pinetMaintenanceDelivery.trySendBrokerFollowUp("Maintenance report", onDelivered);
 
-    expect(sendUserMessage).toHaveBeenNthCalledWith(1, "Maintenance report", {
-      deliverAs: "followUp",
-    });
-    expect(sendUserMessage).toHaveBeenNthCalledWith(2, "Maintenance report");
-    expect(onDelivered).toHaveBeenCalledTimes(1);
+    expect(sendUserMessage).not.toHaveBeenCalled();
+    expect(onDelivered).not.toHaveBeenCalled();
   });
 
-  it("keeps follow-up delivery best effort when both delivery attempts fail", () => {
+  it("keeps follow-up delivery best effort when idle delivery fails", () => {
     const { deps, sendUserMessage } = createDeps();
     sendUserMessage.mockImplementation(() => {
       throw new Error("delivery failed");
@@ -131,10 +141,8 @@ describe("createPinetMaintenanceDelivery", () => {
     expect(() =>
       pinetMaintenanceDelivery.trySendBrokerFollowUp("Maintenance report", onDelivered),
     ).not.toThrow();
-    expect(sendUserMessage).toHaveBeenNthCalledWith(1, "Maintenance report", {
-      deliverAs: "followUp",
-    });
-    expect(sendUserMessage).toHaveBeenNthCalledWith(2, "Maintenance report");
+    expect(sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(sendUserMessage).toHaveBeenCalledWith("Maintenance report");
     expect(onDelivered).not.toHaveBeenCalled();
   });
 });

--- a/slack-bridge/pinet-maintenance-delivery.ts
+++ b/slack-bridge/pinet-maintenance-delivery.ts
@@ -1,5 +1,7 @@
 export interface PinetMaintenanceDeliveryAgentRecord {
   id: string;
+  name?: string;
+  emoji?: string;
 }
 
 export interface PinetMaintenanceDeliveryBrokerDbPort {
@@ -17,19 +19,29 @@ export interface PinetMaintenanceDeliveryBrokerDbPort {
   ) => void;
 }
 
-export interface PinetMaintenanceDeliverySendMessageOptions {
-  deliverAs?: "followUp";
-}
-
 export interface PinetMaintenanceDeliveryDeps {
   getActiveBrokerDb: () => PinetMaintenanceDeliveryBrokerDbPort | null;
   getActiveBrokerSelfId: () => string | null;
-  sendUserMessage: (body: string, options?: PinetMaintenanceDeliverySendMessageOptions) => void;
+  isIdle: () => boolean;
+  sendUserMessage: (body: string) => void;
 }
 
 export interface PinetMaintenanceDelivery {
   sendBrokerMaintenanceMessage: (targetAgentId: string, body: string) => void;
   trySendBrokerFollowUp: (body: string, onDelivered: () => void) => void;
+}
+
+function formatBrokerOnlyMaintenanceMessage(
+  target: PinetMaintenanceDeliveryAgentRecord,
+  body: string,
+): string {
+  const label = [target.emoji, target.name].filter(Boolean).join(" ") || target.id;
+  return [
+    `RALPH broker-only maintenance for ${label} (${target.id}):`,
+    "",
+    "Original worker-directed maintenance note (not delivered to the worker/follower Pi queue):",
+    body,
+  ].join("\n");
 }
 
 export function createPinetMaintenanceDelivery(
@@ -42,29 +54,36 @@ export function createPinetMaintenanceDelivery(
     const target = db.getAgentById(targetAgentId);
     if (!target) return;
 
-    const threadId = `a2a:${selfId}:${target.id}`;
+    const threadId = `a2a:${selfId}:${selfId}`;
     if (!db.getThread(threadId)) {
       db.createThread(threadId, "agent", "", selfId);
     }
 
-    db.insertMessage(threadId, "agent", "outbound", selfId, body, [target.id], {
-      kind: "ralph_loop_nudge",
-      targetAgentId,
-    });
+    db.insertMessage(
+      threadId,
+      "agent",
+      "outbound",
+      selfId,
+      formatBrokerOnlyMaintenanceMessage(target, body),
+      [selfId],
+      {
+        kind: "ralph_loop_nudge",
+        targetAgentId: target.id,
+        brokerOnly: true,
+      },
+    );
   }
 
   function trySendBrokerFollowUp(body: string, onDelivered: () => void): void {
-    try {
-      deps.sendUserMessage(body, { deliverAs: "followUp" });
-      onDelivered();
+    if (!deps.isIdle()) {
       return;
+    }
+
+    try {
+      deps.sendUserMessage(body);
+      onDelivered();
     } catch {
-      try {
-        deps.sendUserMessage(body);
-        onDelivered();
-      } catch {
-        /* best effort */
-      }
+      /* best effort */
     }
   }
 

--- a/slack-bridge/session-ui-runtime.test.ts
+++ b/slack-bridge/session-ui-runtime.test.ts
@@ -100,6 +100,29 @@ describe("createSessionUiRuntime", () => {
     expect(drainInbox).toHaveBeenCalledTimes(2);
   });
 
+  it("schedules an inbox drain retry until the session is truly idle", async () => {
+    vi.useFakeTimers();
+    try {
+      let idle = false;
+      const { deps, drainInbox } = createDeps({ getInboxLength: () => 1 });
+      const runtime = createSessionUiRuntime(deps);
+      const { ctx } = createContext({ idle: false });
+      (ctx as unknown as { isIdle: () => boolean }).isIdle = () => idle;
+
+      expect(runtime.maybeDrainInboxIfIdle(ctx)).toBe(false);
+      expect(drainInbox).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(249);
+      expect(drainInbox).not.toHaveBeenCalled();
+
+      idle = true;
+      await vi.advanceTimersByTimeAsync(1);
+      expect(drainInbox).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("binds terminal input on session start and cleans it up on shutdown", () => {
     const unsubscribe = vi.fn();
     let terminalHandler:

--- a/slack-bridge/session-ui-runtime.ts
+++ b/slack-bridge/session-ui-runtime.ts
@@ -1,6 +1,7 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 
 const AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS = 1_500;
+const AUTO_DRAIN_IDLE_RETRY_MS = 250;
 
 export type SessionUiStatusState = "ok" | "reconnecting" | "error" | "off";
 
@@ -32,6 +33,7 @@ type SessionUiWithTerminalInput = ExtensionContext["ui"] & {
 export function createSessionUiRuntime(deps: SessionUiRuntimeDeps): SessionUiRuntime {
   let suppressAutoDrainUntil = 0;
   let terminalInputUnsubscribe: (() => void) | null = null;
+  let deferredDrainTimer: ReturnType<typeof setTimeout> | null = null;
   let extCtx: ExtensionContext | null = null;
 
   function getExtensionContext(): ExtensionContext | null {
@@ -92,13 +94,43 @@ export function createSessionUiRuntime(deps: SessionUiRuntimeDeps): SessionUiRun
     return true;
   }
 
+  function clearDeferredDrainTimer(): void {
+    if (!deferredDrainTimer) return;
+    clearTimeout(deferredDrainTimer);
+    deferredDrainTimer = null;
+  }
+
+  function scheduleDeferredDrain(ctx: ExtensionContext): void {
+    extCtx = ctx;
+    if (deferredDrainTimer) return;
+
+    deferredDrainTimer = setTimeout(() => {
+      deferredDrainTimer = null;
+      if (deps.getInboxLength() === 0) return;
+      const latestCtx = extCtx;
+      if (!latestCtx) return;
+      maybeDrainInboxIfIdle(latestCtx);
+    }, AUTO_DRAIN_IDLE_RETRY_MS);
+    deferredDrainTimer.unref?.();
+  }
+
   function maybeDrainInboxIfIdle(ctx?: ExtensionContext): boolean {
-    if (!(ctx?.isIdle?.() ?? false)) {
+    if (ctx) {
+      extCtx = ctx;
+    }
+
+    const activeCtx = ctx ?? extCtx;
+    if (!(activeCtx?.isIdle?.() ?? false)) {
+      if (activeCtx && !shouldSuppressAutomaticInboxDrain() && deps.getInboxLength() > 0) {
+        scheduleDeferredDrain(activeCtx);
+      }
       return false;
     }
     if (shouldSuppressAutomaticInboxDrain()) {
       return false;
     }
+
+    clearDeferredDrainTimer();
     deps.drainInbox();
     return true;
   }
@@ -121,6 +153,7 @@ export function createSessionUiRuntime(deps: SessionUiRuntimeDeps): SessionUiRun
   function cleanupForSessionShutdown(): void {
     terminalInputUnsubscribe?.();
     terminalInputUnsubscribe = null;
+    clearDeferredDrainTimer();
     suppressAutoDrainUntil = 0;
   }
 


### PR DESCRIPTION
## Summary
- Stops extension-owned queued Slack/Pinet delivery from using `deliverAs: "followUp"` while the Pi agent loop is active.
- Adds an idle-only, bounded inbox drain (5 messages per cycle) with retry scheduling while non-idle and an extra post-`session_compact` drain hook.
- Routes RALPH maintenance nudges to the broker-only maintenance thread/inbox instead of worker/follower Pi follow-up queues.
- Preserves undelivered human inbox messages while active or on delivery failure; delivered broker inbox ids are only marked after idle prompt handoff succeeds.

## Regression attribution
- Current Pi 0.70.0 still supports auto-compaction and `deliverAs: "followUp"`, but compaction runs at prompt boundaries / `agent_end` checkpoints. If extensions keep adding follow-up turns inside a still-active lifecycle, auto-compaction can be delayed until the chain ends.
- Recent extension history introduced/kept direct extension-owned follow-up injection in extracted runtimes:
  - `947d5bb` extracted maintenance delivery with `pi.sendUserMessage(body, { deliverAs: "followUp" })` and fallback plain send.
  - `58abe54` extracted inbox drain runtime with `deliverAs: "followUp"` first and all-pending inbox drain.
  - RALPH follow-up dedupe/cooldown exists (`245b0f6`), but worker nudges still targeted worker inboxes and queued delivery paths.
- Changelog review for Pi 0.70.0 shows relevant contract remains: `followUp` queues until the agent finishes, compaction triggers at thresholds/overflow and events include `session_compact`. No changelog entry indicates a hard regression that would make extension-owned unbounded follow-up stacking safe. This is best classified as an interaction/regression in extension assumptions under Pi’s queue/compaction semantics, not global Pi compaction absence.

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- Targeted during development: `pnpm --filter @gugu910/pi-slack-bridge test -- inbox-drain-runtime.test.ts session-ui-runtime.test.ts pinet-maintenance-delivery.test.ts index.test.ts ralph-loop.test.ts`

## Notes
- No DB cleanup is included.
- No merge requested; READY FOR HUMAN REVIEW.

Fixes #579.
