### PR TITLE
fix(slack-bridge): prefer Pinet Slack thread delivery

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -69,6 +69,7 @@ import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
 import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
 import { createInboxDrainRuntime } from "./inbox-drain-runtime.js";
 import { createAgentCompletionRuntime } from "./agent-completion-runtime.js";
+import { sendBrokerMessage } from "./broker/message-send.js";
 import {
   type SlackBridgeRuntimeMode,
   resolveSlackBridgeStartupRuntimeMode,
@@ -1058,6 +1059,65 @@ export default function (pi: ExtensionAPI) {
       requireToolPolicy,
       getBotUserId: () => botUserId,
       registerConfirmationRequest,
+      pinetDelivery: {
+        isAvailable: () => pinetEnabled && brokerRole !== null,
+        sendSlackMessage: async (input) => {
+          const content = {
+            text: input.text,
+            markdown: input.text,
+            ...(input.blocks && input.blocks.length > 0 ? { slackBlocks: input.blocks } : {}),
+          };
+          if (brokerRole === "broker") {
+            const broker = getActiveBroker();
+            const selfId = getActiveBrokerSelfId();
+            if (!broker || !selfId) {
+              throw new Error("Broker agent identity is unavailable.");
+            }
+            const result = await sendBrokerMessage(
+              {
+                db: broker.db,
+                adapters: broker.adapters,
+              },
+              {
+                threadId: input.threadId,
+                body: input.text,
+                senderAgentId: selfId,
+                source: "slack",
+                channel: input.channel,
+                content,
+                ...(input.blocks && input.blocks.length > 0 ? { blocks: input.blocks } : {}),
+                agentName,
+                agentEmoji,
+                agentOwnerToken,
+              },
+            );
+            return {
+              adapter: result.adapter,
+              messageId: result.message.id,
+              threadId: result.thread.threadId,
+              channel: result.thread.channel,
+              source: result.thread.source,
+            };
+          }
+          if (brokerRole === "follower") {
+            if (!brokerClient?.client) {
+              throw new Error("Pinet is in an unexpected state.");
+            }
+            return brokerClient.client.sendMessage({
+              threadId: input.threadId,
+              body: input.text,
+              source: "slack",
+              channel: input.channel,
+              content,
+              ...(input.blocks && input.blocks.length > 0 ? { blocks: input.blocks } : {}),
+              agentName,
+              agentEmoji,
+              agentOwnerToken,
+            });
+          }
+          throw new Error("Pinet is in an unexpected state.");
+        },
+      },
     },
     pinetTools: {
       pinetEnabled: () => pinetEnabled,

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1024,12 +1024,13 @@ describe("registerSlackTools", () => {
       expect.any(Object),
     );
     expect(response.details).toMatchObject({
-      ts: "123.456",
+      thread_ts: "123.456",
       channel: "D123",
       delivery: "pinet",
       adapter: "slack",
       messageId: 42,
     });
+    expect(response.details).not.toHaveProperty("ts");
   });
 
   it("falls back to direct Slack delivery when Pinet thread delivery fails", async () => {
@@ -1088,9 +1089,45 @@ describe("registerSlackTools", () => {
       expect.any(Object),
     );
     expect(response.details).toMatchObject({
-      ts: "222.333",
+      thread_ts: "222.333",
       channel: "resolved:deployments",
       delivery: "pinet",
+    });
+    expect(response.details).not.toHaveProperty("ts");
+  });
+
+  it("falls back to direct Slack delivery when Pinet message.send times out", async () => {
+    const {
+      slack,
+      tools,
+      setResolveThreadChannel,
+      setPinetDeliveryAvailable,
+      sendPinetSlackMessage,
+    } = setup();
+    setResolveThreadChannel(async () => "D123");
+    setPinetDeliveryAvailable(true);
+    sendPinetSlackMessage.mockRejectedValueOnce(new Error("Request timed out: message.send"));
+
+    const response = await tools.get("slack_send")!.execute("tool-pinet-timeout-fallback", {
+      thread_ts: "123.456",
+      text: "Timeout fallback reply",
+    });
+
+    expect(sendPinetSlackMessage).toHaveBeenCalledOnce();
+    expect(slack).toHaveBeenCalledWith(
+      "chat.postMessage",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel: "D123",
+        thread_ts: "123.456",
+        text: "Timeout fallback reply",
+      }),
+    );
+    expect(response.details).toMatchObject({
+      ts: "123.456",
+      channel: "D123",
+      delivery: "slack",
+      fallbackReason: "Request timed out: message.send",
     });
   });
 

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { registerSlackTools } from "./slack-tools.js";
+import { registerSlackTools, type SlackPinetDeliveryInput } from "./slack-tools.js";
 import type { InboxMessage } from "./helpers.js";
 import type { SlackResult } from "./slack-api.js";
 
