### PR TITLE
feat(slack-bridge): persist broker-handled inbound

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -250,8 +250,10 @@ describe("BrokerDB message sync identity", () => {
         .prepare("SELECT * FROM unrouted_backlog WHERE message_id = 2")
         .get();
       const inbox = inspect
-        .prepare("SELECT read_at FROM inbox WHERE agent_id = 'agent-1' AND message_id = 1")
-        .get() as { read_at: string | null } | undefined;
+        .prepare(
+          "SELECT read_at, live_delivered_at FROM inbox WHERE agent_id = 'agent-1' AND message_id = 1",
+        )
+        .get() as { read_at: string | null; live_delivered_at: string | null } | undefined;
 
       expect(backlog).toMatchObject({
         status: "assigned",
@@ -261,6 +263,7 @@ describe("BrokerDB message sync identity", () => {
       });
       expect(duplicateBacklog).toBeUndefined();
       expect(inbox?.read_at).toBe("2026-04-25T00:00:02.500Z");
+      expect(inbox?.live_delivered_at).toBe("2026-04-25T00:00:02.000Z");
     } finally {
       inspect.close();
     }

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -273,7 +273,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 13;
+export const CURRENT_BROKER_SCHEMA_VERSION = 14;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -351,6 +351,7 @@ function createCoreTables(db: DatabaseSync): void {
       message_id INTEGER NOT NULL,
       delivered INTEGER NOT NULL DEFAULT 0,
       read_at TEXT,
+      live_delivered_at TEXT,
       created_at TEXT NOT NULL
     );
 
@@ -365,6 +366,8 @@ function createCoreTables(db: DatabaseSync): void {
       ON inbox(agent_id, delivered, created_at);
     CREATE INDEX IF NOT EXISTS idx_inbox_agent_read
       ON inbox(agent_id, read_at, created_at);
+    CREATE INDEX IF NOT EXISTS idx_inbox_agent_live_sync
+      ON inbox(agent_id, delivered, live_delivered_at, created_at);
     CREATE INDEX IF NOT EXISTS idx_inbox_message
       ON inbox(message_id);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_agent_message_pending_unique
@@ -625,6 +628,23 @@ function deleteDuplicateInboxRows(db: DatabaseSync): void {
   `);
 }
 
+function addInboxLiveDeliveryColumn(db: DatabaseSync): void {
+  ensureColumn(
+    db,
+    "inbox",
+    "live_delivered_at",
+    "ALTER TABLE inbox ADD COLUMN live_delivered_at TEXT",
+  );
+  db.exec(`
+    UPDATE inbox
+    SET live_delivered_at = COALESCE(live_delivered_at, created_at)
+    WHERE delivered = 1;
+
+    CREATE INDEX IF NOT EXISTS idx_inbox_agent_live_sync
+      ON inbox(agent_id, delivered, live_delivered_at, created_at);
+  `);
+}
+
 function addMessageSyncIdentityColumns(db: DatabaseSync): void {
   ensureColumn(db, "messages", "external_id", "ALTER TABLE messages ADD COLUMN external_id TEXT");
   ensureColumn(db, "messages", "external_ts", "ALTER TABLE messages ADD COLUMN external_ts TEXT");
@@ -824,6 +844,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 13:
           addMessageSyncIdentityColumns(db);
+          break;
+        case 14:
+          addInboxLiveDeliveryColumn(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -2028,17 +2051,9 @@ export class BrokerDB implements BrokerDBInterface {
 
   // ─── Interface-compatible queueMessage (single agent) ──
 
-  queueMessage(agentId: string, message: InboundMessage): void {
-    const metadata: Record<string, unknown> = {
-      ...message.metadata,
-      channel: message.channel,
-      userName: message.userName,
-      userId: message.userId,
-      timestamp: message.timestamp,
-      ...(message.isChannelMention ? { isChannelMention: true } : {}),
-      ...(message.scope ? { scope: message.scope } : {}),
-    };
-    this.insertMessage(
+  queueMessage(agentId: string, message: InboundMessage): BrokerMessage {
+    const metadata = this.buildInboundMessageMetadata(message);
+    return this.insertMessage(
       message.threadId,
       message.source,
       "inbound",
@@ -2047,6 +2062,50 @@ export class BrokerDB implements BrokerDBInterface {
       [agentId],
       metadata,
     );
+  }
+
+  queueDeliveredMessage(
+    agentId: string,
+    message: InboundMessage,
+  ): { message: BrokerMessage; freshDelivery: boolean } {
+    return this.withTransaction(() => {
+      const db = this.getDb();
+      const metadata = this.buildInboundMessageMetadata(message);
+      const brokerMessage = this.insertMessage(
+        message.threadId,
+        message.source,
+        "inbound",
+        message.userId,
+        message.text,
+        [],
+        metadata,
+      );
+      const existingInbox = db
+        .prepare("SELECT id FROM inbox WHERE agent_id = ? AND message_id = ?")
+        .get(agentId, brokerMessage.id) as { id: number } | undefined;
+      if (existingInbox) {
+        db.prepare("UPDATE inbox SET delivered = 1 WHERE id = ?").run(existingInbox.id);
+        return { message: brokerMessage, freshDelivery: false };
+      }
+
+      db.prepare(
+        `INSERT INTO inbox (agent_id, message_id, delivered, created_at)
+         VALUES (?, ?, 1, ?)`,
+      ).run(agentId, brokerMessage.id, new Date().toISOString());
+      return { message: brokerMessage, freshDelivery: true };
+    });
+  }
+
+  private buildInboundMessageMetadata(message: InboundMessage): Record<string, unknown> {
+    return {
+      ...message.metadata,
+      channel: message.channel,
+      userName: message.userName,
+      userId: message.userId,
+      timestamp: message.timestamp,
+      ...(message.isChannelMention ? { isChannelMention: true } : {}),
+      ...(message.scope ? { scope: message.scope } : {}),
+    };
   }
 
   // ─── Detailed message insert (used by socket server) ──
@@ -2179,7 +2238,8 @@ export class BrokerDB implements BrokerDBInterface {
       .prepare(
         `SELECT
            i.id AS i_id, i.agent_id AS i_agent_id, i.message_id AS i_message_id,
-           i.delivered AS i_delivered, i.read_at AS i_read_at, i.created_at AS i_created_at,
+           i.delivered AS i_delivered, i.read_at AS i_read_at,
+           i.live_delivered_at AS i_live_delivered_at, i.created_at AS i_created_at,
            m.id AS m_id, m.thread_id AS m_thread_id, m.source AS m_source,
            m.direction AS m_direction, m.sender AS m_sender, m.body AS m_body,
            m.metadata AS m_metadata, m.external_id AS m_external_id,
@@ -2196,6 +2256,7 @@ export class BrokerDB implements BrokerDBInterface {
       i_message_id: number;
       i_delivered: number;
       i_read_at: string | null;
+      i_live_delivered_at: string | null;
       i_created_at: string;
       m_id: number;
       m_thread_id: string;
@@ -2216,6 +2277,79 @@ export class BrokerDB implements BrokerDBInterface {
         messageId: r.i_message_id,
         delivered: r.i_delivered === 1,
         readAt: r.i_read_at,
+        liveDeliveredAt: r.i_live_delivered_at,
+        createdAt: r.i_created_at,
+      },
+      message: {
+        id: r.m_id,
+        threadId: r.m_thread_id,
+        source: r.m_source,
+        direction: r.m_direction as "inbound" | "outbound",
+        sender: r.m_sender,
+        body: r.m_body,
+        metadata: r.m_metadata ? (JSON.parse(r.m_metadata) as Record<string, unknown>) : null,
+        ...(r.m_external_id ? { externalId: r.m_external_id } : {}),
+        ...(r.m_external_ts ? { externalTs: r.m_external_ts } : {}),
+        createdAt: r.m_created_at,
+      },
+    }));
+  }
+
+  getInboxForLiveSync(
+    agentId: string,
+    limit = 100,
+  ): { entry: InboxEntry; message: BrokerMessage }[] {
+    const db = this.getDb();
+    const clampedLimit = Math.min(Math.max(Math.trunc(limit), 1), 100);
+
+    const rows = db
+      .prepare(
+        `SELECT
+           i.id AS i_id, i.agent_id AS i_agent_id, i.message_id AS i_message_id,
+           i.delivered AS i_delivered, i.read_at AS i_read_at,
+           i.live_delivered_at AS i_live_delivered_at, i.created_at AS i_created_at,
+           m.id AS m_id, m.thread_id AS m_thread_id, m.source AS m_source,
+           m.direction AS m_direction, m.sender AS m_sender, m.body AS m_body,
+           m.metadata AS m_metadata, m.external_id AS m_external_id,
+           m.external_ts AS m_external_ts, m.created_at AS m_created_at
+         FROM inbox i
+         JOIN messages m ON m.id = i.message_id
+         WHERE i.agent_id = ?
+           AND (
+             i.delivered = 0
+             OR (i.delivered = 1 AND i.read_at IS NULL AND i.live_delivered_at IS NULL)
+           )
+         ORDER BY i.created_at ASC, i.id ASC
+         LIMIT ?`,
+      )
+      .all(agentId, clampedLimit) as unknown as Array<{
+      i_id: number;
+      i_agent_id: string;
+      i_message_id: number;
+      i_delivered: number;
+      i_read_at: string | null;
+      i_live_delivered_at: string | null;
+      i_created_at: string;
+      m_id: number;
+      m_thread_id: string;
+      m_source: string;
+      m_direction: string;
+      m_sender: string;
+      m_body: string;
+      m_metadata: string | null;
+      m_external_id: string | null;
+      m_external_ts: string | null;
+      m_created_at: string;
+    }>;
+
+    return rows.map((r) => ({
+      entry: {
+        id: r.i_id,
+        agentId: r.i_agent_id,
+        messageId: r.i_message_id,
+        delivered: r.i_delivered === 1,
+        readAt: r.i_read_at,
+        liveDeliveredAt: r.i_live_delivered_at,
         createdAt: r.i_created_at,
       },
       message: {
@@ -2256,7 +2390,8 @@ export class BrokerDB implements BrokerDBInterface {
       .prepare(
         `SELECT
            i.id AS i_id, i.agent_id AS i_agent_id, i.message_id AS i_message_id,
-           i.delivered AS i_delivered, i.read_at AS i_read_at, i.created_at AS i_created_at,
+           i.delivered AS i_delivered, i.read_at AS i_read_at,
+           i.live_delivered_at AS i_live_delivered_at, i.created_at AS i_created_at,
            m.id AS m_id, m.thread_id AS m_thread_id, m.source AS m_source,
            m.direction AS m_direction, m.sender AS m_sender, m.body AS m_body,
            m.metadata AS m_metadata, m.external_id AS m_external_id,
@@ -2273,6 +2408,7 @@ export class BrokerDB implements BrokerDBInterface {
       i_message_id: number;
       i_delivered: number;
       i_read_at: string | null;
+      i_live_delivered_at: string | null;
       i_created_at: string;
       m_id: number;
       m_thread_id: string;
@@ -2294,6 +2430,7 @@ export class BrokerDB implements BrokerDBInterface {
         messageId: r.i_message_id,
         delivered: r.i_delivered === 1,
         readAt: r.i_read_at,
+        liveDeliveredAt: r.i_live_delivered_at,
         createdAt: r.i_created_at,
       },
       message: {
@@ -2421,6 +2558,38 @@ export class BrokerDB implements BrokerDBInterface {
     }>;
 
     return rows.map(rowToBrokerMessage);
+  }
+
+  markLiveDelivered(inboxIds: number[], agentId?: string): void {
+    if (inboxIds.length === 0) return;
+    const db = this.getDb();
+    const now = new Date().toISOString();
+
+    if (agentId) {
+      const stmt = db.prepare(
+        "UPDATE inbox SET live_delivered_at = COALESCE(live_delivered_at, ?) WHERE id = ? AND agent_id = ?",
+      );
+      for (const id of inboxIds) {
+        stmt.run(now, id, agentId);
+      }
+      return;
+    }
+
+    const stmt = db.prepare(
+      "UPDATE inbox SET live_delivered_at = COALESCE(live_delivered_at, ?) WHERE id = ?",
+    );
+    for (const id of inboxIds) {
+      stmt.run(now, id);
+    }
+  }
+
+  markLiveDeliveredByMessageId(messageId: number, agentId: string): void {
+    const db = this.getDb();
+    db.prepare(
+      `UPDATE inbox
+       SET live_delivered_at = COALESCE(live_delivered_at, ?)
+       WHERE message_id = ? AND agent_id = ?`,
+    ).run(new Date().toISOString(), messageId, agentId);
   }
 
   markDelivered(inboxIds: number[], agentId?: string): void {

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -49,6 +49,7 @@ export interface InboxEntry {
   messageId: number;
   delivered: boolean;
   readAt: string | null;
+  liveDeliveredAt: string | null;
   createdAt: string;
 }
 

--- a/slack-bridge/broker-inbound-persistence.test.ts
+++ b/slack-bridge/broker-inbound-persistence.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { BrokerDB } from "./broker/schema.js";
+import { persistDeliveredInboundMessage } from "./broker-inbound-persistence.js";
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createDb(): { db: BrokerDB; dir: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "slack-bridge-inbound-persist-"));
+  const db = new BrokerDB(path.join(dir, "broker.db"));
+  db.initialize();
+  return { db, dir };
+}
+
+describe("persistDeliveredInboundMessage", () => {
+  it("stores broker-handled Slack messages as delivered but unread", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      db.createThread("123.456", "slack", "C123", "broker-1");
+      const message = {
+        source: "slack",
+        threadId: "123.456",
+        channel: "C123",
+        userId: "U1",
+        userName: "User One",
+        text: "hello broker",
+        timestamp: "123.456",
+        metadata: { channel: "C123", timestamp: "123.456" },
+      };
+
+      const persisted = persistDeliveredInboundMessage(db, "broker-1", message);
+
+      expect(persisted.freshDelivery).toBe(true);
+      expect(db.getInbox("broker-1")).toHaveLength(0);
+      const liveSync = db.getInboxForLiveSync("broker-1");
+      expect(liveSync).toHaveLength(1);
+      const read = db.readInbox("broker-1", { markRead: false });
+      expect(read.unreadCountBefore).toBe(1);
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0]?.entry).toMatchObject({
+        messageId: persisted.message.id,
+        delivered: true,
+        readAt: null,
+        liveDeliveredAt: null,
+      });
+      expect(read.messages[0]?.message).toMatchObject({
+        externalId: "C123:123.456",
+        externalTs: "123.456",
+        body: "hello broker",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("suppresses broker live sync after a fresh delivery is surfaced", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      db.createThread("123.456", "slack", "C123", "broker-1");
+      const message = {
+        source: "slack",
+        threadId: "123.456",
+        channel: "C123",
+        userId: "U1",
+        userName: "User One",
+        text: "hello broker",
+        timestamp: "123.456",
+        metadata: { channel: "C123", timestamp: "123.456" },
+      };
+
+      const persisted = persistDeliveredInboundMessage(db, "broker-1", message);
+      expect(db.getInboxForLiveSync("broker-1")).toHaveLength(1);
+
+      db.markLiveDeliveredByMessageId(persisted.message.id, "broker-1");
+
+      expect(db.getInboxForLiveSync("broker-1")).toHaveLength(0);
+      const read = db.readInbox("broker-1", { markRead: false });
+      expect(read.unreadCountBefore).toBe(1);
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0]?.entry.liveDeliveredAt).toEqual(expect.any(String));
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not create duplicate unread rows for Slack replays", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      db.createThread("123.456", "slack", "C123", "broker-1");
+      const message = {
+        source: "slack",
+        threadId: "123.456",
+        channel: "C123",
+        userId: "U1",
+        userName: "User One",
+        text: "hello broker",
+        timestamp: "123.456",
+        metadata: { channel: "C123", timestamp: "123.456" },
+      };
+
+      const first = persistDeliveredInboundMessage(db, "broker-1", message);
+      const replay = persistDeliveredInboundMessage(db, "broker-1", {
+        ...message,
+        text: "hello broker replay",
+      });
+
+      const read = db.readInbox("broker-1", { markRead: false });
+      expect(first.freshDelivery).toBe(true);
+      expect(replay.freshDelivery).toBe(false);
+      expect(replay.message.id).toBe(first.message.id);
+      expect(read.unreadCountBefore).toBe(1);
+      expect(read.messages).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/slack-bridge/broker-inbound-persistence.ts
+++ b/slack-bridge/broker-inbound-persistence.ts
@@ -1,0 +1,21 @@
+import type { BrokerMessage, InboundMessage } from "@gugu910/pi-broker-core/types";
+
+export interface DeliveredInboundPersistenceStore {
+  queueDeliveredMessage(
+    agentId: string,
+    message: InboundMessage,
+  ): { message: BrokerMessage; freshDelivery: boolean };
+}
+
+export interface DeliveredInboundPersistenceResult {
+  message: BrokerMessage;
+  freshDelivery: boolean;
+}
+
+export function persistDeliveredInboundMessage(
+  store: DeliveredInboundPersistenceStore,
+  agentId: string,
+  message: InboundMessage,
+): DeliveredInboundPersistenceResult {
+  return store.queueDeliveredMessage(agentId, message);
+}

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -276,7 +276,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     db.recoverPendingTargetedBacklog(agentId);
 
     const pending = db
-      .getInbox(agentId)
+      .getInboxForLiveSync(agentId)
       .filter((item) => !isBrokerInboxIdTracked(deps.deliveryState, item.entry.id));
     if (pending.length === 0) {
       return;
@@ -299,10 +299,12 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     );
 
     const handledInboxIds = new Set<number>();
+    const liveDeliveredInboxIds = new Set<number>();
     const commandsToStart: PinetControlCommand[] = [];
     for (const entry of synced.controlEntries) {
       try {
         const queued = deps.requestRemoteControl(entry.command, ctx);
+        liveDeliveredInboxIds.add(entry.inboxId);
         if (queued.ackDisposition === "immediate") {
           handledInboxIds.add(entry.inboxId);
         } else {
@@ -319,6 +321,11 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     for (const entry of synced.skinEntries) {
       deps.applySkinUpdate(entry.update);
       handledInboxIds.add(entry.inboxId);
+      liveDeliveredInboxIds.add(entry.inboxId);
+    }
+
+    if (liveDeliveredInboxIds.size > 0) {
+      db.markLiveDelivered([...liveDeliveredInboxIds], agentId);
     }
 
     if (handledInboxIds.size > 0) {
@@ -341,6 +348,12 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     );
 
     deps.pushInboxMessages(synced.inboxMessages);
+    db.markLiveDelivered(
+      synced.inboxMessages.flatMap((message) =>
+        message.brokerInboxId != null ? [message.brokerInboxId] : [],
+      ),
+      agentId,
+    );
     deps.updateBadge();
     deps.maybeDrainInboxIfIdle(ctx);
   }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -45,6 +45,7 @@ import {
   type SinglePlayerThreadInfo,
 } from "./single-player-runtime.js";
 import { createBrokerRuntime } from "./broker-runtime.js";
+import { persistDeliveredInboundMessage } from "./broker-inbound-persistence.js";
 import { SlackActivityLogger } from "./activity-log.js";
 import { createBrokerDeliveryState, queueBrokerInboxIds } from "./broker-delivery.js";
 import { buildBrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
@@ -703,6 +704,8 @@ export default function (pi: ExtensionAPI) {
         }
 
         if (decision.action === "deliver" || decision.action === "unrouted") {
+          const persistedInbound = persistDeliveredInboundMessage(broker.db, selfId, routedMessage);
+          if (!persistedInbound.freshDelivery) return;
           inbox.push({
             channel: routedMessage.channel,
             threadTs: routedMessage.threadId,
@@ -712,6 +715,7 @@ export default function (pi: ExtensionAPI) {
             metadata: routedMessage.metadata ?? null,
             ...(routedMessage.scope ? { scope: routedMessage.scope } : {}),
           });
+          broker.db.markLiveDeliveredByMessageId(persistedInbound.message.id, selfId);
           updateBadge();
           maybeDrainInboxIfIdle(ctx);
         }


### PR DESCRIPTION
## Summary
- persist broker-handled Slack inbound messages into broker SQLite even when routed to the broker/self or local unrouted inbox
- mark the persisted self-delivery rows delivered immediately so existing hot-path memory inbox behavior is preserved
- keep rows unread for `pinet_read`, and rely on PR #609 transport identity dedupe to avoid duplicate unread replay rows

## Validation
- pnpm --filter @gugu910/pi-broker-core typecheck
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --dir slack-bridge exec vitest --configLoader runner run broker-inbound-persistence.test.ts broker/helpers.test.ts broker/integration.test.ts pinet-tools.test.ts
- pnpm --filter @gugu910/pi-broker-core test
- pnpm --filter @gugu910/pi-broker-core lint
- pnpm --filter @gugu910/pi-slack-bridge lint
- push hook/root cached test pass

Stacked on PR #609 for #594.