### PR TITLE
fix: harden Slack upload snippet handling and diagnostics (#614)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -266,6 +266,10 @@ migration.
   environments with restricted egress this can fail with `403` (proxy
   allowlist) or DNS errors after `files.getUploadURLExternal`; verify the proxy
   allowlist first, or route through an environment that can reach those hosts.
+- **Upload metadata note.** Slack snippet uploads attempt to use inferred
+  `snippet_type` values for inline content and retry with plain upload metadata
+  when Slack returns `invalid_arguments`, preserving syntax highlighting for
+  supported types while avoiding hard failures on unsupported snippet types.
 - **Canvases are long-lived docs.** `canvas_create` creates standalone or
   channel canvases; `canvas_update` can append, prepend, replace the whole
   canvas, or replace a matched section; `canvas_comments_read` is read-only and

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -261,6 +261,11 @@ migration.
   long diffs, and generated files instead of large inline messages. Inline
   uploads require `filename`; path uploads are guarded and must stay within the
   current working directory or system temp directory.
+- **Upload host egress note.** The second upload leg goes to Slack file upload
+  hosts (`files.slack.com`/`uploads.slack.com`) for the raw payload. In
+  environments with restricted egress this can fail with `403` (proxy
+  allowlist) or DNS errors after `files.getUploadURLExternal`; verify the proxy
+  allowlist first, or route through an environment that can reach those hosts.
 - **Canvases are long-lived docs.** `canvas_create` creates standalone or
   channel canvases; `canvas_update` can append, prepend, replace the whole
   canvas, or replace a matched section; `canvas_comments_read` is read-only and

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -17,7 +17,7 @@ type ToolDefinition = {
 type SlackDispatcherEnvelope = {
   status: "succeeded" | "failed";
   data: unknown;
-  errors: Array<{ message: string }>;
+  errors: Array<{ message: string; class?: string }>;
 };
 
 type SlackDispatcherData = {
@@ -1399,5 +1399,80 @@ describe("registerSlackTools", () => {
     const details = (result as { details: Record<string, unknown> }).details;
     expect(details.channel_id).toBe("C_PROJ");
     expect(details.canvas_id).toBeNull();
+  });
+
+  it("classifies raw upload 403 responses as input when no proxy marker is present", async () => {
+    const { slack, tools } = setup();
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "files.getUploadURLExternal") {
+          return {
+            ok: true,
+            upload_url: "https://uploads.slack.test/file",
+            file_id: "F123",
+          } as SlackResult;
+        }
+        if (method === "files.completeUploadExternal") {
+          return { ok: true, files: [{ id: "F123" }] } as SlackResult;
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("forbidden", { status: 403, statusText: "Forbidden" }));
+
+    const response = await tools.get("slack")!.execute("tool-upload-1", {
+      action: "upload",
+      args: { content: "hello", filename: "hello.txt" },
+    });
+
+    const envelope = response.details as SlackDispatcherEnvelope;
+    expect(envelope.status).toBe("failed");
+    expect(envelope.errors[0]?.class).toBe("input");
+    expect(envelope.errors[0]?.message).toContain("Slack raw upload failed (HTTP 403");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("classifies raw upload responses as network when proxy/firewall markers appear", async () => {
+    const { slack, tools } = setup();
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "files.getUploadURLExternal") {
+          return {
+            ok: true,
+            upload_url: "https://files.slack.com/upload/abc",
+            file_id: "F123",
+          } as SlackResult;
+        }
+        if (method === "files.completeUploadExternal") {
+          return { ok: true, files: [{ id: "F123" }] } as SlackResult;
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("X-Proxy-Error: blocked-by-allowlist", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    const response = await tools.get("slack")!.execute("tool-upload-2", {
+      action: "upload",
+      args: { content: "hello", filename: "hello.txt" },
+    });
+
+    const envelope = response.details as SlackDispatcherEnvelope;
+    expect(envelope.status).toBe("failed");
+    expect(envelope.errors[0]?.class).toBe("network");
+    expect(envelope.errors[0]?.message).toContain("possible outbound proxy/firewall block");
+
+    fetchSpy.mockRestore();
   });
 });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -280,12 +280,50 @@ function classifySlackDispatcherError(error: unknown): SlackDispatcherError {
   }
 
   if (lower.includes("slack raw upload failed")) {
-    if (lower.includes("files.slack.com") || lower.includes("uploads.slack.com")) {
+    const rawStatusMatch = message.match(/Slack raw upload failed \(http\s*(\d{3})/i);
+    const rawStatus = rawStatusMatch?.[1];
+
+    if (rawStatus === "429") {
+      return {
+        class: "rate-limit",
+        message,
+        retryable: true,
+        hint: "Wait for Slack rate limits to clear, then retry the same action if it is idempotent.",
+      };
+    }
+
+    if (
+      lower.includes("transport") ||
+      lower.includes("network") ||
+      lower.includes("fetch") ||
+      lower.includes("timeout") ||
+      lower.includes("econnreset") ||
+      lower.includes("etimedout") ||
+      lower.includes("possible outbound proxy/firewall block")
+    ) {
       return {
         class: "network",
         message,
         retryable: true,
         hint: "Upload data-plane host is unavailable. Verify egress rules/proxy allowlist for files.slack.com and uploads.slack.com, then retry.",
+      };
+    }
+
+    if (rawStatus && rawStatus.startsWith("5")) {
+      return {
+        class: "network",
+        message,
+        retryable: true,
+        hint: "Retry after checking network connectivity. For write actions, verify whether Slack already applied the request before retrying.",
+      };
+    }
+
+    if (rawStatus && rawStatus.startsWith("4")) {
+      return {
+        class: "input",
+        message,
+        retryable: false,
+        hint: "Slack rejected the upload payload. Verify the upload URL/request metadata and retry; if this persists, classify as a Slack-side upload failure.",
       };
     }
 

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -270,6 +270,33 @@ function classifySlackDispatcherError(error: unknown): SlackDispatcherError {
     };
   }
 
+  if (lower.includes("files.getuploadurlexternal") && lower.includes("invalid_arguments")) {
+    return {
+      class: "input",
+      message,
+      retryable: false,
+      hint: "Slack rejected upload metadata for files.getUploadURLExternal (invalid_arguments). Check filename and snippet_type; remove unsupported snippet extensions for inline content and retry.",
+    };
+  }
+
+  if (lower.includes("slack raw upload failed")) {
+    if (lower.includes("files.slack.com") || lower.includes("uploads.slack.com")) {
+      return {
+        class: "network",
+        message,
+        retryable: true,
+        hint: "Upload data-plane host is unavailable. Verify egress rules/proxy allowlist for files.slack.com and uploads.slack.com, then retry.",
+      };
+    }
+
+    return {
+      class: "network",
+      message,
+      retryable: true,
+      hint: "Retry after checking network connectivity. For write actions, verify whether Slack already applied the request before retrying.",
+    };
+  }
+
   if (
     lower.includes("network") ||
     lower.includes("fetch") ||

--- a/slack-bridge/slack-upload.test.ts
+++ b/slack-bridge/slack-upload.test.ts
@@ -46,14 +46,14 @@ describe("chooseSlackSnippetType", () => {
     ).toBe("typescript");
   });
 
-  it("falls back to text for unsupported inline snippet types", () => {
+  it("preserves inferred inline snippet type for known/known-missing extensions", () => {
     expect(
       chooseSlackSnippetType({
         source: "content",
         byteLength: 256,
         filename: "release-notes.txt",
       }),
-    ).toBe("text");
+    ).toBe("txt");
   });
 
   it("does not enable snippet mode for path uploads or oversized content", () => {
@@ -261,6 +261,62 @@ describe("performSlackUpload", () => {
     expect(result.fileId).toBe("F123");
   });
 
+  it("retries files.getUploadURLExternal without snippet_type when invalid arguments happen", async () => {
+    const slack = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Slack files.getUploadURLExternal: invalid_arguments"))
+      .mockResolvedValueOnce({
+        ok: true,
+        upload_url: "https://uploads.slack.test/file",
+        file_id: "F123",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        files: [{ id: "F123", permalink: "https://slack.test/F123" }],
+      });
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "",
+    }));
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "const answer = 42;\n",
+        filename: "release-notes.txt",
+        title: "Release notes",
+      },
+      "/repo",
+      "/tmp",
+    );
+
+    await performSlackUpload({
+      upload,
+      channelId: "C123",
+      threadTs: "171234.5678",
+      slack,
+      token: "xoxb-token",
+      fetchImpl,
+    });
+
+    expect(slack).toHaveBeenCalledTimes(3);
+    expect(slack).toHaveBeenNthCalledWith(1, "files.getUploadURLExternal", "xoxb-token", {
+      filename: "release-notes.txt",
+      length: upload.byteLength,
+      snippet_type: "txt",
+    });
+    expect(slack).toHaveBeenNthCalledWith(2, "files.getUploadURLExternal", "xoxb-token", {
+      filename: "release-notes.txt",
+      length: upload.byteLength,
+    });
+    expect(slack).toHaveBeenNthCalledWith(3, "files.completeUploadExternal", "xoxb-token", {
+      files: [{ id: "F123", title: "Release notes" }],
+      channel_id: "C123",
+      thread_ts: "171234.5678",
+    });
+  });
+
   it("surfaces raw upload failures", async () => {
     const slack = vi.fn().mockResolvedValue({
       ok: true,
@@ -291,7 +347,73 @@ describe("performSlackUpload", () => {
         token: "xoxb-token",
         fetchImpl,
       }),
-    ).rejects.toThrow("Slack raw upload failed (500 Internal Server Error)");
+    ).rejects.toThrow("Slack raw upload failed (HTTP 500 Internal Server Error)");
+  });
+
+  it("flags likely proxy/firewall blocked raw upload responses", async () => {
+    const slack = vi.fn().mockResolvedValue({
+      ok: true,
+      upload_url: "https://files.slack.com/upload/abc",
+      file_id: "F123",
+    });
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: async () => "X-Proxy-Error: blocked-by-allowlist",
+    }));
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "hello",
+        filename: "hello.txt",
+      },
+      "/repo",
+      "/tmp",
+    );
+
+    await expect(
+      performSlackUpload({
+        upload,
+        channelId: "C123",
+        slack,
+        token: "xoxb-token",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("[possible outbound proxy/firewall block]");
+  });
+
+  it("does not label generic HTTP 403 as a proxy/firewall issue", async () => {
+    const slack = vi.fn().mockResolvedValue({
+      ok: true,
+      upload_url: "https://uploads.slack.test/file",
+      file_id: "F123",
+    });
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: async () => "forbidden",
+    }));
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "hello",
+        filename: "hello.txt",
+      },
+      "/repo",
+      "/tmp",
+    );
+
+    await expect(
+      performSlackUpload({
+        upload,
+        channelId: "C123",
+        slack,
+        token: "xoxb-token",
+        fetchImpl,
+      }),
+    ).rejects.not.toThrow("[possible outbound proxy/firewall block]");
   });
 
   it("surfaces network upload transport failures", async () => {
@@ -325,6 +447,6 @@ describe("performSlackUpload", () => {
         token: "xoxb-token",
         fetchImpl,
       }),
-    ).rejects.toThrow("host files.slack.com");
+    ).rejects.toThrow("host=files.slack.com");
   });
 });

