### PR TITLE
feat(slack-bridge): add broker follower spawn plan

### DIFF
--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -13,7 +13,11 @@ import {
   computeReconnectDelay,
 } from "./client.js";
 import type { BrokerConnectOpts } from "./client.js";
-import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
+import {
+  RPC_AGENT_NAME_CONFLICT,
+  RPC_AGENT_STABLE_ID_CONFLICT,
+  RPC_METHOD_NOT_FOUND,
+} from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -24,7 +28,13 @@ interface MockServer {
   received: string[];
   close: () => Promise<void>;
   respondTo: (conn: net.Socket, id: number, result: unknown) => void;
-  respondError: (conn: net.Socket, id: number, code: number, message: string) => void;
+  respondError: (
+    conn: net.Socket,
+    id: number,
+    code: number,
+    message: string,
+    data?: unknown,
+  ) => void;
   connectOpts: BrokerConnectOpts;
 }
 
@@ -67,8 +77,17 @@ function createMockServer(port = 0): Promise<MockServer> {
           const msg = JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n";
           conn.write(msg);
         },
-        respondError: (conn, id, code, message) => {
-          const msg = JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } }) + "\n";
+        respondError: (conn, id, code, message, data) => {
+          const msg =
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              error: {
+                code,
+                message,
+                ...(data === undefined ? {} : { data }),
+              },
+            }) + "\n";
           conn.write(msg);
         },
       });
@@ -1578,6 +1597,109 @@ describe("BrokerClient — onReconnect callback", () => {
     expect(surfacedReconnectFailure.message).toContain(
       'Agent name "Reserved Crane" is already reserved.',
     );
+    expect(reconnectFired).toBe(false);
+    expect(client.isConnected()).toBe(false);
+    expect(client.getReconnectAttempt()).toBe(0);
+    expect(client.getRegisteredIdentity()).toBeNull();
+
+    await new Promise((resolve) => setTimeout(resolve, INITIAL_RECONNECT_DELAY_MS + 250));
+    expect(mock.received).toHaveLength(1);
+
+    client.disconnect();
+    await mock.close();
+  }, 20000);
+
+  it("stops reconnecting and surfaces a terminal error when stableId reconnect collides", async () => {
+    let mock = await createMockServer();
+    const port = mock.port;
+    const client = new BrokerClient(mock.connectOpts);
+    let disconnectFired = false;
+    let reconnectFired = false;
+    let reconnectFailed: Error | null = null;
+
+    client.onDisconnect(() => {
+      disconnectFired = true;
+    });
+    client.onReconnect(() => {
+      reconnectFired = true;
+    });
+    client.onReconnectFailed((err) => {
+      reconnectFailed = err;
+    });
+
+    await client.connect();
+    const registerPromise = client.register(
+      "Worker",
+      "🦙",
+      { cwd: "/repo", branch: "main" },
+      "host:session:/tmp/worker",
+    );
+
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(registerReq.method).toBe("register");
+    expect(registerReq.params.name).toBe("Worker");
+    expect(registerReq.params.emoji).toBe("🦙");
+    expect(registerReq.params.stableId).toBe("host:session:/tmp/worker");
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "worker-1",
+      name: "Worker",
+      emoji: "🦙",
+    });
+    await registerPromise;
+
+    await mock.close();
+    await waitFor(() => disconnectFired, 2000);
+    await waitFor(() => client.getReconnectAttempt() >= 2, 5000);
+
+    mock = await createMockServer(port);
+    await waitFor(() => mock.received.length > 0, 5000);
+
+    const reRegisterReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(reRegisterReq.method).toBe("register");
+    expect(reRegisterReq.params.name).toBe("Worker");
+    expect(reRegisterReq.params.emoji).toBe("🦙");
+    expect(reRegisterReq.params.stableId).toBe("host:session:/tmp/worker");
+
+    mock.respondError(
+      mock.connections[0],
+      reRegisterReq.id,
+      RPC_AGENT_STABLE_ID_CONFLICT,
+      'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying.',
+      {
+        code: "AGENT_STABLE_ID_CONFLICT",
+        stableId: "host:session:/tmp/worker",
+        ownerAgentId: "worker-2",
+        retryable: true,
+      },
+    );
+
+    await waitFor(() => reconnectFailed !== null, 5000);
+    if (!reconnectFailed) {
+      throw new Error("Expected reconnect failure to surface");
+    }
+    const surfacedReconnectFailure = reconnectFailed as Error & {
+      code?: number;
+      data?: unknown;
+    };
+    expect(surfacedReconnectFailure.message).toContain(
+      'Agent stableId "host:session:/tmp/worker" is already active on another live connection.',
+    );
+    expect(surfacedReconnectFailure.code).toBe(RPC_AGENT_STABLE_ID_CONFLICT);
+    expect(surfacedReconnectFailure.data).toEqual({
+      code: "AGENT_STABLE_ID_CONFLICT",
+      stableId: "host:session:/tmp/worker",
+      ownerAgentId: "worker-2",
+      retryable: true,
+    });
     expect(reconnectFired).toBe(false);
     expect(client.isConnected()).toBe(false);
     expect(client.getReconnectAttempt()).toBe(0);

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -1328,6 +1328,29 @@ describe("BrokerClient — onReconnect callback", () => {
     expect(scheduleReconnect).toHaveBeenCalledTimes(1);
   });
 