@@ -233,6 +233,14 @@ describe("registerSlackTools", () => {
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
     const requireToolPolicy = vi.fn();
+    let pinetDeliveryAvailable = false;
+    const sendPinetSlackMessage = vi.fn(async (input: SlackPinetDeliveryInput) => ({
+      adapter: "slack",
+      messageId: 42,
+      threadId: input.threadId,
+      channel: input.channel,
+      source: "slack",
+    }));
 
     registerSlackTools(pi, {
       getBotToken: () => botToken,
@@ -256,6 +264,10 @@ describe("registerSlackTools", () => {
       requireToolPolicy,
       registerConfirmationRequest: () => ({ status: "created" }),
       getBotUserId: () => "U_BOT",
+      pinetDelivery: {
+        isAvailable: () => pinetDeliveryAvailable,
+        sendSlackMessage: sendPinetSlackMessage,
+      },
     });
 
     const registeredTools = new Map(tools);
@@ -339,6 +351,10 @@ describe("registerSlackTools", () => {
       noteThreadReply,
       clearPendingAttention,
       requireToolPolicy,
+      setPinetDeliveryAvailable: (value: boolean) => {
+        pinetDeliveryAvailable = value;
+      },
+      sendPinetSlackMessage,
     };
   }
 
@@ -977,6 +993,105 @@ describe("registerSlackTools", () => {
         blocks: [{ type: "header", text: { type: "plain_text", text: "Deploy status" } }],
       }),
     );
+  });
+
+  it("prefers Pinet delivery for slack_send thread replies when available", async () => {
+    const {
+      slack,
+      tools,
+      setResolveThreadChannel,
+      setPinetDeliveryAvailable,
+      sendPinetSlackMessage,
+    } = setup();
+    setResolveThreadChannel(async () => "D123");
+    setPinetDeliveryAvailable(true);
+
+    const response = await tools.get("slack_send")!.execute("tool-pinet-send", {
+      thread_ts: "123.456",
+      text: "Steady reply",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "*Steady reply*" } }],
+    });
+
+    expect(sendPinetSlackMessage).toHaveBeenCalledWith({
+      threadId: "123.456",
+      channel: "D123",
+      text: "Steady reply",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "*Steady reply*" } }],
+    });
+    expect(slack).not.toHaveBeenCalledWith(
+      "chat.postMessage",
+      expect.any(String),
+      expect.any(Object),
+    );
+    expect(response.details).toMatchObject({
+      ts: "123.456",
+      channel: "D123",
+      delivery: "pinet",
+      adapter: "slack",
+      messageId: 42,
+    });
+  });
+
+  it("falls back to direct Slack delivery when Pinet thread delivery fails", async () => {
+    const {
+      slack,
+      tools,
+      setResolveThreadChannel,
+      setPinetDeliveryAvailable,
+      sendPinetSlackMessage,
+    } = setup();
+    setResolveThreadChannel(async () => "D123");
+    setPinetDeliveryAvailable(true);
+    sendPinetSlackMessage.mockRejectedValueOnce(new Error("broker unavailable"));
+
+    const response = await tools.get("slack_send")!.execute("tool-pinet-fallback", {
+      thread_ts: "123.456",
+      text: "Fallback reply",
+    });
+
+    expect(sendPinetSlackMessage).toHaveBeenCalledOnce();
+    expect(slack).toHaveBeenCalledWith(
+      "chat.postMessage",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel: "D123",
+        thread_ts: "123.456",
+        text: "Fallback reply",
+      }),
+    );
+    expect(response.details).toMatchObject({
+      ts: "123.456",
+      channel: "D123",
+      delivery: "slack",
+      fallbackReason: "broker unavailable",
+    });
+  });
+
+  it("prefers Pinet delivery for threaded slack_post_channel messages", async () => {
+    const { slack, tools, setPinetDeliveryAvailable, sendPinetSlackMessage } = setup();
+    setPinetDeliveryAvailable(true);
+
+    const response = await tools.get("slack_post_channel")!.execute("tool-pinet-channel", {
+      channel: "deployments",
+      thread_ts: "222.333",
+      text: "Threaded status",
+    });
+
+    expect(sendPinetSlackMessage).toHaveBeenCalledWith({
+      threadId: "222.333",
+      channel: "resolved:deployments",
+      text: "Threaded status",
+    });
+    expect(slack).not.toHaveBeenCalledWith(
+      "chat.postMessage",
+      expect.any(String),
+      expect.any(Object),
+    );
+    expect(response.details).toMatchObject({
+      ts: "222.333",
+      channel: "resolved:deployments",
+      delivery: "pinet",
+    });
   });
 
   it("returns structured inbox messages including block action metadata", async () => {

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1094,6 +1094,34 @@ describe("registerSlackTools", () => {
     });
   });
 
