### PR TITLE
fix(slack-bridge): warn on unverified pinet_free delivery claims

### DIFF
--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -14,7 +14,10 @@ import {
 import { startBroker, type Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
-import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
+import {
+  DEFAULT_HEARTBEAT_TIMEOUT_MS,
+  type AgentStatusChangeMetadata,
+} from "./broker/socket-server.js";
 import { MessageRouter } from "./broker/router.js";
 import {
   DEFAULT_BROKER_MAINTENANCE_INTERVAL_MS,
@@ -108,6 +111,7 @@ export interface BrokerRuntimeDeps {
     ctx: ExtensionContext,
     changedAgentId: string,
     status: "working" | "idle",
+    metadata: AgentStatusChangeMetadata,
   ) => void;
   createActivityLogger: (onError: (error: unknown) => void) => SlackActivityLogger;
   formatTrackedAgent: (agentId: string) => string;
@@ -648,11 +652,11 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
           if (targetAgentId !== brokerSelfId) return;
           syncBrokerDbInbox(brokerSelfId, broker.db as BrokerDB, ctx);
         });
-        broker.server.onAgentStatusChange((changedAgentId, status) => {
+        broker.server.onAgentStatusChange((changedAgentId, status, metadata) => {
           if (status === "idle") {
             runMaintenance(ctx);
           }
-          deps.onAgentStatusChange(ctx, changedAgentId, status);
+          deps.onAgentStatusChange(ctx, changedAgentId, status, metadata);
         });
 
         startBrokerHeartbeat();

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -417,8 +417,9 @@ export class BrokerClient {
 
   // ─── Status ────────────────────────────────────────────
 
-  async updateStatus(status: "working" | "idle"): Promise<void> {
-    await this.request("status.update", { status });
+  async updateStatus(status: "working" | "idle", options: { note?: string } = {}): Promise<void> {
+    const note = typeof options.note === "string" ? options.note.trim() : "";
+    await this.request("status.update", { status, ...(note ? { note } : {}) });
   }
 
   // ─── Agent-to-agent messaging ─────────────────────────

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -733,6 +733,55 @@ describe("BrokerDB", () => {
     expect(updated[0].prNumber).toBe(201);
   });
 
+  it("counts outbound evidence for active task assignment threads after the assignment message", () => {
+    db.registerAgent("broker", "Broker Crane", "🪿", 10);
+    db.registerAgent("worker-1", "Hyper Horse", "🐎", 100);
+    db.createThread("a2a:broker:worker-1", "agent", "", "broker");
+
+    db.insertMessage(
+      "a2a:broker:worker-1",
+      "agent",
+      "outbound",
+      "worker-1",
+      "old report before the assignment",
+      ["broker"],
+    );
+    const sourceMessage = db.insertMessage(
+      "a2a:broker:worker-1",
+      "agent",
+      "inbound",
+      "broker",
+      "Please take issue #114",
+      ["worker-1"],
+    );
+    db.recordTaskAssignment(
+      "worker-1",
+      114,
+      "feat/ralph-completion-v2",
+      "a2a:broker:worker-1",
+      sourceMessage.id,
+    );
+
+    expect(db.getActiveTaskAssignmentDeliveryEvidenceForAgent("worker-1")).toEqual({
+      trackedThreadCount: 1,
+      outboundCount: 0,
+    });
+
+    db.insertMessage(
+      "a2a:broker:worker-1",
+      "agent",
+      "outbound",
+      "worker-1",
+      "final report delivered",
+      ["broker"],
+    );
+
+    expect(db.getActiveTaskAssignmentDeliveryEvidenceForAgent("worker-1")).toEqual({
+      trackedThreadCount: 1,
+      outboundCount: 1,
+    });
+  });
+
   it("does not reset tracked progress when the broker sends a reminder on the same branch", () => {
     db.registerAgent("worker-1", "Hyper Horse", "🐎", 100);
 

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -221,19 +221,23 @@ describe("broker integration — client ↔ server ↔ DB", () => {
   });
 
   it("invokes status change callbacks when a client explicitly marks itself free", async () => {
-    const changes: Array<{ agentId: string; status: "working" | "idle" }> = [];
-    server.onAgentStatusChange((agentId, status) => {
-      changes.push({ agentId, status });
+    const changes: Array<{
+      agentId: string;
+      status: "working" | "idle";
+      metadata: { note?: string };
+    }> = [];
+    server.onAgentStatusChange((agentId, status, metadata) => {
+      changes.push({ agentId, status, metadata });
     });
 
     const reg = await client.register("free-agent", "🆓");
 
     await client.updateStatus("working");
-    await client.updateStatus("idle");
+    await client.updateStatus("idle", { note: "delivered report" });
 
     expect(changes).toEqual([
-      { agentId: reg.agentId, status: "working" },
-      { agentId: reg.agentId, status: "idle" },
+      { agentId: reg.agentId, status: "working", metadata: {} },
+      { agentId: reg.agentId, status: "idle", metadata: { note: "delivered report" } },
     ]);
     expect(db.getAgentById(reg.agentId)?.status).toBe("idle");
   });

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -8,6 +8,11 @@ import {
 } from "@gugu910/pi-broker-core/schema";
 import type { RalphCycleRecord } from "../helpers.js";
 
+export interface AgentDeliveryEvidence {
+  trackedThreadCount: number;
+  outboundCount: number;
+}
+
 interface RalphCycleRow {
   id: number;
   started_at: string;
@@ -59,6 +64,43 @@ export class BrokerDB extends CoreBrokerDB {
   override initialize(): void {
     super.initialize();
     ensureRalphCycleTable(this.getDb());
+  }
+
+  getActiveTaskAssignmentDeliveryEvidenceForAgent(agentId: string): AgentDeliveryEvidence {
+    const db = this.getDb();
+    const threadRow = db
+      .prepare(
+        `SELECT COUNT(DISTINCT thread_id) AS count
+         FROM task_assignments
+         WHERE agent_id = ?
+           AND status IN ('assigned', 'branch_pushed', 'pr_open')`,
+      )
+      .get(agentId) as { count: number } | undefined;
+    const outboundRow = db
+      .prepare(
+        `SELECT COUNT(DISTINCT message.id) AS count
+         FROM messages message
+         WHERE message.sender = ?
+           AND message.source = 'agent'
+           AND message.direction = 'outbound'
+           AND EXISTS (
+             SELECT 1
+             FROM task_assignments assignment
+             WHERE assignment.agent_id = ?
+               AND assignment.status IN ('assigned', 'branch_pushed', 'pr_open')
+               AND assignment.thread_id = message.thread_id
+               AND (
+                 assignment.source_message_id IS NULL
+                 OR message.id > assignment.source_message_id
+               )
+           )`,
+      )
+      .get(agentId, agentId) as { count: number } | undefined;
+
+    return {
+      trackedThreadCount: Number(threadRow?.count ?? 0),
+      outboundCount: Number(outboundRow?.count ?? 0),
+    };
   }
 
   recordRalphCycle(record: Omit<RalphCycleRecord, "id">): number {

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -50,7 +50,15 @@ export type AgentMessageCallback = (
   metadata: Record<string, unknown>,
 ) => void;
 
-export type AgentStatusChangeCallback = (agentId: string, status: "working" | "idle") => void;
+export interface AgentStatusChangeMetadata {
+  note?: string;
+}
+
+export type AgentStatusChangeCallback = (
+  agentId: string,
+  status: "working" | "idle",
+  metadata: AgentStatusChangeMetadata,
+) => void;
 
 function toClientAgentInfo(agent: AgentInfo): ClientAgentInfo {
   const { stableId, ...clientAgent } = agent;
@@ -948,9 +956,10 @@ export class BrokerSocketServer {
 
     const params = req.params ?? {};
     const status = params.status === "working" ? "working" : "idle";
+    const note = typeof params.note === "string" ? params.note.trim() : "";
     this.db.updateAgentStatus(state.agentId, status);
     try {
-      this.agentStatusChangeCallback?.(state.agentId, status);
+      this.agentStatusChangeCallback?.(state.agentId, status, note ? { note } : {});
     } catch {
       /* best effort */
     }

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -91,7 +91,7 @@ export interface FollowerRuntime {
   ) => Promise<{ unregisterError: string | null }>;
   syncDesiredStatus: (
     desiredStatus: "working" | "idle",
-    options?: { force?: boolean },
+    options?: { force?: boolean; note?: string },
   ) => Promise<void>;
   flushDeliveredAcks: () => Promise<void>;
   getClientRef: () => BrokerClientRef | null;
@@ -152,7 +152,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
 
   async function syncDesiredStatus(
     desiredStatus: "working" | "idle",
-    options: { force?: boolean } = {},
+    options: { force?: boolean; note?: string } = {},
   ): Promise<void> {
     if (!clientRef) {
       return;
@@ -160,15 +160,23 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
     if (!options.force && syncedFollowerStatus === desiredStatus) {
       return;
     }
-    if (followerStatusSyncPromise && followerStatusSyncTarget === desiredStatus) {
+    const note = typeof options.note === "string" ? options.note.trim() : "";
+    if (
+      !options.force &&
+      !note &&
+      followerStatusSyncPromise &&
+      followerStatusSyncTarget === desiredStatus
+    ) {
       await followerStatusSyncPromise;
       return;
     }
 
     const targetStatus = desiredStatus;
-    const request = clientRef.client.updateStatus(targetStatus).then(() => {
-      syncedFollowerStatus = targetStatus;
-    });
+    const request = clientRef.client
+      .updateStatus(targetStatus, note ? { note } : undefined)
+      .then(() => {
+        syncedFollowerStatus = targetStatus;
+      });
     followerStatusSyncTarget = targetStatus;
     const inFlight = request.finally(() => {
       if (followerStatusSyncPromise === inFlight) {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -46,6 +46,7 @@ import {
   buildRalphLoopCycleNotifications,
   buildRalphLoopFollowUpMessage,
   buildRalphLoopStatusMessage,
+  containsDeliveryClaimLanguage,
   shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -551,6 +552,19 @@ describe("formatInboxMessages", () => {
     expect(result).toContain("will: See attached note");
     expect(result).not.toContain("canvas_comments_read");
     expect(result).not.toContain(" | canvas=");
+  });
+});
+
+describe("containsDeliveryClaimLanguage", () => {
+  it("detects delivery-like self-reports in free notes", () => {
+    expect(containsDeliveryClaimLanguage("delivered report")).toBe(true);
+    expect(containsDeliveryClaimLanguage("reported back to broker")).toBe(true);
+    expect(containsDeliveryClaimLanguage("shared results")).toBe(true);
+  });
+
+  it("ignores neutral completion notes", () => {
+    expect(containsDeliveryClaimLanguage("wrapped up #462")).toBe(false);
+    expect(containsDeliveryClaimLanguage("waiting for more work")).toBe(false);
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1493,6 +1493,13 @@ export function buildRalphLoopStatusMessage(summary: string, cycleStartedAt: str
   return `RALPH loop (${cycleStartedAt}): ${summary}`;
 }
 
+const DELIVERY_CLAIM_NOTE_REGEX =
+  /\b(deliver(?:ed|y|ing)?|reported|replied|sent|posted|shared|submitted|returned|responded)\b/i;
+
+export function containsDeliveryClaimLanguage(note: string): boolean {
+  return DELIVERY_CLAIM_NOTE_REGEX.test(note);
+}
+
 export interface RalphLoopFollowUpDeliveryOptions {
   signature: string;
   lastDeliveredSignature?: string;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -14,6 +14,7 @@ import {
   resolveAgentStableId,
   resolveAllowAllWorkspaceUsers,
   trackBrokerInboundThread,
+  containsDeliveryClaimLanguage,
 } from "./helpers.js";
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
@@ -447,6 +448,23 @@ export default function (pi: ExtensionAPI) {
     getCurrentRuntimeMode: () => currentRuntimeMode,
     maybeDrainInboxIfIdle,
     getExtensionContext: () => sessionUiRuntime.getExtensionContext() ?? undefined,
+    noteClaimsDelivery: containsDeliveryClaimLanguage,
+    logSuspiciousDeliveryClaim: ({ agentId, note, trackedThreadCount, outboundCount }) => {
+      brokerRuntime.logActivity({
+        kind: "suspicious_delivery_claim",
+        level: "actions",
+        title: "Unverified delivery claim in pinet_free note",
+        summary: `${formatTrackedAgent(agentId)} claimed delivery in pinet_free without broker-observed outbound evidence.`,
+        details: [
+          `Note: ${note}`,
+          `Active assignment threads: ${trackedThreadCount}`,
+          `Broker-observed outbound messages on active assignment threads: ${outboundCount}`,
+          "Treat the delivery claim as suspicious until a real pinet_message report is visible.",
+        ],
+        fields: [{ label: "Agent", value: formatTrackedAgent(agentId) }],
+        tone: "warning",
+      });
+    },
   });
   const { reportStatus, signalAgentFree } = pinetAgentStatus;
   reportAgentStatus = reportStatus;
@@ -844,7 +862,7 @@ export default function (pi: ExtensionAPI) {
         tone: "error",
       });
     },
-    onAgentStatusChange: (_ctx, changedAgentId, status) => {
+    onAgentStatusChange: (_ctx, changedAgentId, status, metadata) => {
       brokerRuntime.logActivity({
         kind: "agent_status",
         level: "verbose",
@@ -852,6 +870,32 @@ export default function (pi: ExtensionAPI) {
         summary: `${formatTrackedAgent(changedAgentId)} marked itself ${status}.`,
         fields: [{ label: "Agent", value: formatTrackedAgent(changedAgentId) }],
         tone: status === "idle" ? "success" : "info",
+      });
+
+      const note = typeof metadata.note === "string" ? metadata.note.trim() : "";
+      if (status !== "idle" || !note || !containsDeliveryClaimLanguage(note)) {
+        return;
+      }
+
+      const evidence =
+        getActiveBrokerDb()?.getActiveTaskAssignmentDeliveryEvidenceForAgent(changedAgentId);
+      if (!evidence || evidence.outboundCount > 0) {
+        return;
+      }
+
+      brokerRuntime.logActivity({
+        kind: "suspicious_delivery_claim",
+        level: "actions",
+        title: "Unverified delivery claim in pinet_free note",
+        summary: `${formatTrackedAgent(changedAgentId)} claimed delivery in pinet_free without broker-observed outbound evidence.`,
+        details: [
+          `Note: ${note}`,
+          `Active assignment threads: ${evidence.trackedThreadCount}`,
+          `Broker-observed outbound messages on active assignment threads: ${evidence.outboundCount}`,
+          "Treat the delivery claim as suspicious until a real pinet_message report is visible.",
+        ],
+        fields: [{ label: "Agent", value: formatTrackedAgent(changedAgentId) }],
+        tone: "warning",
       });
     },
   });

--- a/slack-bridge/pinet-agent-status.test.ts
+++ b/slack-bridge/pinet-agent-status.test.ts
@@ -18,8 +18,23 @@ function createDeps(overrides: Partial<PinetAgentStatusDeps> = {}) {
   const syncFollowerDesiredStatus = vi.fn(async () => undefined);
   const runBrokerMaintenance = vi.fn();
   const maybeDrainInboxIfIdle = vi.fn(() => true);
+  const getActiveTaskAssignmentDeliveryEvidenceForAgent = vi.fn(() => ({
+    trackedThreadCount: 0,
+    outboundCount: 0,
+  }));
+  const noteClaimsDelivery = vi.fn<(note: string) => boolean>(() => false);
+  const logSuspiciousDeliveryClaim =
+    vi.fn<
+      (details: {
+        agentId: string;
+        note: string;
+        trackedThreadCount: number;
+        outboundCount: number;
+      }) => void
+    >();
   const brokerDb: PinetAgentStatusBrokerDbPort = {
     updateAgentStatus,
+    getActiveTaskAssignmentDeliveryEvidenceForAgent,
   };
 
   const deps: PinetAgentStatusDeps = {
@@ -38,6 +53,8 @@ function createDeps(overrides: Partial<PinetAgentStatusDeps> = {}) {
     getCurrentRuntimeMode: () => "off",
     maybeDrainInboxIfIdle,
     getExtensionContext: () => ctx,
+    noteClaimsDelivery,
+    logSuspiciousDeliveryClaim,
     ...overrides,
   };
 
@@ -48,6 +65,9 @@ function createDeps(overrides: Partial<PinetAgentStatusDeps> = {}) {
     syncFollowerDesiredStatus,
     runBrokerMaintenance,
     maybeDrainInboxIfIdle,
+    getActiveTaskAssignmentDeliveryEvidenceForAgent,
+    noteClaimsDelivery,
+    logSuspiciousDeliveryClaim,
     getDesiredAgentStatus: () => desiredAgentStatus,
   };
 }
@@ -76,6 +96,23 @@ describe("createPinetAgentStatus", () => {
 
     expect(getDesiredAgentStatus()).toBe("idle");
     expect(syncFollowerDesiredStatus).toHaveBeenCalledWith("idle", {});
+  });
+
+  it("forwards delivery-claim notes to follower status sync even when already idle", async () => {
+    const { deps, syncFollowerDesiredStatus } = createDeps({
+      getBrokerRole: () => "follower",
+      hasFollowerClient: () => true,
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await pinetAgentStatus.reportStatus("idle");
+    syncFollowerDesiredStatus.mockClear();
+    await pinetAgentStatus.signalAgentFree(undefined, { note: "delivered report" });
+
+    expect(syncFollowerDesiredStatus).toHaveBeenCalledWith("idle", {
+      force: true,
+      note: "delivered report",
+    });
   });
 
   it("signals broker free, runs maintenance, and drains queued inbox via the cached context", async () => {
@@ -126,5 +163,53 @@ describe("createPinetAgentStatus", () => {
     await expect(
       pinetAgentStatus.signalAgentFree(undefined, { requirePinet: true }),
     ).rejects.toThrow("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+  });
+
+  it("flags broker-local delivery-claim notes without broker-observed outbound evidence", async () => {
+    const {
+      deps,
+      getActiveTaskAssignmentDeliveryEvidenceForAgent,
+      noteClaimsDelivery,
+      logSuspiciousDeliveryClaim,
+    } = createDeps({
+      getBrokerRole: () => "broker",
+    });
+    noteClaimsDelivery.mockReturnValue(true);
+    getActiveTaskAssignmentDeliveryEvidenceForAgent.mockReturnValue({
+      trackedThreadCount: 1,
+      outboundCount: 0,
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await pinetAgentStatus.signalAgentFree(undefined, { note: "delivered report" });
+
+    expect(getActiveTaskAssignmentDeliveryEvidenceForAgent).toHaveBeenCalledWith("agent-1");
+    expect(logSuspiciousDeliveryClaim).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      note: "delivered report",
+      trackedThreadCount: 1,
+      outboundCount: 0,
+    });
+  });
+
+  it("does not flag delivery-claim notes once outbound evidence exists", async () => {
+    const {
+      deps,
+      getActiveTaskAssignmentDeliveryEvidenceForAgent,
+      noteClaimsDelivery,
+      logSuspiciousDeliveryClaim,
+    } = createDeps({
+      getBrokerRole: () => "broker",
+    });
+    noteClaimsDelivery.mockReturnValue(true);
+    getActiveTaskAssignmentDeliveryEvidenceForAgent.mockReturnValue({
+      trackedThreadCount: 1,
+      outboundCount: 1,
+    });
+    const pinetAgentStatus = createPinetAgentStatus(deps);
+
+    await pinetAgentStatus.signalAgentFree(undefined, { note: "reported back" });
+
+    expect(logSuspiciousDeliveryClaim).not.toHaveBeenCalled();
   });
 });

--- a/slack-bridge/pinet-agent-status.ts
+++ b/slack-bridge/pinet-agent-status.ts
@@ -3,8 +3,14 @@ import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 export type PinetAgentStatusValue = "working" | "idle";
 
+export interface PinetAgentDeliveryEvidence {
+  trackedThreadCount: number;
+  outboundCount: number;
+}
+
 export interface PinetAgentStatusBrokerDbPort {
   updateAgentStatus: (agentId: string, status: PinetAgentStatusValue) => void;
+  getActiveTaskAssignmentDeliveryEvidenceForAgent?: (agentId: string) => PinetAgentDeliveryEvidence;
 }
 
 export interface PinetAgentStatusDeps {
@@ -17,26 +23,35 @@ export interface PinetAgentStatusDeps {
   hasFollowerClient: () => boolean;
   syncFollowerDesiredStatus: (
     status: PinetAgentStatusValue,
-    options: { force?: boolean },
+    options: { force?: boolean; note?: string },
   ) => Promise<void>;
   runBrokerMaintenance: (ctx: ExtensionContext) => void;
   getInboxLength: () => number;
   getCurrentRuntimeMode: () => SlackBridgeRuntimeMode;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
   getExtensionContext: () => ExtensionContext | undefined;
+  noteClaimsDelivery: (note: string) => boolean;
+  logSuspiciousDeliveryClaim: (details: {
+    agentId: string;
+    note: string;
+    trackedThreadCount: number;
+    outboundCount: number;
+  }) => void;
 }
 
 export interface PinetAgentStatus {
-  syncDesiredAgentStatus: (options?: { force?: boolean }) => Promise<void>;
+  syncDesiredAgentStatus: (options?: { force?: boolean; note?: string }) => Promise<void>;
   reportStatus: (status: PinetAgentStatusValue) => Promise<void>;
   signalAgentFree: (
     ctx?: ExtensionContext,
-    options?: { requirePinet?: boolean },
+    options?: { requirePinet?: boolean; note?: string },
   ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
 }
 
 export function createPinetAgentStatus(deps: PinetAgentStatusDeps): PinetAgentStatus {
-  async function syncDesiredAgentStatus(options: { force?: boolean } = {}): Promise<void> {
+  async function syncDesiredAgentStatus(
+    options: { force?: boolean; note?: string } = {},
+  ): Promise<void> {
     if (!deps.getPinetEnabled()) {
       return;
     }
@@ -62,18 +77,43 @@ export function createPinetAgentStatus(deps: PinetAgentStatusDeps): PinetAgentSt
     await syncDesiredAgentStatus();
   }
 
+  function maybeLogSuspiciousDeliveryClaim(note: string): void {
+    if (!note || !deps.noteClaimsDelivery(note)) {
+      return;
+    }
+    const db = deps.getActiveBrokerDb();
+    const selfId = deps.getActiveBrokerSelfId();
+    if (!db || !selfId) {
+      return;
+    }
+    const evidence = db.getActiveTaskAssignmentDeliveryEvidenceForAgent?.(selfId);
+    if (!evidence || evidence.outboundCount > 0) {
+      return;
+    }
+
+    deps.logSuspiciousDeliveryClaim({
+      agentId: selfId,
+      note,
+      trackedThreadCount: evidence.trackedThreadCount,
+      outboundCount: evidence.outboundCount,
+    });
+  }
+
   async function signalAgentFree(
     ctx?: ExtensionContext,
-    options: { requirePinet?: boolean } = {},
+    options: { requirePinet?: boolean; note?: string } = {},
   ): Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }> {
     const pinetEnabled = deps.getPinetEnabled();
     if (!pinetEnabled && options.requirePinet) {
       throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
     }
 
+    const note = typeof options.note === "string" ? options.note.trim() : "";
     const maintenanceCtx = ctx ?? deps.getExtensionContext() ?? undefined;
     if (pinetEnabled) {
-      await reportStatus("idle");
+      deps.setDesiredAgentStatus("idle");
+      await syncDesiredAgentStatus({ force: note.length > 0, ...(note ? { note } : {}) });
+      maybeLogSuspiciousDeliveryClaim(note);
       if (deps.getBrokerRole() === "broker" && maintenanceCtx) {
         deps.runBrokerMaintenance(maintenanceCtx);
       }

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -135,7 +135,10 @@ describe("registerPinetTools", () => {
       details: { status: string; note: string | null; queuedInboxCount: number };
     };
 
-    expect(signalAgentFree).toHaveBeenCalledWith(undefined, { requirePinet: true });
+    expect(signalAgentFree).toHaveBeenCalledWith(undefined, {
+      requirePinet: true,
+      note: "wrapped up #395",
+    });
     expect(result.content[0]?.text).toBe(
       "Marked this Pinet agent idle/free for new work. Note: wrapped up #395. 2 queued inbox items remain.",
     );

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -45,7 +45,7 @@ export interface RegisterPinetToolsDeps {
   };
   signalAgentFree: (
     ctx: ExtensionContext | undefined,
-    options: { requirePinet?: boolean },
+    options: { requirePinet?: boolean; note?: string },
   ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
   scheduleBrokerWakeup: (
     fireAt: string,
@@ -146,7 +146,10 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       deps.requireToolPolicy("pinet_free", undefined, `note=${params.note ?? ""}`);
 
       const note = typeof params.note === "string" ? params.note.trim() : "";
-      const result = await deps.signalAgentFree(undefined, { requirePinet: true });
+      const result = await deps.signalAgentFree(undefined, {
+        requirePinet: true,
+        ...(note ? { note } : {}),
+      });
       const inboxSuffix =
         result.queuedInboxCount > 0
           ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`


### PR DESCRIPTION
## Summary
- forwards `pinet_free` notes through follower idle status updates so the broker can inspect delivery claims
- flags suspicious delivery-claim notes when active assignment threads have no broker-observed outbound `pinet_message` evidence after the assignment message
- adds focused coverage for delivery-claim detection, note propagation, evidence counting, and `pinet_free` note plumbing

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run pinet-agent-status.test.ts pinet-tools.test.ts helpers.test.ts broker/integration.test.ts broker/helpers.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- pre-push hook on `git push` (ran full cached workspace checks; slack-bridge full suite passed: 70 files / 1148 tests)

Follow-up to Thomas PR #517 / issue #462.