### PR TITLE
test(pinet): cover mixed read pointer inbox

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -476,6 +476,40 @@ describe("formatInboxMessages", () => {
     expect(result).not.toContain("secret Slack body");
   });
 
+  it("formats mixed broker-backed Slack and Pinet messages as durable read pointers", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "C789",
+        threadTs: "789.012",
+        userId: "U1",
+        text: "secret Slack body",
+        timestamp: "789.012",
+        brokerInboxId: 13,
+      },
+      {
+        channel: "",
+        threadTs: "a2a:broker:worker",
+        userId: "broker-id",
+        text: "secret Pinet body",
+        timestamp: "790.000",
+        brokerInboxId: 17,
+        metadata: { senderAgent: "Broker Bunny", a2a: true, pinetMailClass: "steering" },
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain("New Slack messages:");
+    expect(result).toContain("New Pinet messages:");
+    expect(result).toContain(
+      "[thread 789.012] will: inbox_id=13 pointer=pinet action=read args.thread_id=789.012 args.unread_only=true",
+    );
+    expect(result).toContain(
+      "[thread a2a:broker:worker] [steering] broker-id (Broker Bunny): inbox_id=17 pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
+    );
+    expect(result).not.toContain("secret Slack body");
+    expect(result).not.toContain("secret Pinet body");
+  });
+
   it("preserves compact Slack metadata on broker-backed pointer notifications", () => {
     const msgs: InboxMessage[] = [
       {


### PR DESCRIPTION
## Summary\n- add a regression test for mixed broker-backed Slack and Pinet/A2A inbox prompts\n- assert both durable messages render compact `pinet action=read` pointers with `inbox_id` values\n- assert original Slack/Pinet body text is not embedded in runtime prompt output\n\n## Validation\n- `pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts`\n- `pnpm --filter @gugu910/pi-slack-bridge typecheck`\n- `pnpm --filter @gugu910/pi-slack-bridge lint`\n- `git diff --check`\n- pre-push hook\n\nRefs #608