### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Issue / problem solved
+
+- Closes/Fixes/Refs: #
+- Why this is prioritized:
+
+## Troubleshooting / diagnosis
+
+- How the problem was reproduced or investigated:
+- Evidence for the root cause (logs, traces, failing tests, screenshots, etc.):
+- Relevant constraints or edge cases:
+
+## Design philosophy
+
+- Guiding principle for this change:
+- If this touches Pinet / `slack-bridge`: how does it preserve token-efficient progressive discovery?
+  - Hot-path schemas/prompts stay compact:
+  - Cold paths remain discoverable through dispatcher `help` / per-action schemas or docs/skills:
+  - Templates/examples/large usage guidance stay out of always-loaded prompts/tool schemas:
+
+## Repo design fit
+
+- Existing architecture/conventions this follows:
+- Extension/package boundaries preserved:
+- Guardrail, security, auth, or local-power implications:
+
+## Alternatives considered
+
+- Alternative(s) considered:
+- Why they were not chosen:
+
+## Testing / validation
+
+- Tests added or updated:
+- Commands run:
+  - [ ] `pnpm lint`
+  - [ ] `pnpm typecheck`
+  - [ ] `pnpm test`
+  - [ ] Other:
+- Manual validation:
+
+## Review notes / follow-ups
+
+- Known limitations or non-blocking concerns:
+- Follow-up issues/PRs:
+- Reviewer focus areas:


### PR DESCRIPTION
## Issue / problem solved

Fixes #587.

Adds a conventional GitHub PR template so reviewers can quickly scan issue context, diagnosis, design fit, alternatives, testing, and follow-ups.

## Troubleshooting / diagnosis

The repo had `.github/workflows/quality.yml` but no `.github/pull_request_template.md`, so new PRs had no consistent prompt for reviewer-critical context.

## Design philosophy

This is workflow/docs-only and behavior-neutral. The template is concise, but prompts for the key context that reviewers repeatedly need. For Pinet / slack-bridge changes, it explicitly asks authors to explain token-efficient progressive discovery: compact hot paths, discoverable cold paths, and moving large examples/templates out of always-loaded prompts/tool schemas, aligned with #586/#589.

## Repo design fit

- Uses GitHub's conventional `.github/pull_request_template.md` location.
- Does not change labels, projects, runtime behavior, or code.
- Leaves package/extension boundaries untouched.

## Alternatives considered

- Multiple template files under `.github/PULL_REQUEST_TEMPLATE/`: unnecessary for the current repo; one default template keeps author flow simple.
- Updating contributor docs too: skipped for this narrow lane because GitHub auto-loads the template and existing agent docs already say to create PRs.

## Testing / validation

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check .github/pull_request_template.md`
- `git push` ran pre-push hook `pnpm prepush` (lint + typecheck + test) successfully from cache

## Review notes / follow-ups

READY FOR HUMAN REVIEW.

No merge performed.
