### PR TITLE
pinet: reclassify arrow-up reaction mail

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -520,6 +520,177 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("reclassifies the original Slack message as steering for linked arrow-up reaction mail", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("111.222", "slack", "C123", "agent-a");
+      const original = db.insertMessage(
+        "111.222",
+        "slack",
+        "inbound",
+        "U_TARGET",
+        "Please keep an eye on this later.",
+        ["agent-a"],
+        { channel: "C123", timestamp: "111.333", userId: "U_TARGET" },
+      );
+
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "111.222",
+        channel: "C123",
+        userId: "U_REACTOR",
+        userName: "Alice",
+        text: "Reaction trigger from Slack: arrow-up",
+        timestamp: "999.000",
+        metadata: {
+          reactionTrigger: true,
+          reactionName: "arrow_up",
+          reactionAction: "steer",
+          reactorUserId: "U_REACTOR",
+          reactorName: "Alice",
+          reactionEventTs: "999.000",
+          referencedSource: "slack",
+          referencedChannel: "C123",
+          referencedThreadTs: "111.222",
+          referencedMessageTs: "111.333",
+          referencedExternalId: "C123:111.333",
+        },
+      });
+
+      const read = db.readInbox("agent-a", { markRead: false });
+      const reclassified = read.messages.find((item) => item.message.id === original.id)?.message;
+      expect(reclassified?.metadata).toMatchObject({
+        pinet_mail_class: "steering",
+        pinet_mail_class_reason: "slack_reaction_arrow_up",
+      });
+      expect(reclassified?.metadata?.pinet_mail_class_audit).toEqual([
+        expect.objectContaining({
+          class: "steering",
+          reason: "slack_reaction_arrow_up",
+          reactionName: "arrow_up",
+          reactorUserId: "U_REACTOR",
+          reactorName: "Alice",
+          reactionEventTs: "999.000",
+          referencedThreadId: "111.222",
+          referencedMessageTs: "111.333",
+        }),
+      ]);
+      expect(
+        classifyPinetMail({
+          source: reclassified?.source,
+          threadId: reclassified?.threadId,
+          sender: reclassified?.sender,
+          body: reclassified?.body,
+          metadata: reclassified?.metadata,
+        }).class,
+      ).toBe("steering");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("reclassifies delivered durable Slack mail from arrow-up reactions", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("222.000", "slack", "C999", "broker");
+      const original = db.queueDeliveredMessage("broker", {
+        source: "slack",
+        threadId: "222.000",
+        channel: "C999",
+        userId: "U_TARGET",
+        text: "Escalate this only if someone reacts upward.",
+        timestamp: "222.111",
+      });
+
+      const reaction = db.queueDeliveredMessage("broker", {
+        source: "slack",
+        threadId: "222.000",
+        channel: "C999",
+        userId: "U_REACTOR",
+        userName: "Alice",
+        text: "Reaction trigger from Slack: arrow-up",
+        timestamp: "999.111",
+        metadata: {
+          reactionTrigger: true,
+          reactionName: "arrow_up",
+          reactionAction: "steer",
+          reactorUserId: "U_REACTOR",
+          referencedSource: "slack",
+          referencedExternalId: "C999:222.111",
+        },
+      });
+
+      expect(reaction.freshDelivery).toBe(true);
+      const read = db.readInbox("broker", { markRead: false });
+      const reclassified = read.messages.find(
+        (item) => item.message.id === original.message.id,
+      )?.message;
+      expect(reclassified?.metadata).toMatchObject({ pinet_mail_class: "steering" });
+      expect(
+        classifyPinetMail({
+          source: reclassified?.source,
+          threadId: reclassified?.threadId,
+          sender: reclassified?.sender,
+          body: reclassified?.body,
+          metadata: reclassified?.metadata,
+        }).class,
+      ).toBe("steering");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not reclassify referenced Slack messages for non-arrow reaction mail", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("111.222", "slack", "C123", "agent-a");
+      const original = db.insertMessage(
+        "111.222",
+        "slack",
+        "inbound",
+        "U_TARGET",
+        "Ordinary follow-up context.",
+        ["agent-a"],
+        { channel: "C123", timestamp: "111.333", userId: "U_TARGET" },
+      );
+
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "111.222",
+        channel: "C123",
+        userId: "U_REACTOR",
+        userName: "Alice",
+        text: "Reaction trigger from Slack: review",
+        timestamp: "999.000",
+        metadata: {
+          reactionTrigger: true,
+          reactionName: "eyes",
+          reactionAction: "review",
+          referencedSource: "slack",
+          referencedExternalId: "C123:111.333",
+        },
+      });
+
+      const read = db.readInbox("agent-a", { markRead: false });
+      const unchanged = read.messages.find((item) => item.message.id === original.id)?.message;
+      expect(unchanged?.metadata).not.toHaveProperty("pinet_mail_class");
+      expect(
+        classifyPinetMail({
+          source: unchanged?.source,
+          threadId: unchanged?.threadId,
+          sender: unchanged?.sender,
+          body: unchanged?.body,
+          metadata: unchanged?.metadata,
+        }).class,
+      ).toBe("fwup");
+    } finally {
+      db.close();
+    }
+  });
+
   it("keeps mail classification derivable from durable inbox records without changing read state", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getDefaultDbPath } from "./paths.js";
