### PR TITLE
fix(browser-playwright): add progressive discovery

### DIFF
--- a/browser-playwright/README.md
+++ b/browser-playwright/README.md
@@ -6,9 +6,10 @@ Instead of exposing a wide `browser_*` family, the extension now exposes a
 single `browser` tool with a shared envelope:
 
 - `action`
+- `args?` — the preferred structured carrier for action-specific scalar fields
 - `session_id?`
 - `page_id?`
-- `input_json?` — the current stable carrier for action-specific fields
+- `input_json?` — compatibility-only JSON string carrier for older callers
 - `backend?` — an advanced/experimental override that should be omitted for normal use
 
 The extension owns the runtime, process, proxy, socket, and artifact complexity
@@ -44,12 +45,17 @@ Parameters:
   - `screenshot`
   - `tabs`
   - `close`
+- `args` — preferred structured object with action-specific scalar inputs such as
+  `url`, `selector`, `value`, `timeout_ms`, `label`, `full_page`, or `topic`
+  - use this for new calls
+  - `args` and `input_json` may carry duplicate fields only when the values match
 - `session_id` — optional session handle for actions that operate on an existing session
+  - top-level `session_id` is authoritative; conflicting nested values fail clearly
 - `page_id` — optional page/tab handle for actions that target a specific page
-- `input_json` — optional JSON object with action-specific inputs such as `url`,
-  `selector`, `value`, `timeout_ms`, `label`, or `full_page`
-  - this is the **current stable** carrier for action-specific fields
-  - the settled cleanup direction is **args-first**, but that contract change has not landed yet
+  - top-level `page_id` is authoritative; conflicting nested values fail clearly
+- `input_json` — compatibility-only JSON string object for older callers
+  - still accepted during migration
+  - do not use for new examples or generated guidance
 - `backend` — advanced/experimental override (`playwright` or `agent-browser`)
   - omit it for normal Anthropic-sandbox use
   - the default local path is Playwright
@@ -72,8 +78,9 @@ This keeps backend differences explicit instead of overpromising parity.
 ## Supported path in Anthropic sandbox
 
 - Use `browser-playwright` and the single `browser` tool for local browsing in this repo.
+- Use `action` + `args` for action-specific fields.
 - Omit `backend` for normal use; Playwright is the supported local path.
-- Treat `input_json` as the stable action-input carrier until the planned args-first cleanup lands.
+- Treat `input_json` as compatibility-only for older callers.
 - Treat `agent-browser` as hidden/experimental only. Local daemon compatibility is a non-goal here.
 
 ## Backend status
@@ -117,6 +124,7 @@ Truthful posture in this harness:
 - Playwright is the supported local backend
 - `agent-browser` stays explicitly unavailable locally
 - local `agent-browser` daemon compatibility is a non-goal for this repo
+- local `agent-browser` reports no runnable supported actions while unavailable
 - the only viable future support shape here is **remote/optional executor**
   unless upstream ships a real published embeddable JS SDK
 
@@ -149,6 +157,39 @@ This backend intentionally includes two same-host local-power assumptions:
 
 Treat both as local operator power, not as generic public-web browsing.
 
+## Progressive discovery
+
+The browser surface stays one tool and one action enum. It does **not** add a
+new `browser_help`/`browser_schema` tool family. Instead, use the existing
+`info` action without a session for compact help/schema discovery:
+
+```json
+{
+  "action": "info"
+}
+```
+
+For all schemas:
+
+```json
+{
+  "action": "info",
+  "args": { "topic": "schema" }
+}
+```
+
+For one action schema:
+
+```json
+{
+  "action": "info",
+  "args": { "topic": "navigate" }
+}
+```
+
+When `info` receives a `session_id` and no discovery `topic`, it keeps returning
+runtime session diagnostics.
+
 ## Example requests
 
 ### Start a session
@@ -156,7 +197,7 @@ Treat both as local operator power, not as generic public-web browsing.
 ```json
 {
   "action": "start",
-  "input_json": "{\"url\":\"https://example.com\"}"
+  "args": { "url": "https://example.com" }
 }
 ```
 
