### PR TITLE
docs(slack-bridge): clarify transport-aware outbound rules

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -164,6 +164,40 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context      |
 | `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                       |
 
+## Transport-aware outbound content (first slice)
+
+Issue `#403` now has a bounded outbound normalization slice in place.
+
+### Canonical model
+
+Shared outbound messages may carry both legacy top-level fields and normalized transport-aware content:
+
+- `text`: canonical plain-text fallback and persistence body
+- `content.text`: canonical normalized plain-text body when `content` is present
+- `content.markdown`: optional markdown-oriented companion for markdown-aware surfaces and exports
+- `content.slackBlocks`: optional Slack-native Block Kit payload
+- `blocks`: legacy Slack Block Kit field kept for backward compatibility
+
+### Rendering rules
+
+Current outbound rendering behavior is intentionally conservative:
+
+- **Slack** posts `content.text` when available, otherwise top-level `text`
+- **Slack** prefers non-empty `content.slackBlocks`
+- **Slack** falls back to legacy `blocks` when `content.slackBlocks` is absent or empty
+- **Slack** omits `blocks` entirely when both normalized and legacy block payloads are empty
+- **iMessage** uses canonical plain text only (`content.text` → `text` fallback)
+- `content.markdown` is currently supplementary metadata for markdown-aware surfaces; it does **not** override iMessage output
+
+### Compatibility guidance
+
+For new outbound send paths:
+
+- always provide canonical plain text
+- add `content.slackBlocks` only when you have a true Slack-native rendering
+- keep `blocks` only for legacy callers or migration periods
+- do not rely on `content.markdown` to render plain-text transports
+
 ## Scope carrier model (compatibility-first)
 
 Slack/Pinet now threads a first-class runtime `scope` carrier through shared message contracts and runtime metadata.

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -834,6 +834,40 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     ).rejects.toThrow("content.text is required when content is provided");
   });
 
+  it("message.send trims normalized markdown while preserving canonical plain text", async () => {
+    let delivered: unknown;
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async (msg) => {
+          delivered = msg;
+        },
+      },
+    ]);
+    await client.register("transport-agent", "📦");
+
+    await client.sendMessage({
+      threadId: "100.203",
+      body: "legacy fallback text",
+      source: "slack",
+      channel: "C123",
+      content: {
+        text: "canonical fallback text",
+        markdown: "  **canonical fallback text**  ",
+      },
+    });
+
+    expect(delivered).toMatchObject({
+      threadId: "100.203",
+      channel: "C123",
+      text: "canonical fallback text",
+      content: {
+        text: "canonical fallback text",
+        markdown: "**canonical fallback text**",
+      },
+    });
+  });
+
   it("thread.claim claims ownership for the calling agent", async () => {
     await client.register("claimer-agent", "🏷️");
 


### PR DESCRIPTION
## Summary
- document the bounded #403 transport-aware outbound rendering and fallback rules in `slack-bridge/README.md`
- add a focused broker integration test that locks in canonical plain text plus trimmed markdown normalization on the Slack send path
- keep this as a distinct follow-up slice stacked on top of #599 instead of reopening the outbound-content salvage PR

## Validation
- `pnpm vitest run slack-bridge/broker/integration.test.ts`
- `pnpm typecheck --filter @gugu910/pi-slack-bridge`

## Hook bypass note
- This branch was pushed with `git push --no-verify` as a one-time exception approved in response to unrelated repo-wide pre-push failures tracked in #626.
- The failing hook surface is outside this slice (`browser-playwright` ambient/dependency errors), while the focused validation above covers the touched files.

Refs #403
Refs #626
Stacked on #599
