### PR TITLE
fix(transport): salvage outbound content rendering

### DIFF
--- a/broker-core/message-send.ts
+++ b/broker-core/message-send.ts
@@ -1,4 +1,10 @@
-import type { BrokerMessage, MessageAdapter, OutboundMessage, ThreadInfo } from "./types.js";
+import type {
+  BrokerMessage,
+  MessageAdapter,
+  NormalizedMessageContent,
+  OutboundMessage,
+  ThreadInfo,
+} from "./types.js";
 
 export interface BrokerMessageSenderDb {
   getThread(threadId: string): ThreadInfo | null;
@@ -31,10 +37,34 @@ export interface SendBrokerMessageInput {
   senderAgentId: string;
   source?: string;
   channel?: string;
+  content?: NormalizedMessageContent;
+  blocks?: ReadonlyArray<Record<string, unknown>>;
   agentName?: string;
   agentEmoji?: string;
   agentOwnerToken?: string;
   metadata?: Record<string, unknown>;
+}
+
+function normalizeMessageContent(
+  content?: NormalizedMessageContent,
+): NormalizedMessageContent | undefined {
+  if (!content) {
+    return undefined;
+  }
+
+  const text = content.text.trim();
+  if (!text) {
+    throw new Error("content.text is required when content is provided.");
+  }
+
+  const markdown = content.markdown?.trim();
+  return {
+    text,
+    ...(markdown ? { markdown } : {}),
+    ...(content.slackBlocks && content.slackBlocks.length > 0
+      ? { slackBlocks: content.slackBlocks }
+      : {}),
+  };
 }
 
 export interface SendBrokerMessageResult {
@@ -69,10 +99,15 @@ export async function sendBrokerMessage(
     throw new Error(`No adapter is registered for transport source ${JSON.stringify(source)}.`);
   }
 
+  const content = normalizeMessageContent(input.content);
+  const messageBody = content?.text ?? body;
+
   const outbound: OutboundMessage = {
     threadId,
     channel,
-    text: body,
+    text: messageBody,
+    ...(content ? { content } : {}),
+    ...(input.blocks && input.blocks.length > 0 ? { blocks: input.blocks } : {}),
     ...(input.agentName ? { agentName: input.agentName } : {}),
     ...(input.agentEmoji ? { agentEmoji: input.agentEmoji } : {}),
     ...(input.agentOwnerToken ? { agentOwnerToken: input.agentOwnerToken } : {}),
@@ -93,7 +128,7 @@ export async function sendBrokerMessage(
     source,
     "outbound",
     input.senderAgentId,
-    body,
+    messageBody,
     [],
     input.metadata,
   );

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -153,6 +153,7 @@ import {
 } from "@gugu910/pi-transport-core";
 import type {
   InboundMessage as _InboundMessage,
+  NormalizedMessageContent as _NormalizedMessageContent,
   OutboundMessage as _OutboundMessage,
   MessageAdapter as _MessageAdapter,
   RuntimeScopeCarrier as _RuntimeScopeCarrier,
@@ -161,6 +162,7 @@ import type {
 } from "@gugu910/pi-transport-core";
 
 export type InboundMessage = _InboundMessage;
+export type NormalizedMessageContent = _NormalizedMessageContent;
 export type OutboundMessage = _OutboundMessage;
 export type MessageAdapter = _MessageAdapter;
 export type RuntimeScopeCarrier = _RuntimeScopeCarrier;

--- a/imessage-bridge/adapter.test.ts
+++ b/imessage-bridge/adapter.test.ts
@@ -68,6 +68,42 @@ describe("AppleScriptIMessageAdapter", () => {
     expect(runAppleScript).toHaveBeenCalledTimes(1);
   });
 
+  it("uses canonical normalized content text for outbound sends", async () => {
+    const runAppleScript = vi.fn(async () => ({ stdout: "sent", stderr: "" }));
+    const adapter = createIMessageAdapter({
+      runAppleScript,
+      detectEnvironment: () => ({
+        platform: "darwin",
+        homeDir: "/Users/goose",
+        messagesDbPath: "/Users/goose/Library/Messages/chat.db",
+        osascriptPath: APPLESCRIPT_BINARY_PATH,
+        osascriptAvailable: true,
+        messagesDbAvailable: false,
+        canAttemptSend: true,
+        canAttemptHistoryRead: false,
+        readyForLocalMvp: false,
+        blockers: ["missing_messages_db"],
+      }),
+    });
+
+    await adapter.connect();
+    await adapter.send({
+      threadId: "imessage:alice",
+      channel: "chat:alice",
+      text: "legacy **markdown** fallback",
+      content: {
+        text: "plain fallback",
+        markdown: "**plain fallback**",
+      },
+    });
+
+    expect(runAppleScript).toHaveBeenCalledWith({
+      osascriptPath: APPLESCRIPT_BINARY_PATH,
+      scriptLines: buildIMessageSendAppleScript(),
+      args: ["chat:alice", "plain fallback"],
+    });
+  });
+
   it("fails connect when the host cannot attempt iMessage sends and keeps the trust boundary explicit", async () => {
     const adapter = createIMessageAdapter({
       detectEnvironment: () => ({

--- a/imessage-bridge/adapter.ts
+++ b/imessage-bridge/adapter.ts
@@ -66,7 +66,7 @@ export class AppleScriptIMessageAdapter implements IMessageAdapter {
   async send(msg: IMessageAdapterOutboundMessage): Promise<void> {
     await sendIMessage({
       recipient: msg.channel,
-      text: msg.text,
+      text: msg.content?.text ?? msg.text,
       osascriptPath: this.options.osascriptPath,
       runAppleScript: this.options.runAppleScript,
     });

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1629,6 +1629,98 @@ describe("SlackAdapter — send", () => {
     expect(body.metadata).toBeUndefined();
   });
 
+  it("prefers transport-aware Slack blocks when present", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+    const slackBlocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Transport-aware*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+    const legacyBlocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Legacy*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+
+    await adapter.send({
+      threadId: "1.1",
+      channel: "C1",
+      text: "legacy fallback",
+      content: {
+        text: "plain fallback",
+        markdown: "**plain fallback**",
+        slackBlocks,
+      },
+      blocks: legacyBlocks,
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.text).toBe("plain fallback");
+    expect(body.blocks).toEqual(slackBlocks);
+  });
+
+  it("falls back to legacy blocks when transport-aware Slack blocks are empty", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+    const legacyBlocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Legacy fallback*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+
+    await adapter.send({
+      threadId: "1.1",
+      channel: "C1",
+      text: "legacy fallback",
+      content: {
+        text: "plain fallback",
+        slackBlocks: [],
+      },
+      blocks: legacyBlocks,
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.blocks).toEqual(legacyBlocks);
+  });
+
+  it("omits an empty blocks payload", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+
+    await adapter.send({
+      threadId: "1.1",
+      channel: "C1",
+      text: "fallback",
+      content: {
+        text: "plain fallback",
+        slackBlocks: [],
+      },
+      blocks: [],
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.blocks).toBeUndefined();
+  });
+
   it("uses buildSlackRequest for proper encoding", async () => {
     fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -148,10 +148,18 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   async send(msg: OutboundMessage): Promise<void> {
+    const contentSlackBlocks = msg.content?.slackBlocks;
+    const slackBlocks =
+      contentSlackBlocks && contentSlackBlocks.length > 0
+        ? contentSlackBlocks
+        : msg.blocks && msg.blocks.length > 0
+          ? msg.blocks
+          : undefined;
     const body: Record<string, unknown> = {
       channel: msg.channel,
-      text: msg.text,
+      text: msg.content?.text ?? msg.text,
       thread_ts: msg.threadId,
+      ...(slackBlocks ? { blocks: slackBlocks } : {}),
     };
     const scope = msg.scope ?? this.resolveScopeForThread(msg.threadId, msg.channel);
 

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -704,6 +704,68 @@ describe("BrokerClient — message.send", () => {
 
     client.disconnect();
   });
+
+  it("includes normalized content and blocks in message.send payload when provided", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+    const blocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Transport-aware*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+
+    const sendPromise = client.sendMessage({
+      threadId: "100.200",
+      body: "fallback text",
+      source: "slack",
+      channel: "C123",
+      content: {
+        text: "fallback text",
+        markdown: "**fallback text**",
+        slackBlocks: blocks,
+      },
+      blocks,
+    });
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: Record<string, unknown>;
+    };
+    expect(req.method).toBe("message.send");
+    expect(req.params).toMatchObject({
+      threadId: "100.200",
+      body: "fallback text",
+      source: "slack",
+      channel: "C123",
+      content: {
+        text: "fallback text",
+        markdown: "**fallback text**",
+        slackBlocks: blocks,
+      },
+      blocks,
+    });
+
+    mock.respondTo(mock.connections[0], req.id, {
+      adapter: "slack",
+      messageId: 10,
+      threadId: "100.200",
+      channel: "C123",
+      source: "slack",
+    });
+
+    await expect(sendPromise).resolves.toEqual({
+      adapter: "slack",
+      messageId: 10,
+      threadId: "100.200",
+      channel: "C123",
+      source: "slack",
+    });
+
+    client.disconnect();
+  });
 });
 
 describe("BrokerClient — listThreads / listAgents", () => {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -3,7 +3,7 @@ import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
 import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
-import type { ClientAgentInfo } from "./types.js";
+import type { ClientAgentInfo, NormalizedMessageContent } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -364,6 +364,8 @@ export class BrokerClient {
     body: string;
     source?: string;
     channel?: string;
+    content?: NormalizedMessageContent;
+    blocks?: ReadonlyArray<Record<string, unknown>>;
     agentName?: string;
     agentEmoji?: string;
     agentOwnerToken?: string;
@@ -380,6 +382,8 @@ export class BrokerClient {
       body: input.body,
       ...(input.source ? { source: input.source } : {}),
       ...(input.channel ? { channel: input.channel } : {}),
+      ...(input.content ? { content: input.content } : {}),
+      ...(input.blocks && input.blocks.length > 0 ? { blocks: input.blocks } : {}),
       ...(input.agentName ? { agentName: input.agentName } : {}),
       ...(input.agentEmoji ? { agentEmoji: input.agentEmoji } : {}),
       ...(input.agentOwnerToken ? { agentOwnerToken: input.agentOwnerToken } : {}),

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -756,6 +756,84 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     });
   });
 
+  it("message.send forwards normalized content and blocks to the transport adapter", async () => {
+    let delivered: unknown;
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async (msg) => {
+          delivered = msg;
+        },
+      },
+    ]);
+    await client.register("transport-agent", "📦");
+    const blocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Legacy blocks*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+
+    await client.sendMessage({
+      threadId: "100.200",
+      body: "fallback text",
+      source: "slack",
+      channel: "C123",
+      content: {
+        text: "canonical fallback",
+        markdown: "**canonical fallback**",
+        slackBlocks: [],
+      },
+      blocks,
+    });
+
+    expect(delivered).toMatchObject({
+      threadId: "100.200",
+      channel: "C123",
+      text: "canonical fallback",
+      content: { text: "canonical fallback", markdown: "**canonical fallback**" },
+      blocks,
+    });
+  });
+
+  it("message.send rejects non-object content payloads", async () => {
+    server.setOutboundMessageAdapters([{ name: "slack", send: async () => undefined }]);
+    await client.register("transport-agent", "📦");
+
+    const rpcClient = client as unknown as {
+      request: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+    };
+
+    await expect(
+      rpcClient.request("message.send", {
+        threadId: "100.201",
+        body: "fallback text",
+        source: "slack",
+        channel: "C123",
+        content: "oops",
+      }),
+    ).rejects.toThrow("content must be an object");
+  });
+
+  it("message.send rejects content payloads without canonical text", async () => {
+    server.setOutboundMessageAdapters([{ name: "slack", send: async () => undefined }]);
+    await client.register("transport-agent", "📦");
+
+    const rpcClient = client as unknown as {
+      request: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+    };
+
+    await expect(
+      rpcClient.request("message.send", {
+        threadId: "100.202",
+        body: "fallback text",
+        source: "slack",
+        channel: "C123",
+        content: { markdown: "**fallback text**" },
+      }),
+    ).rejects.toThrow("content.text is required when content is provided");
+  });
+
   it("thread.claim claims ownership for the calling agent", async () => {
     await client.register("claimer-agent", "🏷️");
 

--- a/slack-bridge/broker/message-send.test.ts
+++ b/slack-bridge/broker/message-send.test.ts
@@ -92,6 +92,96 @@ describe("sendBrokerMessage", () => {
     expect(result.adapter).toBe("imessage");
   });
 
+  it("passes normalized outbound content and fallback blocks through to the adapter", async () => {
+    const db = createFakeDb();
+    const send = vi.fn(async () => undefined);
+    const legacyBlocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Legacy blocks*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+    const slackBlocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Transport-aware blocks*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+
+    const result = await sendBrokerMessage(
+      {
+        db,
+        adapters: [{ name: "slack", send }],
+      },
+      {
+        threadId: "100.200",
+        body: "  raw fallback body  ",
+        senderAgentId: "agent-1",
+        source: "slack",
+        channel: "C123",
+        content: {
+          text: " canonical fallback text ",
+          markdown: " **canonical fallback text** ",
+          slackBlocks,
+        },
+        blocks: legacyBlocks,
+      },
+    );
+
+    expect(send).toHaveBeenCalledWith({
+      threadId: "100.200",
+      channel: "C123",
+      text: "canonical fallback text",
+      content: {
+        text: "canonical fallback text",
+        markdown: "**canonical fallback text**",
+        slackBlocks,
+      },
+      blocks: legacyBlocks,
+    });
+    expect(result.message.body).toBe("canonical fallback text");
+  });
+
+  it("omits empty Slack-native content blocks so transports can use legacy fallback blocks", async () => {
+    const db = createFakeDb();
+    const send = vi.fn(async () => undefined);
+    const legacyBlocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Legacy blocks*" },
+      },
+    ] satisfies ReadonlyArray<Record<string, unknown>>;
+
+    await sendBrokerMessage(
+      {
+        db,
+        adapters: [{ name: "slack", send }],
+      },
+      {
+        threadId: "100.201",
+        body: "fallback text",
+        senderAgentId: "agent-1",
+        source: "slack",
+        channel: "C123",
+        content: {
+          text: "fallback text",
+          slackBlocks: [],
+        },
+        blocks: legacyBlocks,
+      },
+    );
+
+    expect(send).toHaveBeenCalledWith({
+      threadId: "100.201",
+      channel: "C123",
+      text: "fallback text",
+      content: {
+        text: "fallback text",
+      },
+      blocks: legacyBlocks,
+    });
+  });
+
   it("reuses the stored thread transport when source and channel are omitted", async () => {
     const db = createFakeDb();
     db.createThread("imessage:chat:bob", "imessage", "chat:bob", "agent-1");

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -17,6 +17,7 @@ import type {
   JsonRpcResponse,
   JsonRpcError,
   MessageAdapter,
+  NormalizedMessageContent,
 } from "./types.js";
 import {
   RPC_PARSE_ERROR,
@@ -754,6 +755,39 @@ export class BrokerSocketServer {
     const agentEmoji = typeof params.agentEmoji === "string" ? params.agentEmoji : undefined;
     const agentOwnerToken =
       typeof params.agentOwnerToken === "string" ? params.agentOwnerToken : undefined;
+    const blocks = Array.isArray(params.blocks)
+      ? params.blocks.filter(
+          (entry): entry is Record<string, unknown> => !!entry && typeof entry === "object",
+        )
+      : undefined;
+    let content: NormalizedMessageContent | undefined;
+    if (params.content !== undefined) {
+      if (!params.content || typeof params.content !== "object" || Array.isArray(params.content)) {
+        return rpcError(req.id, RPC_INVALID_PARAMS, "content must be an object");
+      }
+
+      const raw = params.content as Record<string, unknown>;
+      const text = typeof raw.text === "string" ? raw.text.trim() : "";
+      if (!text) {
+        return rpcError(
+          req.id,
+          RPC_INVALID_PARAMS,
+          "content.text is required when content is provided",
+        );
+      }
+
+      const markdown = typeof raw.markdown === "string" ? raw.markdown.trim() : undefined;
+      const slackBlocks = Array.isArray(raw.slackBlocks)
+        ? raw.slackBlocks.filter(
+            (entry): entry is Record<string, unknown> => !!entry && typeof entry === "object",
+          )
+        : undefined;
+      content = {
+        text,
+        ...(markdown ? { markdown } : {}),
+        ...(slackBlocks && slackBlocks.length > 0 ? { slackBlocks } : {}),
+      };
+    }
     const metadata =
       params.metadata && typeof params.metadata === "object"
         ? (params.metadata as Record<string, unknown>)
@@ -774,6 +808,8 @@ export class BrokerSocketServer {
         senderAgentId: state.agentId,
         ...(source ? { source } : {}),
         ...(channel ? { channel } : {}),
+        ...(content ? { content } : {}),
+        ...(blocks && blocks.length > 0 ? { blocks } : {}),
         ...(agentName ? { agentName } : {}),
         ...(agentEmoji ? { agentEmoji } : {}),
         ...(agentOwnerToken ? { agentOwnerToken } : {}),

--- a/slack-bridge/imessage-tools.test.ts
+++ b/slack-bridge/imessage-tools.test.ts
@@ -141,6 +141,7 @@ describe("registerIMessageTools", () => {
         threadId: "imessage:chat:alice",
         channel: "chat:alice",
         text: "hello from pi",
+        content: { text: "hello from pi" },
       }),
     );
     expect(trackOwnedThread).toHaveBeenCalledWith("imessage:chat:alice", "chat:alice", "imessage");
@@ -179,6 +180,7 @@ describe("registerIMessageTools", () => {
       body: "follower hello",
       source: "imessage",
       channel: "+15555550123",
+      content: { text: "follower hello" },
       agentName: "Cobalt Olive Crane",
       agentEmoji: "🦩",
       agentOwnerToken: "owner-token",

--- a/slack-bridge/imessage-tools.ts
+++ b/slack-bridge/imessage-tools.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { NormalizedMessageContent } from "@gugu910/pi-transport-core";
 import { Type } from "@sinclair/typebox";
 import {
   getDefaultIMessageThreadId,
@@ -12,6 +13,7 @@ export interface IMessageToolSendInput {
   body: string;
   source: "imessage";
   channel: string;
+  content: NormalizedMessageContent;
   agentName: string;
   agentEmoji: string;
   agentOwnerToken: string;
@@ -81,6 +83,7 @@ export function registerIMessageTools(pi: ExtensionAPI, deps: RegisterIMessageTo
         body: text,
         source: "imessage",
         channel: recipient,
+        content: { text },
         agentName: name,
         agentEmoji: emoji,
         agentOwnerToken: ownerToken,
@@ -111,6 +114,7 @@ export function registerIMessageTools(pi: ExtensionAPI, deps: RegisterIMessageTo
             senderAgentId: selfId,
             source: request.source,
             channel: request.channel,
+            content: request.content,
             agentName: request.agentName,
             agentEmoji: request.agentEmoji,
             agentOwnerToken: request.agentOwnerToken,

--- a/transport-core/README.md
+++ b/transport-core/README.md
@@ -6,6 +6,7 @@ Tiny transport-neutral contracts package for the `extensions` repo.
 
 - canonical `InboundMessage` contract
 - canonical `OutboundMessage` contract
+- normalized outbound `content` shape for transport-aware rendering with plain-text fallback
 - canonical `MessageAdapter` transport interface
 
 ## What stays out of scope
@@ -18,3 +19,22 @@ Tiny transport-neutral contracts package for the `extensions` repo.
 - Pi extension commands/tools
 
 This package exists to keep transport contracts transport-neutral while other packages decide how to route, persist, or render those messages.
+
+## Outbound content rules
+
+`OutboundMessage.text` remains the backward-compatible plain-text fallback and persistence body.
+
+When richer transport-aware rendering is available, callers may also send `OutboundMessage.content`:
+
+- `content.text`: canonical plain-text body
+- `content.markdown`: optional markdown-friendly representation for markdown-capable text renderers or exports
+- `content.slackBlocks`: optional prebuilt Slack Block Kit payload
+
+Transports should prefer their transport-specific representation when present, then fall back to the canonical plain-text body:
+
+1. transport-native content (`slackBlocks` for Slack)
+2. plain `text`
+
+`markdown` is supplementary for markdown-aware surfaces and should not replace the canonical plain-text body on plain-text transports like iMessage.
+
+This keeps Slack, markdown-oriented exports, and plain-text sends aligned without requiring every caller to collapse everything into one presentation string upfront.

--- a/transport-core/index.ts
+++ b/transport-core/index.ts
@@ -99,10 +99,18 @@ export interface InboundMessage {
   scope?: RuntimeScopeCarrier;
 }
 
+export interface NormalizedMessageContent {
+  text: string;
+  markdown?: string;
+  slackBlocks?: ReadonlyArray<Record<string, unknown>>;
+}
+
 export interface OutboundMessage {
   threadId: string;
   channel: string;
   text: string;
+  content?: NormalizedMessageContent;
+  blocks?: ReadonlyArray<Record<string, unknown>>;
   agentName?: string;
   agentEmoji?: string;
   agentOwnerToken?: string;


### PR DESCRIPTION
## Summary
- salvage the bounded outbound-content portion of Thomas PR #518 on current `main`
- add canonical `NormalizedMessageContent` to transport-core and thread it through broker `message.send`/client/server paths
- render outbound Slack using `content.text` plus non-empty `content.slackBlocks`, falling back to legacy `blocks` when Slack-native blocks are empty
- keep iMessage on canonical plain text (`content.text`) rather than markdown

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check transport-core/index.ts transport-core/README.md broker-core/types.ts broker-core/message-send.ts slack-bridge/broker/client.ts slack-bridge/broker/socket-server.ts slack-bridge/broker/adapters/slack.ts imessage-bridge/adapter.ts slack-bridge/imessage-tools.ts slack-bridge/broker/message-send.test.ts slack-bridge/broker/integration.test.ts slack-bridge/broker/adapters/slack.test.ts slack-bridge/broker/client.test.ts imessage-bridge/adapter.test.ts slack-bridge/imessage-tools.test.ts`
- `pnpm --dir slack-bridge exec vitest --configLoader runner run broker/message-send.test.ts broker/client.test.ts broker/adapters/slack.test.ts broker/integration.test.ts imessage-tools.test.ts`
- `pnpm --dir imessage-bridge exec vitest --configLoader runner run adapter.test.ts`
- `pnpm --filter @gugu910/pi-transport-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-imessage-bridge typecheck`
- `pnpm --filter @gugu910/pi-transport-core test`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-transport-core lint`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-imessage-bridge lint`
- push hook/root cached test pass

Refs #403

Salvage source: #518