### PR TITLE
fix(browser): quiet default tool output

### DIFF
--- a/browser-playwright/README.md
+++ b/browser-playwright/README.md
@@ -48,6 +48,8 @@ Parameters:
 - `args` — preferred structured object with action-specific scalar inputs such as
   `url`, `selector`, `value`, `timeout_ms`, `label`, `full_page`, or `topic`
   - use this for new calls
+  - output controls live here too: `format: "cli" | "json"` (or `f`/`-f`) and
+    `full: true` (or `--full: true`)
   - `args` and `input_json` may carry duplicate fields only when the values match
 - `session_id` — optional session handle for actions that operate on an existing session
   - top-level `session_id` is authoritative; conflicting nested values fail clearly
@@ -63,7 +65,13 @@ Parameters:
 
 ## Response shape
 
-Every call returns one shared envelope:
+Default visible output is compact CLI-style text, for example:
+
+```text
+Browser navigated: page=page_abc; url=https://example.com/docs; title="Docs".
+```
+
+Every call still preserves the same structured envelope in tool `details`:
 
 - `backend`
 - `action`
@@ -73,12 +81,17 @@ Every call returns one shared envelope:
 - `result`
 - `artifacts`
 
-This keeps backend differences explicit instead of overpromising parity.
+Use `args.format: "json"` (or `args.f`/`args["-f"]`) to emit that structured
+envelope as visible JSON. Use `args.full: true` (or `args["--full"]: true`) for
+verbose visible output. This keeps backend differences explicit instead of
+overpromising parity while keeping routine successes quiet.
 
 ## Supported path in Anthropic sandbox
 
 - Use `browser-playwright` and the single `browser` tool for local browsing in this repo.
 - Use `action` + `args` for action-specific fields.
+- Omit output options for compact CLI text; opt into `args.format: "json"` or
+  `args.full: true` only when you need verbose details.
 - Omit `backend` for normal use; Playwright is the supported local path.
 - Treat `input_json` as compatibility-only for older callers.
 - Treat `agent-browser` as hidden/experimental only. Local daemon compatibility is a non-goal here.
@@ -311,7 +324,7 @@ Saved Playwright login/session state is supported in a narrow, explicit way.
 
 - place trusted Playwright `storageState` JSON files under
   `.pi/state/browser-playwright/`
-- reuse one explicitly via the `start` action and `storage_state_name` inside `input_json` (today's stable action-input carrier)
+- reuse one explicitly via the `start` action and `storage_state_name` inside `args`
 - the extension never auto-saves browser state on close or shutdown
 
 Treat `.pi/state/browser-playwright/` as trusted, secret-bearing auth material for the current workspace and host.

--- a/browser-playwright/agent-browser.ts
+++ b/browser-playwright/agent-browser.ts
@@ -1,10 +1,16 @@
-import { buildCapabilities, type BrowserToolRequest } from "./protocol.ts";
+import {
+  buildCapabilities,
+  formatBrowserResponseText,
+  normalizeBrowserOutputOptions,
+  type BrowserToolEnvelope,
+  type BrowserToolRequest,
+} from "./protocol.ts";
 
 export function buildAgentBrowserModeResult(request: BrowserToolRequest): {
   content: Array<{ type: "text"; text: string }>;
   details: Record<string, unknown>;
 } {
-  const result: Record<string, unknown> = {
+  const result: BrowserToolEnvelope = {
     backend: "agent-browser",
     action: request.action,
     session_id: request.sessionId ?? null,
@@ -25,9 +31,10 @@ export function buildAgentBrowserModeResult(request: BrowserToolRequest): {
     },
     artifacts: [],
   };
+  const output = normalizeBrowserOutputOptions(request.args);
 
   return {
-    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    content: [{ type: "text", text: formatBrowserResponseText(result, output) }],
     details: result,
   };
 }

--- a/browser-playwright/index.ts
+++ b/browser-playwright/index.ts
@@ -27,12 +27,15 @@ import {
   buildBrowserDiscovery,
   buildCapabilities,
   describeBrowserActions,
+  formatBrowserResponseText,
   getBooleanArg,
   getNumberArg,
   getStringArg,
+  normalizeBrowserOutputOptions,
   parseBrowserToolRequest,
   requireStringArg,
   type BrowserAction,
+  type BrowserToolEnvelope,
   type BrowserToolRequest,
 } from "./protocol.ts";
 import { loadStoredStorageState, type StorageStateSummary } from "./storage-state.ts";
@@ -632,7 +635,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
     result: Record<string, unknown>,
     artifacts: Array<Record<string, unknown>> = [],
   ) {
-    const envelope = {
+    const envelope: BrowserToolEnvelope = {
       backend: request.backend,
       action: request.action,
       session_id:
@@ -644,9 +647,10 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       result,
       artifacts,
     };
+    const output = normalizeBrowserOutputOptions(request.args);
 
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(envelope, null, 2) }],
+      content: [{ type: "text" as const, text: formatBrowserResponseText(envelope, output) }],
       details: envelope,
     };
   }
