### PR TITLE
fix(slack-bridge): cap retryable stableId reconnect conflicts

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -10,10 +10,15 @@ import {
   INITIAL_RECONNECT_DELAY_MS,
   MAX_RECONNECT_DELAY_MS,
   HEARTBEAT_INTERVAL_MS,
+  MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS,
   computeReconnectDelay,
 } from "./client.js";
-import type { BrokerConnectOpts } from "./client.js";
-import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
+import type { BrokerConnectOpts, BrokerRpcRequestError } from "./client.js";
+import {
+  RPC_AGENT_NAME_CONFLICT,
+  RPC_AGENT_STABLE_ID_CONFLICT,
+  RPC_METHOD_NOT_FOUND,
+} from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -24,7 +29,13 @@ interface MockServer {
   received: string[];
   close: () => Promise<void>;
   respondTo: (conn: net.Socket, id: number, result: unknown) => void;
-  respondError: (conn: net.Socket, id: number, code: number, message: string) => void;
+  respondError: (
+    conn: net.Socket,
+    id: number,
+    code: number,
+    message: string,
+    data?: unknown,
+  ) => void;
   connectOpts: BrokerConnectOpts;
 }
 
@@ -67,8 +78,13 @@ function createMockServer(port = 0): Promise<MockServer> {
           const msg = JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n";
           conn.write(msg);
         },
-        respondError: (conn, id, code, message) => {
-          const msg = JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } }) + "\n";
+        respondError: (conn, id, code, message, data) => {
+          const msg =
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              error: { code, message, ...(data === undefined ? {} : { data }) },
+            }) + "\n";
           conn.write(msg);
         },
       });
@@ -83,6 +99,22 @@ async function waitFor(fn: () => boolean, timeoutMs = 2000, intervalMs = 10): Pr
     if (Date.now() > deadline) throw new Error("waitFor timed out");
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+}
+
+function createStableIdConflictError(retryable: boolean): BrokerRpcRequestError {
+  const err = new Error(
+    'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying.',
+  ) as BrokerRpcRequestError;
+  err.name = "BrokerRpcRequestError";
+  err.code = RPC_AGENT_STABLE_ID_CONFLICT;
+  err.method = "register";
+  err.data = {
+    code: "AGENT_STABLE_ID_CONFLICT",
+    stableId: "host:session:/tmp/worker",
+    ownerAgentId: "worker-2",
+    retryable,
+  };
+  return err;
 }
 
 // ─── Tests ───────────────────────────────────────────────
