### PR TITLE
pinet: label Slack durable pointer mail

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -469,7 +469,7 @@ describe("formatInboxMessages", () => {
     const result = formatInboxMessages(msgs, names);
     expect(result).toContain("New Slack messages:");
     expect(result).toContain(
-      "[thread 789.012] (channel mention in <#C789>) will: inbox_id=13 pointer=pinet action=read args.thread_id=789.012 args.unread_only=true",
+      "[thread 789.012] [fwup] (channel mention in <#C789>) will: inbox_id=13 pointer=pinet action=read args.thread_id=789.012 args.unread_only=true",
     );
     expect(result).toContain("Use pinet action=read with the pointer before acting.");
     expect(result).toContain("ACK briefly after reading, do the work");
@@ -501,7 +501,7 @@ describe("formatInboxMessages", () => {
     expect(result).toContain("New Slack messages:");
     expect(result).toContain("New Pinet messages:");
     expect(result).toContain(
-      "[thread 789.012] will: inbox_id=13 pointer=pinet action=read args.thread_id=789.012 args.unread_only=true",
+      "[thread 789.012] [fwup] will: inbox_id=13 pointer=pinet action=read args.thread_id=789.012 args.unread_only=true",
     );
     expect(result).toContain(
       "[thread a2a:broker:worker] [steering] broker-id (Broker Bunny): inbox_id=17 pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
@@ -535,8 +535,58 @@ describe("formatInboxMessages", () => {
     expect(result).toContain(
       "will: inbox_id=14 pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
     );
+    expect(result).toContain("[fwup]");
     expect(result).toContain('canvas={"canvasId":"F_CANVAS_1"');
     expect(result).not.toContain("Alice mentioned you in a comment");
+  });
+
+  it("suppresses reflex ack guidance for maintenance/context-only durable Slack pointer batches", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "C123",
+        threadTs: "123.456",
+        userId: "U1",
+        text: "background context only",
+        timestamp: "123.789",
+        brokerInboxId: 15,
+        metadata: { pinetMailClass: "maintenance_context" },
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain(
+      "[thread 123.456] [maintenance/context] will: inbox_id=15 pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
+    );
+    expect(result).toContain("Treat [maintenance/context] messages as context-only");
+    expect(result).not.toContain("ACK briefly after reading");
+    expect(result).not.toContain("background context only");
+  });
+
+  it("keeps ack guidance when maintenance pointers are batched with inline Slack messages", () => {
+    const msgs: InboxMessage[] = [
+      {
+        channel: "C123",
+        threadTs: "123.456",
+        userId: "U1",
+        text: "background context only",
+        timestamp: "123.789",
+        brokerInboxId: 15,
+        metadata: { pinetMailClass: "maintenance_context" },
+      },
+      {
+        channel: "C123",
+        threadTs: "123.999",
+        userId: "U1",
+        text: "please check this inline message",
+        timestamp: "123.999",
+      },
+    ];
+
+    const result = formatInboxMessages(msgs, names);
+    expect(result).toContain("[maintenance/context]");
+    expect(result).toContain("For [steering]/[fwup] or inline Slack messages, ACK briefly");
+    expect(result).toContain("will: please check this inline message");
+    expect(result).not.toContain("background context only");
   });
 
   it("falls back to userId when name not in map", () => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -324,14 +324,28 @@ function inboxMessageToPinetEntry(message: InboxMessage): FollowerInboxEntry {
   };
 }
 
+function classifySlackInboxMessage(message: InboxMessage) {
+  return classifyPinetMail({
+    source: "slack",
+    threadId: message.threadTs,
+    sender: message.userId,
+    body: message.text,
+    metadata: message.metadata,
+  });
+}
+
 function formatSlackInboxLine(
   message: InboxMessage,
   senderLabel: string,
   metadataSuffix: string,
 ): string {
+  const classLabel =
+    message.brokerInboxId != null
+      ? ` [${formatPinetMailClassLabel(classifySlackInboxMessage(message).class)}]`
+      : "";
   const prefix = message.isChannelMention
-    ? `[thread ${message.threadTs}] (channel mention in <#${message.channel}>) ${senderLabel}:`
-    : `[thread ${message.threadTs}] ${senderLabel}:`;
+    ? `[thread ${message.threadTs}]${classLabel} (channel mention in <#${message.channel}>) ${senderLabel}:`
+    : `[thread ${message.threadTs}]${classLabel} ${senderLabel}:`;
 
   if (message.brokerInboxId != null) {
     return `${prefix} inbox_id=${message.brokerInboxId} ${buildPinetReadPointer(message.threadTs)}${metadataSuffix}`;
@@ -344,14 +358,32 @@ function formatSlackInboxMessages(
   messages: InboxMessage[],
   userNames: { get(key: string): string | undefined },
 ): string {
-  const hasDurablePointer = messages.some((message) => message.brokerInboxId != null);
+  const durableClassifications = messages
+    .filter((message) => message.brokerInboxId != null)
+    .map(classifySlackInboxMessage);
+  const hasDurablePointer = durableClassifications.length > 0;
   const lines = messages.map((m) => {
     const n = userNames.get(m.userId) ?? m.userId;
     return formatSlackInboxLine(m, n, formatInboxMetadata(m.metadata));
   });
 
+  const hasMaintenance = durableClassifications.some(
+    (classification) => classification.class === "maintenance_context",
+  );
+  const hasActionableWork = durableClassifications.some(
+    (classification) => classification.class === "steering",
+  );
+  const hasFollowUp = durableClassifications.some(
+    (classification) => classification.class === "fwup",
+  );
+  const hasInlineSlackMessage = messages.some((message) => message.brokerInboxId == null);
+
   const guidance = hasDurablePointer
-    ? "Use pinet action=read with the pointer before acting. ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+    ? hasMaintenance
+      ? hasActionableWork || hasFollowUp || hasInlineSlackMessage
+        ? "Use pinet action=read with the pointer before acting. For [maintenance/context] messages, do NOT acknowledge or reply unless you have a real blocker or materially new finding. For [steering]/[fwup] or inline Slack messages, ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+        : "Use pinet action=read with the pointer only if you need details. Treat [maintenance/context] messages as context-only; do NOT send another acknowledgement unless you have a real blocker or materially new finding."
+      : "Use pinet action=read with the pointer before acting. ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
     : "ACK briefly, do the work, report blockers immediately, report the outcome when done.";
 
   return `New Slack messages:\n${lines.join("\n")}\n\n${guidance}`;


### PR DESCRIPTION
## Summary
- Label broker-backed Slack durable read-pointer inbox lines with persisted `pinetMailClass` classifications (`[fwup]`, `[maintenance/context]`, etc.)
- Keep durable Slack bodies elided behind `pinet action=read` pointers
- Suppress reflex ACK/reply guidance only for durable maintenance/context Slack pointer-only batches, while preserving ACK guidance when inline Slack work is present

## Validation
- pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge lint
- git diff --check
- pre-push: pnpm lint && pnpm typecheck && pnpm test

No merge performed.