### PR TITLE
Compact noisy Slack and Pinet tool outputs

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -432,6 +432,8 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 Use the dispatcher for all Pinet actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=schedule`, and `pinet action=agents`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
 
+Dispatcher content defaults to compact CLI-style text for noisy reads and agent lists while preserving the structured `data.details` contract for callers. Pass `args.format="json"` for the dispatcher envelope in content, or `args.full=true` for verbose text plus `full_details`.
+
 Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet action=read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
 
 Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are persisted/stamped as Pinet follow-up mail and surfaced through compact `pinet action=read` pointers rather than direct reminder-body prompts. Wake-up bodies and metadata are treated as mail content only; they do not trigger Pinet remote-control commands such as `/exit`, `/reload`, or structured `pinet:control` JSON.

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -196,6 +196,98 @@ describe("registerPinetTools", () => {
     expect(result.details.data.details.markedReadIds).toEqual([31]);
   });
 
+  it("keeps pinet read structured details backward-compatible while compacting default text", async () => {
+    const longBody = `please inspect ${"important context ".repeat(20)}and keep exact body`;
+    const readPinetInbox = vi.fn(async () => ({
+      messages: [
+        {
+          inboxId: 31,
+          delivered: true,
+          readAt: "2026-04-25T12:00:00.000Z",
+          message: {
+            id: 44,
+            threadId: "a2a:broker:worker",
+            source: "agent" as const,
+            direction: "inbound" as const,
+            sender: "broker",
+            body: longBody,
+            metadata: { a2a: true, priority: "high" },
+            createdAt: "2026-04-25T11:59:00.000Z",
+          },
+        },
+      ],
+      unreadCountBefore: 1,
+      unreadCountAfter: 0,
+      unreadThreads: [],
+      markedReadIds: [31],
+    }));
+    const deps = createDeps({ readPinetInbox });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-read-compact-details", {
+      action: "read",
+      args: { thread_id: "a2a:broker:worker" },
+    })) as {
+      content: Array<{ text: string }>;
+      details: {
+        data: {
+          text: string;
+          details: { messages: Array<{ message: { body: string; metadata: unknown } }> };
+          compact_details: { messages: Array<{ preview: string }> };
+        };
+      };
+    };
+
+    expect(result.content[0]?.text).toContain("Use args.full=true");
+    expect(result.content[0]?.text).not.toContain(longBody);
+    expect(result.details.data.text).not.toContain(longBody);
+    expect(result.details.data.details.messages[0]?.message.body).toBe(longBody);
+    expect(result.details.data.details.messages[0]?.message.metadata).toEqual({
+      a2a: true,
+      priority: "high",
+    });
+    expect(result.details.data.compact_details.messages[0]?.preview).toContain("…");
+  });
+
+  it("keeps pinet read format=json structured details backward-compatible", async () => {
+    const body = "exact json body";
+    const readPinetInbox = vi.fn(async () => ({
+      messages: [
+        {
+          inboxId: 31,
+          delivered: true,
+          readAt: "2026-04-25T12:00:00.000Z",
+          message: {
+            id: 44,
+            threadId: "a2a:broker:worker",
+            source: "agent" as const,
+            direction: "inbound" as const,
+            sender: "broker",
+            body,
+            metadata: { a2a: true },
+            createdAt: "2026-04-25T11:59:00.000Z",
+          },
+        },
+      ],
+      unreadCountBefore: 1,
+      unreadCountAfter: 0,
+      unreadThreads: [],
+      markedReadIds: [31],
+    }));
+    const deps = createDeps({ readPinetInbox });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-read-json-details", {
+      action: "read",
+      args: { thread_id: "a2a:broker:worker", format: "json" },
+    })) as { content: Array<{ text: string }> };
+    const envelope = JSON.parse(result.content[0]?.text ?? "{}") as {
+      data: { details: { messages: Array<{ message: { body: string } }> } };
+    };
+
+    expect(envelope.data.details.messages[0]?.message.body).toBe(body);
+  });
+
   it("routes action-dispatched help through the dispatcher", async () => {
     const tools = registerWithDeps(createDeps());
 
@@ -249,6 +341,7 @@ describe("registerPinetTools", () => {
       args: {
         to: "alpha",
         message: "dispatch now",
+        format: "json",
       },
     })) as {
       content: Array<{ text: string }>;
@@ -335,6 +428,7 @@ describe("registerPinetTools", () => {
         repo: "extensions",
         required_tools: "read, edit",
         task: "review #395",
+        full: true,
       },
     })) as {
       details: {
@@ -359,5 +453,42 @@ describe("registerPinetTools", () => {
       requiredTools: ["read", "edit"],
       task: "review #395",
     });
+  });
+
+  it("keeps pinet agents structured details backward-compatible by default", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
+
+    const listBrokerAgents = vi.fn(() => [makeAgent({ metadata: { repo: "extensions" } })]);
+    const deps = createDeps({ listBrokerAgents });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-agents-compact-details", {
+      action: "agents",
+      args: { repo: "extensions" },
+    })) as {
+      content: Array<{ text: string }>;
+      details: {
+        data: {
+          text: string;
+          details: { agents: Array<{ name: string; metadata: unknown }>; hint: { repo?: string } };
+          compact_details: { count: number; agents: Array<{ name: string; repo: string | null }> };
+        };
+      };
+    };
+
+    expect(result.content[0]?.text).toContain("Golden Chalk Rabbit");
+    expect(result.details.data.text).not.toContain("pid:");
+    expect(result.details.data.details.agents[0]?.name).toBe("Golden Chalk Rabbit");
+    expect(result.details.data.details.agents[0]?.metadata).toEqual(
+      expect.objectContaining({ repo: "extensions" }),
+    );
+    expect(result.details.data.details.hint.repo).toBe("extensions");
+    expect(result.details.data.compact_details).toEqual(
+      expect.objectContaining({
+        count: 1,
+        agents: [expect.objectContaining({ name: "Golden Chalk Rabbit", repo: "extensions" })],
+      }),
+    );
   });
 });

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -78,16 +78,29 @@ type PinetDispatcherErrorClass = "input" | "state" | "runtime" | "network";
 
 type PinetDispatcherStatus = "succeeded" | "failed";
 
+type PinetOutputFormat = "cli" | "json";
+
+interface PinetOutputOptions {
+  format: PinetOutputFormat;
+  full: boolean;
+}
+
 interface PinetToolResult {
   content: Array<{ type: "text"; text: string }>;
   details?: unknown;
+  compactDetails?: unknown;
+  fullDetails?: unknown;
 }
 
 interface PinetActionDefinition {
   name: PinetDispatcherAction;
   description: string;
   parameters: unknown;
-  execute: (toolCallId: string, params: Record<string, unknown>) => Promise<PinetToolResult>;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    output: PinetOutputOptions,
+  ) => Promise<PinetToolResult>;
 }
 
 interface PinetDispatcherError {
@@ -107,13 +120,54 @@ interface PinetDispatcherEnvelope {
 const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> = {
   send: [{ action: "send", args: { to: "@worker", message: "Please review PR #123" } }],
   read: [
-    { action: "read", args: { thread_id: "a2a:broker:worker-1", limit: 20 } },
-    { action: "read", args: { unread_only: false, mark_read: false } },
+    { action: "read", args: { thread_id: "a2a:<broker>:<worker>", limit: 20 } },
+    { action: "read", args: { unread_only: false, mark_read: false, full: true } },
   ],
-  free: [{ action: "free", args: { note: "Wrapped up #395" } }],
+  free: [{ action: "free", args: { note: "Wrapped up <issue>" } }],
   schedule: [{ action: "schedule", args: { delay: "30m", message: "Check queue state" } }],
-  agents: [{ action: "agents", args: { repo: "extensions", role: "worker" } }],
+  agents: [{ action: "agents", args: { repo: "<repo>", role: "worker", full: true } }],
 };
+
+const PINET_OUTPUT_OPTION_PARAMETERS = {
+  format: Type.Optional(
+    Type.String({ description: 'Response presentation format: "cli" (default) or "json".' }),
+  ),
+  full: Type.Optional(
+    Type.Boolean({
+      description:
+        "Include full verbose text/full_details; default visible content stays compact while data.details remains backward-compatible.",
+    }),
+  ),
+};
+
+function normalizePinetOutputOptions(args: Record<string, unknown>): PinetOutputOptions {
+  const rawFormat = args.format;
+  const format = rawFormat == null ? "cli" : String(rawFormat).trim().toLowerCase();
+  if (format !== "cli" && format !== "json") {
+    throw new Error('format must be "cli" or "json".');
+  }
+
+  const rawFull = args.full;
+  if (rawFull != null && typeof rawFull !== "boolean") {
+    throw new Error("full must be a boolean when provided.");
+  }
+
+  return { format, full: rawFull === true };
+}
+
+function truncateText(value: string, maxLength = 180): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= maxLength) return collapsed;
+  return `${collapsed.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function getRecordString(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -206,12 +260,31 @@ function buildPinetDispatcherEnvelope(
   return { status, data, errors, warnings };
 }
 
-function wrapDispatcherEnvelope(envelope: PinetDispatcherEnvelope): {
+function getPinetEnvelopeCliText(envelope: PinetDispatcherEnvelope): string {
+  if (envelope.status === "succeeded" && isRecord(envelope.data)) {
+    const text = envelope.data.text;
+    if (typeof text === "string" && text.length > 0) return text;
+  }
+  return JSON.stringify(envelope, null, 2);
+}
+
+function wrapDispatcherEnvelope(
+  envelope: PinetDispatcherEnvelope,
+  output: PinetOutputOptions = { format: "json", full: true },
+): {
   content: Array<{ type: "text"; text: string }>;
   details: PinetDispatcherEnvelope;
 } {
   return {
-    content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
+    content: [
+      {
+        type: "text",
+        text:
+          output.format === "json"
+            ? JSON.stringify(envelope, null, 2)
+            : getPinetEnvelopeCliText(envelope),
+      },
+    ],
     details: envelope,
   };
 }
@@ -278,7 +351,7 @@ function buildPinetAgentsHintText(hint: PinetAgentsRoutingHint): string {
     .join(" · ")}`;
 }
 
-function formatPinetReadResult(result: PinetReadResult, options: PinetReadOptions): string {
+function formatPinetReadResultFull(result: PinetReadResult, options: PinetReadOptions): string {
   const scope = options.threadId ? `thread ${options.threadId}` : "your Pinet inbox";
   const mode = options.unreadOnly === false ? "latest" : "unread";
   const lines = [
@@ -325,6 +398,97 @@ function formatPinetReadResult(result: PinetReadResult, options: PinetReadOption
   if (result.markedReadIds.length > 0) {
     lines.push("", `Marked read: ${result.markedReadIds.join(", ")}.`);
   }
+
+  return lines.join("\n");
+}
+
+function summarizeUnreadThreadCounts(thread: PinetReadResult["unreadThreads"][number]): string {
+  return [
+    thread.mailClassCounts.steering > 0 ? `${thread.mailClassCounts.steering} steering` : null,
+    thread.mailClassCounts.fwup > 0 ? `${thread.mailClassCounts.fwup} fwup` : null,
+    thread.mailClassCounts.maintenance_context > 0
+      ? `${thread.mailClassCounts.maintenance_context} maintenance/context`
+      : null,
+  ]
+    .filter((item): item is string => Boolean(item))
+    .join(", ");
+}
+
+function buildCompactPinetReadDetails(result: PinetReadResult): Record<string, unknown> {
+  return {
+    messageCount: result.messages.length,
+    unreadCountBefore: result.unreadCountBefore,
+    unreadCountAfter: result.unreadCountAfter,
+    markedReadIds: result.markedReadIds,
+    messages: result.messages.map((item) => {
+      const classification = classifyPinetMail({
+        source: item.message.source,
+        threadId: item.message.threadId,
+        sender: item.message.sender,
+        body: item.message.body,
+        metadata: item.message.metadata,
+      });
+      return {
+        inboxId: item.inboxId,
+        messageId: item.message.id,
+        threadId: item.message.threadId,
+        source: item.message.source,
+        sender: item.message.sender,
+        class: classification.class,
+        preview: truncateText(item.message.body),
+      };
+    }),
+    unreadThreads: result.unreadThreads.slice(0, 10).map((thread) => ({
+      threadId: thread.threadId,
+      source: thread.source,
+      unreadCount: thread.unreadCount,
+      latestMessageId: thread.latestMessageId,
+      highestMailClass: thread.highestMailClass,
+      mailClassSummary: summarizeUnreadThreadCounts(thread),
+    })),
+  };
+}
+
+function formatPinetReadResultCompact(result: PinetReadResult, options: PinetReadOptions): string {
+  const scope = options.threadId ? `thread ${options.threadId}` : "your Pinet inbox";
+  const mode = options.unreadOnly === false ? "latest" : "unread";
+  const lines = [
+    `Pinet read (${mode}) from ${scope}: ${result.messages.length} message${result.messages.length === 1 ? "" : "s"}.`,
+    `Unread before: ${result.unreadCountBefore}; unread after: ${result.unreadCountAfter}.`,
+  ];
+
+  if (result.messages.length > 0) {
+    lines.push("");
+    for (const item of result.messages) {
+      const classification = classifyPinetMail({
+        source: item.message.source,
+        threadId: item.message.threadId,
+        sender: item.message.sender,
+        body: item.message.body,
+        metadata: item.message.metadata,
+      });
+      const label = formatPinetMailClassLabel(classification.class);
+      lines.push(
+        `- [${label}] [${item.message.source}/${item.message.threadId} #${item.message.id}] ${item.message.sender}: ${truncateText(item.message.body)}`,
+      );
+    }
+  }
+
+  if (result.unreadThreads.length > 0) {
+    lines.push("", "Unread thread pointers:");
+    for (const thread of result.unreadThreads.slice(0, 10)) {
+      const label = formatPinetMailClassLabel(thread.highestMailClass);
+      const counts = summarizeUnreadThreadCounts(thread);
+      lines.push(
+        `- [${label}] ${thread.threadId} (${thread.source}${thread.channel ? `/${thread.channel}` : ""}): ${thread.unreadCount} unread${counts ? ` (${counts})` : ""}; latest #${thread.latestMessageId}; pointer=pinet action=read args.thread_id=${thread.threadId} args.unread_only=true`,
+      );
+    }
+  }
+
+  if (result.markedReadIds.length > 0) {
+    lines.push("", `Marked read: ${result.markedReadIds.join(", ")}.`);
+  }
+  lines.push("", "Use args.full=true for exact message bodies and full metadata in visible text.");
 
   return lines.join("\n");
 }
