### PR TITLE
Bound Slack adapter retained thread state

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -223,11 +223,17 @@ describe("BrokerDB message sync identity", () => {
           (row) => row.name,
         ),
       );
+      const threadColumns = new Set(
+        (inspect.prepare("PRAGMA table_info(threads)").all() as Array<{ name: string }>).map(
+          (row) => row.name,
+        ),
+      );
 
-      expect(version.user_version).toBe(13);
+      expect(version.user_version).toBe(14);
       expect(messageColumns.has("external_id")).toBe(true);
       expect(messageColumns.has("external_ts")).toBe(true);
       expect(inboxColumns.has("read_at")).toBe(true);
+      expect(threadColumns.has("metadata")).toBe(true);
     } finally {
       inspect.close();
     }
@@ -397,6 +403,31 @@ describe("BrokerDB message sync identity", () => {
       expect(inbox?.read_at).toBe("2026-04-25T00:00:02.500Z");
     } finally {
       inspect.close();
+    }
+  });
+
+  it("persists thread metadata", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread({
+        threadId: "thread-metadata",
+        source: "slack",
+        channel: "C123",
+        ownerAgent: null,
+        metadata: { slackThreadContext: { channelId: "C_TEAM", teamId: "T1" } },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      expect(db.getThread("thread-metadata")?.metadata).toEqual({
+        slackThreadContext: { channelId: "C_TEAM", teamId: "T1" },
+      });
+
+      db.updateThread("thread-metadata", { metadata: { migrated: true } });
+      expect(db.getThread("thread-metadata")?.metadata).toEqual({ migrated: true });
+    } finally {
+      db.close();
     }
   });
 

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -67,6 +67,7 @@ interface ThreadRow {
   channel: string;
   owner_agent: string | null;
   owner_binding: string | null;
+  metadata: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -146,6 +147,7 @@ function rowToThread(row: ThreadRow): ThreadInfo {
     channel: row.channel,
     ownerAgent: row.owner_agent,
     ownerBinding: row.owner_binding === "explicit" ? "explicit" : null,
+    metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -320,7 +322,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 13;
+export const CURRENT_BROKER_SCHEMA_VERSION = 14;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -375,6 +377,7 @@ function createCoreTables(db: DatabaseSync): void {
       channel TEXT NOT NULL,
       owner_agent TEXT,
       owner_binding TEXT,
+      metadata TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -531,6 +534,11 @@ function addInboxReadCursorColumn(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS idx_inbox_agent_read
       ON inbox(agent_id, read_at, created_at);
   `);
+}
+
+function addThreadMetadataColumn(db: DatabaseSync): void {
+  createCoreTables(db);
+  ensureColumn(db, "threads", "metadata", "ALTER TABLE threads ADD COLUMN metadata TEXT");
 }
 
 function backfillMessageSyncIdentities(db: DatabaseSync): void {
@@ -886,6 +894,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 13:
           addMessageSyncIdentityColumns(db);
+          break;
+        case 14:
+          addThreadMetadataColumn(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -1383,12 +1394,14 @@ export class BrokerDB implements BrokerDBInterface {
     const owner = typeof threadOrId === "string" ? (ownerAgent ?? null) : threadOrId.ownerAgent;
 
     const ownerBinding = typeof threadOrId === "string" ? null : (threadOrId.ownerBinding ?? null);
+    const metadata = typeof threadOrId === "string" ? null : (threadOrId.metadata ?? null);
+    const serializedMetadata = metadata ? JSON.stringify(metadata) : null;
 
     db.prepare(
-      `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, metadata, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(thread_id) DO UPDATE SET updated_at = excluded.updated_at`,
-    ).run(tId, src, ch, owner, ownerBinding, now, now);
+    ).run(tId, src, ch, owner, ownerBinding, serializedMetadata, now, now);
 
     return {
       threadId: tId,
@@ -1396,6 +1409,7 @@ export class BrokerDB implements BrokerDBInterface {
       channel: ch,
       ownerAgent: owner,
       ownerBinding,
+      metadata,
       createdAt: now,
       updatedAt: now,
     };
@@ -1409,14 +1423,17 @@ export class BrokerDB implements BrokerDBInterface {
     const existing = this.getThread(threadId);
     if (!existing) {
       db.prepare(
-        `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, metadata, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         threadId,
         updates.source ?? "slack",
         updates.channel ?? "",
         updates.ownerAgent !== undefined ? updates.ownerAgent : null,
         updates.ownerBinding !== undefined ? updates.ownerBinding : null,
+        updates.metadata !== undefined && updates.metadata !== null
+          ? JSON.stringify(updates.metadata)
+          : null,
         now,
         now,
       );
@@ -1442,6 +1459,10 @@ export class BrokerDB implements BrokerDBInterface {
       sets.push("owner_binding = ?");
       values.push(updates.ownerBinding);
     }
+    if (updates.metadata !== undefined) {
+      sets.push("metadata = ?");
+      values.push(updates.metadata === null ? null : JSON.stringify(updates.metadata));
+    }
 
     sets.push("updated_at = ?");
     values.push(now);
@@ -1458,13 +1479,13 @@ export class BrokerDB implements BrokerDBInterface {
     // if the thread is currently unclaimed or already owned by this agent.
     // A single statement avoids the TOCTOU race of read-then-write. (#125)
     db.prepare(
-      `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO threads (thread_id, source, channel, owner_agent, owner_binding, metadata, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(thread_id) DO UPDATE SET
          owner_agent = excluded.owner_agent,
          updated_at = excluded.updated_at
        WHERE threads.owner_agent IS NULL OR threads.owner_agent = excluded.owner_agent`,
-    ).run(threadId, source, channel, agentId, null, now, now);
+    ).run(threadId, source, channel, agentId, null, null, now, now);
 
     // Verify: read back the owner.  If the WHERE clause above didn't
     // match (another agent owns the thread), the row was not updated

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -28,6 +28,7 @@ export interface ThreadInfo {
   channel: string;
   ownerAgent: string | null;
   ownerBinding?: "explicit" | null;
+  metadata?: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-canvas.js";
-import { createBrokerRuntime, type BrokerRuntimeDeps } from "./broker-runtime.js";
+import {
+  createBrokerRuntime,
+  shouldRouteKnownSlackThread,
+  type BrokerRuntimeDeps,
+} from "./broker-runtime.js";
 import type { SlackActivityLogger } from "./activity-log.js";
 
 function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDeps {
@@ -70,6 +74,51 @@ function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDe
     ...overrides,
   };
 }
+
+describe("broker-runtime known Slack thread routing", () => {
+  it("does not route legacy DM assistant threads without persisted context after cache loss", () => {
+    expect(
+      shouldRouteKnownSlackThread({
+        source: "slack",
+        channel: "D123",
+        metadata: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("routes DM assistant threads once Slack context is persisted", () => {
+    expect(
+      shouldRouteKnownSlackThread({
+        source: "slack",
+        channel: "D123",
+        metadata: {
+          slackThreadContext: {
+            channelId: "C_TEAM",
+            scope: {
+              workspace: {
+                provider: "slack",
+                source: "compatibility",
+                compatibilityKey: "default",
+                channelId: "C_TEAM",
+              },
+              instance: { source: "compatibility", compatibilityKey: "default" },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("continues routing non-DM Slack threads without extra context", () => {
+    expect(
+      shouldRouteKnownSlackThread({
+        source: "slack",
+        channel: "C123",
+        metadata: null,
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("broker-runtime", () => {
   it("keeps reusable control-plane canvas ids while clearing transient observability state", async () => {

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -11,9 +11,10 @@ import {
   resolvePinetMeshAuth,
   syncBrokerInboxEntries,
 } from "./helpers.js";
-import { startBroker, type Broker } from "./broker/index.js";
+import { startBroker, type Broker, type ThreadInfo } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
+import type { SlackThreadContext } from "./slack-access.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { MessageRouter } from "./broker/router.js";
 import {
@@ -179,6 +180,35 @@ export interface BrokerRuntime {
 function normalizeOptionalSetting(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function readStoredSlackThreadContext(
+  metadata: Record<string, unknown> | null | undefined,
+): SlackThreadContext | null {
+  const value = metadata?.slackThreadContext;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.channelId !== "string" || record.channelId.length === 0) return null;
+  if (typeof record.scope !== "object" || record.scope === null || Array.isArray(record.scope)) {
+    return null;
+  }
+
+  return {
+    channelId: record.channelId,
+    ...(typeof record.teamId === "string" && record.teamId.length > 0
+      ? { teamId: record.teamId }
+      : {}),
+    scope: record.scope as SlackThreadContext["scope"],
+  };
+}
+
+export function shouldRouteKnownSlackThread(
+  thread: Pick<ThreadInfo, "source" | "channel" | "metadata"> | null,
+): boolean {
+  if (!thread || thread.source !== "slack") return false;
+  if (!thread.channel.startsWith("D")) return true;
+  return readStoredSlackThreadContext(thread.metadata) !== null;
 }
 
 export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
@@ -546,9 +576,26 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         allowAllWorkspaceUsers: deps.shouldAllowAllWorkspaceUsers(),
         suggestedPrompts: settings.suggestedPrompts,
         reactionCommands: settings.reactionCommands,
-        isKnownThread: (threadTs: string) => broker.db.getThread(threadTs) != null,
-        rememberKnownThread: (threadTs: string, channelId: string) => {
-          broker.db.updateThread(threadTs, { source: "slack", channel: channelId });
+        isKnownThread: (threadTs: string) =>
+          shouldRouteKnownSlackThread(broker.db.getThread(threadTs)),
+        getKnownThread: (threadTs: string) => {
+          const thread = broker.db.getThread(threadTs);
+          if (!thread || thread.source !== "slack") return null;
+          return {
+            channelId: thread.channel,
+            context: readStoredSlackThreadContext(thread.metadata),
+          };
+        },
+        rememberKnownThread: (threadTs: string, channelId: string, context) => {
+          const existingMetadata = broker.db.getThread(threadTs)?.metadata ?? {};
+          broker.db.updateThread(threadTs, {
+            source: "slack",
+            channel: channelId,
+            metadata: {
+              ...existingMetadata,
+              ...(context ? { slackThreadContext: context } : {}),
+            },
+          });
         },
         onAppHomeOpened: async ({ userId }) => {
           await deps.onAppHomeOpened(userId, ctx);

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -7,8 +7,10 @@ import {
   parseMemberJoinedChannel,
   SlackAdapter,
   RECONNECT_DELAY_MS,
+  SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD,
+  SLACK_THREAD_CACHE_MAX_SIZE,
 } from "./slack.js";
-import { SlackSocketModeClient } from "../../slack-access.js";
+import { SlackSocketModeClient, type SlackThreadContext } from "../../slack-access.js";
 import type { OutboundMessage } from "./types.js";
 
 async function waitForAssertion(assertion: () => void, attempts = 50): Promise<void> {
@@ -732,7 +734,89 @@ describe("SlackAdapter", () => {
       },
     });
 
-    expect(rememberKnownThread).toHaveBeenCalledWith("123.456", "C123");
+    expect(rememberKnownThread).toHaveBeenCalledWith("123.456", "C123", null);
+  });
+
+  it("bounds the in-memory tracked thread cache", async () => {
+    const adapter = new SlackAdapter(baseConfig);
+    vi.spyOn(
+      adapter as unknown as { setSuggestedPrompts: () => Promise<void> },
+      "setSuggestedPrompts",
+    ).mockResolvedValue(undefined);
+
+    const adapterPort = adapter as unknown as {
+      onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+    };
+
+    for (let i = 0; i <= SLACK_THREAD_CACHE_MAX_SIZE; i += 1) {
+      await adapterPort.onThreadStarted({
+        type: "assistant_thread_started",
+        assistant_thread: {
+          channel_id: "C123",
+          thread_ts: `${i}.000`,
+          user_id: "U123",
+        },
+      });
+    }
+
+    const tracked = adapter.getTrackedThreadIds();
+    expect(tracked.size).toBe(SLACK_THREAD_CACHE_MAX_SIZE);
+    expect(tracked.has("0.000")).toBe(false);
+    expect(tracked.has(`${SLACK_THREAD_CACHE_MAX_SIZE}.000`)).toBe(true);
+  });
+
+  it("bounds pending attention reactions retained per thread", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/users.info")) {
+        return new Response(JSON.stringify({ ok: true, user: { real_name: "Alice" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.endsWith("/reactions.add")) {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock;
+    try {
+      const adapter = new SlackAdapter(baseConfig);
+      adapter.onInbound(vi.fn());
+      const adapterPort = adapter as unknown as {
+        botUserId: string | null;
+        onMessage: (evt: Record<string, unknown>) => Promise<void>;
+        pendingEyes: {
+          get: (threadTs: string) => { channel: string; messageTs: string }[] | undefined;
+        };
+      };
+      adapterPort.botUserId = "U_BOT";
+
+      for (let i = 0; i <= SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD; i += 1) {
+        await adapterPort.onMessage({
+          type: "message",
+          user: "U_ALLOWED",
+          text: `message ${i}`,
+          channel: "D1",
+          channel_type: "im",
+          thread_ts: "1.1",
+          ts: `1.${i + 2}`,
+        });
+      }
+
+      const pending = adapterPort.pendingEyes.get("1.1") ?? [];
+      expect(pending).toHaveLength(SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD);
+      expect(pending[0]?.messageTs).toBe("1.3");
+      expect(pending.at(-1)?.messageTs).toBe(
+        `1.${SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD + 2}`,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("registers an inbound handler", () => {
@@ -961,7 +1045,7 @@ describe("SlackAdapter", () => {
       }),
     );
 
-    expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123");
+    expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123", null);
     expect(handler).toHaveBeenCalledWith({
       source: "slack",
       threadId: "123.000",
@@ -1078,7 +1162,7 @@ describe("SlackAdapter", () => {
       }),
     );
 
-    expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123");
+    expect(rememberKnownThread).toHaveBeenCalledWith("123.000", "C123", null);
     expect(handler).toHaveBeenCalledWith({
       source: "slack",
       threadId: "123.000",
@@ -1247,6 +1331,146 @@ describe("SlackAdapter — allowlist filtering", () => {
       expect(endpoints).toContain("https://slack.com/api/users.info");
       expect(endpoints).toContain("https://slack.com/api/reactions.add");
     });
+  });
+
+  it("suppresses legacy broker-known threaded DMs when durable context is missing", async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error("legacy suppressed path should not call Slack APIs");
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: () => false,
+      getKnownThread: (threadTs) =>
+        threadTs === "1.1" ? { channelId: "D1", context: null } : null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "legacy reply after restart",
+      channel: "D1",
+      channel_type: "im",
+      thread_ts: "1.1",
+      ts: "1.2",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rehydrates known Slack thread context into inbound scope after cache eviction", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const knownThreads = new Map<
+      string,
+      {
+        channelId: string;
+        context?: SlackThreadContext | null;
+      }
+    >();
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: (threadTs) => knownThreads.has(threadTs),
+      getKnownThread: (threadTs) => knownThreads.get(threadTs) ?? null,
+      rememberKnownThread: (threadTs, channelId, context) => {
+        knownThreads.set(threadTs, { channelId, context });
+      },
+    });
+    vi.spyOn(
+      adapter as unknown as { setSuggestedPrompts: () => Promise<void> },
+      "setSuggestedPrompts",
+    ).mockResolvedValue(undefined);
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onThreadStarted: (evt: Record<string, unknown>) => Promise<void>;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onThreadStarted({
+      type: "assistant_thread_started",
+      assistant_thread: {
+        channel_id: "D1",
+        thread_ts: "1.1",
+        user_id: "U_ALLOWED",
+        context: {
+          channel_id: "C_TEAM",
+          team_id: "T001",
+        },
+      },
+    });
+
+    for (let i = 0; i < SLACK_THREAD_CACHE_MAX_SIZE; i += 1) {
+      await adapterPort.onThreadStarted({
+        type: "assistant_thread_started",
+        assistant_thread: {
+          channel_id: "D1",
+          thread_ts: `evict-${i}`,
+          user_id: "U_ALLOWED",
+        },
+      });
+    }
+    expect(adapter.getTrackedThreadIds().has("1.1")).toBe(false);
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "hello after eviction",
+      channel: "D1",
+      channel_type: "im",
+      thread_ts: "1.1",
+      ts: "1.2",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "1.1",
+        scope: {
+          workspace: {
+            provider: "slack",
+            source: "compatibility",
+            compatibilityKey: "default",
+            workspaceId: "T001",
+            channelId: "C_TEAM",
+          },
+          instance: {
+            source: "compatibility",
+            compatibilityKey: "default",
+          },
+        },
+      }),
+    );
   });
 
   it("carries known Slack thread team context into the inbound scope carrier", async () => {
@@ -1418,7 +1642,7 @@ describe("SlackAdapter — reaction triggers", () => {
       event_ts: "999.000",
     });
 
-    expect(rememberKnownThread).toHaveBeenCalledWith("111.222", "C123");
+    expect(rememberKnownThread).toHaveBeenCalledWith("111.222", "C123", null);
     expect(handler).toHaveBeenCalledWith(
       expect.objectContaining({
         source: "slack",

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -53,8 +53,17 @@ export interface SlackAdapterConfig {
   reactionCommands?: ReactionCommandSettings;
   /** Check whether a thread_ts belongs to a known thread in the broker DB. */
   isKnownThread?: (threadTs: string) => boolean;
+  /** Load durable thread metadata from the broker DB after cache eviction. */
+  getKnownThread?: (threadTs: string) => {
+    channelId: string;
+    context?: ParsedThreadStarted["context"] | null;
+  } | null;
   /** Persist thread metadata in the broker DB without claiming ownership. */
-  rememberKnownThread?: (threadTs: string, channelId: string) => void;
+  rememberKnownThread?: (
+    threadTs: string,
+    channelId: string,
+    context?: ParsedThreadStarted["context"] | null,
+  ) => void;
   /** Best-effort callback for Home tab opens. */
   onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
 }
@@ -65,6 +74,12 @@ interface SlackThreadInfo {
   userId: string;
   context?: ParsedThreadStarted["context"];
 }
+
+export const SLACK_THREAD_CACHE_MAX_SIZE = 5000;
+export const SLACK_THREAD_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+export const SLACK_PENDING_ATTENTION_MAX_THREADS = 1000;
+export const SLACK_PENDING_ATTENTION_TTL_MS = 2 * 60 * 60 * 1000;
+export const SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD = 50;
 
 export class SlackAdapter implements MessageAdapter {
   readonly name = "slack";
@@ -78,7 +93,7 @@ export class SlackAdapter implements MessageAdapter {
   private inboundHandler: ((msg: InboundMessage) => void) | null = null;
   private readonly reactionCommands: Map<string, { action: string; prompt: string }>;
 
-  private readonly threads = new Map<string, SlackThreadInfo>();
+  private readonly threads: TtlCache<string, SlackThreadInfo>;
   private readonly userNames = new TtlCache<string, string>({
     maxSize: 2000,
     ttlMs: 60 * 60 * 1000,
@@ -87,10 +102,18 @@ export class SlackAdapter implements MessageAdapter {
     maxSize: SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
     ttlMs: SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
   });
-  private readonly pendingEyes = new Map<string, { channel: string; messageTs: string }[]>();
+  private readonly pendingEyes: TtlCache<string, { channel: string; messageTs: string }[]>;
 
   constructor(config: SlackAdapterConfig) {
     this.config = config;
+    this.threads = new TtlCache<string, SlackThreadInfo>({
+      maxSize: SLACK_THREAD_CACHE_MAX_SIZE,
+      ttlMs: SLACK_THREAD_CACHE_TTL_MS,
+    });
+    this.pendingEyes = new TtlCache<string, { channel: string; messageTs: string }[]>({
+      maxSize: SLACK_PENDING_ATTENTION_MAX_THREADS,
+      ttlMs: SLACK_PENDING_ATTENTION_TTL_MS,
+    });
     this.allowlist = buildAllowlist(
       {
         allowedUsers: config.allowedUsers,
@@ -195,7 +218,8 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   getTrackedThreadIds(): Set<string> {
-    return new Set(this.threads.keys());
+    this.threads.sweep();
+    return new Set([...this.threads.entries()].map(([threadTs]) => threadTs));
   }
 
   isConnected(): boolean {
@@ -205,7 +229,7 @@ export class SlackAdapter implements MessageAdapter {
   private resolveScopeForThread(threadTs: string, channelId: string) {
     return buildSlackThreadRuntimeScope({
       channelId,
-      context: this.threads.get(threadTs)?.context ?? null,
+      context: this.getThread(threadTs)?.context ?? null,
     });
   }
 
@@ -229,7 +253,7 @@ export class SlackAdapter implements MessageAdapter {
 
     this.threads.set(info.threadTs, info);
     try {
-      this.config.rememberKnownThread?.(info.threadTs, info.channelId);
+      this.config.rememberKnownThread?.(info.threadTs, info.channelId, info.context ?? null);
     } catch {
       /* best effort — DB cache sync must not break Slack event handling */
     }
@@ -242,10 +266,16 @@ export class SlackAdapter implements MessageAdapter {
     const parsed = isParsedThreadContextChanged(event) ? event : extractThreadContextChanged(event);
     if (!parsed) return;
 
-    const existing = this.threads.get(parsed.threadTs);
+    const existing = this.getThread(parsed.threadTs);
     if (!existing || !parsed.context) return;
 
     existing.context = parsed.context;
+    this.threads.set(parsed.threadTs, existing);
+    try {
+      this.config.rememberKnownThread?.(parsed.threadTs, existing.channelId, existing.context);
+    } catch {
+      /* best effort — DB cache sync must not break Slack event handling */
+    }
   }
 
   private async onAppHomeOpened(
@@ -312,14 +342,14 @@ export class SlackAdapter implements MessageAdapter {
         (reactedMessage.ts as string | undefined) ??
         item.ts;
 
-      if (!this.threads.has(threadTs)) {
+      if (!this.getThread(threadTs)) {
         this.threads.set(threadTs, {
           channelId: item.channel,
           threadTs,
           userId: (reactedMessage.user as string | undefined) ?? userId,
         });
         try {
-          this.config.rememberKnownThread?.(threadTs, item.channel);
+          this.config.rememberKnownThread?.(threadTs, item.channel, null);
         } catch {
           /* best effort — DB cache sync must not break reaction handling */
         }
@@ -341,7 +371,7 @@ export class SlackAdapter implements MessageAdapter {
           ? reactedMessage.text
           : "(no text)";
 
-      const threadInfo = this.threads.get(threadTs);
+      const threadInfo = this.getThread(threadTs);
       const reactionEventTs = (evt.event_ts as string | undefined) ?? item.ts;
       this.inboundHandler?.({
         source: "slack",
@@ -399,9 +429,18 @@ export class SlackAdapter implements MessageAdapter {
     );
     if (!classified.relevant) return;
 
-    const { threadTs, channel, userId, text, isChannelMention, messageTs, metadata } = classified;
+    const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs, metadata } =
+      classified;
 
-    if (!this.threads.has(threadTs)) {
+    if (
+      isDM &&
+      typeof evt.thread_ts === "string" &&
+      this.shouldSuppressLegacyThreadedDm(threadTs)
+    ) {
+      return;
+    }
+
+    if (!this.getThread(threadTs)) {
       this.threads.set(threadTs, {
         channelId: channel,
         threadTs,
@@ -414,12 +453,15 @@ export class SlackAdapter implements MessageAdapter {
     void this.addReaction(channel, messageTs, "eyes");
     const pending = this.pendingEyes.get(threadTs) ?? [];
     pending.push({ channel, messageTs });
+    if (pending.length > SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD) {
+      pending.splice(0, pending.length - SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD);
+    }
     this.pendingEyes.set(threadTs, pending);
 
     const userName = await this.resolveUser(userId);
     if (this.shuttingDown) return;
 
-    const threadInfo = this.threads.get(threadTs);
+    const threadInfo = this.getThread(threadTs);
     this.inboundHandler?.({
       source: "slack",
       threadId: threadTs,
@@ -445,7 +487,7 @@ export class SlackAdapter implements MessageAdapter {
     timestamp: string;
     metadata: Record<string, unknown>;
   }): Promise<void> {
-    if (!this.threads.has(normalized.threadTs)) {
+    if (!this.getThread(normalized.threadTs)) {
       this.threads.set(normalized.threadTs, {
         channelId: normalized.channel,
         threadTs: normalized.threadTs,
@@ -454,7 +496,7 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     try {
-      this.config.rememberKnownThread?.(normalized.threadTs, normalized.channel);
+      this.config.rememberKnownThread?.(normalized.threadTs, normalized.channel, null);
     } catch {
       /* best effort — DB cache sync must not break Slack event handling */
     }
@@ -464,7 +506,7 @@ export class SlackAdapter implements MessageAdapter {
     const userName = await this.resolveUser(normalized.userId);
     if (this.shuttingDown) return;
 
-    const threadInfo = this.threads.get(normalized.threadTs);
+    const threadInfo = this.getThread(normalized.threadTs);
     this.inboundHandler?.({
       source: "slack",
       threadId: normalized.threadTs,
@@ -493,6 +535,34 @@ export class SlackAdapter implements MessageAdapter {
       timestamp: String(Date.now() / 1000),
       scope: buildSlackThreadRuntimeScope({ channelId: event.channel }),
     });
+  }
+
+  private shouldSuppressLegacyThreadedDm(threadTs: string): boolean {
+    const cached = this.threads.get(threadTs);
+    if (cached) return false;
+
+    const known = this.config.getKnownThread?.(threadTs);
+    return !!known && known.channelId.startsWith("D") && !known.context;
+  }
+
+  private getThread(threadTs: string): SlackThreadInfo | undefined {
+    const cached = this.threads.get(threadTs);
+    if (cached) {
+      this.threads.set(threadTs, cached);
+      return cached;
+    }
+
+    const known = this.config.getKnownThread?.(threadTs);
+    if (!known?.channelId) return undefined;
+
+    const restored: SlackThreadInfo = {
+      channelId: known.channelId,
+      threadTs,
+      userId: "",
+      ...(known.context ? { context: known.context } : {}),
+    };
+    this.threads.set(threadTs, restored);
+    return restored;
   }
 
   private async addReaction(channel: string, ts: string, emoji: string): Promise<void> {

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -38,6 +38,8 @@ export interface ThreadInfo {
   source: string;
   channel: string;
   ownerAgent: string | null;
+  ownerBinding?: "explicit" | null;
+  metadata?: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

Closes #673.

Focused leak found in the long-lived broker Slack adapter:
- `SlackAdapter.threads` was an unbounded `Map` populated by assistant thread starts, inbound Slack messages, reaction triggers, and interactive events.
- `SlackAdapter.pendingEyes` was an unbounded per-thread array map for pending 👀 reactions; threads that never received an outbound reply could retain every inbound message timestamp indefinitely.

## Fix

- Replace the broker Slack adapter thread cache with bounded `TtlCache` (`5000` entries, `24h` TTL).
- Replace pending attention tracking with bounded `TtlCache` (`1000` threads, `2h` TTL).
- Cap retained pending attention message refs per thread to `50`.
- Persist Slack assistant-thread context in broker thread metadata and rehydrate it after cache eviction, so bounded memory does not regress scoped Slack thread routing.
- Add broker schema migration v14 for thread metadata.
- Treat legacy DM/assistant-thread rows with missing persisted Slack context as not safely broker-known after cache loss, avoiding silent rerouting under the wrong scope.

## Validation

- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run broker-runtime.test.ts broker/adapters/slack.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core lint`
- push hook ran workspace tests successfully (`10 successful`, including `@gugu910/pi-slack-bridge:test` 71 files / 1213 tests)

## Follow-up instrumentation worth adding if memory still grows

- Periodic broker memory gauges (`process.memoryUsage`) alongside adapter cache sizes.
- Socket JSON-RPC partial-line buffer high-water metrics.
- Durable DB row counts for `messages`, `inbox`, and `unrouted_backlog` to distinguish heap retention from expected persisted queue growth.

