### PR TITLE
fix(slack-bridge): quiet Pinet tool output

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -432,7 +432,7 @@ Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": tru
 
 Use the dispatcher for all Pinet actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=schedule`, and `pinet action=agents`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
 
-Dispatcher content defaults to compact CLI-style text for noisy reads and agent lists while preserving the structured `data.details` contract for callers. Pass `args.format="json"` for the dispatcher envelope in content, or `args.full=true` for verbose text plus `full_details`.
+Dispatcher content defaults to terse CLI-style confirmations/summaries for noisy reads, sends, and agent lists while preserving the structured `data.details` contract for callers. Pass `args.format="json"` (or `args.f` / `args["-f"]`) for the dispatcher envelope in content, or `args.full=true` / `args["--full"]=true` for verbose text plus `full_details`.
 
 Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet action=read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
 

--- a/slack-bridge/broker-inbound-persistence.test.ts
+++ b/slack-bridge/broker-inbound-persistence.test.ts
@@ -46,7 +46,7 @@ describe("broker inbound persistence", () => {
       "pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
     );
     expect(buildPersistedInboundNotificationText(delivered.message)).toContain(
-      "Durable slack mail stored in SQLite as message #42.",
+      "Durable slack mail stored as #42.",
     );
     expect(buildPersistedInboundNotificationText(delivered.message)).toContain(
       "pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
@@ -62,8 +62,8 @@ describe("broker inbound persistence", () => {
 
     expect(store.queueDeliveredMessage).toHaveBeenCalledWith("broker", message);
     expect(result.result).toBe(delivered);
-    expect(result.notificationText).toContain(
-      "Use pinet action=read with the pointer before acting.",
+    expect(result.notificationText).toBe(
+      "Durable slack mail stored as #42. pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
     );
   });
 });

--- a/slack-bridge/broker-inbound-persistence.ts
+++ b/slack-bridge/broker-inbound-persistence.ts
@@ -25,9 +25,8 @@ export function buildPinetReadPointer(threadId: string): string {
 
 export function buildPersistedInboundNotificationText(message: BrokerMessage): string {
   return [
-    `Durable ${message.source} mail stored in SQLite as message #${message.id}.`,
+    `Durable ${message.source} mail stored as #${message.id}.`,
     buildPinetReadPointer(message.threadId),
-    "Use pinet action=read with the pointer before acting.",
   ].join(" ");
 }
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -471,8 +471,8 @@ describe("formatInboxMessages", () => {
     expect(result).toContain(
       "[thread 789.012] [fwup] (channel mention in <#C789>) will: inbox_id=13 pointer=pinet action=read args.thread_id=789.012 args.unread_only=true",
     );
-    expect(result).toContain("Use pinet action=read with the pointer before acting.");
-    expect(result).toContain("ACK briefly after reading, do the work");
+    expect(result).toContain("Read pointer(s) before acting; reply/ACK only for actionable work.");
+    expect(result).not.toContain("ACK briefly after reading, do the work");
     expect(result).not.toContain("secret Slack body");
   });
 
@@ -557,7 +557,7 @@ describe("formatInboxMessages", () => {
     expect(result).toContain(
       "[thread 123.456] [maintenance/context] will: inbox_id=15 pointer=pinet action=read args.thread_id=123.456 args.unread_only=true",
     );
-    expect(result).toContain("Treat [maintenance/context] messages as context-only");
+    expect(result).toContain("Context-only pointer(s); read only if needed.");
     expect(result).not.toContain("ACK briefly after reading");
     expect(result).not.toContain("background context only");
   });
@@ -584,7 +584,7 @@ describe("formatInboxMessages", () => {
 
     const result = formatInboxMessages(msgs, names);
     expect(result).toContain("[maintenance/context]");
-    expect(result).toContain("For [steering]/[fwup] or inline Slack messages, ACK briefly");
+    expect(result).toContain("Read pointer(s) before acting; reply/ACK only for actionable work.");
     expect(result).toContain("will: please check this inline message");
     expect(result).not.toContain("background context only");
   });