+  it("does not bypass healthy Pinet ownership rejections with direct Slack fallback", async () => {
+    const {
+      slack,
+      tools,
+      setResolveThreadChannel,
+      setPinetDeliveryAvailable,
+      sendPinetSlackMessage,
+    } = setup();
+    setResolveThreadChannel(async () => "D123");
+    setPinetDeliveryAvailable(true);
+    sendPinetSlackMessage.mockRejectedValueOnce(
+      new Error("Thread 123.456 is already owned by another agent."),
+    );
+
+    await expect(
+      tools.get("slack_send")!.execute("tool-pinet-owned-thread", {
+        thread_ts: "123.456",
+        text: "Do not bypass ownership",
+      }),
+    ).rejects.toThrow("already owned");
+
+    expect(slack).not.toHaveBeenCalledWith(
+      "chat.postMessage",
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
   it("returns structured inbox messages including block action metadata", async () => {
     const { inbox, tools } = setup();
     inbox.push({

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -44,6 +44,26 @@ export interface SlackToolsThreadContextPort {
   clearPendingAttention: (threadTs: string) => void;
 }
 
+export interface SlackPinetDeliveryInput {
+  threadId: string;
+  channel: string;
+  text: string;
+  blocks?: ReadonlyArray<Record<string, unknown>>;
+}
+
+export interface SlackPinetDeliveryResult {
+  adapter: string;
+  messageId: number;
+  threadId: string;
+  channel: string;
+  source: string;
+}
+
+export interface SlackPinetDeliveryPort {
+  isAvailable: () => boolean;
+  sendSlackMessage: (input: SlackPinetDeliveryInput) => Promise<SlackPinetDeliveryResult>;
+}
+
 export interface RegisterSlackToolsDeps {
   getBotToken: () => string;
   getDefaultChannel: () => string | undefined;
@@ -69,6 +89,7 @@ export interface RegisterSlackToolsDeps {
     conflict?: { toolPattern: string; action: string };
   };
   getBotUserId: () => string | null;
+  pinetDelivery?: SlackPinetDeliveryPort;
 }
 
 type SlackDispatcherStatus = "succeeded" | "failed";
@@ -575,6 +596,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     requireToolPolicy: requireToolPolicyForName,
     registerConfirmationRequest,
     getBotUserId,
+    pinetDelivery,
   } = deps;
 
   async function resolveTrackedThreadChannel(threadTs: string | undefined): Promise<string | null> {
@@ -591,6 +613,70 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
   function requireToolPolicy(toolName: string, threadTs: string | undefined, action: string): void {
     requireToolPolicyForName(normalizeSlackGuardrailToolName(toolName), threadTs, action);
+  }
+
+  async function deliverSlackMessage(input: {
+    channel: string;
+    text: string;
+    threadTs?: string;
+    blocks?: Array<Record<string, unknown>>;
+  }): Promise<{
+    ts: string;
+    channel: string;
+    blocksCount: number;
+    delivery: "pinet" | "slack";
+    adapter?: string;
+    messageId?: number;
+    fallbackReason?: string;
+  }> {
+    const blocks = input.blocks ? normalizeSlackBlocksInput(input.blocks) : undefined;
+    let fallbackReason: string | undefined;
+
+    if (input.threadTs && pinetDelivery) {
+      try {
+        if (pinetDelivery.isAvailable()) {
+          const result = await pinetDelivery.sendSlackMessage({
+            threadId: input.threadTs,
+            channel: input.channel,
+            text: input.text,
+            ...(blocks ? { blocks } : {}),
+          });
+          return {
+            ts: input.threadTs,
+            channel: result.channel,
+            blocksCount: blocks?.length ?? 0,
+            delivery: "pinet",
+            adapter: result.adapter,
+            messageId: result.messageId,
+          };
+        }
+      } catch (error) {
+        fallbackReason = getErrorMessage(error);
+      }
+    }
+
+    const body: Record<string, unknown> = {
+      channel: input.channel,
+      text: input.text,
+      metadata: {
+        event_type: "pi_agent_msg",
+        event_payload: { agent: getAgentName(), agent_owner: getAgentOwnerToken() },
+      },
+    };
+    if (blocks) {
+      body.blocks = blocks;
+    }
+    if (input.threadTs) body.thread_ts = input.threadTs;
+
+    const response = await slack("chat.postMessage", getBotToken(), body);
+    const ts = (response.message as { ts: string }).ts;
+    return {
+      ts,
+      channel: input.channel,
+      blocksCount: blocks?.length ?? 0,
+      delivery: "slack",
+      ...(fallbackReason ? { fallbackReason } : {}),
+    };
   }
 
   const slackActionRegistry = new Map<string, SlackActionToolDefinition>();
@@ -1465,21 +1551,13 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         );
       }
 
-      const body: Record<string, unknown> = {
+      const delivery = await deliverSlackMessage({
         channel,
         text: params.text,
-        metadata: {
-          event_type: "pi_agent_msg",
-          event_payload: { agent: getAgentName(), agent_owner: getAgentOwnerToken() },
-        },
-      };
-      if (params.blocks) {
-        body.blocks = normalizeSlackBlocksInput(params.blocks);
-      }
-      if (params.thread_ts) body.thread_ts = params.thread_ts;
-
-      const response = await slack("chat.postMessage", getBotToken(), body);
-      const ts = (response.message as { ts: string }).ts;
+        ...(params.thread_ts ? { threadTs: params.thread_ts } : {}),
+        ...(params.blocks ? { blocks: params.blocks } : {}),
+      });
+      const ts = delivery.ts;
       const actualTs = params.thread_ts ?? ts;
 
       noteThreadReply(actualTs, channel);
@@ -1497,7 +1575,15 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
               : `Sent message (thread_ts: ${ts}). Use this to continue the conversation.`,
           },
         ],
-        details: { ts, channel, blocksCount: params.blocks?.length ?? 0 },
+        details: {
+          ts,
+          channel,
+          blocksCount: delivery.blocksCount,
+          delivery: delivery.delivery,
+          ...(delivery.adapter ? { adapter: delivery.adapter } : {}),
+          ...(delivery.messageId ? { messageId: delivery.messageId } : {}),
+          ...(delivery.fallbackReason ? { fallbackReason: delivery.fallbackReason } : {}),
+        },
       };
     },
   });
