### PR TITLE
pinet: classify inbound mail notifications

### DIFF
--- a/broker-core/index.ts
+++ b/broker-core/index.ts
@@ -2,6 +2,7 @@ export * from "./agent-messaging.js";
 export * from "./auth.js";
 export * from "./leader.js";
 export * from "./maintenance.js";
+export * from "./mail-classification.js";
 export * from "./message-send.js";
 export * from "./paths.js";
 export * from "./raw-tcp-loopback.js";

--- a/broker-core/mail-classification.test.ts
+++ b/broker-core/mail-classification.test.ts
@@ -26,6 +26,13 @@ describe("Pinet mail classification", () => {
         metadata: { a2a: true, senderAgent: "Broker Camel" },
       }),
     ).toMatchObject({ class: "steering", explicit: false });
+
+    expect(
+      classifyPinetMail({
+        body: "Task: Final re-review current branch for PR #621 after blocker-report fix. Focus on mail classification false positives/negatives and scope.",
+        metadata: { a2a: true, senderAgent: "Broker Camel" },
+      }),
+    ).toMatchObject({ class: "steering", explicit: false });
   });
 
   it("keeps ordinary issue or PR references as fwup without action cues", () => {
@@ -53,6 +60,13 @@ describe("Pinet mail classification", () => {
     expect(
       classifyPinetMail({
         body: "Tests passed. Blockers: none.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
+
+    expect(
+      classifyPinetMail({
+        body: "Done. Tests passed. No merge performed. Ready for human review.",
         metadata: { a2a: true },
       }),
     ).toMatchObject({ class: "fwup", explicit: false });

--- a/broker-core/mail-classification.test.ts
+++ b/broker-core/mail-classification.test.ts
@@ -69,6 +69,34 @@ describe("Pinet mail classification", () => {
     ).toMatchObject({ class: "maintenance_context" });
   });
 
+  it("classifies terminal stand-down cues as maintenance/context-only", () => {
+    for (const body of [
+      "Stand down on this lane.",
+      "The thread is already satisfied; no reply is needed.",
+      "No further replies are needed unless I ask for a new task.",
+    ]) {
+      expect(classifyPinetMail({ body, metadata: { a2a: true } })).toMatchObject({
+        class: "maintenance_context",
+      });
+    }
+  });
+
+  it("does not treat standalone issue or PR references as steering", () => {
+    expect(
+      classifyPinetMail({
+        body: "PR #621 looks good.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
+
+    expect(
+      classifyPinetMail({
+        body: "Issue #606 is now routed; no action needed.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "maintenance_context", explicit: false });
+  });
+
   it("defaults ordinary durable mail to fwup", () => {
     expect(
       classifyPinetMail({

--- a/broker-core/mail-classification.test.ts
+++ b/broker-core/mail-classification.test.ts
@@ -28,6 +28,31 @@ describe("Pinet mail classification", () => {
     ).toMatchObject({ class: "steering", explicit: false });
   });
 
+  it("keeps ordinary issue or PR references as fwup without action cues", () => {
+    expect(
+      classifyPinetMail({
+        body: "Thanks for the review on PR #621; looks good.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
+  });
+
+  it("classifies legacy control and skin metadata as maintenance/context-only", () => {
+    expect(
+      classifyPinetMail({
+        body: "/reload",
+        metadata: { a2a: true, kind: "pinet_control", command: "reload" },
+      }),
+    ).toMatchObject({ class: "maintenance_context" });
+
+    expect(
+      classifyPinetMail({
+        body: "skin update",
+        metadata: { a2a: true, kind: "pinet_skin", theme: "forest" },
+      }),
+    ).toMatchObject({ class: "maintenance_context" });
+  });
+
   it("classifies RALPH and closed-thread notes as maintenance/context-only", () => {
     expect(
       classifyPinetMail({

--- a/broker-core/mail-classification.test.ts
+++ b/broker-core/mail-classification.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { classifyPinetMail, normalizePinetMailClass } from "./mail-classification.js";
+
+// ─── Mail classification ─────────────────────────────────
+
+describe("Pinet mail classification", () => {
+  it("normalizes explicit fwup aliases", () => {
+    expect(normalizePinetMailClass("fwup")).toBe("fwup");
+    expect(normalizePinetMailClass("follow-up")).toBe("fwup");
+    expect(normalizePinetMailClass("follow_up")).toBe("fwup");
+  });
+
+  it("honors explicit metadata over heuristics", () => {
+    expect(
+      classifyPinetMail({
+        body: "Please take issue #606 and ACK/work/ask/report.",
+        metadata: { pinetMailClass: "fwup" },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: true });
+  });
+
+  it("classifies actionable broker instructions as steering", () => {
+    expect(
+      classifyPinetMail({
+        body: "Please take issue #606. Workflow: ACK/work/ask/report. No merge.",
+        metadata: { a2a: true, senderAgent: "Broker Camel" },
+      }),
+    ).toMatchObject({ class: "steering", explicit: false });
+  });
+
+  it("classifies RALPH and closed-thread notes as maintenance/context-only", () => {
+    expect(
+      classifyPinetMail({
+        body: "RALPH broker-only maintenance: ghost agents detected.",
+        metadata: { kind: "broker_maintenance" },
+      }),
+    ).toMatchObject({ class: "maintenance_context" });
+
+    expect(
+      classifyPinetMail({
+        body: "Hard stop on this thread: no further acknowledgements are needed. Stay free and quiet.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "maintenance_context" });
+  });
+
+  it("defaults ordinary durable mail to fwup", () => {
+    expect(
+      classifyPinetMail({
+        body: "Thanks, looks good.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
+  });
+});

--- a/broker-core/mail-classification.test.ts
+++ b/broker-core/mail-classification.test.ts
@@ -49,6 +49,13 @@ describe("Pinet mail classification", () => {
         metadata: { a2a: true },
       }),
     ).toMatchObject({ class: "fwup", explicit: false });
+
+    expect(
+      classifyPinetMail({
+        body: "Tests passed. Blockers: none.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
   });
 
   it("classifies legacy control and skin metadata as maintenance/context-only", () => {

--- a/broker-core/mail-classification.test.ts
+++ b/broker-core/mail-classification.test.ts
@@ -35,6 +35,20 @@ describe("Pinet mail classification", () => {
         metadata: { a2a: true },
       }),
     ).toMatchObject({ class: "fwup", explicit: false });
+
+    expect(
+      classifyPinetMail({
+        body: "Issue #606 review notes are resolved.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
+
+    expect(
+      classifyPinetMail({
+        body: "PR #621 review looks good.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
   });
 
   it("classifies legacy control and skin metadata as maintenance/context-only", () => {

--- a/broker-core/mail-classification.ts
+++ b/broker-core/mail-classification.ts
@@ -1,0 +1,134 @@
+export const PINET_MAIL_CLASSES = ["steering", "fwup", "maintenance_context"] as const;
+
+export type PinetMailClass = (typeof PINET_MAIL_CLASSES)[number];
+
+export interface PinetMailClassificationInput {
+  source?: string | null;
+  threadId?: string | null;
+  sender?: string | null;
+  body?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface PinetMailClassification {
+  class: PinetMailClass;
+  reason: string;
+  explicit: boolean;
+}
+
+const EXPLICIT_CLASS_KEYS = [
+  "pinetMailClass",
+  "pinet_mail_class",
+  "mailClass",
+  "mail_class",
+  "mailKind",
+  "mail_kind",
+  "classification",
+] as const;
+
+const STEERING_PATTERNS = [
+  /\back(?:\/|\s*)work(?:\/|\s*)ask(?:\/|\s*)report\b/i,
+  /\back briefly\b/i,
+  /\bplease (?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\b/i,
+  /\b(?:new|fresh) (?:implementation )?(?:lane|task|worktree)\b/i,
+  /\b(?:scope|workflow|acceptance criteria|constraints?|blockers?)\s*:/i,
+  /\b(?:issue|pr)\s*#\d+\b/i,
+  /\bready for human review\b/i,
+  /\breport blockers? immediately\b/i,
+  /\bno merge\b/i,
+];
+
+const MAINTENANCE_CONTEXT_PATTERNS = [
+  /\bralph\b.*\b(?:maintenance|ghost|reap|nudge|drain)\b/i,
+  /\bbroker[- ]only maintenance\b/i,
+  /\bmaintenance (?:anomaly|recovery|timer|pass)\b/i,
+  /\bno further repl(?:y|ies) (?:are|is) needed\b/i,
+  /\bno further acknowledg(?:ement|ements) (?:are|is) needed\b/i,
+  /\bno reply is needed\b/i,
+  /\bhard stop on this [^.\n]*thread\b/i,
+  /\bstay free(?:\/| and )quiet\b/i,
+  /\bstay quiet(?:\/| and )free\b/i,
+];
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function normalizePinetMailClass(value: unknown): PinetMailClass | null {
+  const raw = asString(value)
+    ?.toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (!raw) return null;
+
+  if (raw === "steering" || raw === "steer" || raw === "directive") return "steering";
+  if (raw === "fwup" || raw === "follow_up" || raw === "followup") return "fwup";
+  if (
+    raw === "maintenance_context" ||
+    raw === "maintenance" ||
+    raw === "context_only" ||
+    raw === "context"
+  ) {
+    return "maintenance_context";
+  }
+
+  return null;
+}
+
+function getExplicitMailClass(
+  metadata: Record<string, unknown> | null | undefined,
+): PinetMailClass | null {
+  if (!metadata) return null;
+
+  for (const key of EXPLICIT_CLASS_KEYS) {
+    const normalized = normalizePinetMailClass(metadata[key]);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
+function hasPattern(patterns: RegExp[], value: string): boolean {
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+function metadataLooksLikeMaintenance(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  const kind = asString(metadata?.kind)?.toLowerCase() ?? "";
+  const type = asString(metadata?.type)?.toLowerCase() ?? "";
+  const eventType = asString(metadata?.event_type)?.toLowerCase() ?? "";
+  return [kind, type, eventType].some(
+    (value) =>
+      value.includes("maintenance") ||
+      value.includes("ralph") ||
+      value === "pinet:control" ||
+      value === "pinet:skin",
+  );
+}
+
+export function classifyPinetMail(input: PinetMailClassificationInput): PinetMailClassification {
+  const metadata = input.metadata ?? null;
+  const explicitClass = getExplicitMailClass(metadata);
+  if (explicitClass) {
+    return { class: explicitClass, reason: "explicit metadata", explicit: true };
+  }
+
+  const body = input.body ?? "";
+  if (metadataLooksLikeMaintenance(metadata) || hasPattern(MAINTENANCE_CONTEXT_PATTERNS, body)) {
+    return {
+      class: "maintenance_context",
+      reason: "maintenance/context-only cues",
+      explicit: false,
+    };
+  }
+
+  if (hasPattern(STEERING_PATTERNS, body)) {
+    return { class: "steering", reason: "actionable steering cues", explicit: false };
+  }
+
+  return { class: "fwup", reason: "default follow-up mail", explicit: false };
+}
+
+export function formatPinetMailClassLabel(mailClass: PinetMailClass): string {
+  return mailClass === "maintenance_context" ? "maintenance/context" : mailClass;
+}

--- a/broker-core/mail-classification.ts
+++ b/broker-core/mail-classification.ts
@@ -31,12 +31,10 @@ const STEERING_PATTERNS = [
   /\back briefly\b/i,
   /\bplease (?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\b/i,
   /\b(?:new|fresh) (?:implementation )?(?:lane|task|worktree)\b/i,
-  /\b(?:scope|workflow|acceptance criteria|constraints?|blockers?)\s*:/i,
+  /\b(?:task|issue|worktree setup|scope|workflow|acceptance criteria|constraints?)\s*:/i,
   /\b(?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\s+(?:issue|pr)\s*#\d+\b/i,
-  /\b(?:issue|pr)\s*#\d+\b.*\b(?:ack|work|review|fix|implement|take|handle|reassign)\b/i,
-  /\bready for human review\b/i,
+  /\b(?:issue|pr)\s*#\d+\b.*\back(?:\/|\s*)work(?:\/|\s*)ask(?:\/|\s*)report\b/i,
   /\breport blockers? immediately\b/i,
-  /\bno merge\b/i,
 ];
 
 const MAINTENANCE_CONTEXT_PATTERNS = [

--- a/broker-core/mail-classification.ts
+++ b/broker-core/mail-classification.ts
@@ -32,8 +32,8 @@ const STEERING_PATTERNS = [
   /\bplease (?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\b/i,
   /\b(?:new|fresh) (?:implementation )?(?:lane|task|worktree)\b/i,
   /\b(?:scope|workflow|acceptance criteria|constraints?|blockers?)\s*:/i,
-  /\b(?:take|continue|implement|fix|review|inspect|handle|work on)\s+(?:issue|pr)\s*#\d+\b/i,
-  /\b(?:issue|pr)\s*#\d+\b.*\b(?:ack|work|review|fix|implement|take|handle)\b/i,
+  /\b(?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\s+(?:issue|pr)\s*#\d+\b/i,
+  /\b(?:issue|pr)\s*#\d+\b.*\b(?:ack|work|review|fix|implement|take|handle|reassign)\b/i,
   /\bready for human review\b/i,
   /\breport blockers? immediately\b/i,
   /\bno merge\b/i,
@@ -46,7 +46,11 @@ const MAINTENANCE_CONTEXT_PATTERNS = [
   /\bno further repl(?:y|ies) (?:are|is) needed\b/i,
   /\bno further acknowledg(?:ement|ements) (?:are|is) needed\b/i,
   /\bno reply is needed\b/i,
+  /\bno action needed\b/i,
   /\bhard stop on this [^.\n]*thread\b/i,
+  /\bstand down\b/i,
+  /\bthread is already satisfied\b/i,
+  /\bunless I (?:assign|ask for) (?:a )?(?:genuinely )?new task\b/i,
   /\bstay free(?:\/| and )quiet\b/i,
   /\bstay quiet(?:\/| and )free\b/i,
 ];
@@ -98,15 +102,15 @@ function metadataLooksLikeMaintenance(
   const kind = asString(metadata?.kind)?.toLowerCase() ?? "";
   const type = asString(metadata?.type)?.toLowerCase() ?? "";
   const eventType = asString(metadata?.event_type)?.toLowerCase() ?? "";
-  return [kind, type, eventType].some(
-    (value) =>
-      value.includes("maintenance") ||
-      value.includes("ralph") ||
-      value === "pinet:control" ||
-      value === "pinet_control" ||
-      value === "pinet:skin" ||
-      value === "pinet_skin",
-  );
+  return [kind, type, eventType].some((value) => {
+    const normalized = value.replace(/_/g, ":");
+    return (
+      normalized.includes("maintenance") ||
+      normalized.includes("ralph") ||
+      normalized === "pinet:control" ||
+      normalized === "pinet:skin"
+    );
+  });
 }
 
 export function classifyPinetMail(input: PinetMailClassificationInput): PinetMailClassification {

--- a/broker-core/mail-classification.ts
+++ b/broker-core/mail-classification.ts
@@ -32,7 +32,8 @@ const STEERING_PATTERNS = [
   /\bplease (?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\b/i,
   /\b(?:new|fresh) (?:implementation )?(?:lane|task|worktree)\b/i,
   /\b(?:scope|workflow|acceptance criteria|constraints?|blockers?)\s*:/i,
-  /\b(?:issue|pr)\s*#\d+\b/i,
+  /\b(?:take|continue|implement|fix|review|inspect|handle|work on)\s+(?:issue|pr)\s*#\d+\b/i,
+  /\b(?:issue|pr)\s*#\d+\b.*\b(?:ack|work|review|fix|implement|take|handle)\b/i,
   /\bready for human review\b/i,
   /\breport blockers? immediately\b/i,
   /\bno merge\b/i,
@@ -102,7 +103,9 @@ function metadataLooksLikeMaintenance(
       value.includes("maintenance") ||
       value.includes("ralph") ||
       value === "pinet:control" ||
-      value === "pinet:skin",
+      value === "pinet_control" ||
+      value === "pinet:skin" ||
+      value === "pinet_skin",
   );
 }
 

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -20,6 +20,7 @@
     "./auth": "./dist/auth.js",
     "./leader": "./dist/leader.js",
     "./maintenance": "./dist/maintenance.js",
+    "./mail-classification": "./dist/mail-classification.js",
     "./message-send": "./dist/message-send.js",
     "./paths": "./dist/paths.js",
     "./raw-tcp-loopback": "./dist/raw-tcp-loopback.js",

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { classifyPinetMail } from "./mail-classification.js";
 import { BrokerDB } from "./schema.js";
 
 function createDb(): { db: BrokerDB; dir: string } {
@@ -356,6 +357,40 @@ describe("BrokerDB message sync identity", () => {
       expect(replay.id).toBe(first.id);
       expect(db.getInbox("agent-1")).toHaveLength(0);
       expect(db.getInbox("agent-2")).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("derives mail class from durable inbox message records without changing read state", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("a2a:broker:worker", "agent", "", null);
+      db.insertMessage(
+        "a2a:broker:worker",
+        "agent",
+        "inbound",
+        "broker",
+        "Please take issue #606. Workflow: ACK/work/ask/report.",
+        ["worker"],
+        { a2a: true, senderAgent: "Broker Camel" },
+      );
+
+      const read = db.readInbox("worker", { markRead: false });
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0].entry.readAt).toBeNull();
+      expect(read.markedReadIds).toEqual([]);
+      expect(
+        classifyPinetMail({
+          source: read.messages[0].message.source,
+          threadId: read.messages[0].message.threadId,
+          sender: read.messages[0].message.sender,
+          body: read.messages[0].message.body,
+          metadata: read.messages[0].message.metadata,
+        }),
+      ).toMatchObject({ class: "steering" });
+      expect(db.getUnreadInboxCount("worker")).toBe(1);
     } finally {
       db.close();
     }

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -442,6 +442,7 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 - The **broker** runs Slack Socket Mode, routes messages to agents, monitors health via the RALPH loop, and maintains a control plane canvas
 - **Followers** connect to the broker over a local Unix socket, poll for work, and report results
+- Inbound Pinet mail is classified as `steering`, `fwup` (ordinary follow-up), or `maintenance_context` from durable message records; notifications include the class label plus a `pinet read` pointer while delivery/ack/read state remains separate
 - Agents can optionally authenticate using a shared local secret (`meshSecret` or `meshSecretPath`); when both are unset, mesh auth is disabled
 - Thread ownership is first-responder-wins — the first agent to reply claims the thread
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -587,7 +587,10 @@ describe("formatPinetInboxMessages", () => {
 
     expect(result).toContain("New Pinet messages:");
     expect(result).toContain(
-      "[thread a2a:broker:worker] broker-id (Broker Bunny): Take issue #175",
+      "[thread a2a:broker:worker] [steering] broker-id (Broker Bunny): Take issue #175",
+    );
+    expect(result).toContain(
+      "pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
     expect(result).toContain("Reply via pinet_message.");
     expect(result).toContain("ACK briefly, do the work");
@@ -605,7 +608,7 @@ describe("formatPinetInboxMessages", () => {
       },
     ]);
 
-    expect(result).toContain("[thread a2a:broker:worker] broker-id: hello");
+    expect(result).toContain("[thread a2a:broker:worker] [fwup] broker-id: hello");
   });
 
   it("marks terminal stand-down messages as closed and suppresses reflex ack guidance", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { classifyPinetMail, formatPinetMailClassLabel } from "@gugu910/pi-broker-core";
 import {
   buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope,
@@ -361,17 +362,35 @@ export function isTerminalPinetStandDownMessage(body: string | null | undefined)
   return !PINET_ACTIONABLE_TASK_PATTERNS.some((pattern) => pattern.test(normalized));
 }
 
+function formatPinetReadPointer(entry: FollowerInboxEntry): string {
+  const threadId = entry.message.threadId?.trim();
+  const inboxId = typeof entry.inboxId === "number" ? ` inbox=${entry.inboxId}` : "";
+  if (!threadId) {
+    return `pinet action=read args.unread_only=true${inboxId}`;
+  }
+  return `pinet action=read args.thread_id=${threadId} args.unread_only=true${inboxId}`;
+}
+
 export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string {
   const annotatedEntries = entries.map((entry) => ({
     entry,
     terminalStandDown: isTerminalPinetStandDownMessage(entry.message.body),
+    classification: classifyPinetMail({
+      source: entry.message.source,
+      threadId: entry.message.threadId,
+      sender: entry.message.sender,
+      body: entry.message.body,
+      metadata: entry.message.metadata,
+    }),
   }));
 
-  const lines = annotatedEntries.map(({ entry, terminalStandDown }) => {
+  const lines = annotatedEntries.map(({ entry, terminalStandDown, classification }) => {
     const threadTs = entry.message.threadId ?? "";
     const sender = getPinetSenderLabel(entry.message);
+    const classLabel = formatPinetMailClassLabel(classification.class);
     const standDownSuffix = terminalStandDown ? " [terminal stand-down]" : "";
-    return `[thread ${threadTs}] ${sender}${standDownSuffix}: ${entry.message.body ?? ""}`;
+    const pointer = formatPinetReadPointer(entry);
+    return `[thread ${threadTs}] [${classLabel}] ${sender}${standDownSuffix}: ${entry.message.body ?? ""} | pointer=${pointer}`;
   });
 
   const hasTerminalStandDown = annotatedEntries.some((entry) => entry.terminalStandDown);

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -179,7 +179,7 @@ describe("registerPinetTools", () => {
     );
     expect(result.content[0]?.text).toContain("Unread before: 2; unread after: 1.");
     expect(result.content[0]?.text).toContain(
-      "- [agent/a2a:broker:worker #44] broker: please inspect #594",
+      "- [agent/a2a:broker:worker #44] [steering] broker: please inspect #594",
     );
     expect(result.content[0]?.text).toContain("Marked read: 31.");
     expect(result.details.markedReadIds).toEqual([31]);

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { classifyPinetMail, formatPinetMailClassLabel } from "@gugu910/pi-broker-core";
 import { Type } from "@sinclair/typebox";
 import {
   buildAgentDisplayInfo,
@@ -286,8 +287,16 @@ function formatPinetReadResult(result: PinetReadResult, options: PinetReadOption
   if (result.messages.length > 0) {
     lines.push("");
     for (const item of result.messages) {
+      const classification = classifyPinetMail({
+        source: item.message.source,
+        threadId: item.message.threadId,
+        sender: item.message.sender,
+        body: item.message.body,
+        metadata: item.message.metadata,
+      });
+      const classLabel = formatPinetMailClassLabel(classification.class);
       lines.push(
-        `- [${item.message.source}/${item.message.threadId} #${item.message.id}] ${item.message.sender}: ${item.message.body}`,
+        `- [${item.message.source}/${item.message.threadId} #${item.message.id}] [${classLabel}] ${item.message.sender}: ${item.message.body}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- add a transport-neutral Pinet mail classifier for `steering`, `fwup`, and `maintenance_context`
- label inbound Pinet notifications and `pinet read` output with the derived class
- include compact `pinet read` pointers in inbound notifications while keeping delivery/ack/read state separate
- document the inbound mail classification contract

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- pre-push hook on `git push` passed

## PR identity
- GitHub account: `gugu91`

Closes #606
Related #594

No merge requested; ready for independent review.