### PR TITLE
feat(broker-core): add message sync identities

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -1,0 +1,379 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { BrokerDB } from "./schema.js";
+
+function createDb(): { db: BrokerDB; dir: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-core-schema-"));
+  const db = new BrokerDB(path.join(dir, "broker.db"));
+  db.initialize();
+  return { db, dir };
+}
+
+function createLegacyV12Db(dbPath: string): void {
+  const sqlite = new DatabaseSync(dbPath);
+  try {
+    sqlite.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY NOT NULL,
+        stable_id TEXT,
+        name TEXT NOT NULL,
+        emoji TEXT NOT NULL,
+        pid INTEGER NOT NULL,
+        connected_at TEXT NOT NULL,
+        last_seen TEXT NOT NULL,
+        last_heartbeat TEXT,
+        metadata TEXT,
+        status TEXT NOT NULL DEFAULT 'idle',
+        disconnected_at TEXT,
+        resumable_until TEXT,
+        idle_since TEXT,
+        last_activity TEXT
+      );
+      CREATE TABLE threads (
+        thread_id TEXT PRIMARY KEY NOT NULL,
+        source TEXT NOT NULL,
+        channel TEXT NOT NULL,
+        owner_agent TEXT,
+        owner_binding TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        thread_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        direction TEXT NOT NULL CHECK(direction IN ('inbound', 'outbound')),
+        sender TEXT NOT NULL,
+        body TEXT NOT NULL,
+        metadata TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE inbox (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent_id TEXT NOT NULL,
+        message_id INTEGER NOT NULL,
+        delivered INTEGER NOT NULL DEFAULT 0,
+        read_at TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE task_assignments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL UNIQUE,
+        thread_id TEXT NOT NULL,
+        source_message_id INTEGER,
+        assigned_agent_id TEXT,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE unrouted_backlog (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        thread_id TEXT NOT NULL,
+        channel TEXT NOT NULL,
+        message_id INTEGER NOT NULL UNIQUE,
+        reason TEXT NOT NULL,
+        status TEXT NOT NULL,
+        preferred_agent_id TEXT,
+        assigned_agent_id TEXT,
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        last_attempt_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      PRAGMA user_version = 12;
+    `);
+  } finally {
+    sqlite.close();
+  }
+}
+
+describe("BrokerDB message sync identity", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of cleanupDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("migrates v12 message rows before creating sync identity indexes", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-core-schema-"));
+    cleanupDirs.push(dir);
+    const dbPath = path.join(dir, "broker.db");
+    createLegacyV12Db(dbPath);
+
+    const legacy = new DatabaseSync(dbPath);
+    try {
+      legacy
+        .prepare(
+          `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, created_at, updated_at)
+           VALUES (?, 'slack', ?, NULL, NULL, ?, ?)`,
+        )
+        .run("123.456", "C123", "2026-04-25T00:00:00.000Z", "2026-04-25T00:00:00.000Z");
+      legacy
+        .prepare(
+          `INSERT INTO messages (thread_id, source, direction, sender, body, metadata, created_at)
+           VALUES (?, 'slack', 'inbound', 'U1', 'legacy Slack message', ?, ?)`,
+        )
+        .run(
+          "123.456",
+          JSON.stringify({ channel: "C123", timestamp: "123.456" }),
+          "2026-04-25T00:00:01.000Z",
+        );
+      legacy
+        .prepare(
+          "INSERT INTO inbox (agent_id, message_id, delivered, read_at, created_at) VALUES ('agent-1', 1, 0, NULL, ?)",
+        )
+        .run("2026-04-25T00:00:02.000Z");
+      legacy
+        .prepare(
+          "INSERT INTO inbox (agent_id, message_id, delivered, read_at, created_at) VALUES ('agent-1', 1, 0, NULL, ?)",
+        )
+        .run("2026-04-25T00:00:03.000Z");
+    } finally {
+      legacy.close();
+    }
+
+    const db = new BrokerDB(dbPath);
+    try {
+      db.initialize();
+      const migrated = db.insertMessage(
+        "123.456",
+        "slack",
+        "inbound",
+        "U1",
+        "replayed Slack message",
+        ["agent-1", "agent-2"],
+        { channel: "C123", timestamp: "123.456" },
+      );
+
+      expect(migrated.id).toBe(1);
+      expect(migrated.externalId).toBe("C123:123.456");
+      expect(db.getInbox("agent-1")).toHaveLength(1);
+      expect(db.getInbox("agent-2")).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("consolidates legacy duplicate Slack rows onto one replay identity", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-core-schema-"));
+    cleanupDirs.push(dir);
+    const dbPath = path.join(dir, "broker.db");
+    createLegacyV12Db(dbPath);
+
+    const legacy = new DatabaseSync(dbPath);
+    try {
+      legacy
+        .prepare(
+          `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, created_at, updated_at)
+           VALUES (?, 'slack', ?, NULL, NULL, ?, ?)`,
+        )
+        .run("123.456", "C123", "2026-04-25T00:00:00.000Z", "2026-04-25T00:00:00.000Z");
+      for (const body of ["legacy Slack message", "duplicate legacy Slack message"]) {
+        legacy
+          .prepare(
+            `INSERT INTO messages (thread_id, source, direction, sender, body, metadata, created_at)
+             VALUES (?, 'slack', 'inbound', 'U1', ?, ?, ?)`,
+          )
+          .run(
+            "123.456",
+            body,
+            JSON.stringify({ channel: "C123", timestamp: "123.456" }),
+            "2026-04-25T00:00:01.000Z",
+          );
+      }
+      legacy
+        .prepare(
+          "INSERT INTO inbox (agent_id, message_id, delivered, read_at, created_at) VALUES ('agent-1', 2, 1, ?, ?)",
+        )
+        .run("2026-04-25T00:00:02.500Z", "2026-04-25T00:00:02.000Z");
+      legacy
+        .prepare(
+          `INSERT INTO task_assignments (task_id, thread_id, source_message_id, assigned_agent_id, status, created_at, updated_at)
+           VALUES ('task-1', '123.456', 2, 'agent-1', 'assigned', ?, ?)`,
+        )
+        .run("2026-04-25T00:00:03.000Z", "2026-04-25T00:00:03.000Z");
+      legacy
+        .prepare(
+          `INSERT INTO unrouted_backlog (thread_id, channel, message_id, reason, status, attempt_count, created_at, updated_at)
+           VALUES ('123.456', 'C123', 1, 'unmatched', 'pending', 1, ?, ?)`,
+        )
+        .run("2026-04-25T00:00:04.000Z", "2026-04-25T00:00:04.000Z");
+      legacy
+        .prepare(
+          `INSERT INTO unrouted_backlog (thread_id, channel, message_id, reason, status, assigned_agent_id, attempt_count, last_attempt_at, created_at, updated_at)
+           VALUES ('123.456', 'C123', 2, 'assigned', 'assigned', 'agent-1', 3, ?, ?, ?)`,
+        )
+        .run("2026-04-25T00:00:05.000Z", "2026-04-25T00:00:03.500Z", "2026-04-25T00:00:05.000Z");
+    } finally {
+      legacy.close();
+    }
+
+    const db = new BrokerDB(dbPath);
+    try {
+      db.initialize();
+      const replay = db.insertMessage(
+        "123.456",
+        "slack",
+        "inbound",
+        "U1",
+        "replayed Slack message",
+        ["agent-1", "agent-2"],
+        { channel: "C123", timestamp: "123.456" },
+      );
+
+      expect(replay.id).toBe(1);
+      expect(replay.externalId).toBe("C123:123.456");
+      expect(db.getInbox("agent-1")).toHaveLength(0);
+      expect(db.getInbox("agent-2")).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+
+    const inspect = new DatabaseSync(dbPath);
+    try {
+      const backlog = inspect
+        .prepare("SELECT * FROM unrouted_backlog WHERE message_id = 1")
+        .get() as
+        | {
+            status: string;
+            assigned_agent_id: string | null;
+            attempt_count: number;
+            last_attempt_at: string | null;
+          }
+        | undefined;
+      const duplicateBacklog = inspect
+        .prepare("SELECT * FROM unrouted_backlog WHERE message_id = 2")
+        .get();
+      const inbox = inspect
+        .prepare("SELECT read_at FROM inbox WHERE agent_id = 'agent-1' AND message_id = 1")
+        .get() as { read_at: string | null } | undefined;
+
+      expect(backlog).toMatchObject({
+        status: "assigned",
+        assigned_agent_id: "agent-1",
+        attempt_count: 3,
+        last_attempt_at: "2026-04-25T00:00:05.000Z",
+      });
+      expect(duplicateBacklog).toBeUndefined();
+      expect(inbox?.read_at).toBe("2026-04-25T00:00:02.500Z");
+    } finally {
+      inspect.close();
+    }
+  });
+
+  it("deduplicates Slack messages by channel timestamp while preserving inbox recipients", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("123.456", "slack", "C123", null);
+
+      const first = db.insertMessage(
+        "123.456",
+        "slack",
+        "inbound",
+        "U1",
+        "hello from Slack",
+        ["agent-1"],
+        { channel: "C123", timestamp: "123.456", eventId: "Ev1" },
+      );
+      const replay = db.insertMessage(
+        "123.456",
+        "slack",
+        "inbound",
+        "U1",
+        "hello from Slack replay",
+        ["agent-1", "agent-2"],
+        { channel: "C123", timestamp: "123.456", eventId: "Ev1-replay" },
+      );
+
+      expect(replay.id).toBe(first.id);
+      expect(first.externalId).toBe("C123:123.456");
+      expect(first.externalTs).toBe("123.456");
+      expect(db.getInbox("agent-1")).toHaveLength(1);
+      expect(db.getInbox("agent-2")).toHaveLength(1);
+      expect(db.getInbox("agent-2")[0].message.id).toBe(first.id);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not reopen assigned backlog when a Slack message replay is queued unrouted", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      const message = {
+        source: "slack",
+        threadId: "123.456",
+        channel: "C123",
+        userId: "U1",
+        userName: "User One",
+        text: "hello",
+        timestamp: "123.456",
+        metadata: { channel: "C123", timestamp: "123.456" },
+      };
+      const backlog = db.queueUnroutedMessage(message);
+      const assigned = db.assignBacklogEntry(backlog.id, "agent-1");
+      expect(assigned).toMatchObject({ status: "assigned", assignedAgentId: "agent-1" });
+
+      const replay = db.queueUnroutedMessage({ ...message, text: "hello replay" });
+
+      expect(replay.id).toBe(backlog.id);
+      expect(replay).toMatchObject({ status: "assigned", assignedAgentId: "agent-1" });
+      expect(db.getPendingBacklog()).toHaveLength(0);
+      expect(db.getThread("123.456")?.ownerAgent).toBe("agent-1");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not re-enqueue replayed Slack messages after delivery", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      const first = db.insertMessage("123.456", "slack", "inbound", "U1", "hello", ["agent-1"], {
+        channel: "C123",
+        timestamp: "123.456",
+      });
+      db.markDelivered([db.getInbox("agent-1")[0]!.entry.id]);
+
+      const replay = db.insertMessage(
+        "123.456",
+        "slack",
+        "inbound",
+        "U1",
+        "replayed hello",
+        ["agent-1", "agent-2"],
+        { channel: "C123", timestamp: "123.456" },
+      );
+
+      expect(replay.id).toBe(first.id);
+      expect(db.getInbox("agent-1")).toHaveLength(0);
+      expect(db.getInbox("agent-2")).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not deduplicate messages without a transport identity", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("a2a:one:two", "agent", "", null);
+
+      const first = db.insertMessage("a2a:one:two", "agent", "inbound", "one", "same", ["two"]);
+      const second = db.insertMessage("a2a:one:two", "agent", "inbound", "one", "same", ["two"]);
+
+      expect(second.id).not.toBe(first.id);
+      expect(db.getInbox("two")).toHaveLength(2);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -148,6 +148,79 @@ function rowToThread(row: ThreadRow): ThreadInfo {
   };
 }
 
+function getStringMetadataValue(
+  metadata: Record<string, unknown> | undefined,
+  keys: string[],
+): string | null {
+  for (const key of keys) {
+    const value = metadata?.[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function deriveMessageSyncIdentity(
+  source: string,
+  metadata?: Record<string, unknown>,
+): { externalId: string | null; externalTs: string | null } {
+  const explicitExternalId = getStringMetadataValue(metadata, [
+    "externalId",
+    "external_id",
+    "transportMessageId",
+    "transport_message_id",
+  ]);
+  const explicitExternalTs = getStringMetadataValue(metadata, [
+    "externalTs",
+    "external_ts",
+    "timestamp",
+    "ts",
+  ]);
+  if (explicitExternalId) {
+    return { externalId: explicitExternalId, externalTs: explicitExternalTs };
+  }
+
+  if (source === "slack") {
+    const channel = getStringMetadataValue(metadata, ["channel", "channelId", "channel_id"]);
+    const timestamp = getStringMetadataValue(metadata, ["timestamp", "ts"]);
+    if (timestamp && channel) {
+      return { externalId: `${channel}:${timestamp}`, externalTs: timestamp };
+    }
+    if (timestamp) {
+      return { externalId: timestamp, externalTs: timestamp };
+    }
+  }
+
+  return { externalId: null, externalTs: explicitExternalTs };
+}
+
+function rowToBrokerMessage(row: {
+  id: number;
+  thread_id: string;
+  source: string;
+  direction: string;
+  sender: string;
+  body: string;
+  metadata: string | null;
+  external_id?: string | null;
+  external_ts?: string | null;
+  created_at: string;
+}): BrokerMessage {
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    source: row.source,
+    direction: row.direction as "inbound" | "outbound",
+    sender: row.sender,
+    body: row.body,
+    metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null,
+    ...(row.external_id ? { externalId: row.external_id } : {}),
+    ...(row.external_ts ? { externalTs: row.external_ts } : {}),
+    createdAt: row.created_at,
+  };
+}
+
 function rowToBacklog(row: BacklogRow): BacklogEntry {
   return {
     id: row.id,
@@ -200,7 +273,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 12;
+export const CURRENT_BROKER_SCHEMA_VERSION = 13;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -223,6 +296,13 @@ function setUserVersion(db: DatabaseSync, version: number): void {
 function getTableColumns(db: DatabaseSync, tableName: string): Set<string> {
   const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
   return new Set(rows.map((row) => row.name));
+}
+
+function tableExists(db: DatabaseSync, tableName: string): boolean {
+  const row = db
+    .prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as { present: number } | undefined;
+  return row !== undefined;
 }
 
 function ensureColumn(db: DatabaseSync, tableName: string, columnName: string, sql: string): void {
@@ -260,6 +340,8 @@ function createCoreTables(db: DatabaseSync): void {
       sender TEXT NOT NULL,
       body TEXT NOT NULL,
       metadata TEXT,
+      external_id TEXT,
+      external_ts TEXT,
       created_at TEXT NOT NULL
     );
 
@@ -274,12 +356,20 @@ function createCoreTables(db: DatabaseSync): void {
 
     CREATE INDEX IF NOT EXISTS idx_messages_thread
       ON messages(thread_id, created_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_source_external_id
+      ON messages(source, external_id)
+      WHERE external_id IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_messages_source_external_ts
+      ON messages(source, external_ts);
     CREATE INDEX IF NOT EXISTS idx_inbox_agent_delivered
       ON inbox(agent_id, delivered, created_at);
     CREATE INDEX IF NOT EXISTS idx_inbox_agent_read
       ON inbox(agent_id, read_at, created_at);
     CREATE INDEX IF NOT EXISTS idx_inbox_message
       ON inbox(message_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_agent_message_pending_unique
+      ON inbox(agent_id, message_id)
+      WHERE delivered = 0;
   `);
 }
 