--- a/slack-bridge/slack-upload.test.ts
+++ b/slack-bridge/slack-upload.test.ts
@@ -46,6 +46,16 @@ describe("chooseSlackSnippetType", () => {
     ).toBe("typescript");
   });
 
+  it("falls back to text for unsupported inline snippet types", () => {
+    expect(
+      chooseSlackSnippetType({
+        source: "content",
+        byteLength: 256,
+        filename: "release-notes.txt",
+      }),
+    ).toBe("text");
+  });
+
   it("does not enable snippet mode for path uploads or oversized content", () => {
     expect(
       chooseSlackSnippetType({
@@ -281,6 +291,40 @@ describe("performSlackUpload", () => {
         token: "xoxb-token",
         fetchImpl,
       }),
-    ).rejects.toThrow("Slack raw upload failed (500 Internal Server Error): boom");
+    ).rejects.toThrow("Slack raw upload failed (500 Internal Server Error)");
+  });
+
+  it("surfaces network upload transport failures", async () => {
+    const networkError = new Error("fetch failed");
+    const dnsError = new Error("getaddrinfo ENOTFOUND files.slack.com");
+    (dnsError as NodeJS.ErrnoException).code = "ENOTFOUND";
+    (networkError as Error & { cause?: Error }).cause = dnsError;
+    const slack = vi.fn().mockResolvedValue({
+      ok: true,
+      upload_url: "https://files.slack.com/upload/abc",
+      file_id: "F123",
+    });
+    const fetchImpl = vi.fn(async () => {
+      throw networkError;
+    });
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "hello",
+        filename: "hello.txt",
+      },
+      "/repo",
+      "/tmp",
+    );
+
+    await expect(
+      performSlackUpload({
+        upload,
+        channelId: "C123",
+        slack,
+        token: "xoxb-token",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("host files.slack.com");
   });
 });

