### PR TITLE
feat(slack-bridge): slim default Pinet tool surface

### DIFF
--- a/plans/pinet-vision.md
+++ b/plans/pinet-vision.md
@@ -22,7 +22,7 @@ It connects agents to each other, to Slack, to Neovim, and to any future adapter
 
 6. **Workers are computation, broker is infrastructure** — workers do tasks. The broker keeps the lights on. They don't share a process lifetime.
 
-7. **Extensions stay thin** — tools like `slack_send`, `comment_add`, and `pinet_message` are shims over the broker. They don't own state.
+7. **Extensions stay thin** — tools like `slack_send`, `comment_add`, and `pinet action=send` are shims over the broker. They don't own state.
 
 ## What this enables
 

--- a/plans/reviewer-nicopreme-migration.md
+++ b/plans/reviewer-nicopreme-migration.md
@@ -183,7 +183,7 @@ The `subagent` tool call above.
 ### From Pinet delegation
 
 Agents inside this mesh that need a review should still reply via
-`pinet_message` with the final verdict. The reviewer posts to PiComms and
+`pinet action=send` with the final verdict. The reviewer posts to PiComms and
 GitHub itself; the delegating agent just relays the summary.
 
 ## 6. Caveats & known issues

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -426,18 +426,15 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 ### Multi-agent tools
 
-| Tool             | Description                                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `pinet`          | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `schedule`, `agents`) |
-| `pinet_message`  | Send a message to a connected Pinet agent or broker-only broadcast channel                                          |
-| `pinet_read`     | Read durable SQLite-backed Pinet inbox context and unread thread pointers                                           |
-| `pinet_agents`   | List connected Pinet agents with status and capabilities                                                            |
-| `pinet_free`     | Mark this Pinet agent idle/free for new work                                                                        |
-| `pinet_schedule` | Schedule a future wake-up for this Pinet agent as durable follow-up mail                                            |
+| Tool    | Description                                                                                                         |
+| ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `pinet` | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `schedule`, `agents`) |
 
-Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet_read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
+Use the dispatcher for all Pinet actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=schedule`, and `pinet action=agents`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
 
-Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are persisted/stamped as Pinet follow-up mail and surfaced through compact `pinet_read` pointers rather than direct reminder-body prompts. Wake-up bodies and metadata are treated as mail content only; they do not trigger Pinet remote-control commands such as `/exit`, `/reload`, or structured `pinet:control` JSON.
+Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet action=read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
+
+Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are persisted/stamped as Pinet follow-up mail and surfaced through compact `pinet action=read` pointers rather than direct reminder-body prompts. Wake-up bodies and metadata are treated as mail content only; they do not trigger Pinet remote-control commands such as `/exit`, `/reload`, or structured `pinet:control` JSON.
 
 ### Broker commands
 

--- a/slack-bridge/broker-inbound-persistence.test.ts
+++ b/slack-bridge/broker-inbound-persistence.test.ts
@@ -41,7 +41,7 @@ const delivered: DeliveredInboundMessageResult = {
 };
 
 describe("broker inbound persistence", () => {
-  it("builds compact pinet_read pointers for durable inbound mail", () => {
+  it("builds compact dispatcher read pointers for durable inbound mail", () => {
     expect(buildPinetReadPointer("123.456")).toBe(
       "pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
     );
@@ -62,6 +62,8 @@ describe("broker inbound persistence", () => {
 
     expect(store.queueDeliveredMessage).toHaveBeenCalledWith("broker", message);
     expect(result.result).toBe(delivered);
-    expect(result.notificationText).toContain("Use pinet_read with the pointer before acting.");
+    expect(result.notificationText).toContain(
+      "Use pinet action=read with the pointer before acting.",
+    );
   });
 });

--- a/slack-bridge/broker-inbound-persistence.ts
+++ b/slack-bridge/broker-inbound-persistence.ts
@@ -27,7 +27,7 @@ export function buildPersistedInboundNotificationText(message: BrokerMessage): s
   return [
     `Durable ${message.source} mail stored in SQLite as message #${message.id}.`,
     buildPinetReadPointer(message.threadId),
-    "Use pinet_read with the pointer before acting.",
+    "Use pinet action=read with the pointer before acting.",
   ].join(" ");
 }
 

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -65,9 +65,15 @@ describe("matchesToolPattern", () => {
     expect(matchesToolPattern("slack:upload", ["slack_upload"])).toBe(true);
   });
 
-  it("matches legacy pinet underscore patterns against dispatcher action names", () => {
+  it("matches legacy Pinet underscore guardrail patterns against dispatcher action names", () => {
     expect(matchesToolPattern("pinet:send", ["pinet_send"])).toBe(true);
     expect(matchesToolPattern("pinet_read", ["pinet:read"])).toBe(true);
+  });
+
+  it("treats former pinet_message policies as send guardrail aliases", () => {
+    expect(matchesToolPattern("pinet:send", ["pinet_message"])).toBe(true);
+    expect(matchesToolPattern("pinet:send", ["pinet_send"])).toBe(true);
+    expect(matchesToolPattern("pinet_message", ["pinet:send"])).toBe(true);
   });
 });
 
