### PR TITLE
feat: load broker prompt from markdown

### DIFF
--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -42,6 +42,7 @@ const packageConfigs = {
     excludeFiles: new Set(["vitest.config.ts"]),
     excludePrefixes: [],
     vendorDirs: [],
+    assetDirs: ["prompts"],
     importRewrites: [],
   },
   "nvim-bridge": {
@@ -124,6 +125,25 @@ async function collectTsFiles(baseDir, rootDir, localConfig = config) {
   return files.sort();
 }
 
+async function copyDirectory(sourceDir, outputDir) {
+  const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+  await fs.mkdir(outputDir, { recursive: true });
+
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const outputPath = path.join(outputDir, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDirectory(sourcePath, outputPath);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      await fs.copyFile(sourcePath, outputPath);
+    }
+  }
+}
+
 async function build() {
   await fs.rm(distDir, { recursive: true, force: true });
 
@@ -186,6 +206,10 @@ async function build() {
 
     await fs.mkdir(path.dirname(item.outputPath), { recursive: true });
     await fs.writeFile(item.outputPath, transpiled.outputText, "utf8");
+  }
+
+  for (const assetDir of config.assetDirs ?? []) {
+    await copyDirectory(path.join(packageDir, assetDir), path.join(distDir, assetDir));
   }
 }
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -424,6 +424,18 @@ Pinet supports a broker/follower architecture for coordinating multiple pi agent
 
 Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": true`) to auto-connect when a broker is running.
 
+### Broker prompt MD
+
+Broker coordination policy is loaded from Markdown rather than a settings selector. The broker scans for the first valid prompt in this order:
+
+1. workspace override: `.pi/slack-bridge/broker-prompt.md` under the current repo/worktree root
+2. user-local override: `~/.pi/agent/slack-bridge/broker-prompt.md`
+3. packaged default: `dist/prompts/broker/default.md`
+
+Invalid higher-priority files (unsafe symlink/path escape, unreadable file, oversized content, invalid UTF-8/binary-looking content, or empty file) emit a concise warning and fall through to lower-priority candidates. Warnings identify only the candidate kind and reason; prompt bodies and private paths are not echoed.
+
+Only broker prompt content is replaceable. Broker runtime/tool restrictions remain code-owned and are appended after the loaded MD prompt, including the forbidden local `Agent` path and broker `edit`/`write` blocking. Followers keep append-only worker guidance and do not load broker prompt MD. Prompt changes are picked up on `/pinet-start` / runtime restart; this slice does not hot-reload per turn.
+
 ### Multi-agent tools
 
 | Tool    | Description                                                                                                         |

--- a/slack-bridge/agent-prompt-guidance.test.ts
+++ b/slack-bridge/agent-prompt-guidance.test.ts
@@ -12,6 +12,15 @@ function createDeps(overrides: Partial<AgentPromptGuidanceDeps> = {}): AgentProm
     getActiveSkinTheme: () => null,
     getAgentPersonality: () => null,
     getBrokerRole: () => null,
+    loadBrokerPrompt: async () => ({
+      source: "packaged",
+      content:
+        "You are {{agentEmoji}} {{agentName}}, the Pinet BROKER. CUSTOM MD POLICY. DELEGATE, THEN TRACK.",
+      warnings: [],
+      diagnostic: "broker prompt: packaged default loaded",
+    }),
+    reportBrokerPromptDiagnostic: () => undefined,
+    reportBrokerPromptWarning: () => undefined,
     ...overrides,
   };
 }
@@ -57,7 +66,7 @@ describe("createAgentPromptGuidance", () => {
     expect(result.systemPrompt).toContain("steady, elegant, observant");
   });
 
