### PR TITLE
pinet: prioritize unread mail by class

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -691,6 +691,58 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("prioritizes steering mail for unread reads and thread summaries", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-fwup", "agent", "", null);
+      db.createThread("thread-steering", "agent", "", null);
+      db.insertMessage(
+        "thread-fwup",
+        "agent",
+        "inbound",
+        "broker",
+        "Ordinary status follow-up.",
+        ["worker"],
+        { pinet_mail_class: "fwup" },
+      );
+      const steering = db.insertMessage(
+        "thread-steering",
+        "agent",
+        "inbound",
+        "broker",
+        "Escalated operator instruction.",
+        ["worker"],
+        { pinet_mail_class: "steering" },
+      );
+      db.insertMessage(
+        "thread-steering",
+        "agent",
+        "inbound",
+        "broker",
+        "Context-only note.",
+        ["worker"],
+        { pinet_mail_class: "maintenance_context" },
+      );
+
+      const read = db.readInbox("worker", { limit: 1, markRead: false });
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0].message.id).toBe(steering.id);
+      expect(read.unreadThreads[0]).toMatchObject({
+        threadId: "thread-steering",
+        highestMailClass: "steering",
+        mailClassCounts: { steering: 1, fwup: 0, maintenance_context: 1 },
+      });
+      expect(read.unreadThreads[1]).toMatchObject({
+        threadId: "thread-fwup",
+        highestMailClass: "fwup",
+        mailClassCounts: { steering: 0, fwup: 1, maintenance_context: 0 },
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("keeps mail classification derivable from durable inbox records without changing read state", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { classifyPinetMail } from "./mail-classification.js";
 import { getDefaultDbPath } from "./paths.js";
 import type { PinetMailClass } from "./mail-classification.js";
 import type {
@@ -225,6 +226,20 @@ function appendMetadataAudit(
       )
     : [];
   metadata[key] = [...existing.slice(-19), audit];
+}
+
+const PINET_MAIL_CLASS_PRIORITY: Record<PinetMailClass, number> = {
+  steering: 0,
+  fwup: 1,
+  maintenance_context: 2,
+};
+
+function comparePinetMailClassPriority(a: PinetMailClass, b: PinetMailClass): number {
+  return PINET_MAIL_CLASS_PRIORITY[a] - PINET_MAIL_CLASS_PRIORITY[b];
+}
+
+function emptyMailClassCounts(): Record<PinetMailClass, number> {
+  return { steering: 0, fwup: 0, maintenance_context: 0 };
 }
 
 function rowToBrokerMessage(row: {
@@ -2520,6 +2535,8 @@ export class BrokerDB implements BrokerDBInterface {
     }
 
     const order = unreadOnly ? "m.created_at ASC, i.id ASC" : "m.created_at DESC, i.id DESC";
+    const limitClause = unreadOnly ? "" : "\n         LIMIT ?";
+    const queryValues = unreadOnly ? values : [...values, limit];
     const rows = db
       .prepare(
         `SELECT
@@ -2532,10 +2549,9 @@ export class BrokerDB implements BrokerDBInterface {
          FROM inbox i
          JOIN messages m ON m.id = i.message_id
          WHERE ${clauses.join(" AND ")}
-         ORDER BY ${order}
-         LIMIT ?`,
+         ORDER BY ${order}${limitClause}`,
       )
-      .all(...values, limit) as unknown as Array<{
+      .all(...queryValues) as unknown as Array<{
       i_id: number;
       i_agent_id: string;
       i_message_id: number;
@@ -2578,13 +2594,37 @@ export class BrokerDB implements BrokerDBInterface {
       },
     }));
 
-    const markedReadIds = messages
+    const prioritizedMessages = unreadOnly
+      ? messages
+          .map((item, index) => ({
+            item,
+            index,
+            mailClass: classifyPinetMail({
+              source: item.message.source,
+              threadId: item.message.threadId,
+              sender: item.message.sender,
+              body: item.message.body,
+              metadata: item.message.metadata,
+            }).class,
+          }))
+          .sort((a, b) => {
+            const classOrder = comparePinetMailClassPriority(a.mailClass, b.mailClass);
+            if (classOrder !== 0) return classOrder;
+            const createdOrder = a.item.message.createdAt.localeCompare(b.item.message.createdAt);
+            if (createdOrder !== 0) return createdOrder;
+            return a.index - b.index;
+          })
+          .slice(0, limit)
+          .map(({ item }) => item)
+      : messages;
+
+    const markedReadIds = prioritizedMessages
       .filter((item) => item.entry.readAt === null)
       .map((item) => item.entry.id);
     if (markRead && markedReadIds.length > 0) {
       this.markRead(markedReadIds, agentId);
       const readAt = new Date().toISOString();
-      for (const item of messages) {
+      for (const item of prioritizedMessages) {
         if (markedReadIds.includes(item.entry.id)) {
           item.entry.readAt = readAt;
         }
@@ -2594,7 +2634,7 @@ export class BrokerDB implements BrokerDBInterface {
     const unreadCountAfter = this.getUnreadInboxCount(agentId);
     const unreadThreads = this.getUnreadThreadSummary(agentId);
     return {
-      messages,
+      messages: prioritizedMessages,
       unreadCountBefore,
       unreadCountAfter,
       unreadThreads,
@@ -2621,34 +2661,79 @@ export class BrokerDB implements BrokerDBInterface {
            m.thread_id AS thread_id,
            m.source AS source,
            COALESCE(t.channel, '') AS channel,
-           COUNT(*) AS unread_count,
-           MAX(m.id) AS latest_message_id,
-           MAX(m.created_at) AS latest_at
+           m.id AS message_id,
+           m.sender AS sender,
+           m.body AS body,
+           m.metadata AS metadata,
+           m.created_at AS created_at
          FROM inbox i
          JOIN messages m ON m.id = i.message_id
          LEFT JOIN threads t ON t.thread_id = m.thread_id
          WHERE i.agent_id = ? AND i.read_at IS NULL
-         GROUP BY m.thread_id, m.source, t.channel
-         ORDER BY latest_at DESC, latest_message_id DESC
-         LIMIT ?`,
+         ORDER BY m.created_at DESC, m.id DESC`,
       )
-      .all(agentId, clampedLimit) as unknown as Array<{
+      .all(agentId) as unknown as Array<{
       thread_id: string;
       source: string;
       channel: string;
-      unread_count: number;
-      latest_message_id: number;
-      latest_at: string;
+      message_id: number;
+      sender: string;
+      body: string;
+      metadata: string | null;
+      created_at: string;
     }>;
 
-    return rows.map((row) => ({
-      threadId: row.thread_id,
-      source: row.source,
-      channel: row.channel,
-      unreadCount: row.unread_count,
-      latestMessageId: row.latest_message_id,
-      latestAt: row.latest_at,
-    }));
+    const summaries = new Map<string, InboxThreadUnreadSummary>();
+    for (const row of rows) {
+      const key = `${row.source}\u0000${row.thread_id}\u0000${row.channel}`;
+      const metadata = row.metadata ? parseJsonMetadata(row.metadata) : null;
+      const mailClass = classifyPinetMail({
+        source: row.source,
+        threadId: row.thread_id,
+        sender: row.sender,
+        body: row.body,
+        metadata,
+      }).class;
+      const existing = summaries.get(key);
+      if (!existing) {
+        const counts = emptyMailClassCounts();
+        counts[mailClass] = 1;
+        summaries.set(key, {
+          threadId: row.thread_id,
+          source: row.source,
+          channel: row.channel,
+          unreadCount: 1,
+          latestMessageId: row.message_id,
+          latestAt: row.created_at,
+          highestMailClass: mailClass,
+          mailClassCounts: counts,
+        });
+        continue;
+      }
+
+      existing.unreadCount += 1;
+      existing.mailClassCounts[mailClass] += 1;
+      if (comparePinetMailClassPriority(mailClass, existing.highestMailClass) < 0) {
+        existing.highestMailClass = mailClass;
+      }
+      if (
+        row.created_at > existing.latestAt ||
+        (row.created_at === existing.latestAt && row.message_id > existing.latestMessageId)
+      ) {
+        existing.latestAt = row.created_at;
+        existing.latestMessageId = row.message_id;
+      }
+    }
+
+    return Array.from(summaries.values())
+      .sort((a, b) => {
+        const classOrder = comparePinetMailClassPriority(a.highestMailClass, b.highestMailClass);
+        if (classOrder !== 0) return classOrder;
+        const latestOrder = b.latestAt.localeCompare(a.latestAt);
+        if (latestOrder !== 0) return latestOrder;
+        return b.latestMessageId - a.latestMessageId;
+      })
+      .slice(0, clampedLimit);
   }
 
   markRead(inboxIds: number[], agentId: string): void {

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -1,3 +1,5 @@
+import type { PinetMailClass } from "./mail-classification.js";
+
 // ─── Domain types ─────────────────────────────────────────
 
 export interface AgentInfo {
@@ -66,6 +68,8 @@ export interface InboxThreadUnreadSummary {
   unreadCount: number;
   latestMessageId: number;
   latestAt: string;
+  highestMailClass: PinetMailClass;
+  mailClassCounts: Record<PinetMailClass, number>;
 }
 
 export interface InboxReadResult {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -3,6 +3,7 @@ import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
 import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
+import type { PinetMailClass } from "@gugu910/pi-broker-core/mail-classification";
 import type { ClientAgentInfo, NormalizedMessageContent } from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
@@ -35,6 +36,8 @@ export interface PinetUnreadThreadSummary {
   unreadCount: number;
   latestMessageId: number;
   latestAt: string;
+  highestMailClass: PinetMailClass;
+  mailClassCounts: Record<PinetMailClass, number>;
 }
 
 export interface PinetReadResult {

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -158,6 +158,8 @@ describe("registerPinetTools", () => {
           unreadCount: 1,
           latestMessageId: 45,
           latestAt: "2026-04-25T12:01:00.000Z",
+          highestMailClass: "steering" as const,
+          mailClassCounts: { steering: 1, fwup: 0, maintenance_context: 0 },
         },
       ],
       markedReadIds: [31],

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -184,7 +184,7 @@ describe("registerPinetTools", () => {
       "- [steering] [agent/a2a:broker:worker #44] broker: please inspect #594",
     );
     expect(result.content[0]?.text).toContain(
-      "pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
+      "- [steering] a2a:broker:worker (agent): 1 unread (1 steering); latest #45; pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
     expect(result.content[0]?.text).toContain("Marked read: 31.");
     expect(result.details.markedReadIds).toEqual([31]);

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -307,8 +307,18 @@ function formatPinetReadResult(result: PinetReadResult, options: PinetReadOption
   if (result.unreadThreads.length > 0) {
     lines.push("", "Unread thread pointers:");
     for (const thread of result.unreadThreads.slice(0, 10)) {
+      const label = formatPinetMailClassLabel(thread.highestMailClass);
+      const counts = [
+        thread.mailClassCounts.steering > 0 ? `${thread.mailClassCounts.steering} steering` : null,
+        thread.mailClassCounts.fwup > 0 ? `${thread.mailClassCounts.fwup} fwup` : null,
+        thread.mailClassCounts.maintenance_context > 0
+          ? `${thread.mailClassCounts.maintenance_context} maintenance/context`
+          : null,
+      ]
+        .filter((item): item is string => Boolean(item))
+        .join(", ");
       lines.push(
-        `- ${thread.threadId} (${thread.source}${thread.channel ? `/${thread.channel}` : ""}): ${thread.unreadCount} unread; latest #${thread.latestMessageId}; pointer=pinet action=read args.thread_id=${thread.threadId} args.unread_only=true`,
+        `- [${label}] ${thread.threadId} (${thread.source}${thread.channel ? `/${thread.channel}` : ""}): ${thread.unreadCount} unread${counts ? ` (${counts})` : ""}; latest #${thread.latestMessageId}; pointer=pinet action=read args.thread_id=${thread.threadId} args.unread_only=true`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- prioritize unread `readInbox` results by durable mail class (`steering` before `fwup` before `maintenance_context`) before applying the requested read limit
- add mail-class metadata to unread thread summaries (`highestMailClass` + per-class counts)
- surface class labels/counts in `pinet_read` unread thread pointers so steering mail is visibly distinct from ordinary follow-ups

## Stack context
- Refs #594
- Advances #607 / #582 read semantics after merged #639 and #640
- Aligns with #608 by making the durable read surface more useful before broader direct-delivery migration
- No Slack outbound/operator expansion; Slack inbound remains notification/pointer/audit, and Pinet remains the durable mail/read surface

## Validation
- `pnpm exec prettier --write broker-core/types.ts broker-core/schema.ts broker-core/schema.test.ts slack-bridge/broker/client.ts slack-bridge/pinet-tools.ts slack-bridge/pinet-tools.test.ts`
- `pnpm --filter @gugu910/pi-broker-core test -- schema.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test -- pinet-tools.test.ts broker/client.test.ts`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `git diff --check`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook on `git push` passed

## Local review
- `reviewer` subagent completed read-only review: no findings; ready for PR.
