### PR TITLE
test: lock Pinet read ownership boundaries

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -581,6 +581,48 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("scopes explicit thread reads to the requesting agent's inbox rows", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("a2a:broker:agent-a", "agent", "", "broker");
+      db.createThread("a2a:broker:agent-b", "agent", "", "broker");
+      db.insertMessage("a2a:broker:agent-a", "agent", "inbound", "broker", "private for A", [
+        "agent-a",
+      ]);
+      const privateForB = db.insertMessage(
+        "a2a:broker:agent-b",
+        "agent",
+        "inbound",
+        "broker",
+        "private for B",
+        ["agent-b"],
+      );
+
+      const crossRead = db.readInbox("agent-a", {
+        threadId: "a2a:broker:agent-b",
+        unreadOnly: false,
+        markRead: true,
+      });
+
+      expect(crossRead.messages).toEqual([]);
+      expect(crossRead.markedReadIds).toEqual([]);
+      expect(crossRead.unreadCountBefore).toBe(1);
+      expect(crossRead.unreadCountAfter).toBe(1);
+
+      const ownerRead = db.readInbox("agent-b", {
+        threadId: "a2a:broker:agent-b",
+        markRead: false,
+      });
+      expect(ownerRead.messages).toHaveLength(1);
+      expect(ownerRead.messages[0].message.id).toBe(privateForB.id);
+      expect(ownerRead.messages[0].message.body).toBe("private for B");
+      expect(ownerRead.unreadCountBefore).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
   it("preserves explicit Slack mail class metadata when queueing inbound mail", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -160,6 +160,61 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client2.disconnect();
   });
 
+  it("inbox.read denies cross-agent thread reads while preserving broker self-read visibility", async () => {
+    const brokerReg = await client.register("broker-agent", "🐊");
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+    const workerA = new BrokerClient({ host: info.host, port: info.port });
+    const workerB = new BrokerClient({ host: info.host, port: info.port });
+    await workerA.connect();
+    await workerB.connect();
+
+    try {
+      const workerAReg = await workerA.register("worker-a", "🅰️");
+      const workerBReg = await workerB.register("worker-b", "🅱️");
+
+      await client.sendAgentMessage(workerBReg.agentId, "private task for worker B");
+      const workerBThread = `a2a:${brokerReg.agentId}:${workerBReg.agentId}`;
+
+      const crossRead = await workerA.readInbox({
+        threadId: workerBThread,
+        unreadOnly: false,
+        markRead: true,
+      });
+      expect(crossRead.messages).toEqual([]);
+      expect(crossRead.markedReadIds).toEqual([]);
+      expect(crossRead.unreadCountBefore).toBe(0);
+      expect(crossRead.unreadCountAfter).toBe(0);
+
+      const workerBOwnRead = await workerB.readInbox({ threadId: workerBThread, markRead: false });
+      expect(workerBOwnRead.messages.map((item) => item.message.body)).toEqual([
+        "private task for worker B",
+      ]);
+      expect(workerBOwnRead.unreadCountBefore).toBe(1);
+      expect(workerBOwnRead.unreadCountAfter).toBe(1);
+
+      await workerA.sendAgentMessage(brokerReg.agentId, "status for broker only");
+      const brokerThread = `a2a:${workerAReg.agentId}:${brokerReg.agentId}`;
+
+      const workerBProbe = await workerB.readInbox({
+        threadId: brokerThread,
+        unreadOnly: false,
+        markRead: true,
+      });
+      expect(workerBProbe.messages).toEqual([]);
+      expect(workerBProbe.markedReadIds).toEqual([]);
+
+      const brokerRead = await client.readInbox({ threadId: brokerThread, markRead: false });
+      expect(brokerRead.messages.map((item) => item.message.body)).toEqual([
+        "status for broker only",
+      ]);
+    } finally {
+      workerA.disconnect();
+      workerB.disconnect();
+    }
+  });
+
   it("sender does not receive own messages", async () => {
     await client.register("solo-agent", "🤖");
     await client.send("thread-solo", "Talking to myself");

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -673,10 +673,14 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
 
   registerAction({
     name: "read",
-    description: "Read durable SQLite-backed Pinet inbox context with unread/read semantics.",
+    description:
+      "Read this agent's durable SQLite-backed Pinet inbox context with unread/read semantics. Ordinary workers only see rows addressed to their own agent identity; broker coordination visibility is limited to broker-addressed inbox rows.",
     parameters: Type.Object({
       thread_id: Type.Optional(
-        Type.String({ description: "Optional Pinet/Slack broker thread ID to read" }),
+        Type.String({
+          description:
+            "Optional Pinet/Slack broker thread ID to filter this agent's own inbox rows; it does not grant cross-agent thread access.",
+        }),
       ),
       limit: Type.Optional(
         Type.Number({ description: "Maximum messages to return (default 20, max 100)" }),


### PR DESCRIPTION
## Summary

- audit/lock Pinet `read` ownership behavior for issue #682
- add BrokerDB and socket integration regressions proving `thread_id` filters only the caller's own inbox rows and does not expose other agents' private A2A threads
- clarify the Pinet `read` dispatcher help text: ordinary workers see only rows addressed to their own agent identity; broker visibility is limited to broker-addressed inbox rows

## Findings

The current runtime path already derives the readable identity from connection/runtime state, not from user-supplied args:

- follower `pinet read` calls `BrokerClient.readInbox()` → broker RPC `inbox.read`
- `BrokerSocketServer.handleInboxRead()` calls `db.readInbox(state.agentId, ...)`
- broker local path calls `db.readInbox(selfId, ...)`
- `BrokerDB.readInbox()` filters with `i.agent_id = ?` before applying optional `threadId`

So I did not find an arbitrary cross-agent read bug in the current code. This PR adds regression coverage and user-facing dispatcher documentation so that boundary stays explicit.

## Tests

- `pnpm --filter @gugu910/pi-broker-core exec vitest run schema.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run broker/integration.test.ts pinet-tools.test.ts --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm check`
- `pnpm test` (push hook also passed: 10 successful; slack-bridge 71 files / 1207 tests)

Closes #682
