### PR TITLE
feat(slack-bridge): add broker follower spawn plan

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -274,20 +274,22 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 ### Broker commands
 
-| Command                 | Description                                |
-| ----------------------- | ------------------------------------------ |
-| `/pinet-start`          | Start as the mesh broker                   |
-| `/pinet-follow`         | Connect as a follower worker               |
-| `/pinet-unfollow`       | Disconnect from the broker                 |
-| `/pinet-reload <agent>` | Ask another agent to reload                |
-| `/pinet-exit <agent>`   | Ask another agent to exit                  |
-| `/pinet-free`           | Mark this agent as idle                    |
-| `/pinet-skin <theme>`   | Change the mesh naming theme (broker only) |
+| Command                          | Description                                      |
+| -------------------------------- | ------------------------------------------------ |
+| `/pinet-start`                   | Start as the mesh broker                         |
+| `/pinet-follow`                  | Connect as a follower worker                     |
+| `/pinet-unfollow`                | Disconnect from the broker                       |
+| `/pinet-reload <agent>`          | Ask another agent to reload                      |
+| `/pinet-exit <agent>`            | Ask another agent to exit                        |
+| `/pinet-free`                    | Mark this agent as idle                          |
+| `/pinet-skin <theme>`            | Change the mesh naming theme (broker only)       |
+| `/pinet-spawn-followers [count]` | Print a launcher plan for real follower sessions |
 
 ### How it works
 
 - The **broker** runs Slack Socket Mode, routes messages to agents, monitors health via the RALPH loop, and maintains a control plane canvas
 - **Followers** connect to the broker over a local Unix socket, poll for work, and report results
+- `/pinet-spawn-followers [count]` gives the broker a first-class launcher plan: it prints a ready-to-run shell script path, background launch loop, and log directory for spawning real `pi --command /pinet-follow` workers from the broker worktree
 - Agents can optionally authenticate using a shared local secret (`meshSecret` or `meshSecretPath`); when both are unset, mesh auth is disabled
 - Thread ownership is first-responder-wins — the first agent to reply claims the thread
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2307,6 +2307,115 @@ describe("slack-bridge Pinet reconnect", () => {
     }
   });
 