+import type { PinetMailClass } from "./mail-classification.js";
 import type {
   AgentInfo,
   ThreadInfo,
@@ -194,6 +195,36 @@ function deriveMessageSyncIdentity(
   }
 
   return { externalId: null, externalTs: explicitExternalTs };
+}
+
+function parseJsonMetadata(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function isArrowUpReactionName(value: string | null): boolean {
+  return value === "arrow_up" || value === "⬆" || value === "⬆️";
+}
+
+function appendMetadataAudit(
+  metadata: Record<string, unknown>,
+  key: string,
+  audit: Record<string, unknown>,
+): void {
+  const existing = Array.isArray(metadata[key])
+    ? (metadata[key] as unknown[]).filter(
+        (item): item is Record<string, unknown> =>
+          item !== null && typeof item === "object" && !Array.isArray(item),
+      )
+    : [];
+  metadata[key] = [...existing.slice(-19), audit];
 }
 
 function rowToBrokerMessage(row: {
@@ -2051,15 +2082,18 @@ export class BrokerDB implements BrokerDBInterface {
   // ─── Interface-compatible queueMessage (single agent) ──
 
   queueMessage(agentId: string, message: InboundMessage): void {
-    this.insertMessage(
-      message.threadId,
-      message.source,
-      "inbound",
-      message.userId,
-      message.text,
-      [agentId],
-      this.buildInboundMessageMetadata(message),
-    );
+    this.withTransaction(() => {
+      this.insertMessage(
+        message.threadId,
+        message.source,
+        "inbound",
+        message.userId,
+        message.text,
+        [agentId],
+        this.buildInboundMessageMetadata(message),
+      );
+      this.reclassifyReferencedMessageFromReaction(message);
+    });
   }
 
   queueDeliveredMessage(agentId: string, message: InboundMessage): DeliveredInboundMessageResult {
@@ -2074,6 +2108,7 @@ export class BrokerDB implements BrokerDBInterface {
         [],
         this.buildInboundMessageMetadata(message),
       );
+      this.reclassifyReferencedMessageFromReaction(message);
 
       const existing = db
         .prepare(
@@ -2130,6 +2165,75 @@ export class BrokerDB implements BrokerDBInterface {
       ...(message.isChannelMention ? { isChannelMention: true } : {}),
       ...(message.scope ? { scope: message.scope } : {}),
     };
+  }
+
+  private reclassifyReferencedMessageFromReaction(message: InboundMessage): void {
+    const metadata = message.metadata;
+    if (!metadata) return;
+
+    const reactionName = getStringMetadataValue(metadata, ["reactionName", "reaction_name"]);
+    if (!isArrowUpReactionName(reactionName)) return;
+
+    const referencedSource =
+      getStringMetadataValue(metadata, ["referencedSource", "referenced_source"]) ?? message.source;
+    const referencedExternalId = getStringMetadataValue(metadata, [
+      "referencedExternalId",
+      "referenced_external_id",
+    ]);
+    const referencedChannel = getStringMetadataValue(metadata, [
+      "referencedChannel",
+      "referenced_channel",
+    ]);
+    const referencedMessageTs = getStringMetadataValue(metadata, [
+      "referencedMessageTs",
+      "referenced_message_ts",
+      "messageTs",
+      "message_ts",
+    ]);
+    const externalId =
+      referencedExternalId ??
+      (referencedSource === "slack" && referencedChannel && referencedMessageTs
+        ? `${referencedChannel}:${referencedMessageTs}`
+        : null);
+    if (!externalId) return;
+
+    this.reclassifyMessageByExternalId(referencedSource, externalId, "steering", {
+      reason: "slack_reaction_arrow_up",
+      reactionName,
+      reactorUserId: getStringMetadataValue(metadata, ["reactorUserId", "reactor_user_id"]),
+      reactorName: getStringMetadataValue(metadata, ["reactorName", "reactor_name"]),
+      reactionEventTs: getStringMetadataValue(metadata, ["reactionEventTs", "reaction_event_ts"]),
+      referencedThreadId: message.threadId,
+      referencedMessageTs,
+    });
+  }
+
+  reclassifyMessageByExternalId(
+    source: string,
+    externalId: string,
+    mailClass: PinetMailClass,
+    audit: Record<string, unknown>,
+  ): BrokerMessage | null {
+    const db = this.getDb();
+    const row = db
+      .prepare("SELECT id, metadata FROM messages WHERE source = ? AND external_id = ?")
+      .get(source, externalId) as { id: number; metadata: string | null } | undefined;
+    if (!row) return null;
+
+    const metadata = parseJsonMetadata(row.metadata);
+    metadata.pinet_mail_class = mailClass;
+    metadata.pinet_mail_class_reason = audit.reason ?? "manual_reclassification";
+    appendMetadataAudit(metadata, "pinet_mail_class_audit", {
+      ...audit,
+      class: mailClass,
+      at: new Date().toISOString(),
+    });
+
+    db.prepare("UPDATE messages SET metadata = ? WHERE id = ?").run(
+      JSON.stringify(metadata),
+      row.id,
+    );
+    return this.getMessageById(row.id);
   }
 
   private getInboxEntryById(id: number, agentId: string): InboxEntry | null {

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1427,6 +1427,21 @@ describe("SlackAdapter — reaction triggers", () => {
         userId: "U_REACTOR",
         userName: "Alice",
         timestamp: "999.000",
+        metadata: expect.objectContaining({
+          reactionTrigger: true,
+          reactionName: "eyes",
+          reactionAction: "review",
+          reactorUserId: "U_REACTOR",
+          reactorName: "Alice",
+          reactionEventTs: "999.000",
+          referencedSource: "slack",
+          referencedChannel: "C123",
+          referencedThreadTs: "111.222",
+          referencedMessageTs: "111.333",
+          referencedExternalId: "C123:111.333",
+          reactedMessageAuthor: "Bob",
+          reactedMessageAuthorId: "U_TARGET",
+        }),
       }),
     );
     expect(handler.mock.calls[0]?.[0]?.text).toContain("Reaction trigger from Slack:");

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -342,6 +342,7 @@ export class SlackAdapter implements MessageAdapter {
           : "(no text)";
 
       const threadInfo = this.threads.get(threadTs);
+      const reactionEventTs = (evt.event_ts as string | undefined) ?? item.ts;
       this.inboundHandler?.({
         source: "slack",
         threadId: threadTs,
@@ -358,7 +359,22 @@ export class SlackAdapter implements MessageAdapter {
           reactedMessageText,
           reactedMessageAuthor,
         }),
-        timestamp: (evt.event_ts as string) ?? item.ts,
+        timestamp: reactionEventTs,
+        metadata: {
+          reactionTrigger: true,
+          reactionName,
+          reactionAction: command.action,
+          reactorUserId: userId,
+          reactorName,
+          reactionEventTs,
+          referencedSource: "slack",
+          referencedChannel: item.channel,
+          referencedThreadTs: threadTs,
+          referencedMessageTs: item.ts,
+          referencedExternalId: `${item.channel}:${item.ts}`,
+          reactedMessageAuthor,
+          ...(reactedMessageAuthorId ? { reactedMessageAuthorId } : {}),
+        },
         scope: buildSlackThreadRuntimeScope({
           channelId: item.channel,
           context: threadInfo?.context,

--- a/slack-bridge/reaction-triggers.test.ts
+++ b/slack-bridge/reaction-triggers.test.ts
@@ -12,6 +12,8 @@ describe("normalizeReactionName", () => {
     expect(normalizeReactionName("👀")).toBe("eyes");
     expect(normalizeReactionName(":white_check_mark:")).toBe("white_check_mark");
     expect(normalizeReactionName("memo")).toBe("memo");
+    expect(normalizeReactionName("⬆️")).toBe("arrow_up");
+    expect(normalizeReactionName(":arrow_up:")).toBe("arrow_up");
   });
 
   it("throws for unsupported raw emoji input", () => {
@@ -24,6 +26,7 @@ describe("resolveReactionCommands", () => {
     const commands = resolveReactionCommands(undefined);
     expect(commands.get("memo")?.action).toBe("summarize");
     expect(commands.get("bug")?.action).toBe("file-issue");
+    expect(commands.get("arrow_up")?.action).toBe("steer");
   });
 
   it("merges custom settings keyed by emoji or alias", () => {
@@ -40,6 +43,7 @@ describe("resolveReactionCommands", () => {
 describe("formatReactionDisplay", () => {
   it("includes both the emoji and Slack reaction name when known", () => {
     expect(formatReactionDisplay("eyes")).toBe("👀 (:eyes:)");
+    expect(formatReactionDisplay("arrow_up")).toBe("⬆️ (:arrow_up:)");
   });
 });
 

--- a/slack-bridge/reaction-triggers.ts
+++ b/slack-bridge/reaction-triggers.ts
@@ -30,6 +30,9 @@ const REACTION_ALIASES: Record<string, string> = {
   eyes: "eyes",
   "✅": "white_check_mark",
   white_check_mark: "white_check_mark",
+  "⬆️": "arrow_up",
+  "⬆": "arrow_up",
+  arrow_up: "arrow_up",
 };
 
 const REACTION_DISPLAY: Record<string, string> = {
@@ -42,6 +45,7 @@ const REACTION_DISPLAY: Record<string, string> = {
   repeat: "🔄",
   eyes: "👀",
   white_check_mark: "✅",
+  arrow_up: "⬆️",
 };
 
 export const DEFAULT_REACTION_COMMANDS: Record<string, ReactionCommandTemplate> = {
@@ -69,6 +73,11 @@ export const DEFAULT_REACTION_COMMANDS: Record<string, ReactionCommandTemplate> 
     action: "retry",
     prompt:
       "Retry or regenerate the requested work using the reacted message and surrounding thread as the source of truth.",
+  },
+  arrow_up: {
+    action: "steer",
+    prompt:
+      "Treat the reacted-to message as steering. Read the durable message context, then prioritize it as an explicit operator instruction if it is relevant and safe.",
   },
   mag: {
     action: "search",
@@ -103,7 +112,7 @@ export function normalizeReactionName(input: string): string {
   const normalized = normalizeReactionNameOrNull(input);
   if (!normalized) {
     throw new Error(
-      `Unsupported reaction ${JSON.stringify(input)}. Use a Slack reaction name like "eyes" or a supported emoji such as 👀, ✅, 🔄, 📝, or 🐛.`,
+      `Unsupported reaction ${JSON.stringify(input)}. Use a Slack reaction name like "eyes" or a supported emoji such as 👀, ✅, 🔄, 📝, 🐛, or ⬆️.`,
     );
   }
   return normalized;
@@ -121,6 +130,8 @@ function buildDefaultPromptForAction(action: string): string {
       return DEFAULT_REACTION_COMMANDS.white_check_mark.prompt;
     case "retry":
       return DEFAULT_REACTION_COMMANDS.repeat.prompt;
+    case "steer":
+      return DEFAULT_REACTION_COMMANDS.arrow_up.prompt;
     case "search":
       return DEFAULT_REACTION_COMMANDS.mag.prompt;
     case "track":


### PR DESCRIPTION
## Summary
- add `arrow_up` / ⬆️ as an authorized reaction-trigger command that maps to steering
- attach reaction audit/link metadata to broker Slack reaction-trigger inbound messages
- when an authorized arrow-up reaction references an already persisted Slack message, update that original durable message metadata to `pinet_mail_class=steering` with an audit trail

## Stack context
- Refs #594
- Advances #607 and #582 durable steering-reaction semantics
- Builds on #639 persistence foundation (now present on `main`)
- No Slack outbound/operator expansion; Slack inbound remains notification/pointer/audit metadata, and Pinet remains the mail/read surface

## Validation
- `pnpm exec prettier --write broker-core/schema.ts broker-core/schema.test.ts slack-bridge/reaction-triggers.ts slack-bridge/reaction-triggers.test.ts slack-bridge/broker/adapters/slack.ts slack-bridge/broker/adapters/slack.test.ts`
- `pnpm --filter @gugu910/pi-broker-core test -- schema.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test -- reaction-triggers.test.ts broker/adapters/slack.test.ts`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `git diff --check`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook on `git push` passed

## Local review
- `reviewer` subagent completed read-only review: no findings; ready for PR.