@@ -754,8 +754,8 @@ describe("formatPinetInboxMessages", () => {
       "[thread a2a:broker:worker] [steering] broker-id (Broker Bunny): inbox_id=17 pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
     );
     expect(result).not.toContain("Take issue #175");
-    expect(result).toContain("Use pinet action=read with the pointer before acting.");
-    expect(result).toContain("ACK briefly after reading, do the work");
+    expect(result).toContain("Read pointer(s) before acting; reply via pinet action=send.");
+    expect(result).not.toContain("ACK briefly after reading, do the work");
   });
 
   it("falls back to the sender id when no senderAgent metadata exists", () => {
@@ -799,7 +799,9 @@ describe("formatPinetInboxMessages", () => {
       "[thread wakeup:worker-1] [fwup] scheduler (Pinet Scheduler): inbox_id=42 pointer=pinet action=read args.thread_id=wakeup:worker-1 args.unread_only=true",
     );
     expect(result).not.toContain("Check whether PR #62 merged");
-    expect(result).toContain("Use pinet action=read with the pointer before acting.");
+    expect(result).toContain(
+      "Read pointer(s) if follow-up is needed; reply via pinet action=send when needed.",
+    );
   });
 
   it("marks terminal stand-down messages as maintenance/context and suppresses reflex ack guidance", () => {
@@ -815,8 +817,8 @@ describe("formatPinetInboxMessages", () => {
     ]);
 
     expect(result).toContain("[maintenance/context]");
-    expect(result).toContain("Treat [maintenance/context] messages as context-only");
-    expect(result).toContain("do NOT send another acknowledgement");
+    expect(result).toContain("Context-only pointer(s); read only if needed.");
+    expect(result).not.toContain("do NOT send another acknowledgement");
     expect(result).not.toContain("Hard stop on this thread");
     expect(result).not.toContain(
       "ACK briefly, do the work, report blockers immediately, report the outcome when done.",
@@ -845,9 +847,11 @@ describe("formatPinetInboxMessages", () => {
 
     expect(result).toContain("[maintenance/context]");
     expect(result).toContain("[steering]");
-    expect(result).toContain("Reply via pinet action=send for steering/follow-up only.");
-    expect(result).toContain("For [steering], ACK briefly after reading, do the work");
     expect(result).toContain(
+      "Read pointer(s) before acting; reply via pinet action=send for steering/follow-up.",
+    );
+    expect(result).not.toContain("For [steering], ACK briefly after reading, do the work");
+    expect(result).not.toContain(
       "do NOT acknowledge or reply unless you have a real blocker or materially new finding",
     );
   });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -379,11 +379,9 @@ function formatSlackInboxMessages(
   const hasInlineSlackMessage = messages.some((message) => message.brokerInboxId == null);
 
   const guidance = hasDurablePointer
-    ? hasMaintenance
-      ? hasActionableWork || hasFollowUp || hasInlineSlackMessage
-        ? "Use pinet action=read with the pointer before acting. For [maintenance/context] messages, do NOT acknowledge or reply unless you have a real blocker or materially new finding. For [steering]/[fwup] or inline Slack messages, ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
-        : "Use pinet action=read with the pointer only if you need details. Treat [maintenance/context] messages as context-only; do NOT send another acknowledgement unless you have a real blocker or materially new finding."
-      : "Use pinet action=read with the pointer before acting. ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
+    ? hasMaintenance && !hasActionableWork && !hasFollowUp && !hasInlineSlackMessage
+      ? "Context-only pointer(s); read only if needed."
+      : "Read pointer(s) before acting; reply/ACK only for actionable work."
     : "ACK briefly, do the work, report blockers immediately, report the outcome when done.";
 
   return `New Slack messages:\n${lines.join("\n")}\n\n${guidance}`;
@@ -465,11 +463,11 @@ export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string 
 
   const guidance = hasMaintenanceOnly
     ? hasActionableWork || hasFollowUp
-      ? "Use pinet action=read with the pointer before acting. Reply via pinet action=send for steering/follow-up only. For [maintenance/context] messages, do NOT acknowledge or reply unless you have a real blocker or materially new finding. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
-      : "Use pinet action=read with the pointer only if you need details. Treat [maintenance/context] messages as context-only; do NOT send another acknowledgement unless you have a real blocker or materially new finding."
+      ? "Read pointer(s) before acting; reply via pinet action=send for steering/follow-up."
+      : "Context-only pointer(s); read only if needed."
     : hasActionableWork
-      ? "Use pinet action=read with the pointer before acting. Reply via pinet action=send. For [steering], ACK briefly after reading, do the work, report blockers immediately, report the outcome when done."
-      : "Use pinet action=read with the pointer before acting. Reply via pinet action=send if follow-up is needed.";
+      ? "Read pointer(s) before acting; reply via pinet action=send."
+      : "Read pointer(s) if follow-up is needed; reply via pinet action=send when needed.";
 
   return `New Pinet messages:\n${lines.join("\n")}\n\n${guidance}`;
 }

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -88,8 +88,8 @@ describe("registerPinetTools", () => {
     const tools = registerWithDeps(createDeps());
     const pinet = tools.get("pinet");
 
-    expect(pinet?.promptSnippet).toContain("Use this dispatcher for all Pinet actions");
-    expect(pinet?.promptSnippet).toContain('action="send"');
+    expect(pinet?.promptSnippet).toContain("Use this compact dispatcher for Pinet actions");
+    expect(pinet?.promptSnippet).toContain('args.format="json"');
     expect(JSON.stringify(pinet?.parameters)).toContain(
       "help, send, read, free, schedule, or agents",
     );
@@ -120,9 +120,7 @@ describe("registerPinetTools", () => {
     };
 
     expect(sendPinetBroadcastMessage).toHaveBeenCalledWith("#extensions", "hello mesh");
-    expect(result.details.data.text).toBe(
-      "Broadcast sent to #extensions (2 agents: Worker One, Worker Two).",
-    );
+    expect(result.details.data.text).toBe("Pinet broadcast sent to #extensions (2 recipients).");
     expect(result.details.data.details).toEqual({
       channel: "#extensions",
       messageIds: [21, 22],
@@ -182,17 +180,11 @@ describe("registerPinetTools", () => {
     };
 
     expect(readPinetInbox).toHaveBeenCalledWith({ threadId: "a2a:broker:worker", limit: 5 });
-    expect(result.details.data.text).toContain(
-      "Pinet read (unread) from thread a2a:broker:worker: 1 message.",
+    expect(result.details.data.text).toBe(
+      "Pinet read: 1 unread message; unread 2→1; marked 1; 1 unread thread.",
     );
-    expect(result.details.data.text).toContain("Unread before: 2; unread after: 1.");
-    expect(result.details.data.text).toContain(
-      "- [steering] [agent/a2a:broker:worker #44] broker: please inspect #594",
-    );
-    expect(result.details.data.text).toContain(
-      "- [steering] a2a:broker:worker (agent): 1 unread (1 steering); latest #45; pointer=pinet action=read args.thread_id=a2a:broker:worker args.unread_only=true",
-    );
-    expect(result.details.data.text).toContain("Marked read: 31.");
+    expect(result.details.data.text).not.toContain("please inspect #594");
+    expect(result.details.data.text).not.toContain("pointer=pinet action=read");
     expect(result.details.data.details.markedReadIds).toEqual([31]);
   });
 
@@ -238,7 +230,7 @@ describe("registerPinetTools", () => {
       };
     };
 
-    expect(result.content[0]?.text).toContain("Use args.full=true");
+    expect(result.content[0]?.text).toBe("Pinet read: 1 unread message; unread 1→0; marked 1.");
     expect(result.content[0]?.text).not.toContain(longBody);
     expect(result.details.data.text).not.toContain(longBody);
     expect(result.details.data.details.messages[0]?.message.body).toBe(longBody);
@@ -279,13 +271,50 @@ describe("registerPinetTools", () => {
 
     const result = (await tools.get("pinet")?.execute("tool-call-read-json-details", {
       action: "read",
-      args: { thread_id: "a2a:broker:worker", format: "json" },
+      args: { thread_id: "a2a:broker:worker", f: "json" },
     })) as { content: Array<{ text: string }> };
     const envelope = JSON.parse(result.content[0]?.text ?? "{}") as {
       data: { details: { messages: Array<{ message: { body: string } }> } };
     };
 
     expect(envelope.data.details.messages[0]?.message.body).toBe(body);
+  });
+
+  it("shows exact Pinet read bodies only with explicit full output", async () => {
+    const body = "exact full body";
+    const readPinetInbox = vi.fn(async () => ({
+      messages: [
+        {
+          inboxId: 31,
+          delivered: true,
+          readAt: "2026-04-25T12:00:00.000Z",
+          message: {
+            id: 44,
+            threadId: "a2a:broker:worker",
+            source: "agent" as const,
+            direction: "inbound" as const,
+            sender: "broker",
+            body,
+            metadata: { a2a: true },
+            createdAt: "2026-04-25T11:59:00.000Z",
+          },
+        },
+      ],
+      unreadCountBefore: 1,
+      unreadCountAfter: 0,
+      unreadThreads: [],
+      markedReadIds: [31],
+    }));
+    const deps = createDeps({ readPinetInbox });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-read-full-details", {
+      action: "read",
+      args: { thread_id: "a2a:broker:worker", full: true },
+    })) as { content: Array<{ text: string }>; details: { data: { full_details: unknown } } };
+
+    expect(result.content[0]?.text).toContain(body);
+    expect(result.details.data.full_details).toBeDefined();
   });
 
   it("routes action-dispatched help through the dispatcher", async () => {
@@ -351,7 +380,29 @@ describe("registerPinetTools", () => {
     expect(sendPinetAgentMessage).toHaveBeenCalledWith("alpha", "dispatch now");
     expect(result.details.status).toBe("succeeded");
     expect(result.details.data.action).toBe("send");
+    expect(result.details.data.text).toBe("Pinet message sent to alpha.");
     expect(result.content[0]?.text).toContain('"status": "succeeded"');
+  });
+
+  it("honors explicit full output for pinet send", async () => {
+    const sendPinetAgentMessage = vi.fn(async (_to: string, _message: string) => ({
+      messageId: 41,
+      target: "alpha",
+    }));
+    const deps = createDeps({ sendPinetAgentMessage });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-dispatch-send-full", {
+      action: "send",
+      args: {
+        to: "alpha",
+        message: "dispatch now",
+        "--full": true,
+      },
+    })) as { details: { data: { text: string; details: { messageId: number } } } };
+
+    expect(result.details.data.text).toBe("Message sent to alpha (id: 41).");
+    expect(result.details.data.details.messageId).toBe(41);
   });
 
   it("formats action-dispatched free responses with note and queued inbox count", async () => {
@@ -376,9 +427,7 @@ describe("registerPinetTools", () => {
     };
 
     expect(signalAgentFree).toHaveBeenCalledWith(undefined, { requirePinet: true });
-    expect(result.details.data.text).toBe(
-      "Marked this Pinet agent idle/free for new work. Note: wrapped up #395. 2 queued inbox items remain.",
-    );
+    expect(result.details.data.text).toBe("Pinet free: idle; 2 queued.");
     expect(result.details.data.details).toEqual({
       status: "idle",
       note: "wrapped up #395",
@@ -408,9 +457,7 @@ describe("registerPinetTools", () => {
     };
 
     expect(scheduleBrokerWakeup).toHaveBeenCalledWith("2026-04-14T12:05:00.000Z", "check queue");
-    expect(result.details.data.text).toBe(
-      "Wake-up scheduled for 2026-04-14T12:05:00.000Z (id: 7).",
-    );
+    expect(result.details.data.text).toBe("Pinet wake-up scheduled for 2026-04-14T12:05:00.000Z.");
     expect(result.details.data.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
   });
 
@@ -477,7 +524,8 @@ describe("registerPinetTools", () => {
       };
     };
 
-    expect(result.content[0]?.text).toContain("Golden Chalk Rabbit");
+    expect(result.content[0]?.text).toBe("Pinet agents: 1 visible; hints repo=extensions.");
+    expect(result.content[0]?.text).not.toContain("Golden Chalk Rabbit");
     expect(result.details.data.text).not.toContain("pid:");
     expect(result.details.data.details.agents[0]?.name).toBe("Golden Chalk Rabbit");
     expect(result.details.data.details.agents[0]?.metadata).toEqual(

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -141,13 +141,13 @@ const PINET_OUTPUT_OPTION_PARAMETERS = {
 };
 
 function normalizePinetOutputOptions(args: Record<string, unknown>): PinetOutputOptions {
-  const rawFormat = args.format;
+  const rawFormat = args.format ?? args.f ?? args["-f"];
   const format = rawFormat == null ? "cli" : String(rawFormat).trim().toLowerCase();
   if (format !== "cli" && format !== "json") {
     throw new Error('format must be "cli" or "json".');
   }
 
-  const rawFull = args.full;
+  const rawFull = args.full ?? args["--full"];
   if (rawFull != null && typeof rawFull !== "boolean") {
     throw new Error("full must be a boolean when provided.");
   }
@@ -450,53 +450,22 @@ function buildCompactPinetReadDetails(result: PinetReadResult): Record<string, u
 }
 
 function formatPinetReadResultCompact(result: PinetReadResult, options: PinetReadOptions): string {
-  const scope = options.threadId ? `thread ${options.threadId}` : "your Pinet inbox";
   const mode = options.unreadOnly === false ? "latest" : "unread";
-  const lines = [
-    `Pinet read (${mode}) from ${scope}: ${result.messages.length} message${result.messages.length === 1 ? "" : "s"}.`,
-    `Unread before: ${result.unreadCountBefore}; unread after: ${result.unreadCountAfter}.`,
-  ];
+  const markedSuffix =
+    result.markedReadIds.length > 0 ? `; marked ${result.markedReadIds.length}` : "";
+  const unreadThreadSuffix =
+    result.unreadThreads.length > 0
+      ? `; ${result.unreadThreads.length} unread thread${result.unreadThreads.length === 1 ? "" : "s"}`
+      : "";
 
-  if (result.messages.length > 0) {
-    lines.push("");
-    for (const item of result.messages) {
-      const classification = classifyPinetMail({
-        source: item.message.source,
-        threadId: item.message.threadId,
-        sender: item.message.sender,
-        body: item.message.body,
-        metadata: item.message.metadata,
-      });
-      const label = formatPinetMailClassLabel(classification.class);
-      lines.push(
-        `- [${label}] [${item.message.source}/${item.message.threadId} #${item.message.id}] ${item.message.sender}: ${truncateText(item.message.body)}`,
-      );
-    }
-  }
-
-  if (result.unreadThreads.length > 0) {
-    lines.push("", "Unread thread pointers:");
-    for (const thread of result.unreadThreads.slice(0, 10)) {
-      const label = formatPinetMailClassLabel(thread.highestMailClass);
-      const counts = summarizeUnreadThreadCounts(thread);
-      lines.push(
-        `- [${label}] ${thread.threadId} (${thread.source}${thread.channel ? `/${thread.channel}` : ""}): ${thread.unreadCount} unread${counts ? ` (${counts})` : ""}; latest #${thread.latestMessageId}; pointer=pinet action=read args.thread_id=${thread.threadId} args.unread_only=true`,
-      );
-    }
-  }
-
-  if (result.markedReadIds.length > 0) {
-    lines.push("", `Marked read: ${result.markedReadIds.join(", ")}.`);
-  }
-  lines.push("", "Use args.full=true for exact message bodies and full metadata in visible text.");
-
-  return lines.join("\n");
+  return `Pinet read: ${result.messages.length} ${mode} message${result.messages.length === 1 ? "" : "s"}; unread ${result.unreadCountBefore}→${result.unreadCountAfter}${markedSuffix}${unreadThreadSuffix}.`;
 }
 
 function runPinetSendAction(
   params: Record<string, unknown>,
   deps: RegisterPinetToolsDeps,
   toolName: string,
+  output: PinetOutputOptions,
 ): Promise<PinetToolResult> {
   return (async () => {
     const to = typeof params.to === "string" ? params.to.trim() : "";
@@ -520,7 +489,9 @@ function runPinetSendAction(
         content: [
           {
             type: "text",
-            text: `Broadcast sent to ${result.channel} (${result.recipients.length} agents: ${preview}${suffix}).`,
+            text: output.full
+              ? `Broadcast sent to ${result.channel} (${result.recipients.length} agents: ${preview}${suffix}).`
+              : `Pinet broadcast sent to ${result.channel} (${result.recipients.length} recipients).`,
           },
         ],
         details: {
@@ -534,7 +505,12 @@ function runPinetSendAction(
     const result = await deps.sendPinetAgentMessage(to, message);
     return {
       content: [
-        { type: "text", text: `Message sent to ${result.target} (id: ${result.messageId}).` },
+        {
+          type: "text",
+          text: output.full
+            ? `Message sent to ${result.target} (id: ${result.messageId}).`
+            : `Pinet message sent to ${result.target}.`,
+        },
       ],
       details: { messageId: result.messageId, target: result.target },
     };
@@ -590,6 +566,7 @@ function runPinetFreeAction(
   params: Record<string, unknown>,
   deps: RegisterPinetToolsDeps,
   toolName: string,
+  output: PinetOutputOptions,
 ): Promise<PinetToolResult> {
   return (async () => {
     const note = typeof params.note === "string" ? params.note.trim() : "";
@@ -607,7 +584,9 @@ function runPinetFreeAction(
       content: [
         {
           type: "text",
-          text: `Marked this Pinet agent idle/free for new work.${noteSuffix}${inboxSuffix}`,
+          text: output.full
+            ? `Marked this Pinet agent idle/free for new work.${noteSuffix}${inboxSuffix}`
+            : `Pinet free: idle${result.queuedInboxCount > 0 ? `; ${result.queuedInboxCount} queued` : ""}.`,
         },
       ],
       details: {
@@ -623,6 +602,7 @@ function runPinetScheduleAction(
   params: Record<string, unknown>,
   deps: RegisterPinetToolsDeps,
   toolName: string,
+  output: PinetOutputOptions,
 ): Promise<PinetToolResult> {
   return (async () => {
     const delay = typeof params.delay === "string" ? params.delay : undefined;
@@ -650,7 +630,9 @@ function runPinetScheduleAction(
         content: [
           {
             type: "text",
-            text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
+            text: output.full
+              ? `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`
+              : `Pinet wake-up scheduled for ${wakeup.fireAt}.`,
           },
         ],
         details: wakeup,
@@ -663,7 +645,9 @@ function runPinetScheduleAction(
         content: [
           {
             type: "text",
-            text: `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`,
+            text: output.full
+              ? `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`
+              : `Pinet wake-up scheduled for ${wakeup.fireAt}.`,
           },
         ],
         details: wakeup,
@@ -712,26 +696,17 @@ function buildCompactAgentDetails(
   };
 }
 
-function formatCompactAgentList(agents: AgentDisplayInfo[]): string {
-  if (agents.length === 0) return "(no agents connected)";
-
-  return agents
-    .map((agent) => {
-      const parts = [
-        getAgentRepo(agent) ? `repo=${getAgentRepo(agent)}` : null,
-        getAgentBranch(agent) ? `branch=${getAgentBranch(agent)}` : null,
-        getAgentRole(agent) ? `role=${getAgentRole(agent)}` : null,
-        agent.routingScore != null ? `score=${agent.routingScore}` : null,
-      ].filter((item): item is string => Boolean(item));
-      const health = agent.health ? ` [${agent.health}]` : "";
-      const caps = agent.capabilityTags ?? [];
-      const capPreview = caps.slice(0, 4).join(", ");
-      const capSuffix = caps.length > 4 ? ` (+${caps.length - 4} more)` : "";
-      const capsText = capPreview ? ` caps: ${capPreview}${capSuffix}` : "";
-      const context = parts.length > 0 ? ` — ${parts.join(" · ")}` : "";
-      return `${agent.emoji} ${agent.name} (${agent.id}) — ${agent.status}${health}${context}${capsText}`;
-    })
-    .join("\n");
+function formatCompactAgentList(agents: AgentDisplayInfo[], hint: PinetAgentsRoutingHint): string {
+  const hintParts = [
+    hint.repo ? `repo=${hint.repo}` : null,
+    hint.branch ? `branch=${hint.branch}` : null,
+    hint.role ? `role=${hint.role}` : null,
+    hint.requiredTools && hint.requiredTools.length > 0
+      ? `tools=${hint.requiredTools.join(",")}`
+      : null,
+  ].filter((item): item is string => Boolean(item));
+  const hintSuffix = hintParts.length > 0 ? `; hints ${hintParts.join(" · ")}` : "";
+  return `Pinet agents: ${agents.length} visible${hintSuffix}.`;
 }
 
 function runPinetAgentsAction(
@@ -793,9 +768,9 @@ function runPinetAgentsAction(
       recentDisconnectWindowMs: recentGhostWindowMs,
     }).map(toDisplay);
     const agents = rankAgentsForRouting(visibleAgents, hint);
-    const header = hasHint ? `${buildPinetAgentsHintText(hint)}\n\n` : "";
+    const header = hasHint && output.full ? `${buildPinetAgentsHintText(hint)}\n\n` : "";
     const text = `${header}${
-      output.full ? formatAgentList(agents, os.homedir()) : formatCompactAgentList(agents)
+      output.full ? formatAgentList(agents, os.homedir()) : formatCompactAgentList(agents, hint)
     }`;
 
     return {
@@ -825,7 +800,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       message: Type.String({ description: "Message body" }),
       ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
-    execute: (_id, params) => runPinetSendAction(params, deps, "pinet:send"),
+    execute: (_id, params, output) => runPinetSendAction(params, deps, "pinet:send", output),
   });
 
   registerAction({
@@ -858,7 +833,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       ),
       ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
-    execute: (_id, params) => runPinetFreeAction(params, deps, "pinet:free"),
+    execute: (_id, params, output) => runPinetFreeAction(params, deps, "pinet:free", output),
   });
 
   registerAction({
@@ -874,7 +849,8 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       message: Type.String({ description: "Reminder or wake-up message to deliver later" }),
       ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
-    execute: (_id, params) => runPinetScheduleAction(params, deps, "pinet:schedule"),
+    execute: (_id, params, output) =>
+      runPinetScheduleAction(params, deps, "pinet:schedule", output),
   });
 
   registerAction({
@@ -901,7 +877,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     description:
       "Dispatch Pinet worker operations by action with compact help and schema discovery.",
     promptSnippet:
-      'Use this dispatcher for all Pinet actions: send, read, free, schedule, agents, and per-action discovery. Use action="send" for Pinet replies/delegation. Defaults to compact cli output while preserving structured data.details; pass args.format="json" for the envelope in content or args.full=true for verbose text/full_details.',
+      'Use this compact dispatcher for Pinet actions: send, read, free, schedule, agents, and help. Defaults to terse CLI text; pass args.format="json" or args.full=true for explicit detail.',
     parameters: Type.Object({
       action: Type.String({
         description: "Action name: help, send, read, free, schedule, or agents.",
@@ -909,7 +885,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {
           description:
-            'Action arguments. Add format="cli"|"json" and full=true for explicit presentation control. Pinet data.details stays backward-compatible; compact previews may appear as compact_details.',
+            'Action arguments. Add format="cli"|"json" (or f/"-f") and full=true (or "--full": true) for explicit presentation control. data.details stays backward-compatible.',
         }),
       ),
     }),


### PR DESCRIPTION
## Summary
- make default Pinet dispatcher output terse for read/send/free/schedule/agents while preserving `data.details`
- keep explicit detail opt-ins via `args.format="json"` / `args.f` / `args["-f"]` and `args.full=true` / `args["--full"]`
- reduce repeated verbose Pinet read/reply guidance in durable notifications

## Tests
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge test -- pinet-tools.test.ts helpers.test.ts broker-inbound-persistence.test.ts` (Vitest ran package suite: 71 files / 1199 tests)
- push pre-push/turbo: 9 tasks successful

Closes #660