### PR TITLE
fix(slack-bridge): allow Pinet on continued sessions

### DIFF
--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1791,11 +1791,70 @@ describe("resolveBrokerStableId", () => {
 });
 
 describe("isLikelyLocalSubagentContext", () => {
-  it("detects branched or child sessions via parentSession header", () => {
+  it("does not treat parentSession lineage alone as a local subagent", () => {
     expect(
       isLikelyLocalSubagentContext({
         sessionHeader: { parentSession: "/tmp/pi/parent-session.jsonl" },
         argv: [],
+        sessionFile: "/tmp/pi/continued-session.jsonl",
+        leafId: "leaf-1",
+        hasUI: true,
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not classify normal continued sessions with parentSession lineage as subagents", () => {
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionHeader: { parentSession: "/tmp/pi/parent-session.jsonl" },
+        argv: ["--continue"],
+        sessionFile: "/tmp/pi/continued-session.jsonl",
+        leafId: "leaf-continued",
+        hasUI: true,
+        stdinIsTTY: false,
+        stdoutIsTTY: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("detects parented headless sessions as local subagents", () => {
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionHeader: { parentSession: "/tmp/pi/parent-session.jsonl" },
+        argv: ["--mode", "rpc"],
+        sessionFile: "/tmp/pi/subagent-session.jsonl",
+        leafId: "leaf-subagent",
+        hasUI: false,
+        stdinIsTTY: false,
+        stdoutIsTTY: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("still detects continued parented sessions when they are headless", () => {
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionHeader: { parentSession: "/tmp/pi/parent-session.jsonl" },
+        argv: ["--continue"],
+        sessionFile: "/tmp/pi/subagent-session.jsonl",
+        leafId: "leaf-subagent",
+        hasUI: false,
+        stdinIsTTY: false,
+        stdoutIsTTY: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isLikelyLocalSubagentContext({
+        sessionHeader: { parentSession: "/tmp/pi/parent-session.jsonl" },
+        argv: ["--continue", "--mode", "rpc"],
+        sessionFile: "/tmp/pi/subagent-session.jsonl",
+        leafId: "leaf-subagent",
+        hasUI: true,
+        stdinIsTTY: false,
+        stdoutIsTTY: false,
       }),
     ).toBe(true);
   });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1962,22 +1962,12 @@ export interface PinetRegistrationContext {
 }
 
 export function isLikelyLocalSubagentContext(context: PinetRegistrationContext = {}): boolean {
-  const parentSession = context.sessionHeader?.parentSession;
-  if (typeof parentSession === "string" && parentSession.trim().length > 0) {
-    return true;
-  }
-
   const argv = context.argv ?? process.argv.slice(2);
   const hasNoSession = argv.includes("--no-session");
   const hasPrint = argv.includes("--print") || argv.includes("-p");
   const modeIndex = argv.indexOf("--mode");
   const mode = modeIndex >= 0 ? argv[modeIndex + 1] : undefined;
   const hasHeadlessMode = mode === "json" || mode === "rpc";
-
-  if (hasNoSession && (hasPrint || hasHeadlessMode)) {
-    return true;
-  }
-
   const sessionFile =
     typeof context.sessionFile === "string" && context.sessionFile.trim().length > 0
       ? context.sessionFile.trim()
@@ -1986,13 +1976,36 @@ export function isLikelyLocalSubagentContext(context: PinetRegistrationContext =
     typeof context.leafId === "string" && context.leafId.trim().length > 0
       ? context.leafId.trim()
       : undefined;
+  const hasExplicitTTYSignal =
+    context.stdinIsTTY !== undefined || context.stdoutIsTTY !== undefined;
+  const hasTTY = Boolean(
+    (context.stdinIsTTY ?? process.stdin.isTTY) || (context.stdoutIsTTY ?? process.stdout.isTTY),
+  );
+
+  const parentSession = context.sessionHeader?.parentSession;
+  if (typeof parentSession === "string" && parentSession.trim().length > 0) {
+    // parentSession is lineage metadata for both real subagents and normal resumed/forked
+    // sessions. Treat it as a subagent signal only when paired with headless execution
+    // evidence. A persisted `pi --continue` session can legitimately have parent lineage
+    // and no TTY in automated launches, so no-TTY alone is only decisive for parented
+    // sessions when there is no persisted session file.
+    if (
+      hasHeadlessMode ||
+      context.hasUI === false ||
+      (hasExplicitTTYSignal && !hasTTY && !sessionFile)
+    ) {
+      return true;
+    }
+  }
+
+  if (hasNoSession && (hasPrint || hasHeadlessMode)) {
+    return true;
+  }
+
   // Agent-tool subagents commonly show up as ephemeral leaf sessions: no persisted
   // session file, a generated leaf id, and no attached TTY. Those should never join
   // the mesh even when auto-follow is enabled.
   const hasEphemeralLeafSession = !sessionFile && Boolean(leafId);
-  const hasTTY = Boolean(
-    (context.stdinIsTTY ?? process.stdin.isTTY) || (context.stdoutIsTTY ?? process.stdout.isTTY),
-  );
 
   return hasEphemeralLeafSession && (hasHeadlessMode || context.hasUI === false || !hasTTY);
 }

--- a/slack-bridge/pinet-registration-gate.test.ts
+++ b/slack-bridge/pinet-registration-gate.test.ts
@@ -61,11 +61,46 @@ describe("createPinetRegistrationGate", () => {
     expect(() => gate.assertCanRegister()).toThrow(gate.getBlockReason());
   });
 
-  it("uses the session header parentSession signal when evaluating the block state", () => {
+  it("allows normal continued sessions even when the session has parent lineage", () => {
     const gate = createPinetRegistrationGate({
-      getArgv: () => [],
-      getStdinIsTTY: () => true,
-      getStdoutIsTTY: () => true,
+      getArgv: () => ["--continue"],
+      getStdinIsTTY: () => false,
+      getStdoutIsTTY: () => false,
+    });
+    const ctx = createContext({
+      hasUI: true,
+      sessionFile: "/tmp/session.json",
+      leafId: "leaf-2",
+      parentSession: "parent-session-id",
+    });
+
+    expect(gate.evaluateSessionStart(ctx)).toBe(false);
+    expect(gate.isBlocked()).toBe(false);
+    expect(() => gate.assertCanRegister()).not.toThrow();
+  });
+
+  it("blocks parented headless sessions when evaluating the block state", () => {
+    const gate = createPinetRegistrationGate({
+      getArgv: () => ["--mode", "rpc"],
+      getStdinIsTTY: () => false,
+      getStdoutIsTTY: () => false,
+    });
+    const ctx = createContext({
+      hasUI: false,
+      sessionFile: "/tmp/session.json",
+      leafId: "leaf-2",
+      parentSession: "parent-session-id",
+    });
+
+    expect(gate.evaluateSessionStart(ctx)).toBe(true);
+    expect(gate.isBlocked()).toBe(true);
+  });
+
+  it("blocks continued sessions when they still look like parented headless subagents", () => {
+    const gate = createPinetRegistrationGate({
+      getArgv: () => ["--continue", "--mode", "rpc"],
+      getStdinIsTTY: () => false,
+      getStdoutIsTTY: () => false,
     });
     const ctx = createContext({
       hasUI: true,


### PR DESCRIPTION
## Summary

Closes #679.

- Stop treating `parentSession` lineage as sufficient proof that a session is a local subagent.
- Keep blocking real headless/local-subagent contexts using headless mode/UI/TTY/no-session signals.
- Explicitly allow normal `pi --continue` sessions with parent lineage so they do not show the misleading Pinet-disabled local-subagent warning.

## Root cause

`isLikelyLocalSubagentContext()` returned `true` whenever the session header had `parentSession`. Pi uses `parentSession` as general lineage metadata, including sessions resumed with `pi --continue`, so normal continued sessions could be gated as local subagents.

## Validation

- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run helpers.test.ts pinet-registration-gate.test.ts index.test.ts --maxWorkers=1 --no-file-parallelism` (398 tests)
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm check`
- `pnpm test` (pre-push also ran workspace tests successfully; slack-bridge 71 files / 1211 tests)