@@ -378,6 +468,178 @@ function addInboxReadCursorColumn(db: DatabaseSync): void {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_inbox_agent_read
       ON inbox(agent_id, read_at, created_at);
+  `);
+}
+
+function backfillMessageSyncIdentities(db: DatabaseSync): void {
+  const rows = db
+    .prepare("SELECT id, source, metadata FROM messages WHERE metadata IS NOT NULL")
+    .all() as Array<{ id: number; source: string; metadata: string | null }>;
+  const update = db.prepare("UPDATE messages SET external_id = ?, external_ts = ? WHERE id = ?");
+
+  for (const row of rows) {
+    if (!row.metadata) continue;
+    try {
+      const metadata = JSON.parse(row.metadata) as Record<string, unknown>;
+      const identity = deriveMessageSyncIdentity(row.source, metadata);
+      if (identity.externalId || identity.externalTs) {
+        update.run(identity.externalId, identity.externalTs, row.id);
+      }
+    } catch {
+      // Keep corrupt legacy metadata readable; it simply cannot receive a sync identity.
+    }
+  }
+}
+
+function pickBacklogStatus(left: string, right: string): BacklogEntry["status"] {
+  if (left === "assigned" || right === "assigned") return "assigned";
+  if (left === "pending" || right === "pending") return "pending";
+  return "dropped";
+}
+
+function maxNullableIso(left: string | null, right: string | null): string | null {
+  if (!left) return right;
+  if (!right) return left;
+  return left >= right ? left : right;
+}
+
+function minIso(left: string, right: string): string {
+  return left <= right ? left : right;
+}
+
+function mergeBacklogMessageId(
+  db: DatabaseSync,
+  keepMessageId: number,
+  duplicateMessageId: number,
+): void {
+  const getBacklog = db.prepare("SELECT * FROM unrouted_backlog WHERE message_id = ?");
+  const keep = getBacklog.get(keepMessageId) as BacklogRow | undefined;
+  const duplicate = getBacklog.get(duplicateMessageId) as BacklogRow | undefined;
+  if (!duplicate) return;
+
+  if (!keep) {
+    db.prepare("UPDATE unrouted_backlog SET message_id = ? WHERE id = ?").run(
+      keepMessageId,
+      duplicate.id,
+    );
+    return;
+  }
+
+  const mergedStatus = pickBacklogStatus(keep.status, duplicate.status);
+  db.prepare(
+    `UPDATE unrouted_backlog
+     SET reason = ?,
+         status = ?,
+         preferred_agent_id = ?,
+         assigned_agent_id = ?,
+         attempt_count = ?,
+         last_attempt_at = ?,
+         created_at = ?,
+         updated_at = ?
+     WHERE id = ?`,
+  ).run(
+    keep.reason || duplicate.reason,
+    mergedStatus,
+    keep.preferred_agent_id ?? duplicate.preferred_agent_id,
+    mergedStatus === "assigned" ? (keep.assigned_agent_id ?? duplicate.assigned_agent_id) : null,
+    Math.max(keep.attempt_count, duplicate.attempt_count),
+    maxNullableIso(keep.last_attempt_at, duplicate.last_attempt_at),
+    minIso(keep.created_at, duplicate.created_at),
+    maxNullableIso(keep.updated_at, duplicate.updated_at) ?? keep.updated_at,
+    keep.id,
+  );
+  db.prepare("DELETE FROM unrouted_backlog WHERE id = ?").run(duplicate.id);
+}
+
+function consolidateDuplicateMessageSyncIdentities(db: DatabaseSync): void {
+  const duplicateRows = db
+    .prepare(
+      `SELECT source, external_id, MIN(id) AS keep_id
+       FROM messages
+       WHERE external_id IS NOT NULL
+       GROUP BY source, external_id
+       HAVING COUNT(*) > 1`,
+    )
+    .all() as Array<{ source: string; external_id: string; keep_id: number }>;
+  const findDuplicates = db.prepare(
+    `SELECT id
+     FROM messages
+     WHERE source = ?
+       AND external_id = ?
+       AND id <> ?`,
+  );
+  const repointInbox = db.prepare("UPDATE inbox SET message_id = ? WHERE message_id = ?");
+  const repointTaskAssignments = tableExists(db, "task_assignments")
+    ? db.prepare("UPDATE task_assignments SET source_message_id = ? WHERE source_message_id = ?")
+    : null;
+  const hasBacklog = tableExists(db, "unrouted_backlog");
+  const clearDuplicate = db.prepare(
+    `UPDATE messages
+     SET external_id = NULL,
+         external_ts = NULL
+     WHERE id = ?`,
+  );
+
+  for (const row of duplicateRows) {
+    const duplicates = findDuplicates.all(row.source, row.external_id, row.keep_id) as Array<{
+      id: number;
+    }>;
+    for (const duplicate of duplicates) {
+      repointInbox.run(row.keep_id, duplicate.id);
+      repointTaskAssignments?.run(row.keep_id, duplicate.id);
+      if (hasBacklog) {
+        mergeBacklogMessageId(db, row.keep_id, duplicate.id);
+      }
+      clearDuplicate.run(duplicate.id);
+    }
+  }
+}
+
+function deleteDuplicateInboxRows(db: DatabaseSync): void {
+  db.exec(`
+    UPDATE inbox
+    SET read_at = (
+      SELECT MAX(duplicate.read_at)
+      FROM inbox AS duplicate
+      WHERE duplicate.agent_id = inbox.agent_id
+        AND duplicate.message_id = inbox.message_id
+        AND duplicate.read_at IS NOT NULL
+    )
+    WHERE EXISTS (
+      SELECT 1
+      FROM inbox AS duplicate
+      WHERE duplicate.agent_id = inbox.agent_id
+        AND duplicate.message_id = inbox.message_id
+        AND duplicate.read_at IS NOT NULL
+    );
+
+    DELETE FROM inbox
+    WHERE id NOT IN (
+      SELECT COALESCE(
+        MIN(CASE WHEN delivered = 1 THEN id END),
+        MIN(id)
+      )
+      FROM inbox
+      GROUP BY agent_id, message_id
+    );
+  `);
+}
+
+function addMessageSyncIdentityColumns(db: DatabaseSync): void {
+  ensureColumn(db, "messages", "external_id", "ALTER TABLE messages ADD COLUMN external_id TEXT");
+  ensureColumn(db, "messages", "external_ts", "ALTER TABLE messages ADD COLUMN external_ts TEXT");
+  backfillMessageSyncIdentities(db);
+  consolidateDuplicateMessageSyncIdentities(db);
+  deleteDuplicateInboxRows(db);
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_source_external_id
+      ON messages(source, external_id)
+      WHERE external_id IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_messages_source_external_ts
+      ON messages(source, external_ts);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_agent_message_pending_unique
+      ON inbox(agent_id, message_id)
+      WHERE delivered = 0;
   `);
 }
 