@@ -166,7 +207,7 @@ Treat both as local operator power, not as generic public-web browsing.
 {
   "action": "navigate",
   "session_id": "browser_123",
-  "input_json": "{\"url\":\"https://example.com/docs\",\"new_tab\":true}"
+  "args": { "url": "https://example.com/docs", "new_tab": true }
 }
 ```
 
@@ -177,7 +218,7 @@ Treat both as local operator power, not as generic public-web browsing.
   "action": "fill",
   "session_id": "browser_123",
   "page_id": "page_abc",
-  "input_json": "{\"selector\":\"input[name='q']\",\"value\":\"Playwright docs\"}"
+  "args": { "selector": "input[name='q']", "value": "Playwright docs" }
 }
 ```
 
@@ -187,7 +228,7 @@ Treat both as local operator power, not as generic public-web browsing.
 {
   "action": "wait",
   "session_id": "browser_123",
-  "input_json": "{\"text\":\"Playwright\",\"timeout_ms\":10000}"
+  "args": { "text": "Playwright", "timeout_ms": 10000 }
 }
 ```
 
@@ -197,7 +238,7 @@ Treat both as local operator power, not as generic public-web browsing.
 {
   "action": "screenshot",
   "session_id": "browser_123",
-  "input_json": "{\"label\":\"search-results\",\"full_page\":true}"
+  "args": { "label": "search-results", "full_page": true }
 }
 ```
 

--- a/browser-playwright/index.ts
+++ b/browser-playwright/index.ts
@@ -24,6 +24,7 @@ import { buildAgentBrowserModeResult } from "./agent-browser.ts";
 import {
   BROWSER_ACTION_VALUES,
   BROWSER_BACKEND_VALUES,
+  buildBrowserDiscovery,
   buildCapabilities,
   describeBrowserActions,
   getBooleanArg,
@@ -804,6 +805,11 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
 
   async function executeInfo(request: BrowserToolRequest) {
     await cleanupExpiredSessions();
+    const topic = getStringArg(request.args, "topic");
+    if (!request.sessionId || topic) {
+      return respond(request, buildBrowserDiscovery(topic));
+    }
+
     const session = getSessionOrThrow(sessions, requireSessionId(request));
     const pages = await listPages(session);
     return respond(request, {
@@ -1206,14 +1212,15 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
     description:
       "Playwright-first single browser tool. In this environment, use the browser tool without a backend override; the extension owns the runtime, proxy, socket, and session complexity behind one narrow interface.",
     promptSnippet:
-      "Use the single browser tool for browsing in this environment. The supported local path is Playwright; avoid backend overrides unless you are doing explicit experimental work.",
+      "Use the single browser tool for browsing in this environment. The supported local path is Playwright; call action='info' for compact help/schema discovery.",
     promptGuidelines: [
       "Prefer the single browser tool over many browser_* actions.",
+      "Use action + args for action-specific fields; input_json is compatibility-only for older callers.",
+      "Call browser with action='info' and no session_id for the action catalogue, or args.topic='<action>' for a compact action schema.",
       "Omit backend for normal use here; Playwright is the supported local path in this Anthropic sandbox.",
       "Treat agent-browser as experimental and unavailable locally; daemon compatibility is not a supported path in this repo.",
       "Direct top-level localhost navigation is intentionally allowed for same-host local-app testing; treat it as local-power access, not a generic public-web sandbox.",
       "Only mount storage_state_name files when you intentionally trust that workspace-local auth material on the current host.",
-      "The settled contract direction is args-first, but today action-specific fields still travel through input_json.",
     ],
     parameters: Type.Object({
       backend: Type.Optional(
@@ -1237,10 +1244,16 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
           description: "Optional page_id for actions that target a specific page or tab.",
         }),
       ),
+      args: Type.Optional(
+        Type.Record(Type.String(), Type.Unknown(), {
+          description:
+            "Preferred structured action payload. Use scalar fields such as url, selector, value, timeout_ms, label, full_page, or topic. Call action='info' with args.topic='<action>' for help/schema discovery.",
+        }),
+      ),
       input_json: Type.Optional(
         Type.String({
           description:
-            "Current compatibility shape for action-specific inputs such as url, selector, value, timeout_ms, label, or full_page. The planned contract direction is args-first.",
+            "Compatibility-only JSON string for older callers. Prefer args for new browser calls.",
         }),
       ),
     }),
@@ -1250,6 +1263,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
         action: params.action as BrowserAction,
         session_id: params.session_id,
         page_id: params.page_id,
+        args: params.args,
         input_json: params.input_json,
       });
 

