### PR TITLE
fix(slack-bridge): mark arrow-up reactions as steering

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1431,7 +1431,16 @@ describe("SlackAdapter — reaction triggers", () => {
     );
     expect(handler.mock.calls[0]?.[0]?.text).toContain("Reaction trigger from Slack:");
     expect(handler.mock.calls[0]?.[0]?.text).toContain("- action: review");
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("- delivery_classification: follow_up");
     expect(handler.mock.calls[0]?.[0]?.text).toContain("Please review PR #210");
+    expect(handler.mock.calls[0]?.[0]?.metadata).toMatchObject({
+      kind: "slack_reaction_trigger",
+      slackReaction: "eyes",
+      slackReactionAction: "review",
+      deliveryClassification: "follow_up",
+      threadTs: "111.222",
+      messageTs: "111.333",
+    });
 
     const reactionCall = fetchMock.mock.calls.find(([url]) =>
       String(url).endsWith("/reactions.add"),
@@ -1442,6 +1451,82 @@ describe("SlackAdapter — reaction triggers", () => {
       channel: "C123",
       timestamp: "111.333",
       name: "white_check_mark",
+    });
+  });
+
+  it("treats arrow-up reaction triggers as steering by default", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.history")) {
+        return mockSlackResponse({
+          messages: [
+            {
+              ts: "222.333",
+              thread_ts: "222.222",
+              text: "This changes the priority for today",
+              user: "U_TARGET",
+            },
+          ],
+        });
+      }
+
+      if (url.endsWith("/users.info")) {
+        if (parsedBody.user === "U_REACTOR") {
+          return mockSlackResponse({ user: { real_name: "Alice" } });
+        }
+        if (parsedBody.user === "U_TARGET") {
+          return mockSlackResponse({ user: { real_name: "Bob" } });
+        }
+      }
+
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as { onReactionAdded: (evt: Record<string, unknown>) => Promise<void> }
+    ).onReactionAdded({
+      type: "reaction_added",
+      user: "U_REACTOR",
+      reaction: "arrow_up",
+      item_user: "U_TARGET",
+      item: {
+        type: "message",
+        channel: "C123",
+        ts: "222.333",
+      },
+      event_ts: "999.111",
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("- action: steering");
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("- delivery_classification: steering");
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("This changes the priority for today");
+    expect(handler.mock.calls[0]?.[0]?.metadata).toMatchObject({
+      kind: "slack_reaction_trigger",
+      slackReaction: "arrow_up",
+      slackReactionAction: "steering",
+      deliveryClassification: "steering",
+      threadTs: "222.222",
+      messageTs: "222.333",
     });
   });
 });

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -24,6 +24,7 @@ import {
 } from "../../helpers.js";
 import {
   buildReactionTriggerMessage,
+  buildReactionTriggerMetadata,
   normalizeReactionName,
   resolveReactionCommands,
   type ReactionCommandSettings,
@@ -351,6 +352,15 @@ export class SlackAdapter implements MessageAdapter {
           reactedMessageAuthor,
         }),
         timestamp: (evt.event_ts as string) ?? item.ts,
