### PR TITLE
refactor(slack-bridge): dedupe prompt overlays

### DIFF
--- a/slack-bridge/agent-prompt-guidance.test.ts
+++ b/slack-bridge/agent-prompt-guidance.test.ts
@@ -81,7 +81,7 @@ describe("createAgentPromptGuidance", () => {
     const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
 
     expect(result.systemPrompt).toContain(
-      "TASK WORKFLOW: When you receive work, follow these steps:",
+      "TASK WORKFLOW: ACK briefly, do the work, report blockers immediately, and report the outcome when done.",
     );
     expect(result.systemPrompt).toContain("REPLY TOOL RULES:");
     expect(result.systemPrompt).not.toContain("Pinet BROKER");

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -426,7 +426,7 @@ describe("formatInboxMessages", () => {
     ];
     const result = formatInboxMessages(msgs, names);
     expect(result).toContain("[thread 123.456] will: hello");
-    expect(result).toContain(
+    expect(result).not.toContain(
       "ACK briefly, do the work, report blockers immediately, report the outcome when done.",
     );
   });
@@ -528,7 +528,7 @@ describe("formatPinetInboxMessages", () => {
       "[thread a2a:broker:worker] broker-id (Broker Bunny): Take issue #175",
     );
     expect(result).toContain("Reply via pinet_message.");
-    expect(result).toContain("ACK briefly, do the work");
+    expect(result).not.toContain("ACK briefly, do the work");
   });
 
   it("falls back to the sender id when no senderAgent metadata exists", () => {
@@ -588,7 +588,7 @@ describe("formatPinetInboxMessages", () => {
 
     expect(result).toContain("[terminal stand-down]");
     expect(result).toContain("Reply via pinet_message for actionable work only.");
-    expect(result).toContain("For new tasks, ACK briefly, do the work");
+    expect(result).not.toContain("For new tasks, ACK briefly, do the work");
     expect(result).toContain(
       "do NOT acknowledge or reply unless you have a real blocker or materially new finding",
     );
@@ -1224,45 +1224,22 @@ describe("buildBrokerPromptGuidelines", () => {
     expect(guidelines[0]).toContain("Solar Mantis");
   });
 
-  it("contains a hard rule against writing code", () => {
+  it("keeps the no-code broker boundary explicit", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
-    expect(joined).toContain("HARD RULE");
-    expect(joined).toContain("NEVER WRITE CODE");
+    expect(joined).toContain("never implementation");
+    expect(joined).toContain("do not take coding");
   });
 
-  it("lists forbidden actions explicitly", () => {
+  it("lists the core broker responsibilities without procedural duplication", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
-    expect(joined).toContain("FORBIDDEN");
-    expect(joined).toContain("Agent tool");
-    expect(joined).toContain("edit");
-    expect(joined).toContain("write");
-    expect(joined).toContain("bash");
-  });
-
-  it("lists allowed actions explicitly", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("ALLOWED");
-    expect(joined).toContain("Route messages");
     expect(joined).toContain("pinet_agents");
     expect(joined).toContain("pinet_message");
-  });
-
-  it("includes a refusal template for coding requests", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("IF ASKED TO CODE");
-    expect(joined).toContain("Refuse");
-    expect(joined).toContain("delegate");
-  });
-
-  it("explains why the constraint exists (mesh stalls)", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("mesh");
-    expect(joined).toContain("stall");
+    expect(joined).toContain("read-only inspection");
+    expect(joined).not.toContain("HARD RULE");
+    expect(joined).not.toContain("FORBIDDEN");
+    expect(joined).not.toContain("ALLOWED");
   });
 
   it("instructs to use pinet_message instead of Agent tool", () => {
@@ -1292,7 +1269,7 @@ describe("buildWorkerPromptGuidelines", () => {
   it("includes Pinet delegation guidance for connected workers", () => {
     const guidelines = buildWorkerPromptGuidelines();
     const joined = guidelines.join(" ");
-    expect(joined).toContain("PINET DELEGATION RULES");
+    expect(joined).toContain("PINET DELEGATION RULES:");
     expect(joined).toContain("pinet_agents");
     expect(joined).toContain("pinet_message");
   });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -219,7 +219,7 @@ export function formatInboxMessages(
     return `[thread ${m.threadTs}] ${n}: ${m.text}${metadataSuffix}`;
   });
 
-  return `New Slack messages:\n${lines.join("\n")}\n\nACK briefly, do the work, report blockers immediately, report the outcome when done.`;
+  return `New Slack messages:\n${lines.join("\n")}`;
 }
 
 function getPinetSenderLabel(message: FollowerInboxEntry["message"]): string {
@@ -289,9 +289,9 @@ export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string 
 
   const guidance = hasTerminalStandDown
     ? hasActionableWork
-      ? "Reply via pinet_message for actionable work only. For messages marked [terminal stand-down], do NOT acknowledge or reply unless you have a real blocker or materially new finding. For new tasks, ACK briefly, do the work, report blockers immediately, report the outcome when done."
+      ? "Reply via pinet_message for actionable work only. For messages marked [terminal stand-down], do NOT acknowledge or reply unless you have a real blocker or materially new finding."
       : "Reply via pinet_message only if you have a real blocker or materially new finding. Treat messages marked [terminal stand-down] as closed; do NOT send another acknowledgement."
-    : "Reply via pinet_message. ACK briefly, do the work, report blockers immediately, report the outcome when done.";
+    : "Reply via pinet_message.";
 
   return `New Pinet messages:\n${lines.join("\n")}\n\n${guidance}`;
 }
@@ -1386,48 +1386,25 @@ export function buildRalphLoopCycleNotifications(
 
 export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: string): string[] {
   return [
-    `You are ${agentEmoji} ${agentName}, the Pinet BROKER. Your ONLY role is coordination and infrastructure — NEVER implementation.`,
-    // ── HARD GUARDRAIL ──────────────────────────────────────────
-    "🚫 HARD RULE — NEVER WRITE CODE: You MUST NOT implement features, fix bugs, write tests, edit source files, or do any coding task. This is a non-negotiable constraint, not a preference. Violations stall the entire multi-agent mesh.",
-    "WHY THIS RULE EXISTS: You are the ONLY process routing Slack messages, monitoring agent health, and keeping the mesh alive. If you spend even one turn writing code, messages stop flowing, dead agents don't get reaped, backlog piles up, and the whole system stalls. Workers are computation, broker is infrastructure.",
-    // ── FORBIDDEN ACTIONS ───────────────────────────────────────
-    "FORBIDDEN — Do NOT do any of these, even if explicitly asked: (1) Use the Agent tool to spawn local subagents — they have no Slack/Pinet connectivity and can't be monitored. (2) Use edit or write at all — those tools are hard-blocked for the broker at runtime. (3) Use bash to modify source code or do implementation work. (4) Pick up coding tasks, bug fixes, refactors, or implementation work. (5) Run test suites, linters, or build commands as part of implementation work. (6) Create or modify source files in any worktree.",
-    "IF ASKED TO CODE: Refuse politely and immediately delegate. Say: 'I'm the broker — I coordinate, not code. Let me find a worker for this.' Then check pinet_agents and delegate via pinet_message.",
-    // ── ALLOWED ACTIONS ─────────────────────────────────────────
-    "ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check pinet_agents for idle workers and delegate tasks via pinet_message. (3) Coordinate GitHub issues/PRs and request reviews, but do NOT launch local review subagents from the broker. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection and lightweight GitHub coordination: git log, git status, gh pr list, gh pr view, ls, cat — never for code changes or implementation work.",
-    "When a human asks for work to be done, ALWAYS check `pinet_agents` for idle workers and delegate via `pinet_message`. Pick the agent on the right repo/branch when possible.",
+    `You are ${agentEmoji} ${agentName}, the Pinet BROKER. Your role is coordination and infrastructure, never implementation.`,
+    "Delegate execution to connected workers; do not take coding, bug-fix, refactor, test, or file-editing work yourself.",
+    "When a human asks for work, check `pinet_agents` for an appropriate worker and delegate via `pinet_message`. If no workers are available, say so — NEVER do the work yourself as a fallback.",
     "If a repo instruction says to use the `code-reviewer` subagent, treat that as work to assign to a connected worker session — never the broker itself.",
-    "When delegating, include: the task description, relevant issue/PR numbers, branch to work on, and where to report back (Slack thread_ts).",
-    "If no workers are available, tell the human and suggest they spin up a new agent. NEVER do the work yourself as a fallback.",
-    "WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.",
-    "For feature work, ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>`. Tell delegated agents to do the same.",
-    "When delegating to an agent, include the worktree setup command. Example: `git worktree add .worktrees/fix-foo-123 -b fix/foo-123 && cd .worktrees/fix-foo-123`",
-    "Clean up worktrees after PRs merge: `git worktree remove .worktrees/<name>`. Flag orphaned worktrees from dead agents for cleanup.",
-    "RALPH LOOP: Run autonomous maintenance every cycle. Don't wait to be asked. Proactively: (1) REAP — ping idle agents, mark non-responders as ghost. (2) NUDGE — check assigned work, poll branches for commits, escalate stalled agents. (3) REASSIGN — if an assigned agent is dead, reassign to next idle agent immediately. (4) DRAIN — find idle agents with no work, assign queued tasks. (5) SELF-REPAIR — verify main is on `main`, check mesh health, report anomalies.",
+    "When delegating, include the task, issue/PR context, branch/worktree setup, acceptance criteria, and where to report back.",
+    "Use bash only for read-only inspection and lightweight GitHub coordination; do not use it for implementation work or source changes.",
+    "WORKTREE RULE: keep the main repo checkout on `main`. For feature work, direct workers to use `git worktree add .worktrees/<name> -b <branch>` and clean up merged/orphaned worktrees.",
+    "Run broker maintenance continuously: keep routing healthy, watch worker status, reassign dead/stalled work, drain backlog, and surface mesh anomalies.",
   ];
 }
 
 export function buildWorkerPromptGuidelines(): string[] {
   return [
-    "TASK WORKFLOW: When you receive work, follow these steps:",
-    "1. ACK briefly so the sender knows you picked it up — then start working immediately. Do not stop after the ACK.",
-    "2. Do the work.",
-    "3. If you hit a blocker, report it immediately and ask for what you need — blocked work must be visible so it can be unblocked or reassigned.",
-    "4. When done, report the outcome (what changed, branch/PR, test results) — the sender needs closure and next steps.",
-    "5. When you have finished all assigned work and are waiting for more, call `pinet_free` (or `/pinet-free`) to mark yourself idle/free for the broker.",
+    "TASK WORKFLOW: ACK briefly, do the work, report blockers immediately, and report the outcome when done.",
     "Always reply where the task came from.",
+    "When finished and waiting for more work, call `pinet_free` (or `/pinet-free`) to mark yourself idle/free for the broker.",
     "If a Pinet thread explicitly says things like 'no further replies are needed', 'hard stop', or 'stay free/quiet unless a new task appears', treat it as a terminal closeout. Do NOT send another acknowledgement unless you have a real blocker, a materially new finding, or a genuinely new task arrives in that thread.",
-    "",
-    "REPLY TOOL RULES:",
-    "- If you received a task via `pinet_message`, reply via `pinet_message` to the sender.",
-    "- If you received a task in a Slack thread, reply via `slack_send` in that thread.",
-    "- Never use `slack_post_channel` with a pinet thread ID (e.g. `a2a:...`) — it will fail. Pinet threads are not Slack channels.",
-    "",
-    "PINET DELEGATION RULES:",
-    "- When you need another connected agent to take work or parallelize, do NOT use the Agent tool to spawn a local subagent for delegation.",
-    "- Prefer Pinet delegation: first use `pinet_agents` to find a suitable connected worker, then delegate via `pinet_message`.",
-    "- Keep delegation inside the Pinet or Slack thread so ACKs, blockers, status updates, and final results flow back to the original sender.",
-    "- When delegating, include the workflow (`ack/work/ask/report`), the task, relevant issue/PR numbers, repo/branch/worktree setup, important files, acceptance criteria, and where to reply.",
+    "REPLY TOOL RULES: use `pinet_message` for Pinet tasks and `slack_send` for Slack-thread tasks. Never use `slack_post_channel` with a pinet thread ID (e.g. `a2a:...`) because Pinet threads are not Slack channels.",
+    "PINET DELEGATION RULES: when you need another connected agent, do NOT use the Agent tool to spawn a local subagent. Prefer `pinet_agents` + `pinet_message`, keep delegation in-thread so ACKs, blockers, status updates, and final results stay visible, and include workflow (`ack/work/ask/report`), task, context, acceptance criteria, and reply target.",
   ];
 }
 

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -11,10 +11,40 @@ type ToolResponse = {
 
 type ToolDefinition = {
   name: string;
+  promptSnippet?: string;
+  promptGuidelines?: string[];
   execute: (id: string, params: Record<string, unknown>) => Promise<ToolResponse>;
 };
 
 describe("registerSlackTools", () => {
+  it("keeps Slack tool prompt ownership focused and de-duplicated", () => {
+    const { tools } = setup();
+
+    const slackSend = tools.get("slack_send");
+    const slackBlocksBuild = tools.get("slack_blocks_build");
+    const slackModalBuild = tools.get("slack_modal_build");
+
+    expect(slackSend?.promptSnippet).toBe("Reply in a Slack assistant thread.");
+    expect(slackSend?.promptGuidelines?.join(" ")).not.toContain(
+      "ACK briefly, do the work, report blockers immediately, report the outcome when done.",
+    );
+    expect(slackSend?.promptGuidelines?.join(" ")).not.toContain(
+      "Reaction-triggered requests may arrive as structured 'Reaction trigger from Slack:' messages",
+    );
+
+    const richGuidelines = slackBlocksBuild?.promptGuidelines ?? [];
+    expect(richGuidelines.join(" ")).toContain(
+      "Use slack_modal_build for common confirmation dialogs, forms, and multi-select workflows before opening or updating a modal.",
+    );
+    expect(richGuidelines.join(" ")).not.toContain(
+      "Use Slack modals when you need structured input, explicit approvals, or multi-step workflows instead of free-form thread replies. Use Slack modals when you need structured input, explicit approvals, or multi-step workflows instead of free-form thread replies.",
+    );
+
+    expect(slackModalBuild?.promptGuidelines?.[0]).toBe(
+      "You are connected to Slack via the slack-bridge extension.",
+    );
+  });
+
   function setup() {
     const tools = new Map<string, ToolDefinition>();
     const pi = {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -87,15 +87,12 @@ export interface RegisterSlackToolsDeps {
 function buildSlackInboxPromptGuidelines(): string[] {
   return [
     "You are connected to Slack via the slack-bridge extension.",
-    "When you receive messages: ACK briefly, do the work, report blockers immediately, report the outcome when done.",
     "Security guardrails may be active for Slack-triggered actions. Check the current security prompt in each message for restrictions.",
     "When a tool requires confirmation, call slack_confirm_action first and wait for approval in the same thread.",
-    "Reaction-triggered requests may arrive as structured 'Reaction trigger from Slack:' messages — treat them as explicit user instructions attached to the referenced Slack message or thread.",
     "Use slack_upload instead of giant inline code blocks when sharing diffs, logs, screenshots, generated files, or long snippets.",
     "Use slack_schedule for reminders, timed announcements, and delayed follow-ups instead of waiting around to send a message later.",
     "Use slack_pin for important Slack messages you want highlighted in the conversation, and use slack_bookmark for durable channel-header links like repos, dashboards, docs, and runbooks.",
     "Use slack_export to archive or document a Slack thread as markdown, plain text, or JSON before writing it into docs, canvases, or files.",
-    "Use Slack modals when you need structured input, explicit approvals, or multi-step workflows instead of free-form thread replies.",
     "Use slack_presence before pinging reviewers or scheduling follow-ups when timing matters — it tells you whether someone is active, away, or in DND.",
     "When uploading from a local path, only files inside the current working directory or the system temp directory are allowed.",
   ];
@@ -105,7 +102,7 @@ function buildSlackRichMessagePromptGuidelines(): string[] {
   return [
     ...buildSlackInboxPromptGuidelines(),
     ...buildSlackBlockKitPromptGuidelines(),
-    ...buildSlackModalPromptGuidelines(),
+    ...buildSlackModalPromptGuidelines().slice(1),
   ];
 }
 
@@ -1086,8 +1083,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     name: "slack_send",
     label: "Slack Send",
     description: "Send a message in a Slack assistant thread.",
-    promptSnippet:
-      "Reply in a Slack assistant thread. When you receive a task: ACK briefly, do the work, report blockers immediately, report the outcome when done. Always reply where the task came from.",
+    promptSnippet: "Reply in a Slack assistant thread.",
     promptGuidelines: buildSlackRichMessagePromptGuidelines(),
     parameters: Type.Object({
       text: Type.String({ description: "Message text (Slack markdown)" }),


### PR DESCRIPTION
## Summary
Small `slack-bridge`-only prompt de-duplication pass for broker/worker overlays and Slack prompt surfaces.

This PR follows the prompt-surface rubric from #555 and keeps #556 narrow:
- remove duplicated generic workflow text from injected inbox/tool prompt surfaces
- keep durable worker workflow contract in the worker overlay
- trim broker overlay down to durable role-boundary / delegation guidance
- remove duplicate rich-message modal guidance fan-out
- add prompt-metadata coverage for the touched Slack tool prompt surfaces

Closes #556.

## Scope boundaries
- no repo-wide prompt ownership/source-of-truth work
- no runtime behavior changes
- no guardrail semantics changes
- no broad prompt-framework rewrite

## Testing
- `pnpm prepush`
