### PR TITLE
pinet: stamp Slack inbound mail classes

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -303,6 +303,35 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("stamps queued unrouted Slack backlog mail with an explicit class", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      const backlog = db.queueUnroutedMessage({
+        source: "slack",
+        threadId: "123.456",
+        channel: "C123",
+        userId: "U1",
+        userName: "User One",
+        text: "Please handle issue #608 and report blockers immediately.",
+        timestamp: "123.456",
+      });
+      db.assignBacklogEntry(backlog.id, "agent-1");
+
+      const read = db.readInbox("agent-1", { markRead: false });
+      expect(read.messages[0].message.metadata).toMatchObject({
+        channel: "C123",
+        userId: "U1",
+        timestamp: "123.456",
+        pinetMailClass: "steering",
+        threadAffinityOwnerAgentId: "agent-1",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("does not reopen assigned backlog when a Slack message replay is queued unrouted", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);
@@ -392,6 +421,66 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("stamps worker-routed Slack inbox mail with an explicit class", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-a", "slack", "C123", "agent-a");
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "Task: handle issue #608. ACK/work/ask/report.",
+        timestamp: "123.456",
+      });
+
+      const read = db.readInbox("agent-a", { markRead: false });
+      expect(read.messages[0].message.metadata).toMatchObject({
+        channel: "C123",
+        userId: "U1",
+        timestamp: "123.456",
+        threadAffinityOwnerAgentId: "agent-a",
+        pinetMailClass: "steering",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves explicit Slack mail class metadata when queueing inbound mail", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-a", "slack", "C123", "agent-a");
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "Task: handle this now. ACK/work/ask/report.",
+        timestamp: "123.456",
+        metadata: { pinetMailClass: "maintenance_context" },
+      });
+
+      const read = db.readInbox("agent-a", { markRead: false });
+      expect(read.messages[0].message.metadata).toMatchObject({
+        pinetMailClass: "maintenance_context",
+      });
+      expect(
+        classifyPinetMail({
+          source: read.messages[0].message.source,
+          threadId: read.messages[0].message.threadId,
+          sender: read.messages[0].message.sender,
+          body: read.messages[0].message.body,
+          metadata: read.messages[0].message.metadata,
+        }).class,
+      ).toBe("maintenance_context");
+    } finally {
+      db.close();
+    }
+  });
+
   it("drops stale Slack inbox rows when thread ownership changed before delivery", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);
@@ -459,6 +548,7 @@ describe("BrokerDB message sync identity", () => {
         userId: "U1",
         timestamp: "123.456",
         threadAffinityOwnerAgentId: "broker",
+        pinetMailClass: "fwup",
       });
     } finally {
       db.close();

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -1514,14 +1514,14 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   queueUnroutedMessage(message: InboundMessage, reason = "no_route"): BacklogEntry {
-    const metadata: Record<string, unknown> = {
+    const metadata = this.withInboundMailClassMetadata(message, {
       ...message.metadata,
       channel: message.channel,
       userName: message.userName,
       userId: message.userId,
       timestamp: message.timestamp,
       ...(message.isChannelMention ? { isChannelMention: true } : {}),
-    };
+    });
 
     const existingThread = this.getThread(message.threadId);
     if (!existingThread) {
@@ -2172,7 +2172,7 @@ export class BrokerDB implements BrokerDBInterface {
       message.source === "slack" && message.threadId
         ? this.getThread(message.threadId)?.ownerAgent
         : null;
-    return {
+    return this.withInboundMailClassMetadata(message, {
       ...message.metadata,
       channel: message.channel,
       userName: message.userName,
@@ -2181,6 +2181,31 @@ export class BrokerDB implements BrokerDBInterface {
       ...(threadOwner ? { threadAffinityOwnerAgentId: threadOwner } : {}),
       ...(message.isChannelMention ? { isChannelMention: true } : {}),
       ...(message.scope ? { scope: message.scope } : {}),
+    });
+  }
+
+  private withInboundMailClassMetadata(
+    message: InboundMessage,
+    metadata: Record<string, unknown>,
+  ): Record<string, unknown> {
+    if (message.source !== "slack") {
+      return metadata;
+    }
+
+    const classification = classifyPinetMail({
+      source: message.source,
+      threadId: message.threadId,
+      sender: message.userId,
+      body: message.text,
+      metadata,
+    });
+    if (classification.explicit) {
+      return metadata;
+    }
+
+    return {
+      ...metadata,
+      pinetMailClass: classification.class,
     };
   }
 
@@ -2238,6 +2263,7 @@ export class BrokerDB implements BrokerDBInterface {
     if (!row) return null;
 
     const metadata = parseJsonMetadata(row.metadata);
+    metadata.pinetMailClass = mailClass;
     metadata.pinet_mail_class = mailClass;
     metadata.pinet_mail_class_reason = audit.reason ?? "manual_reclassification";
     appendMetadataAudit(metadata, "pinet_mail_class_audit", {


### PR DESCRIPTION
## Summary\n- stamp Slack inbound durable/backlog metadata with explicit pinetMailClass during queueMessage, queueDeliveredMessage, and queueUnroutedMessage flows\n- preserve caller-provided explicit mail-class metadata\n- update arrow-up reaction reclassification to write both camelCase and snake_case class keys so it wins over prior stamped classes\n\n## Validation\n- pnpm --filter @gugu910/pi-broker-core test -- schema.test.ts mail-classification.test.ts\n- pnpm --filter @gugu910/pi-broker-core test\n- pnpm --filter @gugu910/pi-broker-core typecheck\n- pnpm --filter @gugu910/pi-broker-core lint\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- git diff --check\n- pre-push hook\n\nRefs #608 #582