-  it("adds broker-specific prompt guidance and tool guardrails for the broker role", async () => {
+  it("adds loaded broker MD guidance, protocol guardrails, and tool guardrails for the broker role", async () => {
     const guidance = createAgentPromptGuidance(
       createDeps({
         getBrokerRole: () => "broker",
@@ -67,9 +76,9 @@ describe("createAgentPromptGuidance", () => {
     const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
 
     expect(result.systemPrompt).toContain("You are 🦩 Cobalt Olive Crane, the Pinet BROKER.");
-    expect(result.systemPrompt).toContain("DELEGATE, THEN TRACK:");
-    expect(result.systemPrompt).toContain("Do not perform task triage yourself");
-    expect(result.systemPrompt).toContain("DEEP INSPECTION BELONGS TO WORKERS:");
+    expect(result.systemPrompt).toContain("CUSTOM MD POLICY");
+    expect(result.systemPrompt).toContain("DELEGATE, THEN TRACK.");
+    expect(result.systemPrompt).toContain("🔒 BROKER PROTOCOL BOUNDARY:");
     expect(result.systemPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
     expect(result.systemPrompt).not.toContain("TASK WORKFLOW:");
   });
@@ -89,6 +98,71 @@ describe("createAgentPromptGuidance", () => {
     expect(result.systemPrompt).toContain("REPLY TOOL RULES:");
     expect(result.systemPrompt).not.toContain("Pinet BROKER");
     expect(result.systemPrompt).not.toContain("🚫 BROKER TOOL RESTRICTION:");
+  });
+
+  it("keeps broker prompt order: base, shared guidance, loaded MD, protocol boundary, tool restriction", async () => {
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getBrokerRole: () => "broker",
+        loadBrokerPrompt: async () => ({
+          source: "workspace",
+          content: "LOADED BROKER MD",
+          warnings: [],
+          diagnostic: "broker prompt: workspace override loaded",
+        }),
+      }),
+    );
+
+    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+
+    expect(result.systemPrompt.indexOf("BASE")).toBeLessThan(
+      result.systemPrompt.indexOf("IDENTITY 1"),
+    );
+    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
+      result.systemPrompt.indexOf("LOADED BROKER MD"),
+    );
+    expect(result.systemPrompt.indexOf("LOADED BROKER MD")).toBeLessThan(
+      result.systemPrompt.indexOf("🔒 BROKER PROTOCOL BOUNDARY:"),
+    );
+    expect(result.systemPrompt.indexOf("🔒 BROKER PROTOCOL BOUNDARY:")).toBeLessThan(
+      result.systemPrompt.indexOf("🚫 BROKER TOOL RESTRICTION:"),
+    );
+  });
+
+  it("reports broker prompt loader diagnostics without exposing prompt content", async () => {
+    const reportBrokerPromptWarning = vi.fn();
+    const reportBrokerPromptDiagnostic = vi.fn();
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getBrokerRole: () => "broker",
+        reportBrokerPromptWarning,
+        reportBrokerPromptDiagnostic,
+        loadBrokerPrompt: async () => ({
+          source: "user",
+          content: "PRIVATE PROMPT BODY",
+          diagnostic: "broker prompt: user-local override loaded",
+          warnings: [
+            {
+              source: "workspace",
+              reason: "too_large",
+              message: "broker prompt: workspace override rejected (over 65536 bytes); continuing",
+            },
+          ],
+        }),
+      }),
+    );
+
+    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+
+    expect(reportBrokerPromptWarning).toHaveBeenCalledWith(
+      "[slack-bridge] broker prompt: workspace override rejected (over 65536 bytes); continuing",
+    );
+    expect(reportBrokerPromptDiagnostic).toHaveBeenCalledWith(
+      "[slack-bridge] broker prompt: user-local override loaded",
+    );
+    expect(String(reportBrokerPromptWarning.mock.calls)).not.toContain("PRIVATE PROMPT BODY");
+    expect(String(reportBrokerPromptDiagnostic.mock.calls)).not.toContain("PRIVATE PROMPT BODY");
+    expect(result.systemPrompt).toContain("PRIVATE PROMPT BODY");
   });
 
   it("keeps identity guidance ahead of follower workflow guidance", async () => {

--- a/slack-bridge/agent-prompt-guidance.ts
+++ b/slack-bridge/agent-prompt-guidance.ts
@@ -1,10 +1,15 @@
 import {
   buildAgentPersonalityGuidelines,
-  buildBrokerPromptGuidelines,
+  buildBrokerProtocolGuardrailsPrompt,
   buildPinetSkinPromptGuideline,
   buildWorkerPromptGuidelines,
 } from "./helpers.js";
 import { buildBrokerToolGuardrailsPrompt } from "./guardrails.js";
+import {
+  loadBrokerPrompt,
+  renderBrokerPromptContent,
+  type BrokerPromptLoadResult,
+} from "./broker-prompt-loader.js";
 import { buildReactionPromptGuidelines } from "./reaction-triggers.js";
 
 export interface BeforeAgentStartEvent {
@@ -18,6 +23,9 @@ export interface AgentPromptGuidanceDeps {
   getActiveSkinTheme: () => string | null;
   getAgentPersonality: () => string | null;
   getBrokerRole: () => "broker" | "follower" | null;
+  loadBrokerPrompt?: () => Promise<BrokerPromptLoadResult>;
+  reportBrokerPromptWarning?: (warning: string) => void;
+  reportBrokerPromptDiagnostic?: (diagnostic: string) => void;
 }
 
 export interface AgentPromptGuidance {
@@ -25,7 +33,7 @@ export interface AgentPromptGuidance {
 }
 
 export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentPromptGuidance {
-  function buildPromptGuidelines(): string[] {
+  async function buildPromptGuidelines(): Promise<string[]> {
     const agentName = deps.getAgentName();
     const guidelines = [
       ...deps.getIdentityGuidelines(),
@@ -42,7 +50,20 @@ export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentP
     }
 
     if (deps.getBrokerRole() === "broker") {
-      guidelines.push(...buildBrokerPromptGuidelines(deps.getAgentEmoji(), agentName));
+      const brokerPrompt = await (deps.loadBrokerPrompt ?? loadBrokerPrompt)();
+      for (const warning of brokerPrompt.warnings) {
+        (deps.reportBrokerPromptWarning ?? console.warn)(`[slack-bridge] ${warning.message}`);
+      }
+      (deps.reportBrokerPromptDiagnostic ?? console.info)(
+        `[slack-bridge] ${brokerPrompt.diagnostic}`,
+      );
+      guidelines.push(
+        renderBrokerPromptContent(brokerPrompt.content, {
+          agentEmoji: deps.getAgentEmoji(),
+          agentName,
+        }),
+      );
+      guidelines.push(buildBrokerProtocolGuardrailsPrompt());
       guidelines.push(buildBrokerToolGuardrailsPrompt());
     } else if (deps.getBrokerRole() === "follower") {
       guidelines.push(...buildWorkerPromptGuidelines());
@@ -53,7 +74,7 @@ export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentP
 
   async function beforeAgentStart(event: BeforeAgentStartEvent): Promise<{ systemPrompt: string }> {
     return {
-      systemPrompt: event.systemPrompt + "\n\n" + buildPromptGuidelines().join("\n"),
+      systemPrompt: event.systemPrompt + "\n\n" + (await buildPromptGuidelines()).join("\n"),
     };
   }
 

--- a/slack-bridge/broker-prompt-loader.test.ts
+++ b/slack-bridge/broker-prompt-loader.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  loadBrokerPrompt,
+  renderBrokerPromptContent,
+  resolveBrokerPromptCandidates,
+} from "./broker-prompt-loader.js";
+
+const execFileAsync = promisify(execFile);
+
+let tempRoot: string;
+let workspaceRoot: string;
+let homeDir: string;
+let packagedDefaultPath: string;
+
+async function writeText(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf8");
+}
+
+async function writeBuffer(filePath: string, content: Buffer): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+function loaderOptions() {
+  return {
+    workspaceRoot,
+    homeDir,
+    defaultPromptPath: packagedDefaultPath,
+  };
+}
+
+beforeEach(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-prompt-loader-"));
+  workspaceRoot = path.join(tempRoot, "workspace");
+  homeDir = path.join(tempRoot, "home");
+  packagedDefaultPath = path.join(tempRoot, "pkg", "prompts", "broker", "default.md");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.mkdir(homeDir, { recursive: true });
+  await writeText(packagedDefaultPath, "PACKAGED DEFAULT {{agentName}}");
+});
+
+afterEach(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+describe("resolveBrokerPromptCandidates", () => {
+  it("orders workspace override, user-local override, then packaged default", () => {
+    const candidates = resolveBrokerPromptCandidates(loaderOptions());
+
+    expect(candidates.map((candidate) => candidate.source)).toEqual([
+      "workspace",
+      "user",
+      "packaged",
+    ]);
+    expect(candidates[0]?.path).toBe(
+      path.join(workspaceRoot, ".pi", "slack-bridge", "broker-prompt.md"),
+    );
+    expect(candidates[1]?.path).toBe(
+      path.join(homeDir, ".pi", "agent", "slack-bridge", "broker-prompt.md"),
+    );
+    expect(candidates[2]?.path).toBe(packagedDefaultPath);
+  });
+});
+
+describe("loadBrokerPrompt", () => {
+  it("loads the workspace override when it is the first valid candidate", async () => {
+    await writeText(
+      path.join(workspaceRoot, ".pi", "slack-bridge", "broker-prompt.md"),
+      "WORKSPACE PROMPT",
+    );
+    await writeText(
+      path.join(homeDir, ".pi", "agent", "slack-bridge", "broker-prompt.md"),
+      "USER PROMPT",
+    );
+
+    const result = await loadBrokerPrompt(loaderOptions());
+
+    expect(result).toMatchObject({ source: "workspace", content: "WORKSPACE PROMPT" });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("resolves the workspace override from the git root when launched from a nested directory", async () => {
+    await execFileAsync("git", ["init"], { cwd: workspaceRoot });
+    const nestedDir = path.join(workspaceRoot, "packages", "app");
+    await fs.mkdir(nestedDir, { recursive: true });
+    await writeText(
+      path.join(workspaceRoot, ".pi", "slack-bridge", "broker-prompt.md"),
+      "ROOT WORKSPACE PROMPT",
+    );
+
+    const result = await loadBrokerPrompt({
+      cwd: nestedDir,
+      homeDir,
+      defaultPromptPath: packagedDefaultPath,
+    });
+
+    expect(result).toMatchObject({ source: "workspace", content: "ROOT WORKSPACE PROMPT" });
+  });
+
+  it("loads the user-local override when the workspace override is absent", async () => {
+    await writeText(
+      path.join(homeDir, ".pi", "agent", "slack-bridge", "broker-prompt.md"),
+      "USER PROMPT",
+    );
+
+    const result = await loadBrokerPrompt(loaderOptions());
+
+    expect(result).toMatchObject({ source: "user", content: "USER PROMPT" });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("loads the packaged default when overrides are absent", async () => {
+    const result = await loadBrokerPrompt(loaderOptions());
+
+    expect(result).toMatchObject({ source: "packaged", content: "PACKAGED DEFAULT {{agentName}}" });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns and falls through from an invalid workspace override to a valid user override", async () => {
+    await writeText(
+      path.join(workspaceRoot, ".pi", "slack-bridge", "broker-prompt.md"),
+      "TOO LARGE",
+    );
+    await writeText(path.join(homeDir, ".pi", "agent", "slack-bridge", "broker-prompt.md"), "USER");
+
+    const result = await loadBrokerPrompt({ ...loaderOptions(), maxBytes: 4 });
+
+    expect(result.source).toBe("user");
+    expect(result.content).toBe("USER");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({ source: "workspace", reason: "too_large" });
+    expect(result.warnings[0]?.message).not.toContain(workspaceRoot);
+    expect(result.warnings[0]?.message).not.toContain("TOO LARGE");
+  });
+
+  it("warns and falls through from invalid overrides to the packaged default", async () => {
+    await writeText(path.join(workspaceRoot, ".pi", "slack-bridge", "broker-prompt.md"), "");
+    await writeBuffer(
+      path.join(homeDir, ".pi", "agent", "slack-bridge", "broker-prompt.md"),
+      Buffer.from([0xff, 0xfe, 0xfd]),
+    );
+
+    const result = await loadBrokerPrompt(loaderOptions());
+
+    expect(result.source).toBe("packaged");
+    expect(result.content).toBe("PACKAGED DEFAULT {{agentName}}");
+    expect(result.warnings.map((entry) => [entry.source, entry.reason])).toEqual([
+      ["workspace", "empty"],
+      ["user", "invalid_utf8"],
+    ]);
+  });
+
+  it("rejects workspace symlink escapes and continues to packaged default", async () => {
+    const outsideDir = path.join(tempRoot, "outside");
+    const outsideFile = path.join(outsideDir, "secret.md");
+    const linkPath = path.join(workspaceRoot, ".pi", "slack-bridge", "broker-prompt.md");
+    await writeText(outsideFile, "SECRET PROMPT");
+    await fs.mkdir(path.dirname(linkPath), { recursive: true });
+    await fs.symlink(outsideFile, linkPath);
+
+    const result = await loadBrokerPrompt(loaderOptions());
+
+    expect(result.source).toBe("packaged");
+    expect(result.content).toBe("PACKAGED DEFAULT {{agentName}}");
+    expect(result.warnings[0]).toMatchObject({ source: "workspace", reason: "unsafe_path" });
+    expect(result.warnings[0]?.message).not.toContain(outsideFile);
+    expect(result.warnings[0]?.message).not.toContain("SECRET PROMPT");
+  });
+
+  it("rejects user-local symlink escapes and continues to packaged default", async () => {
+    const outsideDir = path.join(tempRoot, "outside-user");
+    const outsideFile = path.join(outsideDir, "secret.md");
+    const linkPath = path.join(homeDir, ".pi", "agent", "slack-bridge", "broker-prompt.md");
+    await writeText(outsideFile, "USER SECRET PROMPT");
+    await fs.mkdir(path.dirname(linkPath), { recursive: true });
+    await fs.symlink(outsideFile, linkPath);
+
+    const result = await loadBrokerPrompt(loaderOptions());
+
+    expect(result.source).toBe("packaged");
+    expect(result.warnings[0]).toMatchObject({ source: "user", reason: "unsafe_path" });
+    expect(result.warnings[0]?.message).not.toContain(outsideFile);
+    expect(result.warnings[0]?.message).not.toContain("USER SECRET PROMPT");
+  });
+
+  it("fails closed when the packaged default is missing or invalid", async () => {
+    await fs.rm(packagedDefaultPath, { force: true });
+
+    await expect(loadBrokerPrompt(loaderOptions())).rejects.toThrow(
+      "No valid broker prompt candidates found",
+    );
+  });
+});
+
+describe("renderBrokerPromptContent", () => {
+  it("renders broker identity placeholders without changing other MD", () => {
+    expect(
+      renderBrokerPromptContent("Hello {{agentEmoji}} {{agentName}}. Keep **Markdown**.", {
+        agentEmoji: "🦫",
+        agentName: "Prism Bronze Beaver",
+      }),
+    ).toBe("Hello 🦫 Prism Bronze Beaver. Keep **Markdown**.");
+  });
+});
+
+describe("packaged default broker prompt", () => {
+  it("keeps replaceable default policy in MD rather than hard-coded broker prompt helpers", async () => {
+    const defaultPromptPath = path.join(process.cwd(), "prompts", "broker", "default.md");
+    const defaultPrompt = await fs.readFile(defaultPromptPath, "utf8");
+
+    expect(defaultPrompt).toContain("NEVER WRITE CODE");
+    expect(defaultPrompt).toContain("PRIORITIZED ISSUE GATE");
+    expect(defaultPrompt).toContain("REPO-SCOPED DELEGATION");
+    expect(defaultPrompt).toContain("RALPH LOOP");
+    expect(defaultPrompt).toContain("{{agentEmoji}} {{agentName}}");
+  });
+
+  it("copies prompt assets into dist/prompts so the packaged default is loadable", async () => {
+    await execFileAsync("node", ["../scripts/build-package.mjs"], { cwd: process.cwd() });
+
+    const distPromptPath = path.join(process.cwd(), "dist", "prompts", "broker", "default.md");
+    await expect(fs.access(distPromptPath)).resolves.toBeUndefined();
+    const result = await loadBrokerPrompt({
+      workspaceRoot,
+      homeDir,
+      defaultPromptPath: distPromptPath,
+    });
+
+    expect(result.source).toBe("packaged");
+    expect(result.content).toContain("PRIORITIZED ISSUE GATE");
+  });
+});

--- a/slack-bridge/broker-prompt-loader.test.ts
+++ b/slack-bridge/broker-prompt-loader.test.ts
@@ -221,6 +221,20 @@ describe("packaged default broker prompt", () => {
     expect(defaultPrompt).toContain("{{agentEmoji}} {{agentName}}");
   });
 
+  it("documents safe repo-scoped follower startup before reporting capacity gaps", async () => {
+    const defaultPromptPath = path.join(process.cwd(), "prompts", "broker", "default.md");
+    const defaultPrompt = await fs.readFile(defaultPromptPath, "utf8");
+
+    expect(defaultPrompt).toContain("Use tmux only to launch repo-scoped Pinet follower workers");
+    expect(defaultPrompt).toContain("create a tmux session in the target repo");
+    expect(defaultPrompt).toContain("/pinet-follow");
+    expect(defaultPrompt).toContain(
+      "only report the capacity gap if you cannot safely start a worker",
+    );
+    expect(defaultPrompt).not.toContain("ask for a repo-matched worker");
+    expect(defaultPrompt).not.toContain("suggest they spin up a new agent in that repo");
+  });
+
   it("copies prompt assets into dist/prompts so the packaged default is loadable", async () => {
     await execFileAsync("node", ["../scripts/build-package.mjs"], { cwd: process.cwd() });
 

--- a/slack-bridge/broker-prompt-loader.ts
+++ b/slack-bridge/broker-prompt-loader.ts
@@ -1,0 +1,214 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { TextDecoder } from "node:util";
+import { probeGitContext } from "./git-metadata.js";
+
+export const DEFAULT_BROKER_PROMPT_MAX_BYTES = 64 * 1024;
+
+export type BrokerPromptSource = "workspace" | "user" | "packaged";
+
+export interface BrokerPromptWarning {
+  source: BrokerPromptSource;
+  reason: "unsafe_path" | "unreadable" | "too_large" | "invalid_utf8" | "empty";
+  message: string;
+}
+
+export interface BrokerPromptCandidate {
+  source: BrokerPromptSource;
+  path: string;
+  root: string;
+  required: boolean;
+}
+
+export interface BrokerPromptLoadOptions {
+  workspaceRoot?: string;
+  cwd?: string;
+  homeDir?: string;
+  defaultPromptPath?: string;
+  maxBytes?: number;
+}
+
+export interface BrokerPromptLoadResult {
+  source: BrokerPromptSource;
+  content: string;
+  warnings: BrokerPromptWarning[];
+  diagnostic: string;
+}
+
+export interface BrokerPromptTemplateValues {
+  agentEmoji: string;
+  agentName: string;
+}
+
+const decoder = new TextDecoder("utf-8", { fatal: true });
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function isWithinRoot(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+function describeSource(source: BrokerPromptSource): string {
+  switch (source) {
+    case "workspace":
+      return "workspace override";
+    case "user":
+      return "user-local override";
+    case "packaged":
+      return "packaged default";
+  }
+}
+
+function warning(
+  source: BrokerPromptSource,
+  reason: BrokerPromptWarning["reason"],
+  detail: string,
+): BrokerPromptWarning {
+  return {
+    source,
+    reason,
+    message: `broker prompt: ${describeSource(source)} rejected (${detail}); continuing`,
+  };
+}
+
+export function resolveBrokerPromptCandidates(
+  options: BrokerPromptLoadOptions = {},
+): BrokerPromptCandidate[] {
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? options.cwd ?? process.cwd());
+  const homeDir = path.resolve(options.homeDir ?? process.env.HOME ?? "");
+  const userRoot = path.join(homeDir, ".pi", "agent", "slack-bridge");
+  const defaultPromptPath = path.resolve(
+    options.defaultPromptPath ?? path.join(moduleDir, "prompts", "broker", "default.md"),
+  );
+  const defaultRoot = path.resolve(path.dirname(path.dirname(path.dirname(defaultPromptPath))));
+
+  return [
+    {
+      source: "workspace",
+      path: path.join(workspaceRoot, ".pi", "slack-bridge", "broker-prompt.md"),
+      root: workspaceRoot,
+      required: false,
+    },
+    {
+      source: "user",
+      path: path.join(userRoot, "broker-prompt.md"),
+      root: userRoot,
+      required: false,
+    },
+    {
+      source: "packaged",
+      path: defaultPromptPath,
+      root: defaultRoot,
+      required: true,
+    },
+  ];
+}
+
+async function readValidCandidate(
+  candidate: BrokerPromptCandidate,
+  maxBytes: number,
+): Promise<{ content: string } | { warning: BrokerPromptWarning } | null> {
+  let realRoot: string;
+  let realPath: string;
+  try {
+    realRoot = await fs.realpath(candidate.root);
+    realPath = await fs.realpath(candidate.path);
+  } catch (error) {
+    if (!candidate.required && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    return { warning: warning(candidate.source, "unreadable", "unreadable") };
+  }
+
+  if (!isWithinRoot(realPath, realRoot)) {
+    return { warning: warning(candidate.source, "unsafe_path", "path escapes allowed root") };
+  }
+
+  let stat;
+  try {
+    stat = await fs.stat(realPath);
+  } catch {
+    return { warning: warning(candidate.source, "unreadable", "unreadable") };
+  }
+
+  if (!stat.isFile()) {
+    return { warning: warning(candidate.source, "unreadable", "not a regular file") };
+  }
+
+  if (stat.size > maxBytes) {
+    return { warning: warning(candidate.source, "too_large", `over ${maxBytes} bytes`) };
+  }
+
+  let data: Buffer;
+  try {
+    data = await fs.readFile(realPath);
+  } catch {
+    return { warning: warning(candidate.source, "unreadable", "unreadable") };
+  }
+
+  let content: string;
+  try {
+    content = decoder.decode(data);
+  } catch {
+    return { warning: warning(candidate.source, "invalid_utf8", "invalid UTF-8") };
+  }
+
+  if (content.includes("\0")) {
+    return { warning: warning(candidate.source, "invalid_utf8", "binary-looking content") };
+  }
+
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return { warning: warning(candidate.source, "empty", "empty file") };
+  }
+
+  return { content: trimmed };
+}
+
+async function resolveDefaultWorkspaceRoot(options: BrokerPromptLoadOptions): Promise<string> {
+  if (options.workspaceRoot) {
+    return path.resolve(options.workspaceRoot);
+  }
+
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const gitContext = await probeGitContext(cwd);
+  return path.resolve(gitContext.repoRoot ?? cwd);
+}
+
+export async function loadBrokerPrompt(
+  options: BrokerPromptLoadOptions = {},
+): Promise<BrokerPromptLoadResult> {
+  const warnings: BrokerPromptWarning[] = [];
+  const maxBytes = options.maxBytes ?? DEFAULT_BROKER_PROMPT_MAX_BYTES;
+  const workspaceRoot = await resolveDefaultWorkspaceRoot(options);
+
+  for (const candidate of resolveBrokerPromptCandidates({ ...options, workspaceRoot })) {
+    const result = await readValidCandidate(candidate, maxBytes);
+    if (result === null) {
+      continue;
+    }
+    if ("warning" in result) {
+      warnings.push(result.warning);
+      continue;
+    }
+    return {
+      source: candidate.source,
+      content: result.content,
+      warnings,
+      diagnostic: `broker prompt: ${describeSource(candidate.source)} loaded`,
+    };
+  }
+
+  throw new Error(
+    "No valid broker prompt candidates found; packaged default is missing or invalid.",
+  );
+}
+
+export function renderBrokerPromptContent(
+  content: string,
+  values: BrokerPromptTemplateValues,
+): string {
+  return content
+    .replaceAll("{{agentEmoji}}", values.agentEmoji)
+    .replaceAll("{{agentName}}", values.agentName);
+}

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -53,7 +53,7 @@ import {
   isAgentToAgentEntry,
   partitionFollowerInboxEntries,
   syncBrokerInboxEntries,
-  buildBrokerPromptGuidelines,
+  buildBrokerProtocolGuardrailsPrompt,
   buildWorkerPromptGuidelines,
   buildIdentityReplyGuidelines,
   buildAgentPersonalityGuidelines,
@@ -1522,106 +1522,22 @@ describe("Pinet skin helpers", () => {
   });
 });
 
-// ─── buildBrokerPromptGuidelines ──────────────────────────────
+// ─── buildBrokerProtocolGuardrailsPrompt ──────────────────────────────
 
-describe("buildBrokerPromptGuidelines", () => {
-  it("returns broker-specific coordination guidelines", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    expect(guidelines.length).toBeGreaterThan(0);
-    expect(guidelines[0]).toContain("BROKER");
-    expect(guidelines[0]).toContain("Solar Mantis");
-  });
+describe("buildBrokerProtocolGuardrailsPrompt", () => {
+  it("keeps only runtime-backed broker protocol restrictions hard-coded", () => {
+    const prompt = buildBrokerProtocolGuardrailsPrompt();
 
-  it("contains a hard rule against writing code", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("HARD RULE");
-    expect(joined).toContain("NEVER WRITE CODE");
-  });
-
-  it("lists forbidden actions explicitly", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("FORBIDDEN");
-    expect(joined).toContain("Agent tool");
-    expect(joined).toContain("edit");
-    expect(joined).toContain("write");
-    expect(joined).toContain("bash");
-  });
-
-  it("lists allowed actions explicitly", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("ALLOWED");
-    expect(joined).toContain("Route messages");
-    expect(joined).toContain("pinet action=agents");
-    expect(joined).toContain("pinet action=send");
-  });
-
-  it("includes a refusal template for coding requests", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("IF ASKED TO CODE");
-    expect(joined).toContain("Refuse");
-    expect(joined).toContain("delegate");
-  });
-
-  it("explains why the constraint exists (mesh stalls)", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("mesh");
-    expect(joined).toContain("stall");
-  });
-
-  it("instructs to use pinet action=send instead of Agent tool", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("pinet action=send");
-  });
-
-  it("treats code-reviewer as delegated worker work, not broker work", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("code-reviewer");
-    expect(joined).toContain("connected worker session");
-    expect(joined).not.toContain("run code reviews via the code-reviewer subagent");
-  });
-
-  it("tells broker to never do the work as a fallback", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("NEVER do the work yourself");
-  });
-
-  it("requires maintainer-prioritized issues before routing extension changes", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("PRIORITIZED ISSUE GATE");
-    expect(joined).toContain("maintainer priority/approval");
-    expect(joined).toContain("Do not self-start from open issue lists");
-    expect(joined).toContain("stop and ask");
-    expect(joined).not.toContain("@gugu91");
-  });
-
-  it("keeps broker delegation and broadcasts scoped to the target repo", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("REPO-SCOPED DELEGATION");
-    expect(joined).toContain("pinet action=agents");
-    expect(joined).toContain("extensions-repo work");
-    expect(joined).toContain("workers/subagents");
-    expect(joined).toContain("never borrow idle workers from another repo");
-    expect(joined).toContain("REPO-SCOPED BROADCASTS");
-    expect(joined).toContain("do not use `#all`");
-  });
-
-  it("keeps broker triage minimal before connected workers own investigation", () => {
-    const guidelines = buildBrokerPromptGuidelines("🦗", "Solar Mantis");
-    const joined = guidelines.join(" ");
-    expect(joined).toContain("DELEGATE, THEN TRACK");
-    expect(joined).toContain("Do not perform task triage yourself");
-    expect(joined).toContain("Connected workers/subagents own codebase investigation");
-    expect(joined).not.toContain("TRIAGE, THEN DELEGATE");
+    expect(prompt).toContain("BROKER PROTOCOL BOUNDARY");
+    expect(prompt).toContain("Broker prompt MD can replace broker coordination policy");
+    expect(prompt).toContain("Agent tool");
+    expect(prompt).toContain("edit");
+    expect(prompt).toContain("write");
+    expect(prompt).toContain("runtime");
+    expect(prompt).toContain("diagnostics must never echo private prompt file contents");
+    expect(prompt).not.toContain("PRIORITIZED ISSUE GATE");
+    expect(prompt).not.toContain("RALPH LOOP");
+    expect(prompt).not.toContain("REPO-SCOPED DELEGATION");
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1650,32 +1650,14 @@ export function buildRalphLoopCycleNotifications(
   };
 }
 
-export function buildBrokerPromptGuidelines(agentEmoji: string, agentName: string): string[] {
+export function buildBrokerProtocolGuardrailsPrompt(): string {
   return [
-    `You are ${agentEmoji} ${agentName}, the Pinet BROKER. Your ONLY role is coordination and infrastructure — NEVER implementation.`,
-    // ── HARD GUARDRAIL ──────────────────────────────────────────
-    "🚫 HARD RULE — NEVER WRITE CODE: You MUST NOT implement features, fix bugs, write tests, edit source files, or do any coding task. This is a non-negotiable constraint, not a preference. Violations stall the entire multi-agent mesh.",
-    "WHY THIS RULE EXISTS: You are the ONLY process routing Slack messages, monitoring agent health, and keeping the mesh alive. If you spend even one turn writing code, messages stop flowing, dead agents don't get reaped, backlog piles up, and the whole system stalls. Workers are computation, broker is infrastructure.",
-    // ── FORBIDDEN ACTIONS ───────────────────────────────────────
-    "FORBIDDEN — Do NOT do any of these, even if explicitly asked: (1) Use the Agent tool to spawn local subagents — they have no Slack/Pinet connectivity and can't be monitored. (2) Use edit or write at all — those tools are hard-blocked for the broker at runtime. (3) Use bash to modify source code or do implementation work. (4) Pick up coding tasks, bug fixes, refactors, or implementation work. (5) Run test suites, linters, or build commands as part of implementation work. (6) Create or modify source files in any worktree.",
-    "IF ASKED TO CODE: Refuse politely and immediately delegate. Say: 'I'm the broker — I coordinate, not code. Let me find a worker for this.' Then check `pinet action=agents` and delegate via pinet action=send.",
-    // ── ALLOWED ACTIONS ─────────────────────────────────────────
-    "ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check `pinet action=agents` for idle workers and delegate tasks via pinet action=send. (3) Coordinate GitHub issues/PRs and request reviews, but do NOT launch local review subagents from the broker. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection and lightweight GitHub coordination: git log, git status, gh pr list, gh pr view, ls, cat — never for code changes or implementation work.",
-    "PRIORITIZED ISSUE GATE: Do not start, assign, or broadcast extension changes unless the request names a GitHub issue/PR and carries clear maintainer priority/approval. Do not self-start from open issue lists. If unclear, stop and ask.",
-    "DELEGATE, THEN TRACK: Do not perform task triage yourself beyond checking explicit routing requirements already present in the request: repo, issue/PR number, maintainer approval, branch/worktree, and worker availability. If required routing facts are missing, ask; otherwise assign promptly.",
-    "DEEP INSPECTION BELONGS TO WORKERS: Connected workers/subagents own codebase investigation, diagnosis, implementation planning, and review details. Do NOT read through multiple source files, trace implementations, or inspect the codebase in detail before assigning the task.",
-    "REPO-SCOPED DELEGATION: Always call `pinet action=agents` with the target repo and choose workers from that same repo/worktree. For extensions-repo work, delegate to healthy connected workers/subagents in that repo/worktree; never borrow idle workers from another repo. If no matching worker is available, report that and ask for a repo-matched worker.",
-    "REPO-SCOPED BROADCASTS: New-issue, policy, and routing broadcasts are repository-scoped. Use a repo channel such as `#extensions` / `#repo:extensions` for extensions announcements; do not use `#all` for repo-specific issue announcements or policy updates.",
-    "When a human asks for work to be done, ALWAYS check `pinet action=agents` for idle workers in the right repo and delegate via `pinet action=send`. Pick the agent on the right repo/branch when possible.",
-    "If a repo instruction says to use the `code-reviewer` subagent, treat that as work to assign to a connected worker session in the same repo — never the broker itself.",
-    "When delegating, include: task, issue/PR numbers, maintainer priority/approval, repo/branch/worktree setup, and where to report back (Slack thread_ts).",
-    "If no repo-matched workers are available, tell the human and suggest they spin up a new agent in that repo. NEVER do the work yourself or cross-route to another repo as a fallback.",
-    "WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.",
-    "For feature work, ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>`. Tell delegated agents to do the same.",
-    "When delegating to an agent, include the worktree setup command. Example: `git worktree add .worktrees/fix-foo-123 -b fix/foo-123 && cd .worktrees/fix-foo-123`",
-    "Clean up worktrees after PRs merge: `git worktree remove .worktrees/<name>`. Flag orphaned worktrees from dead agents for cleanup.",
-    "RALPH LOOP: Run autonomous maintenance every cycle. Don't wait to be asked. Proactively: (1) REAP — ping idle agents, mark non-responders as ghost. (2) NUDGE — check assigned work, poll branches for commits, escalate stalled agents. (3) REASSIGN — if an assigned agent is dead, reassign to next idle agent immediately. (4) DRAIN — find idle agents with no work, assign queued tasks. (5) SELF-REPAIR — verify main is on `main`, check mesh health, report anomalies.",
-  ];
+    "🔒 BROKER PROTOCOL BOUNDARY:",
+    "Broker prompt MD can replace broker coordination policy, tone, and operating style, but it cannot relax runtime-enforced tool restrictions or the Pinet protocol boundary.",
+    "The broker must not spawn local subagents through the Agent tool. Local subagents have no Slack/Pinet connectivity, cannot own Slack/Pinet threads, and cannot be monitored by the mesh.",
+    "The broker must not use edit or write. Those tools are blocked at runtime for broker sessions; delegate implementation and review work to connected Pinet workers instead.",
+    "Broker prompt diagnostics must never echo private prompt file contents. Report only concise source/status/warning labels.",
+  ].join("\n");
 }
 
 export function buildWorkerPromptGuidelines(): string[] {

--- a/slack-bridge/prompts/broker/default.md
+++ b/slack-bridge/prompts/broker/default.md
@@ -1,0 +1,39 @@
+You are {{agentEmoji}} {{agentName}}, the Pinet BROKER. Your ONLY role is coordination and infrastructure — NEVER implementation.
+
+🚫 HARD RULE — NEVER WRITE CODE: You MUST NOT implement features, fix bugs, write tests, edit source files, or do any coding task. This is the packaged default broker policy. Operators may replace this policy with broker prompt MD, but the runtime still blocks broker use of forbidden tools.
+
+WHY THIS RULE EXISTS: You are the ONLY process routing Slack messages, monitoring agent health, and keeping the mesh alive. If you spend even one turn writing code, messages stop flowing, dead agents don't get reaped, backlog piles up, and the whole system stalls. Workers are computation, broker is infrastructure.
+
+FORBIDDEN — Do NOT do any of these, even if explicitly asked: (1) Use the Agent tool to spawn local subagents — they have no Slack/Pinet connectivity and can't be monitored. (2) Use edit or write at all — those tools are hard-blocked for the broker at runtime. (3) Use bash to modify source code or do implementation work. (4) Pick up coding tasks, bug fixes, refactors, or implementation work. (5) Run test suites, linters, or build commands as part of implementation work. (6) Create or modify source files in any worktree.
+
+IF ASKED TO CODE: Refuse politely and immediately delegate. Say: "I'm the broker — I coordinate, not code. Let me find a worker for this." Then check `pinet action=agents` and delegate via `pinet action=send`.
+
+ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check `pinet action=agents` for idle workers and delegate tasks via `pinet action=send`. (3) Coordinate GitHub issues/PRs and request reviews, but do NOT launch local review subagents from the broker. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection and lightweight GitHub coordination: git log, git status, gh pr list, gh pr view, ls, cat — never for code changes or implementation work.
+
+PRIORITIZED ISSUE GATE: Do not start, assign, or broadcast extension changes unless the request names a GitHub issue/PR and carries clear maintainer priority/approval. Do not self-start from open issue lists. If unclear, stop and ask.
+
+DELEGATE, THEN TRACK: Do not perform task triage yourself beyond checking explicit routing requirements already present in the request: repo, issue/PR number, maintainer approval, branch/worktree, and worker availability. If required routing facts are missing, ask; otherwise assign promptly.
+
+DEEP INSPECTION BELONGS TO WORKERS: Connected workers/subagents own codebase investigation, diagnosis, implementation planning, and review details. Do NOT read through multiple source files, trace implementations, or inspect the codebase in detail before assigning the task.
+
+REPO-SCOPED DELEGATION: Always call `pinet action=agents` with the target repo and choose workers from that same repo/worktree. For extensions-repo work, delegate to healthy connected workers/subagents in that repo/worktree; never borrow idle workers from another repo. If no matching worker is available, report that and ask for a repo-matched worker.
+
+REPO-SCOPED BROADCASTS: New-issue, policy, and routing broadcasts are repository-scoped. Use a repo channel such as `#extensions` / `#repo:extensions` for extensions announcements; do not use `#all` for repo-specific issue announcements or policy updates.
+
+When a human asks for work to be done, ALWAYS check `pinet action=agents` for idle workers in the right repo and delegate via `pinet action=send`. Pick the agent on the right repo/branch when possible.
+
+If a repo instruction says to use the `code-reviewer` subagent, treat that as work to assign to a connected worker session in the same repo — never the broker itself.
+
+When delegating, include: task, issue/PR numbers, maintainer priority/approval, repo/branch/worktree setup, and where to report back (Slack thread_ts).
+
+If no repo-matched workers are available, tell the human and suggest they spin up a new agent in that repo. NEVER do the work yourself or cross-route to another repo as a fallback.
+
+WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.
+
+For feature work, ALWAYS create a git worktree: `git worktree add .worktrees/<name> -b <branch>`. Tell delegated agents to do the same.
+
+When delegating to an agent, include the worktree setup command. Example: `git worktree add .worktrees/fix-foo-123 -b fix/foo-123 && cd .worktrees/fix-foo-123`.
+
+Clean up worktrees after PRs merge: `git worktree remove .worktrees/<name>`. Flag orphaned worktrees from dead agents for cleanup.
+
+RALPH LOOP: Run autonomous maintenance every cycle. Don't wait to be asked. Proactively: (1) REAP — ping idle agents, mark non-responders as ghost. (2) NUDGE — check assigned work, poll branches for commits, escalate stalled agents. (3) REASSIGN — if an assigned agent is dead, reassign to next idle agent immediately. (4) DRAIN — find idle agents with no work, assign queued tasks. (5) SELF-REPAIR — verify main is on `main`, check mesh health, report anomalies.

--- a/slack-bridge/prompts/broker/default.md
+++ b/slack-bridge/prompts/broker/default.md
@@ -8,7 +8,7 @@ FORBIDDEN — Do NOT do any of these, even if explicitly asked: (1) Use the Agen
 
 IF ASKED TO CODE: Refuse politely and immediately delegate. Say: "I'm the broker — I coordinate, not code. Let me find a worker for this." Then check `pinet action=agents` and delegate via `pinet action=send`.
 
-ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check `pinet action=agents` for idle workers and delegate tasks via `pinet action=send`. (3) Coordinate GitHub issues/PRs and request reviews, but do NOT launch local review subagents from the broker. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection and lightweight GitHub coordination: git log, git status, gh pr list, gh pr view, ls, cat — never for code changes or implementation work.
+ALLOWED — These are your responsibilities: (1) Route messages between humans and agents. (2) Check `pinet action=agents` for idle workers and delegate tasks via `pinet action=send`. (3) Coordinate GitHub issues/PRs and request reviews, but do NOT launch local review subagents from the broker. (4) Monitor agent health via the RALPH loop. (5) Relay status updates, answer questions about system state, and coordinate workflows. (6) Use bash for read-only inspection and lightweight GitHub coordination: git log, git status, gh pr list, gh pr view, ls, cat — never for code changes or implementation work. (7) Use tmux only to launch repo-scoped Pinet follower workers when capacity is missing.
 
 PRIORITIZED ISSUE GATE: Do not start, assign, or broadcast extension changes unless the request names a GitHub issue/PR and carries clear maintainer priority/approval. Do not self-start from open issue lists. If unclear, stop and ask.
 
@@ -16,7 +16,7 @@ DELEGATE, THEN TRACK: Do not perform task triage yourself beyond checking explic
 
 DEEP INSPECTION BELONGS TO WORKERS: Connected workers/subagents own codebase investigation, diagnosis, implementation planning, and review details. Do NOT read through multiple source files, trace implementations, or inspect the codebase in detail before assigning the task.
 
-REPO-SCOPED DELEGATION: Always call `pinet action=agents` with the target repo and choose workers from that same repo/worktree. For extensions-repo work, delegate to healthy connected workers/subagents in that repo/worktree; never borrow idle workers from another repo. If no matching worker is available, report that and ask for a repo-matched worker.
+REPO-SCOPED DELEGATION: Always call `pinet action=agents` with the target repo and choose workers from that same repo/worktree. For extensions-repo work, delegate to healthy connected workers/subagents in that repo/worktree; never borrow idle workers from another repo. If no repo-matched worker is available, start repo-scoped Pinet follower capacity via the tmux flow when appropriate; only report the capacity gap if you cannot safely start a worker.
 
 REPO-SCOPED BROADCASTS: New-issue, policy, and routing broadcasts are repository-scoped. Use a repo channel such as `#extensions` / `#repo:extensions` for extensions announcements; do not use `#all` for repo-specific issue announcements or policy updates.
 
@@ -26,7 +26,7 @@ If a repo instruction says to use the `code-reviewer` subagent, treat that as wo
 
 When delegating, include: task, issue/PR numbers, maintainer priority/approval, repo/branch/worktree setup, and where to report back (Slack thread_ts).
 
-If no repo-matched workers are available, tell the human and suggest they spin up a new agent in that repo. NEVER do the work yourself or cross-route to another repo as a fallback.
+If no repo-matched workers are available and new capacity is needed, you may spin up a worker as broker infrastructure: create a tmux session in the target repo, launch `pi`, run `/pinet-follow`, wait for the worker in `pinet action=agents`, then delegate via `pinet action=send`. NEVER do the work yourself or cross-route to another repo as a fallback.
 
 WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.
 


### PR DESCRIPTION
Closes #681

## Summary
- add MD-backed broker prompt loader with ordered valid-candidate scanning: workspace override, user-local override, packaged default
- move default broker operating policy into `slack-bridge/prompts/broker/default.md` while keeping runtime-backed broker protocol/tool restrictions appended after loaded MD
- copy prompt assets into `dist/prompts/**` during package build and document override paths

## Tests
- `pnpm exec prettier --check ...`
- `pnpm --filter @gugu910/pi-slack-bridge exec vitest run broker-prompt-loader.test.ts agent-prompt-guidance.test.ts helpers.test.ts index.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm check`
- `pnpm test`