### PR TITLE
pinet: stamp a2a mail classes

### DIFF
--- a/broker-core/agent-messaging.ts
+++ b/broker-core/agent-messaging.ts
@@ -1,3 +1,4 @@
+import { classifyPinetMail } from "./mail-classification.js";
 import type { AgentInfo, BrokerMessage } from "./types.js";
 
 interface AgentCapabilities {
@@ -142,14 +143,21 @@ function ensurePairThread(
 
 function buildAgentMessageMetadata(
   senderAgentName: string,
+  body: string,
   metadata?: Record<string, unknown>,
   broadcastChannel?: string,
 ): Record<string, unknown> {
-  return {
+  const baseMetadata: Record<string, unknown> = {
     ...metadata,
     senderAgent: senderAgentName,
     a2a: true,
     ...(broadcastChannel ? { broadcast: true, broadcastChannel } : {}),
+  };
+  const classification = classifyPinetMail({ source: "agent", body, metadata: baseMetadata });
+
+  return {
+    ...baseMetadata,
+    pinetMailClass: classification.class,
   };
 }
 
@@ -259,7 +267,7 @@ export function dispatchDirectAgentMessage(
   }
 
   const resolvedTarget: AgentDispatchTarget = { id: target.id, name: target.name };
-  const metadata = buildAgentMessageMetadata(input.senderAgentName, input.metadata);
+  const metadata = buildAgentMessageMetadata(input.senderAgentName, input.body, input.metadata);
   const { threadId, messageId } = deliverAgentMessage(
     storage,
     input.senderAgentId,
@@ -298,6 +306,7 @@ export function dispatchBroadcastAgentMessage(
   const broadcastChannel = `#${normalizedChannel}`;
   const metadata = buildAgentMessageMetadata(
     input.senderAgentName,
+    input.body,
     input.metadata,
     broadcastChannel,
   );

--- a/slack-bridge/broker/agent-messaging.test.ts
+++ b/slack-bridge/broker/agent-messaging.test.ts
@@ -178,9 +178,74 @@ describe("dispatchDirectAgentMessage", () => {
         workflow: "ack/work/ask/report",
         senderAgent: "Sender Agent",
         a2a: true,
+        pinetMailClass: "fwup",
       },
     });
     expect(delivered).toEqual(["target:1:Sender Agent"]);
+  });
+
+  it("stamps inferred mail classes on direct a2a messages", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", { capabilities: { repo: "extensions", role: "worker" } }),
+      createAgent("target", "target", { capabilities: { repo: "extensions", role: "worker" } }),
+    ]);
+
+    dispatchDirectAgentMessage(storage, {
+      senderAgentId: "sender",
+      senderAgentName: "Sender Agent",
+      target: "target",
+      body: "Please implement issue #594 and report blockers immediately.",
+    });
+
+    expect(storage.inserted[0]?.metadata).toMatchObject({
+      senderAgent: "Sender Agent",
+      a2a: true,
+      pinetMailClass: "steering",
+    });
+  });
+
+  it("classifies direct control messages as maintenance context", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", { capabilities: { repo: "extensions", role: "worker" } }),
+      createAgent("target", "target", { capabilities: { repo: "extensions", role: "worker" } }),
+    ]);
+
+    dispatchDirectAgentMessage(storage, {
+      senderAgentId: "sender",
+      senderAgentName: "Sender Agent",
+      target: "target",
+      body: '{"type":"pinet:control","action":"reload"}',
+      metadata: { type: "pinet:control", action: "reload" },
+    });
+
+    expect(storage.inserted[0]?.metadata).toMatchObject({
+      senderAgent: "Sender Agent",
+      a2a: true,
+      type: "pinet:control",
+      action: "reload",
+      pinetMailClass: "maintenance_context",
+    });
+  });
+
+  it("preserves caller-provided mail class metadata", () => {
+    const storage = createStorage([
+      createAgent("sender", "sender", { capabilities: { repo: "extensions", role: "worker" } }),
+      createAgent("target", "target", { capabilities: { repo: "extensions", role: "worker" } }),
+    ]);
+
+    dispatchDirectAgentMessage(storage, {
+      senderAgentId: "sender",
+      senderAgentName: "Sender Agent",
+      target: "target",
+      body: "Please implement issue #594 and report blockers immediately.",
+      metadata: { pinetMailClass: "maintenance_context" },
+    });
+
+    expect(storage.inserted[0]?.metadata).toMatchObject({
+      senderAgent: "Sender Agent",
+      a2a: true,
+      pinetMailClass: "maintenance_context",
+    });
   });
 });
 
@@ -226,12 +291,14 @@ describe("dispatchBroadcastAgentMessage", () => {
       a2a: true,
       broadcast: true,
       broadcastChannel: "#extensions",
+      pinetMailClass: "fwup",
     });
     expect(storage.inserted[1]?.metadata).toMatchObject({
       senderAgent: "Broker Agent",
       a2a: true,
       broadcast: true,
       broadcastChannel: "#extensions",
+      pinetMailClass: "fwup",
     });
     expect(delivered).toEqual(["worker-a:a2a:sender:worker-a", "worker-b:a2a:sender:worker-b"]);
   });


### PR DESCRIPTION
## Summary
- stamp direct `pinet_message` / A2A dispatch metadata with canonical `pinetMailClass` using the existing Pinet mail classifier
- classify broker/follower direct control envelopes as `maintenance_context` while preserving control metadata
- preserve caller-provided explicit mail-class metadata and apply the same stamping path to broadcast fan-out

## Stack context
- Refs #594
- Advances #582/#608 by making the A2A delivery path persist an explicit durable mail class instead of only inferring it at read/render time
- Stacked on #642 (`feat/sqlite-sync-next3-594-echo`) while #642 awaits human merge
- Does not duplicate #642 scheduled wake-up/docs behavior; scheduled wake-ups remain handled separately
- No Slack outbound/operator expansion; Pinet remains the durable mail/read surface

## Validation
- `pnpm exec prettier --write broker-core/agent-messaging.ts slack-bridge/broker/agent-messaging.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker/agent-messaging.test.ts pinet-mesh-ops.test.ts broker/integration.test.ts broker/client.test.ts`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `git diff --check`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook passed

## Local review
- Local reviewer found no critical/warning/nit findings after re-review.