+  it("mentions a stableId reconnect hint when the broker reports a live stableId conflict", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, CommandDefinition>();
+    const events = new Map<string, EventHandler>();
+
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    const setStatus = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => false,
+      ui: {
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+        notify,
+        setStatus,
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "leaf",
+        getSessionFile: () => "/tmp/slack-bridge-session.json",
+      },
+    } as unknown as ExtensionContext;
+
+    let disconnectHandler: (() => void) | null = null;
+    let reconnectFailedHandler: ((error: Error) => void) | null = null;
+
+    vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "register").mockResolvedValue({
+      agentId: "worker-1",
+      name: "Worker",
+      emoji: "🦙",
+      metadata: { role: "worker", capabilities: { role: "worker" } },
+    });
+    vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+    vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+    vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+    vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation((handler) => {
+      disconnectHandler = handler;
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {
+      /* mocked */
+    });
+    vi.spyOn(BrokerClient.prototype, "onReconnectFailed").mockImplementation((handler) => {
+      reconnectFailedHandler = handler;
+    });
+
+    slackBridge(pi);
+
+    const sessionStart = events.get("session_start");
+    const sessionShutdown = events.get("session_shutdown");
+    const follow = commands.get("pinet-follow");
+
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+    expect(follow).toBeDefined();
+
+    await sessionStart?.({}, ctx);
+    await follow?.handler("", ctx);
+
+    expect(disconnectHandler).toBeTypeOf("function");
+    expect(reconnectFailedHandler).toBeTypeOf("function");
+
+    if (!disconnectHandler || !reconnectFailedHandler) {
+      throw new Error("Reconnect handlers were not registered");
+    }
+
+    disconnectHandler();
+    reconnectFailedHandler(
+      new Error(
+        'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying. code=AGENT_STABLE_ID_CONFLICT',
+      ),
+    );
+
+    await Promise.resolve();
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Pinet broker disconnected — reconnecting..."),
+      "warning",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Another worker is still connected with this session identity."),
+      "error",
+    );
+
+    await sessionShutdown?.({}, ctx);
+  });
+
   it("keeps worker identities session-scoped across clean restarts in the same repo checkout", async () => {
     const registerCalls: Array<{ stableId?: string }> = [];
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1975,6 +1975,23 @@ describe("slack-bridge Pinet reconnect", () => {
     vi.restoreAllMocks();
   });
 
+  it("registers the broker follower spawn command", async () => {
+    const commands = new Map<string, CommandDefinition>();
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+        commands.set(name, definition);
+      }),
+      on: vi.fn(),
+      sendUserMessage: vi.fn(),
+    } as unknown as ExtensionAPI;
+
+    slackBridge(pi);
+
+    expect(commands.get("pinet-spawn-followers")).toBeDefined();
+  });
+
   it("refreshes follower registration state after broker reconnect", async () => {
     const tools = new Map<string, ToolDefinition>();
     const commands = new Map<string, CommandDefinition>();
@@ -2392,25 +2409,30 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(disconnectHandler).toBeTypeOf("function");
     expect(reconnectFailedHandler).toBeTypeOf("function");
 
-    if (!disconnectHandler || !reconnectFailedHandler) {
+    if (disconnectHandler == null || reconnectFailedHandler == null) {
       throw new Error("Reconnect handlers were not registered");
     }
 
-    disconnectHandler();
-    reconnectFailedHandler(
+    const runDisconnect: () => void = disconnectHandler;
+    const runReconnectFailed: (error: Error) => void = reconnectFailedHandler;
+
+    runDisconnect();
+    runReconnectFailed(
       new Error(
         'Agent stableId "host:session:/tmp/worker" is already active on another live connection. Wait for that agent to disconnect before retrying. code=AGENT_STABLE_ID_CONFLICT',
       ),
     );
 
     await Promise.resolve();
+    await vi.waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("Another worker is still connected with this session identity."),
+        "error",
+      );
+    });
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("Pinet broker disconnected — reconnecting..."),
       "warning",
-    );
-    expect(notify).toHaveBeenCalledWith(
-      expect.stringContaining("Another worker is still connected with this session identity."),
-      "error",
     );
 
     await sessionShutdown?.({}, ctx);

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -110,6 +110,7 @@ export default function (pi: ExtensionAPI) {
   let agentOwnerToken = buildPinetOwnerToken(agentStableId);
   let activeSkinTheme: string | null = null;
   let agentPersonality: string | null = null;
+  const brokerSocketPath = DEFAULT_SOCKET_PATH;
   const agentAliases = new Set<string>();
   const PINET_SKIN_SETTING_KEY = "pinet.skinTheme";
 
@@ -1264,6 +1265,7 @@ export default function (pi: ExtensionAPI) {
       applyLocalAgentIdentity,
       setExtStatus,
       setExtCtx: sessionUiRuntime.setExtCtx,
+      brokerSocketPath: () => brokerSocketPath,
     },
   });
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -17,7 +17,10 @@ import {
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
-import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
+import {
+  DEFAULT_SOCKET_PATH,
+  REQUEST_TIMEOUT_MS as BROKER_REQUEST_TIMEOUT_MS,
+} from "./broker/client.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
@@ -1197,8 +1200,12 @@ export default function (pi: ExtensionAPI) {
         /* best effort */
       });
       setExtStatus(ctx, "error");
+      const reconnectFailureMessage = msg(error);
+      const stableIdConflictHint = reconnectFailureMessage.includes("AGENT_STABLE_ID_CONFLICT")
+        ? ` Another worker is still connected with this session identity. Wait about ${Math.ceil(BROKER_REQUEST_TIMEOUT_MS / 1000)}s for the old socket to clear, then run /pinet-follow again.`
+        : "";
       ctx.ui.notify(
-        `Pinet reconnect stopped: ${msg(error)} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.`,
+        `Pinet reconnect stopped: ${reconnectFailureMessage} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.${stableIdConflictHint}`,
         "error",
       );
     },

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -6,6 +6,7 @@ import {
   resolveAllowAllWorkspaceUsers,
   type SlackBridgeSettings,
 } from "./helpers.js";
+import { buildPinetFollowerSpawnPlan } from "./pinet-spawn-plan.js";
 import { formatRecentActivityLogEntries, type LoggedActivityLogEntry } from "./activity-log.js";
 import type { PinetRuntimeControlContext } from "./pinet-remote-control.js";
 import {
@@ -69,6 +70,7 @@ export interface PinetCommandsDeps {
   applyLocalAgentIdentity: (name: string, emoji: string, personality: string | null) => void;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
   setExtCtx: (ctx: ExtensionContext) => void;
+  brokerSocketPath: () => string | null;
 }
 
 // ─── Registration ────────────────────────────────────────
@@ -260,6 +262,36 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       } catch (err) {
         ctx.ui.notify(`Pinet skin failed: ${errorMsg(err)}`, "error");
       }
