### PR TITLE
fix: clarify Slack upload invalid arguments

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -3386,6 +3386,23 @@ export interface CallSlackAPIOptions {
  * Handles 429 rate-limit responses by waiting retry-after duration and retrying.
  * Throws error if retries are exhausted or API returns error.
  */
+function formatSlackApiResponseMetadata(data: SlackResult): string {
+  const metadata = data.response_metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return "";
+  }
+
+  const messages = (metadata as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) {
+    return "";
+  }
+
+  const details = messages
+    .filter((message): message is string => typeof message === "string" && message.length > 0)
+    .join("; ");
+  return details ? ` (${details})` : "";
+}
+
 export async function callSlackAPI(
   method: string,
   token: string,
@@ -3411,7 +3428,11 @@ export async function callSlackAPI(
   }
 
   const data = (await res.json()) as SlackResult;
-  if (!data.ok) throw new Error(`Slack ${method}: ${data.error ?? "unknown error"}`);
+  if (!data.ok) {
+    throw new Error(
+      `Slack ${method}: ${data.error ?? "unknown error"}${formatSlackApiResponseMetadata(data)}`,
+    );
+  }
   return data;
 }
 

--- a/slack-bridge/slack-api.test.ts
+++ b/slack-bridge/slack-api.test.ts
@@ -86,4 +86,21 @@ describe("callSlackApi", () => {
       "Slack chat.postMessage: channel_not_found",
     );
   });
+
+  it("includes Slack response metadata messages in API errors", async () => {
+    const fetchSpy = vi.fn(async () =>
+      makeResponse(200, {
+        ok: false,
+        error: "invalid_arguments",
+        response_metadata: {
+          messages: ["[ERROR] missing required field: length", "[ERROR] bad snippet_type"],
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy as unknown as typeof fetch);
+
+    await expect(callSlackApi("files.getUploadURLExternal", "xoxb-token", {})).rejects.toThrow(
+      "Slack files.getUploadURLExternal: invalid_arguments ([ERROR] missing required field: length; [ERROR] bad snippet_type)",
+    );
+  });
 });

--- a/slack-bridge/slack-upload.test.ts
+++ b/slack-bridge/slack-upload.test.ts
@@ -317,6 +317,48 @@ describe("performSlackUpload", () => {
     });
   });
 
+  it("adds context when Slack rejects upload metadata after the snippet_type retry", async () => {
+    const slack = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Slack files.getUploadURLExternal: invalid_arguments ([ERROR] bad snippet_type)"),
+      )
+      .mockRejectedValueOnce(
+        new Error(
+          "Slack files.getUploadURLExternal: invalid_arguments ([ERROR] missing required field: filename)",
+        ),
+      );
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "",
+    }));
+
+    const upload = await prepareSlackUpload(
+      {
+        content: "const answer = 42;\n",
+        filename: "release-notes.txt",
+        title: "Release notes",
+      },
+      "/repo",
+      "/tmp",
+    );
+
+    await expect(
+      performSlackUpload({
+        upload,
+        channelId: "C123",
+        slack,
+        token: "xoxb-token",
+        fetchImpl,
+      }),
+    ).rejects.toThrow(
+      'Slack files.getUploadURLExternal: invalid_arguments after retry without snippet_type; Slack rejected upload metadata for filename="release-notes.txt" byte_length=19.',
+    );
+    expect(slack).toHaveBeenCalledTimes(2);
+  });
+
   it("surfaces raw upload failures", async () => {
     const slack = vi.fn().mockResolvedValue({
       ok: true,

--- a/slack-bridge/slack-upload.ts
+++ b/slack-bridge/slack-upload.ts
@@ -114,6 +114,16 @@ function isInvalidUploadMetadataError(error: unknown): boolean {
   return lower.includes("files.getuploadurlexternal") && lower.includes("invalid_arguments");
 }
 
+function formatUploadMetadataRetryError(
+  upload: PreparedSlackUpload,
+  retryError: unknown,
+  originalError: unknown,
+): Error {
+  return new Error(
+    `Slack files.getUploadURLExternal: invalid_arguments after retry without snippet_type; Slack rejected upload metadata for filename=${JSON.stringify(upload.filename)} byte_length=${upload.byteLength}. retry_error=${formatUploadError(retryError)}; original_error=${formatUploadError(originalError)}`,
+  );
+}
+
 function getUploadHost(uploadUrl: string): string {
   try {
     return new URL(uploadUrl).hostname || "<unknown>";
@@ -273,11 +283,18 @@ export async function performSlackUpload({
     );
   } catch (error) {
     if (upload.snippetType && isInvalidUploadMetadataError(error)) {
-      getUploadResponse = await slack(
-        "files.getUploadURLExternal",
-        token,
-        buildUploadMetadataPayload(upload, false),
-      );
+      try {
+        getUploadResponse = await slack(
+          "files.getUploadURLExternal",
+          token,
+          buildUploadMetadataPayload(upload, false),
+        );
+      } catch (retryError) {
+        if (isInvalidUploadMetadataError(retryError)) {
+          throw formatUploadMetadataRetryError(upload, retryError, error);
+        }
+        throw retryError;
+      }
     } else {
       throw error;
     }


### PR DESCRIPTION
## Summary
- Surface Slack response_metadata.messages in Web API errors, including files.getUploadURLExternal invalid_arguments details.
- Preserve the existing snippet_type retry, but if Slack rejects metadata again after retrying without snippet_type, include filename, byte length, original error, and retry error.
- Add focused tests for metadata messages and post-retry upload metadata rejection context.

## Diagnosis
- #616 is not the right active PR to finish: its upload-code changes are already effectively present on current main via #617, and the old branch predates later main work.
- Current active failure is most likely stale/not-restarted runtime or a second Slack metadata rejection after the snippet_type retry. This PR makes that visible instead of the bare `Slack files.getUploadURLExternal: invalid_arguments`.

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run slack-upload.test.ts slack-api.test.ts` (24 tests passed)
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`

No merge by agents.