@@ -2064,21 +2150,13 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         throw new Error("No channel specified and no defaultChannel configured in settings.json.");
       }
 
-      const body: Record<string, unknown> = {
+      const delivery = await deliverSlackMessage({
         channel: channelId,
         text: params.text,
-        metadata: {
-          event_type: "pi_agent_msg",
-          event_payload: { agent: getAgentName(), agent_owner: getAgentOwnerToken() },
-        },
-      };
-      if (params.blocks) {
-        body.blocks = normalizeSlackBlocksInput(params.blocks);
-      }
-      if (params.thread_ts) body.thread_ts = params.thread_ts;
-
-      const response = await slack("chat.postMessage", getBotToken(), body);
-      const ts = (response.message as { ts: string }).ts;
+        ...(params.thread_ts ? { threadTs: params.thread_ts } : {}),
+        ...(params.blocks ? { blocks: params.blocks } : {}),
+      });
+      const ts = delivery.ts;
       const actualTs = params.thread_ts ?? ts;
 
       noteThreadReply(actualTs, channelId);
@@ -2093,7 +2171,15 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
               : `Posted to #${channelLabel} (ts: ${ts}).`,
           },
         ],
-        details: { ts, channel: channelId, blocksCount: params.blocks?.length ?? 0 },
+        details: {
+          ts,
+          channel: channelId,
+          blocksCount: delivery.blocksCount,
+          delivery: delivery.delivery,
+          ...(delivery.adapter ? { adapter: delivery.adapter } : {}),
+          ...(delivery.messageId ? { messageId: delivery.messageId } : {}),
+          ...(delivery.fallbackReason ? { fallbackReason: delivery.fallbackReason } : {}),
+        },
       };
     },
   });

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -257,6 +257,7 @@ function isPinetDeliveryFallbackError(error: unknown): boolean {
     lower.includes("not connected") ||
     lower.includes("disconnected") ||
     lower.includes("timeout") ||
+    lower.includes("timed out") ||
     lower.includes("econn") ||
     lower.includes("socket") ||
     lower.includes("no transport source") ||
@@ -640,7 +641,8 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     threadTs?: string;
     blocks?: Array<Record<string, unknown>>;
   }): Promise<{
-    ts: string;
+    ts?: string;
+    threadTs?: string;
     channel: string;
     blocksCount: number;
     delivery: "pinet" | "slack";
@@ -661,7 +663,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             ...(blocks ? { blocks } : {}),
           });
           return {
-            ts: input.threadTs,
+            threadTs: input.threadTs,
             channel: result.channel,
             blocksCount: blocks?.length ?? 0,
             delivery: "pinet",
@@ -1578,7 +1580,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         ...(params.blocks ? { blocks: params.blocks } : {}),
       });
       const ts = delivery.ts;