@@ -381,12 +545,13 @@ function runPinetReadAction(
   params: Record<string, unknown>,
   deps: RegisterPinetToolsDeps,
   toolName: string,
+  output: PinetOutputOptions,
 ): Promise<PinetToolResult> {
   return (async () => {
     deps.requireToolPolicy(
       toolName,
       undefined,
-      `thread_id=${params.thread_id ?? ""} | limit=${params.limit ?? ""} | unread_only=${params.unread_only ?? ""} | mark_read=${params.mark_read ?? ""}`,
+      `thread_id=${params.thread_id ?? ""} | limit=${params.limit ?? ""} | unread_only=${params.unread_only ?? ""} | mark_read=${params.mark_read ?? ""} | format=${output.format} | full=${output.full}`,
     );
 
     if (!deps.pinetEnabled()) {
@@ -406,8 +571,17 @@ function runPinetReadAction(
 
     const result = await deps.readPinetInbox(options);
     return {
-      content: [{ type: "text", text: formatPinetReadResult(result, options) }],
+      content: [
+        {
+          type: "text",
+          text: output.full
+            ? formatPinetReadResultFull(result, options)
+            : formatPinetReadResultCompact(result, options),
+        },
+      ],
       details: result,
+      compactDetails: buildCompactPinetReadDetails(result),
+      fullDetails: result,
     };
   })();
 }
@@ -500,10 +674,71 @@ function runPinetScheduleAction(
   })();
 }
 
