### PR TITLE
slack-bridge: enforce inbox thread affinity

### DIFF
--- a/broker-core/router.ts
+++ b/broker-core/router.ts
@@ -250,7 +250,7 @@ export class MessageRouter {
     }
 
     const agents = this.db.getAgents();
-    let thread = this.db.getThread(msg.threadId);
+    const thread = this.db.getThread(msg.threadId);
     const explicitDirective = findExplicitThreadDirective(msg.text, agents);
 
     if (explicitDirective) {
@@ -287,14 +287,6 @@ export class MessageRouter {
         return { action: "unrouted" };
       }
 
-      const hintedOwner = resolveAgentFromThreadOwnerHint(msg.metadata, agents);
-      if (hintedOwner && isRoutableOwner(hintedOwner)) {
-        if (thread.ownerAgent !== hintedOwner.id) {
-          this.db.updateThread(msg.threadId, { ownerAgent: hintedOwner.id, channel: msg.channel });
-        }
-        return { action: "deliver", agentId: hintedOwner.id };
-      }
-
       if (thread.ownerAgent) {
         const owner = resolveRoutableThreadOwner(this.db, thread.ownerAgent);
         if (owner) {
@@ -304,11 +296,18 @@ export class MessageRouter {
           return { action: "deliver", agentId: owner.id };
         }
 
-        // Owner is gone or no longer routable — clear ownership so the thread can
-        // be explicitly rebound, but do not leak a known-thread reply to another
-        // worker through generic fallback routing.
+        // Owner is gone or no longer routable — clear ownership and stop. Known
+        // Slack-thread replies must not leak to another worker through latest
+        // bot-message owner hints or channel-assignment fallback; a human must
+        // explicitly retarget the thread if the owner is unavailable.
         this.db.updateThread(msg.threadId, { ownerAgent: null });
-        thread = this.db.getThread(msg.threadId);
+        return { action: "unrouted" };
+      }
+
+      const hintedOwner = resolveAgentFromThreadOwnerHint(msg.metadata, agents);
+      if (hintedOwner && isRoutableOwner(hintedOwner)) {
+        this.db.updateThread(msg.threadId, { ownerAgent: hintedOwner.id, channel: msg.channel });
+        return { action: "deliver", agentId: hintedOwner.id };
       }
 
       const mentioned = findAgentMention(msg.text, agents);

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -332,6 +332,36 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("drops stale Slack backlog assignments when ownership changes before delivery", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      const backlog = db.queueUnroutedMessage({
+        source: "slack",
+        threadId: "123.456",
+        channel: "C123",
+        userId: "U1",
+        userName: "User One",
+        text: "hello from backlog",
+        timestamp: "123.456",
+        metadata: { channel: "C123", timestamp: "123.456" },
+      });
+      const assigned = db.assignBacklogEntry(backlog.id, "agent-1");
+      expect(assigned).toMatchObject({ status: "assigned", assignedAgentId: "agent-1" });
+
+      db.updateThread("123.456", { ownerAgent: "agent-2" });
+
+      expect(db.getInbox("agent-1")).toHaveLength(0);
+      const read = db.readInbox("agent-1", { markRead: false });
+      expect(read.messages).toEqual([]);
+      expect(read.unreadCountBefore).toBe(0);
+      expect(read.unreadThreads).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("does not re-enqueue replayed Slack messages after delivery", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -361,6 +361,75 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("drops stale Slack inbox rows when thread ownership changed before delivery", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-a", "slack", "C123", "agent-a");
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "new reply in thread A",
+        timestamp: "123.456",
+      });
+      db.queueMessage("agent-b", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "new reply in thread A fanout",
+        timestamp: "123.457",
+      });
+
+      expect(db.getInbox("agent-a")).toHaveLength(1);
+      expect(db.getInbox("agent-b")).toHaveLength(0);
+      expect(db.getUnreadInboxCount("agent-b")).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("revalidates stale queued Slack rows on read when the owner changes", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-a", "slack", "C123", "agent-a");
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "reply queued before retarget",
+        timestamp: "123.789",
+      });
+      db.updateThread("thread-a", { ownerAgent: "agent-b" });
+
+      const read = db.readInbox("agent-a", { markRead: false });
+
+      expect(read.messages).toEqual([]);
+      expect(read.unreadCountBefore).toBe(0);
+      expect(read.unreadThreads).toEqual([]);
+      expect(db.getInbox("agent-a")).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not apply Slack thread-affinity pruning to agent-to-agent inbox rows", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("a2a:one:two", "agent", "", "one");
+      db.insertMessage("a2a:one:two", "agent", "inbound", "one", "same", ["two"]);
+
+      expect(db.getInbox("two")).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
   it("does not deduplicate messages without a transport identity", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -1525,6 +1525,27 @@ export class BrokerDB implements BrokerDBInterface {
       if (!row) return null;
 
       const now = new Date().toISOString();
+      const message = db
+        .prepare("SELECT source, direction, metadata FROM messages WHERE id = ?")
+        .get(row.message_id) as
+        | { source: string; direction: string; metadata: string | null }
+        | undefined;
+      if (message?.source === "slack" && message.direction === "inbound") {
+        let metadata: Record<string, unknown> = {};
+        if (message.metadata) {
+          try {
+            metadata = JSON.parse(message.metadata) as Record<string, unknown>;
+          } catch {
+            metadata = {};
+          }
+        }
+        metadata.threadAffinityOwnerAgentId = agentId;
+        db.prepare("UPDATE messages SET metadata = ? WHERE id = ?").run(
+          JSON.stringify(metadata),
+          row.message_id,
+        );
+      }
+
       db.prepare(
         `INSERT OR IGNORE INTO inbox (agent_id, message_id, delivered, created_at)
          VALUES (?, ?, 0, ?)`,

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -2029,12 +2029,17 @@ export class BrokerDB implements BrokerDBInterface {
   // ─── Interface-compatible queueMessage (single agent) ──
 
   queueMessage(agentId: string, message: InboundMessage): void {
+    const threadOwner =
+      message.source === "slack" && message.threadId
+        ? this.getThread(message.threadId)?.ownerAgent
+        : null;
     const metadata: Record<string, unknown> = {
       ...message.metadata,
       channel: message.channel,
       userName: message.userName,
       userId: message.userId,
       timestamp: message.timestamp,
+      ...(threadOwner ? { threadAffinityOwnerAgentId: threadOwner } : {}),
       ...(message.isChannelMention ? { isChannelMention: true } : {}),
       ...(message.scope ? { scope: message.scope } : {}),
     };
@@ -2172,7 +2177,60 @@ export class BrokerDB implements BrokerDBInterface {
     return row ? rowToBrokerMessage(row) : null;
   }
 
+  private dropStaleSlackInboxRows(agentId: string): number {
+    const db = this.getDb();
+    const rows = db
+      .prepare(
+        `SELECT i.id AS inbox_id,
+                i.agent_id AS agent_id,
+                m.metadata AS metadata,
+                t.owner_agent AS owner_agent
+         FROM inbox i
+         JOIN messages m ON m.id = i.message_id
+         JOIN threads t ON t.thread_id = m.thread_id
+         WHERE i.agent_id = ?
+           AND (i.delivered = 0 OR i.read_at IS NULL)
+           AND m.source = 'slack'
+           AND m.direction = 'inbound'
+           AND t.owner_agent IS NOT NULL`,
+      )
+      .all(agentId) as Array<{
+      inbox_id: number;
+      agent_id: string;
+      metadata: string | null;
+      owner_agent: string;
+    }>;
+
+    const staleIds: number[] = [];
+    for (const row of rows) {
+      if (!row.metadata) continue;
+      let metadata: Record<string, unknown>;
+      try {
+        metadata = JSON.parse(row.metadata) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const affinityOwner = metadata.threadAffinityOwnerAgentId;
+      if (typeof affinityOwner !== "string" || affinityOwner.length === 0) continue;
+      if (row.agent_id !== row.owner_agent || affinityOwner !== row.owner_agent) {
+        staleIds.push(row.inbox_id);
+      }
+    }
+
+    if (staleIds.length === 0) return 0;
+
+    const now = new Date().toISOString();
+    const stmt = db.prepare(
+      "UPDATE inbox SET delivered = 1, read_at = COALESCE(read_at, ?) WHERE id = ? AND agent_id = ?",
+    );
+    for (const staleId of staleIds) {
+      stmt.run(now, staleId, agentId);
+    }
+    return staleIds.length;
+  }
+
   getInbox(agentId: string, limit = 50): { entry: InboxEntry; message: BrokerMessage }[] {
+    this.dropStaleSlackInboxRows(agentId);
     const db = this.getDb();
 
     const rows = db
@@ -2234,6 +2292,7 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   readInbox(agentId: string, options: InboxReadOptions = {}): InboxReadResult {
+    this.dropStaleSlackInboxRows(agentId);
     const db = this.getDb();
     const unreadOnly = options.unreadOnly ?? true;
     const markRead = options.markRead ?? true;
@@ -2335,6 +2394,7 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   getUnreadInboxCount(agentId: string): number {
+    this.dropStaleSlackInboxRows(agentId);
     const db = this.getDb();
     const row = db
       .prepare("SELECT COUNT(*) AS count FROM inbox WHERE agent_id = ? AND read_at IS NULL")
@@ -2343,6 +2403,7 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   getUnreadThreadSummary(agentId: string, limit = 20): InboxThreadUnreadSummary[] {
+    this.dropStaleSlackInboxRows(agentId);
     const db = this.getDb();
     const clampedLimit = Math.min(Math.max(Math.trunc(limit), 1), 100);
     const rows = db

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -274,11 +274,32 @@ describe("MessageRouter — route", () => {
     expect(decision).toEqual({ action: "deliver", agentId: "a1" });
   });
 
-  it("prefers the canonical Slack thread owner hint over a stale competing owner for generic in-thread follow-ups", () => {
+  it("keeps a known Slack thread on its broker owner instead of latest bot owner hint", () => {
     const hippo = makeAgent({ id: "hippo", name: "Pixel Lime Hippo", stableId: "stable-hippo" });
     const cobra = makeAgent({ id: "cobra", name: "Aurora Pearl Cobra", stableId: "stable-cobra" });
     db.agents = [hippo, cobra];
     db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: "cobra" }));
+
+    const decision = router.route(
+      makeMessage({
+        threadId: "t-100",
+        text: "also check for hardcoded routes pls",
+        metadata: {
+          threadOwnerAgentOwner: "owner:99b0f2b5e8a7874e",
+          threadOwnerAgentName: "Pixel Lime Hippo",
+        },
+      }),
+    );
+
+    expect(decision).toEqual({ action: "deliver", agentId: "cobra" });
+    expect(db.threads.get("t-100")?.ownerAgent).toBe("cobra");
+  });
+
+  it("uses a Slack thread owner hint only for an existing unowned thread", () => {
+    const hippo = makeAgent({ id: "hippo", name: "Pixel Lime Hippo", stableId: "stable-hippo" });
+    const cobra = makeAgent({ id: "cobra", name: "Aurora Pearl Cobra", stableId: "stable-cobra" });
+    db.agents = [hippo, cobra];
+    db.threads.set("t-100", makeThread({ threadId: "t-100", ownerAgent: null }));
 
     const decision = router.route(
       makeMessage({
@@ -468,7 +489,7 @@ describe("MessageRouter — route", () => {
 
     const decision = router.route(makeMessage({ threadId: "t-100" }));
 
-    // Owner is gone — clears ownership and falls through to unrouted
+    // Owner is gone — clears ownership and stops instead of using generic fallback routing.
     expect(decision).toEqual({ action: "unrouted" });
     // Ownership should be cleared
     expect(db.threads.get("t-100")?.ownerAgent).toBeNull();


### PR DESCRIPTION
## Summary
- keep known Slack threads pinned to the broker-owned agent instead of letting the latest bot metadata steal ownership
- stamp queued Slack inbox rows with the owner at queue time and prune stale/wrong-owner rows before poll/read/count delivery
- add focused regression tests for wrong-recipient fanout, stale queued ownership changes, and owner-hint routing behavior

## Validation
- `pnpm --filter @gugu910/pi-broker-core test -- schema.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker/router.test.ts broker/helpers.test.ts`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- pre-push hook on `git push` passed

Closes #636
