### PR TITLE
docs: document manual npm release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this repository are documented in this file.
 
+## [Unreleased]
+
+### Docs
+
+- Added `docs/releases.md`, a manual release checklist that makes the path from
+  merged fixes on `main` to published npm packages explicit, including focused
+  package verification and `pnpm --filter <package> pack` tarball review.
+- Linked the root README's development workflow to the release checklist so
+  shipping a fix and publishing it are no longer separate tribal-knowledge
+  steps.
+
 ## [0.1.3] - 2026-04-08
 
 Pinet v0.1.3 is a narrow follow-up patch for `@gugu910/pi-slack-bridge` after `0.1.2` was published with real Slack identifiers in the package README settings example. Because published npm tarballs are immutable, this release corrects the npm-visible package surface with scrubbed example placeholders while leaving the runtime behavior unchanged.

--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ caching.
 ### Release workflow
 
 Public npm releases are currently **manual by design**. If a fix merged to
-`main` should reach npm users, prepare a small release PR, verify the package
-with `pnpm --filter <package> pack`, then publish from `main`.
+`main` should reach npm users, prepare a small release PR, publish only from
+`main`, and verify the tarball with both `pnpm --filter <package> pack` and a
+local install/smoke-import before publish.
 
 See [`docs/releases.md`](docs/releases.md) for the package list, the manual
 release checklist, and the tarball verification policy.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ caching.
 | `pnpm format`       | Prettier + Stylua                                               |
 | `pnpm check`        | lint + typecheck + format check                                 |
 
