### PR TITLE
feat(slack-bridge): standardize Slack tool surface

### DIFF
--- a/.research/588-extension-tool-audit.md
+++ b/.research/588-extension-tool-audit.md
@@ -1,5 +1,10 @@
 # Issue #588 — Extension tool token-footprint audit
 
+> Follow-up note: the Slack surface has since been standardized on a single
+> `slack` dispatcher. Historical references below to direct tools such as
+> `slack_inbox` and `slack_send` describe the measured pre-consolidation
+> surface, not the current default registration target.
+
 ## Scope
 
 Repo tool surfaces audited in this pass:

--- a/plans/pinet-vision.md
+++ b/plans/pinet-vision.md
@@ -22,7 +22,7 @@ It connects agents to each other, to Slack, to Neovim, and to any future adapter
 
 6. **Workers are computation, broker is infrastructure** — workers do tasks. The broker keeps the lights on. They don't share a process lifetime.
 
-7. **Extensions stay thin** — tools like `slack_send`, `comment_add`, and `pinet action=send` are shims over the broker. They don't own state.
+7. **Extensions stay thin** — tools like `slack action=send`, `comment_add`, and `pinet action=send` are shims over the broker. They don't own state.
 
 ## What this enables
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -185,7 +185,7 @@ User opens Pinet in Slack sidebar
   └─► types a message
         └─► 👀 reaction appears (thinking)
               └─► message queued for pi agent
