### PR TITLE
feat(pinet): add durable inbox read tool

### DIFF
--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -7,6 +7,9 @@ import type {
   ThreadInfo,
   BrokerMessage,
   InboxEntry,
+  InboxReadOptions,
+  InboxReadResult,
+  InboxThreadUnreadSummary,
   BacklogEntry,
   BrokerDBInterface,
   InboundMessage,
@@ -197,7 +200,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 11;
+export const CURRENT_BROKER_SCHEMA_VERSION = 12;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -265,6 +268,7 @@ function createCoreTables(db: DatabaseSync): void {
       agent_id TEXT NOT NULL,
       message_id INTEGER NOT NULL,
       delivered INTEGER NOT NULL DEFAULT 0,
+      read_at TEXT,
       created_at TEXT NOT NULL
     );
 
@@ -272,6 +276,8 @@ function createCoreTables(db: DatabaseSync): void {
       ON messages(thread_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_inbox_agent_delivered
       ON inbox(agent_id, delivered, created_at);
+    CREATE INDEX IF NOT EXISTS idx_inbox_agent_read
+      ON inbox(agent_id, read_at, created_at);
     CREATE INDEX IF NOT EXISTS idx_inbox_message
       ON inbox(message_id);
   `);
@@ -364,6 +370,15 @@ function addObservabilityColumns(db: DatabaseSync): void {
 function addThreadOwnershipBindingColumn(db: DatabaseSync): void {
   createCoreTables(db);
   ensureColumn(db, "threads", "owner_binding", "ALTER TABLE threads ADD COLUMN owner_binding TEXT");
+}
+
+function addInboxReadCursorColumn(db: DatabaseSync): void {
+  createCoreTables(db);
+  ensureColumn(db, "inbox", "read_at", "ALTER TABLE inbox ADD COLUMN read_at TEXT");
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_inbox_agent_read
+      ON inbox(agent_id, read_at, created_at);
+  `);
 }
 
 function addBacklogAffinityColumns(db: DatabaseSync): void {
@@ -541,6 +556,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 11:
           addThreadOwnershipBindingColumn(db);
+          break;
+        case 12:
+          addInboxReadCursorColumn(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -1814,7 +1832,7 @@ export class BrokerDB implements BrokerDBInterface {
       .prepare(
         `SELECT
            i.id AS i_id, i.agent_id AS i_agent_id, i.message_id AS i_message_id,
-           i.delivered AS i_delivered, i.created_at AS i_created_at,
+           i.delivered AS i_delivered, i.read_at AS i_read_at, i.created_at AS i_created_at,
            m.id AS m_id, m.thread_id AS m_thread_id, m.source AS m_source,
            m.direction AS m_direction, m.sender AS m_sender, m.body AS m_body,
            m.metadata AS m_metadata, m.created_at AS m_created_at
@@ -1829,6 +1847,7 @@ export class BrokerDB implements BrokerDBInterface {
       i_agent_id: string;
       i_message_id: number;
       i_delivered: number;
+      i_read_at: string | null;
       i_created_at: string;
       m_id: number;
       m_thread_id: string;
@@ -1846,6 +1865,7 @@ export class BrokerDB implements BrokerDBInterface {
         agentId: r.i_agent_id,
         messageId: r.i_message_id,
         delivered: r.i_delivered === 1,
+        readAt: r.i_read_at,
         createdAt: r.i_created_at,
       },
       message: {
@@ -1859,6 +1879,161 @@ export class BrokerDB implements BrokerDBInterface {
         createdAt: r.m_created_at,
       },
     }));
+  }
+
+  readInbox(agentId: string, options: InboxReadOptions = {}): InboxReadResult {
+    const db = this.getDb();
+    const unreadOnly = options.unreadOnly ?? true;
+    const markRead = options.markRead ?? true;
+    const limit = Math.min(Math.max(Math.trunc(options.limit ?? 20), 1), 100);
+    const threadId = options.threadId?.trim();
+    const unreadCountBefore = this.getUnreadInboxCount(agentId);
+
+    const clauses = ["i.agent_id = ?"];
+    const values: Array<string | number> = [agentId];
+    if (unreadOnly) {
+      clauses.push("i.read_at IS NULL");
+    }
+    if (threadId) {
+      clauses.push("m.thread_id = ?");
+      values.push(threadId);
+    }
+
+    const order = unreadOnly ? "m.created_at ASC, i.id ASC" : "m.created_at DESC, i.id DESC";
+    const rows = db
+      .prepare(
+        `SELECT
+           i.id AS i_id, i.agent_id AS i_agent_id, i.message_id AS i_message_id,
+           i.delivered AS i_delivered, i.read_at AS i_read_at, i.created_at AS i_created_at,
+           m.id AS m_id, m.thread_id AS m_thread_id, m.source AS m_source,
+           m.direction AS m_direction, m.sender AS m_sender, m.body AS m_body,
+           m.metadata AS m_metadata, m.created_at AS m_created_at
+         FROM inbox i
+         JOIN messages m ON m.id = i.message_id
+         WHERE ${clauses.join(" AND ")}
+         ORDER BY ${order}
+         LIMIT ?`,
+      )
+      .all(...values, limit) as unknown as Array<{
+      i_id: number;
+      i_agent_id: string;
+      i_message_id: number;
+      i_delivered: number;
+      i_read_at: string | null;
+      i_created_at: string;
+      m_id: number;
+      m_thread_id: string;
+      m_source: string;
+      m_direction: string;
+      m_sender: string;
+      m_body: string;
+      m_metadata: string | null;
+      m_created_at: string;
+    }>;
+
+    const orderedRows = unreadOnly ? rows : rows.reverse();
+    const messages = orderedRows.map((r) => ({
+      entry: {
+        id: r.i_id,
+        agentId: r.i_agent_id,
+        messageId: r.i_message_id,
+        delivered: r.i_delivered === 1,
+        readAt: r.i_read_at,
+        createdAt: r.i_created_at,
+      },
+      message: {
+        id: r.m_id,
+        threadId: r.m_thread_id,
+        source: r.m_source,
+        direction: r.m_direction as "inbound" | "outbound",
+        sender: r.m_sender,
+        body: r.m_body,
+        metadata: r.m_metadata ? (JSON.parse(r.m_metadata) as Record<string, unknown>) : null,
+        createdAt: r.m_created_at,
+      },
+    }));
+
+    const markedReadIds = messages
+      .filter((item) => item.entry.readAt === null)
+      .map((item) => item.entry.id);
+    if (markRead && markedReadIds.length > 0) {
+      this.markRead(markedReadIds, agentId);
+      const readAt = new Date().toISOString();
+      for (const item of messages) {
+        if (markedReadIds.includes(item.entry.id)) {
+          item.entry.readAt = readAt;
+        }
+      }
+    }
+
+    const unreadCountAfter = this.getUnreadInboxCount(agentId);
+    const unreadThreads = this.getUnreadThreadSummary(agentId);
+    return {
+      messages,
+      unreadCountBefore,
+      unreadCountAfter,
+      unreadThreads,
+      markedReadIds: markRead ? markedReadIds : [],
+    };
+  }
+
+  getUnreadInboxCount(agentId: string): number {
+    const db = this.getDb();
+    const row = db
+      .prepare("SELECT COUNT(*) AS count FROM inbox WHERE agent_id = ? AND read_at IS NULL")
+      .get(agentId) as { count?: number } | undefined;
+    return Number(row?.count ?? 0);
+  }
+
+  getUnreadThreadSummary(agentId: string, limit = 20): InboxThreadUnreadSummary[] {
+    const db = this.getDb();
+    const clampedLimit = Math.min(Math.max(Math.trunc(limit), 1), 100);
+    const rows = db
+      .prepare(
+        `SELECT
+           m.thread_id AS thread_id,
+           m.source AS source,
+           COALESCE(t.channel, '') AS channel,
+           COUNT(*) AS unread_count,
+           MAX(m.id) AS latest_message_id,
+           MAX(m.created_at) AS latest_at
+         FROM inbox i
+         JOIN messages m ON m.id = i.message_id
+         LEFT JOIN threads t ON t.thread_id = m.thread_id
+         WHERE i.agent_id = ? AND i.read_at IS NULL
+         GROUP BY m.thread_id, m.source, t.channel
+         ORDER BY latest_at DESC, latest_message_id DESC
+         LIMIT ?`,
+      )
+      .all(agentId, clampedLimit) as unknown as Array<{
+      thread_id: string;
+      source: string;
+      channel: string;
+      unread_count: number;
+      latest_message_id: number;
+      latest_at: string;
+    }>;
+
+    return rows.map((row) => ({
+      threadId: row.thread_id,
+      source: row.source,
+      channel: row.channel,
+      unreadCount: row.unread_count,
+      latestMessageId: row.latest_message_id,
+      latestAt: row.latest_at,
+    }));
+  }
+
+  markRead(inboxIds: number[], agentId: string): void {
+    if (inboxIds.length === 0) return;
+    const db = this.getDb();
+    const now = new Date().toISOString();
+    const stmt = db.prepare(
+      "UPDATE inbox SET read_at = COALESCE(read_at, ?) WHERE id = ? AND agent_id = ?",
+    );
+    for (const id of inboxIds) {
+      stmt.run(now, id, agentId);
+    }
   }
 
   getMessagesByIds(messageIds: number[]): BrokerMessage[] {

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -46,7 +46,32 @@ export interface InboxEntry {
   agentId: string;
   messageId: number;
   delivered: boolean;
+  readAt: string | null;
   createdAt: string;
+}
+
+export interface InboxReadOptions {
+  threadId?: string;
+  limit?: number;
+  unreadOnly?: boolean;
+  markRead?: boolean;
+}
+
+export interface InboxThreadUnreadSummary {
+  threadId: string;
+  source: string;
+  channel: string;
+  unreadCount: number;
+  latestMessageId: number;
+  latestAt: string;
+}
+
+export interface InboxReadResult {
+  messages: Array<{ entry: InboxEntry; message: BrokerMessage }>;
+  unreadCountBefore: number;
+  unreadCountAfter: number;
+  unreadThreads: InboxThreadUnreadSummary[];
+  markedReadIds: number[];
 }
 
 export interface ChannelAssignment {

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -311,6 +311,7 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 | Tool             | Description                                                                |
 | ---------------- | -------------------------------------------------------------------------- |
 | `pinet_message`  | Send a message to a connected Pinet agent or broker-only broadcast channel |
+| `pinet_read`     | Read durable SQLite-backed Pinet inbox context and unread thread pointers  |
 | `pinet_agents`   | List connected Pinet agents with status and capabilities                   |
 | `pinet_free`     | Mark this Pinet agent idle/free for new work                               |
 | `pinet_schedule` | Schedule a future wake-up for this Pinet agent                             |

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -533,6 +533,80 @@ describe("BrokerClient — pollInbox", () => {
   });
 });
 
+describe("BrokerClient — readInbox", () => {
+  let mock: MockServer;
+
+  beforeEach(async () => {
+    mock = await createMockServer();
+  });
+
+  afterEach(async () => {
+    await mock.close();
+  });
+
+  it("sends inbox.read and normalizes durable read rows", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const readPromise = client.readInbox({ threadId: "a2a:broker:worker", limit: 5 });
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { threadId: string; limit: number };
+    };
+    expect(req.method).toBe("inbox.read");
+    expect(req.params).toEqual({ threadId: "a2a:broker:worker", limit: 5 });
+
+    mock.respondTo(mock.connections[0], req.id, {
+      messages: [
+        {
+          entry: { id: 31, delivered: true, readAt: "2026-04-25T12:00:00.000Z" },
+          message: {
+            id: 44,
+            threadId: "a2a:broker:worker",
+            source: "agent",
+            direction: "inbound",
+            sender: "broker",
+            body: "please inspect #594",
+            metadata: { a2a: true },
+            createdAt: "2026-04-25T11:59:00.000Z",
+          },
+        },
+      ],
+      unreadCountBefore: 2,
+      unreadCountAfter: 1,
+      unreadThreads: [],
+      markedReadIds: [31],
+    });
+
+    const result = await readPromise;
+    expect(result.messages).toEqual([
+      {
+        inboxId: 31,
+        delivered: true,
+        readAt: "2026-04-25T12:00:00.000Z",
+        message: {
+          id: 44,
+          threadId: "a2a:broker:worker",
+          source: "agent",
+          direction: "inbound",
+          sender: "broker",
+          body: "please inspect #594",
+          metadata: { a2a: true },
+          createdAt: "2026-04-25T11:59:00.000Z",
+        },
+      },
+    ]);
+    expect(result.unreadCountBefore).toBe(2);
+    expect(result.unreadCountAfter).toBe(1);
+    expect(result.markedReadIds).toEqual([31]);
+
+    client.disconnect();
+  });
+});
+
 describe("BrokerClient — ackMessages", () => {
   let mock: MockServer;
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -21,6 +21,37 @@ export interface InboxItem {
   };
 }
 
+export interface PinetReadMessage {
+  inboxId: number;
+  delivered: boolean;
+  readAt: string | null;
+  message: InboxItem["message"];
+}
+
+export interface PinetUnreadThreadSummary {
+  threadId: string;
+  source: string;
+  channel: string;
+  unreadCount: number;
+  latestMessageId: number;
+  latestAt: string;
+}
+
+export interface PinetReadResult {
+  messages: PinetReadMessage[];
+  unreadCountBefore: number;
+  unreadCountAfter: number;
+  unreadThreads: PinetUnreadThreadSummary[];
+  markedReadIds: number[];
+}
+
+export interface PinetReadOptions {
+  threadId?: string;
+  limit?: number;
+  unreadOnly?: boolean;
+  markRead?: boolean;
+}
+
 export interface ThreadInfo {
   threadId: string;
   source: string;
@@ -349,6 +380,37 @@ export class BrokerClient {
   async pollInbox(): Promise<InboxItem[]> {
     const result = (await this.request("inbox.poll")) as InboxItem[];
     return result;
+  }
+
+  async readInbox(options: PinetReadOptions = {}): Promise<PinetReadResult> {
+    const result = (await this.request("inbox.read", {
+      ...(options.threadId ? { threadId: options.threadId } : {}),
+      ...(typeof options.limit === "number" ? { limit: options.limit } : {}),
+      ...(typeof options.unreadOnly === "boolean" ? { unreadOnly: options.unreadOnly } : {}),
+      ...(typeof options.markRead === "boolean" ? { markRead: options.markRead } : {}),
+    })) as {
+      messages: Array<{
+        entry: { id: number; delivered: boolean; readAt: string | null };
+        message: InboxItem["message"];
+      }>;
+      unreadCountBefore: number;
+      unreadCountAfter: number;
+      unreadThreads: PinetUnreadThreadSummary[];
+      markedReadIds: number[];
+    };
+
+    return {
+      messages: result.messages.map((item) => ({
+        inboxId: item.entry.id,
+        delivered: item.entry.delivered,
+        readAt: item.entry.readAt,
+        message: item.message,
+      })),
+      unreadCountBefore: result.unreadCountBefore,
+      unreadCountAfter: result.unreadCountAfter,
+      unreadThreads: result.unreadThreads,
+      markedReadIds: result.markedReadIds,
+    };
   }
 
   async ackMessages(ids: number[]): Promise<void> {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -96,6 +96,40 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("inbox.read returns unread context and marks it read independently from delivery ack", async () => {
+    const reg1 = await client.register("sender-agent", "📤");
+    expect(reg1.agentId).toBeDefined();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    await client2.register("receiver-agent", "📥");
+
+    await client.send("thread-read", "First unread message");
+    await client.send("thread-read", "Second unread message");
+
+    const read = await client2.readInbox({ threadId: "thread-read", limit: 10 });
+    expect(read.unreadCountBefore).toBe(2);
+    expect(read.messages.map((item) => item.message.body)).toEqual([
+      "First unread message",
+      "Second unread message",
+    ]);
+    expect(read.markedReadIds).toHaveLength(2);
+    expect(read.unreadCountAfter).toBe(0);
+
+    const unreadAgain = await client2.readInbox({ threadId: "thread-read" });
+    expect(unreadAgain.messages).toEqual([]);
+    expect(unreadAgain.unreadCountBefore).toBe(0);
+
+    const stillUndelivered = await client2.pollInbox();
+    expect(stillUndelivered).toHaveLength(2);
+    await client2.ackMessages(stillUndelivered.map((item) => item.inboxId));
+    expect(await client2.pollInbox()).toEqual([]);
+
+    client2.disconnect();
+  });
+
   it("sender does not receive own messages", async () => {
     await client.register("solo-agent", "🤖");
     await client.send("thread-solo", "Talking to myself");

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -476,6 +476,8 @@ export class BrokerSocketServer {
           return this.handleHeartbeat(req, state);
         case "inbox.poll":
           return this.handleInboxPoll(req, state);
+        case "inbox.read":
+          return this.handleInboxRead(req, state);
         case "inbox.ack":
           return this.handleInboxAck(req, state);
         case "send":
@@ -663,6 +665,45 @@ export class BrokerSocketServer {
         inboxId: item.entry.id,
         message: item.message,
       })),
+    );
+  }
+
+  private handleInboxRead(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
+    this.db.touchAgent(state.agentId);
+
+    const params = req.params ?? {};
+    const threadId = typeof params.threadId === "string" ? params.threadId.trim() : undefined;
+    if (params.threadId !== undefined && !threadId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "threadId must be a non-empty string");
+    }
+
+    const limit = params.limit === undefined ? undefined : params.limit;
+    if (limit !== undefined && (typeof limit !== "number" || !Number.isFinite(limit))) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "limit must be a finite number");
+    }
+
+    const unreadOnly = params.unreadOnly === undefined ? undefined : params.unreadOnly;
+    if (unreadOnly !== undefined && typeof unreadOnly !== "boolean") {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "unreadOnly must be a boolean");
+    }
+
+    const markRead = params.markRead === undefined ? undefined : params.markRead;
+    if (markRead !== undefined && typeof markRead !== "boolean") {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "markRead must be a boolean");
+    }
+
+    return rpcOk(
+      req.id,
+      this.db.readInbox(state.agentId, {
+        ...(threadId ? { threadId } : {}),
+        ...(typeof limit === "number" ? { limit } : {}),
+        ...(typeof unreadOnly === "boolean" ? { unreadOnly } : {}),
+        ...(typeof markRead === "boolean" ? { markRead } : {}),
+      }),
     );
   }
 

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -21,6 +21,7 @@ export const READ_ONLY_TOOLS = new Set([
   "slack:canvas_comments_read",
   "slack:confirm_action",
   "pinet_agents",
+  "pinet_read",
   "pinet_message",
   "memory_read",
   "memory_search",

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -877,6 +877,40 @@ export default function (pi: ExtensionAPI) {
     listFollowerAgents,
   } = pinetMeshOps;
 
+  async function readPinetInbox(options: {
+    threadId?: string;
+    limit?: number;
+    unreadOnly?: boolean;
+    markRead?: boolean;
+  }) {
+    if (brokerRole === "broker") {
+      const db = getActiveBrokerDb();
+      const selfId = getActiveBrokerSelfId();
+      if (!db || !selfId) {
+        throw new Error("Broker agent identity is unavailable.");
+      }
+      const result = db.readInbox(selfId, options);
+      return {
+        messages: result.messages.map((item) => ({
+          inboxId: item.entry.id,
+          delivered: item.entry.delivered,
+          readAt: item.entry.readAt,
+          message: item.message,
+        })),
+        unreadCountBefore: result.unreadCountBefore,
+        unreadCountAfter: result.unreadCountAfter,
+        unreadThreads: result.unreadThreads,
+        markedReadIds: result.markedReadIds,
+      };
+    }
+
+    if (brokerRole === "follower" && brokerClient?.client) {
+      return await brokerClient.client.readInbox(options);
+    }
+
+    throw new Error("Pinet is in an unexpected state.");
+  }
+
   async function transitionToRuntimeMode(
     ctx: ExtensionContext,
     mode: SlackBridgeRuntimeMode,
@@ -1023,6 +1057,7 @@ export default function (pi: ExtensionAPI) {
       signalAgentFree,
       scheduleBrokerWakeup,
       scheduleFollowerWakeup,
+      readPinetInbox,
       listBrokerAgents,
       listFollowerAgents,
     },

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -46,6 +46,13 @@ function createDeps(overrides: Partial<RegisterPinetToolsDeps> = {}): RegisterPi
     }),
     scheduleBrokerWakeup: async (fireAt: string, _message: string) => ({ id: 7, fireAt }),
     scheduleFollowerWakeup: async (fireAt: string, _message: string) => ({ id: 9, fireAt }),
+    readPinetInbox: async () => ({
+      messages: [],
+      unreadCountBefore: 0,
+      unreadCountAfter: 0,
+      unreadThreads: [],
+      markedReadIds: [],
+    }),
     listBrokerAgents: () => [makeAgent()],
     listFollowerAgents: async (_includeGhosts: boolean) => [makeAgent({ id: "agent-2" })],
   };
@@ -71,11 +78,12 @@ describe("registerPinetTools", () => {
     vi.restoreAllMocks();
   });
 
-  it("registers the four generic Pinet tools", () => {
+  it("registers the generic Pinet tools", () => {
     const tools = registerWithDeps(createDeps());
 
     expect([...tools.keys()]).toEqual([
       "pinet_message",
+      "pinet_read",
       "pinet_free",
       "pinet_schedule",
       "pinet_agents",
@@ -118,6 +126,62 @@ describe("registerPinetTools", () => {
       messageIds: [21, 22],
       recipients: ["Worker One", "Worker Two"],
     });
+  });
+
+  it("reads durable Pinet inbox context and marks returned rows read by default", async () => {
+    const readPinetInbox = vi.fn(async () => ({
+      messages: [
+        {
+          inboxId: 31,
+          delivered: true,
+          readAt: "2026-04-25T12:00:00.000Z",
+          message: {
+            id: 44,
+            threadId: "a2a:broker:worker",
+            source: "agent",
+            direction: "inbound",
+            sender: "broker",
+            body: "please inspect #594",
+            metadata: { a2a: true },
+            createdAt: "2026-04-25T11:59:00.000Z",
+          },
+        },
+      ],
+      unreadCountBefore: 2,
+      unreadCountAfter: 1,
+      unreadThreads: [
+        {
+          threadId: "a2a:broker:worker",
+          source: "agent",
+          channel: "",
+          unreadCount: 1,
+          latestMessageId: 45,
+          latestAt: "2026-04-25T12:01:00.000Z",
+        },
+      ],
+      markedReadIds: [31],
+    }));
+    const deps = createDeps({ readPinetInbox });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet_read")?.execute("tool-call-read", {
+      thread_id: "a2a:broker:worker",
+      limit: 5,
+    })) as {
+      content: Array<{ text: string }>;
+      details: { markedReadIds: number[] };
+    };
+
+    expect(readPinetInbox).toHaveBeenCalledWith({ threadId: "a2a:broker:worker", limit: 5 });
+    expect(result.content[0]?.text).toContain(
+      "Pinet read (unread) from thread a2a:broker:worker: 1 message.",
+    );
+    expect(result.content[0]?.text).toContain("Unread before: 2; unread after: 1.");
+    expect(result.content[0]?.text).toContain(
+      "- [agent/a2a:broker:worker #44] broker: please inspect #594",
+    );
+    expect(result.content[0]?.text).toContain("Marked read: 31.");
+    expect(result.details.markedReadIds).toEqual([31]);
   });
 
   it("formats pinet_free responses with note and queued inbox count", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -11,6 +11,7 @@ import {
 import { isBroadcastChannelTarget } from "./broker/agent-messaging.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import type { PinetReadOptions, PinetReadResult } from "./broker/client.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 
 export interface PinetToolsAgentRecord {
@@ -55,6 +56,7 @@ export interface RegisterPinetToolsDeps {
     fireAt: string,
     message: string,
   ) => Promise<{ id: number; fireAt: string }>;
+  readPinetInbox: (options: PinetReadOptions) => Promise<PinetReadResult>;
   listBrokerAgents: () => PinetToolsAgentRecord[];
   listFollowerAgents: (includeGhosts: boolean) => Promise<PinetToolsAgentRecord[]>;
 }
@@ -79,6 +81,39 @@ function buildPinetAgentsHintText(hint: PinetAgentsRoutingHint): string {
   ]
     .filter((item): item is string => Boolean(item))
     .join(" · ")}`;
+}
+
+function formatPinetReadResult(result: PinetReadResult, options: PinetReadOptions): string {
+  const scope = options.threadId ? `thread ${options.threadId}` : "your Pinet inbox";
+  const mode = options.unreadOnly === false ? "latest" : "unread";
+  const lines = [
+    `Pinet read (${mode}) from ${scope}: ${result.messages.length} message${result.messages.length === 1 ? "" : "s"}.`,
+    `Unread before: ${result.unreadCountBefore}; unread after: ${result.unreadCountAfter}.`,
+  ];
+
+  if (result.messages.length > 0) {
+    lines.push("");
+    for (const item of result.messages) {
+      lines.push(
+        `- [${item.message.source}/${item.message.threadId} #${item.message.id}] ${item.message.sender}: ${item.message.body}`,
+      );
+    }
+  }
+
+  if (result.unreadThreads.length > 0) {
+    lines.push("", "Unread thread pointers:");
+    for (const thread of result.unreadThreads.slice(0, 10)) {
+      lines.push(
+        `- ${thread.threadId} (${thread.source}${thread.channel ? `/${thread.channel}` : ""}): ${thread.unreadCount} unread; latest #${thread.latestMessageId}`,
+      );
+    }
+  }
+
+  if (result.markedReadIds.length > 0) {
+    lines.push("", `Marked read: ${result.markedReadIds.join(", ")}.`);
+  }
+
+  return lines.join("\n");
 }
 
 export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDeps): void {
@@ -128,6 +163,55 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
           { type: "text", text: `Message sent to ${result.target} (id: ${result.messageId}).` },
         ],
         details: { messageId: result.messageId, target: result.target },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "pinet_read",
+    label: "Pinet Read",
+    description: "Read durable SQLite-backed Pinet inbox context with unread/read semantics.",
+    promptSnippet:
+      "Read bounded Pinet/Slack broker context from the durable SQLite inbox. Use unread counts first, then read a specific thread or latest messages when needed. Reading marks returned unread rows as read by default; use mark_read=false to peek.",
+    parameters: Type.Object({
+      thread_id: Type.Optional(
+        Type.String({ description: "Optional Pinet/Slack broker thread ID to read" }),
+      ),
+      limit: Type.Optional(
+        Type.Number({ description: "Maximum messages to return (default 20, max 100)" }),
+      ),
+      unread_only: Type.Optional(
+        Type.Boolean({ description: "Only return unread rows (default true)" }),
+      ),
+      mark_read: Type.Optional(
+        Type.Boolean({ description: "Mark returned unread rows as read (default true)" }),
+      ),
+    }),
+    async execute(_id, params) {
+      deps.requireToolPolicy(
+        "pinet_read",
+        undefined,
+        `thread_id=${params.thread_id ?? ""} | limit=${params.limit ?? ""} | unread_only=${params.unread_only ?? ""} | mark_read=${params.mark_read ?? ""}`,
+      );
+
+      if (!deps.pinetEnabled()) {
+        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      }
+
+      const options: PinetReadOptions = {
+        ...(typeof params.thread_id === "string" ? { threadId: params.thread_id.trim() } : {}),
+        ...(typeof params.limit === "number" ? { limit: params.limit } : {}),
+        ...(typeof params.unread_only === "boolean" ? { unreadOnly: params.unread_only } : {}),
+        ...(typeof params.mark_read === "boolean" ? { markRead: params.mark_read } : {}),
+      };
+      if (options.threadId !== undefined && options.threadId.length === 0) {
+        throw new Error("thread_id must be a non-empty string when provided.");
+      }
+
+      const result = await deps.readPinetInbox(options);
+      return {
+        content: [{ type: "text", text: formatPinetReadResult(result, options) }],
+        details: result,
       };
     },
   });


### PR DESCRIPTION
## Summary
- add the first bounded `pinet_read` slice for #594 using the existing broker SQLite `inbox`/`messages` tables
- add a durable `read_at` cursor on inbox rows so explicit reads are tracked separately from delivery/ack
- expose `inbox.read` over the broker RPC/client and wire a hot `pinet_read` tool for broker and follower roles
- return bounded unread/latest messages plus unread thread pointers; mark returned unread rows read by default

## Notes
- This intentionally does not implement broad Slack API backfill or the future unified `pinet` dispatcher. It gives the durable inbox/read model that later `pinet send`, help/discovery, unread counts, and #582 steering can build on.
- Existing `inbox.poll`/`inbox.ack` delivery semantics are preserved.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check broker-core/types.ts broker-core/schema.ts slack-bridge/broker/client.ts slack-bridge/broker/socket-server.ts slack-bridge/pinet-tools.ts slack-bridge/pinet-tools.test.ts slack-bridge/broker/client.test.ts slack-bridge/broker/integration.test.ts slack-bridge/guardrails.ts slack-bridge/README.md`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --dir slack-bridge exec vitest --configLoader runner run pinet-tools.test.ts broker/client.test.ts broker/integration.test.ts broker/helpers.test.ts`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- push hook / root cached test pass

Refs #594