--- a/slack-bridge/slack-upload.ts
+++ b/slack-bridge/slack-upload.ts
@@ -18,6 +18,27 @@ const FILETYPE_ALIASES: Record<string, string> = {
   zsh: "shell",
 };
 
+const ALLOWED_SNIPPET_TYPES = new Set([
+  "bash",
+  "c",
+  "cpp",
+  "css",
+  "diff",
+  "html",
+  "javascript",
+  "json",
+  "markdown",
+  "objective-c",
+  "perl",
+  "python",
+  "ruby",
+  "shell",
+  "swift",
+  "text",
+  "typescript",
+  "yaml",
+]);
+
 const DEFAULT_SNIPPET_TYPE = "text";
 const MAX_SNIPPET_BYTES = 1_000_000;
 
@@ -83,13 +104,49 @@ export function chooseSlackSnippetType(upload: {
 }): string | undefined {
   if (upload.source !== "content") return undefined;
   if (upload.byteLength > MAX_SNIPPET_BYTES) return undefined;
-  return inferSlackUploadFiletype(upload.filename, upload.filetype) ?? DEFAULT_SNIPPET_TYPE;
+  return normalizeSnippetType(inferSlackUploadFiletype(upload.filename, upload.filetype));
 }
 
 function isWithinRoot(candidate: string, root: string): boolean {
   return candidate === root || candidate.startsWith(`${root}${path.sep}`);
 }
 