+function getAgentRepo(agent: AgentDisplayInfo): string | undefined {
+  return getRecordString(agent.metadata, "repo");
+}
+
+function getAgentBranch(agent: AgentDisplayInfo): string | undefined {
+  return getRecordString(agent.metadata, "branch");
+}
+
+function getAgentRole(agent: AgentDisplayInfo): string | undefined {
+  return getRecordString(agent.metadata, "role");
+}
+
+function buildCompactAgentDetails(
+  agents: AgentDisplayInfo[],
+  hint: PinetAgentsRoutingHint,
+): Record<string, unknown> {
+  return {
+    count: agents.length,
+    hint,
+    agents: agents.map((agent) => {
+      const capabilityTags = agent.capabilityTags ?? [];
+      return {
+        id: agent.id,
+        name: agent.name,
+        emoji: agent.emoji,
+        status: agent.status,
+        health: agent.health ?? null,
+        repo: getAgentRepo(agent) ?? null,
+        branch: getAgentBranch(agent) ?? null,
+        role: getAgentRole(agent) ?? null,
+        routingScore: agent.routingScore ?? null,
+        capabilityTags: capabilityTags.slice(0, 4),
+        capabilityCount: capabilityTags.length,
+      };
+    }),
+  };
+}
+
+function formatCompactAgentList(agents: AgentDisplayInfo[]): string {
+  if (agents.length === 0) return "(no agents connected)";
+
+  return agents
+    .map((agent) => {
+      const parts = [
+        getAgentRepo(agent) ? `repo=${getAgentRepo(agent)}` : null,
+        getAgentBranch(agent) ? `branch=${getAgentBranch(agent)}` : null,
+        getAgentRole(agent) ? `role=${getAgentRole(agent)}` : null,
+        agent.routingScore != null ? `score=${agent.routingScore}` : null,
+      ].filter((item): item is string => Boolean(item));
+      const health = agent.health ? ` [${agent.health}]` : "";
+      const caps = agent.capabilityTags ?? [];
+      const capPreview = caps.slice(0, 4).join(", ");
+      const capSuffix = caps.length > 4 ? ` (+${caps.length - 4} more)` : "";
+      const capsText = capPreview ? ` caps: ${capPreview}${capSuffix}` : "";
+      const context = parts.length > 0 ? ` — ${parts.join(" · ")}` : "";
+      return `${agent.emoji} ${agent.name} (${agent.id}) — ${agent.status}${health}${context}${capsText}`;
+    })
+    .join("\n");
+}
+
 function runPinetAgentsAction(
   params: Record<string, unknown>,
   deps: RegisterPinetToolsDeps,
   toolName: string,
+  output: PinetOutputOptions,
 ): Promise<PinetToolResult> {
   return (async () => {
     const hint: PinetAgentsRoutingHint = {
@@ -523,7 +758,7 @@ function runPinetAgentsAction(
     deps.requireToolPolicy(
       toolName,
       undefined,
-      `repo=${hint.repo ?? ""} | branch=${hint.branch ?? ""} | role=${hint.role ?? ""} | required_tools=${params.required_tools ?? ""} | task=${hint.task ?? ""}`,
+      `repo=${hint.repo ?? ""} | branch=${hint.branch ?? ""} | role=${hint.role ?? ""} | required_tools=${params.required_tools ?? ""} | task=${hint.task ?? ""} | format=${output.format} | full=${output.full}`,
     );
 
     if (!deps.pinetEnabled()) {
@@ -559,11 +794,15 @@ function runPinetAgentsAction(
     }).map(toDisplay);
     const agents = rankAgentsForRouting(visibleAgents, hint);
     const header = hasHint ? `${buildPinetAgentsHintText(hint)}\n\n` : "";
-    const text = `${header}${formatAgentList(agents, os.homedir())}`;
+    const text = `${header}${
+      output.full ? formatAgentList(agents, os.homedir()) : formatCompactAgentList(agents)
+    }`;
 
     return {
       content: [{ type: "text", text }],
       details: { agents, hint },
+      compactDetails: buildCompactAgentDetails(agents, hint),
+      fullDetails: { agents, hint },
     };
   })();
 }
@@ -584,6 +823,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
           "Target agent name/ID, or a broker-only broadcast channel like #extensions. Avoid #all for repo-specific issue/policy announcements.",
       }),
       message: Type.String({ description: "Message body" }),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
     execute: (_id, params) => runPinetSendAction(params, deps, "pinet:send"),
   });
