### PR TITLE
pinet: point Slack inbox prompts at read

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -130,6 +130,36 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("inbox.read still returns unread context after delivery ack", async () => {
+    const reg1 = await client.register("sender-agent", "📤");
+    expect(reg1.agentId).toBeDefined();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const client2 = new BrokerClient({ host: info.host, port: info.port });
+    await client2.connect();
+    await client2.register("receiver-agent", "📥");
+
+    await client.send("thread-ack-read", "Unread until read");
+
+    const pending = await client2.pollInbox();
+    expect(pending).toHaveLength(1);
+    await client2.ackMessages([pending[0].inboxId]);
+    expect(await client2.pollInbox()).toEqual([]);
+
+    const unread = await client2.readInbox({ threadId: "thread-ack-read", unreadOnly: true });
+    expect(unread.unreadCountBefore).toBe(1);
+    expect(unread.messages.map((item) => item.message.body)).toEqual(["Unread until read"]);
+    expect(unread.markedReadIds).toHaveLength(1);
+    expect(unread.unreadCountAfter).toBe(0);
+
+    const unreadAgain = await client2.readInbox({ threadId: "thread-ack-read", unreadOnly: true });
+    expect(unreadAgain.messages).toEqual([]);
+    expect(unreadAgain.unreadCountBefore).toBe(0);
+
+    client2.disconnect();
+  });
+
   it("sender does not receive own messages", async () => {
     await client.register("solo-agent", "🤖");
     await client.send("thread-solo", "Talking to myself");

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -453,6 +453,58 @@ describe("formatInboxMessages", () => {
     expect(result).toContain("will: check this");
   });
 
+  it("formats broker-backed Slack messages as Pinet read pointers without the body", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "C789",
+        threadTs: "789.012",
+        userId: "U1",
+        text: "secret Slack body",
+        timestamp: "789.012",
+        brokerInboxId: 13,
+        isChannelMention: true,
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain("New Slack messages:");
+    expect(result).toContain(
+      "[thread 789.012] (channel mention in <#C789>) will: inbox_id=13 pointer=pinet action=read args.thread_id=789.012 args.unread_only=true",
+    );
+    expect(result).toContain("Use pinet action=read with the pointer before acting.");
+    expect(result).toContain("ACK briefly after reading, do the work");
+    expect(result).not.toContain("secret Slack body");
+  });
+
+  it("preserves compact Slack metadata on broker-backed pointer notifications", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "C123",
+        threadTs: "123.456",
+        userId: "U1",
+        text: "Alice mentioned you in a comment",
+        timestamp: "123.789",
+        brokerInboxId: 14,
+        metadata: {
+          slackFiles: [
+            {
+              id: "F_CANVAS_1",
+              title: "Launch plan",
+              permalink: "https://example.slack.com/docs/T/F_CANVAS_1",
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain(
+      "will: inbox_id=14 pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
+    );
+    expect(result).toContain('canvas={"canvasId":"F_CANVAS_1"');
+    expect(result).not.toContain("Alice mentioned you in a comment");
+  });
+
   it("falls back to userId when name not in map", () => {
     const msgs: InboxMessage[] = [
       {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -12,6 +12,7 @@ import {
   type RuntimeScopeCarrier,
 } from "@gugu910/pi-transport-core";
 import type { ReactionCommandSettings } from "./reaction-triggers.js";
+import { buildPinetReadPointer } from "./broker-inbound-persistence.js";
 import { matchesToolPattern } from "./guardrails.js";
 
 // ─── Settings ────────────────────────────────────────────
@@ -323,20 +324,37 @@ function inboxMessageToPinetEntry(message: InboxMessage): FollowerInboxEntry {
   };
 }
 
+function formatSlackInboxLine(
+  message: InboxMessage,
+  senderLabel: string,
+  metadataSuffix: string,
+): string {
+  const prefix = message.isChannelMention
+    ? `[thread ${message.threadTs}] (channel mention in <#${message.channel}>) ${senderLabel}:`
+    : `[thread ${message.threadTs}] ${senderLabel}:`;
+
+  if (message.brokerInboxId != null) {
+    return `${prefix} inbox_id=${message.brokerInboxId} ${buildPinetReadPointer(message.threadTs)}${metadataSuffix}`;
+  }
+
+  return `${prefix} ${message.text}${metadataSuffix}`;
+}
+
 function formatSlackInboxMessages(
   messages: InboxMessage[],
   userNames: { get(key: string): string | undefined },
 ): string {
+  const hasDurablePointer = messages.some((message) => message.brokerInboxId != null);
   const lines = messages.map((m) => {
     const n = userNames.get(m.userId) ?? m.userId;
-    const metadataSuffix = formatInboxMetadata(m.metadata);
-    if (m.isChannelMention) {
-      return `[thread ${m.threadTs}] (channel mention in <#${m.channel}>) ${n}: ${m.text}${metadataSuffix}`;
-    }
-    return `[thread ${m.threadTs}] ${n}: ${m.text}${metadataSuffix}`;
+    return formatSlackInboxLine(m, n, formatInboxMetadata(m.metadata));
   });
 
-  return `New Slack messages:\n${lines.join("\n")}\n\nACK briefly, do the work, report blockers immediately, report the outcome when done.`;
+  const guidance = hasDurablePointer
+    ? "Use pinet action=read with the pointer before acting. ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+    : "ACK briefly, do the work, report blockers immediately, report the outcome when done.";
+
+  return `New Slack messages:\n${lines.join("\n")}\n\n${guidance}`;
 }
 
 export function formatInboxMessages(
@@ -382,13 +400,7 @@ export function isTerminalPinetStandDownMessage(body: string | null | undefined)
 }
 
 function formatPinetInboxPointer(entry: FollowerInboxEntry): string {
-  const threadId = entry.message.threadId?.trim() ?? "";
-  const parts = [
-    "pointer=pinet action=read",
-    threadId ? `args.thread_id=${threadId}` : null,
-    "args.unread_only=true",
-  ].filter((part): part is string => Boolean(part));
-  return parts.join(" ");
+  return buildPinetReadPointer(entry.message.threadId ?? "");
 }
 
 export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -3648,8 +3648,13 @@ describe("slack-bridge Pinet reconnect", () => {
 
       await vi.advanceTimersByTimeAsync(2_000);
       await vi.waitFor(() => {
-        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"));
+        expect(sendUserMessage).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "pointer=pinet action=read args.thread_id=100.1 args.unread_only=true",
+          ),
+        );
       });
+      expect(sendUserMessage.mock.calls[0]?.[0]).not.toContain("hello from broker");
       expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working"]);
 
       const failedFree = (await pinet!.execute("tool-call-1", {
@@ -3792,8 +3797,13 @@ describe("slack-bridge Pinet reconnect", () => {
 
       await vi.advanceTimersByTimeAsync(2_000);
       await vi.waitFor(() => {
-        expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"));
+        expect(sendUserMessage).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "pointer=pinet action=read args.thread_id=100.1 args.unread_only=true",
+          ),
+        );
       });
+      expect(sendUserMessage.mock.calls[0]?.[0]).not.toContain("hello from broker");
       expect(updateStatus.mock.calls.map(([status]) => status)).toEqual(["working"]);
 
       await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
@@ -3951,7 +3961,12 @@ describe("slack-bridge Pinet reconnect", () => {
       await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
 
       expect(sendUserMessage).toHaveBeenCalledTimes(1);
-      expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("hello from broker"));
+      expect(sendUserMessage).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "pointer=pinet action=read args.thread_id=100.1 args.unread_only=true",
+        ),
+      );
+      expect(sendUserMessage.mock.calls[0]?.[0]).not.toContain("hello from broker");
 
       await sessionShutdown?.({}, ctx);
       expect(setStatus).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- render broker-backed Slack inbox rows as compact durable `pinet action=read` pointer notifications instead of including the Slack body in runtime prompts
- keep compact Slack metadata suffixes (for example canvas comment hints) on pointer notifications
- reuse the shared Pinet read pointer builder and preserve delivery ACK vs durable read semantics

## Stack context
- Refs #594
- Advances #608 by migrating the worker-routed Slack follower prompt path toward SQLite mail/read semantics
- Base includes #646, so this keeps the dispatcher-only wording (`pinet action=read`) and does not reintroduce the removed direct `pinet_read` tool
- #648 has merged, so this branch is rebased onto current `main` with the A2A mail-class stamping restoration included upstream

## Validation
- `pnpm exec prettier --write slack-bridge/helpers.ts slack-bridge/helpers.test.ts slack-bridge/index.test.ts slack-bridge/broker/integration.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts inbox-drain-runtime.test.ts index.test.ts broker/integration.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `git diff --check`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook passed while pushing `feat/pinet-slack-pointer-notifications`

## Subagents
- `scout`: refreshed the #608 pointer-notification slice against current #646 dispatcher-only mainline
- `worker`: checked the implementation and added the delivery-ACK/read-separation integration regression
- `reviewer`: reviewed the final diff; no critical/warning findings

No merge without explicit human approval.
