### PR TITLE
pinet: classify durable inbox mail

### DIFF
--- a/broker-core/index.ts
+++ b/broker-core/index.ts
@@ -2,6 +2,7 @@ export * from "./agent-messaging.js";
 export * from "./auth.js";
 export * from "./leader.js";
 export * from "./maintenance.js";
+export * from "./mail-classification.js";
 export * from "./message-send.js";
 export * from "./paths.js";
 export * from "./raw-tcp-loopback.js";

--- a/broker-core/mail-classification.test.ts
+++ b/broker-core/mail-classification.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { classifyPinetMail, normalizePinetMailClass } from "./mail-classification.js";
+
+// ─── Mail classification ─────────────────────────────────
+
+describe("Pinet mail classification", () => {
+  it("normalizes explicit class aliases", () => {
+    expect(normalizePinetMailClass("steer")).toBe("steering");
+    expect(normalizePinetMailClass("follow-up")).toBe("fwup");
+    expect(normalizePinetMailClass("follow_up")).toBe("fwup");
+    expect(normalizePinetMailClass("context-only")).toBe("maintenance_context");
+    expect(normalizePinetMailClass("maintenance")).toBe("maintenance_context");
+  });
+
+  it("honors explicit metadata over heuristics", () => {
+    expect(
+      classifyPinetMail({
+        body: "Please take issue #606 and ACK/work/ask/report.",
+        metadata: { pinetMailClass: "fwup" },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: true });
+  });
+
+  it("classifies actionable broker instructions as steering", () => {
+    expect(
+      classifyPinetMail({
+        body: "Please take issue #606. Workflow: ACK/work/ask/report. No merge.",
+        metadata: { a2a: true, senderAgent: "Broker Camel" },
+      }),
+    ).toMatchObject({ class: "steering", explicit: false });
+
+    expect(
+      classifyPinetMail({
+        body: "Task: Final re-review current branch for PR #621. Focus on mail classification semantics.",
+        metadata: { a2a: true, senderAgent: "Broker Camel" },
+      }),
+    ).toMatchObject({ class: "steering", explicit: false });
+  });
+
+  it("keeps ordinary issue or PR status references as follow-up", () => {
+    for (const body of [
+      "Thanks for the review on PR #621; looks good.",
+      "Issue #606 review notes are resolved.",
+      "PR #621 review looks good.",
+      "Tests passed. Blockers: none.",
+      "Done. Tests passed. No merge performed. Ready for human review.",
+    ]) {
+      expect(classifyPinetMail({ body, metadata: { a2a: true } })).toMatchObject({
+        class: "fwup",
+        explicit: false,
+      });
+    }
+  });
+
+  it("classifies legacy control and skin metadata as maintenance/context-only", () => {
+    expect(
+      classifyPinetMail({
+        body: "/reload",
+        metadata: { a2a: true, kind: "pinet_control", command: "reload" },
+      }),
+    ).toMatchObject({ class: "maintenance_context" });
+
+    expect(
+      classifyPinetMail({
+        body: "skin update",
+        metadata: { a2a: true, kind: "pinet_skin", theme: "forest" },
+      }),
+    ).toMatchObject({ class: "maintenance_context" });
+  });
+
+  it("classifies RALPH and terminal stand-down notes as maintenance/context-only", () => {
+    for (const body of [
+      "RALPH broker-only maintenance: ghost agents detected.",
+      "Stand down on this lane.",
+      "The thread is already satisfied; no reply is needed.",
+      "No further replies are needed unless I ask for a new task.",
+      "Issue #606 is now routed; no action needed.",
+    ]) {
+      expect(classifyPinetMail({ body, metadata: { a2a: true } })).toMatchObject({
+        class: "maintenance_context",
+        explicit: false,
+      });
+    }
+  });
+
+  it("defaults ordinary durable mail to follow-up", () => {
+    expect(
+      classifyPinetMail({
+        body: "Thanks, looks good.",
+        metadata: { a2a: true },
+      }),
+    ).toMatchObject({ class: "fwup", explicit: false });
+  });
+});

--- a/broker-core/mail-classification.ts
+++ b/broker-core/mail-classification.ts
@@ -1,0 +1,139 @@
+export const PINET_MAIL_CLASSES = ["steering", "fwup", "maintenance_context"] as const;
+
+export type PinetMailClass = (typeof PINET_MAIL_CLASSES)[number];
+
+export interface PinetMailClassificationInput {
+  source?: string | null;
+  threadId?: string | null;
+  sender?: string | null;
+  body?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface PinetMailClassification {
+  class: PinetMailClass;
+  reason: string;
+  explicit: boolean;
+}
+
+const EXPLICIT_CLASS_KEYS = [
+  "pinetMailClass",
+  "pinet_mail_class",
+  "mailClass",
+  "mail_class",
+  "mailKind",
+  "mail_kind",
+  "classification",
+] as const;
+
+const STEERING_PATTERNS = [
+  /\back(?:\/|\s*)work(?:\/|\s*)ask(?:\/|\s*)report\b/i,
+  /\back briefly\b/i,
+  /\bplease (?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\b/i,
+  /\b(?:new|fresh) (?:implementation )?(?:lane|task|worktree)\b/i,
+  /\b(?:task|issue|worktree setup|scope|workflow|acceptance criteria|constraints?)\s*:/i,
+  /\b(?:take|continue|implement|fix|review|inspect|reassign|handle|work on)\s+(?:issue|pr)\s*#\d+\b/i,
+  /\b(?:issue|pr)\s*#\d+\b.*\back(?:\/|\s*)work(?:\/|\s*)ask(?:\/|\s*)report\b/i,
+  /\breport blockers? immediately\b/i,
+];
+
+const MAINTENANCE_CONTEXT_PATTERNS = [
+  /\bralph\b.*\b(?:maintenance|ghost|reap|nudge|drain)\b/i,
+  /\bbroker[- ]only maintenance\b/i,
+  /\bmaintenance (?:anomaly|recovery|timer|pass)\b/i,
+  /\bno further repl(?:y|ies) (?:are|is) needed\b/i,
+  /\bno further acknowledg(?:ement|ements) (?:are|is) needed\b/i,
+  /\bno reply is needed\b/i,
+  /\bno action needed\b/i,
+  /\bhard stop on this [^.\n]*thread\b/i,
+  /\bstand down\b/i,
+  /\bthread is already satisfied\b/i,
+  /\bunless I (?:assign|ask for) (?:a )?(?:genuinely )?new task\b/i,
+  /\bstay free(?:\/| and )quiet\b/i,
+  /\bstay quiet(?:\/| and )free\b/i,
+];
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function normalizePinetMailClass(value: unknown): PinetMailClass | null {
+  const raw = asString(value)
+    ?.toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (!raw) return null;
+
+  if (raw === "steering" || raw === "steer" || raw === "directive") return "steering";
+  if (raw === "fwup" || raw === "follow_up" || raw === "followup") return "fwup";
+  if (
+    raw === "maintenance_context" ||
+    raw === "maintenance" ||
+    raw === "context_only" ||
+    raw === "context"
+  ) {
+    return "maintenance_context";
+  }
+
+  return null;
+}
+
+function getExplicitMailClass(
+  metadata: Record<string, unknown> | null | undefined,
+): PinetMailClass | null {
+  if (!metadata) return null;
+
+  for (const key of EXPLICIT_CLASS_KEYS) {
+    const normalized = normalizePinetMailClass(metadata[key]);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
+function hasPattern(patterns: RegExp[], value: string): boolean {
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+function metadataLooksLikeMaintenance(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  const kind = asString(metadata?.kind)?.toLowerCase() ?? "";
+  const type = asString(metadata?.type)?.toLowerCase() ?? "";
+  const eventType = asString(metadata?.event_type)?.toLowerCase() ?? "";
+  return [kind, type, eventType].some((value) => {
+    const normalized = value.replace(/_/g, ":");
+    return (
+      normalized.includes("maintenance") ||
+      normalized.includes("ralph") ||
+      normalized === "pinet:control" ||
+      normalized === "pinet:skin"
+    );
+  });
+}
+
+export function classifyPinetMail(input: PinetMailClassificationInput): PinetMailClassification {
+  const metadata = input.metadata ?? null;
+  const explicitClass = getExplicitMailClass(metadata);
+  if (explicitClass) {
+    return { class: explicitClass, reason: "explicit metadata", explicit: true };
+  }
+
+  const body = input.body ?? "";
+  if (metadataLooksLikeMaintenance(metadata) || hasPattern(MAINTENANCE_CONTEXT_PATTERNS, body)) {
+    return {
+      class: "maintenance_context",
+      reason: "maintenance/context-only cues",
+      explicit: false,
+    };
+  }
+
+  if (hasPattern(STEERING_PATTERNS, body)) {
+    return { class: "steering", reason: "actionable steering cues", explicit: false };
+  }
+
+  return { class: "fwup", reason: "default follow-up mail", explicit: false };
+}
+
+export function formatPinetMailClassLabel(mailClass: PinetMailClass): string {
+  return mailClass === "maintenance_context" ? "maintenance/context" : mailClass;
+}

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -20,6 +20,7 @@
     "./auth": "./dist/auth.js",
     "./leader": "./dist/leader.js",
     "./maintenance": "./dist/maintenance.js",
+    "./mail-classification": "./dist/mail-classification.js",
     "./message-send": "./dist/message-send.js",
     "./paths": "./dist/paths.js",
     "./raw-tcp-loopback": "./dist/raw-tcp-loopback.js",

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { classifyPinetMail } from "./mail-classification.js";
 import { BrokerDB } from "./schema.js";
 
 function createDb(): { db: BrokerDB; dir: string } {
@@ -372,6 +373,61 @@ describe("BrokerDB message sync identity", () => {
 
       expect(second.id).not.toBe(first.id);
       expect(db.getInbox("two")).toHaveLength(2);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps mail classification derivable from durable inbox records without changing read state", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("a2a:broker:worker", "agent", "", null);
+      db.insertMessage(
+        "a2a:broker:worker",
+        "agent",
+        "inbound",
+        "broker",
+        "Task: implement issue #606. Workflow: ACK/work/ask/report.",
+        ["worker"],
+        { a2a: true },
+      );
+      db.insertMessage(
+        "a2a:broker:worker",
+        "agent",
+        "inbound",
+        "broker",
+        "Tests passed. Blockers: none.",
+        ["worker"],
+        { a2a: true },
+      );
+      db.insertMessage(
+        "a2a:broker:worker",
+        "agent",
+        "inbound",
+        "broker",
+        "RALPH broker-only maintenance: ghost agents detected.",
+        ["worker"],
+        { kind: "broker_maintenance" },
+      );
+
+      const result = db.readInbox("worker", { markRead: false });
+      expect(result.markedReadIds).toEqual([]);
+      expect(result.unreadCountBefore).toBe(3);
+      expect(result.unreadCountAfter).toBe(3);
+      expect(result.messages.map((item) => item.entry.readAt)).toEqual([null, null, null]);
+      expect(
+        result.messages.map(
+          (item) =>
+            classifyPinetMail({
+              source: item.message.source,
+              threadId: item.message.threadId,
+              sender: item.message.sender,
+              body: item.message.body,
+              metadata: item.message.metadata,
+            }).class,
+        ),
+      ).toEqual(["steering", "fwup", "maintenance_context"]);
     } finally {
       db.close();
     }

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -426,6 +426,8 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 | `pinet_free`     | Mark this Pinet agent idle/free for new work                                                                        |
 | `pinet_schedule` | Schedule a future wake-up for this Pinet agent                                                                      |
 
+Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet_read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
+
 ### Broker commands
 
 | Command                 | Description                                |

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -573,9 +573,10 @@ describe("isTerminalPinetStandDownMessage", () => {
 });
 
 describe("formatPinetInboxMessages", () => {
-  it("formats agent messages with reply guidance", () => {
+  it("formats agent messages as compact steering pointers with reply guidance", () => {
     const result = formatPinetInboxMessages([
       {
+        inboxId: 17,
         message: {
           threadId: "a2a:broker:worker",
           sender: "broker-id",
@@ -587,10 +588,11 @@ describe("formatPinetInboxMessages", () => {
 
     expect(result).toContain("New Pinet messages:");
     expect(result).toContain(
-      "[thread a2a:broker:worker] broker-id (Broker Bunny): Take issue #175",
+      "[thread a2a:broker:worker] [steering] broker-id (Broker Bunny): inbox_id=17 pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
-    expect(result).toContain("Reply via pinet_message.");
-    expect(result).toContain("ACK briefly, do the work");
+    expect(result).not.toContain("Take issue #175");
+    expect(result).toContain("Use pinet_read with the pointer before acting.");
+    expect(result).toContain("ACK briefly after reading, do the work");
   });
 
   it("falls back to the sender id when no senderAgent metadata exists", () => {
@@ -605,10 +607,13 @@ describe("formatPinetInboxMessages", () => {
       },
     ]);
 
-    expect(result).toContain("[thread a2a:broker:worker] broker-id: hello");
+    expect(result).toContain(
+      "[thread a2a:broker:worker] [fwup] broker-id: pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
+    );
+    expect(result).not.toContain("broker-id: hello");
   });
 
-  it("marks terminal stand-down messages as closed and suppresses reflex ack guidance", () => {
+  it("marks terminal stand-down messages as maintenance/context and suppresses reflex ack guidance", () => {
     const result = formatPinetInboxMessages([
       {
         message: {
@@ -620,15 +625,16 @@ describe("formatPinetInboxMessages", () => {
       },
     ]);
 
-    expect(result).toContain("[terminal stand-down]");
-    expect(result).toContain("Treat messages marked [terminal stand-down] as closed");
+    expect(result).toContain("[maintenance/context]");
+    expect(result).toContain("Treat [maintenance/context] messages as context-only");
     expect(result).toContain("do NOT send another acknowledgement");
+    expect(result).not.toContain("Hard stop on this thread");
     expect(result).not.toContain(
       "ACK briefly, do the work, report blockers immediately, report the outcome when done.",
     );
   });
 
-  it("keeps new-task reply guidance when a batch mixes closeout and actionable work", () => {
+  it("keeps steering reply guidance when a batch mixes context-only and actionable work", () => {
     const result = formatPinetInboxMessages([
       {
         message: {
@@ -648,9 +654,10 @@ describe("formatPinetInboxMessages", () => {
       },
     ]);
 
-    expect(result).toContain("[terminal stand-down]");
-    expect(result).toContain("Reply via pinet_message for actionable work only.");
-    expect(result).toContain("For new tasks, ACK briefly, do the work");
+    expect(result).toContain("[maintenance/context]");
+    expect(result).toContain("[steering]");
+    expect(result).toContain("Reply via pinet_message for steering/follow-up only.");
+    expect(result).toContain("For [steering], ACK briefly after reading, do the work");
     expect(result).toContain(
       "do NOT acknowledge or reply unless you have a real blocker or materially new finding",
     );

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -2,6 +2,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+  classifyPinetMail,
+  formatPinetMailClassLabel,
+} from "@gugu910/pi-broker-core/mail-classification";
+import {
   buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope,
   buildRuntimeScopeCarrier,
@@ -324,64 +328,62 @@ function getPinetSenderLabel(message: FollowerInboxEntry["message"]): string {
   return senderId || senderAgent || "unknown-agent";
 }
 
-const PINET_TERMINAL_STAND_DOWN_PATTERNS = [
-  /\bno further repl(?:y|ies) (?:are|is) needed\b/i,
-  /\bno further acknowledg(?:ement|ements) (?:are|is) needed\b/i,
-  /\bno reply is needed\b/i,
-  /\bhard stop on this [^.\n]*thread\b/i,
-  /\bno more work is needed\b/i,
-  /\bstand down\b/i,
-  /\bstay free(?:\/| and )quiet\b/i,
-  /\bstay quiet(?:\/| and )free\b/i,
-  /\bthread is already satisfied\b/i,
-  /\bunless I (?:assign|ask for) (?:a )?(?:genuinely )?new task\b/i,
-];
-
-const PINET_ACTIONABLE_TASK_PATTERNS = [
-  /\bnew [a-z-]+ lane\b/i,
-  /\bissue:\b/i,
-  /\btask:\b/i,
-  /\bworktree setup:\b/i,
-  /\bplease ACK\/work\/ask\/report\b/i,
-];
-
 export function isTerminalPinetStandDownMessage(body: string | null | undefined): boolean {
   const normalized = body?.replace(/\s+/g, " ").trim() ?? "";
   if (!normalized) {
     return false;
   }
 
-  const hasTerminalCue = PINET_TERMINAL_STAND_DOWN_PATTERNS.some((pattern) =>
-    pattern.test(normalized),
+  return (
+    classifyPinetMail({ body: normalized, metadata: { a2a: true } }).class === "maintenance_context"
   );
-  if (!hasTerminalCue) {
-    return false;
-  }
+}
 
-  return !PINET_ACTIONABLE_TASK_PATTERNS.some((pattern) => pattern.test(normalized));
+function formatPinetInboxPointer(entry: FollowerInboxEntry): string {
+  const threadId = entry.message.threadId?.trim() ?? "";
+  const parts = [
+    "pointer=pinet action=read",
+    threadId ? `args.thread_id=${threadId}` : null,
+    "args.unread_only=true",
+  ].filter((part): part is string => Boolean(part));
+  return parts.join(" ");
 }
 
 export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string {
-  const annotatedEntries = entries.map((entry) => ({
-    entry,
-    terminalStandDown: isTerminalPinetStandDownMessage(entry.message.body),
-  }));
-
-  const lines = annotatedEntries.map(({ entry, terminalStandDown }) => {
-    const threadTs = entry.message.threadId ?? "";
-    const sender = getPinetSenderLabel(entry.message);
-    const standDownSuffix = terminalStandDown ? " [terminal stand-down]" : "";
-    return `[thread ${threadTs}] ${sender}${standDownSuffix}: ${entry.message.body ?? ""}`;
+  const annotatedEntries = entries.map((entry) => {
+    const classification = classifyPinetMail({
+      source: entry.message.source,
+      threadId: entry.message.threadId,
+      sender: entry.message.sender,
+      body: entry.message.body,
+      metadata: entry.message.metadata,
+    });
+    return { entry, classification };
   });
 
-  const hasTerminalStandDown = annotatedEntries.some((entry) => entry.terminalStandDown);
-  const hasActionableWork = annotatedEntries.some((entry) => !entry.terminalStandDown);
+  const lines = annotatedEntries.map(({ entry, classification }) => {
+    const threadTs = entry.message.threadId ?? "";
+    const sender = getPinetSenderLabel(entry.message);
+    const label = formatPinetMailClassLabel(classification.class);
+    const inboxSuffix = entry.inboxId != null ? ` inbox_id=${entry.inboxId}` : "";
+    return `[thread ${threadTs}] [${label}] ${sender}:${inboxSuffix} ${formatPinetInboxPointer(entry)}`;
+  });
 
-  const guidance = hasTerminalStandDown
-    ? hasActionableWork
-      ? "Reply via pinet_message for actionable work only. For messages marked [terminal stand-down], do NOT acknowledge or reply unless you have a real blocker or materially new finding. For new tasks, ACK briefly, do the work, report blockers immediately, report the outcome when done."
-      : "Reply via pinet_message only if you have a real blocker or materially new finding. Treat messages marked [terminal stand-down] as closed; do NOT send another acknowledgement."
-    : "Reply via pinet_message. ACK briefly, do the work, report blockers immediately, report the outcome when done.";
+  const hasMaintenanceOnly = annotatedEntries.some(
+    (entry) => entry.classification.class === "maintenance_context",
+  );
+  const hasActionableWork = annotatedEntries.some(
+    (entry) => entry.classification.class === "steering",
+  );
+  const hasFollowUp = annotatedEntries.some((entry) => entry.classification.class === "fwup");
+
+  const guidance = hasMaintenanceOnly
+    ? hasActionableWork || hasFollowUp
+      ? "Use pinet_read with the pointer before acting. Reply via pinet_message for steering/follow-up only. For [maintenance/context] messages, do NOT acknowledge or reply unless you have a real blocker or materially new finding. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+      : "Use pinet_read with the pointer only if you need details. Treat [maintenance/context] messages as context-only; do NOT send another acknowledgement unless you have a real blocker or materially new finding."
+    : hasActionableWork
+      ? "Use pinet_read with the pointer before acting. Reply via pinet_message. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+      : "Use pinet_read with the pointer before acting. Reply via pinet_message if follow-up is needed.";
 
   return `New Pinet messages:\n${lines.join("\n")}\n\n${guidance}`;
 }

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -179,7 +179,10 @@ describe("registerPinetTools", () => {
     );
     expect(result.content[0]?.text).toContain("Unread before: 2; unread after: 1.");
     expect(result.content[0]?.text).toContain(
-      "- [agent/a2a:broker:worker #44] broker: please inspect #594",
+      "- [steering] [agent/a2a:broker:worker #44] broker: please inspect #594",
+    );
+    expect(result.content[0]?.text).toContain(
+      "pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
     expect(result.content[0]?.text).toContain("Marked read: 31.");
     expect(result.details.markedReadIds).toEqual([31]);

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -1,4 +1,8 @@
 import os from "node:os";
+import {
+  classifyPinetMail,
+  formatPinetMailClassLabel,
+} from "@gugu910/pi-broker-core/mail-classification";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import {
@@ -286,8 +290,16 @@ function formatPinetReadResult(result: PinetReadResult, options: PinetReadOption
   if (result.messages.length > 0) {
     lines.push("");
     for (const item of result.messages) {
+      const classification = classifyPinetMail({
+        source: item.message.source,
+        threadId: item.message.threadId,
+        sender: item.message.sender,
+        body: item.message.body,
+        metadata: item.message.metadata,
+      });
+      const label = formatPinetMailClassLabel(classification.class);
       lines.push(
-        `- [${item.message.source}/${item.message.threadId} #${item.message.id}] ${item.message.sender}: ${item.message.body}`,
+        `- [${label}] [${item.message.source}/${item.message.threadId} #${item.message.id}] ${item.message.sender}: ${item.message.body}`,
       );
     }
   }
@@ -296,7 +308,7 @@ function formatPinetReadResult(result: PinetReadResult, options: PinetReadOption
     lines.push("", "Unread thread pointers:");
     for (const thread of result.unreadThreads.slice(0, 10)) {
       lines.push(
-        `- ${thread.threadId} (${thread.source}${thread.channel ? `/${thread.channel}` : ""}): ${thread.unreadCount} unread; latest #${thread.latestMessageId}`,
+        `- ${thread.threadId} (${thread.source}${thread.channel ? `/${thread.channel}` : ""}): ${thread.unreadCount} unread; latest #${thread.latestMessageId}; pointer=pinet action=read args.thread_id=${thread.threadId} args.unread_only=true`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- add a narrow durable Pinet mail classifier for `steering`, `fwup`, and `maintenance_context`
- label compact inbound Pinet notifications with classification and `pinet_read` pointer metadata instead of delivering full durable message bodies as runtime context
- label `pinet_read` output with classifications and keep delivery/read/ack state separate from classification

## Scope / boundaries
- preserves Slack CLI-only outbound/operator boundary
- does not broaden Slack agent tool surfaces
- avoids #620/#600 cleanup work

## Validation
- `pnpm --filter @gugu910/pi-broker-core test -- mail-classification.test.ts schema.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts pinet-tools.test.ts`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook completed successfully during `git push`

Closes #606
Related #594