+        metadata: buildReactionTriggerMetadata({
+          reactionName,
+          command,
+          reactorName,
+          channel: item.channel,
+          threadTs,
+          messageTs: item.ts,
+          reactedMessageAuthor,
+        }),
         scope: buildSlackThreadRuntimeScope({
           channelId: item.channel,
           context: threadInfo?.context,

--- a/slack-bridge/reaction-triggers.test.ts
+++ b/slack-bridge/reaction-triggers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildReactionPromptGuidelines,
   buildReactionTriggerMessage,
+  buildReactionTriggerMetadata,
   formatReactionDisplay,
   normalizeReactionName,
   resolveReactionCommands,
@@ -11,6 +12,8 @@ describe("normalizeReactionName", () => {
   it("normalizes supported emoji characters and Slack aliases", () => {
     expect(normalizeReactionName("👀")).toBe("eyes");
     expect(normalizeReactionName(":white_check_mark:")).toBe("white_check_mark");
+    expect(normalizeReactionName("⬆️")).toBe("arrow_up");
+    expect(normalizeReactionName(":arrow_up:")).toBe("arrow_up");
     expect(normalizeReactionName("memo")).toBe("memo");
   });
 
@@ -20,10 +23,11 @@ describe("normalizeReactionName", () => {
 });
 
 describe("resolveReactionCommands", () => {
-  it("provides default mappings for summary and file-issue triggers", () => {
+  it("provides default mappings for summary, file-issue, and steering triggers", () => {
     const commands = resolveReactionCommands(undefined);
     expect(commands.get("memo")?.action).toBe("summarize");
     expect(commands.get("bug")?.action).toBe("file-issue");
+    expect(commands.get("arrow_up")?.action).toBe("steering");
   });
 
   it("merges custom settings keyed by emoji or alias", () => {
@@ -40,6 +44,7 @@ describe("resolveReactionCommands", () => {
 describe("formatReactionDisplay", () => {
   it("includes both the emoji and Slack reaction name when known", () => {
     expect(formatReactionDisplay("eyes")).toBe("👀 (:eyes:)");
+    expect(formatReactionDisplay("arrow_up")).toBe("⬆️ (:arrow_up:)");
   });
 });
 
@@ -62,8 +67,35 @@ describe("buildReactionTriggerMessage", () => {
     expect(message).toContain("Reaction trigger from Slack:");
     expect(message).toContain("- reaction: 👀 (:eyes:)");
     expect(message).toContain("- action: review");
+    expect(message).toContain("- delivery_classification: follow_up");
     expect(message).toContain("- reacted_message_text: Please review PR #210");
     expect(message).toContain("Requested action: Review the referenced message or work item.");
+  });
+});
+
+describe("buildReactionTriggerMetadata", () => {
+  it("marks arrow-up reactions as steering for downstream classifiers", () => {
+    expect(
+      buildReactionTriggerMetadata({
+        reactionName: "arrow_up",
+        command: {
+          action: "steering",
+          prompt: "Steer from here.",
+        },
+        reactorName: "Alice",
+        channel: "C123",
+        threadTs: "111.222",
+        messageTs: "111.333",
+        reactedMessageAuthor: "Bob",
+      }),
+    ).toMatchObject({
+      kind: "slack_reaction_trigger",
+      slackReaction: "arrow_up",
+      slackReactionAction: "steering",
+      deliveryClassification: "steering",
+      threadTs: "111.222",
+      messageTs: "111.333",
+    });
   });
 });
 
@@ -72,5 +104,6 @@ describe("buildReactionPromptGuidelines", () => {
     const joined = buildReactionPromptGuidelines().join(" ");
     expect(joined).toContain("Reaction trigger from Slack");
     expect(joined).toContain("emoji reactions");
+    expect(joined).toContain(":arrow_up:");
   });
 });

--- a/slack-bridge/reaction-triggers.ts
+++ b/slack-bridge/reaction-triggers.ts
@@ -30,6 +30,9 @@ const REACTION_ALIASES: Record<string, string> = {
   eyes: "eyes",
   "✅": "white_check_mark",
   white_check_mark: "white_check_mark",
+  "⬆": "arrow_up",
+  "⬆️": "arrow_up",
+  arrow_up: "arrow_up",
 };
 
 const REACTION_DISPLAY: Record<string, string> = {
@@ -42,6 +45,7 @@ const REACTION_DISPLAY: Record<string, string> = {
   repeat: "🔄",
   eyes: "👀",
   white_check_mark: "✅",
+  arrow_up: "⬆️",
 };
 
 export const DEFAULT_REACTION_COMMANDS: Record<string, ReactionCommandTemplate> = {
@@ -85,6 +89,11 @@ export const DEFAULT_REACTION_COMMANDS: Record<string, ReactionCommandTemplate> 
     prompt:
       "If the reacted message contains a URL, fetch the linked page and summarize the important information for the user.",
   },
+  arrow_up: {
+    action: "steering",
+    prompt:
+      "Treat the reacted-to message as high-priority steering for the current Slack/Pinet thread. Reprioritize the current or next action around that message, preserve its thread context, and report what changed.",
+  },
 };
 
 function normalizeReactionNameOrNull(input: string): string | null {
@@ -127,6 +136,8 @@ function buildDefaultPromptForAction(action: string): string {
       return DEFAULT_REACTION_COMMANDS.pushpin.prompt;
     case "fetch-url":
       return DEFAULT_REACTION_COMMANDS.globe_with_meridians.prompt;
+    case "steering":
+      return DEFAULT_REACTION_COMMANDS.arrow_up.prompt;
     default:
       return `Carry out the "${action}" action for the reacted Slack message or thread, using the included context before you decide what to do.`;
   }
@@ -170,6 +181,38 @@ export function formatReactionDisplay(reactionName: string): string {
   return `${REACTION_DISPLAY[reactionName] ?? `:${reactionName}:`} (:${reactionName}:)`;
 }
 
+export function isSteeringReaction(
+  reactionName: string,
+  command: ReactionCommandTemplate,
+): boolean {
+  const action = command.action.trim().toLowerCase();
+  return reactionName === "arrow_up" || action === "steering" || action === "steer";
+}
+
+export function buildReactionTriggerMetadata(input: {
+  reactionName: string;
+  command: ReactionCommandTemplate;
+  reactorName: string;
+  channel: string;
+  threadTs: string;
+  messageTs: string;
+  reactedMessageAuthor: string;
+}): Record<string, unknown> {
+  return {
+    kind: "slack_reaction_trigger",
+    slackReaction: input.reactionName,
+    slackReactionAction: input.command.action,
+    deliveryClassification: isSteeringReaction(input.reactionName, input.command)
+      ? "steering"
+      : "follow_up",
+    reactor: input.reactorName,
+    channel: input.channel,
+    threadTs: input.threadTs,
+    messageTs: input.messageTs,
+    reactedMessageAuthor: input.reactedMessageAuthor,
+  };
+}
+
 export interface ReactionTriggerMessageInput {
   reactionName: string;
   command: ReactionCommandTemplate;
@@ -183,10 +226,14 @@ export interface ReactionTriggerMessageInput {
 
 export function buildReactionTriggerMessage(input: ReactionTriggerMessageInput): string {
   const reactedMessageText = input.reactedMessageText.trim() || "(no text)";
+  const deliveryClassification = isSteeringReaction(input.reactionName, input.command)
+    ? "steering"
+    : "follow_up";
   return [
     "Reaction trigger from Slack:",
     `- reaction: ${formatReactionDisplay(input.reactionName)}`,
     `- action: ${input.command.action}`,
+    `- delivery_classification: ${deliveryClassification}`,
     `- reactor: ${input.reactorName}`,
     `- channel: <#${input.channel}>`,
     `- thread_ts: ${input.threadTs}`,
@@ -203,5 +250,6 @@ export function buildReactionPromptGuidelines(): string[] {
   return [
     "Reaction-triggered requests may appear in your Slack inbox as structured 'Reaction trigger from Slack:' messages.",
     "Treat them as explicit user requests keyed off emoji reactions. Use the included action, reacted message text, and thread context to decide what to do.",
+    "An up-arrow reaction (⬆️ / :arrow_up:) marks the referenced message as high-priority steering for the current or next action.",
   ];
 }

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { agentOwnsThread, type InboxMessage, normalizeOwnedThreads } from "./helpers.js";
 import {
   buildReactionTriggerMessage,
+  buildReactionTriggerMetadata,
   normalizeReactionName,
   type ReactionCommandTemplate,
 } from "./reaction-triggers.js";
@@ -330,6 +331,15 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         userId: user,
         text: reactionMessage,
         timestamp: (evt.event_ts as string) ?? item.ts,
+        metadata: buildReactionTriggerMetadata({
+          reactionName,
+          command,
+          reactorName,
+          channel: item.channel,
+          threadTs,
+          messageTs: item.ts,
+          reactedMessageAuthor,
+        }),
         scope: buildSlackThreadRuntimeScope({
           channelId: item.channel,
           context: threadInfo?.context,


### PR DESCRIPTION
## Issue / problem solved

Refs #582.

Slack reaction triggers already turn mapped reactions into structured inbox messages, but the up-arrow steering reaction called out in #582 was not recognized as a default reaction command and did not carry a machine-readable steering classification.

## Troubleshooting / diagnosis

- `reaction_added` is handled in both the broker Slack adapter and single-player runtime.
- Reaction triggers are mapped through `resolveReactionCommands(...)` and delivered as `Reaction trigger from Slack:` inbox text.
- Existing defaults covered review/approve/retry/etc., but not `⬆️` / `:arrow_up:`.
- `InboundMessage.metadata` already exists and is preserved through broker/inbox paths, so the smallest safe slice is to mark reaction-trigger classification there without adding a broad broker delivery classifier in this PR.

## Design philosophy

Smallest bounded slice for the requested priority:

- Add `⬆️` / `:arrow_up:` as a built-in reaction trigger.
- Classify it as `steering` in both human-readable inbox text and structured metadata.
- Preserve existing reaction behavior and settings overrides.
- Do not attempt the full #582 broker steering-vs-follow-up delivery classifier here.

## What changed

- Added `arrow_up` reaction normalization/display/default command.
- Added `isSteeringReaction(...)` and `buildReactionTriggerMetadata(...)`.
- Broker and single-player reaction handlers now attach reaction metadata including `deliveryClassification`.
- Reaction prompt guidance now calls out up-arrow steering.
- Added focused coverage for default arrow-up steering and existing follow-up reaction behavior.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test -- reaction-triggers.test.ts broker/adapters/slack.test.ts single-player-runtime.test.ts`
  - Note: the package test script runs the full slack-bridge suite; 70 files / 1144 tests passed.
- `git push` pre-push hook ran the repo Turbo test pipeline; 9/9 tasks successful.

## Follow-up / non-goals

- This PR does **not** close #582. The broader delivery-time classifier for steering/follow-up/maintenance remains open.
- A later #582 slice can consume `metadata.deliveryClassification === "steering"` to implement queue priority, diagnostics, or different active-session delivery semantics.