+### Release workflow
+
+Public npm releases are currently **manual by design**. If a fix merged to
+`main` should reach npm users, prepare a small release PR, verify the package
+with `pnpm --filter <package> pack`, then publish from `main`.
+
+See [`docs/releases.md`](docs/releases.md) for the package list, the manual
+release checklist, and the tarball verification policy.
+
 ### Structure
 
 ```
@@ -179,6 +188,8 @@ expectations and the required smoke checklist.
 2. Write tests for any new logic
 3. Run `pnpm lint && pnpm typecheck && pnpm test`
 4. Create a PR — merge to `main`
+5. If the change should reach npm users, follow [`docs/releases.md`](docs/releases.md)
+   to prep and publish the relevant package release from `main`
 
 ## Contributors
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,78 @@
+# Release workflow
+
+This repo ships workspace packages to npm manually after code lands on `main`.
+The goal is simple: merged fixes should have a short, explicit path from GitHub
+into published npm packages.
+
+## Release policy
+
+- Treat every user-facing fix as **unreleased** until the relevant package is
+  published to npm.
+- Keep release prep **small and package-scoped**. Do not batch unrelated fixes
+  just because they landed near each other.
+- Prefer a patch release for bug fixes unless the package surface clearly needs
+  a minor or major bump.
+- Update `CHANGELOG.md` in the same PR that prepares a release.
+- Verify the package tarball locally before publishing.
+- Publish from `main`, not from a stale feature branch.
+
+## Package list
+
+Public workspace packages in this repo:
+
+- `@gugu910/pi-slack-bridge`
+- `@gugu910/pi-nvim-bridge`
+- `@gugu910/pi-neon-psql`
+- `@gugu910/pi-slack-api`
+- `@gugu910/pi-transport-core`
+
+The root `pi-extensions` package is private and is only bumped for repo-level
+tracking when a release note needs to reflect the current published surface.
+
+## Manual release checklist
+
+1. Start from an up-to-date `main` checkout.
+2. Identify the package(s) whose fixes should ship.
+3. Bump only the package version(s) that need a release.
+4. Update `CHANGELOG.md` with:
+   - release date
+   - version verification
+   - the shipped highlights
+   - linked PRs/issues when useful
+5. Run focused verification for each releasing package:
+   - `pnpm --filter <package> lint`
+   - `pnpm --filter <package> typecheck`
+   - `pnpm --filter <package> test` (if the package has tests)
+   - `pnpm --filter <package> pack`
+6. Inspect the tarball contents to confirm the npm surface is correct.
+7. Merge the release-prep PR.
+8. Publish from `main`:
+   - `pnpm --filter <package> publish --access public --no-git-checks`
+9. Tag the release if maintainers want a matching git tag.
+10. Confirm npm shows the new version.
+
+## Pack verification
+
+`pnpm --filter <package> pack` is the minimum pre-publish gate because it checks
+what npm users will actually receive, not just what exists in the repo.
+
+For this repo, a good pack review confirms:
+
+- `dist/` is present and up to date
+- `README.md` and `LICENSE` are included
+- package-specific runtime assets are included (`manifest.yaml`, `nvim/`,
+  Python helpers, CLI bin files, etc.)
+- no local-only or sensitive files leaked into the tarball
+
+## Current gap this workflow closes
+
+Historically, `main` has been ahead of npm, which leaves users installing stale
+packages even after fixes merged. This workflow makes the release path explicit:
+
+- merge the fix
+- prep a small release PR
+- verify the exact npm tarball
+- publish from `main`
+
+That is intentionally manual for now so maintainers do not need to wire npm
+secrets into CI before the release process is clear and repeatable.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -14,7 +14,8 @@ into published npm packages.
   a minor or major bump.
 - Update `CHANGELOG.md` in the same PR that prepares a release.
 - Verify the package tarball locally before publishing.
-- Publish from `main`, not from a stale feature branch.
+- **Publish only from `main`.** Never publish from a feature branch, stacked branch,
+  or worktree branch even if the commits are already approved.
 
 ## Package list
 
@@ -32,29 +33,38 @@ tracking when a release note needs to reflect the current published surface.
 ## Manual release checklist
 
 1. Start from an up-to-date `main` checkout.
-2. Identify the package(s) whose fixes should ship.
-3. Bump only the package version(s) that need a release.
-4. Update `CHANGELOG.md` with:
+2. Confirm you are publishing from `main`, not a feature branch or issue worktree branch.
+3. Identify the package(s) whose fixes should ship.
+4. Bump only the package version(s) that need a release.
+5. Update `CHANGELOG.md` with:
    - release date
    - version verification
    - the shipped highlights
    - linked PRs/issues when useful
-5. Run focused verification for each releasing package:
+6. Run focused verification for each releasing package:
    - `pnpm --filter <package> lint`
    - `pnpm --filter <package> typecheck`
    - `pnpm --filter <package> test` (if the package has tests)
    - `pnpm --filter <package> pack`
-6. Inspect the tarball contents to confirm the npm surface is correct.
-7. Merge the release-prep PR.
-8. Publish from `main`:
-   - `pnpm --filter <package> publish --access public --no-git-checks`
-9. Tag the release if maintainers want a matching git tag.
-10. Confirm npm shows the new version.
+7. Inspect the tarball contents to confirm the npm surface is correct.
+8. Install the tarball locally in a temp directory and smoke-import the published exports before `npm publish`.
+9. Merge the release-prep PR.
+10. Publish from `main`:
+
+- `pnpm --filter <package> publish --access public --no-git-checks`
+
+11. Tag the release if maintainers want a matching git tag.
+12. Confirm npm shows the new version.
 
 ## Pack verification
 
 `pnpm --filter <package> pack` is the minimum pre-publish gate because it checks
 what npm users will actually receive, not just what exists in the repo.
+
+After generating the tarball, do one more operator-level check before publish:
+install that tarball into a temporary directory and smoke-test the exports that
+npm users rely on. At minimum, confirm the package installs cleanly and that a
+basic `import` of the documented entrypoint works.
 
 For this repo, a good pack review confirms:
 
@@ -63,6 +73,22 @@ For this repo, a good pack review confirms:
 - package-specific runtime assets are included (`manifest.yaml`, `nvim/`,
   Python helpers, CLI bin files, etc.)
 - no local-only or sensitive files leaked into the tarball
+
+A simple pattern is:
+
+```bash
+PACKAGE="@gugu910/pi-slack-bridge"
+TARBALL="$(pnpm --filter "$PACKAGE" pack | tail -n 1)"
+TMPDIR="$(mktemp -d)"
+
+cd "$TMPDIR"
+npm init -y
+npm install "/absolute/path/to/$TARBALL"
+node --input-type=module -e 'await import("@gugu910/pi-slack-bridge")'
+```
+
+The exact smoke import can vary by package, but the rule stays the same: verify
+real installability and real exports before `npm publish`.
 
 ## Current gap this workflow closes
 


### PR DESCRIPTION
## Summary
- add a dedicated manual release workflow doc for public workspace packages
- link the root README development flow to the release checklist
- note the new release-path docs in the changelog

## Testing
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge test
- pnpm --filter @gugu910/pi-slack-bridge pack

Closes #364