-                    └─► agent responds via slack_send
+                    └─► agent responds via `slack` action `send`
                           └─► 👀 removed, reply appears in thread
 ```
 
@@ -196,16 +196,16 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 Slack-bridge uses progressive disclosure to keep the per-turn tool surface
 small:
 
-| Tool          | Description                                                                 |
-| ------------- | --------------------------------------------------------------------------- |
-| `slack_inbox` | Hot-path inbox drain for pending incoming Slack messages                    |
-| `slack_send`  | Hot-path reply tool for Slack assistant threads                             |
-| `slack`       | Dispatcher for all non-hot Slack actions; call `action: "help"` for schemas |
+| Tool    | Description                                                                                 |
+| ------- | ------------------------------------------------------------------------------------------- |
+| `slack` | Single Slack dispatcher; call `action: "help"` for schemas and progressive action discovery |
 
-Cold Slack actions live behind the `slack` dispatcher:
+All Slack actions live behind the `slack` dispatcher:
 
 | Dispatcher action      | Description                                                                       |
 | ---------------------- | --------------------------------------------------------------------------------- |
+| `inbox`                | Drain pending incoming Slack messages                                             |
+| `send`                 | Reply in the current Slack assistant thread                                       |
 | `react`                | Add an emoji reaction to a message                                                |
 | `read`                 | Read messages from a thread                                                       |
 | `upload`               | Upload files, snippets, or diffs into Slack                                       |
@@ -231,24 +231,26 @@ Use `slack` with `action: "help"` for the action catalogue, or
 `action: "help", args: { "topic": "canvas_update" }` for a specific JSON
 schema and example invocations. Dispatcher responses use a consistent
 `{ "status", "data", "errors", "warnings" }` envelope. Guardrails match
-cold Slack actions as `slack:<action>` (for example `slack:upload` or
-`slack:canvas_update`); legacy `slack_<action>` patterns are accepted during
-migration.
+Slack actions as `slack:<action>` (for example `slack:send`, `slack:upload`, or
+`slack:canvas_update`); legacy `slack_<action>` guardrail patterns are accepted
+during migration. Dispatcher action inputs should use the bare action name such
+as `send` or `upload`; old direct-tool spellings such as `slack_send` or
+`slack_upload` are rejected as unknown actions so stale prompts fail closed.
 
 #### Tool and workflow usage notes
 
-- **Reply where the work arrived.** Use `slack_send` for assistant-thread
-  replies. If a task was delivered in a Slack thread, acknowledge briefly,
-  do the work, report blockers immediately, and finish with the outcome. If
-  you know only a channel/thread pair, use dispatcher action `post_channel`
-  with `channel` and optional `thread_ts` instead.
+- **Reply where the work arrived.** Use dispatcher action `send` for
+  assistant-thread replies. If a task was delivered in a Slack thread,
+  acknowledge briefly, do the work, report blockers immediately, and finish
+  with the outcome. If you know only a channel/thread pair, use dispatcher
+  action `post_channel` with `channel` and optional `thread_ts` instead.
 - **Channel posting is explicit.** `post_channel` posts to a named channel or
   channel ID. When `channel` is omitted, it first resolves a provided
   `thread_ts` to a tracked thread channel, then falls back to `defaultChannel`
-  from settings. `slack_send` is intentionally narrower and resolves the
-  current tracked assistant thread/DM context.
+  from settings. Dispatcher action `send` is intentionally narrower and resolves
+  the current tracked assistant thread/DM context.
 - **Rich messages use Block Kit JSON.** Pass `blocks` directly to
-  `slack_send` or `post_channel`; keep `text` as the notification/fallback.
+  dispatcher action `send` or `post_channel`; keep `text` as the notification/fallback.
   Block Kit builder tools are not registered by this package. Load the bundled
   `slack-bridge` skill for copyable status-report, button, code, and diff
   templates.
@@ -290,11 +292,11 @@ migration.
   name, and the exact action string required by the guarded tool. The safest
   flow is: attempt the guarded call, copy the `requires confirmation for action
 ...` string from the error, request confirmation, wait for the user's approval
-  via `slack_inbox`, then retry the guarded call unchanged. Batched
+  via dispatcher action `inbox`, then retry the guarded call unchanged. Batched
   multi-thread Slack turns cannot satisfy a single-thread confirmation.
 - **Reaction and interaction triggers are explicit tasks.** Reaction-triggered
-  requests and Block Kit/modal interaction payloads arrive through
-  `slack_inbox` with metadata; treat them as user instructions tied to the
+  requests and Block Kit/modal interaction payloads arrive through dispatcher
+  action `inbox` with metadata; treat them as user instructions tied to the
   referenced Slack thread or message.
 
 #### Common dispatcher examples
@@ -303,16 +305,19 @@ Reply in the current Slack assistant thread with Block Kit:
 
 ```json
 {
-  "text": "Deploy complete — branch main, checks passed.",
-  "blocks": [
-    {
-      "type": "section",
-      "fields": [
-        { "type": "mrkdwn", "text": "*Branch*\n`main`" },
-        { "type": "mrkdwn", "text": "*Checks*\n✅ lint/typecheck/test" }
-      ]
-    }
-  ]
+  "action": "send",
+  "args": {
+    "text": "Deploy complete — branch main, checks passed.",
+    "blocks": [
+      {
+        "type": "section",
+        "fields": [
+          { "type": "mrkdwn", "text": "*Branch*\n`main`" },
+          { "type": "mrkdwn", "text": "*Checks*\n✅ lint/typecheck/test" }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/slack-bridge/core-tool-guardrails.test.ts
+++ b/slack-bridge/core-tool-guardrails.test.ts
@@ -117,9 +117,9 @@ describe("core tool Slack guardrails", () => {
     expect(
       evaluateSlackOriginCoreToolPolicy({
         turn: { threadTs: "100.1", threadCount: 1 },
-        toolName: "slack_send",
+        toolName: "slack:send",
         input: { thread_ts: "100.1", text: "hi" },
-        guardrails: { blockedTools: ["slack_send"] },
+        guardrails: { blockedTools: ["slack:send"] },
         requireToolPolicy: () => {
           throw new Error("should not run");
         },

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -63,6 +63,10 @@ describe("matchesToolPattern", () => {
   it("matches legacy Slack underscore patterns against dispatcher action names", () => {
     expect(matchesToolPattern("slack:canvas_update", ["slack_canvas_*"])).toBe(true);
     expect(matchesToolPattern("slack:upload", ["slack_upload"])).toBe(true);
+    expect(matchesToolPattern("slack:send", ["slack_send"])).toBe(true);
+    expect(matchesToolPattern("slack:inbox", ["slack_inbox"])).toBe(true);
+    expect(matchesToolPattern("slack_send", ["slack:send"])).toBe(true);
+    expect(matchesToolPattern("slack_inbox", ["slack:inbox"])).toBe(true);
   });
 
   it("matches legacy Pinet underscore guardrail patterns against dispatcher action names", () => {
@@ -124,6 +128,10 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("slack:modal_open")).toBe(true);
     expect(WRITE_TOOLS.has("slack:modal_push")).toBe(true);
     expect(WRITE_TOOLS.has("slack:modal_update")).toBe(true);
+    expect(READ_ONLY_TOOLS.has("slack:send")).toBe(true);
+    expect(READ_ONLY_TOOLS.has("slack:inbox")).toBe(true);
+    expect(READ_ONLY_TOOLS.has("slack_send")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("slack_inbox")).toBe(false);
     expect(READ_ONLY_TOOLS.has("slack:export")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack:presence")).toBe(true);
     expect(READ_ONLY_TOOLS.has("slack:canvas_comments_read")).toBe(true);
@@ -174,6 +182,8 @@ describe("isToolBlocked", () => {
   });
 
   it("applies legacy send blocks to dispatcher send", () => {
+    expect(isToolBlocked("slack:send", { blockedTools: ["slack_send"] })).toBe(true);
+    expect(isToolBlocked("slack_send", { blockedTools: ["slack:send"] })).toBe(true);
     expect(isToolBlocked("pinet:send", { blockedTools: ["pinet_send"] })).toBe(true);
     expect(isToolBlocked("pinet:send", { blockedTools: ["pinet_message"] })).toBe(true);
   });
@@ -304,7 +314,7 @@ describe("buildSecurityPrompt", () => {
     expect(prompt).toContain("write");
     // Should mention allowed tools
     expect(prompt).toContain("read");
-    expect(prompt).toContain("slack_send");
+    expect(prompt).toContain("slack:send");
   });
 
   it("includes blocked tools section", () => {
@@ -320,6 +330,7 @@ describe("buildSecurityPrompt", () => {
     expect(prompt).toContain("bash");
     expect(prompt).toContain("edit");
     expect(prompt).toContain('action "confirm_action"');
+    expect(prompt).toContain("slack action='inbox'");
   });
 
   it("includes all sections when all guardrails are active", () => {
@@ -405,7 +416,7 @@ describe("isBrokerForbiddenTool", () => {
 
   it("returns false for allowed tools", () => {
     expect(isBrokerForbiddenTool("pinet")).toBe(false);
-    expect(isBrokerForbiddenTool("slack_send")).toBe(false);
+    expect(isBrokerForbiddenTool("slack:send")).toBe(false);
     expect(isBrokerForbiddenTool("read")).toBe(false);
     expect(isBrokerForbiddenTool("bash")).toBe(false);
   });

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -11,8 +11,8 @@ export const READ_ONLY_TOOLS = new Set([
   "read",
   "rg",
   "slack",
-  "slack_inbox",
-  "slack_send",
+  "slack:inbox",
+  "slack:send",
   "slack:help",
   "slack:read",
   "slack:read_channel",
@@ -242,7 +242,7 @@ export function buildSecurityPrompt(guardrails: SecurityGuardrails): string {
       [
         "✋ CONFIRMATION REQUIRED:",
         `Before using tools matching these patterns: [${guardrails.requireConfirmation!.join(", ")}], you MUST first call slack with action "confirm_action" and args containing thread_ts, the exact action string required by the guarded tool, and the tool name (for dispatcher actions, use slack:<action> or pinet:<action>).`,
-        "Wait for the user's response via slack_inbox. Only proceed if the user approves. If denied, inform the user and skip the action.",
+        "Wait for the user's response via slack action='inbox'. Only proceed if the user approves. If denied, inform the user and skip the action.",
       ].join("\n"),
     );
   }

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1649,7 +1649,7 @@ export function buildWorkerPromptGuidelines(): string[] {
     "",
     "REPLY TOOL RULES:",
     "- If you received a task via `pinet action=send`, reply via `pinet action=send` to the sender.",
-    "- If you received a task in a Slack thread, reply via `slack_send` in that thread.",
+    "- If you received a task in a Slack thread, reply via `slack` with `action=send` in that thread.",
     "- Never use the `slack` dispatcher `post_channel` action with a pinet thread ID (e.g. `a2a:...`) — it will fail. Pinet threads are not Slack channels.",
     "",
     "PINET DELEGATION RULES:",

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2086,11 +2086,11 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const slackSend = tools.get("slack_send");
+    const slackDispatcher = tools.get("slack");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
-    expect(slackSend).toBeDefined();
+    expect(slackDispatcher).toBeDefined();
 
     await sessionStart?.({}, ctx);
     await Promise.resolve();
@@ -2136,9 +2136,12 @@ describe("slack-bridge top-level shutdown", () => {
       }),
     });
 
-    await slackSend!.execute("tool-1", {
-      thread_ts: "100.1",
-      text: "reply from the agent",
+    await slackDispatcher!.execute("tool-1", {
+      action: "send",
+      args: {
+        thread_ts: "100.1",
+        text: "reply from the agent",
+      },
     });
 
     const chatPostMessageCall = fetchSpy.mock.calls.find(

--- a/slack-bridge/repo-tool-guardrails.test.ts
+++ b/slack-bridge/repo-tool-guardrails.test.ts
@@ -101,9 +101,9 @@ describe("repo tool Slack guardrails", () => {
     expect(
       evaluateSlackOriginRepoToolPolicy({
         turn: { threadTs: "100.1", threadCount: 1 },
-        toolName: "slack_send",
+        toolName: "slack:send",
         input: { text: "hi" },
-        guardrails: { blockedTools: ["slack_send"] },
+        guardrails: { blockedTools: ["slack:send"] },
         requireToolPolicy: () => {
           throw new Error("should not run");
         },

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -6,8 +6,8 @@ description: Warm reference for the @gugu910/pi-slack-bridge Slack dispatcher. U
 # Slack Bridge Warm Reference
 
 Use this skill when the compact `slack` dispatcher schema is not enough. The
-hot path stays small: `slack_inbox` receives work, `slack_send` replies in the
-current assistant thread, and `slack` handles the cold action surface.
+public Slack surface is a single tool: `slack` with actions such as `inbox`,
+`send`, `upload`, and `canvas_update`.
 
 ## Dispatcher contract
 
@@ -35,13 +35,14 @@ On failure, inspect `errors[0].class`, `retryable`, and `hint`. Prefer
 `slack({"action":"help","args":{"topic":"..."}})` before guessing an action
 schema.
 
-Guardrails match cold actions as `slack:<action>` (for example
-`slack:upload`, `slack:delete`, `slack:canvas_update`). Legacy
-`slack_<action>` patterns may be accepted during migration, but new configs
-should use the colon form.
+Guardrails match actions as `slack:<action>` (for example `slack:send`,
+`slack:upload`, `slack:delete`, `slack:canvas_update`). Legacy `slack_<action>`
+patterns may be accepted during migration, but new configs should use the colon
+form.
 
 ## Action quick map
 
+- Inbox/replies: `inbox`, `send`
 - Thread/channel messaging: `post_channel`, `read`, `read_channel`, `export`
 - Lightweight acknowledgement: `react`
 - Files/snippets: `upload`
@@ -57,7 +58,7 @@ should use the colon form.
 ## Block Kit patterns
 
 No Block Kit builder tool is registered. Build the JSON inline and pass it to
-`slack_send` or `slack` action `post_channel` as `blocks`.
+`slack` action `send` or `post_channel` as `blocks`.
 
 ### Status report
 
@@ -85,9 +86,12 @@ Use with:
 
 ```json
 {
-  "text": "Deploy complete — branch main, checks passed.",
-  "thread_ts": "1712345678.000100",
-  "blocks": []
+  "action": "send",
+  "args": {
+    "text": "Deploy complete — branch main, checks passed.",
+    "thread_ts": "1712345678.000100",
+    "blocks": []
+  }
 }
 ```
 
@@ -336,7 +340,7 @@ error and retry the guarded call unchanged after approval:
 }
 ```
 
-Wait for `slack_inbox` to deliver the approval before retrying the guarded
+Wait for `slack` action `inbox` to deliver the approval before retrying the guarded
 action. Every destructive delete also needs `confirm: true` after verifying the
 target; whole-thread deletion additionally needs `thread: true` and only works
 when every message in the target thread was posted by the current bot:

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -38,6 +38,20 @@ function unwrapSlackDispatcherResponse(response: ToolResponse): ToolResponse {
   };
 }
 
+async function executeSlackAction(
+  tools: Map<string, ToolDefinition>,
+  action: string,
+  args: Record<string, unknown> = {},
+): Promise<ToolResponse> {
+  const dispatcher = tools.get("slack");
+  if (!dispatcher) {
+    throw new Error("Expected slack dispatcher to be registered");
+  }
+  return unwrapSlackDispatcherResponse(
+    await dispatcher.execute(`slack:${action}`, { action, args }),
+  );
+}
+
 describe("registerSlackTools", () => {
   function setup() {
     const tools = new Map<string, ToolDefinition>();
@@ -342,7 +356,7 @@ describe("registerSlackTools", () => {
     };
   }
 
-  it("reads the latest security prompt when slack_inbox executes", async () => {
+  it("reads the latest security prompt when slack inbox action executes", async () => {
     const { inbox, tools, setSecurityPrompt } = setup();
     inbox.push({
       channel: "D123",
@@ -354,7 +368,7 @@ describe("registerSlackTools", () => {
 
     setSecurityPrompt("UPDATED SECURITY PROMPT");
 
-    const response = await tools.get("slack_inbox")!.execute("tool-1", {});
+    const response = await executeSlackAction(tools, "inbox");
     expect(response.content?.[0]?.text).toContain("UPDATED SECURITY PROMPT");
     expect(response.content?.[0]?.text).not.toContain("INITIAL SECURITY PROMPT");
   });
@@ -928,12 +942,12 @@ describe("registerSlackTools", () => {
     expect(response.details?.count).toBe(1);
   });
 
-  it("includes blocks when slack_send posts a rich message", async () => {
+  it("includes blocks when slack send action posts a rich message", async () => {
     const { slack, tools, setResolveThreadChannel, noteThreadReply, clearPendingAttention } =
       setup();
     setResolveThreadChannel(async () => "D123");
 
-    await tools.get("slack_send")!.execute("tool-14", {
+    await executeSlackAction(tools, "send", {
       thread_ts: "123.456",
       text: "Deploy complete",
       blocks: [
@@ -994,7 +1008,7 @@ describe("registerSlackTools", () => {
       },
     });
 
-    const response = await tools.get("slack_inbox")!.execute("tool-16", {});
+    const response = await executeSlackAction(tools, "inbox");
 
     expect(response.content?.[0]?.text).toContain('metadata={"kind":"slack_block_action"');
     expect(response.content?.[0]?.text).toContain('"actionId":"review.approve"');
@@ -1017,12 +1031,14 @@ describe("registerSlackTools", () => {
     });
   });
 
-  it("registers only the hot Slack tools plus the dispatcher", () => {
+  it("registers only the Slack dispatcher tool", () => {
     const { registeredTools } = setup();
 
     const slackTools = [...registeredTools.keys()].filter((name) => name.startsWith("slack"));
 
-    expect(slackTools).toEqual(["slack", "slack_inbox", "slack_send"]);
+    expect(slackTools).toEqual(["slack"]);
+    expect(registeredTools.has("slack_inbox")).toBe(false);
+    expect(registeredTools.has("slack_send")).toBe(false);
     expect(registeredTools.has("slack_blocks_build")).toBe(false);
     expect(registeredTools.has("slack_modal_build")).toBe(false);
     expect(registeredTools.has("slack_post_channel")).toBe(false);
@@ -1037,7 +1053,21 @@ describe("registerSlackTools", () => {
     const catalogEnvelope = catalogResponse.details as SlackDispatcherEnvelope;
     expect(catalogEnvelope.status).toBe("succeeded");
     expect(catalogResponse.content?.[0]?.text).toContain('"status": "succeeded"');
+    expect(catalogResponse.content?.[0]?.text).toContain('"action": "inbox"');
+    expect(catalogResponse.content?.[0]?.text).toContain('"action": "send"');
     expect(catalogResponse.content?.[0]?.text).toContain('"action": "post_channel"');
+
+    const sendSchemaResponse = await dispatcher.execute("tool-help-send", {
+      action: "help",
+      args: { topic: "send" },
+    });
+    const sendSchemaEnvelope = sendSchemaResponse.details as SlackDispatcherEnvelope;
+    expect(sendSchemaEnvelope.status).toBe("succeeded");
+    expect(sendSchemaEnvelope.data).toMatchObject({
+      action: "send",
+      guardrail_tool: "slack:send",
+      examples: [expect.objectContaining({ action: "send" })],
+    });
 
     const schemaResponse = await dispatcher.execute("tool-help-topic", {
       action: "help",
@@ -1070,6 +1100,27 @@ describe("registerSlackTools", () => {
         }),
       ],
     });
+  });
+
+  it("rejects legacy direct-tool names as dispatcher action values", async () => {
+    const { registeredTools } = setup();
+    const dispatcher = registeredTools.get("slack")!;
+
+    const sendResponse = await dispatcher.execute("tool-legacy-send-action", {
+      action: "slack_send",
+    });
+    const sendEnvelope = sendResponse.details as SlackDispatcherEnvelope;
+
+    expect(sendEnvelope.status).toBe("failed");
+    expect(sendEnvelope.errors[0]?.message).toContain("Unknown Slack action 'slack_send'");
+
+    const inboxResponse = await dispatcher.execute("tool-legacy-inbox-action", {
+      action: "slack_inbox",
+    });
+    const inboxEnvelope = inboxResponse.details as SlackDispatcherEnvelope;
+
+    expect(inboxEnvelope.status).toBe("failed");
+    expect(inboxEnvelope.errors[0]?.message).toContain("Unknown Slack action 'slack_inbox'");
   });
 
   it("opens a modal and embeds thread context in private_metadata", async () => {
@@ -1153,7 +1204,7 @@ describe("registerSlackTools", () => {
       },
     });
 
-    const response = await tools.get("slack_inbox")!.execute("tool-21", {});
+    const response = await executeSlackAction(tools, "inbox");
 
     expect(response.content?.[0]?.text).toContain('metadata={"kind":"slack_view_submission"');
     expect(response.content?.[0]?.text).toContain('"triggerId":"trigger-1"');

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -96,6 +96,13 @@ interface SlackActionToolDefinition extends ToolDefinition {
 }
 
 const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> = {
+  inbox: [{ action: "inbox", args: {} }],
+  send: [
+    {
+      action: "send",
+      args: { text: "ACK — I’m taking a look now.", thread_ts: "1712345678.000100" },
+    },
+  ],
   react: [{ action: "react", args: { emoji: "👀", thread_ts: "1712345678.000100" } }],
   read: [{ action: "read", args: { thread_ts: "1712345678.000100", limit: 20 } }],
   upload: [
@@ -201,6 +208,12 @@ function normalizeSlackDispatcherActionName(value: unknown): string {
     throw new Error("slack action is required. Use action='help' to list available actions.");
   }
   if (normalized.startsWith("slack:")) return normalized.slice("slack:".length);
+  return normalized;
+}
+
+function normalizeRegisteredSlackActionName(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/-/g, "_");
+  if (normalized.startsWith("slack:")) return normalized.slice("slack:".length);
   if (normalized.startsWith("slack_")) return normalized.slice("slack_".length);
   return normalized;
 }
@@ -208,11 +221,7 @@ function normalizeSlackDispatcherActionName(value: unknown): string {
 function normalizeSlackGuardrailToolName(toolName: string): string {
   const normalized = toolName.trim().toLowerCase().replace(/-/g, "_");
   if (normalized.startsWith("slack:")) return normalized;
-  if (
-    normalized.startsWith("slack_") &&
-    normalized !== "slack_inbox" &&
-    normalized !== "slack_send"
-  ) {
+  if (normalized.startsWith("slack_")) {
     return `slack:${normalized.slice("slack_".length)}`;
   }
   return toolName;
@@ -413,8 +422,8 @@ function buildSlackInboxPromptGuidelines(): string[] {
   return [
     "You are connected to Slack via the slack-bridge extension.",
     "When Slack messages arrive: ACK briefly, do the work, report blockers immediately, and report the outcome when done.",
-    "Use slack_send for direct assistant-thread replies. Use the slack dispatcher for non-hot Slack actions such as reactions, reads, uploads, schedules, channel posts, pins, bookmarks, canvases, modals, presence, exports, and confirmations.",
-    "Call slack with action='help' for the cold-action catalogue, or action='help' with args.topic for a specific action schema and examples.",
+    "Use slack with action='send' for assistant-thread replies and action='inbox' to drain pending Slack messages. Use the same dispatcher for reactions, reads, uploads, schedules, channel posts, pins, bookmarks, canvases, modals, presence, exports, and confirmations.",
+    "Call slack with action='help' for the action catalogue, or action='help' with args.topic for a specific action schema and examples.",
     "Security guardrails may be active for Slack-triggered actions. Cold Slack actions are checked with slack:<action> guardrail names.",
     "Reaction-triggered requests may arrive as structured 'Reaction trigger from Slack:' messages — treat them as explicit user instructions attached to the referenced Slack message or thread.",
   ];
@@ -422,7 +431,7 @@ function buildSlackInboxPromptGuidelines(): string[] {
 
 function buildSlackSendPromptGuidelines(): string[] {
   return [
-    "Use slack_send for replies in the current Slack assistant thread; always reply where the task came from.",
+    "Use slack with action='send' for replies in the current Slack assistant thread; always reply where the task came from.",
     "For rich Block Kit JSON examples or modal/canvas patterns, load the slack-bridge skill instead of relying on tool schemas.",
   ];
 }
@@ -596,7 +605,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
   const slackActionRegistry = new Map<string, SlackActionToolDefinition>();
 
   function registerSlackAction(definition: SlackActionToolDefinition): void {
-    const action = normalizeSlackDispatcherActionName(definition.name);
+    const action = normalizeRegisteredSlackActionName(definition.name);
     if (action === "help") {
       throw new Error("slack help is reserved for dispatcher schema discovery.");
     }
@@ -657,19 +666,19 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     name: "slack",
     label: "Slack",
     description:
-      "Dispatcher for non-hot Slack actions: react, read, upload, schedule, presence, export, post_channel, read_channel, confirm_action, delete, pin, bookmark, create_channel, project_create, canvas_comments_read, canvas_create, canvas_update, modal_open, modal_push, modal_update, and help. Use slack_inbox and slack_send for hot-path inbox/reply work.",
+      "Single dispatcher for Slack actions: inbox, send, react, read, upload, schedule, presence, export, post_channel, read_channel, confirm_action, delete, pin, bookmark, create_channel, project_create, canvas_comments_read, canvas_create, canvas_update, modal_open, modal_push, modal_update, and help.",
     promptSnippet:
-      "Run non-hot Slack actions through a compact dispatcher. Use action='help' for the action catalogue or args.topic for a specific schema.",
+      "Run Slack actions through a compact dispatcher. Use action='help' for the action catalogue or args.topic for a specific schema.",
     promptGuidelines: [
-      "Use slack_inbox and slack_send for the hot path. Use this dispatcher for every other Slack action.",
-      "Cold actions are guarded as slack:<action>, for example slack:upload or slack:canvas_update.",
+      "Use slack action='inbox' for pending messages and action='send' for replies. Use the same dispatcher for every Slack action.",
+      "Actions are guarded as slack:<action>, for example slack:send, slack:upload, or slack:canvas_update.",
       "The dispatcher returns {status,data,errors,warnings}. On input errors, call action='help' with args.topic for the action schema.",
       "For Block Kit templates, modal patterns, and canvas examples, load the slack-bridge skill lazily.",
     ],
     parameters: Type.Object({
       action: Type.String({
         description:
-          "Action name: help | react | read | upload | schedule | presence | export | post_channel | read_channel | confirm_action | delete | pin | bookmark | create_channel | project_create | canvas_comments_read | canvas_create | canvas_update | modal_open | modal_push | modal_update",
+          "Action name: help | inbox | send | react | read | upload | schedule | presence | export | post_channel | read_channel | confirm_action | delete | pin | bookmark | create_channel | project_create | canvas_comments_read | canvas_create | canvas_update | modal_open | modal_push | modal_update",
       }),
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {
@@ -1189,8 +1198,8 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     return snapshot;
   }
 
-  pi.registerTool({
-    name: "slack_inbox",
+  registerSlackAction({
+    name: "inbox",
     label: "Slack Inbox",
     description:
       "Return pending Slack messages that arrived since the last check, then clear the queue.",
@@ -1431,8 +1440,8 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     },
   });
 
-  pi.registerTool({
-    name: "slack_send",
+  registerSlackAction({
+    name: "send",
     label: "Slack Send",
     description: "Send a message in a Slack assistant thread.",
     promptSnippet:
@@ -1453,7 +1462,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     }),
     async execute(_id, params) {
       requireToolPolicy(
-        "slack_send",
+        "slack:send",
         params.thread_ts,
         `thread_ts=${params.thread_ts ?? ""} | text=${params.text} | blocks=${summarizeSlackBlocksForPolicy(params.blocks)}`,
       );
@@ -2921,7 +2930,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           content: [
             {
               type: "text",
-              text: `A matching confirmation request is already pending in thread ${params.thread_ts}. Wait for the user's response via slack_inbox before proceeding.`,
+              text: `A matching confirmation request is already pending in thread ${params.thread_ts}. Wait for the user's response via slack action='inbox' before proceeding.`,
             },
           ],
           details: {
@@ -2946,7 +2955,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         content: [
           {
             type: "text",
-            text: `Confirmation requested in thread ${params.thread_ts}. Wait for the user's response via slack_inbox before proceeding. If the user approves, continue with the action. If denied, inform them and skip the action.`,
+            text: `Confirmation requested in thread ${params.thread_ts}. Wait for the user's response via slack action='inbox' before proceeding. If the user approves, continue with the action. If denied, inform them and skip the action.`,
           },
         ],
         details: {


### PR DESCRIPTION
## Summary
- standardize the default Slack tool surface on the single `slack` dispatcher
- move the former direct `slack_inbox` and `slack_send` tools behind dispatcher actions `inbox` and `send`
- keep existing Slack cold actions behind progressive `slack action=help` / `args.topic` discovery
- preserve fail-closed guardrail compatibility so legacy `slack_<action>` patterns such as `slack_send` and `slack_inbox` still match dispatcher guardrail names like `slack:send` and `slack:inbox`
- update prompts/docs/tests for `slack action=send` / `slack action=inbox`

## Notes
- `slack:send` remains read-only-mode allowed, preserving the previous `slack_send` behavior so agents can still ACK/report in Slack even under read-only runtime guardrails.
- Dispatcher action input no longer accepts legacy direct-tool names like `slack_send`; those fail with a structured unknown-action error. Legacy names are retained only as guardrail aliases.

## Hard registry audit
Code-level `pi.registerTool(...)` audit across `slack-bridge/*.ts`:

- Current `origin/main` exposes these Slack top-level tools: `slack`, `slack_inbox`, `slack_send`.
- This PR head exposes exactly one Slack top-level tool: `slack`.
- This PR moves `slack_inbox` / `slack_send` to dispatcher actions `inbox` / `send`.
- The remaining Slack operations are dispatcher actions/templates, not top-level tools: `slack_modal_open`, `slack_modal_push`, `slack_modal_update`, `slack_react`, `slack_upload`, `slack_read`, `slack_presence`, `slack_export`, `slack_create_channel`, `slack_project_create`, `slack_post_channel`, `slack_delete`, `slack_pin`, `slack_bookmark`, `slack_schedule`, `slack_read_channel`, `slack_canvas_comments_read`, `slack_canvas_create`, `slack_canvas_update`, `slack_confirm_action`.
- A currently running agent prompt/session may still show older `slack_*` tool names because tool schemas are injected when that session starts and do not hot-reload from this worktree/PR. The merge criterion here is the code registry after extension reload/build.

## Archaeology / revert check
- I found no evidence that a previously merged Slack single-tool removal was reverted.
- #566 requested reducing the large Slack tool schema footprint. PR #581 landed the first progressive-disclosure slice by adding the compact `slack` dispatcher for cold actions, but its accepted scope explicitly kept `slack_inbox` and `slack_send` registered directly as hot-path tools.
- #618 tracked broader Slack consolidation, then was later narrowed/superseded by a temporary Slack CLI-only / inbound-only / Pinet-read-surface direction.
- #620 was the follow-up dispatcher/schema/urgency PR, but it was closed unmerged as stale/conflicting and also preserved `slack_inbox` / `slack_send`.
- #631 was docs/research, not a removal PR, and documented the then-current hot top-level tools.
- Regression mechanism: this was a partial/superseded rollout rather than a revert. #581 made the collapse look complete while retaining two hot exceptions; Pinet later received the final “delete the hot exception too” cleanup in #646, and this PR applies that same final phase to Slack.
- Prevention: tests now assert the registered Slack surface is exactly `["slack"]`, reject stale dispatcher action values like `slack_send` / `slack_inbox`, and preserve fail-closed guardrail alias matching from old policy names to `slack:send` / `slack:inbox`.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --write .research/588-extension-tool-audit.md slack-bridge/slack-tools.ts slack-bridge/slack-tools.test.ts slack-bridge/guardrails.ts slack-bridge/guardrails.test.ts slack-bridge/helpers.ts slack-bridge/index.test.ts slack-bridge/core-tool-guardrails.test.ts slack-bridge/repo-tool-guardrails.test.ts slack-bridge/README.md slack-bridge/skills/slack-bridge/SKILL.md plans/pinet-vision.md`
- `pnpm --filter @gugu910/pi-slack-bridge test -- slack-tools.test.ts guardrails.test.ts index.test.ts helpers.test.ts core-tool-guardrails.test.ts repo-tool-guardrails.test.ts` (Vitest ran package suite: 71 files / 1184 tests)
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `git diff --check`
- `git push --set-upstream origin feat/slack-single-tool-surface` (pre-push/turbo passed: 9 tasks)

## Review
- Used `scout` to map the current Slack surface and guardrail/doc/test touch points.
- Used `reviewer` on the uncommitted implementation; addressed its non-blocking stale-test-name suggestion.
- No merge requested/performed.