--- a/browser-playwright/protocol.test.ts
+++ b/browser-playwright/protocol.test.ts
@@ -150,6 +150,34 @@ test("buildBrowserDiscovery returns catalog and action schemas through the exist
   assert.match(JSON.stringify(navigate), /Navigate the active page/);
 });
 
+test("buildBrowserDiscovery action schemas match runtime-supported argument names", () => {
+  type RuntimeArgSchema = { args?: { required?: string[]; optional?: string[] } };
+  function schemaFor(action: string): RuntimeArgSchema {
+    const discovery = buildBrowserDiscovery(action);
+    assert.equal(typeof discovery.schema, "object");
+    assert.notEqual(discovery.schema, null);
+    return discovery.schema as RuntimeArgSchema;
+  }
+
+  assert.deepEqual(schemaFor("snapshot").args, undefined);
+  assert.deepEqual(schemaFor("extract").args, {
+    optional: ["selector", "attribute", "max_items"],
+  });
+  assert.deepEqual(schemaFor("click").args, {
+    required: ["selector"],
+    optional: ["timeout_ms", "double_click"],
+  });
+  assert.deepEqual(schemaFor("fill").args, {
+    required: ["selector", "value"],
+    optional: ["timeout_ms"],
+  });
+  assert.deepEqual(schemaFor("wait").args, {
+    optional: ["selector", "text", "url_includes", "load_state", "delay_ms", "timeout_ms"],
+  });
+  assert.deepEqual(schemaFor("tabs").args, { optional: ["activate_page_id"] });
+  assert.deepEqual(schemaFor("close").args, { optional: ["close_session"] });
+});
+
 test("buildBrowserDiscovery rejects unknown schema topics clearly", () => {
   assert.throws(() => buildBrowserDiscovery("unknown"), /Unsupported browser info topic/i);
 });

--- a/browser-playwright/protocol.test.ts
+++ b/browser-playwright/protocol.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildBrowserDiscovery,
   buildCapabilities,
   describeBrowserActions,
   getBooleanArg,
@@ -9,12 +10,12 @@ import {
   parseBrowserToolRequest,
 } from "./protocol.ts";
 
