### PR TITLE
fix(slack-bridge): compact prompt overlays

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -432,9 +432,8 @@ describe("formatInboxMessages", () => {
     ];
     const result = formatInboxMessages(msgs, names);
     expect(result).toContain("[thread 123.456] will: hello");
-    expect(result).toContain(
-      "ACK briefly, do the work, report blockers immediately, report the outcome when done.",
-    );
+    expect(result).toContain("Reply in the relevant Slack thread using the thread IDs above.");
+    expect(result).not.toContain("ACK briefly, do the work");
   });
 
   it("formats a channel mention", () => {
@@ -589,8 +588,9 @@ describe("formatPinetInboxMessages", () => {
     expect(result).toContain(
       "[thread a2a:broker:worker] broker-id (Broker Bunny): Take issue #175",
     );
-    expect(result).toContain("Reply via pinet_message.");
-    expect(result).toContain("ACK briefly, do the work");
+    expect(result).toContain("Reply via pinet_message for actionable work");
+    expect(result).toContain("use the thread context above for routing");
+    expect(result).not.toContain("ACK briefly, do the work");
   });
 
   it("falls back to the sender id when no senderAgent metadata exists", () => {
@@ -623,9 +623,7 @@ describe("formatPinetInboxMessages", () => {
     expect(result).toContain("[terminal stand-down]");
     expect(result).toContain("Treat messages marked [terminal stand-down] as closed");
     expect(result).toContain("do NOT send another acknowledgement");
-    expect(result).not.toContain(
-      "ACK briefly, do the work, report blockers immediately, report the outcome when done.",
-    );
+    expect(result).not.toContain("ACK briefly, do the work");
   });
 
   it("keeps new-task reply guidance when a batch mixes closeout and actionable work", () => {
@@ -650,7 +648,7 @@ describe("formatPinetInboxMessages", () => {
 
     expect(result).toContain("[terminal stand-down]");
     expect(result).toContain("Reply via pinet_message for actionable work only.");
-    expect(result).toContain("For new tasks, ACK briefly, do the work");
+    expect(result).not.toContain("ACK briefly, do the work");
     expect(result).toContain(
       "do NOT acknowledge or reply unless you have a real blocker or materially new finding",
     );
@@ -1400,6 +1398,15 @@ describe("buildWorkerPromptGuidelines", () => {
     const joined = guidelines.join(" ");
     expect(joined).toContain("ACKs, blockers, status updates, and final results");
     expect(joined).toContain("ack/work/ask/report");
+  });
+
+  it("keeps the durable ACK, blocker, outcome, and reply-routing contract", () => {
+    const guidelines = buildWorkerPromptGuidelines();
+    const joined = guidelines.join(" ");
+    expect(joined).toContain("ACK briefly");
+    expect(joined).toContain("report it immediately");
+    expect(joined).toContain("report the outcome");
+    expect(joined).toContain("Always reply where the task came from");
   });
 
   it("tells workers to explicitly mark themselves idle/free when work is done", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -309,7 +309,7 @@ export function formatInboxMessages(
     return `[thread ${m.threadTs}] ${n}: ${m.text}${metadataSuffix}`;
   });
 
-  return `New Slack messages:\n${lines.join("\n")}\n\nACK briefly, do the work, report blockers immediately, report the outcome when done.`;
+  return `New Slack messages:\n${lines.join("\n")}\n\nReply in the relevant Slack thread using the thread IDs above.`;
 }
 
 function getPinetSenderLabel(message: FollowerInboxEntry["message"]): string {
@@ -379,9 +379,9 @@ export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string 
 
   const guidance = hasTerminalStandDown
     ? hasActionableWork
-      ? "Reply via pinet_message for actionable work only. For messages marked [terminal stand-down], do NOT acknowledge or reply unless you have a real blocker or materially new finding. For new tasks, ACK briefly, do the work, report blockers immediately, report the outcome when done."
+      ? "Reply via pinet_message for actionable work only. For messages marked [terminal stand-down], do NOT acknowledge or reply unless you have a real blocker or materially new finding."
       : "Reply via pinet_message only if you have a real blocker or materially new finding. Treat messages marked [terminal stand-down] as closed; do NOT send another acknowledgement."
-    : "Reply via pinet_message. ACK briefly, do the work, report blockers immediately, report the outcome when done.";
+    : "Reply via pinet_message for actionable work; use the thread context above for routing.";
 
   return `New Pinet messages:\n${lines.join("\n")}\n\n${guidance}`;
 }

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -11,6 +11,8 @@ type ToolResponse = {
 
 type ToolDefinition = {
   name: string;
+  promptSnippet?: string;
+  promptGuidelines?: string[];
   execute: (id: string, params: Record<string, unknown>) => Promise<ToolResponse>;
 };
 
@@ -341,6 +343,54 @@ describe("registerSlackTools", () => {
       requireToolPolicy,
     };
   }
+
+  it("keeps slack_inbox prompt guidance Slack-specific instead of restating the worker loop", () => {
+    const { registeredTools } = setup();
+    const inboxTool = registeredTools.get("slack_inbox");
+    const guidance = inboxTool?.promptGuidelines?.join("\n") ?? "";
+
+    expect(inboxTool?.promptSnippet).toBe("Check for new incoming Slack messages.");
+    expect(guidance).toContain("Use slack_inbox to read and clear pending Slack messages");
+    expect(guidance).toContain("slack dispatcher for non-hot Slack actions");
+    expect(guidance).toContain("Security guardrails may be active");
+    expect(guidance).not.toContain("ACK briefly");
+    expect(guidance).not.toContain("Reaction-triggered requests");
+  });
+
+  it("keeps slack_send prompt metadata concise and tool-local", () => {
+    const { registeredTools } = setup();
+    const sendTool = registeredTools.get("slack_send");
+    const guidance = sendTool?.promptGuidelines?.join("\n") ?? "";
+
+    expect(sendTool?.promptSnippet).toBe(
+      "Send a message in a Slack assistant thread; include thread_ts when replying to an existing thread.",
+    );
+    expect(guidance).toContain("Use slack_send for messages in the current Slack assistant thread");
+    expect(guidance).toContain("include thread_ts when replying");
+    expect(guidance).not.toContain("ACK briefly");
+    expect(guidance).not.toContain("always reply where the task came from");
+  });
+
+  it("keeps dispatcher prompt metadata focused on cold Slack actions", () => {
+    const { registeredTools } = setup();
+    const dispatcher = registeredTools.get("slack");
+    const guidance = dispatcher?.promptGuidelines?.join("\n") ?? "";
+
+    expect(dispatcher?.promptSnippet).toContain(
+      "Run non-hot Slack actions through a compact dispatcher",
+    );
+    expect(guidance).toContain("Use slack_inbox and slack_send for the hot path");
+    expect(guidance).toContain("Cold actions are guarded as slack:<action>");
+    expect(guidance).not.toContain("ACK briefly");
+  });
+
+  it("does not register retired rich-message builder tools with duplicated inbox guidance", () => {
+    const { registeredTools } = setup();
+
+    expect(registeredTools.has("slack_blocks_build")).toBe(false);
+    expect(registeredTools.has("slack_modal_build")).toBe(false);
+    expect(registeredTools.has("slack_post_channel")).toBe(false);
+  });
 
   it("reads the latest security prompt when slack_inbox executes", async () => {
     const { inbox, tools, setSecurityPrompt } = setup();

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -345,18 +345,16 @@ function getSlackDispatcherExamples(action: string): Array<Record<string, unknow
 
 function buildSlackInboxPromptGuidelines(): string[] {
   return [
-    "You are connected to Slack via the slack-bridge extension.",
-    "When Slack messages arrive: ACK briefly, do the work, report blockers immediately, and report the outcome when done.",
+    "Use slack_inbox to read and clear pending Slack messages; returned text carries message/thread-local context.",
     "Use slack_send for direct assistant-thread replies. Use the slack dispatcher for non-hot Slack actions such as reactions, reads, uploads, schedules, channel posts, pins, bookmarks, canvases, modals, presence, exports, and confirmations.",
     "Call slack with action='help' for the cold-action catalogue, or action='help' with args.topic for a specific action schema and examples.",
     "Security guardrails may be active for Slack-triggered actions. Cold Slack actions are checked with slack:<action> guardrail names.",
-    "Reaction-triggered requests may arrive as structured 'Reaction trigger from Slack:' messages — treat them as explicit user instructions attached to the referenced Slack message or thread.",
   ];
 }
 
 function buildSlackSendPromptGuidelines(): string[] {
   return [
-    "Use slack_send for replies in the current Slack assistant thread; always reply where the task came from.",
+    "Use slack_send for messages in the current Slack assistant thread; include thread_ts when replying to an existing thread.",
     "For rich Block Kit JSON examples or modal/canvas patterns, load the slack-bridge skill instead of relying on tool schemas.",
   ];
 }
@@ -1370,7 +1368,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     label: "Slack Send",
     description: "Send a message in a Slack assistant thread.",
     promptSnippet:
-      "Reply in a Slack assistant thread. When you receive a task: ACK briefly, do the work, report blockers immediately, report the outcome when done. Always reply where the task came from.",
+      "Send a message in a Slack assistant thread; include thread_ts when replying to an existing thread.",
     promptGuidelines: buildSlackSendPromptGuidelines(),
     parameters: Type.Object({
       text: Type.String({ description: "Message text (Slack markdown)" }),


### PR DESCRIPTION
## Summary
- follows the #555 ownership rubric: one instruction/one owner, least-sticky layer that works, tool prompts own tool-local hints, injected messages own ephemeral context, runtime/tool policy owns hard safety
- trims duplicated generic work-loop and reaction-trigger prose from Slack tool prompt metadata while keeping Slack-specific affordance/security guidance
- trims injected Slack/Pinet inbox follow-up text to routing/thread-local context while leaving the durable worker ACK/blocker/outcome/reply-routing contract in `buildWorkerPromptGuidelines()`
- adds prompt-metadata coverage for `slack_inbox`, `slack_send`, and the Slack dispatcher, plus formatter contract coverage

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- push hook also ran Turbo-backed workspace tests successfully (9 tasks, 8 cached)

Fixes #556

READY FOR HUMAN REVIEW