@@ -139,6 +145,7 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("pinet:send")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:schedule")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:free")).toBe(true);
+    expect(WRITE_TOOLS.has("pinet_message")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:read")).toBe(true);
     expect(READ_ONLY_TOOLS.has("pinet:agents")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:read")).toBe(false);
@@ -146,11 +153,13 @@ describe("isToolBlocked", () => {
     expect(READ_ONLY_TOOLS.has("pinet:send")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:schedule")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:free")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("pinet_message")).toBe(false);
   });
 
-  it("maps pinet dispatcher and legacy names for readOnly checks", () => {
+  it("classifies Pinet dispatcher and legacy policy names for readOnly checks", () => {
     const g: SecurityGuardrails = { readOnly: true };
     expect(isToolBlocked("pinet:send", g)).toBe(true);
+    expect(isToolBlocked("pinet_message", g)).toBe(true);
     expect(isToolBlocked("pinet_send", g)).toBe(true);
     expect(isToolBlocked("pinet:read", g)).toBe(false);
     expect(isToolBlocked("pinet_read", g)).toBe(false);
@@ -162,6 +171,11 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("slack:create_channel", g)).toBe(true); // explicit block via legacy pattern
     expect(isToolBlocked("slack_create_channel", g)).toBe(true); // legacy spelling still maps
     expect(isToolBlocked("read", g)).toBe(false); // read-only tool
+  });
+
+  it("applies legacy send blocks to dispatcher send", () => {
+    expect(isToolBlocked("pinet:send", { blockedTools: ["pinet_send"] })).toBe(true);
+    expect(isToolBlocked("pinet:send", { blockedTools: ["pinet_message"] })).toBe(true);
   });
 });
 