@@ -559,6 +821,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 12:
           addInboxReadCursorColumn(db);
+          break;
+        case 13:
+          addMessageSyncIdentityColumns(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -1214,12 +1479,6 @@ export class BrokerDB implements BrokerDBInterface {
     const existingThread = this.getThread(message.threadId);
     if (!existingThread) {
       this.createThread(message.threadId, message.source, message.channel, null);
-    } else {
-      this.updateThread(message.threadId, {
-        channel: message.channel,
-        source: message.source,
-        ownerAgent: null,
-      });
     }
 
     const brokerMessage = this.insertMessage(
@@ -1231,6 +1490,19 @@ export class BrokerDB implements BrokerDBInterface {
       [],
       metadata,
     );
+
+    const existingBacklog = this.getBacklogByMessageId(brokerMessage.id);
+    if (existingBacklog) {
+      return existingBacklog;
+    }
+
+    if (existingThread) {
+      this.updateThread(message.threadId, {
+        channel: message.channel,
+        source: message.source,
+        ownerAgent: null,
+      });
+    }
 
     return this.upsertBacklogEntry(
       brokerMessage.id,
@@ -1254,7 +1526,7 @@ export class BrokerDB implements BrokerDBInterface {
 
       const now = new Date().toISOString();
       db.prepare(
-        `INSERT INTO inbox (agent_id, message_id, delivered, created_at)
+        `INSERT OR IGNORE INTO inbox (agent_id, message_id, delivered, created_at)
          VALUES (?, ?, 0, ?)`,
       ).run(agentId, row.message_id, now);
 
@@ -1791,38 +2063,113 @@ export class BrokerDB implements BrokerDBInterface {
     const db = this.getDb();
     const now = new Date().toISOString();
     const metaJson = metadata ? JSON.stringify(metadata) : null;
+    const identity = deriveMessageSyncIdentity(source, metadata);
 
     const info = db
       .prepare(
-        `INSERT INTO messages (thread_id, source, direction, sender, body, metadata, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT OR IGNORE INTO messages (
+           thread_id,
+           source,
+           direction,
+           sender,
+           body,
+           metadata,
+           external_id,
+           external_ts,
+           created_at
+         )
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(threadId, source, direction, sender, body, metaJson, now);
+      .run(
+        threadId,
+        source,
+        direction,
+        sender,
+        body,
+        metaJson,
+        identity.externalId,
+        identity.externalTs,
+        now,
+      );
 
-    const messageId = Number(info.lastInsertRowid);
+    const insertedMessageId = Number(info.lastInsertRowid);
+    const messageId =
+      Number(info.changes ?? 0) > 0
+        ? insertedMessageId
+        : this.getExistingMessageIdForIdentity(source, identity.externalId);
+    if (messageId == null) {
+      throw new Error("Failed to persist broker message");
+    }
 
     const insertInbox = db.prepare(
       `INSERT INTO inbox (agent_id, message_id, delivered, created_at)
-       VALUES (?, ?, 0, ?)`,
+       SELECT ?, ?, 0, ?
+       WHERE NOT EXISTS (
+         SELECT 1
+         FROM inbox
+         WHERE agent_id = ?
+           AND message_id = ?
+       )`,
     );
 
     for (const agentId of targetAgentIds) {
-      insertInbox.run(agentId, messageId, now);
+      insertInbox.run(agentId, messageId, now, agentId, messageId);
     }
 
     // Update thread timestamp
     db.prepare("UPDATE threads SET updated_at = ? WHERE thread_id = ?").run(now, threadId);
 
-    return {
-      id: messageId,
-      threadId,
-      source,
-      direction,
-      sender,
-      body,
-      metadata: metadata ?? null,
-      createdAt: now,
-    };
+    return (
+      this.getMessageById(messageId) ?? {
+        id: messageId,
+        threadId,
+        source,
+        direction,
+        sender,
+        body,
+        metadata: metadata ?? null,
+        ...(identity.externalId ? { externalId: identity.externalId } : {}),
+        ...(identity.externalTs ? { externalTs: identity.externalTs } : {}),
+        createdAt: now,
+      }
+    );
+  }
+
+  private getExistingMessageIdForIdentity(
+    source: string,
+    externalId: string | null,
+  ): number | null {
+    if (!externalId) {
+      return null;
+    }
+    const row = this.getDb()
+      .prepare("SELECT id FROM messages WHERE source = ? AND external_id = ?")
+      .get(source, externalId) as { id?: number } | undefined;
+    return typeof row?.id === "number" ? row.id : null;
+  }
+
+  private getMessageById(messageId: number): BrokerMessage | null {
+    const row = this.getDb()
+      .prepare(
+        `SELECT id, thread_id, source, direction, sender, body, metadata, external_id, external_ts, created_at
+         FROM messages
+         WHERE id = ?`,
+      )
+      .get(messageId) as
+      | {
+          id: number;
+          thread_id: string;
+          source: string;
+          direction: string;
+          sender: string;
+          body: string;
+          metadata: string | null;
+          external_id: string | null;
+          external_ts: string | null;
+          created_at: string;
+        }
+      | undefined;
+    return row ? rowToBrokerMessage(row) : null;
   }
 
   getInbox(agentId: string, limit = 50): { entry: InboxEntry; message: BrokerMessage }[] {
@@ -1835,7 +2182,8 @@ export class BrokerDB implements BrokerDBInterface {
            i.delivered AS i_delivered, i.read_at AS i_read_at, i.created_at AS i_created_at,
            m.id AS m_id, m.thread_id AS m_thread_id, m.source AS m_source,
            m.direction AS m_direction, m.sender AS m_sender, m.body AS m_body,
-           m.metadata AS m_metadata, m.created_at AS m_created_at
+           m.metadata AS m_metadata, m.external_id AS m_external_id,
+           m.external_ts AS m_external_ts, m.created_at AS m_created_at
          FROM inbox i
          JOIN messages m ON m.id = i.message_id
          WHERE i.agent_id = ? AND i.delivered = 0
@@ -1856,6 +2204,8 @@ export class BrokerDB implements BrokerDBInterface {
       m_sender: string;
       m_body: string;
       m_metadata: string | null;
+      m_external_id: string | null;
+      m_external_ts: string | null;
       m_created_at: string;
     }>;
 
@@ -1876,6 +2226,8 @@ export class BrokerDB implements BrokerDBInterface {
         sender: r.m_sender,
         body: r.m_body,
         metadata: r.m_metadata ? (JSON.parse(r.m_metadata) as Record<string, unknown>) : null,
+        ...(r.m_external_id ? { externalId: r.m_external_id } : {}),
+        ...(r.m_external_ts ? { externalTs: r.m_external_ts } : {}),
         createdAt: r.m_created_at,
       },
     }));
@@ -1907,7 +2259,8 @@ export class BrokerDB implements BrokerDBInterface {
            i.delivered AS i_delivered, i.read_at AS i_read_at, i.created_at AS i_created_at,
            m.id AS m_id, m.thread_id AS m_thread_id, m.source AS m_source,
            m.direction AS m_direction, m.sender AS m_sender, m.body AS m_body,
-           m.metadata AS m_metadata, m.created_at AS m_created_at
+           m.metadata AS m_metadata, m.external_id AS m_external_id,
+           m.external_ts AS m_external_ts, m.created_at AS m_created_at
          FROM inbox i
          JOIN messages m ON m.id = i.message_id
          WHERE ${clauses.join(" AND ")}
@@ -1928,6 +2281,8 @@ export class BrokerDB implements BrokerDBInterface {
       m_sender: string;
       m_body: string;
       m_metadata: string | null;
+      m_external_id: string | null;
+      m_external_ts: string | null;
       m_created_at: string;
     }>;
 
@@ -1949,6 +2304,8 @@ export class BrokerDB implements BrokerDBInterface {
         sender: r.m_sender,
         body: r.m_body,
         metadata: r.m_metadata ? (JSON.parse(r.m_metadata) as Record<string, unknown>) : null,
+        ...(r.m_external_id ? { externalId: r.m_external_id } : {}),
+        ...(r.m_external_ts ? { externalTs: r.m_external_ts } : {}),
         createdAt: r.m_created_at,
       },
     }));
@@ -2045,7 +2402,7 @@ export class BrokerDB implements BrokerDBInterface {
     const placeholders = messageIds.map(() => "?").join(", ");
     const rows = db
       .prepare(
-        `SELECT id, thread_id, source, direction, sender, body, metadata, created_at
+        `SELECT id, thread_id, source, direction, sender, body, metadata, external_id, external_ts, created_at
          FROM messages
          WHERE id IN (${placeholders})
          ORDER BY id ASC`,
@@ -2058,19 +2415,12 @@ export class BrokerDB implements BrokerDBInterface {
       sender: string;
       body: string;
       metadata: string | null;
+      external_id: string | null;
+      external_ts: string | null;
       created_at: string;
     }>;
 
-    return rows.map((row) => ({
-      id: row.id,
-      threadId: row.thread_id,
-      source: row.source,
-      direction: row.direction as "inbound" | "outbound",
-      sender: row.sender,
-      body: row.body,
-      metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null,
-      createdAt: row.created_at,
-    }));
+    return rows.map(rowToBrokerMessage);
   }
 
   markDelivered(inboxIds: number[], agentId?: string): void {
@@ -2184,6 +2534,14 @@ export class BrokerDB implements BrokerDBInterface {
   private getBacklogById(id: number): BacklogEntry | null {
     const db = this.getDb();
     const row = db.prepare("SELECT * FROM unrouted_backlog WHERE id = ?").get(id) as
+      | BacklogRow
+      | undefined;
+    return row ? rowToBacklog(row) : null;
+  }
+
+  private getBacklogByMessageId(messageId: number): BacklogEntry | null {
+    const db = this.getDb();
+    const row = db.prepare("SELECT * FROM unrouted_backlog WHERE message_id = ?").get(messageId) as
       | BacklogRow
       | undefined;
     return row ? rowToBacklog(row) : null;

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -39,6 +39,8 @@ export interface BrokerMessage {
   body: string;
   metadata: Record<string, unknown> | null;
   createdAt: string;
+  externalId?: string;
+  externalTs?: string;
 }
 
 export interface InboxEntry {


### PR DESCRIPTION
## Summary
- PR1 / #604 of the #594 SQLite sync stack (base: `main`, after merged #601)
- extend existing broker SQLite `messages` rows with source-native `external_id` / `external_ts` identity fields
- derive Slack message identity from channel + timestamp so event replays/backfills reuse the same durable message row
- add inbox idempotency so repeated sync/delivery for the same `(agent_id, message_id)` does not duplicate rows, including after delivery/read state changes
- migrate/backfill legacy rows and consolidate duplicate legacy Slack rows while preserving inbox read state, task assignments, and backlog state

## Stack notes
- This PR is the foundation for event-first Slack/Pinet context sync.
- Follow-up #605 / PR2 should stack on this branch and use the idempotent insert path to persist broker-handled Slack inbound messages without changing delivery semantics.
- Out of scope here: Slack API backfill, steering classifier, arrow-up reclassification, semantic memory, broad transport-core/Pinet refactor, and migration away from direct delivery.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --dir slack-bridge exec vitest --configLoader runner run broker/helpers.test.ts broker/integration.test.ts pinet-tools.test.ts`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- push hook / root cached test pass
- GitHub `quality` success
- automated `code-reviewer` final verdict: APPROVE / no critical or warning findings

Closes #604
Refs #594
