### PR TITLE
pinet: route scheduled wakeups to mail pointers

### DIFF
--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -2044,6 +2044,8 @@ export class BrokerDB implements BrokerDBInterface {
           {
             senderAgent: "Pinet Scheduler",
             scheduledWakeup: true,
+            a2a: true,
+            pinetMailClass: "fwup",
             wakeupId: row.id,
             fireAt: row.fire_at,
           },

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -433,9 +433,11 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 | `pinet_read`     | Read durable SQLite-backed Pinet inbox context and unread thread pointers                                           |
 | `pinet_agents`   | List connected Pinet agents with status and capabilities                                                            |
 | `pinet_free`     | Mark this Pinet agent idle/free for new work                                                                        |
-| `pinet_schedule` | Schedule a future wake-up for this Pinet agent                                                                      |
+| `pinet_schedule` | Schedule a future wake-up for this Pinet agent as durable follow-up mail                                            |
 
 Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet_read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
+
+Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are persisted/stamped as Pinet follow-up mail and surfaced through compact `pinet_read` pointers rather than direct reminder-body prompts. Wake-up bodies and metadata are treated as mail content only; they do not trigger Pinet remote-control commands such as `/exit`, `/reload`, or structured `pinet:control` JSON.
 
 ### Broker commands
 

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1001,7 +1001,13 @@ describe("BrokerDB", () => {
     expect(deliveries[0].wakeup.id).toBe(scheduled.id);
     expect(deliveries[0].message.body).toBe("Check whether PR #62 merged");
     expect(deliveries[0].message.threadId).toBe("wakeup:worker-1");
-    expect((deliveries[0].message.metadata as Record<string, unknown>).scheduledWakeup).toBe(true);
+    expect(deliveries[0].message.metadata).toEqual(
+      expect.objectContaining({
+        scheduledWakeup: true,
+        a2a: true,
+        pinetMailClass: "fwup",
+      }),
+    );
     expect(db.listScheduledWakeups("worker-1")).toHaveLength(0);
 
     const inbox = db.getInbox("worker-1");

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -527,6 +527,33 @@ describe("formatInboxMessages", () => {
     );
   });
 
+  it("formats broker-side scheduled wake-ups as Pinet read pointers without the reminder body", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "",
+        threadTs: "wakeup:broker-1",
+        userId: "scheduler",
+        text: "/exit",
+        timestamp: "2026-04-28T10:00:00.000Z",
+        brokerInboxId: 77,
+        metadata: {
+          senderAgent: "Pinet Scheduler",
+          scheduledWakeup: true,
+          a2a: true,
+          pinetMailClass: "fwup",
+        },
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain("New Pinet messages:");
+    expect(result).toContain(
+      "[thread wakeup:broker-1] [fwup] scheduler (Pinet Scheduler): inbox_id=77 pointer=pinet action=read args.thread_id=wakeup:broker-1 args.unread_only=true",
+    );
+    expect(result).not.toContain("New Slack messages:");
+    expect(result).not.toContain("scheduler: /exit");
+  });
+
   it("keeps generic Slack file metadata out of the canvas-only suffix", () => {
     const msgs: InboxMessage[] = [
       {
@@ -611,6 +638,32 @@ describe("formatPinetInboxMessages", () => {
       "[thread a2a:broker:worker] [fwup] broker-id: pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
     expect(result).not.toContain("broker-id: hello");
+  });
+
+  it("formats scheduled wake-ups as durable follow-up pointers without the reminder body", () => {
+    const result = formatPinetInboxMessages([
+      {
+        inboxId: 42,
+        message: {
+          threadId: "wakeup:worker-1",
+          sender: "scheduler",
+          body: "Check whether PR #62 merged",
+          metadata: {
+            senderAgent: "Pinet Scheduler",
+            scheduledWakeup: true,
+            a2a: true,
+            pinetMailClass: "fwup",
+          },
+        },
+      },
+    ]);
+
+    expect(result).toContain("New Pinet messages:");
+    expect(result).toContain(
+      "[thread wakeup:worker-1] [fwup] scheduler (Pinet Scheduler): inbox_id=42 pointer=pinet action=read args.thread_id=wakeup:worker-1 args.unread_only=true",
+    );
+    expect(result).not.toContain("Check whether PR #62 merged");
+    expect(result).toContain("Use pinet_read with the pointer before acting.");
   });
 
   it("marks terminal stand-down messages as maintenance/context and suppresses reflex ack guidance", () => {
@@ -748,6 +801,23 @@ describe("Pinet control helpers", () => {
         threadId: "a2a:sender:target",
         body: '{"type":"pinet:control","action":"noop"}',
         metadata: { a2a: true },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not treat scheduled wake-up mail bodies as remote-control commands", () => {
+    expect(
+      extractPinetControlCommand({
+        threadId: "wakeup:worker-1",
+        body: "/exit",
+        metadata: { scheduledWakeup: true, a2a: true, senderAgent: "Pinet Scheduler" },
+      }),
+    ).toBeNull();
+    expect(
+      extractPinetControlCommand({
+        threadId: "wakeup:worker-1",
+        body: '{"type":"pinet:control","action":"reload"}',
+        metadata: { scheduledWakeup: true, a2a: true, type: "pinet:control", action: "reload" },
       }),
     ).toBeNull();
   });
@@ -3469,14 +3539,23 @@ describe("partitionFollowerInboxEntries", () => {
           metadata: { a2a: true, senderAgent: "Broker Bunny" },
         },
       },
+      {
+        inboxId: 4,
+        message: {
+          threadId: "wakeup:worker",
+          sender: "scheduler",
+          body: "check queue",
+          metadata: { scheduledWakeup: true, senderAgent: "Pinet Scheduler" },
+        },
+      },
     ];
 
     const result = partitionFollowerInboxEntries(entries);
     expect(result.nudges).toHaveLength(1);
-    expect(result.agentMessages).toHaveLength(1);
+    expect(result.agentMessages).toHaveLength(2);
     expect(result.regular).toHaveLength(1);
     expect(result.nudges[0].inboxId).toBe(1);
-    expect(result.agentMessages[0].inboxId).toBe(3);
+    expect(result.agentMessages.map((entry) => entry.inboxId)).toEqual([3, 4]);
     expect(result.regular[0].inboxId).toBe(2);
   });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -300,7 +300,30 @@ function formatInboxMetadata(metadata: Record<string, unknown> | null | undefine
   return "";
 }
 
-export function formatInboxMessages(
+function isPinetPointerInboxMessage(message: InboxMessage): boolean {
+  const metadata = message.metadata ?? null;
+  return (
+    metadata?.a2a === true ||
+    metadata?.scheduledWakeup === true ||
+    message.threadTs.startsWith("a2a:") ||
+    message.threadTs.startsWith("wakeup:")
+  );
+}
+
+function inboxMessageToPinetEntry(message: InboxMessage): FollowerInboxEntry {
+  return {
+    ...(message.brokerInboxId != null ? { inboxId: message.brokerInboxId } : {}),
+    message: {
+      threadId: message.threadTs,
+      sender: message.userId,
+      body: message.text,
+      createdAt: message.timestamp,
+      metadata: message.metadata ?? null,
+    },
+  };
+}
+
+function formatSlackInboxMessages(
   messages: InboxMessage[],
   userNames: { get(key: string): string | undefined },
 ): string {
@@ -314,6 +337,25 @@ export function formatInboxMessages(
   });
 
   return `New Slack messages:\n${lines.join("\n")}\n\nACK briefly, do the work, report blockers immediately, report the outcome when done.`;
+}
+
+export function formatInboxMessages(
+  messages: InboxMessage[],
+  userNames: { get(key: string): string | undefined },
+): string {
+  const pinetMessages = messages.filter(isPinetPointerInboxMessage);
+  if (pinetMessages.length === messages.length) {
+    return formatPinetInboxMessages(pinetMessages.map(inboxMessageToPinetEntry));
+  }
+
+  if (pinetMessages.length === 0) {
+    return formatSlackInboxMessages(messages, userNames);
+  }
+
+  const slackMessages = messages.filter((message) => !isPinetPointerInboxMessage(message));
+  return `${formatSlackInboxMessages(slackMessages, userNames)}\n\n${formatPinetInboxMessages(
+    pinetMessages.map(inboxMessageToPinetEntry),
+  )}`;
 }
 
 function getPinetSenderLabel(message: FollowerInboxEntry["message"]): string {
@@ -625,6 +667,8 @@ export function extractPinetControlCommand(message: {
   metadata?: Record<string, unknown> | null;
 }): PinetControlCommand | null {
   const metadata = message.metadata ?? {};
+  if (metadata.scheduledWakeup === true) return null;
+
   const isAgentToAgent =
     metadata.a2a === true ||
     (typeof message.threadId === "string" && message.threadId.startsWith("a2a:"));
@@ -3339,7 +3383,10 @@ export function isAgentToAgentEntry(entry: {
   message: { threadId?: string; metadata?: Record<string, unknown> | null };
 }): boolean {
   const threadId = entry.message.threadId ?? "";
-  return threadId.startsWith("a2a:") || entry.message.metadata?.a2a === true;
+  const metadata = entry.message.metadata ?? null;
+  return (
+    threadId.startsWith("a2a:") || metadata?.a2a === true || metadata?.scheduledWakeup === true
+  );
 }
 
 export function partitionFollowerInboxEntries<


### PR DESCRIPTION
## Summary
- route due Pinet scheduled wake-up mail through durable `pinet_read` pointer surfaces instead of direct reminder body prompts
- stamp scheduled wake-up inbox messages as follow-up Pinet mail (`a2a`, `pinetMailClass: fwup`)
- keep scheduled wake-up bodies/metadata from triggering Pinet remote-control commands (`/exit`, `/reload`, structured control JSON)

## Stack context
- Refs #594
- Advances #608 by migrating a direct-delivery path toward SQLite mail/read semantics
- Builds after #639/#640 and #641; #641 merged while this branch was in progress, so this PR is based on `main`
- No Slack outbound/operator expansion; Slack inbound remains notification/pointer/audit; Pinet remains the durable mail/read surface

## Validation
- `pnpm exec prettier --write slack-bridge/helpers.ts slack-bridge/helpers.test.ts broker-core/schema.ts slack-bridge/broker/helpers.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts broker/helpers.test.ts broker/integration.test.ts inbox-drain-runtime.test.ts broker-runtime.test.ts`
- `pnpm --filter @gugu910/pi-broker-core test -- schema.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `git diff --check`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook passed

## Local review
- Initial local reviewer found remote-control/scheduled-wakeup risks; fixed.
- Final local reviewer re-review found no blocking issues and marked ready for PR.