@@ -1307,6 +1339,133 @@ describe("BrokerClient — onReconnect callback", () => {
     expect(client.isConnected()).toBe(false);
     expect((client as unknown as { socket: net.Socket | null }).socket).toBeNull();
     expect(scheduleReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps retrying retryable stableId conflicts and resets the streak after re-registering", async () => {
+    const client = new BrokerClient({ host: "127.0.0.1", port: 1 });
+    const failedSocket = { destroy: vi.fn() } as unknown as net.Socket;
+    const scheduleReconnect = vi.fn();
+    const reconnectFired = vi.fn();
+    let registerAttempts = 0;
+
+    client.onReconnect(reconnectFired);
+    (
+      client as unknown as {
+        registrationSnapshot: { name: string; emoji: string; stableId: string };
+      }
+    ).registrationSnapshot = {
+      name: "Worker",
+      emoji: "🦙",
+      stableId: "host:session:/tmp/worker",
+    };
+    (
+      client as unknown as {
+        connectSocket: () => Promise<void>;
+        socket: net.Socket | null;
+        connected: boolean;
+      }
+    ).connectSocket = vi.fn(async () => {
+      (client as unknown as { socket: net.Socket | null }).socket = failedSocket;
+      (client as unknown as { connected: boolean }).connected = true;
+    });
+    (client as unknown as { performRegister: () => Promise<unknown> }).performRegister = vi.fn(
+      async () => {
+        registerAttempts++;
+        if (registerAttempts < MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS) {
+          throw createStableIdConflictError(true);
+        }
+        return { agentId: "worker-1", name: "Worker", emoji: "🦙" };
+      },
+    );
+    (client as unknown as { scheduleReconnect: () => void }).scheduleReconnect = scheduleReconnect;
+
+    await (client as unknown as { reconnectOnce: () => Promise<void> }).reconnectOnce();
+    await (client as unknown as { reconnectOnce: () => Promise<void> }).reconnectOnce();
+    await (client as unknown as { reconnectOnce: () => Promise<void> }).reconnectOnce();
+
+    expect(scheduleReconnect).toHaveBeenCalledTimes(MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS - 1);
+    expect(reconnectFired).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { stableIdConflictAttempt: number }).stableIdConflictAttempt).toBe(
+      0,
+    );
+    expect(client.getReconnectAttempt()).toBe(0);
+  });
+
+  it("stops reconnecting after three consecutive retryable stableId conflicts", async () => {
+    const client = new BrokerClient({ host: "127.0.0.1", port: 1 });
+    const failedSocket = { destroy: vi.fn() } as unknown as net.Socket;
+    const scheduleReconnect = vi.fn();
+    const reconnectFailed = vi.fn();
+
+    client.onReconnectFailed(reconnectFailed);
+    (
+      client as unknown as {
+        registrationSnapshot: { name: string; emoji: string; stableId: string };
+      }
+    ).registrationSnapshot = {
+      name: "Worker",
+      emoji: "🦙",
+      stableId: "host:session:/tmp/worker",
+    };
+    (
+      client as unknown as {
+        connectSocket: () => Promise<void>;
+        socket: net.Socket | null;
+        connected: boolean;
+      }
+    ).connectSocket = vi.fn(async () => {
+      (client as unknown as { socket: net.Socket | null }).socket = failedSocket;
+      (client as unknown as { connected: boolean }).connected = true;
+    });
+    (client as unknown as { performRegister: () => Promise<unknown> }).performRegister = vi.fn(
+      async () => {
+        throw createStableIdConflictError(true);
+      },
+    );
+    (client as unknown as { scheduleReconnect: () => void }).scheduleReconnect = scheduleReconnect;
+
+    for (let i = 0; i < MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS; i++) {
+      await (client as unknown as { reconnectOnce: () => Promise<void> }).reconnectOnce();
+    }
+
+    expect(scheduleReconnect).toHaveBeenCalledTimes(MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS - 1);
+    expect(reconnectFailed).toHaveBeenCalledTimes(1);
+    expect(reconnectFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: RPC_AGENT_STABLE_ID_CONFLICT,
+        data: expect.objectContaining({ retryable: true }),
+      }),
+    );
+    expect(client.isConnected()).toBe(false);
+    expect(client.getReconnectAttempt()).toBe(0);
+    expect(client.getRegisteredIdentity()).toBeNull();
+    expect((client as unknown as { stableIdConflictAttempt: number }).stableIdConflictAttempt).toBe(
+      0,
+    );
+  });
+
+  it("resets the stableId conflict streak when reconnect fails before re-registering", async () => {
+    const client = new BrokerClient({ host: "127.0.0.1", port: 1 });
+    const scheduleReconnect = vi.fn();
+
+    (
+      client as unknown as {
+        connectSocket: () => Promise<void>;
+        stableIdConflictAttempt: number;
+      }
+    ).connectSocket = vi.fn(async () => {
+      throw new Error("connect failed");
+    });
+    (client as unknown as { stableIdConflictAttempt: number }).stableIdConflictAttempt =
+      MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS - 1;
+    (client as unknown as { scheduleReconnect: () => void }).scheduleReconnect = scheduleReconnect;
+
+    await (client as unknown as { reconnectOnce: () => Promise<void> }).reconnectOnce();
+
+    expect(scheduleReconnect).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { stableIdConflictAttempt: number }).stableIdConflictAttempt).toBe(
+      0,
+    );
   });
 
   it("scheduleReconnect fires onDisconnect then onReconnect after server restart", async () => {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -2,7 +2,11 @@ import * as net from "node:net";
 import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
-import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
+import {
+  RPC_AGENT_NAME_CONFLICT,
+  RPC_AGENT_STABLE_ID_CONFLICT,
+  RPC_METHOD_NOT_FOUND,
+} from "./types.js";
 import type { ClientAgentInfo } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
@@ -62,6 +66,7 @@ export const RECONNECT_DELAY_MS = 3000;
 export const INITIAL_RECONNECT_DELAY_MS = 1000;
 export const MAX_RECONNECT_DELAY_MS = 30000;
 export const HEARTBEAT_INTERVAL_MS = 5000;
+export const MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS = 3;
 
 /** Compute reconnect delay with exponential backoff and jitter. */
 export function computeReconnectDelay(attempt: number, random = Math.random()): number {
@@ -81,7 +86,7 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
-interface BrokerRpcRequestError extends Error {
+export interface BrokerRpcRequestError extends Error {
   code?: number;
   data?: unknown;
   method?: string;
@@ -112,13 +117,17 @@ function isRpcMethodNotFoundError(err: unknown, method: string): boolean {
   return rpcErr.code === RPC_METHOD_NOT_FOUND || err.message === `Unknown method: ${method}`;
 }
 
-function isRpcAgentNameConflictError(err: unknown): err is BrokerRpcRequestError {
+function isRpcConflictError(
+  err: unknown,
+  rpcCode: number,
+  dataCode: string,
+): err is BrokerRpcRequestError {
   if (!(err instanceof Error)) {
     return false;
   }
 
   const rpcErr = err as BrokerRpcRequestError;
-  if (rpcErr.code === RPC_AGENT_NAME_CONFLICT) {
+  if (rpcErr.code === rpcCode) {
     return true;
   }
 
@@ -126,7 +135,23 @@ function isRpcAgentNameConflictError(err: unknown): err is BrokerRpcRequestError
     return false;
   }
 
-  return (rpcErr.data as { code?: unknown }).code === "AGENT_NAME_CONFLICT";
+  return (rpcErr.data as { code?: unknown }).code === dataCode;
+}
+
+function isRpcAgentNameConflictError(err: unknown): err is BrokerRpcRequestError {
+  return isRpcConflictError(err, RPC_AGENT_NAME_CONFLICT, "AGENT_NAME_CONFLICT");
+}
+
+export function isRpcAgentStableIdConflictError(err: unknown): err is BrokerRpcRequestError {
+  return isRpcConflictError(err, RPC_AGENT_STABLE_ID_CONFLICT, "AGENT_STABLE_ID_CONFLICT");
+}
+
+function isRpcRetryableError(err: BrokerRpcRequestError): boolean {
+  if (typeof err.data !== "object" || err.data == null) {
+    return false;
+  }
+
+  return (err.data as { retryable?: unknown }).retryable === true;
 }
 
 function getMeshAuthCompatibilityError(): Error {
@@ -188,6 +213,7 @@ export class BrokerClient {
   private reconnectHandler: (() => void) | null = null;
   private reconnectFailedHandler: ((error: Error) => void) | null = null;
   private reconnectAttempt = 0;
+  private stableIdConflictAttempt = 0;
   private registrationSnapshot: RegistrationSnapshot | null = null;
   private registeredIdentity: RegistrationResult | null = null;
 
@@ -227,6 +253,7 @@ export class BrokerClient {
 
   async connect(): Promise<void> {
     this.shuttingDown = false;
+    this.stableIdConflictAttempt = 0;
     await this.connectSocket();
     try {
       await this.authenticateIfNeeded();
@@ -251,6 +278,7 @@ export class BrokerClient {
     }
     this.socket = null;
     this.connected = false;
+    this.stableIdConflictAttempt = 0;
   }
 
   async disconnectGracefully(): Promise<void> {
@@ -666,6 +694,7 @@ export class BrokerClient {
     try {
       await this.connectSocket();
     } catch {
+      this.stableIdConflictAttempt = 0;
       this.scheduleReconnect();
       return;
     }
@@ -676,6 +705,7 @@ export class BrokerClient {
         await this.performRegister(this.registrationSnapshot);
       }
       this.reconnectAttempt = 0;
+      this.stableIdConflictAttempt = 0;
       this.reconnectHandler?.();
     } catch (err) {
       // Re-registration failed after the socket connected. Clear the connection
@@ -698,9 +728,31 @@ export class BrokerClient {
       }
       if (isRpcAgentNameConflictError(reconnectError)) {
         this.reconnectAttempt = 0;
+        this.stableIdConflictAttempt = 0;
         this.reconnectFailedHandler?.(reconnectError);
         return;
       }
+
+      if (isRpcAgentStableIdConflictError(reconnectError)) {
+        const retryableStableIdConflict = isRpcRetryableError(reconnectError);
+        this.stableIdConflictAttempt = retryableStableIdConflict
+          ? this.stableIdConflictAttempt + 1
+          : 0;
+        const shouldKeepRetrying =
+          retryableStableIdConflict &&
+          this.stableIdConflictAttempt < MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS;
+        if (!shouldKeepRetrying) {
+          this.reconnectAttempt = 0;
+          this.stableIdConflictAttempt = 0;
+          this.reconnectFailedHandler?.(reconnectError);
+          return;
+        }
+
+        this.scheduleReconnect();
+        return;
+      }
+
+      this.stableIdConflictAttempt = 0;
       this.scheduleReconnect();
     }
   }

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -4,13 +4,14 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { DatabaseSync } from "node:sqlite";
-import { BrokerClient } from "./broker/client.js";
+import { BrokerClient, type BrokerRpcRequestError } from "./broker/client.js";
+import { RPC_AGENT_STABLE_ID_CONFLICT } from "./broker/types.js";
 import * as brokerModule from "./broker/index.js";
 import * as maintenanceModule from "./broker/maintenance.js";
 import { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import * as imessageModule from "@gugu910/pi-imessage-bridge";
-import slackBridge from "./index.js";
+import slackBridge, { buildPinetReconnectStoppedMessage } from "./index.js";
 
 type ToolDefinition = {
   name: string;
@@ -50,6 +51,48 @@ function stubIsTTY(stream: NodeJS.ReadStream | NodeJS.WriteStream, value: boolea
     Reflect.deleteProperty(target, "isTTY");
   };
 }
+
+function createStableIdReconnectError(): BrokerRpcRequestError {
+  const err = new Error(
+    'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying.',
+  ) as BrokerRpcRequestError;
+  err.name = "BrokerRpcRequestError";
+  err.code = RPC_AGENT_STABLE_ID_CONFLICT;
+  err.data = {
+    code: "AGENT_STABLE_ID_CONFLICT",
+    stableId: "host:session:/tmp/worker",
+    ownerAgentId: "worker-2",
+    retryable: true,
+  };
+  err.method = "register";
+  return err;
+}
+
+describe("buildPinetReconnectStoppedMessage", () => {
+  it("gives stableId-specific recovery guidance after retry exhaustion", () => {
+    const message = buildPinetReconnectStoppedMessage(createStableIdReconnectError());
+
+    expect(message).toContain("Pinet reconnect stopped after repeated stableId conflicts");
+    expect(message).toContain("Automatic retries were exhausted");
+    expect(message).toContain("Stop or disconnect the other worker");
+    expect(message).toContain("/pinet-follow");
+    expect(message).not.toContain("agentName/agentEmoji");
+    expect(message).not.toContain("PI_NICKNAME");
+  });
+
+  it("keeps name/emoji guidance for other terminal reconnect errors", () => {
+    const message = buildPinetReconnectStoppedMessage(
+      new Error(
+        'Agent name "Reserved Crane" is already reserved. Retry with a different name or leave the name empty so the broker can assign one.',
+      ),
+    );
+
+    expect(message).toContain("Pinet reconnect stopped");
+    expect(message).toContain("slack-bridge.agentName/agentEmoji");
+    expect(message).toContain("PI_NICKNAME");
+    expect(message).toContain("/pinet-follow");
+  });
+});
 
 describe("slack-bridge top-level shutdown", () => {
   const originalBotToken = process.env.SLACK_BOT_TOKEN;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -18,7 +18,7 @@ import {
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
-import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
+import { DEFAULT_SOCKET_PATH, isRpcAgentStableIdConflictError } from "./broker/client.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
@@ -1208,10 +1208,7 @@ export default function (pi: ExtensionAPI) {
         /* best effort */
       });
       setExtStatus(ctx, "error");
-      ctx.ui.notify(
-        `Pinet reconnect stopped: ${msg(error)} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.`,
-        "error",
-      );
+      ctx.ui.notify(buildPinetReconnectStoppedMessage(error), "error");
     },
     formatError: msg,
     deliveryState: followerDeliveryState,
@@ -1362,6 +1359,14 @@ export default function (pi: ExtensionAPI) {
     await stopPinetRuntime(ctx, { releaseIdentity: true });
     pinetRegistrationGate.reset();
   });
+}
+
+export function buildPinetReconnectStoppedMessage(error: Error): string {
+  if (isRpcAgentStableIdConflictError(error)) {
+    return `Pinet reconnect stopped after repeated stableId conflicts: ${msg(error)} Automatic retries were exhausted because another live worker is still using this session identity. Stop or disconnect the other worker, then run /pinet-follow to retry.`;
+  }
+
+  return `Pinet reconnect stopped: ${msg(error)} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.`;
 }
 
 function msg(err: unknown): string {


### PR DESCRIPTION
## Summary
- retry broker reconnects for retryable `AGENT_STABLE_ID_CONFLICT` responses, but stop after 3 consecutive conflicts
- reset the stableId conflict streak on successful reconnects, ordinary reconnect failures, manual connect/disconnect, and name-conflict terminal paths
- surface stableId-specific terminal guidance that tells users to stop/disconnect the other worker instead of changing agent name/emoji

## Context
- Respin of the useful, bounded #516 behavior after @gugu91 approved the policy: retry retryable stableId conflicts up to 3 consecutive times, then stop with explicit guidance.
- Related salvage/audit tracker: #577. I did not find a more specific open behavior issue for this exact retry policy.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run broker/client.test.ts index.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- push pre-push hook (`turbo run typecheck`, `turbo run test`)

## Status
READY FOR HUMAN REVIEW. No merge performed.