### PR TITLE
fix(slack-bridge): preserve degraded restart diagnostics

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -179,6 +179,13 @@ User opens Pinet in Slack sidebar
 
 Messages queue while the agent is busy. When the agent finishes, it automatically drains the inbox and responds.
 
+When running as a **broker**, Slack threads now get explicit operational visibility:
+
+- periodic `⏳` progress updates while a turn is still running
+- per-attempt error updates when an assistant turn errors
+- a final failure summary with retry count and provider/model context
+- automatic pause messaging for terminal provider errors (for example usage/auth failures)
+
 ### Available tools
 
 | Tool                         | Description                                                                       |
@@ -283,6 +290,27 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 | `/pinet-exit <agent>`   | Ask another agent to exit                  |
 | `/pinet-free`           | Mark this agent as idle                    |
 | `/pinet-skin <theme>`   | Change the mesh naming theme (broker only) |
+
+### Broker in-thread control commands (from Slack)
+
+In any broker-owned Slack thread, you can now send:
+
+- `pinet reload`
+- `pinet reload <provider/model>`
+- `pinet reload <provider/model> <thinking>`
+- `/pinet-reload <provider/model> <thinking>` (plain-text alias when your Slack client forwards slash text)
+
+Examples:
+
+- `pinet reload openai/gpt-5.4`
+- `pinet reload openai/gpt-5.4 xhigh`
+
+Behavior:
+
+- aborts the active broker turn (same intent as pressing `Esc` in the TUI)
+- applies model/thinking overrides when runtime model controls are available
+- reloads the broker runtime in place
+- resumes queued inbox work after reload
 
 ### How it works
 