+    },
+  });
+
+  pi.registerCommand("pinet-spawn-followers", {
+    description: "Show a broker-managed launcher plan for real Pinet follower sessions",
+    handler: async (args, ctx) => {
+      if (deps.runtimeMode() !== "broker" || deps.brokerRole() !== "broker") {
+        ctx.ui.notify("/pinet-spawn-followers can only run on the active broker.", "warning");
+        return;
+      }
+
+      const [countToken] = args.trim().split(/\s+/, 1);
+      const parsedCount = countToken ? Number.parseInt(countToken, 10) : Number.NaN;
+      const count = Number.isNaN(parsedCount) ? 1 : parsedCount;
+      const plan = buildPinetFollowerSpawnPlan({
+        cwd: ctx.cwd,
+        socketPath: deps.brokerSocketPath(),
+        count,
+      });
+
+      ctx.ui.notify(
+        [
+          plan.summary,
+          `Launcher: ${plan.launcherScriptPath}`,
+          `Logs: ${plan.logDir}`,
+          "Run from the broker worktree:",
+          ...plan.commands.map((command, index) => `${index + 1}. ${command}`),
+        ].join("\n"),
+        "info",
+      );
     },
   });
 

--- a/slack-bridge/pinet-spawn-plan.test.ts
+++ b/slack-bridge/pinet-spawn-plan.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildPinetFollowerSpawnPlan } from "./pinet-spawn-plan.js";
+
+describe("buildPinetFollowerSpawnPlan", () => {
+  it("builds a default single-worker launcher plan", () => {
+    const plan = buildPinetFollowerSpawnPlan({
+      cwd: "/repo/extensions/.worktrees/feat-406",
+      socketPath: "/tmp/pinet.sock",
+    });
+
+    expect(plan.count).toBe(1);
+    expect(plan.launcherScriptPath).toBe(".pi/tmp/pinet-follow-pinet-follower.sh");
+    expect(plan.logDir).toBe(".pi/tmp/pinet-follow-pinet-follower-logs");
+    expect(plan.summary).toContain("Launch 1 real Pinet follower");
+    expect(plan.commands[0]).toBe('mkdir -p ".pi/tmp/pinet-follow-pinet-follower-logs"');
+    expect(plan.commands.join("\n")).toContain(
+      'pi --broker-socket="/tmp/pinet.sock" --command /pinet-follow',
+    );
+    expect(plan.commands.join("\n")).toContain("for N in $(seq 1 1)");
+  });
+
+  it("sanitizes branch names into worktree and launcher paths", () => {
+    const plan = buildPinetFollowerSpawnPlan({
+      cwd: "/repo/extensions/.worktrees/feat-406",
+      branch: " refs/heads/feat/406-broker-worker-spawn ",
+      count: 3,
+    });
+
+    expect(plan.branch).toBe("feat/406-broker-worker-spawn");
+    expect(plan.launcherScriptPath).toBe(".pi/tmp/pinet-follow-feat-406-broker-worker-spawn.sh");
+    expect(plan.logDir).toBe(".pi/tmp/pinet-follow-feat-406-broker-worker-spawn-logs");
+    expect(plan.summary).toContain("Launch 3 real Pinet followers");
+    expect(plan.commands.join("\n")).toContain(
+      "git worktree add .worktrees/feat-406-broker-worker-spawn-worker-$N -b feat/406-broker-worker-spawn-worker-$N",
+    );
+    expect(plan.commands.join("\n")).toContain("for N in $(seq 1 3)");
+  });
+
+  it("clamps invalid counts to one worker", () => {
+    expect(
+      buildPinetFollowerSpawnPlan({
+        cwd: "/repo",
+        count: 0,
+      }).count,
+    ).toBe(1);
+
+    expect(
+      buildPinetFollowerSpawnPlan({
+        cwd: "/repo",
+        count: Number.NaN,
+      }).count,
+    ).toBe(1);
+  });
+});