@@ -604,8 +844,9 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       mark_read: Type.Optional(
         Type.Boolean({ description: "Mark returned unread rows as read (default true)" }),
       ),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
-    execute: (_id, params) => runPinetReadAction(params, deps, "pinet:read"),
+    execute: (_id, params, output) => runPinetReadAction(params, deps, "pinet:read", output),
   });
 
   registerAction({
@@ -615,6 +856,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       note: Type.Optional(
         Type.String({ description: "Optional short note about what you just finished" }),
       ),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
     execute: (_id, params) => runPinetFreeAction(params, deps, "pinet:free"),
   });
@@ -630,6 +872,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
         Type.String({ description: "Absolute ISO-8601 UTC time, e.g. 2026-04-02T14:30:00Z" }),
       ),
       message: Type.String({ description: "Reminder or wake-up message to deliver later" }),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
     execute: (_id, params) => runPinetScheduleAction(params, deps, "pinet:schedule"),
   });
@@ -647,8 +890,9 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
         Type.String({ description: "Comma-separated required capability/tool tags" }),
       ),
       task: Type.Optional(Type.String({ description: "Optional natural-language task hint" })),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
-    execute: (_id, params) => runPinetAgentsAction(params, deps, "pinet:agents"),
+    execute: (_id, params, output) => runPinetAgentsAction(params, deps, "pinet:agents", output),
   });
 
   pi.registerTool({
@@ -657,12 +901,17 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     description:
       "Dispatch Pinet worker operations by action with compact help and schema discovery.",
     promptSnippet:
-      'Use this dispatcher for all Pinet actions: send, read, free, schedule, agents, and per-action discovery. Use action="help" for the action catalog and action="send" for Pinet replies/delegation.',
+      'Use this dispatcher for all Pinet actions: send, read, free, schedule, agents, and per-action discovery. Use action="send" for Pinet replies/delegation. Defaults to compact cli output while preserving structured data.details; pass args.format="json" for the envelope in content or args.full=true for verbose text/full_details.',
     parameters: Type.Object({
       action: Type.String({
         description: "Action name: help, send, read, free, schedule, or agents.",
       }),
-      args: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+      args: Type.Optional(
+        Type.Record(Type.String(), Type.Unknown(), {
+          description:
+            'Action arguments. Add format="cli"|"json" and full=true for explicit presentation control. Pinet data.details stays backward-compatible; compact previews may appear as compact_details.',
+        }),
+      ),
     }),
     async execute(toolCallId, params) {
       let normalizedAction: PinetDispatcherAction;
@@ -683,7 +932,25 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
 
       if (normalizedAction === "help") {
         const args = isRecord(params.args) ? params.args : {};
-        return wrapDispatcherEnvelope(buildPinetDispatcherHelpEnvelope(args, actionDefinitions));
+        let output: PinetOutputOptions;
+        try {
+          output = normalizePinetOutputOptions(args);
+        } catch (error) {
+          return wrapDispatcherEnvelope(
+            buildPinetDispatcherEnvelope("failed", null, [
+              {
+                class: "input",
+                message: getErrorMessage(error),
+                retryable: false,
+                hint: 'Use format="cli" or format="json" and full as a boolean.',
+              },
+            ]),
+          );
+        }
+        return wrapDispatcherEnvelope(
+          buildPinetDispatcherHelpEnvelope(args, actionDefinitions),
+          output,
+        );
       }
 
       const definition = actionDefinitions.get(normalizedAction);
@@ -713,14 +980,37 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
         );
       }
 
+      let output: PinetOutputOptions;
       try {
-        const result = await definition.execute(toolCallId, params.args);
+        output = normalizePinetOutputOptions(params.args);
+      } catch (error) {
+        return wrapDispatcherEnvelope(
+          buildPinetDispatcherEnvelope("failed", null, [
+            {
+              class: "input",
+              message: getErrorMessage(error),
+              retryable: false,
+              hint: 'Use format="cli" or format="json" and full as a boolean.',
+            },
+          ]),
+        );
+      }
+
+      try {
+        const result = await definition.execute(toolCallId, params.args, output);
         return wrapDispatcherEnvelope(
           buildPinetDispatcherEnvelope("succeeded", {
             action: definition.name,
             text: result.content[0]?.text ?? "",
             details: result.details ?? null,
+            ...(result.compactDetails !== undefined && !output.full
+              ? { compact_details: result.compactDetails }
+              : {}),
+            ...(output.full && result.fullDetails !== undefined
+              ? { full_details: result.fullDetails }
+              : {}),
           }),
+          output,
         );
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -20,7 +20,8 @@ Call the dispatcher with an action and action-specific args:
 }
 ```
 
-Every dispatcher response uses this envelope:
+Every dispatcher response has this envelope in tool `details`, while the default
+visible `content` is compact CLI-style text:
 
 ```json
 {
@@ -30,6 +31,11 @@ Every dispatcher response uses this envelope:
   "warnings": []
 }
 ```
+
+Pass `args.format="json"` when you need the envelope in visible content, and
+`args.full=true` when you need full structured details instead of compact
+defaults. If an action already owns a `format` argument, such as `export`, use
+`args.response_format="json"` for response presentation.
 
 On failure, inspect `errors[0].class`, `retryable`, and `hint`. Prefer
 `slack({"action":"help","args":{"topic":"..."}})` before guessing an action

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -437,6 +437,77 @@ describe("registerSlackTools", () => {
     });
   });
 
+  it("returns compact Slack read previews by default and full text on request", async () => {
+    const { tools, setConversationsReplies, setResolveThreadChannel, setResolveUser } = setup();
+    setResolveThreadChannel(async () => "C-DB");
+    setResolveUser(async (userId: string) => (userId === "U123" ? "Ada" : userId));
+    const longText = `${"status ".repeat(40)}done`;
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [{ ts: "123.001", user: "U123", text: longText }],
+      } as SlackResult,
+      {
+        ok: true,
+        messages: [{ ts: "123.001", user: "U123", text: longText }],
+      } as SlackResult,
+    ]);
+
+    const compact = await tools.get("slack_read")!.execute("tool-read-compact", {
+      thread_ts: "123.456",
+    });
+    expect(compact.content?.[0]?.text).toContain("Use args.full=true for exact message text.");
+    expect(compact.content?.[0]?.text).not.toContain(longText);
+    expect(compact.details?.messages).toEqual([
+      expect.objectContaining({
+        ts: "123.001",
+        user: "Ada",
+        preview: expect.stringContaining("status"),
+      }),
+    ]);
+
+    const full = await tools.get("slack_read")!.execute("tool-read-full", {
+      thread_ts: "123.456",
+      full: true,
+    });
+    expect(full.content?.[0]?.text).toContain(longText);
+    expect(full.details?.messages).toEqual([
+      expect.objectContaining({ ts: "123.001", user: "Ada", text: longText }),
+    ]);
+  });
+
+  it("uses compact dispatcher text by default and JSON when requested", async () => {
+    const { registeredTools, setConversationsReplies, setResolveThreadChannel, setResolveUser } =
+      setup();
+    setResolveThreadChannel(async () => "C-DB");
+    setResolveUser(async (userId: string) => (userId === "U123" ? "Ada" : userId));
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [{ ts: "123.001", user: "U123", text: "compact dispatcher body" }],
+      } as SlackResult,
+      {
+        ok: true,
+        messages: [{ ts: "123.002", user: "U123", text: "json dispatcher body" }],
+      } as SlackResult,
+    ]);
+    const dispatcher = registeredTools.get("slack")!;
+
+    const compact = await dispatcher.execute("tool-dispatch-read-compact", {
+      action: "read",
+      args: { thread_ts: "123.456" },
+    });
+    expect(compact.content?.[0]?.text).toContain("Ada: compact dispatcher body");
+    expect(compact.content?.[0]?.text).not.toContain('"status": "succeeded"');
+
+    const json = await dispatcher.execute("tool-dispatch-read-json", {
+      action: "read",
+      args: { thread_ts: "123.456", format: "json" },
+    });
+    expect(json.content?.[0]?.text).toContain('"status": "succeeded"');
+    expect(json.content?.[0]?.text).toContain("json dispatcher body");
+  });
+
   it("uses thread channel resolution for slack_delete", async () => {
     const { slack, tools, setResolveThreadChannel } = setup();
     setResolveThreadChannel(async (threadTs: string | undefined) => {
@@ -928,6 +999,41 @@ describe("registerSlackTools", () => {
     expect(response.details?.count).toBe(1);
   });
 
+  it("keeps slack_export format separate from dispatcher response_format", async () => {
+    const { registeredTools, setConversationsReplies, setResolveThreadChannel, setResolveUser } =
+      setup();
+    setResolveThreadChannel(async () => "C-DB");
+    setResolveUser(async (userId: string) => (userId === "U123" ? "alice" : userId));
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [{ ts: "123.456", user: "U123", text: "export json body" }],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+      {
+        ok: true,
+        messages: [{ ts: "123.456", user: "U123", text: "export envelope body" }],
+        response_metadata: { next_cursor: "" },
+      } as SlackResult,
+    ]);
+    const dispatcher = registeredTools.get("slack")!;
+
+    const exportJson = await dispatcher.execute("tool-export-json", {
+      action: "export",
+      args: { thread_ts: "123.456", format: "json" },
+    });
+    expect(exportJson.content?.[0]?.text).toContain("export json body");
+    expect(exportJson.content?.[0]?.text).toContain('"messages"');
+    expect(exportJson.content?.[0]?.text).not.toContain('"status": "succeeded"');
+
+    const envelopeJson = await dispatcher.execute("tool-export-response-json", {
+      action: "export",
+      args: { thread_ts: "123.456", format: "json", response_format: "json" },
+    });
+    expect(envelopeJson.content?.[0]?.text).toContain('"status": "succeeded"');
+    expect(envelopeJson.content?.[0]?.text).toContain("export envelope body");
+  });
+
   it("includes blocks when slack_send posts a rich message", async () => {
     const { slack, tools, setResolveThreadChannel, noteThreadReply, clearPendingAttention } =
       setup();
@@ -1051,6 +1157,8 @@ describe("registerSlackTools", () => {
       examples: [expect.objectContaining({ action: "post_channel" })],
     });
     expect(schemaResponse.content?.[0]?.text).toContain("args_schema");
+    expect(JSON.stringify(schemaEnvelope.data)).toContain("output_controls");
+    expect(JSON.stringify(schemaEnvelope.data)).toContain("response_format");
 
     const confirmationHelp = await dispatcher.execute("tool-help-confirm", {
       action: "help",

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -88,6 +88,32 @@ interface SlackDispatcherEnvelope {
   warnings: string[];
 }
 
+type SlackOutputFormat = "cli" | "json";
+
+interface SlackOutputOptions {
+  format: SlackOutputFormat;
+  full: boolean;
+}
+
+const SLACK_OUTPUT_OPTION_PARAMETERS = {
+  format: Type.Optional(
+    Type.String({ description: 'Response presentation format: "cli" (default) or "json".' }),
+  ),
+  response_format: Type.Optional(
+    Type.String({
+      description:
+        "Alias for response presentation format. Use this when an action already owns a format argument, such as export.",
+    }),
+  ),
+  full: Type.Optional(
+    Type.Boolean({
+      description: "Include full structured details instead of compact default details.",
+    }),
+  ),
+};
+
+const SLACK_ACTIONS_WITH_FORMAT_ARG = new Set(["export"]);
+
 interface SlackActionToolDefinition extends ToolDefinition {
   name: string;
   description?: string;
@@ -374,22 +400,77 @@ function extractToolResponseDetails(response: unknown): unknown {
   return isRecord(response) && "details" in response ? response.details : undefined;
 }
 
-function buildSlackDispatcherResponse(envelope: SlackDispatcherEnvelope): {
+function extractToolResponseFullDetails(response: unknown): unknown {
+  return isRecord(response) && "fullDetails" in response ? response.fullDetails : undefined;
+}
+
+function normalizeSlackOutputOptions(action: string, args: unknown): SlackOutputOptions {
+  if (args != null && !isRecord(args)) {
+    throw new Error("slack args must be an object.");
+  }
+
+  const ownsFormatArg = SLACK_ACTIONS_WITH_FORMAT_ARG.has(action);
+  const rawResponseFormat = isRecord(args) ? args.response_format : undefined;
+  const rawFormat =
+    rawResponseFormat ?? (isRecord(args) && !ownsFormatArg ? args.format : undefined);
+  const normalizedFormat = rawFormat == null ? "cli" : String(rawFormat).trim().toLowerCase();
+  if (normalizedFormat !== "cli" && normalizedFormat !== "json") {
+    throw new Error(
+      ownsFormatArg
+        ? 'response_format must be "cli" or "json" when provided.'
+        : 'format must be "cli" or "json" when provided.',
+    );
+  }
+  const format: SlackOutputFormat = normalizedFormat;
+
+  const rawFull = isRecord(args) ? args.full : undefined;
+  if (rawFull != null && typeof rawFull !== "boolean") {
+    throw new Error("full must be a boolean when provided.");
+  }
+
+  return { format, full: rawFull === true };
+}
+
+function getSlackEnvelopeCliText(envelope: SlackDispatcherEnvelope): string {
+  if (envelope.status === "succeeded" && isRecord(envelope.data)) {
+    const text = envelope.data.text;
+    if (typeof text === "string" && text.length > 0) return text;
+  }
+  return JSON.stringify(envelope, null, 2);
+}
+
+function buildSlackDispatcherResponse(
+  envelope: SlackDispatcherEnvelope,
+  output: SlackOutputOptions = { format: "json", full: true },
+): {
   content: Array<{ type: "text"; text: string }>;
   details: SlackDispatcherEnvelope;
 } {
   return {
-    content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
+    content: [
+      {
+        type: "text",
+        text:
+          output.format === "json"
+            ? JSON.stringify(envelope, null, 2)
+            : getSlackEnvelopeCliText(envelope),
+      },
+    ],
     details: envelope,
   };
 }
 
-function buildSlackActionSuccessEnvelope(response: unknown): SlackDispatcherEnvelope {
+function buildSlackActionSuccessEnvelope(
+  response: unknown,
+  output: SlackOutputOptions = { format: "json", full: true },
+): SlackDispatcherEnvelope {
   return {
     status: "succeeded",
     data: {
       text: extractToolResponseText(response),
-      details: extractToolResponseDetails(response),
+      details: output.full
+        ? (extractToolResponseFullDetails(response) ?? extractToolResponseDetails(response))
+        : extractToolResponseDetails(response),
     },
     errors: [],
     warnings: [],
@@ -407,6 +488,24 @@ function buildSlackActionFailureEnvelope(error: unknown): SlackDispatcherEnvelop
 
 function getSlackDispatcherExamples(action: string): Array<Record<string, unknown>> {
   return SLACK_DISPATCHER_EXAMPLES[action] ?? [{ action, args: {} }];
+}
+
+function buildSlackOutputControlsHelp(action?: string): Record<string, unknown> {
+  const ownsFormatArg = action != null && SLACK_ACTIONS_WITH_FORMAT_ARG.has(action);
+  return {
+    format: ownsFormatArg
+      ? "Reserved for this action's own payload format; use response_format for dispatcher output."
+      : 'Optional response presentation: "cli" (default) or "json".',
+    response_format:
+      'Optional response presentation alias: "cli" (default) or "json". Prefer this when an action already owns a format argument.',
+    full: "Optional boolean. Include full structured details instead of compact default details.",
+  };
+}
+
+function truncateSlackText(value: string, maxLength = 180): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= maxLength) return collapsed;
+  return `${collapsed.slice(0, Math.max(0, maxLength - 1))}…`;
 }
 
 function buildSlackInboxPromptGuidelines(): string[] {
@@ -626,6 +725,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           guardrail_tool: `slack:${action}`,
           args_schema: definition.parameters ?? {},
           examples: getSlackDispatcherExamples(action),
+          output_controls: buildSlackOutputControlsHelp(action),
         },
         errors: [],
         warnings: [],
@@ -647,6 +747,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             guardrail_tool: `slack:${action}`,
           })),
         ],
+        output_controls: buildSlackOutputControlsHelp(),
       },
       errors: [],
       warnings: [],
@@ -659,7 +760,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     description:
       "Dispatcher for non-hot Slack actions: react, read, upload, schedule, presence, export, post_channel, read_channel, confirm_action, delete, pin, bookmark, create_channel, project_create, canvas_comments_read, canvas_create, canvas_update, modal_open, modal_push, modal_update, and help. Use slack_inbox and slack_send for hot-path inbox/reply work.",
     promptSnippet:
-      "Run non-hot Slack actions through a compact dispatcher. Use action='help' for the action catalogue or args.topic for a specific schema.",
+      "Run non-hot Slack actions through a compact dispatcher. Use action='help' for the action catalogue or args.topic for a specific schema. Defaults to compact cli output; pass args.format='json' (or args.response_format='json' when the action owns format) or args.full=true for structured/full details.",
     promptGuidelines: [
       "Use slack_inbox and slack_send for the hot path. Use this dispatcher for every other Slack action.",
       "Cold actions are guarded as slack:<action>, for example slack:upload or slack:canvas_update.",
@@ -674,7 +775,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {
           description:
-            "Action arguments. Call slack with action='help' and args.topic='<action>' for the exact JSON schema and examples.",
+            "Action arguments. Call slack with action='help' and args.topic='<action>' for the exact JSON schema and examples. Add format='cli'|'json' and full=true for explicit presentation control; use response_format when the action already has a format field.",
         }),
       ),
     }),
@@ -683,13 +784,21 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         const action = normalizeSlackDispatcherActionName(params.action);
         const args = params.args ?? {};
 
+        let output: SlackOutputOptions;
+        try {
+          output = normalizeSlackOutputOptions(action, args);
+        } catch (error) {
+          return buildSlackDispatcherResponse(buildSlackActionFailureEnvelope(error));
+        }
+
         if (action === "help") {
-          return buildSlackDispatcherResponse(buildSlackDispatcherHelpEnvelope(args));
+          return buildSlackDispatcherResponse(buildSlackDispatcherHelpEnvelope(args), output);
         }
 
         if (!isRecord(args)) {
           return buildSlackDispatcherResponse(
             buildSlackActionFailureEnvelope(new Error("slack args must be an object.")),
+            output,
           );
         }
 
@@ -699,6 +808,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             buildSlackActionFailureEnvelope(
               new Error(`Unknown Slack action '${action}'. Use action='help' to list actions.`),
             ),
+            output,
           );
         }
 
@@ -709,12 +819,18 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           undefined,
           undefined as unknown as ExtensionContext,
         );
-        return buildSlackDispatcherResponse(buildSlackActionSuccessEnvelope(response));
+        return buildSlackDispatcherResponse(
+          buildSlackActionSuccessEnvelope(response, output),
+          output,
+        );
       } catch (error) {
         if (isAbortError(error)) {
           throw error;
         }
-        return buildSlackDispatcherResponse(buildSlackActionFailureEnvelope(error));
+        return buildSlackDispatcherResponse(buildSlackActionFailureEnvelope(error), {
+          format: "json",
+          full: true,
+        });
       }
     },
   });
@@ -1675,6 +1791,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     parameters: Type.Object({
       thread_ts: Type.String({ description: "Thread to read." }),
       limit: Type.Optional(Type.Number({ description: "Max messages (default 20)" })),
+      ...SLACK_OUTPUT_OPTION_PARAMETERS,
     }),
     async execute(_id, params) {
       requireToolPolicy(
@@ -1695,18 +1812,45 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       });
 
       const messages = response.messages as Record<string, unknown>[];
-      const lines: string[] = [];
-      for (const message of messages) {
-        const userId = message.user as string | undefined;
-        const name = userId ? await resolveUser(userId) : "bot";
-        const text = (message.text as string) ?? "";
-        const ts = message.ts as string;
-        lines.push(`[${ts}] ${name}: ${text}`);
+      const full = params.full === true;
+      const formattedMessages = await Promise.all(
+        messages.map(async (message) => {
+          const userId = message.user as string | undefined;
+          const name = userId ? await resolveUser(userId) : "bot";
+          const text = (message.text as string) ?? "";
+          const ts = message.ts as string;
+          return { ts, name, text, preview: truncateSlackText(text) };
+        }),
+      );
+      const lines = formattedMessages.map((message) =>
+        full
+          ? `[${message.ts}] ${message.name}: ${message.text}`
+          : `[${message.ts}] ${message.name}: ${message.preview}`,
+      );
+      if (!full && messages.length > 0) {
+        lines.push("", "Use args.full=true for exact message text.");
       }
 
       return {
         content: [{ type: "text", text: lines.join("\n") || "(no messages)" }],
-        details: { count: messages.length },
+        details: full
+          ? { count: messages.length }
+          : {
+              count: messages.length,
+              messages: formattedMessages.map((message) => ({
+                ts: message.ts,
+                user: message.name,
+                preview: message.preview,
+              })),
+            },
+        fullDetails: {
+          count: messages.length,
+          messages: formattedMessages.map((message) => ({
+            ts: message.ts,
+            user: message.name,
+            text: message.text,
+          })),
+        },
       };
     },
   });
@@ -2520,6 +2664,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         Type.String({ description: "Thread timestamp to read replies from" }),
       ),
       limit: Type.Optional(Type.Number({ description: "Max messages to return (default 20)" })),
+      ...SLACK_OUTPUT_OPTION_PARAMETERS,
     }),
     async execute(_id, params) {
       requireToolPolicy(
@@ -2547,18 +2692,47 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         messages = (response.messages as Record<string, unknown>[]).reverse();
       }
 
-      const lines: string[] = [];
-      for (const message of messages) {
-        const userId = message.user as string | undefined;
-        const name = userId ? await resolveUser(userId) : "bot";
-        const text = (message.text as string) ?? "";
-        const ts = message.ts as string;
-        lines.push(`[${ts}] ${name}: ${text}`);
+      const full = params.full === true;
+      const formattedMessages = await Promise.all(
+        messages.map(async (message) => {
+          const userId = message.user as string | undefined;
+          const name = userId ? await resolveUser(userId) : "bot";
+          const text = (message.text as string) ?? "";
+          const ts = message.ts as string;
+          return { ts, name, text, preview: truncateSlackText(text) };
+        }),
+      );
+      const lines = formattedMessages.map((message) =>
+        full
+          ? `[${message.ts}] ${message.name}: ${message.text}`
+          : `[${message.ts}] ${message.name}: ${message.preview}`,
+      );
+      if (!full && messages.length > 0) {
+        lines.push("", "Use args.full=true for exact channel message text.");
       }
 
       return {
         content: [{ type: "text", text: lines.join("\n") || "(no messages)" }],
-        details: { count: messages.length, channel: channelId },
+        details: full
+          ? { count: messages.length, channel: channelId }
+          : {
+              count: messages.length,
+              channel: channelId,
+              messages: formattedMessages.map((message) => ({
+                ts: message.ts,
+                user: message.name,
+                preview: message.preview,
+              })),
+            },
+        fullDetails: {
+          count: messages.length,
+          channel: channelId,
+          messages: formattedMessages.map((message) => ({
+            ts: message.ts,
+            user: message.name,
+            text: message.text,
+          })),
+        },
       };
     },
   });


### PR DESCRIPTION
## Summary
- add explicit compact/json/full output controls to Pinet dispatcher actions
- make Pinet read/agents default to compact CLI-style summaries with full details behind full=true
- make Slack dispatcher default to compact CLI text, with json/full controls and compact read/read_channel previews

## Tests
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pnpm --filter @gugu910/pi-slack-bridge exec vitest run slack-tools.test.ts pinet-tools.test.ts
- pre-push hook on git push (turbo test suite; 9 successful tasks)

Closes #656