-      const actualTs = params.thread_ts ?? ts;
+      const threadTs = params.thread_ts ?? delivery.threadTs;
+      const actualTs = threadTs ?? ts;
+      if (!actualTs) {
+        throw new Error("Slack delivery did not return a message timestamp.");
+      }
 
       noteThreadReply(actualTs, channel);
 
@@ -1592,11 +1598,12 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             type: "text",
             text: params.thread_ts
               ? `Replied in thread ${params.thread_ts}.`
-              : `Sent message (thread_ts: ${ts}). Use this to continue the conversation.`,
+              : `Sent message (thread_ts: ${actualTs}). Use this to continue the conversation.`,
           },
         ],
         details: {
-          ts,
+          ...(ts ? { ts } : {}),
+          ...(threadTs ? { thread_ts: threadTs } : {}),
           channel,
           blocksCount: delivery.blocksCount,
           delivery: delivery.delivery,
@@ -2177,7 +2184,11 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         ...(params.blocks ? { blocks: params.blocks } : {}),
       });
       const ts = delivery.ts;
-      const actualTs = params.thread_ts ?? ts;
+      const threadTs = params.thread_ts ?? delivery.threadTs;
+      const actualTs = threadTs ?? ts;
+      if (!actualTs) {
+        throw new Error("Slack delivery did not return a message timestamp.");
+      }
 
       noteThreadReply(actualTs, channelId);
 
@@ -2188,11 +2199,12 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             type: "text",
             text: params.thread_ts
               ? `Replied in thread ${params.thread_ts} in channel ${channelLabel}.`
-              : `Posted to #${channelLabel} (ts: ${ts}).`,
+              : `Posted to #${channelLabel} (ts: ${actualTs}).`,
           },
         ],
         details: {
-          ts,
+          ...(ts ? { ts } : {}),
+          ...(threadTs ? { thread_ts: threadTs } : {}),
           channel: channelId,
           blocksCount: delivery.blocksCount,
           delivery: delivery.delivery,

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -247,6 +247,25 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isPinetDeliveryFallbackError(error: unknown): boolean {
+  const lower = getErrorMessage(error).toLowerCase();
+  if (lower.includes("already owned")) return false;
+  return (
+    lower.includes("not running") ||
+    lower.includes("unexpected state") ||
+    lower.includes("unavailable") ||
+    lower.includes("not connected") ||
+    lower.includes("disconnected") ||
+    lower.includes("timeout") ||
+    lower.includes("econn") ||
+    lower.includes("socket") ||
+    lower.includes("no transport source") ||
+    lower.includes("no transport channel") ||
+    lower.includes("no adapter") ||
+    lower.includes("identity is unavailable")
+  );
+}
+
 function classifySlackDispatcherError(error: unknown): SlackDispatcherError {
   const message = getErrorMessage(error);
   const lower = message.toLowerCase();
@@ -651,6 +670,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           };
         }
       } catch (error) {
+        if (!isPinetDeliveryFallbackError(error)) throw error;
         fallbackReason = getErrorMessage(error);
       }
     }


### PR DESCRIPTION
## Summary
- route threaded `slack_send` and `slack post_channel` delivery through Pinet `message.send` when the mesh is active
- retain direct Slack `chat.postMessage` fallback when Pinet is inactive or delivery fails
- keep compact tool output while adding details fields for delivery path/fallback diagnostics

## Tests
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge test -- slack-tools.test.ts` (Vitest ran package suite: 71 files / 1194 tests)
- push pre-push hook / turbo: 9 tasks successful

Closes #658