--- a/slack-bridge/pinet-spawn-plan.ts
+++ b/slack-bridge/pinet-spawn-plan.ts
@@ -1,0 +1,104 @@
+export interface PinetSpawnPlanOptions {
+  cwd: string;
+  branch?: string | null;
+  socketPath?: string | null;
+  count?: number | null;
+}
+
+export interface PinetSpawnPlan {
+  branch: string | null;
+  count: number;
+  launcherScriptPath: string;
+  logDir: string;
+  commands: string[];
+  summary: string;
+}
+
+function normalizeOptional(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function sanitizeBranchName(branch: string): string {
+  return branch
+    .trim()
+    .replace(/^refs\/heads\//, "")
+    .replace(/[^a-zA-Z0-9._/-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/^-+|-+$/g, "");
+}
+
+function buildSpawnSlug(branch: string | null): string {
+  const source = branch ?? "pinet-follower";
+  return source
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+function clampCount(count?: number | null): number {
+  if (typeof count !== "number" || !Number.isFinite(count)) {
+    return 1;
+  }
+  const normalized = Math.trunc(count);
+  if (normalized < 1) {
+    return 1;
+  }
+  return normalized;
+}
+
+export function buildPinetFollowerSpawnPlan(options: PinetSpawnPlanOptions): PinetSpawnPlan {
+  const branch = normalizeOptional(options.branch);
+  const sanitizedBranch = branch ? sanitizeBranchName(branch) : null;
+  const slug = buildSpawnSlug(sanitizedBranch);
+  const count = clampCount(options.count);
+  const socketPath = normalizeOptional(options.socketPath);
+  const launcherScriptPath = `.pi/tmp/pinet-follow-${slug}.sh`;
+  const logDir = `.pi/tmp/pinet-follow-${slug}-logs`;
+
+  const commandParts = [
+    "pi",
+    ...(socketPath ? [`--broker-socket=${JSON.stringify(socketPath)}`] : []),
+  ];
+  const piInvocation = commandParts.join(" ");
+  const branchCommand = sanitizedBranch
+    ? `git worktree add .worktrees/${slug}-worker-$N -b ${sanitizedBranch}-worker-$N`
+    : `mkdir -p .worktrees/${slug}-worker-$N`;
+  const moveCommand = sanitizedBranch
+    ? `cd .worktrees/${slug}-worker-$N`
+    : `cd ${JSON.stringify(options.cwd)}`;
+  const launcherBody = [
+    "#!/bin/bash",
+    "set -euo pipefail",
+    `ROOT=${JSON.stringify(options.cwd)}`,
+    "N=${1:-1}",
+    `LOG_DIR=${JSON.stringify(logDir)}`,
+    'mkdir -p "$ROOT/$LOG_DIR"',
+    'cd "$ROOT"',
+    branchCommand,
+    moveCommand,
+    `exec ${piInvocation} --command /pinet-follow > \"$ROOT/$LOG_DIR/worker-$N.log\" 2>&1`,
+  ].join("\n");
+
+  const spawnLoop = [
+    `mkdir -p ${JSON.stringify(logDir)}`,
+    `cat > ${JSON.stringify(launcherScriptPath)} <<'EOF'\n${launcherBody}\nEOF`,
+    `chmod +x ${JSON.stringify(launcherScriptPath)}`,
+    `for N in $(seq 1 ${count}); do (${JSON.stringify(launcherScriptPath)} \"$N\" </dev/null &); done`,
+  ];
+
+  return {
+    branch: sanitizedBranch,
+    count,
+    launcherScriptPath,
+    logDir,
+    commands: spawnLoop,
+    summary:
+      `Launch ${count} real Pinet follower${count === 1 ? "" : "s"}` +
+      (sanitizedBranch
+        ? ` on worktrees branched from ${sanitizedBranch}`
+        : " in the current checkout") +
+      `. Logs stream to ${logDir}.`,
+  };
+}

--- a/slack-bridge/pinet-spawn-plan.ts
+++ b/slack-bridge/pinet-spawn-plan.ts
@@ -78,14 +78,14 @@ export function buildPinetFollowerSpawnPlan(options: PinetSpawnPlanOptions): Pin
     'cd "$ROOT"',
     branchCommand,
     moveCommand,
-    `exec ${piInvocation} --command /pinet-follow > \"$ROOT/$LOG_DIR/worker-$N.log\" 2>&1`,
+    `exec ${piInvocation} --command /pinet-follow > "$ROOT/$LOG_DIR/worker-$N.log" 2>&1`,
   ].join("\n");
 
   const spawnLoop = [
     `mkdir -p ${JSON.stringify(logDir)}`,
     `cat > ${JSON.stringify(launcherScriptPath)} <<'EOF'\n${launcherBody}\nEOF`,
     `chmod +x ${JSON.stringify(launcherScriptPath)}`,
-    `for N in $(seq 1 ${count}); do (${JSON.stringify(launcherScriptPath)} \"$N\" </dev/null &); done`,
+    `for N in $(seq 1 ${count}); do (${JSON.stringify(launcherScriptPath)} "$N" </dev/null &); done`,
   ];
 
   return {


### PR DESCRIPTION
## Summary
- add a broker-side `/pinet-spawn-followers [count]` command that prints a launch plan for real Pinet followers
- extract typed spawn-plan generation into a dedicated helper with tests
- document the new broker command and launcher-plan workflow

Note: the original branch name `feat/406-broker-worker-spawn` was already occupied on the fork by unrelated stableId work, so this PR uses a fresh branch for clean isolation.

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #406.
