### PR TITLE
pinet: persist broker Slack inbound mail

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -422,6 +422,49 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("stores delivered Slack inbox rows as unread durable mail without pending runtime delivery", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-a", "slack", "C123", "broker");
+      const first = db.queueDeliveredMessage("broker", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "durable self-handled Slack mail",
+        timestamp: "123.456",
+      });
+      const replay = db.queueDeliveredMessage("broker", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "durable self-handled Slack mail replay",
+        timestamp: "123.456",
+      });
+
+      expect(first.freshDelivery).toBe(true);
+      expect(replay.freshDelivery).toBe(false);
+      expect(replay.message.id).toBe(first.message.id);
+      expect(db.getInbox("broker")).toHaveLength(0);
+      expect(db.getUnreadInboxCount("broker")).toBe(1);
+
+      const read = db.readInbox("broker", { markRead: false });
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0].message.id).toBe(first.message.id);
+      expect(read.messages[0].entry.delivered).toBe(true);
+      expect(read.messages[0].message.metadata).toMatchObject({
+        channel: "C123",
+        userId: "U1",
+        timestamp: "123.456",
+        threadAffinityOwnerAgentId: "broker",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("revalidates stale queued Slack rows on read when the owner changes", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -10,6 +10,7 @@ import type {
   InboxReadOptions,
   InboxReadResult,
   InboxThreadUnreadSummary,
+  DeliveredInboundMessageResult,
   BacklogEntry,
   BrokerDBInterface,
   InboundMessage,
@@ -2050,11 +2051,76 @@ export class BrokerDB implements BrokerDBInterface {
   // ─── Interface-compatible queueMessage (single agent) ──
 
   queueMessage(agentId: string, message: InboundMessage): void {
+    this.insertMessage(
+      message.threadId,
+      message.source,
+      "inbound",
+      message.userId,
+      message.text,
+      [agentId],
+      this.buildInboundMessageMetadata(message),
+    );
+  }
+
+  queueDeliveredMessage(agentId: string, message: InboundMessage): DeliveredInboundMessageResult {
+    return this.withTransaction(() => {
+      const db = this.getDb();
+      const brokerMessage = this.insertMessage(
+        message.threadId,
+        message.source,
+        "inbound",
+        message.userId,
+        message.text,
+        [],
+        this.buildInboundMessageMetadata(message),
+      );
+
+      const existing = db
+        .prepare(
+          "SELECT id FROM inbox WHERE agent_id = ? AND message_id = ? ORDER BY id ASC LIMIT 1",
+        )
+        .get(agentId, brokerMessage.id) as { id: number } | undefined;
+      if (existing) {
+        db.prepare("UPDATE inbox SET delivered = 1 WHERE id = ? AND agent_id = ?").run(
+          existing.id,
+          agentId,
+        );
+        const entry = this.getInboxEntryById(existing.id, agentId);
+        if (!entry) {
+          throw new Error("Failed to read delivered inbox entry");
+        }
+        return { entry, message: brokerMessage, freshDelivery: false };
+      }
+
+      const now = new Date().toISOString();
+      const result = db
+        .prepare(
+          `INSERT INTO inbox (agent_id, message_id, delivered, created_at)
+           VALUES (?, ?, 1, ?)`,
+        )
+        .run(agentId, brokerMessage.id, now);
+      const inboxId = Number(result.lastInsertRowid);
+      return {
+        entry: {
+          id: inboxId,
+          agentId,
+          messageId: brokerMessage.id,
+          delivered: true,
+          readAt: null,
+          createdAt: now,
+        },
+        message: brokerMessage,
+        freshDelivery: true,
+      };
+    });
+  }
+
+  private buildInboundMessageMetadata(message: InboundMessage): Record<string, unknown> {
     const threadOwner =
       message.source === "slack" && message.threadId
         ? this.getThread(message.threadId)?.ownerAgent
         : null;
-    const metadata: Record<string, unknown> = {
+    return {
       ...message.metadata,
       channel: message.channel,
       userName: message.userName,
@@ -2064,15 +2130,33 @@ export class BrokerDB implements BrokerDBInterface {
       ...(message.isChannelMention ? { isChannelMention: true } : {}),
       ...(message.scope ? { scope: message.scope } : {}),
     };
-    this.insertMessage(
-      message.threadId,
-      message.source,
-      "inbound",
-      message.userId,
-      message.text,
-      [agentId],
-      metadata,
-    );
+  }
+
+  private getInboxEntryById(id: number, agentId: string): InboxEntry | null {
+    const row = this.getDb()
+      .prepare(
+        "SELECT id, agent_id, message_id, delivered, read_at, created_at FROM inbox WHERE id = ? AND agent_id = ?",
+      )
+      .get(id, agentId) as
+      | {
+          id: number;
+          agent_id: string;
+          message_id: number;
+          delivered: number;
+          read_at: string | null;
+          created_at: string;
+        }
+      | undefined;
+    return row
+      ? {
+          id: row.id,
+          agentId: row.agent_id,
+          messageId: row.message_id,
+          delivered: row.delivered === 1,
+          readAt: row.read_at,
+          createdAt: row.created_at,
+        }
+      : null;
   }
 
   // ─── Detailed message insert (used by socket server) ──

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -76,6 +76,12 @@ export interface InboxReadResult {
   markedReadIds: number[];
 }
 
+export interface DeliveredInboundMessageResult {
+  entry: InboxEntry;
+  message: BrokerMessage;
+  freshDelivery: boolean;
+}
+
 export interface ChannelAssignment {
   channel: string;
   agentId: string;

--- a/slack-bridge/broker-inbound-persistence.test.ts
+++ b/slack-bridge/broker-inbound-persistence.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DeliveredInboundMessageResult, InboundMessage } from "@gugu910/pi-broker-core/types";
+import {
+  buildPersistedInboundNotificationText,
+  buildPinetReadPointer,
+  persistDeliveredInboundMessage,
+  type DeliveredInboundPersistenceStore,
+} from "./broker-inbound-persistence.js";
+
+const message: InboundMessage = {
+  source: "slack",
+  threadId: "123.456",
+  channel: "C123",
+  userId: "U1",
+  text: "hello",
+  timestamp: "123.456",
+};
+
+const delivered: DeliveredInboundMessageResult = {
+  entry: {
+    id: 7,
+    agentId: "broker",
+    messageId: 42,
+    delivered: true,
+    readAt: null,
+    createdAt: "2026-04-28T00:00:00.000Z",
+  },
+  message: {
+    id: 42,
+    threadId: "123.456",
+    source: "slack",
+    direction: "inbound",
+    sender: "U1",
+    body: "hello",
+    metadata: { channel: "C123", timestamp: "123.456" },
+    createdAt: "2026-04-28T00:00:00.000Z",
+    externalId: "C123:123.456",
+    externalTs: "123.456",
+  },
+  freshDelivery: true,
+};
+
+describe("broker inbound persistence", () => {
+  it("builds compact pinet_read pointers for durable inbound mail", () => {
+    expect(buildPinetReadPointer("123.456")).toBe(
+      "pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
+    );
+    expect(buildPersistedInboundNotificationText(delivered.message)).toContain(
+      "Durable slack mail stored in SQLite as message #42.",
+    );
+    expect(buildPersistedInboundNotificationText(delivered.message)).toContain(
+      "pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
+    );
+  });
+
+  it("persists delivered inbound mail through the store before notification", () => {
+    const store: DeliveredInboundPersistenceStore = {
+      queueDeliveredMessage: vi.fn(() => delivered),
+    };
+
+    const result = persistDeliveredInboundMessage(store, "broker", message);
+
+    expect(store.queueDeliveredMessage).toHaveBeenCalledWith("broker", message);
+    expect(result.result).toBe(delivered);
+    expect(result.notificationText).toContain("Use pinet_read with the pointer before acting.");
+  });
+});

--- a/slack-bridge/broker-inbound-persistence.ts
+++ b/slack-bridge/broker-inbound-persistence.ts
@@ -1,0 +1,44 @@
+import type {
+  BrokerMessage,
+  DeliveredInboundMessageResult,
+  InboundMessage,
+} from "@gugu910/pi-broker-core/types";
+
+export interface DeliveredInboundPersistenceStore {
+  queueDeliveredMessage(agentId: string, message: InboundMessage): DeliveredInboundMessageResult;
+}
+
+export interface PersistedInboundNotification {
+  result: DeliveredInboundMessageResult;
+  notificationText: string;
+}
+
+export function buildPinetReadPointer(threadId: string): string {
+  const trimmed = threadId.trim();
+  const parts = [
+    "pointer=pinet action=read",
+    trimmed ? `args.thread_id=${trimmed}` : null,
+    "args.unread_only=true",
+  ].filter((part): part is string => Boolean(part));
+  return parts.join(" ");
+}
+
+export function buildPersistedInboundNotificationText(message: BrokerMessage): string {
+  return [
+    `Durable ${message.source} mail stored in SQLite as message #${message.id}.`,
+    buildPinetReadPointer(message.threadId),
+    "Use pinet_read with the pointer before acting.",
+  ].join(" ");
+}
+
+export function persistDeliveredInboundMessage(
+  store: DeliveredInboundPersistenceStore,
+  agentId: string,
+  message: InboundMessage,
+): PersistedInboundNotification {
+  const result = store.queueDeliveredMessage(agentId, message);
+  return {
+    result,
+    notificationText: buildPersistedInboundNotificationText(result.message),
+  };
+}

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -24,6 +24,7 @@ import { createCommandRegistrationRuntime } from "./command-registration-runtime
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
 import { createSlackRuntimeAccess } from "./slack-runtime-access.js";
 import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
+import { persistDeliveredInboundMessage } from "./broker-inbound-persistence.js";
 import {
   createIMessageAdapter,
   detectIMessageMvpEnvironment,
@@ -703,13 +704,23 @@ export default function (pi: ExtensionAPI) {
         }
 
         if (decision.action === "deliver" || decision.action === "unrouted") {
+          const persisted =
+            routedMessage.source === "slack" && routedMessage.threadId
+              ? persistDeliveredInboundMessage(broker.db, selfId, routedMessage)
+              : null;
+
+          if (persisted && !persisted.result.freshDelivery) {
+            return;
+          }
+
           inbox.push({
             channel: routedMessage.channel,
             threadTs: routedMessage.threadId,
             userId: routedMessage.userId,
-            text: routedMessage.text,
+            text: persisted?.notificationText ?? routedMessage.text,
             timestamp: routedMessage.timestamp,
             metadata: routedMessage.metadata ?? null,
+            ...(persisted ? { brokerInboxId: persisted.result.entry.id } : {}),
             ...(routedMessage.scope ? { scope: routedMessage.scope } : {}),
           });
           updateBadge();


### PR DESCRIPTION
## Summary
- add `queueDeliveredMessage()` so broker/self-handled inbound Slack events are stored in SQLite as delivered-but-unread durable mail
- persist broker-handled Slack inbound before local runtime notification and suppress duplicate replay notifications
- make the local Slack notification a compact `pinet_read` pointer instead of the durable context payload

## Stack context
- Refs #594
- Advances #605 / #608 from current `main` after #635 and #638
- Keeps Slack outbound/operator surfaces untouched; Pinet remains the mail/read surface

## Validation
- `pnpm --filter @gugu910/pi-broker-core test -- schema.test.ts`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker-inbound-persistence.test.ts pinet-tools.test.ts broker/helpers.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook on `git push` passed
