### PR TITLE
chore(openai-execution-shaping): cache normalized provider set

### DIFF
--- a/openai-execution-shaping/config.ts
+++ b/openai-execution-shaping/config.ts
@@ -24,6 +24,7 @@ export interface OpenAIExecutionShapingConfig {
 export interface ResolvedOpenAIExecutionShapingConfig {
   enabled: boolean;
   providers: string[];
+  providerSet: ReadonlySet<string>;
   modelRegexSource: string;
   modelRegex: RegExp;
   promptOverlayEnabled: boolean;
@@ -65,15 +66,28 @@ function readSettingsConfig(
   };
 }
 
+function normalizeProviders(rawProviders: string[] | undefined): {
+  providers: string[];
+  providerSet: ReadonlySet<string>;
+} {
+  const providers = Array.isArray(rawProviders)
+    ? rawProviders
+        .map((value) => (typeof value === "string" ? value.trim() : ""))
+        .filter((value) => value.length > 0)
+    : [...DEFAULT_PROVIDER_IDS];
+
+  const effectiveProviders = providers.length > 0 ? providers : [...DEFAULT_PROVIDER_IDS];
+  return {
+    providers: effectiveProviders,
+    providerSet: new Set(effectiveProviders.map((provider) => provider.toLowerCase())),
+  };
+}
+
 export function resolveConfig(
   raw: OpenAIExecutionShapingConfig | null | undefined,
   sourcePath: string | null = null,
 ): ResolvedOpenAIExecutionShapingConfig {
-  const providers = Array.isArray(raw?.providers)
-    ? raw.providers
-        .map((value) => (typeof value === "string" ? value.trim() : ""))
-        .filter((value) => value.length > 0)
-    : [...DEFAULT_PROVIDER_IDS];
+  const { providers, providerSet } = normalizeProviders(raw?.providers);
 
   const modelRegexSource =
     typeof raw?.modelRegex === "string" && raw.modelRegex.trim().length > 0
@@ -103,7 +117,8 @@ export function resolveConfig(
 
   return {
     enabled: raw?.enabled === true,
-    providers: providers.length > 0 ? providers : [...DEFAULT_PROVIDER_IDS],
+    providers,
+    providerSet,
     modelRegexSource,
     modelRegex,
     promptOverlayEnabled: raw?.promptOverlay?.enabled ?? true,

--- a/openai-execution-shaping/helpers.test.ts
+++ b/openai-execution-shaping/helpers.test.ts
@@ -43,6 +43,15 @@ describe("resolveConfig", () => {
     expect(config.debug).toBe(true);
     expect(config.sourcePath).toBe("/tmp/settings.json#openai-execution-shaping");
   });
+
+  it("normalizes provider ids case-insensitively for fast membership checks", () => {
+    const config = resolveConfig({ providers: ["OpenAI", "OpenAI-CODEX"] });
+
+    expect(config.providers).toEqual(["OpenAI", "OpenAI-CODEX"]);
+    expect(config.providerSet.has("openai")).toBe(true);
+    expect(config.providerSet.has("openai-codex")).toBe(true);
+    expect(config.providerSet.has("anthropic")).toBe(false);
+  });
 });
 
 describe("target model matching", () => {
@@ -53,6 +62,26 @@ describe("target model matching", () => {
     expect(
       isTargetModel({ provider: "openai-codex", id: "openai-codex/gpt-5.4" }, enabledConfig),
     ).toBe(true);
+  });
+
+  it("matches providers with mixed-case names when normalized once", () => {
+    const mixedCaseConfig = resolveConfig({ enabled: true, providers: ["OpenAI", "OPENAI-CODEX"] });
+
+    expect(isTargetModel({ provider: "openai", id: "gpt-5-advanced" }, mixedCaseConfig)).toBe(true);
+    expect(isTargetModel({ provider: "OPENAI-CODEX", id: "gpt-5-pro" }, mixedCaseConfig)).toBe(
+      true,
+    );
+  });
+
+  it("falls back to providers list when providerSet is absent (legacy config shape)", () => {
+    const legacyConfig = {
+      enabled: true,
+      providers: ["OpenAI", "Anthropic"],
+      modelRegex: /^gpt-5/i,
+    } as Parameters<typeof isTargetModel>[1];
+
+    expect(isTargetModel({ provider: "openai", id: "gpt-5-legacy" }, legacyConfig)).toBe(true);
+    expect(isTargetModel({ provider: "google", id: "gpt-5-legacy" }, legacyConfig)).toBe(false);
   });
 
   it("does not match non-target providers or models", () => {

--- a/openai-execution-shaping/helpers.ts
+++ b/openai-execution-shaping/helpers.ts
@@ -80,16 +80,25 @@ export function normalizeModelId(
   return trimmed.replace(new RegExp(`^${providerPrefix}[:/]`, "i"), "").toLowerCase();
 }
 
-export function isTargetModel(
-  model: ModelLike | undefined,
-  config: { providers: string[]; modelRegex: RegExp; enabled: boolean },
-): boolean {
+type ModelMatchConfig = {
+  providers: string[];
+  providerSet?: ReadonlySet<string>;
+  modelRegex: RegExp;
+  enabled: boolean;
+};
+
+export function isTargetModel(model: ModelLike | undefined, config: ModelMatchConfig): boolean {
   if (!config.enabled || !model?.provider || !model.id) {
     return false;
   }
 
   const provider = model.provider.trim().toLowerCase();
-  if (!config.providers.map((value) => value.toLowerCase()).includes(provider)) {
+  const hasProvider =
+    config.providerSet !== undefined
+      ? config.providerSet.has(provider)
+      : config.providers.some((value) => value.toLowerCase() === provider);
+
+  if (!hasProvider) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Narrow, surgical cleanup in `openai-execution-shaping`: cache normalized provider IDs at config resolution.
- Uses cached lowercase `providerSet` in `ResolvedOpenAIExecutionShapingConfig` for O(1) membership checks.
- Preserves legacy fallback behavior in `isTargetModel` when `providerSet` is absent.
- Added focused tests for mixed-case matching and legacy fallback.

## Stack / status
- #601 is merged.
- #603 remains optional/parked and stays narrow (no broad refactor).
- Base/head: `main` -> `chore/codebase-hygiene-overnight`
- Head SHA: `b042ba97c0990fbfa8267720ffba9367c3d14c44`

## Validation
- `pnpm --filter @gugu910/pi-openai-execution-shaping test`
- `pnpm --filter @gugu910/pi-openai-execution-shaping lint`
- `pnpm --filter @gugu910/pi-openai-execution-shaping typecheck`
- `gh pr checks 603` (quality pass)

## Automated review
- `code-reviewer`: **Approve**
- Findings: **none (no critical/warning)**
