### PR TITLE
Consolidate Slack non-hot actions under dispatcher schema/urgency (#618)

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -228,20 +228,25 @@ Cold Slack actions live behind the `slack` dispatcher:
 | `confirm_action`       | Request user confirmation before a dangerous action                               |
 
 Use `slack` with `action: "help"` for the action catalogue, or
-`action: "help", args: { "topic": "canvas_update" }` for a specific JSON
-schema and example invocations. Dispatcher responses use a consistent
-`{ "status", "data", "errors", "warnings" }` envelope. Guardrails match
-cold Slack actions as `slack:<action>` (for example `slack:upload` or
-`slack:canvas_update`); legacy `slack_<action>` patterns are accepted during
-migration.
+`action: "schema"` as an explicit alias, and `action: "help"|"schema"`,
+`args: { "topic": "canvas_update" }` for a specific JSON schema and
+example invocations. Actions accept an optional top-level `urgency` (`normal`,
+`high`, `critical`) field; urgency is returned in help/schema metadata.
+Dispatcher responses use a consistent `{ "status", "data", "errors", "warnings" }`
+envelope. Guardrails match cold Slack actions as `slack:<action>` (for example
+`slack:upload` or `slack:canvas_update`); legacy `slack_<action>` patterns are
+accepted during migration.
 
 #### Tool and workflow usage notes
 
 - **Reply where the work arrived.** Use `slack_send` for assistant-thread
   replies. If a task was delivered in a Slack thread, acknowledge briefly,
-  do the work, report blockers immediately, and finish with the outcome. If
-  you know only a channel/thread pair, use dispatcher action `post_channel`
-  with `channel` and optional `thread_ts` instead.
+  do the work, report blockers immediately, and finish with the outcome.
+- **Use urgency for time-sensitive reads or posts.** Set `urgency: "high"` for
+  fast-turn requests (`read`, `read_channel`, `post_channel`, `presence`,
+  `export`) and `urgency: "critical"` for escalation contexts. Urgency is
+  reflected in dispatcher metadata and can trigger concise-response hints for
+  urgent actions.
 - **Channel posting is explicit.** `post_channel` posts to a named channel or
   channel ID. When `channel` is omitted, it first resolves a provided
   `thread_ts` to a tracked thread channel, then falls back to `defaultChannel`

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -64,6 +64,12 @@ describe("matchesToolPattern", () => {
     expect(matchesToolPattern("slack:canvas_update", ["slack_canvas_*"])).toBe(true);
     expect(matchesToolPattern("slack:upload", ["slack_upload"])).toBe(true);
   });
+
+  it("supports dotted slack action aliases in guardrail patterns", () => {
+    expect(matchesToolPattern("slack:canvas.update", ["slack:*.update"])).toBe(true);
+    expect(matchesToolPattern("slack:canvas.update", ["slack_canvas_*"])).toBe(true);
+    expect(matchesToolPattern("slack_canvas_update", ["slack:canvas.update"])).toBe(true);
+  });
 });
 
 // ─── isToolBlocked ────────────────────────────────────────

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -63,11 +63,22 @@ export const WRITE_TOOLS = new Set([
  * Returns true if the tool name matches any of the patterns.
  */
 export function matchesToolPattern(toolName: string, patterns: string[]): boolean {
-  const candidates = new Set([toolName]);
+  const candidates = new Set<string>([toolName]);
+  const addCandidate = (value: string) => {
+    candidates.add(value);
+  };
+
   if (toolName.startsWith("slack:")) {
-    candidates.add(`slack_${toolName.slice("slack:".length)}`);
+    const action = toolName.slice("slack:".length);
+    addCandidate(`slack_${action}`);
+    addCandidate(`slack_${action.replace(/\./g, "_")}`);
+    addCandidate(`slack:${action.replace(/_/g, ".")}`);
+    addCandidate(`slack_${action.replace(/_/g, ".")}`);
   } else if (toolName.startsWith("slack_")) {
-    candidates.add(`slack:${toolName.slice("slack_".length)}`);
+    const action = toolName.slice("slack_".length);
+    addCandidate(`slack:${action}`);
+    addCandidate(`slack:${action.replace(/_/g, ".")}`);
+    addCandidate(`slack_${action.replace(/\./g, "_")}`);
   }
 
   for (const pattern of patterns) {
@@ -92,7 +103,9 @@ export function isToolBlocked(toolName: string, guardrails: SecurityGuardrails):
   }
   const readOnlyToolName = toolName.startsWith("slack_")
     ? `slack:${toolName.slice("slack_".length)}`
-    : toolName;
+    : toolName.startsWith("slack:")
+      ? `slack:${toolName.slice("slack:".length).replace(/\./g, "_")}`
+      : toolName;
   if (guardrails.readOnly && WRITE_TOOLS.has(readOnlyToolName)) {
     return true;
   }

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -15,7 +15,8 @@ Call the dispatcher with an action and action-specific args:
 
 ```json
 {
-  "action": "help",
+  "action": "schema",
+  "urgency": "high",
   "args": { "topic": "canvas_update" }
 }
 ```
@@ -38,7 +39,9 @@ schema.
 Guardrails match cold actions as `slack:<action>` (for example
 `slack:upload`, `slack:delete`, `slack:canvas_update`). Legacy
 `slack_<action>` patterns may be accepted during migration, but new configs
-should use the colon form.
+should use the colon form. `urgency` is optional (`normal`/`high`/`critical`),
+and is returned in action metadata with urgency relevance metadata and warnings
+for critical read/notification paths.
 
 ## Action quick map
 

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -18,6 +18,7 @@ type SlackDispatcherEnvelope = {
   status: "succeeded" | "failed";
   data: unknown;
   errors: Array<{ message: string }>;
+  warnings?: string[];
 };
 
 type SlackDispatcherData = {
@@ -1070,6 +1071,75 @@ describe("registerSlackTools", () => {
         }),
       ],
     });
+  });
+
+  it("supports schema/action discovery aliases and urgency metadata", async () => {
+    const { registeredTools } = setup();
+    const dispatcher = registeredTools.get("slack")!;
+
+    const schemaAliasResponse = await dispatcher.execute("tool-schema", {
+      action: "schema",
+      urgency: "critical",
+    });
+    const schemaAliasEnvelope = schemaAliasResponse.details as SlackDispatcherEnvelope & {
+      data: { actions?: Array<{ action: string; metadata?: Record<string, unknown> }> };
+    };
+    expect(schemaAliasEnvelope.status).toBe("succeeded");
+
+    const postChannelAction = schemaAliasEnvelope.data.actions?.find(
+      (actionItem) => actionItem.action === "post_channel",
+    );
+    expect(postChannelAction?.metadata).toMatchObject({
+      urgency: {
+        default: "normal",
+        requested: "critical",
+        allowed: ["normal", "high", "critical"],
+      },
+    });
+
+    const topicAliasResponse = await dispatcher.execute("tool-schema-topic", {
+      action: "schema",
+      urgency: "high",
+      args: { topic: "read_channel" },
+    });
+    const topicAliasEnvelope = topicAliasResponse.details as SlackDispatcherEnvelope;
+    expect(topicAliasEnvelope.status).toBe("succeeded");
+    const serializedTopicData = JSON.stringify(topicAliasEnvelope.data);
+    expect(serializedTopicData).toContain('"requested":"high"');
+    expect(serializedTopicData).toContain('"allowed":["normal","high","critical"]');
+  });
+
+  it("normalizes dot-style dispatcher actions and surfaces urgency warnings", async () => {
+    const { tools, setConversationsReplies, setResolveThreadChannel } = setup();
+    setResolveThreadChannel(async () => "C-DB");
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [{ ts: "123.456", text: "Status check", user: "U123" }],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+
+    const response = await tools.get("slack")!.execute("tool-read-urgent", {
+      action: "slack.read",
+      urgency: "high",
+      args: { thread_ts: "123.456", limit: 1 },
+    });
+    const envelope = response.details as SlackDispatcherEnvelope;
+    expect(envelope.status).toBe("succeeded");
+    expect(envelope.warnings?.join(" ")).toContain("Dispatcher urgency high for read");
+  });
+
+  it("returns a clear error for unsupported urgency values", async () => {
+    const { tools } = setup();
+    const response = await tools.get("slack")!.execute("tool-invalid-urgency", {
+      action: "read",
+      urgency: "urgent",
+      args: { thread_ts: "123.456" },
+    });
+    const envelope = response.details as SlackDispatcherEnvelope;
+    expect(envelope.status).toBe("failed");
+    expect(envelope.errors[0]?.message).toContain("slack urgency must be one of");
   });
 
   it("opens a modal and embeds thread context in private_metadata", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -73,6 +73,7 @@ export interface RegisterSlackToolsDeps {
 
 type SlackDispatcherStatus = "succeeded" | "failed";
 type SlackDispatcherErrorClass = "input" | "auth" | "network" | "rate-limit" | "not-found";
+type SlackDispatcherUrgency = "normal" | "high" | "critical";
 
 interface SlackDispatcherError {
   class: SlackDispatcherErrorClass;
@@ -94,6 +95,21 @@ interface SlackActionToolDefinition extends ToolDefinition {
   parameters?: unknown;
   execute: NonNullable<ToolDefinition["execute"]>;
 }
+
+const SLACK_DISPATCHER_HELP_ACTIONS = new Set(["help", "schema"]);
+const SLACK_DISPATCHER_URGENCY_LEVELS: readonly SlackDispatcherUrgency[] = [
+  "normal",
+  "high",
+  "critical",
+] as const;
+const SLACK_DISPATCHER_DEFAULT_URGENCY: SlackDispatcherUrgency = "normal";
+const SLACK_DISPATCHER_URGENT_ACTIONS = new Set([
+  "read",
+  "read_channel",
+  "export",
+  "presence",
+  "post_channel",
+]);
 
 const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> = {
   react: [{ action: "react", args: { emoji: "👀", thread_ts: "1712345678.000100" } }],
@@ -191,14 +207,76 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function normalizeSlackDispatcherUrgency(value: unknown): SlackDispatcherUrgency {
+  if (typeof value === "undefined") {
+    return SLACK_DISPATCHER_DEFAULT_URGENCY;
+  }
+
+  if (typeof value !== "string") {
+    throw new Error("slack urgency must be a string.");
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "normal" || normalized === "high" || normalized === "critical") {
+    return normalized;
+  }
+
+  throw new Error(
+    "slack urgency must be one of: normal, high, critical. Omit urgency for default normal behavior.",
+  );
+}
+
+function isUrgentAction(action: string): boolean {
+  return SLACK_DISPATCHER_URGENT_ACTIONS.has(action);
+}
+
+function buildSlackDispatcherUrgencyWarnings(
+  action: string,
+  urgency: SlackDispatcherUrgency,
+): string[] {
+  if (urgency === "normal" || !isUrgentAction(action)) {
+    return [];
+  }
+
+  const label = urgency === "critical" ? "critical" : "high";
+  return [
+    `Dispatcher urgency ${label} for ${action}: prioritize concise outcomes and keep follow-up context minimal.`,
+  ];
+}
+
+function buildSlackDispatcherActionMetadata(
+  action: string,
+  urgency: SlackDispatcherUrgency,
+): {
+  urgency: {
+    requested: SlackDispatcherUrgency;
+    allowed: SlackDispatcherUrgency[];
+    default: SlackDispatcherUrgency;
+    relevant: boolean;
+  };
+  legacy_guardrail_alias: string;
+  hot_path: boolean;
+} {
+  return {
+    urgency: {
+      requested: urgency,
+      allowed: [...SLACK_DISPATCHER_URGENCY_LEVELS],
+      default: SLACK_DISPATCHER_DEFAULT_URGENCY,
+      relevant: isUrgentAction(action),
+    },
+    legacy_guardrail_alias: `slack_${action}`,
+    hot_path: false,
+  };
+}
+
 function normalizeSlackDispatcherActionName(value: unknown): string {
   if (typeof value !== "string") {
     throw new Error("slack action must be a string. Use action='help' to list available actions.");
   }
 
-  const normalized = value.trim().toLowerCase().replace(/-/g, "_");
+  const normalized = value.trim().toLowerCase().replace(/[-.]/g, "_");
   if (!normalized) {
-    throw new Error("slack action is required. Use action='help' to list available actions.");
+    throw new Error("slack action is required. Use action='help' to list actions.");
   }
   if (normalized.startsWith("slack:")) return normalized.slice("slack:".length);
   if (normalized.startsWith("slack_")) return normalized.slice("slack_".length);
@@ -207,7 +285,12 @@ function normalizeSlackDispatcherActionName(value: unknown): string {
 
 function normalizeSlackGuardrailToolName(toolName: string): string {
   const normalized = toolName.trim().toLowerCase().replace(/-/g, "_");
-  if (normalized.startsWith("slack:")) return normalized;
+  if (normalized.startsWith("slack:")) {
+    return normalized;
+  }
+  if (normalized.startsWith("slack.")) {
+    return `slack:${normalized.slice("slack.".length).replace(/\./g, "_")}`;
+  }
   if (
     normalized.startsWith("slack_") &&
     normalized !== "slack_inbox" &&
@@ -215,7 +298,7 @@ function normalizeSlackGuardrailToolName(toolName: string): string {
   ) {
     return `slack:${normalized.slice("slack_".length)}`;
   }
-  return toolName;
+  return normalized;
 }
 
 function isAbortError(error: unknown): boolean {
@@ -319,7 +402,11 @@ function buildSlackDispatcherResponse(envelope: SlackDispatcherEnvelope): {
   };
 }
 
-function buildSlackActionSuccessEnvelope(response: unknown): SlackDispatcherEnvelope {
+function buildSlackActionSuccessEnvelope(
+  response: unknown,
+  action: string,
+  urgency: SlackDispatcherUrgency,
+): SlackDispatcherEnvelope {
   return {
     status: "succeeded",
     data: {
@@ -327,16 +414,19 @@ function buildSlackActionSuccessEnvelope(response: unknown): SlackDispatcherEnve
       details: extractToolResponseDetails(response),
     },
     errors: [],
-    warnings: [],
+    warnings: buildSlackDispatcherUrgencyWarnings(action, urgency),
   };
 }
 
-function buildSlackActionFailureEnvelope(error: unknown): SlackDispatcherEnvelope {
+function buildSlackActionFailureEnvelope(
+  error: unknown,
+  urgency: SlackDispatcherUrgency,
+): SlackDispatcherEnvelope {
   return {
     status: "failed",
     data: null,
     errors: [classifySlackDispatcherError(error)],
-    warnings: [],
+    warnings: urgency === "normal" ? [] : [`Dispatcher urgency ${urgency} request was recorded.`],
   };
 }
 
@@ -349,7 +439,7 @@ function buildSlackInboxPromptGuidelines(): string[] {
     "You are connected to Slack via the slack-bridge extension.",
     "When Slack messages arrive: ACK briefly, do the work, report blockers immediately, and report the outcome when done.",
     "Use slack_send for direct assistant-thread replies. Use the slack dispatcher for non-hot Slack actions such as reactions, reads, uploads, schedules, channel posts, pins, bookmarks, canvases, modals, presence, exports, and confirmations.",
-    "Call slack with action='help' for the cold-action catalogue, or action='help' with args.topic for a specific action schema and examples.",
+    "Call slack with action='help' (or 'schema') for the cold-action catalogue, or action='help' with args.topic for a specific action schema and examples.",
     "Security guardrails may be active for Slack-triggered actions. Cold Slack actions are checked with slack:<action> guardrail names.",
     "Reaction-triggered requests may arrive as structured 'Reaction trigger from Slack:' messages — treat them as explicit user instructions attached to the referenced Slack message or thread.",
   ];
@@ -538,9 +628,15 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     slackActionRegistry.set(action, definition);
   }
 
-  function buildSlackDispatcherHelpEnvelope(args: unknown): SlackDispatcherEnvelope {
+  function buildSlackDispatcherHelpEnvelope(
+    args: unknown,
+    urgency: SlackDispatcherUrgency,
+  ): SlackDispatcherEnvelope {
     if (args != null && !isRecord(args)) {
-      return buildSlackActionFailureEnvelope(new Error("slack help args must be an object."));
+      return buildSlackActionFailureEnvelope(
+        new Error("slack help args must be an object."),
+        urgency,
+      );
     }
 
     const topic = isRecord(args) && typeof args.topic === "string" ? args.topic : undefined;
@@ -550,6 +646,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       if (!definition) {
         return buildSlackActionFailureEnvelope(
           new Error(`Unknown Slack action topic '${topic}'. Use action='help' to list actions.`),
+          urgency,
         );
       }
 
@@ -561,6 +658,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           guardrail_tool: `slack:${action}`,
           args_schema: definition.parameters ?? {},
           examples: getSlackDispatcherExamples(action),
+          metadata: buildSlackDispatcherActionMetadata(action, urgency),
         },
         errors: [],
         warnings: [],
@@ -575,11 +673,13 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             action: "help",
             summary: "List Slack dispatcher actions or return a specific action argument schema.",
             guardrail_tool: null,
+            metadata: buildSlackDispatcherActionMetadata("help", urgency),
           },
           ...[...slackActionRegistry.entries()].map(([action, definition]) => ({
             action,
             summary: definition.description ?? "",
             guardrail_tool: `slack:${action}`,
+            metadata: buildSlackDispatcherActionMetadata(action, urgency),
           })),
         ],
       },
@@ -604,8 +704,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     parameters: Type.Object({
       action: Type.String({
         description:
-          "Action name: help | react | read | upload | schedule | presence | export | post_channel | read_channel | confirm_action | delete | pin | bookmark | create_channel | project_create | canvas_comments_read | canvas_create | canvas_update | modal_open | modal_push | modal_update",
+          "Action name: help | schema | react | read | upload | schedule | presence | export | post_channel | read_channel | confirm_action | delete | pin | bookmark | create_channel | project_create | canvas_comments_read | canvas_create | canvas_update | modal_open | modal_push | modal_update",
       }),
+      urgency: Type.Optional(
+        Type.Union([Type.Literal("normal"), Type.Literal("high"), Type.Literal("critical")]),
+      ),
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {
           description:
@@ -614,17 +717,19 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       ),
     }),
     async execute(_id, params) {
+      let urgency: SlackDispatcherUrgency = SLACK_DISPATCHER_DEFAULT_URGENCY;
       try {
+        urgency = normalizeSlackDispatcherUrgency((params as { urgency?: unknown }).urgency);
         const action = normalizeSlackDispatcherActionName(params.action);
         const args = params.args ?? {};
 
-        if (action === "help") {
-          return buildSlackDispatcherResponse(buildSlackDispatcherHelpEnvelope(args));
+        if (SLACK_DISPATCHER_HELP_ACTIONS.has(action)) {
+          return buildSlackDispatcherResponse(buildSlackDispatcherHelpEnvelope(args, urgency));
         }
 
         if (!isRecord(args)) {
           return buildSlackDispatcherResponse(
-            buildSlackActionFailureEnvelope(new Error("slack args must be an object.")),
+            buildSlackActionFailureEnvelope(new Error("slack args must be an object."), urgency),
           );
         }
 
@@ -633,23 +738,26 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           return buildSlackDispatcherResponse(
             buildSlackActionFailureEnvelope(
               new Error(`Unknown Slack action '${action}'. Use action='help' to list actions.`),
+              urgency,
             ),
           );
         }
 
         const response = await definition.execute(
           `slack:${action}`,
-          args,
+          { ...args, urgency },
           undefined,
           undefined,
           undefined as unknown as ExtensionContext,
         );
-        return buildSlackDispatcherResponse(buildSlackActionSuccessEnvelope(response));
+        return buildSlackDispatcherResponse(
+          buildSlackActionSuccessEnvelope(response, action, urgency),
+        );
       } catch (error) {
         if (isAbortError(error)) {
           throw error;
         }
-        return buildSlackDispatcherResponse(buildSlackActionFailureEnvelope(error));
+        return buildSlackDispatcherResponse(buildSlackActionFailureEnvelope(error, urgency));
       }
     },
   });


### PR DESCRIPTION
## Summary
- Consolidate Slack non-hot actions behind the `slack` dispatcher with explicit discovery and alias support.
- Add top-level urgency semantics (`normal` | `high` | `critical`) with metadata and warnings in dispatcher envelopes.
- Preserve hot-path tools `slack_inbox` and `slack_send`.
- Preserve guardrail compatibility, including legacy `slack_` and dotted/colon action name variants.
- Update docs/examples and test coverage for discovery/urgency and aliasing.

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`

Refs: #618
