### PR TITLE
feat(slack-bridge): add pinet read summaries

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -364,6 +364,53 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("returns thread-scoped unread summaries without marking messages read", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.queueMessage("agent-1", {
+        source: "agent",
+        threadId: "thread-a",
+        channel: "",
+        userId: "sender",
+        userName: "Sender",
+        text: "first",
+        timestamp: "2026-04-25T00:00:01.000Z",
+      });
+      db.queueMessage("agent-1", {
+        source: "agent",
+        threadId: "thread-a",
+        channel: "",
+        userId: "sender",
+        userName: "Sender",
+        text: "second",
+        timestamp: "2026-04-25T00:00:02.000Z",
+      });
+      db.queueMessage("agent-1", {
+        source: "agent",
+        threadId: "thread-b",
+        channel: "",
+        userId: "sender",
+        userName: "Sender",
+        text: "third",
+        timestamp: "2026-04-25T00:00:03.000Z",
+      });
+
+      const summary = db.readInbox("agent-1", { threadId: "thread-a", summaryOnly: true });
+
+      expect(summary.messages).toEqual([]);
+      expect(summary.unreadCountBefore).toBe(2);
+      expect(summary.unreadCountAfter).toBe(2);
+      expect(summary.markedReadIds).toEqual([]);
+      expect(summary.unreadThreads).toEqual([
+        expect.objectContaining({ threadId: "thread-a", unreadCount: 2 }),
+      ]);
+      expect(db.getUnreadInboxCount("agent-1")).toBe(3);
+    } finally {
+      db.close();
+    }
+  });
+
   it("does not deduplicate messages without a transport identity", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -2370,10 +2370,21 @@ export class BrokerDB implements BrokerDBInterface {
   readInbox(agentId: string, options: InboxReadOptions = {}): InboxReadResult {
     const db = this.getDb();
     const unreadOnly = options.unreadOnly ?? true;
-    const markRead = options.markRead ?? true;
+    const summaryOnly = options.summaryOnly ?? false;
+    const markRead = summaryOnly ? false : (options.markRead ?? true);
     const limit = Math.min(Math.max(Math.trunc(options.limit ?? 20), 1), 100);
     const threadId = options.threadId?.trim();
     const unreadCountBefore = this.getUnreadInboxCount(agentId);
+    if (summaryOnly) {
+      const summaryUnreadCount = this.getUnreadInboxCount(agentId, threadId);
+      return {
+        messages: [],
+        unreadCountBefore: summaryUnreadCount,
+        unreadCountAfter: summaryUnreadCount,
+        unreadThreads: this.getUnreadThreadSummary(agentId, limit, threadId),
+        markedReadIds: [],
+      };
+    }
 
     const clauses = ["i.agent_id = ?"];
     const values: Array<string | number> = [agentId];
@@ -2471,17 +2482,37 @@ export class BrokerDB implements BrokerDBInterface {
     };
   }
 
-  getUnreadInboxCount(agentId: string): number {
+  getUnreadInboxCount(agentId: string, threadId?: string): number {
     const db = this.getDb();
+    if (threadId) {
+      const row = db
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM inbox i
+           JOIN messages m ON m.id = i.message_id
+           WHERE i.agent_id = ? AND i.read_at IS NULL AND m.thread_id = ?`,
+        )
+        .get(agentId, threadId) as { count?: number } | undefined;
+      return Number(row?.count ?? 0);
+    }
+
     const row = db
       .prepare("SELECT COUNT(*) AS count FROM inbox WHERE agent_id = ? AND read_at IS NULL")
       .get(agentId) as { count?: number } | undefined;
     return Number(row?.count ?? 0);
   }
 
-  getUnreadThreadSummary(agentId: string, limit = 20): InboxThreadUnreadSummary[] {
+  getUnreadThreadSummary(
+    agentId: string,
+    limit = 20,
+    threadId?: string,
+  ): InboxThreadUnreadSummary[] {
     const db = this.getDb();
     const clampedLimit = Math.min(Math.max(Math.trunc(limit), 1), 100);
+    const threadClause = threadId ? " AND m.thread_id = ?" : "";
+    const values: Array<string | number> = threadId
+      ? [agentId, threadId, clampedLimit]
+      : [agentId, clampedLimit];
     const rows = db
       .prepare(
         `SELECT
@@ -2494,12 +2525,12 @@ export class BrokerDB implements BrokerDBInterface {
          FROM inbox i
          JOIN messages m ON m.id = i.message_id
          LEFT JOIN threads t ON t.thread_id = m.thread_id
-         WHERE i.agent_id = ? AND i.read_at IS NULL
+         WHERE i.agent_id = ? AND i.read_at IS NULL${threadClause}
          GROUP BY m.thread_id, m.source, t.channel
          ORDER BY latest_at DESC, latest_message_id DESC
          LIMIT ?`,
       )
-      .all(agentId, clampedLimit) as unknown as Array<{
+      .all(...values) as unknown as Array<{
       thread_id: string;
       source: string;
       channel: string;

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -58,6 +58,7 @@ export interface InboxReadOptions {
   limit?: number;
   unreadOnly?: boolean;
   markRead?: boolean;
+  summaryOnly?: boolean;
 }
 
 export interface InboxThreadUnreadSummary {

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -308,13 +308,13 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 ### Multi-agent tools
 
-| Tool             | Description                                                                |
-| ---------------- | -------------------------------------------------------------------------- |
-| `pinet_message`  | Send a message to a connected Pinet agent or broker-only broadcast channel |
-| `pinet_read`     | Read durable SQLite-backed Pinet inbox context and unread thread pointers  |
-| `pinet_agents`   | List connected Pinet agents with status and capabilities                   |
-| `pinet_free`     | Mark this Pinet agent idle/free for new work                               |
-| `pinet_schedule` | Schedule a future wake-up for this Pinet agent                             |
+| Tool             | Description                                                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `pinet_message`  | Send a message to a connected Pinet agent or broker-only broadcast channel                                                 |
+| `pinet_read`     | Read durable SQLite-backed Pinet inbox context and unread thread pointers (`summary_only=true` peeks without marking read) |
+| `pinet_agents`   | List connected Pinet agents with status and capabilities                                                                   |
+| `pinet_free`     | Mark this Pinet agent idle/free for new work                                                                               |
+| `pinet_schedule` | Schedule a future wake-up for this Pinet agent                                                                             |
 
 ### Broker commands
 

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -605,6 +605,116 @@ describe("BrokerClient — readInbox", () => {
 
     client.disconnect();
   });
+
+  it("sends inbox.read summaryOnly without accepting destructive summary responses", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const readPromise = client.readInbox({ summaryOnly: true });
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { summaryOnly: boolean };
+    };
+    expect(req.method).toBe("inbox.read");
+    expect(req.params).toEqual({ summaryOnly: true });
+
+    mock.respondTo(mock.connections[0], req.id, {
+      messages: [],
+      unreadCountBefore: 2,
+      unreadCountAfter: 2,
+      unreadThreads: [
+        {
+          threadId: "a2a:broker:worker",
+          source: "agent",
+          channel: "",
+          unreadCount: 2,
+          latestMessageId: 45,
+          latestAt: "2026-04-25T12:01:00.000Z",
+        },
+      ],
+      markedReadIds: [],
+    });
+
+    const result = await readPromise;
+    expect(result.messages).toEqual([]);
+    expect(result.unreadCountBefore).toBe(2);
+    expect(result.unreadCountAfter).toBe(2);
+    expect(result.markedReadIds).toEqual([]);
+
+    client.disconnect();
+  });
+
+  it("fails closed when an older broker returns global summaries for thread summary reads", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const readPromise = client.readInbox({ threadId: "thread-empty", summaryOnly: true });
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as { id: number };
+    mock.respondTo(mock.connections[0], req.id, {
+      messages: [],
+      unreadCountBefore: 1,
+      unreadCountAfter: 1,
+      unreadThreads: [
+        {
+          threadId: "thread-other",
+          source: "agent",
+          channel: "",
+          unreadCount: 1,
+          latestMessageId: 55,
+          latestAt: "2026-04-25T12:02:00.000Z",
+        },
+      ],
+      markedReadIds: [],
+    });
+
+    await expect(readPromise).rejects.toThrow(
+      "Broker does not support non-destructive Pinet read summaries",
+    );
+
+    client.disconnect();
+  });
+
+  it("fails closed when an older broker treats summaryOnly as a normal read", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const readPromise = client.readInbox({ summaryOnly: true });
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as { id: number };
+    mock.respondTo(mock.connections[0], req.id, {
+      messages: [
+        {
+          entry: { id: 31, delivered: false, readAt: "2026-04-25T12:00:00.000Z" },
+          message: {
+            id: 44,
+            threadId: "a2a:broker:worker",
+            source: "agent",
+            direction: "inbound",
+            sender: "broker",
+            body: "normal read from an older broker",
+            metadata: null,
+            createdAt: "2026-04-25T11:59:00.000Z",
+          },
+        },
+      ],
+      unreadCountBefore: 2,
+      unreadCountAfter: 1,
+      unreadThreads: [],
+      markedReadIds: [31],
+    });
+
+    await expect(readPromise).rejects.toThrow(
+      "Broker does not support non-destructive Pinet read summaries",
+    );
+
+    client.disconnect();
+  });
 });
 
 describe("BrokerClient — ackMessages", () => {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -50,6 +50,7 @@ export interface PinetReadOptions {
   limit?: number;
   unreadOnly?: boolean;
   markRead?: boolean;
+  summaryOnly?: boolean;
 }
 
 export interface ThreadInfo {
@@ -388,6 +389,7 @@ export class BrokerClient {
       ...(typeof options.limit === "number" ? { limit: options.limit } : {}),
       ...(typeof options.unreadOnly === "boolean" ? { unreadOnly: options.unreadOnly } : {}),
       ...(typeof options.markRead === "boolean" ? { markRead: options.markRead } : {}),
+      ...(typeof options.summaryOnly === "boolean" ? { summaryOnly: options.summaryOnly } : {}),
     })) as {
       messages: Array<{
         entry: { id: number; delivered: boolean; readAt: string | null };
@@ -398,6 +400,35 @@ export class BrokerClient {
       unreadThreads: PinetUnreadThreadSummary[];
       markedReadIds: number[];
     };
+
+    if (options.summaryOnly) {
+      const requestedThreadId = options.threadId?.trim();
+      const threadSummaryCount = requestedThreadId
+        ? result.unreadThreads.reduce(
+            (count, thread) => count + (thread.threadId === requestedThreadId ? 1 : 0),
+            0,
+          )
+        : 0;
+      const threadUnreadCount = requestedThreadId
+        ? (result.unreadThreads.find((thread) => thread.threadId === requestedThreadId)
+            ?.unreadCount ?? 0)
+        : result.unreadCountBefore;
+      const invalidThreadSummary = requestedThreadId
+        ? result.unreadThreads.some((thread) => thread.threadId !== requestedThreadId) ||
+          threadSummaryCount > 1 ||
+          result.unreadCountBefore !== threadUnreadCount
+        : false;
+      if (
+        result.messages.length > 0 ||
+        result.markedReadIds.length > 0 ||
+        result.unreadCountBefore !== result.unreadCountAfter ||
+        invalidThreadSummary
+      ) {
+        throw new Error(
+          "Broker does not support non-destructive Pinet read summaries. Upgrade the broker before using summaryOnly.",
+        );
+      }
+    }
 
     return {
       messages: result.messages.map((item) => ({

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -109,6 +109,19 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     await client.send("thread-read", "First unread message");
     await client.send("thread-read", "Second unread message");
 
+    const summary = await client2.readInbox({ summaryOnly: true });
+    expect(summary.messages).toEqual([]);
+    expect(summary.unreadCountBefore).toBe(2);
+    expect(summary.unreadCountAfter).toBe(2);
+    expect(summary.markedReadIds).toEqual([]);
+    expect(summary.unreadThreads).toEqual([
+      expect.objectContaining({
+        threadId: "thread-read",
+        source: "agent",
+        unreadCount: 2,
+      }),
+    ]);
+
     const read = await client2.readInbox({ threadId: "thread-read", limit: 10 });
     expect(read.unreadCountBefore).toBe(2);
     expect(read.messages.map((item) => item.message.body)).toEqual([

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -696,6 +696,11 @@ export class BrokerSocketServer {
       return rpcError(req.id, RPC_INVALID_PARAMS, "markRead must be a boolean");
     }
 
+    const summaryOnly = params.summaryOnly === undefined ? undefined : params.summaryOnly;
+    if (summaryOnly !== undefined && typeof summaryOnly !== "boolean") {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "summaryOnly must be a boolean");
+    }
+
     return rpcOk(
       req.id,
       this.db.readInbox(state.agentId, {
@@ -703,6 +708,7 @@ export class BrokerSocketServer {
         ...(typeof limit === "number" ? { limit } : {}),
         ...(typeof unreadOnly === "boolean" ? { unreadOnly } : {}),
         ...(typeof markRead === "boolean" ? { markRead } : {}),
+        ...(typeof summaryOnly === "boolean" ? { summaryOnly } : {}),
       }),
     );
   }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -886,6 +886,7 @@ export default function (pi: ExtensionAPI) {
     limit?: number;
     unreadOnly?: boolean;
     markRead?: boolean;
+    summaryOnly?: boolean;
   }) {
     if (brokerRole === "broker") {
       const db = getActiveBrokerDb();

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -184,6 +184,43 @@ describe("registerPinetTools", () => {
     expect(result.details.markedReadIds).toEqual([31]);
   });
 
+  it("summarizes durable Pinet inbox context without marking rows read", async () => {
+    const readPinetInbox = vi.fn(async () => ({
+      messages: [],
+      unreadCountBefore: 3,
+      unreadCountAfter: 3,
+      unreadThreads: [
+        {
+          threadId: "a2a:broker:worker",
+          source: "agent",
+          channel: "",
+          unreadCount: 2,
+          latestMessageId: 45,
+          latestAt: "2026-04-25T12:01:00.000Z",
+        },
+      ],
+      markedReadIds: [],
+    }));
+    const deps = createDeps({ readPinetInbox });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet_read")?.execute("tool-call-summary", {
+      summary_only: true,
+    })) as {
+      content: Array<{ text: string }>;
+      details: { unreadCountBefore: number; markedReadIds: number[] };
+    };
+
+    expect(readPinetInbox).toHaveBeenCalledWith({ summaryOnly: true });
+    expect(result.content[0]?.text).toContain(
+      "Pinet unread summary for your Pinet inbox: 3 unread messages.",
+    );
+    expect(result.content[0]?.text).toContain("Unread thread pointers:");
+    expect(result.content[0]?.text).toContain("a2a:broker:worker");
+    expect(result.content[0]?.text).not.toContain("Marked read:");
+    expect(result.details).toMatchObject({ unreadCountBefore: 3, markedReadIds: [] });
+  });
+
   it("formats pinet_free responses with note and queued inbox count", async () => {
     const signalAgentFree = vi.fn(async () => ({
       queuedInboxCount: 2,

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -86,10 +86,14 @@ function buildPinetAgentsHintText(hint: PinetAgentsRoutingHint): string {
 function formatPinetReadResult(result: PinetReadResult, options: PinetReadOptions): string {
   const scope = options.threadId ? `thread ${options.threadId}` : "your Pinet inbox";
   const mode = options.unreadOnly === false ? "latest" : "unread";
-  const lines = [
-    `Pinet read (${mode}) from ${scope}: ${result.messages.length} message${result.messages.length === 1 ? "" : "s"}.`,
-    `Unread before: ${result.unreadCountBefore}; unread after: ${result.unreadCountAfter}.`,
-  ];
+  const lines = options.summaryOnly
+    ? [
+        `Pinet unread summary for ${scope}: ${result.unreadCountBefore} unread message${result.unreadCountBefore === 1 ? "" : "s"}.`,
+      ]
+    : [
+        `Pinet read (${mode}) from ${scope}: ${result.messages.length} message${result.messages.length === 1 ? "" : "s"}.`,
+        `Unread before: ${result.unreadCountBefore}; unread after: ${result.unreadCountAfter}.`,
+      ];
 
   if (result.messages.length > 0) {
     lines.push("");
@@ -172,7 +176,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     label: "Pinet Read",
     description: "Read durable SQLite-backed Pinet inbox context with unread/read semantics.",
     promptSnippet:
-      "Read bounded Pinet/Slack broker context from the durable SQLite inbox. Use unread counts first, then read a specific thread or latest messages when needed. Reading marks returned unread rows as read by default; use mark_read=false to peek.",
+      "Read bounded Pinet/Slack broker context from the durable SQLite inbox. Use summary_only=true for unread/thread discovery, then read a specific thread or latest messages when needed. Reading marks returned unread rows as read by default; use mark_read=false to peek.",
     parameters: Type.Object({
       thread_id: Type.Optional(
         Type.String({ description: "Optional Pinet/Slack broker thread ID to read" }),
@@ -186,12 +190,18 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       mark_read: Type.Optional(
         Type.Boolean({ description: "Mark returned unread rows as read (default true)" }),
       ),
+      summary_only: Type.Optional(
+        Type.Boolean({
+          description:
+            "Return unread counts and thread pointers without message bodies or read-state changes (default false)",
+        }),
+      ),
     }),
     async execute(_id, params) {
       deps.requireToolPolicy(
         "pinet_read",
         undefined,
-        `thread_id=${params.thread_id ?? ""} | limit=${params.limit ?? ""} | unread_only=${params.unread_only ?? ""} | mark_read=${params.mark_read ?? ""}`,
+        `thread_id=${params.thread_id ?? ""} | limit=${params.limit ?? ""} | unread_only=${params.unread_only ?? ""} | mark_read=${params.mark_read ?? ""} | summary_only=${params.summary_only ?? ""}`,
       );
 
       if (!deps.pinetEnabled()) {
@@ -203,6 +213,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
         ...(typeof params.limit === "number" ? { limit: params.limit } : {}),
         ...(typeof params.unread_only === "boolean" ? { unreadOnly: params.unread_only } : {}),
         ...(typeof params.mark_read === "boolean" ? { markRead: params.mark_read } : {}),
+        ...(typeof params.summary_only === "boolean" ? { summaryOnly: params.summary_only } : {}),
       };
       if (options.threadId !== undefined && options.threadId.length === 0) {
         throw new Error("thread_id must be a non-empty string when provided.");


### PR DESCRIPTION
## Summary
- add `summary_only` to `pinet_read` for unread/thread discovery without returning message bodies or marking rows read
- carry `summaryOnly` through follower RPC/client and broker self-read paths
- cover summary behavior in pinet tool, broker client, and broker integration tests

Stacked on PR #610 for #594. Depends on PR #609/#610.

## Validation
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --dir slack-bridge exec vitest --configLoader runner run pinet-tools.test.ts broker/client.test.ts broker/integration.test.ts broker-inbound-persistence.test.ts`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- push hook/root quality ran on `git push` (GitHub quality pending at PR open)

Refs #594