@@ -178,6 +192,13 @@ describe("toolNeedsConfirmation", () => {
     const g: SecurityGuardrails = { requireConfirmation: ["memory_*"] };
     expect(toolNeedsConfirmation("memory_write", g)).toBe(true);
     expect(toolNeedsConfirmation("memory_sync", g)).toBe(true);
+  });
+
+  it("applies legacy send confirmation policies to dispatcher send", () => {
+    expect(toolNeedsConfirmation("pinet:send", { requireConfirmation: ["pinet_send"] })).toBe(true);
+    expect(toolNeedsConfirmation("pinet:send", { requireConfirmation: ["pinet_message"] })).toBe(
+      true,
+    );
   });
 
   it("returns false when tool does not match", () => {
@@ -383,8 +404,7 @@ describe("isBrokerForbiddenTool", () => {
   });
 
   it("returns false for allowed tools", () => {
-    expect(isBrokerForbiddenTool("pinet_message")).toBe(false);
-    expect(isBrokerForbiddenTool("pinet_agents")).toBe(false);
+    expect(isBrokerForbiddenTool("pinet")).toBe(false);
     expect(isBrokerForbiddenTool("slack_send")).toBe(false);
     expect(isBrokerForbiddenTool("read")).toBe(false);
     expect(isBrokerForbiddenTool("bash")).toBe(false);
@@ -405,9 +425,9 @@ describe("buildBrokerToolGuardrailsPrompt", () => {
     expect(prompt).toContain("BLOCKED");
   });
 
-  it("recommends pinet_message as the alternative", () => {
+  it("recommends dispatcher send as the alternative", () => {
     const prompt = buildBrokerToolGuardrailsPrompt();
-    expect(prompt).toContain("pinet_message");
+    expect(prompt).toContain("pinet action=send");
   });
 
   it("explains why local subagents and file mutation tools are forbidden", () => {

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -22,9 +22,6 @@ export const READ_ONLY_TOOLS = new Set([
   "slack:confirm_action",
   "pinet:agents",
   "pinet:read",
-  "pinet_agents",
-  "pinet_read",
-  "pinet_message",
   "memory_read",
   "memory_search",
   "memory_list",
@@ -58,16 +55,14 @@ export const WRITE_TOOLS = new Set([
   "pinet:schedule",
   "pinet:send",
   "pinet:free",
-  "pinet_schedule",
-  "pinet_free",
-  "pinet_send",
 ]);
 
 /**
  * Match a tool name against glob patterns (supports `*` wildcard).
- * Slack dispatcher actions use `slack:<action>` names; legacy `slack_<action>`
- * guardrail patterns still match during migration. Pinet follows the same
- * `pinet:<action>` / `pinet_<action>` compatibility pattern.
+ * Slack and Pinet dispatcher actions use `<namespace>:<action>` names; legacy
+ * `<namespace>_<action>` guardrail patterns still match during migration. Pinet
+ * direct tools are no longer registered, but keeping alias matching prevents old
+ * security configs from silently failing open.
  * Returns true if the tool name matches any of the patterns.
  */
 export function matchesToolPattern(toolName: string, patterns: string[]): boolean {
@@ -82,6 +77,11 @@ export function matchesToolPattern(toolName: string, patterns: string[]): boolea
     candidates.add(`pinet_${toolName.slice("pinet:".length)}`);
   } else if (toolName.startsWith("pinet_")) {
     candidates.add(`pinet:${toolName.slice("pinet_".length)}`);
+  }
+  if (toolName === "pinet_message" || toolName === "pinet:send" || toolName === "pinet_send") {
+    candidates.add("pinet_message");
+    candidates.add("pinet:send");
+    candidates.add("pinet_send");
   }
 
   for (const pattern of patterns) {
@@ -120,6 +120,11 @@ export function isToolBlocked(toolName: string, guardrails: SecurityGuardrails):
     readOnlyCandidates.add(`pinet_${toolName.slice("pinet:".length)}`);
   } else if (toolName.startsWith("pinet_")) {
     readOnlyCandidates.add(`pinet:${toolName.slice("pinet_".length)}`);
+  }
+  if (toolName === "pinet_message" || toolName === "pinet:send" || toolName === "pinet_send") {
+    readOnlyCandidates.add("pinet_message");
+    readOnlyCandidates.add("pinet:send");
+    readOnlyCandidates.add("pinet_send");
   }
 
   for (const candidate of readOnlyCandidates) {
@@ -276,7 +281,7 @@ export function buildBrokerToolGuardrailsPrompt(): string {
     `The following tools are BLOCKED for the broker role: ${forbidden}.`,
     "The Agent tool (including code-reviewer and other local subagents) spawns local workers with no Slack/Pinet connectivity — they can't be monitored, can't own threads, and can't coordinate with humans.",
     "The edit and write tools are blocked because the broker is coordination infrastructure, not an implementation worker.",
-    "Use pinet_message to delegate coding or review work to connected Pinet agents instead.",
+    "Use pinet action=send to delegate coding or review work to connected Pinet agents instead.",
   ].join("\n");
 }
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -618,7 +618,7 @@ describe("formatPinetInboxMessages", () => {
       "[thread a2a:broker:worker] [steering] broker-id (Broker Bunny): inbox_id=17 pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
     expect(result).not.toContain("Take issue #175");
-    expect(result).toContain("Use pinet_read with the pointer before acting.");
+    expect(result).toContain("Use pinet action=read with the pointer before acting.");
     expect(result).toContain("ACK briefly after reading, do the work");
   });
 
@@ -663,7 +663,7 @@ describe("formatPinetInboxMessages", () => {
       "[thread wakeup:worker-1] [fwup] scheduler (Pinet Scheduler): inbox_id=42 pointer=pinet action=read args.thread_id=wakeup:worker-1 args.unread_only=true",
     );
     expect(result).not.toContain("Check whether PR #62 merged");
-    expect(result).toContain("Use pinet_read with the pointer before acting.");
+    expect(result).toContain("Use pinet action=read with the pointer before acting.");
   });
 
   it("marks terminal stand-down messages as maintenance/context and suppresses reflex ack guidance", () => {
@@ -709,7 +709,7 @@ describe("formatPinetInboxMessages", () => {
 
     expect(result).toContain("[maintenance/context]");
     expect(result).toContain("[steering]");
-    expect(result).toContain("Reply via pinet_message for steering/follow-up only.");
+    expect(result).toContain("Reply via pinet action=send for steering/follow-up only.");
     expect(result).toContain("For [steering], ACK briefly after reading, do the work");
     expect(result).toContain(
       "do NOT acknowledge or reply unless you have a real blocker or materially new finding",
@@ -1414,8 +1414,8 @@ describe("buildBrokerPromptGuidelines", () => {
     const joined = guidelines.join(" ");
     expect(joined).toContain("ALLOWED");
     expect(joined).toContain("Route messages");
-    expect(joined).toContain("pinet_agents");
-    expect(joined).toContain("pinet_message");
+    expect(joined).toContain("pinet action=agents");
+    expect(joined).toContain("pinet action=send");
   });
 
   it("includes a refusal template for coding requests", () => {
@@ -1433,10 +1433,10 @@ describe("buildBrokerPromptGuidelines", () => {
     expect(joined).toContain("stall");
   });
 
-  it("instructs to use pinet_message instead of Agent tool", () => {
+  it("instructs to use pinet action=send instead of Agent tool", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
-    expect(joined).toContain("pinet_message");
+    expect(joined).toContain("pinet action=send");
   });
 
   it("treats code-reviewer as delegated worker work, not broker work", () => {
@@ -1467,7 +1467,7 @@ describe("buildBrokerPromptGuidelines", () => {
     const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
     const joined = guidelines.join(" ");
     expect(joined).toContain("REPO-SCOPED DELEGATION");
-    expect(joined).toContain("pinet_agents");
+    expect(joined).toContain("pinet action=agents");
     expect(joined).toContain("extensions-repo work");
     expect(joined).toContain("workers/subagents");
     expect(joined).toContain("never borrow idle workers from another repo");
@@ -1492,8 +1492,8 @@ describe("buildWorkerPromptGuidelines", () => {
     const guidelines = buildWorkerPromptGuidelines();
     const joined = guidelines.join(" ");
     expect(joined).toContain("PINET DELEGATION RULES");
-    expect(joined).toContain("pinet_agents");
-    expect(joined).toContain("pinet_message");
+    expect(joined).toContain("pinet action=agents");
+    expect(joined).toContain("pinet action=send");
   });
 
   it("tells workers not to use the Agent tool for mesh delegation", () => {
@@ -1513,7 +1513,7 @@ describe("buildWorkerPromptGuidelines", () => {
   it("mirrors repo-scoped and prioritized-issue delegation rules for workers", () => {
     const guidelines = buildWorkerPromptGuidelines();
     const joined = guidelines.join(" ");
-    expect(joined).toContain("pinet_agents` with the target repo");
+    expect(joined).toContain("pinet action=agents` with the target repo");
     expect(joined).toContain("same repo/worktree");
     expect(joined).toContain("maintainer priority/approval");
     expect(joined).toContain("maintainer approval");
@@ -1523,7 +1523,7 @@ describe("buildWorkerPromptGuidelines", () => {
   it("tells workers to explicitly mark themselves idle/free when work is done", () => {
     const guidelines = buildWorkerPromptGuidelines();
     const joined = guidelines.join(" ");
-    expect(joined).toContain("pinet_free");
+    expect(joined).toContain("pinet action=free");
     expect(joined).toContain("/pinet-free");
     expect(joined).toContain("idle/free");
   });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -421,11 +421,11 @@ export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string 
 
   const guidance = hasMaintenanceOnly
     ? hasActionableWork || hasFollowUp
-      ? "Use pinet_read with the pointer before acting. Reply via pinet_message for steering/follow-up only. For [maintenance/context] messages, do NOT acknowledge or reply unless you have a real blocker or materially new finding. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
-      : "Use pinet_read with the pointer only if you need details. Treat [maintenance/context] messages as context-only; do NOT send another acknowledgement unless you have a real blocker or materially new finding."
+      ? "Use pinet action=read with the pointer before acting. Reply via pinet action=send for steering/follow-up only. For [maintenance/context] messages, do NOT acknowledge or reply unless you have a real blocker or materially new finding. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+      : "Use pinet action=read with the pointer only if you need details. Treat [maintenance/context] messages as context-only; do NOT send another acknowledgement unless you have a real blocker or materially new finding."
     : hasActionableWork
-      ? "Use pinet_read with the pointer before acting. Reply via pinet_message. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
-      : "Use pinet_read with the pointer before acting. Reply via pinet_message if follow-up is needed.";
+      ? "Use pinet action=read with the pointer before acting. Reply via pinet action=send. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+      : "Use pinet action=read with the pointer before acting. Reply via pinet action=send if follow-up is needed.";
 
   return `New Pinet messages:\n${lines.join("\n")}\n\n${guidance}`;
 }
@@ -1616,15 +1616,15 @@ export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: strin
     "WHY THIS RULE EXISTS: You are the ONLY process routing Slack messages, monitoring agent health, and keeping the mesh alive. If you spend even one turn writing code, messages stop flowing, dead agents don't get reaped, backlog piles up, and the whole system stalls. Workers are computation, broker is infrastructure.",
     // ── FORBIDDEN ACTIONS ───────────────────────────────────────
     "FORBIDDEN — Do NOT do any of these, even if explicitly asked: (1) Use the Agent tool to spawn local subagents — they have no Slack/Pinet connectivity and can't be monitored. (2) Use edit or write at all — those tools are hard-blocked for the broker at runtime. (3) Use bash to modify source code or do implementation work. (4) Pick up coding tasks, bug fixes, refactors, or implementation work. (5) Run test suites, linters, or build commands as part of implementation work. (6) Create or modify source files in any worktree.",
-    "IF ASKED TO CODE: Refuse politely and immediately delegate. Say: 'I'm the broker — I coordinate, not code. Let me find a worker for this.' Then check pinet_agents and delegate via pinet_message.",
+    "IF ASKED TO CODE: Refuse politely and immediately delegate. Say: 'I'm the broker — I coordinate, not code. Let me find a worker for this.' Then check `pinet action=agents` and delegate via pinet action=send.",
     // ── ALLOWED ACTIONS ─────────────────────────────────────────
-    "ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check pinet_agents for idle workers and delegate tasks via pinet_message. (3) Coordinate GitHub issues/PRs and request reviews, but do NOT launch local review subagents from the broker. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection and lightweight GitHub coordination: git log, git status, gh pr list, gh pr view, ls, cat — never for code changes or implementation work.",
+    "ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check `pinet action=agents` for idle workers and delegate tasks via pinet action=send. (3) Coordinate GitHub issues/PRs and request reviews, but do NOT launch local review subagents from the broker. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection and lightweight GitHub coordination: git log, git status, gh pr list, gh pr view, ls, cat — never for code changes or implementation work.",
     "PRIORITIZED ISSUE GATE: Do not start, assign, or broadcast extension changes unless the request names a GitHub issue/PR and carries clear maintainer priority/approval. Do not self-start from open issue lists. If unclear, stop and ask.",
     "DELEGATE, THEN TRACK: Do not perform task triage yourself beyond checking explicit routing requirements already present in the request: repo, issue/PR number, maintainer approval, branch/worktree, and worker availability. If required routing facts are missing, ask; otherwise assign promptly.",
     "DEEP INSPECTION BELONGS TO WORKERS: Connected workers/subagents own codebase investigation, diagnosis, implementation planning, and review details. Do NOT read through multiple source files, trace implementations, or inspect the codebase in detail before assigning the task.",
-    "REPO-SCOPED DELEGATION: Always call `pinet_agents` with the target repo and choose workers from that same repo/worktree. For extensions-repo work, delegate to healthy connected workers/subagents in that repo/worktree; never borrow idle workers from another repo. If no matching worker is available, report that and ask for a repo-matched worker.",
+    "REPO-SCOPED DELEGATION: Always call `pinet action=agents` with the target repo and choose workers from that same repo/worktree. For extensions-repo work, delegate to healthy connected workers/subagents in that repo/worktree; never borrow idle workers from another repo. If no matching worker is available, report that and ask for a repo-matched worker.",
     "REPO-SCOPED BROADCASTS: New-issue, policy, and routing broadcasts are repository-scoped. Use a repo channel such as `#extensions` / `#repo:extensions` for extensions announcements; do not use `#all` for repo-specific issue announcements or policy updates.",
-    "When a human asks for work to be done, ALWAYS check `pinet_agents` for idle workers in the right repo and delegate via `pinet_message`. Pick the agent on the right repo/branch when possible.",
+    "When a human asks for work to be done, ALWAYS check `pinet action=agents` for idle workers in the right repo and delegate via `pinet action=send`. Pick the agent on the right repo/branch when possible.",
     "If a repo instruction says to use the `code-reviewer` subagent, treat that as work to assign to a connected worker session in the same repo — never the broker itself.",
     "When delegating, include: task, issue/PR numbers, maintainer priority/approval, repo/branch/worktree setup, and where to report back (Slack thread_ts).",
     "If no repo-matched workers are available, tell the human and suggest they spin up a new agent in that repo. NEVER do the work yourself or cross-route to another repo as a fallback.",
@@ -1643,18 +1643,18 @@ export function buildWorkerPromptGuidelines(): string[] {
     "2. Do the work.",
     "3. If you hit a blocker, report it immediately and ask for what you need — blocked work must be visible so it can be unblocked or reassigned.",
     "4. When done, report the outcome (what changed, branch/PR, test results) — the sender needs closure and next steps.",
-    "5. When you have finished all assigned work and are waiting for more, call `pinet_free` (or `/pinet-free`) to mark yourself idle/free for the broker.",
+    "5. When you have finished all assigned work and are waiting for more, call `pinet action=free` (or `/pinet-free`) to mark yourself idle/free for the broker.",
     "Always reply where the task came from.",
     "If a Pinet thread explicitly says things like 'no further replies are needed', 'hard stop', or 'stay free/quiet unless a new task appears', treat it as a terminal closeout. Do NOT send another acknowledgement unless you have a real blocker, a materially new finding, or a genuinely new task arrives in that thread.",
     "",
     "REPLY TOOL RULES:",
-    "- If you received a task via `pinet_message`, reply via `pinet_message` to the sender.",
+    "- If you received a task via `pinet action=send`, reply via `pinet action=send` to the sender.",
     "- If you received a task in a Slack thread, reply via `slack_send` in that thread.",
     "- Never use the `slack` dispatcher `post_channel` action with a pinet thread ID (e.g. `a2a:...`) — it will fail. Pinet threads are not Slack channels.",
     "",
     "PINET DELEGATION RULES:",
     "- When you need another connected agent to take work or parallelize, do NOT use the Agent tool to spawn a local subagent for delegation.",
-    "- Prefer Pinet delegation: first use `pinet_agents` with the target repo to find a suitable connected worker in the same repo/worktree, then delegate via `pinet_message`.",
+    "- Prefer Pinet delegation: first use `pinet action=agents` with the target repo to find a suitable connected worker in the same repo/worktree, then delegate via `pinet action=send`.",
     "- Keep delegation inside the Pinet or Slack thread so ACKs, blockers, status updates, and final results flow back to the original sender.",
     "- Do not start or delegate extension changes unless the request names a GitHub issue/PR with clear maintainer priority/approval; if missing or unclear, ask first.",
     "- When delegating, include the workflow (`ack/work/ask/report`), the task, issue/PR numbers, maintainer approval, repo/branch/worktree setup, important files, acceptance criteria, and where to reply.",

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -166,7 +166,12 @@ describe("slack-bridge top-level shutdown", () => {
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(slackDispatcher).toBeDefined();
-    expect(tools.has("pinet_free")).toBe(true);
+    expect(tools.has("pinet")).toBe(true);
+    expect(tools.has("pinet_message")).toBe(false);
+    expect(tools.has("pinet_read")).toBe(false);
+    expect(tools.has("pinet_free")).toBe(false);
+    expect(tools.has("pinet_schedule")).toBe(false);
+    expect(tools.has("pinet_agents")).toBe(false);
     expect(commands.has("pinet-start")).toBe(true);
     expect(commands.has("pinet-free")).toBe(true);
     expect(commands.has("pinet-skin")).toBe(true);
@@ -3525,7 +3530,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("following broker"), "info");
   });
 
-  it("retries follower idle status sync after pinet_free fails once so workers do not stay stuck working", async () => {
+  it("retries follower idle status sync after dispatcher free fails once so workers do not stay stuck working", async () => {
     vi.useFakeTimers();
 
     const tools = new Map<string, ToolDefinition>();
@@ -3630,12 +3635,12 @@ describe("slack-bridge Pinet reconnect", () => {
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
     const follow = commands.get("pinet-follow");
-    const pinetFree = tools.get("pinet_free");
+    const pinet = tools.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(follow).toBeDefined();
-    expect(pinetFree).toBeDefined();
+    expect(pinet).toBeDefined();
 
     try {
       await sessionStart?.({}, ctx);
@@ -3647,9 +3652,12 @@ describe("slack-bridge Pinet reconnect", () => {
       });
       expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working"]);
 
-      await expect(pinetFree!.execute("tool-call-1", {})).rejects.toThrow(
-        "status sync failed once",
-      );
+      const failedFree = (await pinet!.execute("tool-call-1", {
+        action: "free",
+        args: {},
+      })) as { details: { status: string; errors: Array<{ message: string }> } };
+      expect(failedFree.details.status).toBe("failed");
+      expect(failedFree.details.errors[0]?.message).toContain("status sync failed once");
       expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working", "idle"]);
 
       await vi.advanceTimersByTimeAsync(2_000);
@@ -3953,7 +3961,7 @@ describe("slack-bridge Pinet reconnect", () => {
     }
   });
 
-  it("sends structured control envelopes for follower pinet_message commands", async () => {
+  it("sends structured control envelopes for follower dispatcher send commands", async () => {
     const tools = new Map<string, ToolDefinition>();
     const commands = new Map<string, CommandDefinition>();
     const events = new Map<string, EventHandler>();
@@ -4017,18 +4025,21 @@ describe("slack-bridge Pinet reconnect", () => {
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
     const follow = commands.get("pinet-follow");
-    const pinetMessage = tools.get("pinet_message");
+    const pinet = tools.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(follow).toBeDefined();
-    expect(pinetMessage).toBeDefined();
+    expect(pinet).toBeDefined();
 
     await sessionStart?.({}, ctx);
     await follow?.handler("", ctx);
-    await pinetMessage?.execute("tool-call-1", {
-      to: "receiver-agent",
-      message: "/reload",
+    await pinet?.execute("tool-call-1", {
+      action: "send",
+      args: {
+        to: "receiver-agent",
+        message: "/reload",
+      },
     });
 
     expect(sendCalls).toEqual([

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -78,30 +78,24 @@ describe("registerPinetTools", () => {
     vi.restoreAllMocks();
   });
 
-  it("registers the generic Pinet tools", () => {
+  it("registers the default Pinet surface", () => {
     const tools = registerWithDeps(createDeps());
 
-    expect([...tools.keys()]).toEqual([
-      "pinet",
-      "pinet_message",
-      "pinet_read",
-      "pinet_free",
-      "pinet_schedule",
-      "pinet_agents",
-    ]);
+    expect([...tools.keys()]).toEqual(["pinet"]);
   });
 
-  it("guides repo-scoped broadcasts away from #all", () => {
+  it("standardizes send/delegation on the dispatcher", () => {
     const tools = registerWithDeps(createDeps());
-    const pinetMessage = tools.get("pinet_message");
+    const pinet = tools.get("pinet");
 
-    expect(pinetMessage?.promptSnippet).toContain("Avoid #all");
-    expect(pinetMessage?.promptSnippet).toContain("#extensions");
-    expect(pinetMessage?.promptSnippet).toContain("repo-specific");
-    expect(JSON.stringify(pinetMessage?.parameters)).toContain("Avoid #all");
+    expect(pinet?.promptSnippet).toContain("Use this dispatcher for all Pinet actions");
+    expect(pinet?.promptSnippet).toContain('action="send"');
+    expect(JSON.stringify(pinet?.parameters)).toContain(
+      "help, send, read, free, schedule, or agents",
+    );
   });
 
-  it("uses the broker broadcast path for broadcast pinet_message targets", async () => {
+  it("uses the broker broadcast path for broadcast dispatcher send targets", async () => {
     const sendPinetBroadcastMessage = vi.fn((channel: string, _body: string) => ({
       channel,
       messageIds: [21, 22],
@@ -110,19 +104,26 @@ describe("registerPinetTools", () => {
     const deps = createDeps({ sendPinetBroadcastMessage });
     const tools = registerWithDeps(deps);
 
-    const result = (await tools.get("pinet_message")?.execute("tool-call-1", {
-      to: "#extensions",
-      message: "hello mesh",
+    const result = (await tools.get("pinet")?.execute("tool-call-1", {
+      action: "send",
+      args: {
+        to: "#extensions",
+        message: "hello mesh",
+      },
     })) as {
-      content: Array<{ text: string }>;
-      details: { channel: string; messageIds: number[]; recipients: string[] };
+      details: {
+        data: {
+          text: string;
+          details: { channel: string; messageIds: number[]; recipients: string[] };
+        };
+      };
     };
 
     expect(sendPinetBroadcastMessage).toHaveBeenCalledWith("#extensions", "hello mesh");
-    expect(result.content[0]?.text).toBe(
+    expect(result.details.data.text).toBe(
       "Broadcast sent to #extensions (2 agents: Worker One, Worker Two).",
     );
-    expect(result.details).toEqual({
+    expect(result.details.data.details).toEqual({
       channel: "#extensions",
       messageIds: [21, 22],
       recipients: ["Worker One", "Worker Two"],
@@ -167,27 +168,32 @@ describe("registerPinetTools", () => {
     const deps = createDeps({ readPinetInbox });
     const tools = registerWithDeps(deps);
 
-    const result = (await tools.get("pinet_read")?.execute("tool-call-read", {
-      thread_id: "a2a:broker:worker",
-      limit: 5,
+    const result = (await tools.get("pinet")?.execute("tool-call-read", {
+      action: "read",
+      args: {
+        thread_id: "a2a:broker:worker",
+        limit: 5,
+      },
     })) as {
-      content: Array<{ text: string }>;
-      details: { markedReadIds: number[] };
+      details: {
+        status: "succeeded";
+        data: { text: string; details: { markedReadIds: number[] } };
+      };
     };
 
     expect(readPinetInbox).toHaveBeenCalledWith({ threadId: "a2a:broker:worker", limit: 5 });
-    expect(result.content[0]?.text).toContain(
+    expect(result.details.data.text).toContain(
       "Pinet read (unread) from thread a2a:broker:worker: 1 message.",
     );
-    expect(result.content[0]?.text).toContain("Unread before: 2; unread after: 1.");
-    expect(result.content[0]?.text).toContain(
+    expect(result.details.data.text).toContain("Unread before: 2; unread after: 1.");
+    expect(result.details.data.text).toContain(
       "- [steering] [agent/a2a:broker:worker #44] broker: please inspect #594",
     );
-    expect(result.content[0]?.text).toContain(
+    expect(result.details.data.text).toContain(
       "- [steering] a2a:broker:worker (agent): 1 unread (1 steering); latest #45; pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
-    expect(result.content[0]?.text).toContain("Marked read: 31.");
-    expect(result.details.markedReadIds).toEqual([31]);
+    expect(result.details.data.text).toContain("Marked read: 31.");
+    expect(result.details.data.details.markedReadIds).toEqual([31]);
   });
 
   it("routes action-dispatched help through the dispatcher", async () => {
@@ -219,6 +225,17 @@ describe("registerPinetTools", () => {
     );
   });
 
+  it("rejects legacy direct-tool names as dispatcher action values", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-legacy-action", {
+      action: "pinet_send",
+    })) as { details: { status: string; errors: Array<{ message: string }> } };
+
+    expect(result.details.status).toBe("failed");
+    expect(result.details.errors[0]?.message).toContain("Unknown Pinet action: pinet_send");
+  });
+
   it("routes action-dispatched pinet send", async () => {
     const sendPinetAgentMessage = vi.fn(async (_to: string, _message: string) => ({
       messageId: 41,
@@ -244,7 +261,7 @@ describe("registerPinetTools", () => {
     expect(result.content[0]?.text).toContain('"status": "succeeded"');
   });
 
-  it("formats pinet_free responses with note and queued inbox count", async () => {
+  it("formats action-dispatched free responses with note and queued inbox count", async () => {
     const signalAgentFree = vi.fn(async () => ({
       queuedInboxCount: 2,
       drainedQueuedInbox: false,
@@ -252,25 +269,31 @@ describe("registerPinetTools", () => {
     const deps = createDeps({ signalAgentFree });
     const tools = registerWithDeps(deps);
 
-    const result = (await tools.get("pinet_free")?.execute("tool-call-2", {
-      note: "wrapped up #395",
+    const result = (await tools.get("pinet")?.execute("tool-call-2", {
+      action: "free",
+      args: { note: "wrapped up #395" },
     })) as {
-      content: Array<{ text: string }>;
-      details: { status: string; note: string | null; queuedInboxCount: number };
+      details: {
+        status: "succeeded";
+        data: {
+          text: string;
+          details: { status: string; note: string | null; queuedInboxCount: number };
+        };
+      };
     };
 
     expect(signalAgentFree).toHaveBeenCalledWith(undefined, { requirePinet: true });
-    expect(result.content[0]?.text).toBe(
+    expect(result.details.data.text).toBe(
       "Marked this Pinet agent idle/free for new work. Note: wrapped up #395. 2 queued inbox items remain.",
     );
-    expect(result.details).toEqual({
+    expect(result.details.data.details).toEqual({
       status: "idle",
       note: "wrapped up #395",
       queuedInboxCount: 2,
     });
   });
 
-  it("routes pinet_schedule through the broker wake-up callback", async () => {
+  it("routes action-dispatched schedule through the broker wake-up callback", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
 
@@ -281,20 +304,24 @@ describe("registerPinetTools", () => {
     const deps = createDeps({ scheduleBrokerWakeup });
     const tools = registerWithDeps(deps);
 
-    const result = (await tools.get("pinet_schedule")?.execute("tool-call-3", {
-      delay: "5m",
-      message: "check queue",
+    const result = (await tools.get("pinet")?.execute("tool-call-3", {
+      action: "schedule",
+      args: { delay: "5m", message: "check queue" },
     })) as {
-      content: Array<{ text: string }>;
-      details: { id: number; fireAt: string };
+      details: {
+        status: "succeeded";
+        data: { text: string; details: { id: number; fireAt: string } };
+      };
     };
 
     expect(scheduleBrokerWakeup).toHaveBeenCalledWith("2026-04-14T12:05:00.000Z", "check queue");
-    expect(result.content[0]?.text).toBe("Wake-up scheduled for 2026-04-14T12:05:00.000Z (id: 7).");
-    expect(result.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
+    expect(result.details.data.text).toBe(
+      "Wake-up scheduled for 2026-04-14T12:05:00.000Z (id: 7).",
+    );
+    expect(result.details.data.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
   });
 
-  it("renders broker pinet_agents output with routing hints and outbound counts", async () => {
+  it("renders broker pinet agents output with routing hints and outbound counts", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
 
@@ -302,22 +329,30 @@ describe("registerPinetTools", () => {
     const deps = createDeps({ listBrokerAgents });
     const tools = registerWithDeps(deps);
 
-    const result = (await tools.get("pinet_agents")?.execute("tool-call-4", {
-      repo: "extensions",
-      required_tools: "read, edit",
-      task: "review #395",
+    const result = (await tools.get("pinet")?.execute("tool-call-4", {
+      action: "agents",
+      args: {
+        repo: "extensions",
+        required_tools: "read, edit",
+        task: "review #395",
+      },
     })) as {
-      content: Array<{ text: string }>;
-      details: { hint: { repo?: string; requiredTools?: string[]; task?: string } };
+      details: {
+        status: "succeeded";
+        data: {
+          text: string;
+          details: { hint: { repo?: string; requiredTools?: string[]; task?: string } };
+        };
+      };
     };
 
     expect(listBrokerAgents).toHaveBeenCalledTimes(1);
-    expect(result.content[0]?.text).toContain(
+    expect(result.details.data.text).toContain(
       "Agent routing hints: repo=extensions · tools=read,edit · task=review #395",
     );
-    expect(result.content[0]?.text).toContain("Golden Chalk Rabbit");
-    expect(result.content[0]?.text).toContain("outbound: 3 this session");
-    expect(result.details.hint).toEqual({
+    expect(result.details.data.text).toContain("Golden Chalk Rabbit");
+    expect(result.details.data.text).toContain("outbound: 3 this session");
+    expect(result.details.data.details.hint).toEqual({
       repo: "extensions",
       branch: undefined,
       role: undefined,

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -127,7 +127,6 @@ function normalizeDispatcherAction(value: unknown): PinetDispatcherAction {
   const normalized = value
     .trim()
     .replace(/^pinet:/, "")
-    .replace(/^pinet_/, "")
     .toLowerCase() as PinetDispatcherAction;
 
   if (!normalized) {
@@ -658,7 +657,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     description:
       "Dispatch Pinet worker operations by action with compact help and schema discovery.",
     promptSnippet:
-      'Use this dispatcher for token-efficient Pinet actions and per-action discovery. Use action="help" for action catalog.',
+      'Use this dispatcher for all Pinet actions: send, read, free, schedule, agents, and per-action discovery. Use action="help" for the action catalog and action="send" for Pinet replies/delegation.',
     parameters: Type.Object({
       action: Type.String({
         description: "Action name: help, send, read, free, schedule, or agents.",
@@ -732,104 +731,6 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
           buildPinetDispatcherEnvelope("failed", null, [classifyPinetError(message)]),
         );
       }
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_message",
-    label: "Pinet Message",
-    description: "Send a message to a connected Pinet agent or broker-only broadcast channel.",
-    promptSnippet:
-      "Compatibility shim for legacy usage. Prefer pinet action=send. Use this for repo-scoped channels like #extensions and Avoid #all for repo-specific announcements.",
-    parameters: Type.Object({
-      to: Type.String({
-        description:
-          "Target agent name/ID, or a broker-only broadcast channel like #extensions. Avoid #all for repo-specific issue/policy announcements.",
-      }),
-      message: Type.String({ description: "Message body" }),
-    }),
-    async execute(_id, params) {
-      return runPinetSendAction(params, deps, "pinet_message");
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_read",
-    label: "Pinet Read",
-    description: "Read durable SQLite-backed Pinet inbox context with unread/read semantics.",
-    promptSnippet:
-      "Compatibility shim for legacy usage. Prefer pinet action=read. Read bounded Pinet/Slack broker context from the durable SQLite inbox.",
-    parameters: Type.Object({
-      thread_id: Type.Optional(
-        Type.String({ description: "Optional Pinet/Slack broker thread ID to read" }),
-      ),
-      limit: Type.Optional(
-        Type.Number({ description: "Maximum messages to return (default 20, max 100)" }),
-      ),
-      unread_only: Type.Optional(
-        Type.Boolean({ description: "Only return unread rows (default true)" }),
-      ),
-      mark_read: Type.Optional(
-        Type.Boolean({ description: "Mark returned unread rows as read (default true)" }),
-      ),
-    }),
-    async execute(_id, params) {
-      return runPinetReadAction(params, deps, "pinet_read");
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_free",
-    label: "Pinet Free",
-    description: "Mark this Pinet agent idle/free for new work.",
-    promptSnippet: "Compatibility shim for legacy usage. Prefer pinet action=free.",
-    parameters: Type.Object({
-      note: Type.Optional(
-        Type.String({ description: "Optional short note about what you just finished" }),
-      ),
-    }),
-    async execute(_id, params) {
-      return runPinetFreeAction(params, deps, "pinet_free");
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_schedule",
-    label: "Pinet Schedule",
-    description: "Schedule a future wake-up for this Pinet agent.",
-    promptSnippet: "Compatibility shim for legacy usage. Prefer pinet action=schedule.",
-    parameters: Type.Object({
-      delay: Type.Optional(
-        Type.String({ description: "Relative delay like 5m, 30s, 1h30m, or 1d" }),
-      ),
-      at: Type.Optional(
-        Type.String({ description: "Absolute ISO-8601 UTC time, e.g. 2026-04-02T14:30:00Z" }),
-      ),
-      message: Type.String({ description: "Reminder or wake-up message to deliver later" }),
-    }),
-    async execute(_id, params) {
-      return runPinetScheduleAction(params, deps, "pinet_schedule");
-    },
-  });
-
-  pi.registerTool({
-    name: "pinet_agents",
-    label: "Pinet Agents",
-    description: "List connected Pinet agents with status and capabilities.",
-    promptSnippet: "Compatibility shim for legacy usage. Prefer pinet action=agents.",
-    parameters: Type.Object({
-      repo: Type.Optional(Type.String({ description: "Preferred repo name for routing" })),
-      branch: Type.Optional(Type.String({ description: "Preferred branch for routing" })),
-      role: Type.Optional(
-        Type.String({ description: "Preferred agent role, e.g. broker or worker" }),
-      ),
-      required_tools: Type.Optional(
-        Type.String({ description: "Comma-separated required capability/tool tags" }),
-      ),
-      task: Type.Optional(Type.String({ description: "Optional natural-language task hint" })),
-    }),
-    async execute(_toolCallId, params) {
-      return runPinetAgentsAction(params, deps, "pinet_agents");
     },
   });
 }

--- a/slack-bridge/slack-tool-policy-runtime.test.ts
+++ b/slack-bridge/slack-tool-policy-runtime.test.ts
@@ -207,7 +207,7 @@ describe("createSlackToolPolicyRuntime", () => {
     ).resolves.toEqual({
       block: true,
       reason:
-        'Tool "edit" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.',
+        'Tool "edit" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet action=send to delegate to a connected worker instead.',
     });
     expect(requireToolPolicy).not.toHaveBeenCalled();
   });

--- a/slack-bridge/slack-tool-policy-runtime.ts
+++ b/slack-bridge/slack-tool-policy-runtime.ts
@@ -82,7 +82,7 @@ export function createSlackToolPolicyRuntime(
     if (deps.getBrokerRole() === "broker" && isBrokerForbiddenTool(event.toolName)) {
       return {
         block: true,
-        reason: `Tool "${event.toolName}" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet_message to delegate to a connected worker instead.`,
+        reason: `Tool "${event.toolName}" is forbidden for the broker role. The broker coordinates — it does not code. Use pinet action=send to delegate to a connected worker instead.`,
       };
     }
 


### PR DESCRIPTION
## Summary
- standardize the default Pinet tool surface on the single `pinet` dispatcher
- route sends/delegation through `pinet action=send`; remove the dedicated `pinet_message` tool entirely
- delete the legacy direct Pinet tool registrations (`pinet_message`, `pinet_read`, `pinet_free`, `pinet_schedule`, `pinet_agents`) instead of retaining compatibility-mode shims
- update Pinet prompts/docs/tests/guardrails to use `pinet action=send/read/free/schedule/agents`

Refs #615

## Product / migration note
This follows the latest human review direction to standardize the Pinet surface: the supported tool surface is now only `pinet`, with action-based routing for `send`, `read`, `free`, `schedule`, and `agents`.

Security guardrails still map legacy `pinet_*` policy patterns to dispatcher action names so existing `blockedTools` / `requireConfirmation` configs fail closed while operators migrate config spelling. Former `pinet_message` policy names also continue to cover `pinet action=send`.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --write slack-bridge/pinet-tools.ts slack-bridge/pinet-tools.test.ts slack-bridge/helpers.ts slack-bridge/helpers.test.ts slack-bridge/index.ts slack-bridge/index.test.ts slack-bridge/broker-inbound-persistence.ts slack-bridge/broker-inbound-persistence.test.ts slack-bridge/README.md slack-bridge/guardrails.ts slack-bridge/guardrails.test.ts slack-bridge/slack-tool-policy-runtime.ts slack-bridge/slack-tool-policy-runtime.test.ts plans/pinet-vision.md plans/reviewer-nicopreme-migration.md`
- `pnpm --filter @gugu910/pi-slack-bridge test -- pinet-tools.test.ts guardrails.test.ts helpers.test.ts index.test.ts slack-tool-policy-runtime.test.ts` (Vitest ran package suite: 71 files / 1180 tests passed)
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `git diff --check`
- `git push --force-with-lease` (pre-push hook passed; turbo reported 9 successful tasks)

## Review
- Used `scout` to map legacy compatibility references.
- Used `reviewer` and `code-reviewer` for focused review passes across the tool-surface changes.
- Addressed the latest standardization request by deleting `pinet_message` and routing all sends through `pinet action=send`.
- Latest `code-reviewer` pass approved the standardized single-dispatcher surface, with no critical blockers.
- No merge requested/performed.