@@ -1212,11 +1216,12 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
     description:
       "Playwright-first single browser tool. In this environment, use the browser tool without a backend override; the extension owns the runtime, proxy, socket, and session complexity behind one narrow interface.",
     promptSnippet:
-      "Use the single browser tool for browsing in this environment. The supported local path is Playwright; call action='info' for compact help/schema discovery.",
+      "Use the single browser tool for browsing in this environment. Defaults are compact CLI-style; pass args.format='json' or args.full=true for verbose details.",
     promptGuidelines: [
       "Prefer the single browser tool over many browser_* actions.",
       "Use action + args for action-specific fields; input_json is compatibility-only for older callers.",
       "Call browser with action='info' and no session_id for the action catalogue, or args.topic='<action>' for a compact action schema.",
+      "Default visible output is terse CLI text; use args.format='json' (or args.f/args['-f']) or args.full=true (or args['--full']=true) for full envelope details.",
       "Omit backend for normal use here; Playwright is the supported local path in this Anthropic sandbox.",
       "Treat agent-browser as experimental and unavailable locally; daemon compatibility is not a supported path in this repo.",
       "Direct top-level localhost navigation is intentionally allowed for same-host local-app testing; treat it as local-power access, not a generic public-web sandbox.",
@@ -1247,7 +1252,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {
           description:
-            "Preferred structured action payload. Use scalar fields such as url, selector, value, timeout_ms, label, full_page, or topic. Call action='info' with args.topic='<action>' for help/schema discovery.",
+            "Preferred structured action payload. Use scalar fields such as url, selector, value, timeout_ms, label, full_page, or topic. Output controls: format='cli'|'json' (or f/'-f') and full=true (or '--full'). Call action='info' with args.topic='<action>' for help/schema discovery.",
         }),
       ),
       input_json: Type.Optional(

--- a/browser-playwright/protocol.test.ts
+++ b/browser-playwright/protocol.test.ts
@@ -4,10 +4,13 @@ import {
   buildBrowserDiscovery,
   buildCapabilities,
   describeBrowserActions,
+  formatBrowserResponseText,
   getBooleanArg,
   getNumberArg,
   getStringArg,
+  normalizeBrowserOutputOptions,
   parseBrowserToolRequest,
+  type BrowserToolEnvelope,
 } from "./protocol.ts";
 
 test("parseBrowserToolRequest prefers top-level args for the single browser tool envelope", () => {
@@ -180,6 +183,82 @@ test("buildBrowserDiscovery action schemas match runtime-supported argument name
 
 test("buildBrowserDiscovery rejects unknown schema topics clearly", () => {
   assert.throws(() => buildBrowserDiscovery("unknown"), /Unsupported browser info topic/i);
+});
+
+test("normalizeBrowserOutputOptions defaults to compact cli and accepts aliases", () => {
+  assert.deepEqual(normalizeBrowserOutputOptions({}), { format: "cli", full: false });
+  assert.deepEqual(normalizeBrowserOutputOptions({ f: "json", "--full": true }), {
+    format: "json",
+    full: true,
+  });
+  assert.deepEqual(normalizeBrowserOutputOptions({ "-f": "cli", full: true }), {
+    format: "cli",
+    full: true,
+  });
+});
+
+test("normalizeBrowserOutputOptions rejects invalid format and full values", () => {
+  assert.throws(
+    () => normalizeBrowserOutputOptions({ format: "xml" }),
+    /format must be "cli" or "json"/i,
+  );
+  assert.throws(() => normalizeBrowserOutputOptions({ full: "true" }), /full must be a boolean/i);
+});
+
+test("formatBrowserResponseText uses compact cli text by default while preserving details", () => {
+  const envelope: BrowserToolEnvelope = {
+    backend: "playwright",
+    action: "navigate",
+    session_id: "browser_123",
+    page_id: "page_abc",
+    capabilities: buildCapabilities("playwright"),
+    result: {
+      session_id: "browser_123",
+      page: {
+        page_id: "page_abc",
+        url: "https://example.com/docs",
+        title: "Docs",
+      },
+    },
+    artifacts: [],
+  };
+
+  const text = formatBrowserResponseText(envelope, { format: "cli", full: false });
+  assert.match(text, /^Browser navigated:/);
+  assert.match(text, /https:\/\/example\.com\/docs/);
+  assert.doesNotMatch(text, /"capabilities"/);
+});
+
+test("formatBrowserResponseText returns the structured envelope for explicit json or full", () => {
+  const envelope: BrowserToolEnvelope = {
+    backend: "playwright",
+    action: "screenshot",
+    session_id: "browser_123",
+    page_id: "page_abc",
+    capabilities: buildCapabilities("playwright"),
+    result: {
+      session_id: "browser_123",
+      page_id: "page_abc",
+      path: ".pi/artifacts/browser-playwright/browser_123/example.png",
+      full_page: false,
+    },
+    artifacts: [
+      { kind: "screenshot", path: ".pi/artifacts/browser-playwright/browser_123/example.png" },
+    ],
+  };
+
+  const jsonText = formatBrowserResponseText(envelope, { format: "json", full: false });
+  assert.deepEqual(JSON.parse(jsonText), envelope);
+
+  const fullText = formatBrowserResponseText(envelope, { format: "cli", full: true });
+  assert.deepEqual(JSON.parse(fullText), envelope);
+});
+
+test("buildBrowserDiscovery advertises compact defaults and output opt-ins", () => {
+  const catalog = buildBrowserDiscovery(undefined);
+  assert.match(JSON.stringify(catalog), /Defaults to compact CLI text/);
+  assert.match(JSON.stringify(catalog), /args\.format='json'/);
+  assert.match(JSON.stringify(catalog), /--full/);
 });
 
 test("describeBrowserActions summarizes the typed browser action enum", () => {

--- a/browser-playwright/protocol.ts
+++ b/browser-playwright/protocol.ts
@@ -45,6 +45,21 @@ export type BrowserCapabilities = {
   notes?: string[];
 };
 
+export type BrowserToolEnvelope = {
+  backend: BrowserBackend;
+  action: BrowserAction;
+  session_id: string | null;
+  page_id: string | null;
+  capabilities: BrowserCapabilities;
+  result: Record<string, unknown>;
+  artifacts: Array<Record<string, unknown>>;
+};
+
+export type BrowserOutputOptions = {
+  format: "cli" | "json";
+  full: boolean;
+};
+
 type BrowserActionSchema = {
   description: string;
   requires_session_id?: boolean;
@@ -270,6 +285,197 @@ export function getNumberArg(args: BrowserArgs, key: string): number | undefined
   return typeof value === "number" ? value : undefined;
 }
 
+export function normalizeBrowserOutputOptions(args: BrowserArgs): BrowserOutputOptions {
+  const rawFormat = args.format ?? args.f ?? args["-f"];
+  const format = rawFormat == null ? "cli" : String(rawFormat).trim().toLowerCase();
+  if (format !== "cli" && format !== "json") {
+    throw new Error('browser output format must be "cli" or "json".');
+  }
+
+  const rawFull = args.full ?? args["--full"];
+  if (rawFull != null && typeof rawFull !== "boolean") {
+    throw new Error("browser output full must be a boolean when provided.");
+  }
+
+  return { format, full: rawFull === true };
+}
+
+function compactTruncate(value: string, maxLength = 900): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 18)).trimEnd()}… [truncated]`;
+}
+
+function recordValue(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = record[key];
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function arrayValue(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function stringValue(record: Record<string, unknown> | null, key: string): string | null {
+  const value = record?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberValue(record: Record<string, unknown> | null, key: string): number | null {
+  const value = record?.[key];
+  return typeof value === "number" ? value : null;
+}
+
+function booleanValue(record: Record<string, unknown> | null, key: string): boolean | null {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+function countFromCollection(record: Record<string, unknown>, key: string): number | null {
+  const collection = recordValue(record, key);
+  return numberValue(collection, "count");
+}
+
+function formatMaybeTitle(title: string | null): string {
+  return title ? `; title=${JSON.stringify(compactTruncate(title, 120))}` : "";
+}
+
+function formatPageSummary(page: Record<string, unknown> | null): string {
+  if (!page) return "page=unknown";
+  const pageId = stringValue(page, "page_id") ?? "unknown";
+  const url = stringValue(page, "url");
+  const title = stringValue(page, "title");
+  return `page=${pageId}${url ? `; url=${compactTruncate(url, 180)}` : ""}${formatMaybeTitle(title)}`;
+}
+
+function formatItemPreview(items: unknown[], maxItems = 5): string {
+  const lines = items
+    .slice(0, maxItems)
+    .map((item) => {
+      if (item == null || typeof item !== "object" || Array.isArray(item)) {
+        return null;
+      }
+      const record = item as Record<string, unknown>;
+      const text = stringValue(record, "text") ?? stringValue(record, "name") ?? null;
+      const href = stringValue(record, "href");
+      const value = text ?? href;
+      return value ? `- ${compactTruncate(value.replace(/\s+/g, " ").trim(), 180)}` : null;
+    })
+    .filter((line): line is string => Boolean(line));
+  return lines.length > 0 ? `\n${lines.join("\n")}` : "";
+}
+
+function formatBrowserCompactText(envelope: BrowserToolEnvelope): string {
+  const result = envelope.result;
+  const blockedStatus = stringValue(result, "status") === "blocked";
+  const unavailable = booleanValue(result, "available") === false;
+  if (blockedStatus || unavailable) {
+    const reason = stringValue(result, "reason");
+    return `Browser ${envelope.backend} unavailable${reason ? `: ${compactTruncate(reason, 220)}` : "."}`;
+  }
+
+  const sessionId = stringValue(result, "session_id") ?? envelope.session_id;
+  const pageId = stringValue(result, "page_id") ?? envelope.page_id;
+
+  switch (envelope.action) {
+    case "start": {
+      const pages = arrayValue(result, "pages");
+      const activePageId = stringValue(result, "active_page_id") ?? "none";
+      const headless = booleanValue(result, "headless");
+      return `Browser started: session=${sessionId ?? "unknown"}; active=${activePageId}; pages=${pages.length}${headless == null ? "" : `; headless=${headless}`}.`;
+    }
+    case "info": {
+      const actions = arrayValue(result, "actions");
+      if (actions.length > 0 && !sessionId) {
+        const names = actions
+          .map((action) =>
+            action != null && typeof action === "object" && !Array.isArray(action)
+              ? stringValue(action as Record<string, unknown>, "action")
+              : null,
+          )
+          .filter((action): action is string => Boolean(action));
+        return `Browser actions: ${names.join(", ")}. Use action='info' args.topic='<action|schema>'; args.format='json' for full details.`;
+      }
+      const network = recordValue(result, "network_summary");
+      const blocked = numberValue(network, "blocked_requests") ?? 0;
+      const failed = numberValue(network, "failed_requests") ?? 0;
+      return `Browser info: session=${sessionId ?? "unknown"}; pages=${numberValue(result, "page_count") ?? arrayValue(result, "pages").length}; active=${stringValue(result, "active_page_id") ?? "none"}; blocked=${blocked}; failed=${failed}.`;
+    }
+    case "navigate":
+      return `Browser navigated: ${formatPageSummary(recordValue(result, "page"))}.`;
+    case "snapshot": {
+      const title = stringValue(result, "title");
+      const url = stringValue(result, "url");
+      const text = stringValue(result, "text");
+      const counts = [
+        ["headings", countFromCollection(result, "headings")],
+        ["links", countFromCollection(result, "links")],
+        ["buttons", countFromCollection(result, "buttons")],
+        ["fields", countFromCollection(result, "fields")],
+      ]
+        .filter((entry): entry is [string, number] => typeof entry[1] === "number")
+        .map(([name, count]) => `${name}=${count}`)
+        .join("; ");
+      const header = `Browser snapshot: page=${pageId ?? "unknown"}${url ? `; url=${compactTruncate(url, 180)}` : ""}${formatMaybeTitle(title)}${counts ? `; ${counts}` : ""}.`;
+      return text ? `${header}\n${compactTruncate(text.replace(/\n{3,}/g, "\n\n"))}` : header;
+    }
+    case "extract": {
+      const selector = stringValue(result, "selector");
+      const text = stringValue(result, "text");
+      const items = arrayValue(result, "items");
+      const matchCount = numberValue(result, "match_count");
+      const truncated = booleanValue(result, "truncated") === true ? "; truncated=true" : "";
+      const header = selector
+        ? `Browser extract: selector=${JSON.stringify(selector)}; matches=${matchCount ?? "unknown"}; items=${items.length}${truncated}.`
+        : `Browser extract: body text${stringValue(result, "url") ? `; url=${compactTruncate(stringValue(result, "url")!, 180)}` : ""}.`;
+      if (!selector && text)
+        return `${header}\n${compactTruncate(text.replace(/\n{3,}/g, "\n\n"))}`;
+      return `${header}${formatItemPreview(items)}`;
+    }
+    case "click": {
+      const blocked = recordValue(result, "blocked_request") ? "; blocked_request=true" : "";
+      return `Browser clicked: selector=${JSON.stringify(stringValue(result, "clicked_selector") ?? "")}; ${formatPageSummary(recordValue(result, "active_page"))}${blocked}.`;
+    }
+    case "fill":
+      return `Browser filled: selector=${JSON.stringify(stringValue(result, "selector") ?? "")}; value_length=${numberValue(result, "value_length") ?? 0}; page=${pageId ?? "unknown"}.`;
+    case "press": {
+      const blocked = recordValue(result, "blocked_request") ? "; blocked_request=true" : "";
+      return `Browser pressed: key=${JSON.stringify(stringValue(result, "key") ?? "")}; page=${pageId ?? "unknown"}${stringValue(result, "url") ? `; url=${compactTruncate(stringValue(result, "url")!, 180)}` : ""}${blocked}.`;
+    }
+    case "wait":
+      return `Browser wait matched: ${stringValue(result, "matched") ?? "unknown"}; page=${pageId ?? "unknown"}${stringValue(result, "url") ? `; url=${compactTruncate(stringValue(result, "url")!, 180)}` : ""}.`;
+    case "screenshot":
+      return `Browser screenshot: path=${stringValue(result, "path") ?? "unknown"}; page=${pageId ?? "unknown"}; full_page=${booleanValue(result, "full_page") === true}.`;
+    case "tabs": {
+      const pages = arrayValue(result, "pages");
+      const pagePreview = pages
+        .slice(0, 5)
+        .map((page) =>
+          page != null && typeof page === "object" && !Array.isArray(page)
+            ? stringValue(page as Record<string, unknown>, "page_id")
+            : null,
+        )
+        .filter((id): id is string => Boolean(id));
+      return `Browser tabs: pages=${numberValue(result, "page_count") ?? pages.length}; active=${stringValue(result, "active_page_id") ?? "none"}${pagePreview.length > 0 ? `; ids=${pagePreview.join(",")}` : ""}.`;
+    }
+    case "close":
+      return `Browser closed: ${stringValue(result, "closed") ?? "target"}${pageId ? `; page=${pageId}` : ""}${booleanValue(result, "session_closed") === true ? "; session_closed=true" : ""}.`;
+    default:
+      return `Browser ${envelope.action}: ok.`;
+  }
+}
+
+export function formatBrowserResponseText(
+  envelope: BrowserToolEnvelope,
+  options: BrowserOutputOptions,
+): string {
+  if (options.format === "json" || options.full) {
+    return JSON.stringify(envelope, null, 2);
+  }
+  return formatBrowserCompactText(envelope);
+}
+
 export function buildCapabilities(backend: BrowserBackend): BrowserCapabilities {
   if (backend === "playwright") {
     return {
@@ -308,6 +514,8 @@ export function buildBrowserDiscovery(topic: string | undefined): Record<string,
     contract: {
       preferred_shape: "browser({ action, args?, session_id?, page_id?, backend? })",
       args: "Preferred structured carrier for action-specific scalar fields.",
+      output:
+        "Defaults to compact CLI text. Use args.format='json' (or args.f/args['-f']) for the structured envelope, or args.full=true (or args['--full']=true) for verbose visible output.",
       input_json: "Compatibility-only JSON string carrier; do not use for new calls.",
       backend: "Omit for normal local use; Playwright is the supported local path.",
       top_level_ids: "Top-level session_id/page_id are authoritative; conflicting nested IDs fail.",


### PR DESCRIPTION
## Summary
- make browser tool visible responses compact CLI text by default while keeping the structured envelope in `details`
- add explicit output controls through `args.format` / `args.f` / `args["-f"]` and `args.full` / `args["--full"]`
- keep full JSON envelope visible for explicit `format: "json"` or `full: true`, including the unavailable `agent-browser` path
- document quiet defaults and output opt-ins

## Tests
- `pnpm --filter @gugu910/pi-browser-playwright typecheck`
- `pnpm --filter @gugu910/pi-browser-playwright lint`
- `pnpm --filter @gugu910/pi-browser-playwright test`
- push pre-push/turbo: 9 tasks successful

Closes #663