### PR TITLE
fix(slack): default slack_send to configured channel

### DIFF
--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -49,8 +49,9 @@ describe("registerSlackTools", () => {
 
     const inbox: InboxMessage[] = [];
     let botToken = "xoxb-initial";
-    let defaultChannel = "general";
+    let defaultChannel: string | undefined = "general";
     let securityPrompt = "INITIAL SECURITY PROMPT";
+    let lastDmChannel: string | null = null;
     let resolveUser = async (userId: string) => userId;
     let conversationsRepliesResponses: SlackResult[] = [];
     let usersListResponse: SlackResult = {
@@ -251,7 +252,7 @@ describe("registerSlackTools", () => {
       getAgentName: () => "Radiant Koala",
       getAgentEmoji: () => "🐨",
       getAgentOwnerToken: () => "owner:test-token",
-      getLastDmChannel: () => null,
+      getLastDmChannel: () => lastDmChannel,
       updateBadge: () => {},
       resolveUser: async (userId) => resolveUser(userId),
       threadContext: {
@@ -315,11 +316,14 @@ describe("registerSlackTools", () => {
       setBotToken: (value: string) => {
         botToken = value;
       },
-      setDefaultChannel: (value: string) => {
+      setDefaultChannel: (value: string | undefined) => {
         defaultChannel = value;
       },
       setSecurityPrompt: (value: string) => {
         securityPrompt = value;
+      },
+      setLastDmChannel: (value: string | null) => {
+        lastDmChannel = value;
       },
       setResolveUser: (fn: (userId: string) => Promise<string>) => {
         resolveUser = fn;
@@ -1048,6 +1052,53 @@ describe("registerSlackTools", () => {
     });
     expect(envelopeJson.content?.[0]?.text).toContain('"status": "succeeded"');
     expect(envelopeJson.content?.[0]?.text).toContain("export envelope body");
+  });
+
+  it("sends slack_send to the configured default channel when no thread context exists", async () => {
+    const { slack, tools, setDefaultChannel, setLastDmChannel, noteThreadReply } = setup();
+    setDefaultChannel("ops-alerts");
+    setLastDmChannel("D-STALE");
+
+    const response = await tools.get("slack_send")!.execute("tool-send-default-channel", {
+      text: "Default channel update",
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "chat.postMessage",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel: "resolved:ops-alerts",
+        text: "Default channel update",
+      }),
+    );
+    expect(response.content?.[0]?.text).toBe(
+      "Sent message (thread_ts: 123.456). Use this to continue the conversation.",
+    );
+    expect(response.details).toMatchObject({
+      ts: "123.456",
+      channel: "resolved:ops-alerts",
+      delivery: "slack",
+    });
+    expect(noteThreadReply).toHaveBeenCalledWith("123.456", "resolved:ops-alerts");
+  });
+
+  it("keeps a clear slack_send error when no thread context or default channel exists", async () => {
+    const { slack, tools, setDefaultChannel } = setup();
+    setDefaultChannel(undefined);
+
+    await expect(
+      tools.get("slack_send")!.execute("tool-send-no-default-channel", {
+        text: "No target update",
+      }),
+    ).rejects.toThrow(
+      "No active Slack thread and no defaultChannel configured in settings.json. Set slack-bridge.defaultChannel or use the slack dispatcher action post_channel with a channel.",
+    );
+
+    expect(slack).not.toHaveBeenCalledWith(
+      "chat.postMessage",
+      expect.any(String),
+      expect.any(Object),
+    );
   });
 
   it("includes blocks when slack_send posts a rich message", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -734,6 +734,22 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     requireToolPolicyForName(normalizeSlackGuardrailToolName(toolName), threadTs, action);
   }
 
+  async function resolveSlackSendChannel(threadTs: string | undefined): Promise<string | null> {
+    const trackedThreadChannel = await resolveTrackedThreadChannel(threadTs);
+    if (trackedThreadChannel) return trackedThreadChannel;
+
+    if (!threadTs) {
+      const defaultChannel = getDefaultChannel();
+      if (defaultChannel) return resolveChannel(defaultChannel);
+      return null;
+    }
+
+    const lastDmChannel = getLastDmChannel();
+    if (lastDmChannel) return lastDmChannel;
+
+    return null;
+  }
+
   async function deliverSlackMessage(input: {
     channel: string;
     text: string;
@@ -1682,10 +1698,12 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         `thread_ts=${params.thread_ts ?? ""} | text=${params.text} | blocks=${summarizeSlackBlocksForPolicy(params.blocks)}`,
       );
 
-      const channel = (await resolveTrackedThreadChannel(params.thread_ts)) ?? getLastDmChannel();
+      const channel = await resolveSlackSendChannel(params.thread_ts);
       if (!channel) {
         throw new Error(
-          "No active Slack thread. If you know the channel and thread_ts, use the slack dispatcher action post_channel instead.",
+          params.thread_ts
+            ? "No active Slack thread. If you know the channel and thread_ts, use the slack dispatcher action post_channel instead."
+            : "No active Slack thread and no defaultChannel configured in settings.json. Set slack-bridge.defaultChannel or use the slack dispatcher action post_channel with a channel.",
         );
       }
 


### PR DESCRIPTION
## Summary
- Make channel-less `slack_send` use the configured `defaultChannel` instead of failing when no active thread target exists.
- Keep tracked thread resolution first for replies, and keep Pinet threaded delivery/ownership behavior on the existing thread path.
- Add regression coverage for default-channel routing, stale DM precedence, and the no-default actionable error.

Fixes #669

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run slack-tools.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge test` — 71 files / 1206 tests passing
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `git diff --check`
- push pre-push/turbo suite passed

## Review
- Local code-reviewer first found stale last-DM precedence; fixed by making `defaultChannel` win for no-thread sends.
- Local code-reviewer re-review approved; no actionable findings.