+function normalizeSnippetType(filetype: string | undefined): string {
+  const normalized = filetype?.trim().toLowerCase();
+  if (!normalized) return DEFAULT_SNIPPET_TYPE;
+  return ALLOWED_SNIPPET_TYPES.has(normalized) ? normalized : DEFAULT_SNIPPET_TYPE;
+}
+
+function getUploadHost(uploadUrl: string): string {
+  try {
+    return new URL(uploadUrl).hostname || "<unknown>";
+  } catch {
+    return "<unknown>";
+  }
+}
+
+function formatUploadError(error: unknown): string {
+  if (error instanceof Error) {
+    if (typeof error.cause === "string") {
+      return `${error.message}; cause: ${error.cause}`;
+    }
+
+    if (error.cause instanceof Error) {
+      const cause = [
+        error.cause.message,
+        (error.cause as { code?: unknown }).code,
+        error.cause.name,
+      ]
+        .filter((value): value is string => typeof value === "string" && value.length > 0)
+        .join("; ");
+      return cause ? `${error.message}; cause: ${cause}` : error.message;
+    }
+
+    return error.message;
+  }
+
+  return String(error);
+}
 export async function resolveSlackUploadPath(
   inputPath: string,
   cwd: string,
@@ -202,6 +259,7 @@ export async function performSlackUpload({
 
   const uploadUrl =
     typeof getUploadResponse.upload_url === "string" ? getUploadResponse.upload_url : null;
+  const uploadHost = uploadUrl ? getUploadHost(uploadUrl) : "<unknown>";
   const fileId = typeof getUploadResponse.file_id === "string" ? getUploadResponse.file_id : null;
   if (!uploadUrl || !fileId) {
     throw new Error("Slack files.getUploadURLExternal did not return an upload URL and file ID.");
@@ -210,20 +268,34 @@ export async function performSlackUpload({
   const rawBody = new Uint8Array(upload.bytes.byteLength);
   rawBody.set(upload.bytes);
 
-  const rawUploadResponse = await fetchImpl(uploadUrl, {
-    method: "POST",
-    headers: {
-      "Content-Length": String(upload.byteLength),
-      "Content-Type":
-        upload.source === "content" ? "text/plain; charset=utf-8" : "application/octet-stream",
-    },
-    body: new Blob([rawBody]),
-  });
+  let rawUploadResponse: Pick<Response, "ok" | "status" | "statusText" | "text">;
+  try {
+    rawUploadResponse = await fetchImpl(uploadUrl, {
+      method: "POST",
+      headers: {
+        "Content-Length": String(upload.byteLength),
+        "Content-Type":
+          upload.source === "content" ? "text/plain; charset=utf-8" : "application/octet-stream",
+      },
+      body: new Blob([rawBody]),
+    });
+  } catch (error) {
+    throw new Error(
+      `Slack raw upload failed for host ${uploadHost}: ${formatUploadError(error)}; filename=${upload.filename} byte_length=${upload.byteLength}`,
+    );
+  }
 
   if (!rawUploadResponse.ok) {
     const details = (await rawUploadResponse.text()).trim();
+    const statusText = rawUploadResponse.statusText;
+    const statusTextForHeader = statusText ? ` ${statusText}` : "";
+    const withDetails =
+      details.length > 0 ? `${statusText ? `${statusText}: ` : ""}${details}` : "";
+    const hint = /^(403|429|502|503)$/.test(String(rawUploadResponse.status))
+      ? " [possible outbound proxy/firewall block]"
+      : "";
     throw new Error(
-      `Slack raw upload failed (${rawUploadResponse.status}${rawUploadResponse.statusText ? ` ${rawUploadResponse.statusText}` : ""})${details ? `: ${details}` : ""}`,
+      `Slack raw upload failed (${rawUploadResponse.status}${statusTextForHeader})${withDetails ? ` ${withDetails}` : ""}${hint}; host=${uploadHost}; filename=${upload.filename} byte_length=${upload.byteLength}`,
     );
   }
 

--- a/slack-bridge/slack-upload.ts
+++ b/slack-bridge/slack-upload.ts
@@ -18,27 +18,6 @@ const FILETYPE_ALIASES: Record<string, string> = {
   zsh: "shell",
 };
 
-const ALLOWED_SNIPPET_TYPES = new Set([
-  "bash",
-  "c",
-  "cpp",
-  "css",
-  "diff",
-  "html",
-  "javascript",
-  "json",
-  "markdown",
-  "objective-c",
-  "perl",
-  "python",
-  "ruby",
-  "shell",
-  "swift",
-  "text",
-  "typescript",
-  "yaml",
-]);
-
 const DEFAULT_SNIPPET_TYPE = "text";
 const MAX_SNIPPET_BYTES = 1_000_000;
 
@@ -112,9 +91,27 @@ function isWithinRoot(candidate: string, root: string): boolean {
 }
 
 function normalizeSnippetType(filetype: string | undefined): string {
-  const normalized = filetype?.trim().toLowerCase();
-  if (!normalized) return DEFAULT_SNIPPET_TYPE;
-  return ALLOWED_SNIPPET_TYPES.has(normalized) ? normalized : DEFAULT_SNIPPET_TYPE;
+  return filetype?.trim().toLowerCase() || DEFAULT_SNIPPET_TYPE;
+}
+
+function buildUploadMetadataPayload(
+  upload: PreparedSlackUpload,
+  includeSnippetType: boolean,
+): Record<string, unknown> {
+  return {
+    filename: upload.filename,
+    length: upload.byteLength,
+    ...(includeSnippetType && upload.snippetType ? { snippet_type: upload.snippetType } : {}),
+  };
+}
+
+function isInvalidUploadMetadataError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const lower = error.message.toLowerCase();
+  return lower.includes("files.getuploadurlexternal") && lower.includes("invalid_arguments");
 }
 
 function getUploadHost(uploadUrl: string): string {
@@ -146,6 +143,22 @@ function formatUploadError(error: unknown): string {
   }
 
   return String(error);
+}
+
+function isLikelyProxyOrFirewallFailure(responseText: string, headers?: Headers): boolean {
+  const headerText = [
+    headers?.get("x-proxy-error"),
+    headers?.get("x-proxy-status"),
+    headers?.get("via"),
+    headers?.get("server"),
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+  const combined = `${responseText} ${headerText}`.toLowerCase();
+
+  return /(blocked-by-allowlist|possible outbound proxy|blocked by proxy|proxy-firewall|firewall)/.test(
+    combined,
+  );
 }
 export async function resolveSlackUploadPath(
   inputPath: string,
@@ -251,11 +264,24 @@ export async function performSlackUpload({
   token,
   fetchImpl = fetch,
 }: PerformSlackUploadOptions): Promise<CompletedSlackUpload> {
-  const getUploadResponse = await slack("files.getUploadURLExternal", token, {
-    filename: upload.filename,
-    length: upload.byteLength,
-    ...(upload.snippetType ? { snippet_type: upload.snippetType } : {}),
-  });
+  let getUploadResponse: SlackResult;
+  try {
+    getUploadResponse = await slack(
+      "files.getUploadURLExternal",
+      token,
+      buildUploadMetadataPayload(upload, true),
+    );
+  } catch (error) {
+    if (upload.snippetType && isInvalidUploadMetadataError(error)) {
+      getUploadResponse = await slack(
+        "files.getUploadURLExternal",
+        token,
+        buildUploadMetadataPayload(upload, false),
+      );
+    } else {
+      throw error;
+    }
+  }
 
   const uploadUrl =
     typeof getUploadResponse.upload_url === "string" ? getUploadResponse.upload_url : null;
@@ -268,7 +294,10 @@ export async function performSlackUpload({
   const rawBody = new Uint8Array(upload.bytes.byteLength);
   rawBody.set(upload.bytes);
 
-  let rawUploadResponse: Pick<Response, "ok" | "status" | "statusText" | "text">;
+  type RawUploadResponse = Pick<Response, "ok" | "status" | "statusText" | "text"> & {
+    headers?: Headers;
+  };
+  let rawUploadResponse: RawUploadResponse;
   try {
     rawUploadResponse = await fetchImpl(uploadUrl, {
       method: "POST",
@@ -281,7 +310,7 @@ export async function performSlackUpload({
     });
   } catch (error) {
     throw new Error(
-      `Slack raw upload failed for host ${uploadHost}: ${formatUploadError(error)}; filename=${upload.filename} byte_length=${upload.byteLength}`,
+      `Slack raw upload failed (transport): ${formatUploadError(error)}; host=${uploadHost}; filename=${upload.filename} byte_length=${upload.byteLength}`,
     );
   }
 
@@ -291,11 +320,15 @@ export async function performSlackUpload({
     const statusTextForHeader = statusText ? ` ${statusText}` : "";
     const withDetails =
       details.length > 0 ? `${statusText ? `${statusText}: ` : ""}${details}` : "";
-    const hint = /^(403|429|502|503)$/.test(String(rawUploadResponse.status))
-      ? " [possible outbound proxy/firewall block]"
-      : "";
+    const rawUploadResponseHeaders =
+      rawUploadResponse.headers instanceof Headers ? rawUploadResponse.headers : undefined;
+    const isProxyOrFirewallFailure = isLikelyProxyOrFirewallFailure(
+      details,
+      rawUploadResponseHeaders,
+    );
+    const hint = isProxyOrFirewallFailure ? " [possible outbound proxy/firewall block]" : "";
     throw new Error(
-      `Slack raw upload failed (${rawUploadResponse.status}${statusTextForHeader})${withDetails ? ` ${withDetails}` : ""}${hint}; host=${uploadHost}; filename=${upload.filename} byte_length=${upload.byteLength}`,
+      `Slack raw upload failed (HTTP ${rawUploadResponse.status}${statusTextForHeader})${withDetails ? ` ${withDetails}` : ""}${hint}; host=${uploadHost}; filename=${upload.filename} byte_length=${upload.byteLength}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Harden inline snippet type handling for Slack upload metadata so unsupported snippet_type values are normalized to `text` before calling `files.getUploadURLExternal`.
- Add robust diagnostics for raw upload failures with host-aware context (`files.slack.com` / `uploads.slack.com`) and cleaner error detail formatting.
- Classify upload failures by error class:
  - `files.getUploadURLExternal` `invalid_arguments` as input errors with actionable hint
  - raw upload host failures as network/retry hints (egress/proxy allowlist)
- Update tests for new upload behavior and transport failure coverage.
- Document upload-host egress troubleshooting in `slack-bridge` README.

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm --filter @gugu910/pi-slack-bridge test slack-upload.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test slack-tools.test.ts`

## Notes
Environment in task showed proxy/DNS restrictions to `files.slack.com` and `uploads.slack.com`; this PR improves diagnostics and classifies those failures as network issues while preserving existing retry guidance.

Closes #614