-test("parseBrowserToolRequest builds a typed request from the single browser tool envelope", () => {
+test("parseBrowserToolRequest prefers top-level args for the single browser tool envelope", () => {
   const parsed = parseBrowserToolRequest({
     backend: "playwright",
     action: "navigate",
     session_id: "browser_123",
-    input_json: JSON.stringify({ url: "https://example.com", new_tab: true, timeout_ms: 1500 }),
+    args: { url: "https://example.com", new_tab: true, timeout_ms: 1500 },
   });
 
   assert.equal(parsed.backend, "playwright");
@@ -25,12 +26,46 @@ test("parseBrowserToolRequest builds a typed request from the single browser too
   assert.equal(getNumberArg(parsed.args, "timeout_ms"), 1500);
 });
 
+test("parseBrowserToolRequest keeps input_json-only calls compatible", () => {
+  const parsed = parseBrowserToolRequest({
+    action: "navigate",
+    input_json: JSON.stringify({ url: "https://example.com", new_tab: true }),
+  });
+
+  assert.equal(parsed.backend, "playwright");
+  assert.equal(getStringArg(parsed.args, "url"), "https://example.com");
+  assert.equal(getBooleanArg(parsed.args, "new_tab"), true);
+});
+
+test("parseBrowserToolRequest accepts identical args and input_json fields", () => {
+  const parsed = parseBrowserToolRequest({
+    action: "navigate",
+    args: { url: "https://example.com", new_tab: true },
+    input_json: JSON.stringify({ url: "https://example.com", new_tab: true }),
+  });
+
+  assert.equal(getStringArg(parsed.args, "url"), "https://example.com");
+  assert.equal(getBooleanArg(parsed.args, "new_tab"), true);
+});
+
+test("parseBrowserToolRequest rejects conflicting args and input_json fields", () => {
+  assert.throws(
+    () =>
+      parseBrowserToolRequest({
+        action: "navigate",
+        args: { url: "https://example.com/a" },
+        input_json: JSON.stringify({ url: "https://example.com/b" }),
+      }),
+    /args\.url and input_json\.url differ/i,
+  );
+});
+
 test("parseBrowserToolRequest allows session_id and page_id to flow through top-level fields", () => {
   const parsed = parseBrowserToolRequest({
     action: "click",
     session_id: "browser_123",
     page_id: "page_abc",
-    input_json: JSON.stringify({ selector: "button" }),
+    args: { selector: "button" },
   });
 
   assert.equal(parsed.backend, "playwright");
@@ -39,16 +74,45 @@ test("parseBrowserToolRequest allows session_id and page_id to flow through top-
   assert.equal(getStringArg(parsed.args, "selector"), "button");
 });
 
-test("parseBrowserToolRequest lets input_json override top-level session_id when needed", () => {
+test("parseBrowserToolRequest keeps top-level ids authoritative when nested values match", () => {
   const parsed = parseBrowserToolRequest({
     action: "screenshot",
-    session_id: "browser_inline",
-    input_json: JSON.stringify({ session_id: "browser_json", full_page: true, label: "override" }),
+    session_id: "browser_123",
+    page_id: "page_abc",
+    args: {
+      session_id: "browser_123",
+      page_id: "page_abc",
+      full_page: true,
+      label: "matching-ids",
+    },
+  });
+
+  assert.equal(parsed.sessionId, "browser_123");
+  assert.equal(parsed.pageId, "page_abc");
+  assert.equal(getBooleanArg(parsed.args, "full_page"), true);
+  assert.equal(getStringArg(parsed.args, "label"), "matching-ids");
+});
+
+test("parseBrowserToolRequest rejects nested ids that conflict with top-level ids", () => {
+  assert.throws(
+    () =>
+      parseBrowserToolRequest({
+        action: "screenshot",
+        session_id: "browser_inline",
+        args: { session_id: "browser_args", full_page: true },
+      }),
+    /top-level session_id is authoritative/i,
+  );
+});
+
+test("parseBrowserToolRequest still supports backward-compatible nested ids without top-level ids", () => {
+  const parsed = parseBrowserToolRequest({
+    action: "screenshot",
+    input_json: JSON.stringify({ session_id: "browser_json", page_id: "page_json" }),
   });
 
   assert.equal(parsed.sessionId, "browser_json");
-  assert.equal(getBooleanArg(parsed.args, "full_page"), true);
-  assert.equal(getStringArg(parsed.args, "label"), "override");
+  assert.equal(parsed.pageId, "page_json");
 });
 
 test("parseBrowserToolRequest rejects invalid input_json", () => {
@@ -58,13 +122,36 @@ test("parseBrowserToolRequest rejects invalid input_json", () => {
   );
 });
 
-test("buildCapabilities reports playwright as available and agent-browser as scaffolded", () => {
+test("parseBrowserToolRequest rejects non-scalar args fields", () => {
+  assert.throws(
+    () => parseBrowserToolRequest({ action: "start", args: { nested: { url: "x" } } }),
+    /args field `nested` must be a string, number, boolean, or null/i,
+  );
+});
+
+test("buildCapabilities reports playwright as available and agent-browser as unavailable locally", () => {
   const playwright = buildCapabilities("playwright");
   const agentBrowser = buildCapabilities("agent-browser");
 
   assert.equal(playwright.available, true);
+  assert.match(playwright.notes?.join(" ") ?? "", /help\/schema discovery/i);
   assert.equal(agentBrowser.available, false);
-  assert.match(agentBrowser.notes?.join(" ") ?? "", /scaffolded/i);
+  assert.deepEqual(agentBrowser.supported_actions, []);
+  assert.match(agentBrowser.notes?.join(" ") ?? "", /unavailable locally/i);
+});
+
+test("buildBrowserDiscovery returns catalog and action schemas through the existing info action", () => {
+  const catalog = buildBrowserDiscovery(undefined);
+  const navigate = buildBrowserDiscovery("navigate");
+
+  assert.equal(catalog.tool, "browser");
+  assert.match(JSON.stringify(catalog), /preferred_shape/);
+  assert.match(JSON.stringify(catalog), /action_schema/);
+  assert.match(JSON.stringify(navigate), /Navigate the active page/);
+});
+
+test("buildBrowserDiscovery rejects unknown schema topics clearly", () => {
+  assert.throws(() => buildBrowserDiscovery("unknown"), /Unsupported browser info topic/i);
 });
 
 test("describeBrowserActions summarizes the typed browser action enum", () => {

--- a/browser-playwright/protocol.ts
+++ b/browser-playwright/protocol.ts
@@ -19,12 +19,14 @@ export type BrowserAction = (typeof BROWSER_ACTION_VALUES)[number];
 
 export type BrowserScalar = string | number | boolean | null;
 export type BrowserArgs = Record<string, BrowserScalar>;
+export type BrowserArgsInput = Record<string, unknown>;
 
 export type BrowserToolInput = {
   backend?: BrowserBackend;
   action: BrowserAction;
   session_id?: string;
   page_id?: string;
+  args?: BrowserArgsInput;
   input_json?: string;
 };
 
@@ -43,6 +45,114 @@ export type BrowserCapabilities = {
   notes?: string[];
 };
 
+type BrowserActionSchema = {
+  description: string;
+  requires_session_id?: boolean;
+  optional_session_id?: boolean;
+  requires_page_id?: boolean;
+  args?: {
+    required?: string[];
+    optional?: string[];
+  };
+  example: Record<string, unknown>;
+};
+
+const BROWSER_ACTION_SCHEMAS: Record<BrowserAction, BrowserActionSchema> = {
+  start: {
+    description: "Start a Playwright browser session and optionally open an initial URL.",
+    args: {
+      optional: [
+        "url",
+        "browser",
+        "headless",
+        "viewport_width",
+        "viewport_height",
+        "storage_state_name",
+      ],
+    },
+    example: { action: "start", args: { url: "https://example.com" } },
+  },
+  info: {
+    description:
+      "Return session diagnostics when session_id is provided, or return the compact browser action catalogue/schema when no session_id is provided.",
+    optional_session_id: true,
+    args: { optional: ["topic"] },
+    example: { action: "info", args: { topic: "schema" } },
+  },
+  navigate: {
+    description: "Navigate the active page, or a new tab, to a URL.",
+    requires_session_id: true,
+    args: { required: ["url"], optional: ["new_tab", "wait_until", "timeout_ms"] },
+    example: {
+      action: "navigate",
+      session_id: "browser_123",
+      args: { url: "https://example.com/docs", new_tab: true },
+    },
+  },
+  snapshot: {
+    description: "Capture a compact text/metadata snapshot of the current page.",
+    requires_session_id: true,
+    args: { optional: ["selector"] },
+    example: { action: "snapshot", session_id: "browser_123" },
+  },
+  extract: {
+    description: "Extract text or simple attributes from matching page elements.",
+    requires_session_id: true,
+    args: { required: ["selector"], optional: ["attribute", "limit"] },
+    example: { action: "extract", session_id: "browser_123", args: { selector: "h1" } },
+  },
+  click: {
+    description: "Click an element matched by selector or accessible label.",
+    requires_session_id: true,
+    args: { optional: ["selector", "label", "timeout_ms"] },
+    example: { action: "click", session_id: "browser_123", args: { selector: "button" } },
+  },
+  fill: {
+    description: "Fill an input-like element.",
+    requires_session_id: true,
+    args: { required: ["value"], optional: ["selector", "label", "timeout_ms"] },
+    example: {
+      action: "fill",
+      session_id: "browser_123",
+      args: { selector: "input[name='q']", value: "Playwright docs" },
+    },
+  },
+  press: {
+    description: "Send a keyboard key press, optionally scoped to an element.",
+    requires_session_id: true,
+    args: { required: ["key"], optional: ["selector", "timeout_ms"] },
+    example: { action: "press", session_id: "browser_123", args: { key: "Enter" } },
+  },
+  wait: {
+    description: "Wait for text, selector, URL, timeout, or load state.",
+    requires_session_id: true,
+    args: { optional: ["text", "selector", "url", "timeout_ms", "load_state"] },
+    example: { action: "wait", session_id: "browser_123", args: { text: "Loaded" } },
+  },
+  screenshot: {
+    description: "Capture a screenshot artifact for the active or selected page.",
+    requires_session_id: true,
+    args: { optional: ["label", "full_page"] },
+    example: {
+      action: "screenshot",
+      session_id: "browser_123",
+      args: { label: "search-results", full_page: true },
+    },
+  },
+  tabs: {
+    description: "List pages/tabs, switch active page, or close a page.",
+    requires_session_id: true,
+    args: { optional: ["op", "page_id"] },
+    example: { action: "tabs", session_id: "browser_123", args: { op: "list" } },
+  },
+  close: {
+    description: "Close a page or an entire browser session.",
+    requires_session_id: true,
+    args: { optional: ["page_id"] },
+    example: { action: "close", session_id: "browser_123" },
+  },
+};
+
 function parseInputJson(raw: string | undefined): BrowserArgs {
   if (!raw) return {};
 
@@ -55,12 +165,17 @@ function parseInputJson(raw: string | undefined): BrowserArgs {
     );
   }
 
-  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("input_json must decode to a JSON object.");
+  return parseArgsObject(parsed, "input_json");
+}
+
+function parseArgsObject(raw: unknown, source: "args" | "input_json"): BrowserArgs {
+  if (raw === undefined) return {};
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`${source} must be a JSON object.`);
   }
 
   const result: BrowserArgs = {};
-  for (const [key, value] of Object.entries(parsed)) {
+  for (const [key, value] of Object.entries(raw)) {
     if (
       value === null ||
       typeof value === "string" ||
@@ -70,24 +185,55 @@ function parseInputJson(raw: string | undefined): BrowserArgs {
       result[key] = value;
       continue;
     }
-    throw new Error(`input_json field \`${key}\` must be a string, number, boolean, or null.`);
+    throw new Error(`${source} field \`${key}\` must be a string, number, boolean, or null.`);
   }
   return result;
+}
+
+function mergeArgs(preferredArgs: BrowserArgs, compatibilityArgs: BrowserArgs): BrowserArgs {
+  const merged: BrowserArgs = { ...compatibilityArgs };
+  for (const [key, value] of Object.entries(preferredArgs)) {
+    const compatibilityValue = compatibilityArgs[key];
+    if (compatibilityValue !== undefined && !Object.is(compatibilityValue, value)) {
+      throw new Error(
+        `Conflicting browser input for \`${key}\`: args.${key} and input_json.${key} differ. Use one value.`,
+      );
+    }
+    merged[key] = value;
+  }
+  return merged;
+}
+
+function applyTopLevelId(
+  args: BrowserArgs,
+  topLevelValue: string | undefined,
+  key: "session_id" | "page_id",
+): void {
+  if (!topLevelValue) return;
+  const nestedValue = args[key];
+  if (nestedValue !== undefined && nestedValue !== topLevelValue) {
+    throw new Error(
+      `Conflicting browser input for \`${key}\`: top-level ${key} is authoritative and differs from the nested args/input_json value.`,
+    );
+  }
+  args[key] = topLevelValue;
 }
 
 function stringFrom(value: BrowserScalar | undefined): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-export function parseBrowserToolRequest(input: BrowserToolInput): BrowserToolRequest {
-  const args = parseInputJson(input.input_json);
+function isBrowserAction(value: string): value is BrowserAction {
+  return BROWSER_ACTION_VALUES.includes(value as BrowserAction);
+}
 
-  if (input.session_id && args.session_id === undefined) {
-    args.session_id = input.session_id;
-  }
-  if (input.page_id && args.page_id === undefined) {
-    args.page_id = input.page_id;
-  }
+export function parseBrowserToolRequest(input: BrowserToolInput): BrowserToolRequest {
+  const compatibilityArgs = parseInputJson(input.input_json);
+  const preferredArgs = parseArgsObject(input.args, "args");
+  const args = mergeArgs(preferredArgs, compatibilityArgs);
+
+  applyTopLevelId(args, input.session_id, "session_id");
+  applyTopLevelId(args, input.page_id, "page_id");
 
   return {
     backend: input.backend ?? "playwright",
@@ -106,7 +252,7 @@ export function getStringArg(args: BrowserArgs, key: string): string | undefined
 export function requireStringArg(args: BrowserArgs, key: string): string {
   const value = getStringArg(args, key);
   if (!value) {
-    throw new Error(`browser action requires string field \`${key}\` in input_json.`);
+    throw new Error(`browser action requires string field \`${key}\` in args.`);
   }
   return value;
 }
@@ -129,6 +275,7 @@ export function buildCapabilities(backend: BrowserBackend): BrowserCapabilities 
       supported_actions: [...BROWSER_ACTION_VALUES],
       notes: [
         "Playwright is the supported local browsing path in this Anthropic sandbox.",
+        "Use action='info' without a session_id for compact action help/schema discovery.",
         "Artifacts and storage state stay rooted in the active workspace.",
       ],
     };
@@ -137,13 +284,64 @@ export function buildCapabilities(backend: BrowserBackend): BrowserCapabilities 
   return {
     backend,
     available: false,
-    supported_actions: [...BROWSER_ACTION_VALUES],
+    supported_actions: [],
     notes: [
-      "agent-browser is scaffolded behind the same one-tool contract.",
-      "Local agent-browser support is unavailable in this harness.",
+      "agent-browser is scaffolded behind the same one-tool contract but is unavailable locally.",
       "Local daemon compatibility is a non-goal here; any truthful future support is remote/optional executor mode unless upstream ships a real embeddable SDK.",
     ],
   };
+}
+
+export function buildBrowserDiscovery(topic: string | undefined): Record<string, unknown> {
+  const normalizedTopic = topic?.trim().toLowerCase();
+  const actionSummaries = BROWSER_ACTION_VALUES.map((action) => ({
+    action,
+    description: BROWSER_ACTION_SCHEMAS[action].description,
+    requires_session_id: BROWSER_ACTION_SCHEMAS[action].requires_session_id ?? false,
+  }));
+
+  const base = {
+    tool: "browser",
+    contract: {
+      preferred_shape: "browser({ action, args?, session_id?, page_id?, backend? })",
+      args: "Preferred structured carrier for action-specific scalar fields.",
+      input_json: "Compatibility-only JSON string carrier; do not use for new calls.",
+      backend: "Omit for normal local use; Playwright is the supported local path.",
+      top_level_ids: "Top-level session_id/page_id are authoritative; conflicting nested IDs fail.",
+    },
+    discovery: {
+      catalog: { action: "info" },
+      all_schemas: { action: "info", args: { topic: "schema" } },
+      action_schema: { action: "info", args: { topic: "navigate" } },
+    },
+  };
+
+  if (!normalizedTopic || normalizedTopic === "help" || normalizedTopic === "actions") {
+    return {
+      ...base,
+      actions: actionSummaries,
+    };
+  }
+
+  if (normalizedTopic === "schema" || normalizedTopic === "schemas") {
+    return {
+      ...base,
+      actions: actionSummaries,
+      schemas: BROWSER_ACTION_SCHEMAS,
+    };
+  }
+
+  if (isBrowserAction(normalizedTopic)) {
+    return {
+      ...base,
+      action: normalizedTopic,
+      schema: BROWSER_ACTION_SCHEMAS[normalizedTopic],
+    };
+  }
+
+  throw new Error(
+    `Unsupported browser info topic \`${topic}\`. Use help, schema, or one of: ${describeBrowserActions()}.`,
+  );
 }
 
 export function describeBrowserActions(): string {

--- a/browser-playwright/protocol.ts
+++ b/browser-playwright/protocol.ts
@@ -92,25 +92,25 @@ const BROWSER_ACTION_SCHEMAS: Record<BrowserAction, BrowserActionSchema> = {
   snapshot: {
     description: "Capture a compact text/metadata snapshot of the current page.",
     requires_session_id: true,
-    args: { optional: ["selector"] },
     example: { action: "snapshot", session_id: "browser_123" },
   },
   extract: {
-    description: "Extract text or simple attributes from matching page elements.",
+    description:
+      "Extract body text when no selector is provided, or extract text/attributes from matching page elements.",
     requires_session_id: true,
-    args: { required: ["selector"], optional: ["attribute", "limit"] },
+    args: { optional: ["selector", "attribute", "max_items"] },
     example: { action: "extract", session_id: "browser_123", args: { selector: "h1" } },
   },
   click: {
-    description: "Click an element matched by selector or accessible label.",
+    description: "Click an element matched by selector.",
     requires_session_id: true,
-    args: { optional: ["selector", "label", "timeout_ms"] },
+    args: { required: ["selector"], optional: ["timeout_ms", "double_click"] },
     example: { action: "click", session_id: "browser_123", args: { selector: "button" } },
   },
   fill: {
-    description: "Fill an input-like element.",
+    description: "Fill an input-like element matched by selector.",
     requires_session_id: true,
-    args: { required: ["value"], optional: ["selector", "label", "timeout_ms"] },
+    args: { required: ["selector", "value"], optional: ["timeout_ms"] },
     example: {
       action: "fill",
       session_id: "browser_123",
@@ -124,9 +124,11 @@ const BROWSER_ACTION_SCHEMAS: Record<BrowserAction, BrowserActionSchema> = {
     example: { action: "press", session_id: "browser_123", args: { key: "Enter" } },
   },
   wait: {
-    description: "Wait for text, selector, URL, timeout, or load state.",
+    description: "Wait for selector, text, URL substring, load state, or explicit delay.",
     requires_session_id: true,
-    args: { optional: ["text", "selector", "url", "timeout_ms", "load_state"] },
+    args: {
+      optional: ["selector", "text", "url_includes", "load_state", "delay_ms", "timeout_ms"],
+    },
     example: { action: "wait", session_id: "browser_123", args: { text: "Loaded" } },
   },
   screenshot: {
@@ -140,16 +142,17 @@ const BROWSER_ACTION_SCHEMAS: Record<BrowserAction, BrowserActionSchema> = {
     },
   },
   tabs: {
-    description: "List pages/tabs, switch active page, or close a page.",
+    description: "List pages/tabs and optionally activate a page by id.",
     requires_session_id: true,
-    args: { optional: ["op", "page_id"] },
-    example: { action: "tabs", session_id: "browser_123", args: { op: "list" } },
+    args: { optional: ["activate_page_id"] },
+    example: { action: "tabs", session_id: "browser_123" },
   },
   close: {
-    description: "Close a page or an entire browser session.",
+    description:
+      "Close the selected page when page_id is provided, or close the entire browser session.",
     requires_session_id: true,
-    args: { optional: ["page_id"] },
-    example: { action: "close", session_id: "browser_123" },
+    args: { optional: ["close_session"] },
+    example: { action: "close", session_id: "browser_123", args: { close_session: true } },
   },
 };
 


### PR DESCRIPTION
## Summary
- Fits #557 as a narrow single-tool contract/capability slice: progressive discovery is exposed through the existing `info` action instead of adding `browser_*` tools or new help/schema actions.
- Adds top-level `args` as the preferred structured payload while keeping `input_json` compatibility and clear conflict validation.
- Makes `agent-browser` local capability reporting truthful while unavailable.
- Updates browser-playwright README/tool guidance and protocol tests.

## Validation
- `pnpm --filter @gugu910/pi-browser-playwright check`
- `pnpm exec prettier --check browser-playwright/README.md browser-playwright/index.ts browser-playwright/protocol.ts browser-playwright/protocol.test.ts`
- pre-push hook on `git push` also completed successfully (repo test task: 9 successful, 7 cached).

Refs #557. Audit context #588.

READY FOR HUMAN REVIEW — no merge performed.