### PR TITLE
fix(pinet): persist Slack thread routing ownership

### DIFF
--- a/broker-core/message-send.ts
+++ b/broker-core/message-send.ts
@@ -15,6 +15,7 @@ export interface BrokerMessageSenderDb {
     ownerAgent: string | null,
   ): ThreadInfo;
   updateThread(threadId: string, updates: Partial<ThreadInfo>): void;
+  claimThread(threadId: string, agentId: string, source?: string, channel?: string): boolean;
   insertMessage(
     threadId: string,
     source: string,
@@ -102,6 +103,27 @@ export async function sendBrokerMessage(
   const content = normalizeMessageContent(input.content);
   const messageBody = content?.text ?? body;
 
+  let thread = existingThread;
+  if (thread?.ownerAgent && thread.ownerAgent !== input.senderAgentId) {
+    throw new Error(`Thread ${threadId} is already owned by another agent.`);
+  }
+
+  if (!thread || thread.ownerAgent === null) {
+    const claimed = deps.db.claimThread(threadId, input.senderAgentId, source, channel);
+    if (!claimed) {
+      throw new Error(`Thread ${threadId} is already owned by another agent.`);
+    }
+    thread = deps.db.getThread(threadId);
+    if (!thread) {
+      throw new Error(`Thread ${threadId} was claimed but could not be read back.`);
+    }
+  }
+
+  if (thread.source !== source || thread.channel !== channel) {
+    deps.db.updateThread(threadId, { source, channel });
+    thread = { ...thread, source, channel };
+  }
+
   const outbound: OutboundMessage = {
     threadId,
     channel,
@@ -114,14 +136,6 @@ export async function sendBrokerMessage(
     ...(input.metadata ? { metadata: input.metadata } : {}),
   };
   await adapter.send(outbound);
-
-  let thread = existingThread;
-  if (!thread) {
-    thread = deps.db.createThread(threadId, source, channel, input.senderAgentId);
-  } else if (thread.source !== source || thread.channel !== channel) {
-    deps.db.updateThread(threadId, { source, channel });
-    thread = { ...thread, source, channel };
-  }
 
   const message = deps.db.insertMessage(
     threadId,

--- a/broker-core/router.ts
+++ b/broker-core/router.ts
@@ -328,11 +328,24 @@ export class MessageRouter {
     }
 
     // New thread / top-level message: channel assignment can still steer work.
+    // Persist that assignment as thread ownership so later generic replies in
+    // the same Slack thread route back to the same agent without another
+    // manual broker/human assignment. Existing known threads stay protected by
+    // the `thread` branch above and do not fall back to channel assignment.
     const assignment = this.db.getChannelAssignment(msg.channel);
     if (assignment) {
       const assigned = agents.find((agent) => agent.id === assignment.agentId);
       if (assigned) {
-        return { action: "deliver", agentId: assigned.id };
+        const claimed = this.db.claimThread(msg.threadId, assigned.id, msg.source, msg.channel);
+        if (claimed) {
+          return { action: "deliver", agentId: assigned.id };
+        }
+
+        const claimedThread = this.db.getThread(msg.threadId);
+        const claimedOwner = resolveRoutableThreadOwner(this.db, claimedThread?.ownerAgent ?? null);
+        if (claimedOwner) {
+          return { action: "deliver", agentId: claimedOwner.id };
+        }
       }
     }
 

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -970,6 +970,7 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     const thread = db.getThread("new-msg-ts");
     expect(thread).not.toBeNull();
     expect(thread!.ownerAgent).toBe(reg.agentId);
+    expect(thread!.channel).toBe("C-AUTO");
   });
 
   it("slack.proxy chat.postMessage with thread_ts claims the existing thread", async () => {
@@ -1006,6 +1007,7 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     const thread = db.getThread("existing-thread-ts");
     expect(thread).not.toBeNull();
     expect(thread!.ownerAgent).toBe(reg.agentId);
+    expect(thread!.channel).toBe("C-REPLY");
 
     // The reply ts itself should NOT create a separate thread
     expect(db.getThread("reply-ts")).toBeNull();

--- a/slack-bridge/broker/message-send.test.ts
+++ b/slack-bridge/broker/message-send.test.ts
@@ -32,6 +32,27 @@ function createFakeDb() {
       }
       threads.set(threadId, { ...existing, ...updates });
     },
+    claimThread(threadId: string, agentId: string, source = "slack", channel = "") {
+      const existing = threads.get(threadId);
+      if (existing) {
+        if (existing.ownerAgent && existing.ownerAgent !== agentId) {
+          return false;
+        }
+        threads.set(threadId, { ...existing, ownerAgent: agentId });
+        return true;
+      }
+      const now = new Date().toISOString();
+      threads.set(threadId, {
+        threadId,
+        source,
+        channel,
+        ownerAgent: agentId,
+        ownerBinding: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return true;
+    },
     insertMessage(
       threadId: string,
       source: string,
@@ -204,6 +225,109 @@ describe("sendBrokerMessage", () => {
       channel: "chat:bob",
       text: "follow-up",
     });
+  });
+
+  it("claims an existing unowned transport thread for the sending agent", async () => {
+    const db = createFakeDb();
+    db.createThread("100.300", "slack", "C-OLD", null);
+    const send = vi.fn(async () => undefined);
+
+    const result = await sendBrokerMessage(
+      {
+        db,
+        adapters: [{ name: "slack", send }],
+      },
+      {
+        threadId: "100.300",
+        body: "first agent response",
+        senderAgentId: "agent-1",
+        source: "slack",
+        channel: "C-NEW",
+      },
+    );
+
+    expect(db.getThread("100.300")).toMatchObject({
+      source: "slack",
+      channel: "C-NEW",
+      ownerAgent: "agent-1",
+    });
+    expect(result.thread).toMatchObject({ ownerAgent: "agent-1", channel: "C-NEW" });
+  });
+
+  it("does not steal or send to an existing transport thread owned by another agent", async () => {
+    const db = createFakeDb();
+    db.createThread("100.301", "slack", "C123", "other-agent");
+    const send = vi.fn(async () => undefined);
+
+    await expect(
+      sendBrokerMessage(
+        {
+          db,
+          adapters: [{ name: "slack", send }],
+        },
+        {
+          threadId: "100.301",
+          body: "agent response",
+          senderAgentId: "agent-1",
+        },
+      ),
+    ).rejects.toThrow("Thread 100.301 is already owned by another agent.");
+
+    expect(send).not.toHaveBeenCalled();
+    expect(db.getThread("100.301")?.ownerAgent).toBe("other-agent");
+  });
+
+  it("sends only the winning first response for an existing unowned thread", async () => {
+    const db = createFakeDb();
+    db.createThread("100.302", "slack", "C123", null);
+    const send = vi.fn(async () => undefined);
+    const deps = { db, adapters: [{ name: "slack", send }] };
+
+    const results = await Promise.allSettled([
+      sendBrokerMessage(deps, {
+        threadId: "100.302",
+        body: "first response",
+        senderAgentId: "agent-1",
+      }),
+      sendBrokerMessage(deps, {
+        threadId: "100.302",
+        body: "racing response",
+        senderAgentId: "agent-2",
+      }),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(db.getThread("100.302")?.ownerAgent).toBe("agent-1");
+  });
+
+  it("sends only the winning first response for a fresh thread", async () => {
+    const db = createFakeDb();
+    const send = vi.fn(async () => undefined);
+    const deps = { db, adapters: [{ name: "slack", send }] };
+
+    const results = await Promise.allSettled([
+      sendBrokerMessage(deps, {
+        threadId: "100.303",
+        body: "first fresh response",
+        senderAgentId: "agent-1",
+        source: "slack",
+        channel: "C123",
+      }),
+      sendBrokerMessage(deps, {
+        threadId: "100.303",
+        body: "racing fresh response",
+        senderAgentId: "agent-2",
+        source: "slack",
+        channel: "C123",
+      }),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(db.getThread("100.303")?.ownerAgent).toBe("agent-1");
   });
 
   it("fails cleanly when no adapter is registered for the thread source", async () => {

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -335,7 +335,7 @@ describe("MessageRouter — route", () => {
     expect(db.threads.get("t-100")?.ownerAgent).toBeNull();
   });
 
-  it("routes to channel assignment when no thread owner", () => {
+  it("routes to channel assignment and claims new Slack threads for later follow-up", () => {
     const agent = makeAgent({ id: "a2", name: "ChannelBot" });
     db.agents = [agent];
     db.channelAssignments.set("C001", { channel: "C001", agentId: "a2" });
@@ -343,6 +343,21 @@ describe("MessageRouter — route", () => {
     const decision = router.route(makeMessage({ channel: "C001" }));
 
     expect(decision).toEqual({ action: "deliver", agentId: "a2" });
+    expect(db.threads.get("t-100")).toMatchObject({
+      source: "slack",
+      channel: "C001",
+      ownerAgent: "a2",
+    });
+
+    const followUp = router.route(
+      makeMessage({
+        threadId: "t-100",
+        channel: "C001",
+        text: "generic follow-up without another assignment cue",
+      }),
+    );
+
+    expect(followUp).toEqual({ action: "deliver", agentId: "a2" });
   });
 
   it("routes by agent name mention when no thread owner or channel assignment", () => {

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -1062,9 +1062,13 @@ export class BrokerSocketServer {
       if (method === "chat.postMessage" && state.agentId) {
         const threadTs = typeof apiParams.thread_ts === "string" ? apiParams.thread_ts : null;
         const messageTs = typeof result.ts === "string" ? (result.ts as string) : null;
+        const postChannel = typeof apiParams.channel === "string" ? apiParams.channel : undefined;
         const effectiveTs = threadTs ?? messageTs;
         if (effectiveTs) {
-          this.router.claimThread(effectiveTs, state.agentId, undefined, "slack");
+          const claimed = this.router.claimThread(effectiveTs, state.agentId, postChannel, "slack");
+          if (claimed && postChannel) {
+            this.db.updateThread(effectiveTs, { source: "slack", channel: postChannel });
+          }
         }
       }
 

--- a/slack-bridge/imessage-tools.test.ts
+++ b/slack-bridge/imessage-tools.test.ts
@@ -50,6 +50,24 @@ function createBrokerStub() {
         }
       },
     ),
+    claimThread: vi.fn((threadId: string, ownerAgent: string, source = "slack", channel = "") => {
+      if (thread && thread.threadId === threadId) {
+        if (thread.ownerAgent && thread.ownerAgent !== ownerAgent) {
+          return false;
+        }
+        thread = { ...thread, ownerAgent };
+        return true;
+      }
+      thread = {
+        threadId,
+        source,
+        channel,
+        ownerAgent,
+        createdAt: now,
+        updatedAt: now,
+      };
+      return true;
+    }),
     insertMessage: vi.fn(
       (
         threadId: string,


### PR DESCRIPTION
## Summary
- claim new channel-assigned Slack threads so generic follow-up replies route back to the assigned agent
- claim existing unowned transport threads on first agent-side message send without stealing from another owner
- preserve Slack channel metadata when `slack.proxy chat.postMessage` auto-claims thread ownership

Fixes #645.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker/router.test.ts broker/message-send.test.ts broker/integration.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core test`
- `git diff --check`
- `pnpm lint && pnpm typecheck && pnpm test`

## Review
- Scout subagent mapped the ownership gaps before implementation.
- Reviewer subagent found no blocking issues; noted only possible future contention coverage for simultaneous first responses.