--- a/slack-bridge/follower-runtime.test.ts
+++ b/slack-bridge/follower-runtime.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  createFollowerRuntime,
+  type FollowerRuntimeDeps,
+  type FollowerRuntimeFailureEvent,
+} from "./follower-runtime.js";
+
+function createCtx(): ExtensionContext {
+  return {
+    hasUI: true,
+    isIdle: () => true,
+    ui: {
+      notify: vi.fn(),
+      theme: { fg: (_color: string, text: string) => text },
+      setStatus: vi.fn(),
+    },
+    sessionManager: {
+      getSessionFile: () => "/tmp/follower-runtime-test.json",
+      getLeafId: () => "leaf-1",
+      getEntries: () => [],
+      getHeader: () => null,
+    },
+  } as unknown as ExtensionContext;
+}
+
+function createDeps(overrides: Partial<FollowerRuntimeDeps> = {}): FollowerRuntimeDeps {
+  return {
+    getSettings: () => ({}),
+    refreshSettings: vi.fn(),
+    getPinetEnabled: () => true,
+    getAgentIdentity: () => ({ name: "Worker", emoji: "🐧" }),
+    getAgentStableId: () => "stable-worker",
+    getAgentOwnerToken: () => "owner-token",
+    setAgentOwnerToken: vi.fn(),
+    getDesiredAgentStatus: () => "idle",
+    getAgentAliases: () => [],
+    getThreads: () => new Map(),
+    getLastDmChannel: () => null,
+    setLastDmChannel: vi.fn(),
+    pushInboxMessages: vi.fn(),
+    getAgentMetadata: async () => ({}),
+    applyRegistrationIdentity: vi.fn(),
+    applySkinUpdate: vi.fn(),
+    persistState: vi.fn(),
+    updateBadge: vi.fn(),
+    maybeDrainInboxIfIdle: vi.fn(() => false),
+    requestRemoteControl: vi.fn(),
+    deferControlAck: vi.fn(),
+    runRemoteControl: vi.fn(),
+    deliverFollowUpMessage: vi.fn(() => false),
+    setExtStatus: vi.fn(),
+    noteRuntimeFailure: vi.fn(),
+    clearRuntimeFailure: vi.fn(),
+    getRuntimeFailure: () => null,
+    handleTerminalReconnectFailure: vi.fn(),
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    deliveryState: {
+      queuedButUndeliveredIds: new Set<number>(),
+      deliveredAwaitingAckIds: new Set<number>(),
+      ackInFlightIds: new Set<number>(),
+    },
+    ...overrides,
+  };
+}
+
+describe("createFollowerRuntime types", () => {
+  it("accepts structured follower runtime failure events", () => {
+    const event: FollowerRuntimeFailureEvent = {
+      kind: "poll_error",
+      message: "socket unavailable",
+      retryable: true,
+      nextStep: "Follower will keep polling automatically.",
+      error: new Error("socket unavailable"),
+    };
+
+    const deps = createDeps({
+      noteRuntimeFailure: vi.fn((_, received) => {
+        expect(received).toEqual(event);
+      }),
+    });
+
+    deps.noteRuntimeFailure(createCtx(), event);
+    expect(deps.noteRuntimeFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("constructs the runtime with explicit failure hooks", () => {
+    const runtime = createFollowerRuntime(createDeps());
+    expect(runtime.getClientRef()).toBeNull();
+  });
+});

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -37,6 +37,19 @@ type SharedFollowerThreadState = Pick<
   "channelId" | "threadTs" | "userId" | "source" | "owner"
 >;
 
+export type FollowerRuntimeFailureKind =
+  | "poll_error"
+  | "registration_refresh_failed"
+  | "reconnect_failed";
+
+export interface FollowerRuntimeFailureEvent {
+  kind: FollowerRuntimeFailureKind;
+  message: string;
+  retryable: boolean;
+  nextStep: string;
+  error: Error;
+}
+
 export interface FollowerRuntimeDeps {
   getSettings: () => SlackBridgeSettings;
   refreshSettings: () => void;
@@ -74,6 +87,9 @@ export interface FollowerRuntimeDeps {
   runRemoteControl: (command: PinetControlCommand, ctx: ExtensionContext) => void;
   deliverFollowUpMessage: (text: string) => boolean;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
+  noteRuntimeFailure: (ctx: ExtensionContext, event: FollowerRuntimeFailureEvent) => void;
+  clearRuntimeFailure: () => void;
+  getRuntimeFailure: () => FollowerRuntimeFailureEvent | null;
   handleTerminalReconnectFailure: (ctx: ExtensionContext, error: Error) => Promise<void> | void;
   formatError: (error: unknown) => string;
   deliveryState: FollowerDeliveryState;
@@ -366,8 +382,15 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
             deps.updateBadge();
             deps.maybeDrainInboxIfIdle(ctx);
           }
-        } catch {
-          /* broker may be restarting */
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          deps.noteRuntimeFailure(ctx, {
+            kind: "poll_error",
+            message: deps.formatError(err),
+            retryable: true,
+            nextStep: "Broker may be restarting; follower will keep polling automatically.",
+            error: err,
+          });
         } finally {
           void syncDesiredStatus(deps.getDesiredAgentStatus()).catch(() => {
             /* best effort */
@@ -397,7 +420,13 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
         }
         stopPolling();
         deps.setExtStatus(ctx, "reconnecting");
-        const uiUpdate = getFollowerReconnectUiUpdate("disconnect", wasDisconnected);
+        const runtimeFailure = deps.getRuntimeFailure();
+        const uiUpdate = getFollowerReconnectUiUpdate({
+          event: "disconnect",
+          wasDisconnected,
+          degradedReason: runtimeFailure?.message ?? null,
+          degradedNextStep: runtimeFailure?.nextStep ?? null,
+        });
         wasDisconnected = uiUpdate.nextWasDisconnected;
         if (uiUpdate.notify) {
           ctx.ui.notify(uiUpdate.notify.message, uiUpdate.notify.level);
@@ -412,9 +441,18 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
           try {
             await registerFollowerRuntime();
           } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error));
             console.error(
-              `[slack-bridge] follower reconnect registration refresh failed: ${deps.formatError(error)}`,
+              `[slack-bridge] follower reconnect registration refresh failed: ${deps.formatError(err)}`,
             );
+            deps.noteRuntimeFailure(ctx, {
+              kind: "registration_refresh_failed",
+              message: deps.formatError(err),
+              retryable: true,
+              nextStep:
+                "Follower reconnected with the broker-assigned identity; fix the explicit identity request if this persists.",
+              error: err,
+            });
             const registration = client.getRegisteredIdentity();
             if (registration) {
               deps.applyRegistrationIdentity(registration);
@@ -429,8 +467,15 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
           if (hasDeliveredFollowerInboxIds(deps.deliveryState)) {
             void flushDeliveredAcks();
           }
+          const runtimeFailure = deps.getRuntimeFailure();
+          deps.clearRuntimeFailure();
           deps.setExtStatus(ctx, "ok");
-          const uiUpdate = getFollowerReconnectUiUpdate("reconnect", wasDisconnected);
+          const uiUpdate = getFollowerReconnectUiUpdate({
+            event: "reconnect",
+            wasDisconnected,
+            degradedReason: runtimeFailure?.message ?? null,
+            degradedNextStep: runtimeFailure?.nextStep ?? null,
+          });
           wasDisconnected = uiUpdate.nextWasDisconnected;
           if (uiUpdate.notify) {
             ctx.ui.notify(uiUpdate.notify.message, uiUpdate.notify.level);

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -15,6 +15,10 @@ import {
   isTerminalPinetStandDownMessage,
   parsePinetControlCommand,
   getPinetControlCommandFromText,
+  parseSlackBrokerReloadCommand,
+  isBrokerThinkingLevel,
+  isBrokerTerminalProviderError,
+  isLikelyRetryableAssistantError,
   buildPinetControlMetadata,
   buildPinetControlMessage,
   normalizeOutgoingPinetControlMessage,
@@ -613,6 +617,51 @@ describe("Pinet control helpers", () => {
     expect(getPinetControlCommandFromText('{"type":"pinet:control","action":"noop"}')).toBe(null);
     expect(getPinetControlCommandFromText("/exit now please")).toBeNull();
     expect(getPinetControlCommandFromText("please /reload")).toBeNull();
+  });
+
+  it("parses broker reload commands from Slack text", () => {
+    expect(parseSlackBrokerReloadCommand("pinet reload")).toEqual({
+      kind: "command",
+      command: { modelRef: null, thinkingLevel: null },
+    });
+    expect(parseSlackBrokerReloadCommand("/pinet-reload openai/gpt-5.4 xhigh")).toEqual({
+      kind: "command",
+      command: { modelRef: "openai/gpt-5.4", thinkingLevel: "xhigh" },
+    });
+    expect(parseSlackBrokerReloadCommand("pinet-reload minimal")).toEqual({
+      kind: "command",
+      command: { modelRef: null, thinkingLevel: "minimal" },
+    });
+    expect(parseSlackBrokerReloadCommand("hello world")).toEqual({ kind: "none" });
+  });
+
+  it("rejects invalid broker reload command shapes", () => {
+    expect(parseSlackBrokerReloadCommand("pinet reload gpt-5.4")).toEqual({
+      kind: "invalid",
+      reason: 'Model "gpt-5.4" is invalid. Use <provider>/<model>, e.g. openai/gpt-5.4',
+    });
+    expect(parseSlackBrokerReloadCommand("pinet reload openai/gpt-5.4 turbo")).toEqual({
+      kind: "invalid",
+      reason:
+        'Thinking level "turbo" is invalid. Use one of: off, minimal, low, medium, high, xhigh.',
+    });
+  });
+
+  it("classifies broker provider errors and retryability", () => {
+    expect(isBrokerThinkingLevel("xhigh")).toBe(true);
+    expect(isBrokerThinkingLevel("turbo")).toBe(false);
+
+    expect(
+      isBrokerTerminalProviderError(
+        "You're out of extra usage. Add more at claude.ai/settings/usage",
+      ),
+    ).toBe(true);
+    expect(isBrokerTerminalProviderError("Authentication failed: invalid API key")).toBe(true);
+    expect(isBrokerTerminalProviderError("Error: fetch failed")).toBe(false);
+
+    expect(isLikelyRetryableAssistantError("provider returned error: overloaded_error")).toBe(true);
+    expect(isLikelyRetryableAssistantError("network timeout while calling upstream")).toBe(true);
+    expect(isLikelyRetryableAssistantError("You're out of extra usage")).toBe(false);
   });
 
   it("builds structured control metadata and body", () => {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -3064,9 +3064,7 @@ describe("getFollowerReconnectUiUpdate", () => {
       degradedReason: "registration refresh failed",
       degradedNextStep: "Follower reconnected with the broker-assigned identity.",
     });
-    expect(result.notify?.message).toContain(
-      "after degraded state: registration refresh failed",
-    );
+    expect(result.notify?.message).toContain("after degraded state: registration refresh failed");
     expect(result.notify?.message).toContain(
       "Next step: Follower reconnected with the broker-assigned identity.",
     );

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -3031,25 +3031,49 @@ describe("resolveFollowerThreadChannel", () => {
 
 describe("getFollowerReconnectUiUpdate", () => {
   it("notifies on first disconnect", () => {
-    const result = getFollowerReconnectUiUpdate("disconnect", false);
+    const result = getFollowerReconnectUiUpdate({ event: "disconnect", wasDisconnected: false });
     expect(result.nextWasDisconnected).toBe(true);
     expect(result.notify?.level).toBe("warning");
   });
 
+  it("includes the last degraded reason in the disconnect notice", () => {
+    const result = getFollowerReconnectUiUpdate({
+      event: "disconnect",
+      wasDisconnected: false,
+      degradedReason: "socket unavailable",
+    });
+    expect(result.notify?.message).toContain("Last degraded state: socket unavailable");
+  });
+
   it("suppresses notification on repeated disconnect", () => {
-    const result = getFollowerReconnectUiUpdate("disconnect", true);
+    const result = getFollowerReconnectUiUpdate({ event: "disconnect", wasDisconnected: true });
     expect(result.nextWasDisconnected).toBe(true);
     expect(result.notify).toBeUndefined();
   });
 
   it("notifies on reconnect after disconnect", () => {
-    const result = getFollowerReconnectUiUpdate("reconnect", true);
+    const result = getFollowerReconnectUiUpdate({ event: "reconnect", wasDisconnected: true });
     expect(result.nextWasDisconnected).toBe(false);
     expect(result.notify?.level).toBe("info");
   });
 
+  it("includes degraded reason and next step after reconnect", () => {
+    const result = getFollowerReconnectUiUpdate({
+      event: "reconnect",
+      wasDisconnected: true,
+      degradedReason: "registration refresh failed",
+      degradedNextStep: "Follower reconnected with the broker-assigned identity.",
+    });
+    expect(result.notify?.message).toContain(
+      "after degraded state: registration refresh failed",
+    );
+    expect(result.notify?.message).toContain(
+      "Next step: Follower reconnected with the broker-assigned identity.",
+    );
+  });
+
   it("suppresses notification on reconnect when not disconnected", () => {
-    const result = getFollowerReconnectUiUpdate("reconnect", false);
+    const result = getFollowerReconnectUiUpdate({ event: "reconnect", wasDisconnected: false });
     expect(result.nextWasDisconnected).toBe(false);
     expect(result.notify).toBeUndefined();
   });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -2080,23 +2080,30 @@ export interface FollowerReconnectUiUpdate {
   };
 }
 
-export function getFollowerReconnectUiUpdate(
-  event: "disconnect" | "reconnect",
-  wasDisconnected: boolean,
-): FollowerReconnectUiUpdate {
-  if (event === "disconnect") {
-    return wasDisconnected
+export function getFollowerReconnectUiUpdate(input: {
+  event: "disconnect" | "reconnect";
+  wasDisconnected: boolean;
+  degradedReason?: string | null;
+  degradedNextStep?: string | null;
+}): FollowerReconnectUiUpdate {
+  const degradedReason = input.degradedReason?.trim() || null;
+  const degradedNextStep = input.degradedNextStep?.trim() || null;
+
+  if (input.event === "disconnect") {
+    return input.wasDisconnected
       ? { nextWasDisconnected: true }
       : {
           nextWasDisconnected: true,
           notify: {
             level: "warning",
-            message: "Pinet broker disconnected — reconnecting...",
+            message: degradedReason
+              ? `Pinet broker disconnected — reconnecting... Last degraded state: ${degradedReason}`
+              : "Pinet broker disconnected — reconnecting...",
           },
         };
   }
 
-  if (!wasDisconnected) {
+  if (!input.wasDisconnected) {
     return { nextWasDisconnected: false };
   }
 
@@ -2104,7 +2111,10 @@ export function getFollowerReconnectUiUpdate(
     nextWasDisconnected: false,
     notify: {
       level: "info",
-      message: "Pinet broker reconnected",
+      message:
+        degradedReason || degradedNextStep
+          ? `Pinet broker reconnected${degradedReason ? ` after degraded state: ${degradedReason}` : ""}${degradedNextStep ? ` Next step: ${degradedNextStep}` : ""}`
+          : "Pinet broker reconnected",
     },
   };
 }

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -298,6 +298,141 @@ export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string 
 
 // ─── Pinet control messages ─────────────────────────────
 
+export type BrokerThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+export interface SlackBrokerReloadCommand {
+  modelRef: string | null;
+  thinkingLevel: BrokerThinkingLevel | null;
+}
+
+export type SlackBrokerReloadParseResult =
+  | { kind: "none" }
+  | { kind: "invalid"; reason: string }
+  | { kind: "command"; command: SlackBrokerReloadCommand };
+
+const BROKER_RELOAD_COMMAND_PATTERN = /^(?:\/pinet-reload|pinet-reload|pinet\s+reload)\b(.*)$/i;
+
+const RETRYABLE_ASSISTANT_ERROR_PATTERN =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay/i;
+
+const TERMINAL_BROKER_PROVIDER_ERROR_PATTERN =
+  /out of (?:extra )?usage|quota|billing|payment required|insufficient credits|invalid[_\s-]?api[_\s-]?key|unauthorized|forbidden|auth(?:entication)?\s+failed|claude\.ai\/settings\/usage/i;
+
+function normalizeSlackMessageFirstLine(text: string | undefined): string {
+  const firstLine = text?.split(/\r?\n/, 1)[0] ?? "";
+  return firstLine.trim();
+}
+
+function normalizeBrokerThinkingLevel(value: string | undefined): BrokerThinkingLevel | null {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  switch (normalized) {
+    case "off":
+    case "minimal":
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+export function isBrokerThinkingLevel(value: string | undefined): value is BrokerThinkingLevel {
+  return normalizeBrokerThinkingLevel(value) !== null;
+}
+
+export function parseSlackBrokerReloadCommand(
+  text: string | undefined,
+): SlackBrokerReloadParseResult {
+  const firstLine = normalizeSlackMessageFirstLine(text);
+  if (!firstLine) {
+    return { kind: "none" };
+  }
+
+  const match = firstLine.match(BROKER_RELOAD_COMMAND_PATTERN);
+  if (!match) {
+    return { kind: "none" };
+  }
+
+  const remainder = match[1]?.trim() ?? "";
+  if (!remainder) {
+    return {
+      kind: "command",
+      command: { modelRef: null, thinkingLevel: null },
+    };
+  }
+
+  const tokens = remainder.split(/\s+/).filter(Boolean);
+  if (tokens.length > 2) {
+    return {
+      kind: "invalid",
+      reason:
+        "Usage: pinet reload [provider/model] [thinking]. Example: pinet reload openai/gpt-5.4 xhigh",
+    };
+  }
+
+  const singleTokenThinkingLevel = normalizeBrokerThinkingLevel(tokens[0]);
+  if (tokens.length === 1 && singleTokenThinkingLevel) {
+    return {
+      kind: "command",
+      command: { modelRef: null, thinkingLevel: singleTokenThinkingLevel },
+    };
+  }
+
+  const modelRef = tokens[0]?.trim() ?? "";
+  if (!modelRef.includes("/")) {
+    return {
+      kind: "invalid",
+      reason: `Model ${JSON.stringify(modelRef)} is invalid. Use <provider>/<model>, e.g. openai/gpt-5.4`,
+    };
+  }
+
+  const thinkingToken = tokens[1]?.trim();
+  if (!thinkingToken) {
+    return {
+      kind: "command",
+      command: { modelRef, thinkingLevel: null },
+    };
+  }
+
+  const thinkingLevel = normalizeBrokerThinkingLevel(thinkingToken);
+  if (!thinkingLevel) {
+    return {
+      kind: "invalid",
+      reason: `Thinking level ${JSON.stringify(thinkingToken)} is invalid. Use one of: off, minimal, low, medium, high, xhigh.`,
+    };
+  }
+
+  return {
+    kind: "command",
+    command: {
+      modelRef,
+      thinkingLevel,
+    },
+  };
+}
+
+export function isLikelyRetryableAssistantError(errorMessage: string | undefined): boolean {
+  const text = errorMessage?.trim();
+  if (!text) {
+    return false;
+  }
+  return RETRYABLE_ASSISTANT_ERROR_PATTERN.test(text);
+}
+
+export function isBrokerTerminalProviderError(errorMessage: string | undefined): boolean {
+  const text = errorMessage?.trim();
+  if (!text) {
+    return false;
+  }
+  return TERMINAL_BROKER_PROVIDER_ERROR_PATTERN.test(text);
+}
+
 export type PinetControlCommand = "reload" | "exit";
 
 export interface PinetRemoteControlState {

--- a/slack-bridge/inbox-drain-runtime.ts
+++ b/slack-bridge/inbox-drain-runtime.ts
@@ -19,6 +19,8 @@ export interface InboxDrainRuntimeDeps {
   flushFollowerDeliveredAcks: () => Promise<void>;
   markBrokerInboxIdsDelivered: (inboxIds: number[]) => void;
   getFollowerDeliveryState: () => FollowerDeliveryState;
+  shouldPauseDrain?: () => boolean;
+  onInboxDelivered?: (messages: InboxMessage[]) => void;
 }
 
 export interface InboxDrainRuntime {
@@ -51,6 +53,10 @@ export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrain
   }
 
   function drainInbox(): void {
+    if (deps.shouldPauseDrain?.()) {
+      return;
+    }
+
     const pending = deps.takeInboxMessages();
     if (pending.length === 0) {
       return;
@@ -74,6 +80,7 @@ export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrain
         messages: pending,
       })
     ) {
+      deps.onInboxDelivered?.(pending);
       if (brokerInboxIds.length > 0) {
         if (deps.getBrokerRole() === "follower") {
           markFollowerInboxIdsDelivered(deps.getFollowerDeliveryState(), brokerInboxIds);

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2368,6 +2368,170 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(setStatus).toHaveBeenCalled();
   });
 
+  it("surfaces the last degraded follower reason when the broker reconnects", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let disconnectHandler: (() => void) | null = null;
+    let reconnectHandler: (() => void) | null = null;
+    const registerCalls: Array<{
+      name: string;
+      emoji: string;
+      metadata?: Record<string, unknown>;
+      stableId?: string;
+    }> = [];
+    let pollCount = 0;
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async function (
+      this: BrokerClient,
+      name: string,
+      emoji: string,
+      metadata?: Record<string, unknown>,
+      stableId?: string,
+    ) {
+      const result = {
+        agentId: "worker-1",
+        name,
+        emoji,
+        metadata: metadata ?? null,
+      };
+      (
+        this as unknown as {
+          registeredIdentity: typeof result | null;
+          registrationSnapshot: {
+            name: string;
+            emoji: string;
+            metadata?: Record<string, unknown>;
+            stableId?: string;
+          } | null;
+        }
+      ).registeredIdentity = result;
+      (
+        this as unknown as {
+          registrationSnapshot: {
+            name: string;
+            emoji: string;
+            metadata?: Record<string, unknown>;
+            stableId?: string;
+          } | null;
+        }
+      ).registrationSnapshot = {
+        name,
+        emoji,
+        ...(metadata ? { metadata } : {}),
+        ...(stableId ? { stableId } : {}),
+      };
+      registerCalls.push({ name, emoji, metadata, stableId });
+      return result;
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockImplementation(async () => {
+      pollCount += 1;
+      if (pollCount === 1) {
+        throw new Error("socket unavailable");
+      }
+      return [];
+    });
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation((handler) => {
+      disconnectHandler = handler;
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation((handler) => {
+      reconnectHandler = handler;
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await follow?.handler("", ctx);
+
+    expect(registerCalls).toHaveLength(1);
+    expect(disconnectHandler).toBeTypeOf("function");
+    expect(reconnectHandler).toBeTypeOf("function");
+
+    if (!disconnectHandler || !reconnectHandler) {
+      throw new Error("Reconnect handlers were not registered");
+    }
+
+    const runDisconnect: () => void = disconnectHandler;
+    const runReconnect: () => void = reconnectHandler;
+
+    await new Promise((resolve) => setTimeout(resolve, 2100));
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet poll error: socket unavailable Broker may be restarting; follower will keep polling automatically.",
+      "warning",
+    );
+
+    runDisconnect();
+    runReconnect();
+
+    await vi.waitFor(() => {
+      expect(registerCalls).toHaveLength(2);
+    });
+
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet broker disconnected — reconnecting... Last degraded state: socket unavailable",
+      "warning",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet broker reconnected after degraded state: socket unavailable Next step: Broker may be restarting; follower will keep polling automatically.",
+      "info",
+    );
+
+    await sessionShutdown?.({}, ctx);
+  });
+
   it("stops follower reconnect retries after a terminal name conflict and allows a clean retry", async () => {
     const originalNickname = process.env.PI_NICKNAME;
     process.env.PI_NICKNAME = "Reserved Crane";

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -591,6 +591,248 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionShutdown?.({}, ctx);
   });
 
+  it("completes broker reload overrides before a queued exit runs", async () => {
+    const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+    const resolvedModel = { provider: "openai", id: "gpt-5.4" };
+    const setModel = vi.fn(async () => true);
+    const setThinkingLevel = vi.fn(async () => undefined);
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+      setModel,
+      setThinkingLevel,
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const shutdown = vi.fn();
+    const modelRegistry = {
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai" && modelId === "gpt-5.4") {
+          return resolvedModel;
+        }
+        return null;
+      }),
+    };
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      shutdown,
+      modelRegistry,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "broker-reload-settle-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-broker-reload-settle-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    const postedMessages: Array<{ thread_ts?: string; text?: string }> = [];
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://slack.com/api/chat.postMessage") {
+        postedMessages.push(
+          JSON.parse(String(init?.body ?? "{}")) as { thread_ts?: string; text?: string },
+        );
+        return new Response(JSON.stringify({ ok: true, message: { ts: "300.1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === "https://slack.com/api/conversations.replies") {
+        return new Response(JSON.stringify({ ok: true, messages: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    const brokerRuntimes: Array<{
+      db: BrokerDB;
+      server: {
+        setAgentRegistrationResolver: ReturnType<typeof vi.fn>;
+        onAgentMessage: ReturnType<typeof vi.fn>;
+        onAgentStatusChange: ReturnType<typeof vi.fn>;
+      };
+      stop: ReturnType<typeof vi.fn>;
+      adapters: Array<{ name?: string }>;
+    }> = [];
+    let releaseReloadStop: (() => void) | null = null;
+    const reloadStopGate = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("Broker reload did not unblock"));
+      }, 1_000);
+      releaseReloadStop = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+    });
+
+    vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation((db) => ({
+      reapedAgentIds: [],
+      repairedThreadClaims: 0,
+      assignedBacklogCount: 0,
+      nudgedAgentIds: [],
+      pendingBacklogCount: db.getBacklogCount("pending"),
+      anomalies: [],
+    }));
+    const startBrokerSpy = vi.spyOn(brokerModule, "startBroker").mockImplementation(async () => {
+      const runtimeIndex = brokerRuntimes.length;
+      const db = new BrokerDB(dbPath);
+      db.initialize();
+      const adapters: Array<{ name?: string }> = [];
+      const server = {
+        setAgentRegistrationResolver: vi.fn(),
+        onAgentMessage: vi.fn(),
+        onAgentStatusChange: vi.fn(),
+      };
+      const stop = vi.fn(async () => {
+        if (runtimeIndex === 0) {
+          await reloadStopGate;
+        }
+        db.close();
+      });
+      brokerRuntimes.push({ db, server, stop, adapters });
+      return {
+        db,
+        server,
+        lock: {
+          isLeader: () => true,
+          release: vi.fn(),
+        },
+        adapters,
+        addAdapter: vi.fn((adapter) => {
+          adapters.push(adapter as { name?: string });
+        }),
+        stop,
+      } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
+    });
+    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
+    vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const pinetStart = commands.get("pinet-start");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(pinetStart).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await pinetStart?.handler("", ctx);
+
+    const slackAdapter = brokerRuntimes[0]?.adapters.find((adapter) => adapter.name === "slack") as
+      | {
+          inboundHandler?: (message: {
+            source: string;
+            threadId: string;
+            channel: string;
+            userId: string;
+            text: string;
+            timestamp: string;
+            metadata: Record<string, unknown> | null;
+          }) => void;
+        }
+      | undefined;
+    expect(slackAdapter).toBeDefined();
+    expect(slackAdapter?.inboundHandler).toBeDefined();
+
+    slackAdapter?.inboundHandler?.({
+      source: "slack",
+      threadId: "1700.1",
+      channel: "C1700",
+      userId: "U_SENDER",
+      text: "pinet reload openai/gpt-5.4 xhigh",
+      timestamp: "1700.2",
+      metadata: null,
+    });
+
+    await vi.waitFor(() => {
+      expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
+    });
+
+    brokerRuntimes[0]?.db.registerAgent("sender", "Sender", "📤", 202);
+    brokerRuntimes[0]?.db.queueMessage("broker-reload-settle-leaf", {
+      source: "agent",
+      threadId: "a2a:sender:broker-reload-settle-leaf",
+      channel: "",
+      userId: "sender",
+      text: "/exit",
+      timestamp: "1800.1",
+      metadata: { a2a: true, kind: "pinet_control", command: "exit" },
+    });
+
+    const onAgentMessage = brokerRuntimes[0]?.server.onAgentMessage.mock.calls[0]?.[0] as
+      | ((targetAgentId: string) => void)
+      | undefined;
+    expect(onAgentMessage).toBeDefined();
+    onAgentMessage?.("broker-reload-settle-leaf");
+
+    await vi.waitFor(() => {
+      expect(notify).toHaveBeenCalledWith("Pinet remote control queued: /exit", "warning");
+    });
+
+    const unblockReloadStop: () => void =
+      releaseReloadStop ??
+      (() => {
+        throw new Error("Expected broker reload stop gate to be available");
+      });
+    unblockReloadStop();
+
+    await vi.waitFor(() => {
+      expect(startBrokerSpy).toHaveBeenCalledTimes(2);
+    });
+
+    await vi.waitFor(() => {
+      expect(setModel).toHaveBeenCalledWith(resolvedModel);
+      expect(setThinkingLevel).toHaveBeenCalledWith("xhigh");
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      postedMessages.some(
+        (message) =>
+          message.thread_ts === "1700.1" &&
+          message.text ===
+            "✅ Broker reload complete with model `openai/gpt-5.4` + thinking `xhigh`.",
+      ),
+    ).toBe(true);
+    expect(notify).toHaveBeenCalledWith(
+      "Pinet remote control continuing with queued /exit",
+      "warning",
+    );
+
+    await sessionShutdown?.({}, ctx);
+  });
+
   it("restores the previous broker runtime if /pinet-start reload fails", async () => {
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -709,30 +709,42 @@ export default function (pi: ExtensionAPI) {
     flushDeferredRemoteControlAcks,
     reloadPinetRuntime,
     formatError: msg,
+    onReloadSuccess: () => {
+      brokerAutoDrainPause = null;
+      brokerPauseNotifiedThreads.clear();
+      maybeDrainInboxIfIdle(extCtx ?? undefined);
+    },
   });
   const { requestRemoteControl, resetRemoteControlState } = pinetRemoteControl;
 
   function runRemoteControl(command: "reload" | "exit", ctx: ExtensionContext): void {
     stopActiveBrokerTurnState();
-    if (command === "reload") {
-      brokerAutoDrainPause = null;
-      brokerPauseNotifiedThreads.clear();
-    }
     pinetRemoteControl.runRemoteControl(command, ctx);
   }
 
-  function asRecord(value: unknown): Record<string, unknown> | null {
-    if (typeof value !== "object" || value === null) {
-      return null;
+  function getObjectProperty(target: unknown, property: string): unknown {
+    if (typeof target !== "object" || target === null) {
+      return undefined;
     }
-    return Object.fromEntries(Object.entries(value));
+    return Reflect.get(target, property);
   }
 
-  function asFunction(value: unknown): ((...args: unknown[]) => unknown) | null {
-    if (typeof value !== "function") {
-      return null;
+  function hasObjectMethod(target: unknown, methodName: string): boolean {
+    if (typeof target !== "object" || target === null) {
+      return false;
     }
-    return (...args: unknown[]) => Reflect.apply(value, undefined, args);
+    return typeof Reflect.get(target, methodName) === "function";
+  }
+
+  function callObjectMethod(target: unknown, methodName: string, ...args: unknown[]): unknown {
+    if (typeof target !== "object" || target === null) {
+      return undefined;
+    }
+    const method = Reflect.get(target, methodName);
+    if (typeof method !== "function") {
+      return undefined;
+    }
+    return Reflect.apply(method, target, args);
   }
 
   async function applyBrokerReloadOverrides(
@@ -753,27 +765,23 @@ export default function (pi: ExtensionAPI) {
         );
       }
 
-      const ctxRecord = asRecord(ctx);
-      const modelRegistryRecord = ctxRecord ? asRecord(ctxRecord["modelRegistry"]) : null;
-      const findModel = modelRegistryRecord ? asFunction(modelRegistryRecord["find"]) : null;
-      if (!findModel) {
+      const modelRegistry = getObjectProperty(ctx, "modelRegistry");
+      if (!hasObjectMethod(modelRegistry, "find")) {
         throw new Error("This pi build does not expose runtime model switching via Slack reload.");
       }
 
-      const model = findModel(provider, modelId);
+      const model = callObjectMethod(modelRegistry, "find", provider, modelId);
       if (!model) {
         throw new Error(
           `Model ${JSON.stringify(command.modelRef)} is not available in this session.`,
         );
       }
 
-      const piRecord = asRecord(pi);
-      const setModel = piRecord ? asFunction(piRecord["setModel"]) : null;
-      if (!setModel) {
+      if (!hasObjectMethod(pi, "setModel")) {
         throw new Error("This pi build does not expose setModel for Slack-driven reloads.");
       }
 
-      const switchedResult = await Promise.resolve(setModel(model));
+      const switchedResult = await Promise.resolve(callObjectMethod(pi, "setModel", model));
       if (switchedResult === false) {
         throw new Error(
           `Failed to switch to ${JSON.stringify(command.modelRef)}. Check API keys for that provider/model.`,
@@ -784,12 +792,10 @@ export default function (pi: ExtensionAPI) {
 
     let appliedThinkingLevel: BrokerThinkingLevel | null = null;
     if (command.thinkingLevel) {
-      const piRecord = asRecord(pi);
-      const setThinkingLevel = piRecord ? asFunction(piRecord["setThinkingLevel"]) : null;
-      if (!setThinkingLevel) {
+      if (!hasObjectMethod(pi, "setThinkingLevel")) {
         throw new Error("This pi build does not expose thinking-level controls for Slack reload.");
       }
-      setThinkingLevel(command.thinkingLevel);
+      callObjectMethod(pi, "setThinkingLevel", command.thinkingLevel);
       appliedThinkingLevel = command.thinkingLevel;
     }
 
@@ -828,8 +834,6 @@ export default function (pi: ExtensionAPI) {
 
     try {
       const applied = await applyBrokerReloadOverrides(parsed.command, ctx);
-      brokerAutoDrainPause = null;
-      brokerPauseNotifiedThreads.clear();
 
       const queued = requestRemoteControl("reload", ctx);
       const statusText = queued.shouldStartNow
@@ -1002,16 +1006,22 @@ export default function (pi: ExtensionAPI) {
     handleInboundMessage: async ({ message, broker, router, selfId, ctx }) => {
       try {
         if (message.source === "slack" && message.threadId && message.channel) {
-          const handledReloadCommand = await handleSlackBrokerReloadCommand(
-            {
-              channel: message.channel,
-              threadTs: message.threadId,
-              text: message.text,
-            },
-            ctx,
-          );
-          if (handledReloadCommand) {
-            return;
+          const existingThreadOwner = broker.db.getThread(message.threadId)?.ownerAgent ?? null;
+          const shouldHandleBrokerReload =
+            existingThreadOwner === null || existingThreadOwner === selfId;
+
+          if (shouldHandleBrokerReload) {
+            const handledReloadCommand = await handleSlackBrokerReloadCommand(
+              {
+                channel: message.channel,
+                threadTs: message.threadId,
+                text: message.text,
+              },
+              ctx,
+            );
+            if (handledReloadCommand) {
+              return;
+            }
           }
 
           if (brokerAutoDrainPause) {
@@ -1784,9 +1794,6 @@ export default function (pi: ExtensionAPI) {
           ),
         );
       }
-    } else if (!assistantError) {
-      brokerAutoDrainPause = null;
-      brokerPauseNotifiedThreads.clear();
     }
   });
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -41,7 +41,11 @@ import {
   markFollowerInboxIdsDelivered,
   queueFollowerInboxIds,
 } from "./follower-delivery.js";
-import { createFollowerRuntime, type BrokerClientRef } from "./follower-runtime.js";
+import {
+  createFollowerRuntime,
+  type BrokerClientRef,
+  type FollowerRuntimeFailureEvent,
+} from "./follower-runtime.js";
 import {
   createSinglePlayerRuntime,
   type SinglePlayerPendingAttentionEntry,
@@ -281,6 +285,7 @@ export default function (pi: ExtensionAPI) {
 
   let activeBrokerTurnState: ActiveBrokerTurnState | null = null;
   let brokerAutoDrainPause: BrokerAutoDrainPauseState | null = null;
+  let followerRuntimeFailure: FollowerRuntimeFailureEvent | null = null;
   let pendingBrokerReloadRequest: PendingBrokerReloadRequest | null = null;
 
   function maybeDrainInboxIfIdle(ctx?: ExtensionContext): boolean {
@@ -1697,8 +1702,28 @@ export default function (pi: ExtensionAPI) {
     runRemoteControl,
     deliverFollowUpMessage,
     setExtStatus,
+    noteRuntimeFailure: (ctx, event) => {
+      followerRuntimeFailure = event;
+      setExtStatus(ctx, event.retryable ? "reconnecting" : "error");
+      ctx.ui.notify(
+        `Pinet ${event.kind.replaceAll("_", " ")}: ${event.message} ${event.nextStep}`,
+        event.retryable ? "warning" : "error",
+      );
+    },
+    clearRuntimeFailure: () => {
+      followerRuntimeFailure = null;
+    },
+    getRuntimeFailure: () => followerRuntimeFailure,
     handleTerminalReconnectFailure: async (ctx, error) => {
       console.error(`[slack-bridge] follower reconnect failed: ${msg(error)}`);
+      followerRuntimeFailure = {
+        kind: "reconnect_failed",
+        message: msg(error),
+        retryable: false,
+        nextStep:
+          "Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.",
+        error,
+      };
       await disconnectFollower(ctx, { preserveErrorState: true }).catch(() => {
         /* best effort */
       });
@@ -1740,6 +1765,15 @@ export default function (pi: ExtensionAPI) {
       recentActivityLogEntries: (limit) => brokerRuntime.getRecentActivityEntries(limit),
       slackScopeDiagnostics: () => slackScopeDiagnostics,
       settings: () => settings,
+      followerRuntimeFailure: () =>
+        followerRuntimeFailure
+          ? {
+              kind: followerRuntimeFailure.kind,
+              message: followerRuntimeFailure.message,
+              retryable: followerRuntimeFailure.retryable,
+              nextStep: followerRuntimeFailure.nextStep,
+            }
+          : null,
       lastBrokerMaintenance: () => brokerRuntime.getLastMaintenance(),
       isBrokerControlPlaneCanvasEnabled: () => brokerRuntime.isBrokerControlPlaneCanvasEnabled(),
       getConfiguredBrokerControlPlaneCanvasId: () =>
@@ -1932,6 +1966,7 @@ export default function (pi: ExtensionAPI) {
     resetPendingRemoteControlAcks();
     stopActiveBrokerTurnState();
     brokerAutoDrainPause = null;
+    followerRuntimeFailure = null;
     pendingBrokerReloadRequest = null;
     brokerPauseNotifiedThreads.clear();
     sessionUiRuntime.cleanupForSessionShutdown();

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -265,6 +265,14 @@ export default function (pi: ExtensionAPI) {
     retryErrorCount: number;
   }
 
+  interface PendingBrokerReloadRequest {
+    target: BrokerTurnThreadTarget;
+    command: {
+      modelRef: string | null;
+      thinkingLevel: BrokerThinkingLevel | null;
+    };
+  }
+
   const BROKER_PROGRESS_UPDATE_INTERVAL_MS = 2 * 60_000;
   const brokerPauseNotifiedThreads = new TtlSet<string>({
     maxSize: 2000,
@@ -273,6 +281,7 @@ export default function (pi: ExtensionAPI) {
 
   let activeBrokerTurnState: ActiveBrokerTurnState | null = null;
   let brokerAutoDrainPause: BrokerAutoDrainPauseState | null = null;
+  let pendingBrokerReloadRequest: PendingBrokerReloadRequest | null = null;
 
   function maybeDrainInboxIfIdle(ctx?: ExtensionContext): boolean {
     if (brokerAutoDrainPause) {
@@ -709,11 +718,7 @@ export default function (pi: ExtensionAPI) {
     flushDeferredRemoteControlAcks,
     reloadPinetRuntime,
     formatError: msg,
-    onReloadSuccess: () => {
-      brokerAutoDrainPause = null;
-      brokerPauseNotifiedThreads.clear();
-      maybeDrainInboxIfIdle(extCtx ?? undefined);
-    },
+    onCommandSettled: handlePinetRemoteControlSettled,
   });
   const { requestRemoteControl, resetRemoteControlState } = pinetRemoteControl;
 
@@ -747,6 +752,38 @@ export default function (pi: ExtensionAPI) {
     return Reflect.apply(method, target, args);
   }
 
+  function hasBrokerReloadOverrides(command: {
+    modelRef: string | null;
+    thinkingLevel: BrokerThinkingLevel | null;
+  }): boolean {
+    return command.modelRef !== null || command.thinkingLevel !== null;
+  }
+
+  function formatBrokerReloadScope(command: {
+    modelRef: string | null;
+    thinkingLevel: BrokerThinkingLevel | null;
+  }): string {
+    const scope = [
+      command.modelRef ? `model \`${command.modelRef}\`` : null,
+      command.thinkingLevel ? `thinking \`${command.thinkingLevel}\`` : null,
+    ]
+      .filter((entry): entry is string => entry != null)
+      .join(" + ");
+    return scope.length > 0 ? ` with ${scope}` : "";
+  }
+
+  function validateBrokerReloadOverrideSupport(command: {
+    modelRef: string | null;
+    thinkingLevel: BrokerThinkingLevel | null;
+  }): void {
+    if (command.modelRef && !hasObjectMethod(pi, "setModel")) {
+      throw new Error("This pi build does not expose setModel for Slack-driven reloads.");
+    }
+    if (command.thinkingLevel && !hasObjectMethod(pi, "setThinkingLevel")) {
+      throw new Error("This pi build does not expose thinking-level controls for Slack reload.");
+    }
+  }
+
   async function applyBrokerReloadOverrides(
     command: {
       modelRef: string | null;
@@ -754,11 +791,15 @@ export default function (pi: ExtensionAPI) {
     },
     ctx: ExtensionContext,
   ): Promise<{ modelRef: string | null; thinkingLevel: BrokerThinkingLevel | null }> {
-    let appliedModelRef: string | null = null;
+    validateBrokerReloadOverrideSupport(command);
+
+    let provider: string | null = null;
+    let modelId: string | null = null;
+    let model: unknown = null;
     if (command.modelRef) {
       const separatorIndex = command.modelRef.indexOf("/");
-      const provider = command.modelRef.slice(0, separatorIndex).trim();
-      const modelId = command.modelRef.slice(separatorIndex + 1).trim();
+      provider = command.modelRef.slice(0, separatorIndex).trim();
+      modelId = command.modelRef.slice(separatorIndex + 1).trim();
       if (!provider || !modelId) {
         throw new Error(
           `Model ${JSON.stringify(command.modelRef)} is invalid. Use <provider>/<model>, e.g. openai/gpt-5.4`,
@@ -770,39 +811,110 @@ export default function (pi: ExtensionAPI) {
         throw new Error("This pi build does not expose runtime model switching via Slack reload.");
       }
 
-      const model = callObjectMethod(modelRegistry, "find", provider, modelId);
+      model = callObjectMethod(modelRegistry, "find", provider, modelId);
       if (!model) {
         throw new Error(
           `Model ${JSON.stringify(command.modelRef)} is not available in this session.`,
         );
       }
+    }
 
-      if (!hasObjectMethod(pi, "setModel")) {
-        throw new Error("This pi build does not expose setModel for Slack-driven reloads.");
-      }
-
+    if (command.modelRef && model) {
       const switchedResult = await Promise.resolve(callObjectMethod(pi, "setModel", model));
       if (switchedResult === false) {
         throw new Error(
           `Failed to switch to ${JSON.stringify(command.modelRef)}. Check API keys for that provider/model.`,
         );
       }
-      appliedModelRef = `${provider}/${modelId}`;
     }
 
-    let appliedThinkingLevel: BrokerThinkingLevel | null = null;
     if (command.thinkingLevel) {
-      if (!hasObjectMethod(pi, "setThinkingLevel")) {
-        throw new Error("This pi build does not expose thinking-level controls for Slack reload.");
-      }
-      callObjectMethod(pi, "setThinkingLevel", command.thinkingLevel);
-      appliedThinkingLevel = command.thinkingLevel;
+      await Promise.resolve(callObjectMethod(pi, "setThinkingLevel", command.thinkingLevel));
     }
 
     return {
-      modelRef: appliedModelRef,
-      thinkingLevel: appliedThinkingLevel,
+      modelRef: provider && modelId ? `${provider}/${modelId}` : null,
+      thinkingLevel: command.thinkingLevel,
     };
+  }
+
+  async function handlePinetRemoteControlSettled(event: {
+    command: "reload" | "exit";
+    success: boolean;
+    error: unknown;
+    nextCommand: "reload" | "exit" | null;
+    ctx: ExtensionContext;
+  }): Promise<void> {
+    if (event.command !== "reload") {
+      return;
+    }
+
+    if (event.nextCommand === "reload") {
+      return;
+    }
+
+    const pending = pendingBrokerReloadRequest;
+    pendingBrokerReloadRequest = null;
+
+    if (!event.success) {
+      if (pending) {
+        await postBrokerThreadNotice(
+          pending.target,
+          `⚠️ Broker reload failed: ${msg(event.error)}`,
+          {
+            kind: "broker_reload_error",
+          },
+        );
+      }
+      return;
+    }
+
+    const pauseWasActive = brokerAutoDrainPause !== null;
+    let overridesApplied = true;
+
+    if (pending && hasBrokerReloadOverrides(pending.command)) {
+      try {
+        const applied = await applyBrokerReloadOverrides(pending.command, event.ctx);
+        await postBrokerThreadNotice(
+          pending.target,
+          `✅ Broker reload complete${formatBrokerReloadScope(applied)}.`,
+          {
+            kind: "broker_reload_complete",
+            ...(applied.modelRef ? { model_ref: applied.modelRef } : {}),
+            ...(applied.thinkingLevel ? { thinking: applied.thinkingLevel } : {}),
+          },
+        );
+      } catch (error) {
+        overridesApplied = false;
+        await postBrokerThreadNotice(
+          pending.target,
+          `⚠️ Broker reload completed, but override apply failed: ${msg(error)}`,
+          {
+            kind: "broker_reload_error",
+          },
+        );
+
+        if (pauseWasActive) {
+          await postBrokerThreadNotice(
+            pending.target,
+            "⏸️ Broker remains paused. Retry with `pinet reload [provider/model] [thinking]` or run `pinet reload` with no overrides.",
+            { kind: "broker_paused" },
+          );
+        }
+      }
+    } else if (pending) {
+      await postBrokerThreadNotice(pending.target, "✅ Broker reload complete.", {
+        kind: "broker_reload_complete",
+      });
+    }
+
+    if (!pauseWasActive || overridesApplied) {
+      brokerAutoDrainPause = null;
+      brokerPauseNotifiedThreads.clear();
+      if (event.nextCommand === null) {
+        maybeDrainInboxIfIdle(event.ctx);
+      }
+    }
   }
 
   async function handleSlackBrokerReloadCommand(
@@ -833,29 +945,45 @@ export default function (pi: ExtensionAPI) {
     }
 
     try {
-      const applied = await applyBrokerReloadOverrides(parsed.command, ctx);
+      validateBrokerReloadOverrideSupport(parsed.command);
 
       const queued = requestRemoteControl("reload", ctx);
+      if (queued.scheduledCommand !== "reload") {
+        await postBrokerThreadNotice(
+          target,
+          "⚠️ Broker reload was ignored because an `/exit` control action is already scheduled.",
+          {
+            kind: "broker_reload_error",
+            queue_status: queued.status,
+            scheduled_command: queued.scheduledCommand,
+          },
+        );
+        return true;
+      }
+
+      pendingBrokerReloadRequest = {
+        target,
+        command: parsed.command,
+      };
+
       const statusText = queued.shouldStartNow
         ? "starting now"
         : queued.status === "queued"
           ? "queued behind an in-flight control action"
           : "already scheduled";
-      const scope = [
-        applied.modelRef ? `model \`${applied.modelRef}\`` : null,
-        applied.thinkingLevel ? `thinking \`${applied.thinkingLevel}\`` : null,
-      ]
-        .filter((entry): entry is string => entry != null)
-        .join(" + ");
-      const scopeText = scope.length > 0 ? ` with ${scope}` : "";
+      const scopeText = formatBrokerReloadScope(parsed.command);
 
-      await postBrokerThreadNotice(target, `🔄 Broker reload requested${scopeText} — ${statusText}.`, {
-        kind: "broker_reload_requested",
-        ...(applied.modelRef ? { model_ref: applied.modelRef } : {}),
-        ...(applied.thinkingLevel ? { thinking: applied.thinkingLevel } : {}),
-        queue_status: queued.status,
-        queue_start: queued.shouldStartNow,
-      });
+      await postBrokerThreadNotice(
+        target,
+        `🔄 Broker reload requested${scopeText} — ${statusText}.`,
+        {
+          kind: "broker_reload_requested",
+          ...(parsed.command.modelRef ? { model_ref: parsed.command.modelRef } : {}),
+          ...(parsed.command.thinkingLevel ? { thinking: parsed.command.thinkingLevel } : {}),
+          queue_status: queued.status,
+          queue_start: queued.shouldStartNow,
+        },
+      );
 
       if (queued.shouldStartNow) {
         runRemoteControl("reload", ctx);
@@ -1804,6 +1932,7 @@ export default function (pi: ExtensionAPI) {
     resetPendingRemoteControlAcks();
     stopActiveBrokerTurnState();
     brokerAutoDrainPause = null;
+    pendingBrokerReloadRequest = null;
     brokerPauseNotifiedThreads.clear();
     sessionUiRuntime.cleanupForSessionShutdown();
     await stopPinetRuntime(ctx, { releaseIdentity: true });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -13,6 +13,10 @@ import {
   resolveAgentStableId,
   resolveAllowAllWorkspaceUsers,
   trackBrokerInboundThread,
+  parseSlackBrokerReloadCommand,
+  isBrokerTerminalProviderError,
+  isLikelyRetryableAssistantError,
+  type BrokerThinkingLevel,
 } from "./helpers.js";
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
@@ -202,7 +206,11 @@ export default function (pi: ExtensionAPI) {
       drainInboxPort?.();
     },
   });
-  const { updateBadge, setExtStatus, maybeDrainInboxIfIdle } = sessionUiRuntime;
+  const {
+    updateBadge,
+    setExtStatus,
+    maybeDrainInboxIfIdle: maybeDrainInboxIfIdleFromSession,
+  } = sessionUiRuntime;
   let reportAgentStatus: (status: "working" | "idle") => Promise<void> = async () => {};
   let deliverTrackedSlackFollowUpMessage: (options: {
     prompt: string;
@@ -228,9 +236,183 @@ export default function (pi: ExtensionAPI) {
       brokerRuntime.markDelivered(inboxIds);
     },
     getFollowerDeliveryState: () => followerDeliveryState,
+    shouldPauseDrain: () => brokerAutoDrainPause !== null,
+    onInboxDelivered: (messages) => {
+      if (brokerRole === "broker") {
+        startActiveBrokerTurnState(messages);
+      }
+    },
   });
   const { deliverFollowUpMessage, flushDeliveredFollowerAcks, drainInbox } = inboxDrainRuntime;
   drainInboxPort = drainInbox;
+
+  interface BrokerTurnThreadTarget {
+    channel: string;
+    threadTs: string;
+  }
+
+  interface ActiveBrokerTurnState {
+    startedAtMs: number;
+    targets: BrokerTurnThreadTarget[];
+    retryErrorCount: number;
+    lastProgressUpdateMinutes: number;
+    timer: ReturnType<typeof setInterval>;
+  }
+
+  interface BrokerAutoDrainPauseState {
+    reason: string;
+    pausedAtMs: number;
+    retryErrorCount: number;
+  }
+
+  const BROKER_PROGRESS_UPDATE_INTERVAL_MS = 2 * 60_000;
+  const brokerPauseNotifiedThreads = new TtlSet<string>({
+    maxSize: 2000,
+    ttlMs: 5 * 60_000,
+  });
+
+  let activeBrokerTurnState: ActiveBrokerTurnState | null = null;
+  let brokerAutoDrainPause: BrokerAutoDrainPauseState | null = null;
+
+  function maybeDrainInboxIfIdle(ctx?: ExtensionContext): boolean {
+    if (brokerAutoDrainPause) {
+      return false;
+    }
+    return maybeDrainInboxIfIdleFromSession(ctx);
+  }
+
+  function buildAgentSlackMetadata(extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      event_type: "pi_agent_msg",
+      event_payload: {
+        agent: agentName,
+        agent_owner: agentOwnerToken,
+        ...extra,
+      },
+    };
+  }
+
+  async function postBrokerThreadNotice(
+    target: BrokerTurnThreadTarget,
+    text: string,
+    metadata: Record<string, unknown> = {},
+  ): Promise<void> {
+    try {
+      await slack("chat.postMessage", botToken!, {
+        channel: target.channel,
+        thread_ts: target.threadTs,
+        text,
+        metadata: buildAgentSlackMetadata(metadata),
+      });
+    } catch (error) {
+      console.error(`[slack-bridge] broker notice failed: ${msg(error)}`);
+    }
+  }
+
+  function collectBrokerTurnTargets(messages: InboxMessage[]): BrokerTurnThreadTarget[] {
+    const seen = new Set<string>();
+    const targets: BrokerTurnThreadTarget[] = [];
+
+    for (const message of messages) {
+      const channel = message.channel.trim();
+      const threadTs = message.threadTs.trim();
+      if (!channel || !threadTs) {
+        continue;
+      }
+
+      const key = `${channel}:${threadTs}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      targets.push({ channel, threadTs });
+    }
+
+    return targets;
+  }
+
+  function stopActiveBrokerTurnState(): ActiveBrokerTurnState | null {
+    const current = activeBrokerTurnState;
+    if (!current) {
+      return null;
+    }
+
+    clearInterval(current.timer);
+    activeBrokerTurnState = null;
+    return current;
+  }
+
+  async function emitBrokerTurnProgressUpdate(startedAtMs: number): Promise<void> {
+    const state = activeBrokerTurnState;
+    if (!state || state.startedAtMs !== startedAtMs) {
+      return;
+    }
+
+    const elapsedMinutes = Math.floor((Date.now() - state.startedAtMs) / 60_000);
+    if (elapsedMinutes <= 0 || elapsedMinutes === state.lastProgressUpdateMinutes) {
+      return;
+    }
+
+    state.lastProgressUpdateMinutes = elapsedMinutes;
+    await Promise.all(
+      state.targets.map((target) =>
+        postBrokerThreadNotice(
+          target,
+          `⏳ Broker still processing this request (${elapsedMinutes}m elapsed).`,
+          {
+            kind: "broker_progress",
+            elapsed_minutes: elapsedMinutes,
+          },
+        ),
+      ),
+    );
+  }
+
+  function startActiveBrokerTurnState(messages: InboxMessage[]): void {
+    stopActiveBrokerTurnState();
+
+    const targets = collectBrokerTurnTargets(messages);
+    if (targets.length === 0) {
+      return;
+    }
+
+    const startedAtMs = Date.now();
+    const timer = setInterval(() => {
+      void emitBrokerTurnProgressUpdate(startedAtMs);
+    }, BROKER_PROGRESS_UPDATE_INTERVAL_MS);
+    timer.unref?.();
+
+    activeBrokerTurnState = {
+      startedAtMs,
+      targets,
+      retryErrorCount: 0,
+      lastProgressUpdateMinutes: 0,
+      timer,
+    };
+  }
+
+  function summarizeAssistantError(
+    messages: readonly {
+      role: string;
+      stopReason?: string;
+      errorMessage?: string;
+      provider?: string;
+      model?: string;
+    }[],
+  ): { message: string; provider: string | null; model: string | null } | null {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (!message || message.role !== "assistant" || message.stopReason !== "error") {
+        continue;
+      }
+      return {
+        message: message.errorMessage?.trim() || "Unknown provider error",
+        provider: message.provider?.trim() || null,
+        model: message.model?.trim() || null,
+      };
+    }
+    return null;
+  }
 
   // ─── Helpers ─────────────────────────────────────────
 
@@ -528,7 +710,161 @@ export default function (pi: ExtensionAPI) {
     reloadPinetRuntime,
     formatError: msg,
   });
-  const { requestRemoteControl, runRemoteControl, resetRemoteControlState } = pinetRemoteControl;
+  const { requestRemoteControl, resetRemoteControlState } = pinetRemoteControl;
+
+  function runRemoteControl(command: "reload" | "exit", ctx: ExtensionContext): void {
+    stopActiveBrokerTurnState();
+    if (command === "reload") {
+      brokerAutoDrainPause = null;
+      brokerPauseNotifiedThreads.clear();
+    }
+    pinetRemoteControl.runRemoteControl(command, ctx);
+  }
+
+  function asRecord(value: unknown): Record<string, unknown> | null {
+    if (typeof value !== "object" || value === null) {
+      return null;
+    }
+    return Object.fromEntries(Object.entries(value));
+  }
+
+  function asFunction(value: unknown): ((...args: unknown[]) => unknown) | null {
+    if (typeof value !== "function") {
+      return null;
+    }
+    return (...args: unknown[]) => Reflect.apply(value, undefined, args);
+  }
+
+  async function applyBrokerReloadOverrides(
+    command: {
+      modelRef: string | null;
+      thinkingLevel: BrokerThinkingLevel | null;
+    },
+    ctx: ExtensionContext,
+  ): Promise<{ modelRef: string | null; thinkingLevel: BrokerThinkingLevel | null }> {
+    let appliedModelRef: string | null = null;
+    if (command.modelRef) {
+      const separatorIndex = command.modelRef.indexOf("/");
+      const provider = command.modelRef.slice(0, separatorIndex).trim();
+      const modelId = command.modelRef.slice(separatorIndex + 1).trim();
+      if (!provider || !modelId) {
+        throw new Error(
+          `Model ${JSON.stringify(command.modelRef)} is invalid. Use <provider>/<model>, e.g. openai/gpt-5.4`,
+        );
+      }
+
+      const ctxRecord = asRecord(ctx);
+      const modelRegistryRecord = ctxRecord ? asRecord(ctxRecord["modelRegistry"]) : null;
+      const findModel = modelRegistryRecord ? asFunction(modelRegistryRecord["find"]) : null;
+      if (!findModel) {
+        throw new Error("This pi build does not expose runtime model switching via Slack reload.");
+      }
+
+      const model = findModel(provider, modelId);
+      if (!model) {
+        throw new Error(
+          `Model ${JSON.stringify(command.modelRef)} is not available in this session.`,
+        );
+      }
+
+      const piRecord = asRecord(pi);
+      const setModel = piRecord ? asFunction(piRecord["setModel"]) : null;
+      if (!setModel) {
+        throw new Error("This pi build does not expose setModel for Slack-driven reloads.");
+      }
+
+      const switchedResult = await Promise.resolve(setModel(model));
+      if (switchedResult === false) {
+        throw new Error(
+          `Failed to switch to ${JSON.stringify(command.modelRef)}. Check API keys for that provider/model.`,
+        );
+      }
+      appliedModelRef = `${provider}/${modelId}`;
+    }
+
+    let appliedThinkingLevel: BrokerThinkingLevel | null = null;
+    if (command.thinkingLevel) {
+      const piRecord = asRecord(pi);
+      const setThinkingLevel = piRecord ? asFunction(piRecord["setThinkingLevel"]) : null;
+      if (!setThinkingLevel) {
+        throw new Error("This pi build does not expose thinking-level controls for Slack reload.");
+      }
+      setThinkingLevel(command.thinkingLevel);
+      appliedThinkingLevel = command.thinkingLevel;
+    }
+
+    return {
+      modelRef: appliedModelRef,
+      thinkingLevel: appliedThinkingLevel,
+    };
+  }
+
+  async function handleSlackBrokerReloadCommand(
+    input: {
+      channel: string;
+      threadTs: string;
+      text: string;
+    },
+    ctx: ExtensionContext,
+  ): Promise<boolean> {
+    const parsed = parseSlackBrokerReloadCommand(input.text);
+    if (parsed.kind === "none") {
+      return false;
+    }
+
+    const target = {
+      channel: input.channel,
+      threadTs: input.threadTs,
+    };
+
+    if (parsed.kind === "invalid") {
+      await postBrokerThreadNotice(
+        target,
+        `⚠️ ${parsed.reason}\n\nUse: \`pinet reload [provider/model] [thinking]\`\nExample: \`pinet reload openai/gpt-5.4 xhigh\``,
+        { kind: "broker_reload_invalid" },
+      );
+      return true;
+    }
+
+    try {
+      const applied = await applyBrokerReloadOverrides(parsed.command, ctx);
+      brokerAutoDrainPause = null;
+      brokerPauseNotifiedThreads.clear();
+
+      const queued = requestRemoteControl("reload", ctx);
+      const statusText = queued.shouldStartNow
+        ? "starting now"
+        : queued.status === "queued"
+          ? "queued behind an in-flight control action"
+          : "already scheduled";
+      const scope = [
+        applied.modelRef ? `model \`${applied.modelRef}\`` : null,
+        applied.thinkingLevel ? `thinking \`${applied.thinkingLevel}\`` : null,
+      ]
+        .filter((entry): entry is string => entry != null)
+        .join(" + ");
+      const scopeText = scope.length > 0 ? ` with ${scope}` : "";
+
+      await postBrokerThreadNotice(target, `🔄 Broker reload requested${scopeText} — ${statusText}.`, {
+        kind: "broker_reload_requested",
+        ...(applied.modelRef ? { model_ref: applied.modelRef } : {}),
+        ...(applied.thinkingLevel ? { thinking: applied.thinkingLevel } : {}),
+        queue_status: queued.status,
+        queue_start: queued.shouldStartNow,
+      });
+
+      if (queued.shouldStartNow) {
+        runRemoteControl("reload", ctx);
+      }
+    } catch (error) {
+      await postBrokerThreadNotice(target, `⚠️ Broker reload failed: ${msg(error)}`, {
+        kind: "broker_reload_error",
+      });
+    }
+
+    return true;
+  }
+
   const pinetActivityFormatting = createPinetActivityFormatting({
     getActiveBrokerDb,
   });
@@ -665,6 +1001,38 @@ export default function (pi: ExtensionAPI) {
       getMeshRoleFromMetadata(metadata ?? undefined, fallbackRole),
     handleInboundMessage: async ({ message, broker, router, selfId, ctx }) => {
       try {
+        if (message.source === "slack" && message.threadId && message.channel) {
+          const handledReloadCommand = await handleSlackBrokerReloadCommand(
+            {
+              channel: message.channel,
+              threadTs: message.threadId,
+              text: message.text,
+            },
+            ctx,
+          );
+          if (handledReloadCommand) {
+            return;
+          }
+
+          if (brokerAutoDrainPause) {
+            const pauseNoticeKey = `${message.channel}:${message.threadId}`;
+            if (!brokerPauseNotifiedThreads.has(pauseNoticeKey)) {
+              brokerPauseNotifiedThreads.add(pauseNoticeKey);
+              await postBrokerThreadNotice(
+                {
+                  channel: message.channel,
+                  threadTs: message.threadId,
+                },
+                `⚠️ Broker is paused after a terminal provider error: ${brokerAutoDrainPause.reason}\n\nUse \`pinet reload [provider/model] [thinking]\` to recover. Example: \`pinet reload openai/gpt-5.4 xhigh\`.`,
+                {
+                  kind: "broker_paused",
+                  retry_error_count: brokerAutoDrainPause.retryErrorCount,
+                },
+              );
+            }
+          }
+        }
+
         const ownerHint =
           message.source === "slack" && message.threadId && message.channel
             ? await resolveBrokerThreadOwnerHint(message.channel, message.threadId)
@@ -1334,11 +1702,102 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Agent event wiring ──────────────────────────────
 
+  pi.on("message_end", async (event) => {
+    if (event.message.role !== "assistant" || event.message.stopReason !== "error") {
+      return;
+    }
+
+    const state = activeBrokerTurnState;
+    if (!state) {
+      return;
+    }
+
+    state.retryErrorCount += 1;
+    if (brokerRole !== "broker") {
+      return;
+    }
+
+    const errorMessage = event.message.errorMessage?.trim() || "Unknown provider error";
+    const attempt = state.retryErrorCount;
+    const retryable = isLikelyRetryableAssistantError(errorMessage);
+    const retryHint = retryable
+      ? "Pi will retry automatically if retries remain."
+      : "This error looks terminal and may require a reload.";
+
+    await Promise.all(
+      state.targets.map((target) =>
+        postBrokerThreadNotice(
+          target,
+          `⚠️ Broker attempt ${attempt} failed: ${errorMessage}\n${retryHint}`,
+          {
+            kind: "broker_error_attempt",
+            attempt,
+            retryable,
+          },
+        ),
+      ),
+    );
+  });
+
+  pi.on("agent_end", async (event) => {
+    const turnState = stopActiveBrokerTurnState();
+    const assistantError = summarizeAssistantError(event.messages);
+
+    if (assistantError && brokerRole === "broker" && turnState) {
+      const retryCount = Math.max(0, turnState.retryErrorCount - 1);
+      const modelLabel =
+        assistantError.provider && assistantError.model
+          ? ` (${assistantError.provider}/${assistantError.model})`
+          : "";
+      await Promise.all(
+        turnState.targets.map((target) =>
+          postBrokerThreadNotice(
+            target,
+            `❌ Broker failed after ${retryCount} retr${retryCount === 1 ? "y" : "ies"}${modelLabel}: ${assistantError.message}`,
+            {
+              kind: "broker_error_final",
+              retries: retryCount,
+              ...(assistantError.provider ? { provider: assistantError.provider } : {}),
+              ...(assistantError.model ? { model: assistantError.model } : {}),
+            },
+          ),
+        ),
+      );
+
+      if (isBrokerTerminalProviderError(assistantError.message)) {
+        brokerAutoDrainPause = {
+          reason: assistantError.message,
+          pausedAtMs: Date.now(),
+          retryErrorCount: turnState.retryErrorCount,
+        };
+
+        await Promise.all(
+          turnState.targets.map((target) =>
+            postBrokerThreadNotice(
+              target,
+              "⏸️ Auto-processing is paused until reload to prevent repeated failures. Use `pinet reload [provider/model] [thinking]` (example: `pinet reload openai/gpt-5.4 xhigh`).",
+              {
+                kind: "broker_paused",
+                retries: turnState.retryErrorCount,
+              },
+            ),
+          ),
+        );
+      }
+    } else if (!assistantError) {
+      brokerAutoDrainPause = null;
+      brokerPauseNotifiedThreads.clear();
+    }
+  });
+
   agentEventRuntime.register(pi);
 
   pi.on("session_shutdown", async (_event, ctx) => {
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
+    stopActiveBrokerTurnState();
+    brokerAutoDrainPause = null;
+    brokerPauseNotifiedThreads.clear();
     sessionUiRuntime.cleanupForSessionShutdown();
     await stopPinetRuntime(ctx, { releaseIdentity: true });
     pinetRegistrationGate.reset();

--- a/slack-bridge/pinet-agent-status.ts
+++ b/slack-bridge/pinet-agent-status.ts
@@ -31,7 +31,7 @@ export interface PinetAgentStatus {
   reportStatus: (status: PinetAgentStatusValue) => Promise<void>;
   signalAgentFree: (
     ctx?: ExtensionContext,
-    options?: { requirePinet?: boolean },
+    options?: { requirePinet?: boolean; drainQueuedInbox?: boolean },
   ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
 }
 
@@ -64,7 +64,7 @@ export function createPinetAgentStatus(deps: PinetAgentStatusDeps): PinetAgentSt
 
   async function signalAgentFree(
     ctx?: ExtensionContext,
-    options: { requirePinet?: boolean } = {},
+    options: { requirePinet?: boolean; drainQueuedInbox?: boolean } = {},
   ): Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }> {
     const pinetEnabled = deps.getPinetEnabled();
     if (!pinetEnabled && options.requirePinet) {
@@ -80,7 +80,9 @@ export function createPinetAgentStatus(deps: PinetAgentStatusDeps): PinetAgentSt
     }
 
     const queuedInboxCount = deps.getInboxLength();
-    const shouldDrainQueuedInbox = pinetEnabled || deps.getCurrentRuntimeMode() === "single";
+    const shouldDrainQueuedInbox =
+      options.drainQueuedInbox !== false &&
+      (pinetEnabled || deps.getCurrentRuntimeMode() === "single");
     const drainedQueuedInbox =
       shouldDrainQueuedInbox && queuedInboxCount > 0 && maintenanceCtx
         ? deps.maybeDrainInboxIfIdle(maintenanceCtx)

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -35,6 +35,12 @@ export interface PinetCommandsDeps {
   recentActivityLogEntries: (limit: number) => ReadonlyArray<LoggedActivityLogEntry>;
   slackScopeDiagnostics: () => SlackScopeDiagnostics;
   settings: () => SlackBridgeSettings;
+  followerRuntimeFailure: () => {
+    kind: string;
+    message: string;
+    retryable: boolean;
+    nextStep: string;
+  } | null;
   lastBrokerMaintenance: () => {
     pendingBacklogCount: number;
     assignedBacklogCount: number;
@@ -294,6 +300,8 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
               ...(lbm.anomalies.length > 0 ? [`Health: ${lbm.anomalies.join("; ")}`] : []),
             ]
           : [];
+      const brokerCanvasError = deps.lastBrokerControlPlaneCanvasError();
+      const brokerHomeTabError = deps.lastBrokerControlPlaneHomeTabError();
       const brokerCanvasInfo =
         mode === "broker"
           ? [
@@ -306,16 +314,21 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
               ...(deps.lastBrokerControlPlaneCanvasRefreshAt()
                 ? [`Canvas refreshed: ${deps.lastBrokerControlPlaneCanvasRefreshAt()}`]
                 : []),
-              ...(deps.lastBrokerControlPlaneCanvasError()
-                ? [`Canvas status: ${deps.lastBrokerControlPlaneCanvasError()}`]
-                : []),
+              ...(brokerCanvasError ? [`Canvas degraded: ${brokerCanvasError}`] : []),
               `Home tab viewers: ${deps.getBrokerControlPlaneHomeTabViewerIds().length}`,
               ...(deps.lastBrokerControlPlaneHomeTabRefreshAt()
                 ? [`Home tab refreshed: ${deps.lastBrokerControlPlaneHomeTabRefreshAt()}`]
                 : []),
-              ...(deps.lastBrokerControlPlaneHomeTabError()
-                ? [`Home tab status: ${deps.lastBrokerControlPlaneHomeTabError()}`]
-                : []),
+              ...(brokerHomeTabError ? [`Home tab degraded: ${brokerHomeTabError}`] : []),
+            ]
+          : [];
+      const followerFailure = deps.followerRuntimeFailure();
+      const followerHealthInfo =
+        mode === "follower" && followerFailure
+          ? [
+              `Follower health: ${followerFailure.kind} — ${followerFailure.message}`,
+              `Follower action: ${followerFailure.nextStep}`,
+              `Follower recovery: ${followerFailure.retryable ? "automatic retry in progress" : "manual follow required"}`,
             ]
           : [];
       ctx.ui.notify(
@@ -334,6 +347,7 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
           slackToolHealthInfo,
           ...brokerHealthInfo,
           ...brokerCanvasInfo,
+          ...followerHealthInfo,
         ].join("\n"),
         "info",
       );

--- a/slack-bridge/pinet-remote-control.test.ts
+++ b/slack-bridge/pinet-remote-control.test.ts
@@ -156,6 +156,70 @@ describe("createPinetRemoteControl", () => {
     expect(notify).toHaveBeenNthCalledWith(4, "Pinet remote control requested: /exit", "warning");
   });
 
+  it("invokes onCommandSettled with queue state after each command", async () => {
+    const onCommandSettled = vi.fn();
+    const { deps } = createDeps({ onCommandSettled });
+    const shutdown = vi.fn();
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx } = createCtx({ idle: true, shutdown });
+
+    pinetRemoteControl.requestRemoteControl("reload", ctx);
+    pinetRemoteControl.requestRemoteControl("exit", ctx);
+    pinetRemoteControl.runRemoteControl("reload", ctx);
+    await settleRemoteControl();
+
+    expect(onCommandSettled).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        command: "reload",
+        success: true,
+        nextCommand: "exit",
+        ctx,
+      }),
+    );
+    expect(onCommandSettled).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        command: "exit",
+        success: true,
+        nextCommand: null,
+        ctx,
+      }),
+    );
+  });
+
+  it("reports command failures to onCommandSettled", async () => {
+    const failure = new Error("reload exploded");
+    const onCommandSettled = vi.fn();
+    const { deps } = createDeps({
+      onCommandSettled,
+      reloadPinetRuntime: vi.fn(async () => {
+        throw failure;
+      }),
+    });
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx, notify } = createCtx({ idle: true });
+
+    pinetRemoteControl.requestRemoteControl("reload", ctx);
+    pinetRemoteControl.runRemoteControl("reload", ctx);
+    await settleRemoteControl();
+
+    expect(onCommandSettled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "reload",
+        success: false,
+        error: failure,
+        nextCommand: null,
+        ctx,
+      }),
+    );
+    expect(notify).toHaveBeenNthCalledWith(
+      2,
+      "Pinet remote control failed: reload exploded",
+      "error",
+    );
+  });
+
   it("reports remote-control failures and resets cleanly", async () => {
     const { deps, flushDeferredRemoteControlAcks } = createDeps();
     const pinetRemoteControl = createPinetRemoteControl(deps);

--- a/slack-bridge/pinet-remote-control.ts
+++ b/slack-bridge/pinet-remote-control.ts
@@ -16,6 +16,8 @@ export interface PinetRemoteControlDeps {
   flushDeferredRemoteControlAcks: (command: PinetControlCommand) => void;
   reloadPinetRuntime: (ctx: ExtensionContext) => Promise<void>;
   formatError: (error: unknown) => string;
+  onReloadSuccess?: () => void;
+  onReloadError?: (error: unknown) => void;
 }
 
 export interface PinetRemoteControl {
@@ -58,6 +60,7 @@ export function createPinetRemoteControl(deps: PinetRemoteControlDeps): PinetRem
       try {
         if (command === "reload") {
           await deps.reloadPinetRuntime(ctx);
+          deps.onReloadSuccess?.();
           return;
         }
 
@@ -66,6 +69,9 @@ export function createPinetRemoteControl(deps: PinetRemoteControlDeps): PinetRem
         }
         controlCtx.shutdown();
       } catch (err) {
+        if (command === "reload") {
+          deps.onReloadError?.(err);
+        }
         ctx.ui.notify(`Pinet remote control failed: ${deps.formatError(err)}`, "error");
       } finally {
         const next = finishPinetRemoteControl(remoteControlState);

--- a/slack-bridge/pinet-remote-control.ts
+++ b/slack-bridge/pinet-remote-control.ts
@@ -16,8 +16,13 @@ export interface PinetRemoteControlDeps {
   flushDeferredRemoteControlAcks: (command: PinetControlCommand) => void;
   reloadPinetRuntime: (ctx: ExtensionContext) => Promise<void>;
   formatError: (error: unknown) => string;
-  onReloadSuccess?: () => void;
-  onReloadError?: (error: unknown) => void;
+  onCommandSettled?: (event: {
+    command: PinetControlCommand;
+    success: boolean;
+    error: unknown;
+    nextCommand: PinetControlCommand | null;
+    ctx: ExtensionContext;
+  }) => void | Promise<void>;
 }
 
 export interface PinetRemoteControl {
@@ -57,21 +62,21 @@ export function createPinetRemoteControl(deps: PinetRemoteControlDeps): PinetRem
 
     ctx.ui.notify(`Pinet remote control requested: /${command}`, "warning");
     void (async () => {
+      let success = false;
+      let commandError: unknown = null;
       try {
         if (command === "reload") {
           await deps.reloadPinetRuntime(ctx);
-          deps.onReloadSuccess?.();
-          return;
+          success = true;
+        } else {
+          if (typeof controlCtx.shutdown !== "function") {
+            throw new Error("Shutdown is not available in this extension context.");
+          }
+          controlCtx.shutdown();
+          success = true;
         }
-
-        if (typeof controlCtx.shutdown !== "function") {
-          throw new Error("Shutdown is not available in this extension context.");
-        }
-        controlCtx.shutdown();
       } catch (err) {
-        if (command === "reload") {
-          deps.onReloadError?.(err);
-        }
+        commandError = err;
         ctx.ui.notify(`Pinet remote control failed: ${deps.formatError(err)}`, "error");
       } finally {
         const next = finishPinetRemoteControl(remoteControlState);
@@ -79,6 +84,17 @@ export function createPinetRemoteControl(deps: PinetRemoteControlDeps): PinetRem
           currentCommand: next.currentCommand,
           queuedCommand: next.queuedCommand,
         };
+        try {
+          await deps.onCommandSettled?.({
+            command,
+            success,
+            error: commandError,
+            nextCommand: next.nextCommand,
+            ctx,
+          });
+        } catch {
+          /* best effort */
+        }
         if (next.nextCommand) {
           ctx.ui.notify(
             `Pinet remote control continuing with queued /${next.nextCommand}`,


### PR DESCRIPTION
## Summary
Follow-up to the closed #404 thread.

This PR keeps the already-stacked broker reload work intact and adds a narrow operator-facing diagnostics slice that was still missing:
- preserve the last meaningful follower degraded reason across disconnect/reconnect
- surface degraded follower reconnect context in the reconnect/disconnect notices
- surface broker control-plane/Home-tab degraded state more clearly in `/pinet-status`
- add focused tests for the degraded restart/reconnect UX

## Why this is separate from #404
Issue #404 is already closed, but this branch contains a distinct follow-up diagnostic slice that was not covered by the existing broker reload/reconnect PRs.

## Non-overlap with PR #598
I checked this branch against PR #598 (`cap retryable stableId reconnect conflicts`). PR #598 focuses on retryable stableId conflict handling during follower reconnect. This branch instead focuses on preserving and surfacing degraded restart/reconnect reasons plus operator-visible degraded status messaging.

## Validation
- `pnpm prepush`
