### PR TITLE
docs(slack-bridge): sync confirmation examples

### DIFF
--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -204,7 +204,7 @@ export function buildSecurityPrompt(guardrails: SecurityGuardrails): string {
     sections.push(
       [
         "✋ CONFIRMATION REQUIRED:",
-        `Before using tools matching these patterns: [${guardrails.requireConfirmation!.join(", ")}], you MUST first call slack with action "confirm_action" and args containing thread_ts, a description of the action, and the tool name (for dispatcher actions, use slack:<action>).`,
+        `Before using tools matching these patterns: [${guardrails.requireConfirmation!.join(", ")}], you MUST first call slack with action "confirm_action" and args containing thread_ts, the exact action string required by the guarded tool, and the tool name (for dispatcher actions, use slack:<action>).`,
         "Wait for the user's response via slack_inbox. Only proceed if the user approves. If denied, inform the user and skip the action.",
       ].join("\n"),
     );

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -320,7 +320,10 @@ Add a bookmark:
 
 ## Confirmation and destructive actions
 
-If guardrails require confirmation, request it in the same Slack thread:
+If guardrails require confirmation, request it in the same Slack thread. The
+`action` value must be the exact action string required by the guarded tool;
+the safest flow is to copy it from the `requires confirmation for action ...`
+error and retry the guarded call unchanged after approval:
 
 ```json
 {
@@ -328,14 +331,15 @@ If guardrails require confirmation, request it in the same Slack thread:
   "args": {
     "thread_ts": "1712345678.000100",
     "tool": "slack:delete",
-    "action": "delete message 1712345678.000200"
+    "action": "channel=#proj-alpha | thread_ts=1712345678.000100 | ts=1712345678.000200 | thread=false"
   }
 }
 ```
 
 Wait for `slack_inbox` to deliver the approval before retrying the guarded
-action. For destructive deletes, also set `confirm: true` after verifying the
-target:
+action. Every destructive delete also needs `confirm: true` after verifying the
+target; whole-thread deletion additionally needs `thread: true` and only works
+when every message in the target thread was posted by the current bot:
 
 ```json
 {

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1051,6 +1051,25 @@ describe("registerSlackTools", () => {
       examples: [expect.objectContaining({ action: "post_channel" })],
     });
     expect(schemaResponse.content?.[0]?.text).toContain("args_schema");
+
+    const confirmationHelp = await dispatcher.execute("tool-help-confirm", {
+      action: "help",
+      args: { topic: "confirm_action" },
+    });
+    const confirmationEnvelope = confirmationHelp.details as SlackDispatcherEnvelope;
+    expect(confirmationEnvelope.status).toBe("succeeded");
+    expect(JSON.stringify(confirmationEnvelope.data)).toContain("Exact action string");
+    expect(JSON.stringify(confirmationEnvelope.data)).toContain("slack:<action>");
+    expect(confirmationEnvelope.data).toMatchObject({
+      action: "confirm_action",
+      guardrail_tool: "slack:confirm_action",
+      examples: [
+        expect.objectContaining({
+          action: "confirm_action",
+          args: expect.objectContaining({ tool: "slack:delete" }),
+        }),
+      ],
+    });
   });
 
   it("opens a modal and embeds thread context in private_metadata", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -2818,8 +2818,14 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     promptSnippet: "Request confirmation in Slack before dangerous actions.",
     parameters: Type.Object({
       thread_ts: Type.String({ description: "Thread to post confirmation request in" }),
-      action: Type.String({ description: "Description of the action needing approval" }),
-      tool: Type.String({ description: "Name of the tool that requires confirmation" }),
+      action: Type.String({
+        description:
+          "Exact action string required by the guarded tool. Copy it from the guardrail error and retry the guarded call unchanged after approval.",
+      }),
+      tool: Type.String({
+        description:
+          "Exact guardrail tool name that requires confirmation. For Slack dispatcher actions, use slack:<action> such as slack:delete.",
+      }),
     }),
     async execute(_id, params) {
       const channelId = await resolveTrackedThreadChannel(params.thread_ts);

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -130,7 +130,8 @@ const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
       args: {
         thread_ts: "1712345678.000100",
         tool: "slack:delete",
-        action: "delete message ts=1712345678.000200",
+        action:
+          "channel=#deployments | thread_ts=1712345678.000100 | ts=1712345678.000200 | thread=false",
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Sync live Slack dispatcher help, bundled `slack-bridge` skill guidance, and guardrail prompt wording with the confirmation contract documented in PR #612.
- Clarify that guarded confirmations require the exact action string emitted by the guarded tool.
- Update the `confirm_action` example to use the canonical `slack:delete` action string shape.

## Validation
- `pnpm exec prettier --check slack-bridge/README.md slack-bridge/skills/slack-bridge/SKILL.md slack-bridge/slack-tools.ts slack-bridge/guardrails.ts`
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run slack-tools.test.ts guardrails.test.ts thread-confirmations.test.ts`
- `pnpm lint`
- pre-push hook on `git push` ran workspace checks, including full slack-bridge test suite

## Notes
Follow-up to PR #612. Docs/guidance metadata only. No merge requested.