+  it("resets the stableId conflict streak when reconnect fails before re-registering", async () => {
+    const client = new BrokerClient({ host: "127.0.0.1", port: 1 });
+    const scheduleReconnect = vi.fn();
+
+    (
+      client as unknown as {
+        connectSocket: () => Promise<void>;
+        stableIdConflictAttempt: number;
+      }
+    ).connectSocket = vi.fn(async () => {
+      throw new Error("connect failed");
+    });
+    (client as unknown as { stableIdConflictAttempt: number }).stableIdConflictAttempt = 2;
+    (client as unknown as { scheduleReconnect: () => void }).scheduleReconnect = scheduleReconnect;
+
+    await (client as unknown as { reconnectOnce: () => Promise<void> }).reconnectOnce();
+
+    expect(scheduleReconnect).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { stableIdConflictAttempt: number }).stableIdConflictAttempt).toBe(
+      0,
+    );
+  });
+
   it("scheduleReconnect fires onDisconnect then onReconnect after server restart", async () => {
     const mock = await createMockServer();
     const port = mock.port;

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -1609,7 +1609,7 @@ describe("BrokerClient — onReconnect callback", () => {
     await mock.close();
   }, 20000);
 
-  it("stops reconnecting and surfaces a terminal error when stableId reconnect collides", async () => {
+  it("keeps retrying when a retryable stableId reconnect conflict clears on a later attempt", async () => {
     let mock = await createMockServer();
     const port = mock.port;
     const client = new BrokerClient(mock.connectOpts);
@@ -1659,19 +1659,19 @@ describe("BrokerClient — onReconnect callback", () => {
     mock = await createMockServer(port);
     await waitFor(() => mock.received.length > 0, 5000);
 
-    const reRegisterReq = JSON.parse(mock.received[0]) as {
+    const firstReRegisterReq = JSON.parse(mock.received[0]) as {
       id: number;
       method: string;
       params: { name: string; emoji: string; stableId?: string };
     };
-    expect(reRegisterReq.method).toBe("register");
-    expect(reRegisterReq.params.name).toBe("Worker");
-    expect(reRegisterReq.params.emoji).toBe("🦙");
-    expect(reRegisterReq.params.stableId).toBe("host:session:/tmp/worker");
+    expect(firstReRegisterReq.method).toBe("register");
+    expect(firstReRegisterReq.params.name).toBe("Worker");
+    expect(firstReRegisterReq.params.emoji).toBe("🦙");
+    expect(firstReRegisterReq.params.stableId).toBe("host:session:/tmp/worker");
 
     mock.respondError(
       mock.connections[0],
-      reRegisterReq.id,
+      firstReRegisterReq.id,
       RPC_AGENT_STABLE_ID_CONFLICT,
       'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying.',
       {
@@ -1681,6 +1681,114 @@ describe("BrokerClient — onReconnect callback", () => {
         retryable: true,
       },
     );
+
+    await waitFor(() => mock.received.length >= 2, 5000);
+    const secondReRegisterReq = JSON.parse(mock.received[1]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(secondReRegisterReq.method).toBe("register");
+    expect(secondReRegisterReq.params.stableId).toBe("host:session:/tmp/worker");
+    expect(reconnectFailed).toBeNull();
+    expect(reconnectFired).toBe(false);
+
+    const latestConnection = mock.connections[mock.connections.length - 1];
+    mock.respondTo(latestConnection, secondReRegisterReq.id, {
+      agentId: "worker-1",
+      name: "Worker",
+      emoji: "🦙",
+    });
+
+    await waitFor(() => reconnectFired, 5000);
+    expect(reconnectFailed).toBeNull();
+    expect(client.isConnected()).toBe(true);
+    expect(client.getReconnectAttempt()).toBe(0);
+    expect(client.getRegisteredIdentity()).toEqual({
+      agentId: "worker-1",
+      name: "Worker",
+      emoji: "🦙",
+    });
+
+    client.disconnect();
+    await mock.close();
+  }, 20000);
+
+  it("stops reconnecting after repeated retryable stableId reconnect conflicts", async () => {
+    let mock = await createMockServer();
+    const port = mock.port;
+    const client = new BrokerClient(mock.connectOpts);
+    let disconnectFired = false;
+    let reconnectFired = false;
+    let reconnectFailed: Error | null = null;
+
+    client.onDisconnect(() => {
+      disconnectFired = true;
+    });
+    client.onReconnect(() => {
+      reconnectFired = true;
+    });
+    client.onReconnectFailed((err) => {
+      reconnectFailed = err;
+    });
+
+    await client.connect();
+    const registerPromise = client.register(
+      "Worker",
+      "🦙",
+      { cwd: "/repo", branch: "main" },
+      "host:session:/tmp/worker",
+    );
+
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { name: string; emoji: string; stableId?: string };
+    };
+    expect(registerReq.method).toBe("register");
+    expect(registerReq.params.name).toBe("Worker");
+    expect(registerReq.params.emoji).toBe("🦙");
+    expect(registerReq.params.stableId).toBe("host:session:/tmp/worker");
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "worker-1",
+      name: "Worker",
+      emoji: "🦙",
+    });
+    await registerPromise;
+
+    await mock.close();
+    await waitFor(() => disconnectFired, 2000);
+    await waitFor(() => client.getReconnectAttempt() >= 2, 5000);
+
+    mock = await createMockServer(port);
+
+    for (let attemptIndex = 0; attemptIndex < 3; attemptIndex++) {
+      await waitFor(() => mock.received.length > attemptIndex, 10000);
+      const reRegisterReq = JSON.parse(mock.received[attemptIndex]) as {
+        id: number;
+        method: string;
+        params: { name: string; emoji: string; stableId?: string };
+      };
+      expect(reRegisterReq.method).toBe("register");
+      expect(reRegisterReq.params.name).toBe("Worker");
+      expect(reRegisterReq.params.emoji).toBe("🦙");
+      expect(reRegisterReq.params.stableId).toBe("host:session:/tmp/worker");
+
+      const latestConnection = mock.connections[mock.connections.length - 1];
+      mock.respondError(
+        latestConnection,
+        reRegisterReq.id,
+        RPC_AGENT_STABLE_ID_CONFLICT,
+        'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying.',
+        {
+          code: "AGENT_STABLE_ID_CONFLICT",
+          stableId: "host:session:/tmp/worker",
+          ownerAgentId: "worker-2",
+          retryable: true,
+        },
+      );
+    }
 
     await waitFor(() => reconnectFailed !== null, 5000);
     if (!reconnectFailed) {
@@ -1706,7 +1814,7 @@ describe("BrokerClient — onReconnect callback", () => {
     expect(client.getRegisteredIdentity()).toBeNull();
 
     await new Promise((resolve) => setTimeout(resolve, INITIAL_RECONNECT_DELAY_MS + 250));
-    expect(mock.received).toHaveLength(1);
+    expect(mock.received).toHaveLength(3);
 
     client.disconnect();
     await mock.close();

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -2,7 +2,11 @@ import * as net from "node:net";
 import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
-import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
+import {
+  RPC_AGENT_NAME_CONFLICT,
+  RPC_AGENT_STABLE_ID_CONFLICT,
+  RPC_METHOD_NOT_FOUND,
+} from "./types.js";
 import type { ClientAgentInfo } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
@@ -81,7 +85,7 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
-interface BrokerRpcRequestError extends Error {
+export interface BrokerRpcRequestError extends Error {
   code?: number;
   data?: unknown;
   method?: string;
@@ -112,13 +116,17 @@ function isRpcMethodNotFoundError(err: unknown, method: string): boolean {
   return rpcErr.code === RPC_METHOD_NOT_FOUND || err.message === `Unknown method: ${method}`;
 }
 
-function isRpcAgentNameConflictError(err: unknown): err is BrokerRpcRequestError {
+function isRpcConflictError(
+  err: unknown,
+  rpcCode: number,
+  dataCode: string,
+): err is BrokerRpcRequestError {
   if (!(err instanceof Error)) {
     return false;
   }
 
   const rpcErr = err as BrokerRpcRequestError;
-  if (rpcErr.code === RPC_AGENT_NAME_CONFLICT) {
+  if (rpcErr.code === rpcCode) {
     return true;
   }
 
@@ -126,7 +134,15 @@ function isRpcAgentNameConflictError(err: unknown): err is BrokerRpcRequestError
     return false;
   }
 
-  return (rpcErr.data as { code?: unknown }).code === "AGENT_NAME_CONFLICT";
+  return (rpcErr.data as { code?: unknown }).code === dataCode;
+}
+
+function isRpcAgentNameConflictError(err: unknown): err is BrokerRpcRequestError {
+  return isRpcConflictError(err, RPC_AGENT_NAME_CONFLICT, "AGENT_NAME_CONFLICT");
+}
+
+export function isRpcAgentStableIdConflictError(err: unknown): err is BrokerRpcRequestError {
+  return isRpcConflictError(err, RPC_AGENT_STABLE_ID_CONFLICT, "AGENT_STABLE_ID_CONFLICT");
 }
 
 function getMeshAuthCompatibilityError(): Error {
@@ -696,7 +712,10 @@ export class BrokerClient {
       } catch {
         /* ignore */
       }
-      if (isRpcAgentNameConflictError(reconnectError)) {
+      if (
+        isRpcAgentNameConflictError(reconnectError) ||
+        isRpcAgentStableIdConflictError(reconnectError)
+      ) {
         this.reconnectAttempt = 0;
         this.reconnectFailedHandler?.(reconnectError);
         return;

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -66,6 +66,7 @@ export const RECONNECT_DELAY_MS = 3000;
 export const INITIAL_RECONNECT_DELAY_MS = 1000;
 export const MAX_RECONNECT_DELAY_MS = 30000;
 export const HEARTBEAT_INTERVAL_MS = 5000;
+const MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS = 3;
 
 /** Compute reconnect delay with exponential backoff and jitter. */
 export function computeReconnectDelay(attempt: number, random = Math.random()): number {
@@ -145,6 +146,14 @@ export function isRpcAgentStableIdConflictError(err: unknown): err is BrokerRpcR
   return isRpcConflictError(err, RPC_AGENT_STABLE_ID_CONFLICT, "AGENT_STABLE_ID_CONFLICT");
 }
 
+function isRpcRetryableError(err: BrokerRpcRequestError): boolean {
+  if (typeof err.data !== "object" || err.data == null) {
+    return false;
+  }
+
+  return (err.data as { retryable?: unknown }).retryable === true;
+}
+
 function getMeshAuthCompatibilityError(): Error {
   return new Error(
     "Broker does not support Pinet mesh auth (`auth`). Upgrade the broker or disable follower mesh auth when connecting to older/no-auth brokers.",
@@ -204,6 +213,7 @@ export class BrokerClient {
   private reconnectHandler: (() => void) | null = null;
   private reconnectFailedHandler: ((error: Error) => void) | null = null;
   private reconnectAttempt = 0;
+  private stableIdConflictAttempt = 0;
   private registrationSnapshot: RegistrationSnapshot | null = null;
   private registeredIdentity: RegistrationResult | null = null;
 
@@ -243,6 +253,7 @@ export class BrokerClient {
 
   async connect(): Promise<void> {
     this.shuttingDown = false;
+    this.stableIdConflictAttempt = 0;
     await this.connectSocket();
     try {
       await this.authenticateIfNeeded();
@@ -267,6 +278,7 @@ export class BrokerClient {
     }
     this.socket = null;
     this.connected = false;
+    this.stableIdConflictAttempt = 0;
   }
 
   async disconnectGracefully(): Promise<void> {
@@ -692,6 +704,7 @@ export class BrokerClient {
         await this.performRegister(this.registrationSnapshot);
       }
       this.reconnectAttempt = 0;
+      this.stableIdConflictAttempt = 0;
       this.reconnectHandler?.();
     } catch (err) {
       // Re-registration failed after the socket connected. Clear the connection
@@ -712,14 +725,33 @@ export class BrokerClient {
       } catch {
         /* ignore */
       }
-      if (
-        isRpcAgentNameConflictError(reconnectError) ||
-        isRpcAgentStableIdConflictError(reconnectError)
-      ) {
+      if (isRpcAgentNameConflictError(reconnectError)) {
         this.reconnectAttempt = 0;
+        this.stableIdConflictAttempt = 0;
         this.reconnectFailedHandler?.(reconnectError);
         return;
       }
+
+      if (isRpcAgentStableIdConflictError(reconnectError)) {
+        const retryableStableIdConflict = isRpcRetryableError(reconnectError);
+        this.stableIdConflictAttempt = retryableStableIdConflict
+          ? this.stableIdConflictAttempt + 1
+          : 0;
+        const shouldKeepRetrying =
+          retryableStableIdConflict &&
+          this.stableIdConflictAttempt < MAX_RETRYABLE_STABLE_ID_CONFLICT_ATTEMPTS;
+        if (!shouldKeepRetrying) {
+          this.reconnectAttempt = 0;
+          this.stableIdConflictAttempt = 0;
+          this.reconnectFailedHandler?.(reconnectError);
+          return;
+        }
+
+        this.scheduleReconnect();
+        return;
+      }
+
+      this.stableIdConflictAttempt = 0;
       this.scheduleReconnect();
     }
   }

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -694,6 +694,7 @@ export class BrokerClient {
     try {
       await this.connectSocket();
     } catch {
+      this.stableIdConflictAttempt = 0;
       this.scheduleReconnect();
       return;
     }

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -4,8 +4,9 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { DatabaseSync } from "node:sqlite";
-import { BrokerClient } from "./broker/client.js";
+import { BrokerClient, type BrokerRpcRequestError } from "./broker/client.js";
 import * as brokerModule from "./broker/index.js";
+import { RPC_AGENT_STABLE_ID_CONFLICT } from "./broker/types.js";
 import * as maintenanceModule from "./broker/maintenance.js";
 import { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
@@ -3000,13 +3001,21 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const triggerDisconnect = disconnectHandler as () => void;
     const triggerReconnectFailed = reconnectFailedHandler as (error: Error) => void;
+    const stableIdReconnectError = new Error(
+      'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying.',
+    ) as BrokerRpcRequestError;
+    stableIdReconnectError.name = "BrokerRpcRequestError";
+    stableIdReconnectError.code = RPC_AGENT_STABLE_ID_CONFLICT;
+    stableIdReconnectError.data = {
+      code: "AGENT_STABLE_ID_CONFLICT",
+      stableId: "host:session:/tmp/worker",
+      ownerAgentId: "worker-2",
+      retryable: true,
+    };
+    stableIdReconnectError.method = "register";
 
     triggerDisconnect();
-    triggerReconnectFailed(
-      new Error(
-        'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying. code=AGENT_STABLE_ID_CONFLICT',
-      ),
-    );
+    triggerReconnectFailed(stableIdReconnectError);
 
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("Pinet broker disconnected — reconnecting..."),
@@ -3018,6 +3027,10 @@ describe("slack-bridge Pinet reconnect", () => {
         "error",
       );
     });
+    expect(notify).not.toHaveBeenCalledWith(
+      expect.stringContaining("Update slack-bridge.agentName/agentEmoji or PI_NICKNAME"),
+      "error",
+    );
 
     await sessionShutdown?.({}, ctx);
   });

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -3027,6 +3027,10 @@ describe("slack-bridge Pinet reconnect", () => {
         "error",
       );
     });
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Stop or disconnect the other worker"),
+      "error",
+    );
     expect(notify).not.toHaveBeenCalledWith(
       expect.stringContaining("Update slack-bridge.agentName/agentEmoji or PI_NICKNAME"),
       "error",

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2909,6 +2909,119 @@ describe("slack-bridge Pinet reconnect", () => {
     }
   });
 
+  it("mentions a stableId reconnect hint when the broker reports a live stableId conflict", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let disconnectHandler: (() => void) | null = null;
+    let reconnectFailedHandler: ((error: Error) => void) | null = null;
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Worker",
+      emoji: "🦙",
+      metadata: { role: "worker", capabilities: { role: "worker" } },
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation((handler) => {
+      disconnectHandler = handler;
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnectFailed").mockImplementation((handler) => {
+      reconnectFailedHandler = handler;
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await follow?.handler("", ctx);
+
+    expect(disconnectHandler).toBeTypeOf("function");
+    expect(reconnectFailedHandler).toBeTypeOf("function");
+
+    if (!disconnectHandler || !reconnectFailedHandler) {
+      throw new Error("Reconnect handlers were not registered");
+    }
+
+    const triggerDisconnect = disconnectHandler as () => void;
+    const triggerReconnectFailed = reconnectFailedHandler as (error: Error) => void;
+
+    triggerDisconnect();
+    triggerReconnectFailed(
+      new Error(
+        'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying. code=AGENT_STABLE_ID_CONFLICT',
+      ),
+    );
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Pinet broker disconnected — reconnecting..."),
+      "warning",
+    );
+    await vi.waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("Another worker is still connected with this session identity."),
+        "error",
+      );
+    });
+
+    await sessionShutdown?.({}, ctx);
+  });
+
   it("keeps worker identities session-scoped across clean restarts in the same repo checkout", async () => {
     const registerCalls: Array<{ stableId?: string }> = [];
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -18,7 +18,10 @@ import {
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
-import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
+import {
+  DEFAULT_SOCKET_PATH,
+  REQUEST_TIMEOUT_MS as BROKER_REQUEST_TIMEOUT_MS,
+} from "./broker/client.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
@@ -1203,8 +1206,12 @@ export default function (pi: ExtensionAPI) {
         /* best effort */
       });
       setExtStatus(ctx, "error");
+      const reconnectFailureMessage = msg(error);
+      const stableIdConflictHint = reconnectFailureMessage.includes("AGENT_STABLE_ID_CONFLICT")
+        ? ` Another worker is still connected with this session identity. Wait about ${Math.ceil(BROKER_REQUEST_TIMEOUT_MS / 1000)}s for the old socket to clear, then run /pinet-follow again.`
+        : "";
       ctx.ui.notify(
-        `Pinet reconnect stopped: ${msg(error)} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.`,
+        `Pinet reconnect stopped: ${reconnectFailureMessage} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.${stableIdConflictHint}`,
         "error",
       );
     },

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -19,7 +19,6 @@ import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
 import { DEFAULT_SOCKET_PATH, isRpcAgentStableIdConflictError } from "./broker/client.js";
-import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
@@ -1206,7 +1205,7 @@ export default function (pi: ExtensionAPI) {
       setExtStatus(ctx, "error");
       const reconnectFailureMessage = msg(error);
       const reconnectGuidance = isRpcAgentStableIdConflictError(error)
-        ? `Another worker is still connected with this session identity. Wait about ${Math.ceil(DEFAULT_HEARTBEAT_TIMEOUT_MS / 1000)}s for the old socket to clear, then run /pinet-follow again.`
+        ? "Another worker is still connected with this session identity. Stop or disconnect the other worker, or wait for it to fully disconnect, then run /pinet-follow again."
         : "Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.";
       ctx.ui.notify(
         `Pinet reconnect stopped: ${reconnectFailureMessage} ${reconnectGuidance}`,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -18,10 +18,8 @@ import {
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
-import {
-  DEFAULT_SOCKET_PATH,
-  REQUEST_TIMEOUT_MS as BROKER_REQUEST_TIMEOUT_MS,
-} from "./broker/client.js";
+import { DEFAULT_SOCKET_PATH, isRpcAgentStableIdConflictError } from "./broker/client.js";
+import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
@@ -1207,11 +1205,11 @@ export default function (pi: ExtensionAPI) {
       });
       setExtStatus(ctx, "error");
       const reconnectFailureMessage = msg(error);
-      const stableIdConflictHint = reconnectFailureMessage.includes("AGENT_STABLE_ID_CONFLICT")
-        ? ` Another worker is still connected with this session identity. Wait about ${Math.ceil(BROKER_REQUEST_TIMEOUT_MS / 1000)}s for the old socket to clear, then run /pinet-follow again.`
-        : "";
+      const reconnectGuidance = isRpcAgentStableIdConflictError(error)
+        ? `Another worker is still connected with this session identity. Wait about ${Math.ceil(DEFAULT_HEARTBEAT_TIMEOUT_MS / 1000)}s for the old socket to clear, then run /pinet-follow again.`
+        : "Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.";
       ctx.ui.notify(
-        `Pinet reconnect stopped: ${reconnectFailureMessage} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.${stableIdConflictHint}`,
+        `Pinet reconnect stopped: ${reconnectFailureMessage} ${reconnectGuidance}`,
         "error",
       );
     },


### PR DESCRIPTION
## Summary
- add a broker-side `/pinet-spawn-followers [count]` command that prints a launch plan for real Pinet followers
- extract typed spawn-plan generation into a dedicated helper with tests
- document the new broker command and the launcher-plan workflow

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #406.
