### PR TITLE
feat: track Pinet PM lane metadata

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -229,7 +229,7 @@ describe("BrokerDB message sync identity", () => {
         ),
       );
 
-      expect(version.user_version).toBe(14);
+      expect(version.user_version).toBe(15);
       expect(messageColumns.has("external_id")).toBe(true);
       expect(messageColumns.has("external_ts")).toBe(true);
       expect(inboxColumns.has("read_at")).toBe(true);
@@ -428,6 +428,87 @@ describe("BrokerDB message sync identity", () => {
       expect(db.getThread("thread-metadata")?.metadata).toEqual({ migrated: true });
     } finally {
       db.close();
+    }
+  });
+
+  it("persists PM lane metadata and participants across reopen", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    const dbPath = path.join(dir, "broker.db");
+
+    try {
+      db.upsertPinetLane({
+        laneId: "issue-detached",
+        issueNumber: 123,
+        ownerAgentId: "worker-human",
+        state: "detached",
+        summary: "Human supervised lane.",
+      });
+      db.upsertPinetLane({
+        laneId: "issue-688",
+        name: "Issue #688 PM lane",
+        task: "Coordinate follower delegation metadata",
+        issueNumber: 688,
+        threadId: "a2a:broker:pm",
+        ownerAgentId: "worker-pm",
+        implementationLeadAgentId: "worker-lead",
+        pmMode: true,
+        state: "active",
+        summary: "PM mode enabled after maintainer consent.",
+        metadata: { consent: "maintainer", source: "broker-thread" },
+      });
+      db.setPinetLaneParticipant({
+        laneId: "issue-688",
+        agentId: "worker-pm",
+        role: "pm",
+        status: "coordinating",
+        summary: "Owns status, blockers, and second-pass review.",
+      });
+      db.setPinetLaneParticipant({
+        laneId: "issue-688",
+        agentId: "worker-lead",
+        role: "lead",
+        status: "implementing",
+        metadata: { worktree: ".worktrees/fix-lane-metadata-688" },
+      });
+
+      const [lane] = db.listPinetLanes();
+      expect(db.listPinetLanes().map((entry) => entry.laneId)).not.toContain("issue-detached");
+      expect(db.listPinetLanes({ state: "detached" })[0]).toMatchObject({
+        laneId: "issue-detached",
+        state: "detached",
+      });
+      expect(lane).toMatchObject({
+        laneId: "issue-688",
+        ownerAgentId: "worker-pm",
+        implementationLeadAgentId: "worker-lead",
+        pmMode: true,
+        state: "active",
+        issueNumber: 688,
+        metadata: { consent: "maintainer", source: "broker-thread" },
+      });
+      expect(lane.participants).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ agentId: "worker-pm", role: "pm" }),
+          expect.objectContaining({ agentId: "worker-lead", role: "lead" }),
+        ]),
+      );
+    } finally {
+      db.close();
+    }
+
+    const reopened = new BrokerDB(dbPath);
+    try {
+      reopened.initialize();
+      expect(reopened.listPinetLanes({ ownerAgentId: "worker-pm" })[0]).toMatchObject({
+        laneId: "issue-688",
+        pmMode: true,
+        participants: expect.arrayContaining([
+          expect.objectContaining({ agentId: "worker-pm", role: "pm" }),
+        ]),
+      });
+    } finally {
+      reopened.close();
     }
   });
 

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -512,6 +512,92 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("clears nullable lane and participant fields explicitly", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      db.upsertPinetLane({
+        laneId: "issue-clear",
+        issueNumber: 688,
+        prNumber: 689,
+        threadId: "a2a:broker:pm",
+        ownerAgentId: "worker-pm",
+        implementationLeadAgentId: "worker-lead",
+        summary: "stale summary",
+        metadata: { stale: true },
+      });
+      db.setPinetLaneParticipant({
+        laneId: "issue-clear",
+        agentId: "worker-pm",
+        role: "pm",
+        status: "coordinating",
+        summary: "stale participant summary",
+        metadata: { stale: true },
+      });
+
+      const cleared = db.upsertPinetLane({
+        laneId: "issue-clear",
+        prNumber: null,
+        threadId: null,
+        ownerAgentId: null,
+        implementationLeadAgentId: null,
+        summary: null,
+        metadata: null,
+      });
+      const clearedParticipant = db.setPinetLaneParticipant({
+        laneId: "issue-clear",
+        agentId: "worker-pm",
+        role: "observer",
+        status: null,
+        summary: null,
+        metadata: null,
+      });
+
+      expect(cleared).toMatchObject({
+        issueNumber: 688,
+        prNumber: null,
+        threadId: null,
+        ownerAgentId: null,
+        implementationLeadAgentId: null,
+        summary: null,
+        metadata: null,
+      });
+      expect(clearedParticipant).toMatchObject({
+        role: "observer",
+        status: null,
+        summary: null,
+        metadata: null,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects invalid lane states and participant roles on writes", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+
+    try {
+      expect(() =>
+        db.upsertPinetLane({
+          laneId: "issue-invalid",
+          state: "bogus" as never,
+        }),
+      ).toThrow("Invalid Pinet lane state");
+      db.upsertPinetLane({ laneId: "issue-invalid" });
+      expect(() =>
+        db.setPinetLaneParticipant({
+          laneId: "issue-invalid",
+          agentId: "worker-1",
+          role: "helper" as never,
+        }),
+      ).toThrow("Invalid Pinet lane role");
+    } finally {
+      db.close();
+    }
+  });
+
   it("deduplicates Slack messages by channel timestamp while preserving inbox recipients", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -429,6 +429,13 @@ function normalizePinetLaneState(
     : fallback;
 }
 
+function requirePinetLaneState(value: unknown): PinetLaneState {
+  if (typeof value === "string" && PINET_LANE_STATES.has(value as PinetLaneState)) {
+    return value as PinetLaneState;
+  }
+  throw new Error(`Invalid Pinet lane state: ${String(value)}`);
+}
+
 function normalizePinetLaneRole(
   value: unknown,
   fallback: PinetLaneRole = "observer",
@@ -436,6 +443,13 @@ function normalizePinetLaneRole(
   return typeof value === "string" && PINET_LANE_ROLES.has(value as PinetLaneRole)
     ? (value as PinetLaneRole)
     : fallback;
+}
+
+function requirePinetLaneRole(value: unknown): PinetLaneRole {
+  if (typeof value === "string" && PINET_LANE_ROLES.has(value as PinetLaneRole)) {
+    return value as PinetLaneRole;
+  }
+  throw new Error(`Invalid Pinet lane role: ${String(value)}`);
 }
 
 function normalizeLaneId(value: string): string {
@@ -2173,10 +2187,12 @@ export class BrokerDB implements BrokerDBInterface {
     const existing = db.prepare("SELECT * FROM pinet_lanes WHERE lane_id = ?").get(laneId) as
       | PinetLaneRow
       | undefined;
-    const nextState = normalizePinetLaneState(
-      input.state,
-      existing ? rowToPinetLane(existing).state : "active",
-    );
+    const nextState =
+      input.state === undefined
+        ? existing
+          ? rowToPinetLane(existing).state
+          : "active"
+        : requirePinetLaneState(input.state);
 
     if (!existing) {
       db.prepare(
@@ -2222,18 +2238,31 @@ export class BrokerDB implements BrokerDBInterface {
            last_activity_at = ?
        WHERE lane_id = ?`,
     ).run(
-      normalizeOptionalText(input.name) ?? existing.name,
-      normalizeOptionalText(input.task) ?? existing.task,
-      normalizeOptionalInteger(input.issueNumber) ?? existing.issue_number,
-      normalizeOptionalInteger(input.prNumber) ?? existing.pr_number,
-      normalizeOptionalText(input.threadId) ?? existing.thread_id,
-      normalizeOptionalText(input.ownerAgentId) ?? existing.owner_agent_id,
-      normalizeOptionalText(input.implementationLeadAgentId) ??
-        existing.implementation_lead_agent_id,
+      input.name === undefined ? existing.name : (normalizeOptionalText(input.name) ?? null),
+      input.task === undefined ? existing.task : (normalizeOptionalText(input.task) ?? null),
+      input.issueNumber === undefined
+        ? existing.issue_number
+        : (normalizeOptionalInteger(input.issueNumber) ?? null),
+      input.prNumber === undefined
+        ? existing.pr_number
+        : (normalizeOptionalInteger(input.prNumber) ?? null),
+      input.threadId === undefined
+        ? existing.thread_id
+        : (normalizeOptionalText(input.threadId) ?? null),
+      input.ownerAgentId === undefined
+        ? existing.owner_agent_id
+        : (normalizeOptionalText(input.ownerAgentId) ?? null),
+      input.implementationLeadAgentId === undefined
+        ? existing.implementation_lead_agent_id
+        : (normalizeOptionalText(input.implementationLeadAgentId) ?? null),
       input.pmMode === undefined ? existing.pm_mode : input.pmMode ? 1 : 0,
       nextState,
-      normalizeOptionalText(input.summary) ?? existing.summary,
-      serializeOptionalMetadata(input.metadata) ?? existing.metadata,
+      input.summary === undefined
+        ? existing.summary
+        : (normalizeOptionalText(input.summary) ?? null),
+      input.metadata === undefined
+        ? existing.metadata
+        : (serializeOptionalMetadata(input.metadata) ?? null),
       now,
       now,
       laneId,
@@ -2246,7 +2275,7 @@ export class BrokerDB implements BrokerDBInterface {
     const db = this.getDb();
     const laneId = normalizeLaneId(input.laneId);
     const agentId = normalizeLaneId(input.agentId);
-    const role = normalizePinetLaneRole(input.role);
+    const role = requirePinetLaneRole(input.role);
     if (!this.getPinetLane(laneId)) {
       throw new Error(`Pinet lane not found: ${laneId}`);
     }
@@ -2285,9 +2314,15 @@ export class BrokerDB implements BrokerDBInterface {
          WHERE lane_id = ? AND agent_id = ?`,
       ).run(
         role,
-        normalizeOptionalText(input.status) ?? existing.status,
-        normalizeOptionalText(input.summary) ?? existing.summary,
-        serializeOptionalMetadata(input.metadata) ?? existing.metadata,
+        input.status === undefined
+          ? existing.status
+          : (normalizeOptionalText(input.status) ?? null),
+        input.summary === undefined
+          ? existing.summary
+          : (normalizeOptionalText(input.summary) ?? null),
+        input.metadata === undefined
+          ? existing.metadata
+          : (serializeOptionalMetadata(input.metadata) ?? null),
         now,
         now,
         laneId,
@@ -2329,7 +2364,7 @@ export class BrokerDB implements BrokerDBInterface {
     const values: string[] = [];
     if (options.state) {
       clauses.push("state = ?");
-      values.push(normalizePinetLaneState(options.state));
+      values.push(requirePinetLaneState(options.state));
     } else if (!options.includeDone) {
       clauses.push("state NOT IN ('done', 'cancelled', 'detached')");
     }

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -21,6 +21,13 @@ import type {
   TaskAssignmentStatus,
   ScheduledWakeupInfo,
   ScheduledWakeupDelivery,
+  PinetLaneInfo,
+  PinetLaneListOptions,
+  PinetLaneParticipantInfo,
+  PinetLaneParticipantUpsertInput,
+  PinetLaneRole,
+  PinetLaneState,
+  PinetLaneUpsertInput,
 } from "./types.js";
 interface SqliteJournalModeResult {
   journal_mode?: string | null;
@@ -108,6 +115,36 @@ interface ScheduledWakeupRow {
   body: string;
   fire_at: string;
   created_at: string;
+}
+
+interface PinetLaneRow {
+  lane_id: string;
+  name: string | null;
+  task: string | null;
+  issue_number: number | null;
+  pr_number: number | null;
+  thread_id: string | null;
+  owner_agent_id: string | null;
+  implementation_lead_agent_id: string | null;
+  pm_mode: number;
+  state: string;
+  summary: string | null;
+  metadata: string | null;
+  created_at: string;
+  updated_at: string;
+  last_activity_at: string;
+}
+
+interface PinetLaneParticipantRow {
+  lane_id: string;
+  agent_id: string;
+  lane_role: string;
+  status: string | null;
+  summary: string | null;
+  metadata: string | null;
+  created_at: string;
+  updated_at: string;
+  last_activity_at: string;
 }
 
 export interface TaskAssignmentAwaitingReplyInfo {
@@ -314,6 +351,123 @@ function rowToScheduledWakeup(row: ScheduledWakeupRow): ScheduledWakeupInfo {
   };
 }
 
+const PINET_LANE_STATES = new Set<PinetLaneState>([
+  "planned",
+  "active",
+  "blocked",
+  "review",
+  "ready",
+  "done",
+  "cancelled",
+  "detached",
+]);
+
+const PINET_LANE_ROLES = new Set<PinetLaneRole>([
+  "broker",
+  "coordinator",
+  "pm",
+  "lead",
+  "implementer",
+  "reviewer",
+  "second_pass_reviewer",
+  "observer",
+]);
+
+function parseMetadataJson(value: string | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function rowToPinetLaneParticipant(row: PinetLaneParticipantRow): PinetLaneParticipantInfo {
+  return {
+    laneId: row.lane_id,
+    agentId: row.agent_id,
+    role: normalizePinetLaneRole(row.lane_role),
+    status: row.status,
+    summary: row.summary,
+    metadata: parseMetadataJson(row.metadata),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastActivityAt: row.last_activity_at,
+  };
+}
+
+function rowToPinetLane(
+  row: PinetLaneRow,
+  participants: PinetLaneParticipantInfo[] = [],
+): PinetLaneInfo {
+  return {
+    laneId: row.lane_id,
+    name: row.name,
+    task: row.task,
+    issueNumber: row.issue_number,
+    prNumber: row.pr_number,
+    threadId: row.thread_id,
+    ownerAgentId: row.owner_agent_id,
+    implementationLeadAgentId: row.implementation_lead_agent_id,
+    pmMode: row.pm_mode === 1,
+    state: normalizePinetLaneState(row.state),
+    summary: row.summary,
+    metadata: parseMetadataJson(row.metadata),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastActivityAt: row.last_activity_at,
+    participants,
+  };
+}
+
+function normalizePinetLaneState(
+  value: unknown,
+  fallback: PinetLaneState = "active",
+): PinetLaneState {
+  return typeof value === "string" && PINET_LANE_STATES.has(value as PinetLaneState)
+    ? (value as PinetLaneState)
+    : fallback;
+}
+
+function normalizePinetLaneRole(
+  value: unknown,
+  fallback: PinetLaneRole = "observer",
+): PinetLaneRole {
+  return typeof value === "string" && PINET_LANE_ROLES.has(value as PinetLaneRole)
+    ? (value as PinetLaneRole)
+    : fallback;
+}
+
+function normalizeLaneId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("laneId must be a non-empty string");
+  }
+  return trimmed;
+}
+
+function normalizeOptionalText(value: string | null | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeOptionalInteger(value: number | null | undefined): number | null | undefined {
+  if (value === undefined || value === null) return value;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error("lane issue/PR numbers must be non-negative integers");
+  }
+  return value;
+}
+
+function serializeOptionalMetadata(
+  value: Record<string, unknown> | null | undefined,
+): string | null | undefined {
+  if (value === undefined) return undefined;
+  return value === null ? null : JSON.stringify(value);
+}
+
 // ─── Default DB path ─────────────────────────────────────
 
 export function defaultDbPath(): string {
@@ -322,7 +476,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 14;
+export const CURRENT_BROKER_SCHEMA_VERSION = 15;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -842,6 +996,52 @@ function addScheduledWakeupStableIdColumn(db: DatabaseSync): void {
   ).run();
 }
 
+function createPinetLaneTables(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pinet_lanes (
+      lane_id TEXT PRIMARY KEY NOT NULL,
+      name TEXT,
+      task TEXT,
+      issue_number INTEGER,
+      pr_number INTEGER,
+      thread_id TEXT,
+      owner_agent_id TEXT,
+      implementation_lead_agent_id TEXT,
+      pm_mode INTEGER NOT NULL DEFAULT 0 CHECK(pm_mode IN (0, 1)),
+      state TEXT NOT NULL DEFAULT 'active'
+        CHECK(state IN ('planned', 'active', 'blocked', 'review', 'ready', 'done', 'cancelled', 'detached')),
+      summary TEXT,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_activity_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS pinet_lane_participants (
+      lane_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      lane_role TEXT NOT NULL
+        CHECK(lane_role IN ('broker', 'coordinator', 'pm', 'lead', 'implementer', 'reviewer', 'second_pass_reviewer', 'observer')),
+      status TEXT,
+      summary TEXT,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_activity_at TEXT NOT NULL,
+      PRIMARY KEY(lane_id, agent_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pinet_lanes_state_updated
+      ON pinet_lanes(state, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_pinet_lanes_owner_state
+      ON pinet_lanes(owner_agent_id, state, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_pinet_lanes_issue
+      ON pinet_lanes(issue_number);
+    CREATE INDEX IF NOT EXISTS idx_pinet_lane_participants_agent
+      ON pinet_lane_participants(agent_id, lane_role, updated_at DESC);
+  `);
+}
+
 function runSchemaMigrations(db: DatabaseSync): void {
   const currentVersion = getUserVersion(db);
   if (currentVersion >= CURRENT_BROKER_SCHEMA_VERSION) {
@@ -897,6 +1097,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 14:
           addThreadMetadataColumn(db);
+          break;
+        case 15:
+          createPinetLaneTables(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -1959,6 +2162,187 @@ export class BrokerDB implements BrokerDBInterface {
            updated_at = ?
        WHERE id = ?`,
     ).run(status, prNumber, new Date().toISOString(), id);
+  }
+
+  // ─── Pinet lane metadata ─────────────────────────────
+
+  upsertPinetLane(input: PinetLaneUpsertInput): PinetLaneInfo {
+    const db = this.getDb();
+    const laneId = normalizeLaneId(input.laneId);
+    const now = new Date().toISOString();
+    const existing = db.prepare("SELECT * FROM pinet_lanes WHERE lane_id = ?").get(laneId) as
+      | PinetLaneRow
+      | undefined;
+    const nextState = normalizePinetLaneState(
+      input.state,
+      existing ? rowToPinetLane(existing).state : "active",
+    );
+
+    if (!existing) {
+      db.prepare(
+        `INSERT INTO pinet_lanes (
+           lane_id, name, task, issue_number, pr_number, thread_id,
+           owner_agent_id, implementation_lead_agent_id, pm_mode, state,
+           summary, metadata, created_at, updated_at, last_activity_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        laneId,
+        normalizeOptionalText(input.name) ?? null,
+        normalizeOptionalText(input.task) ?? null,
+        normalizeOptionalInteger(input.issueNumber) ?? null,
+        normalizeOptionalInteger(input.prNumber) ?? null,
+        normalizeOptionalText(input.threadId) ?? null,
+        normalizeOptionalText(input.ownerAgentId) ?? null,
+        normalizeOptionalText(input.implementationLeadAgentId) ?? null,
+        input.pmMode === true ? 1 : 0,
+        nextState,
+        normalizeOptionalText(input.summary) ?? null,
+        serializeOptionalMetadata(input.metadata) ?? null,
+        now,
+        now,
+        now,
+      );
+      return this.getPinetLane(laneId)!;
+    }
+
+    db.prepare(
+      `UPDATE pinet_lanes
+       SET name = ?,
+           task = ?,
+           issue_number = ?,
+           pr_number = ?,
+           thread_id = ?,
+           owner_agent_id = ?,
+           implementation_lead_agent_id = ?,
+           pm_mode = ?,
+           state = ?,
+           summary = ?,
+           metadata = ?,
+           updated_at = ?,
+           last_activity_at = ?
+       WHERE lane_id = ?`,
+    ).run(
+      normalizeOptionalText(input.name) ?? existing.name,
+      normalizeOptionalText(input.task) ?? existing.task,
+      normalizeOptionalInteger(input.issueNumber) ?? existing.issue_number,
+      normalizeOptionalInteger(input.prNumber) ?? existing.pr_number,
+      normalizeOptionalText(input.threadId) ?? existing.thread_id,
+      normalizeOptionalText(input.ownerAgentId) ?? existing.owner_agent_id,
+      normalizeOptionalText(input.implementationLeadAgentId) ??
+        existing.implementation_lead_agent_id,
+      input.pmMode === undefined ? existing.pm_mode : input.pmMode ? 1 : 0,
+      nextState,
+      normalizeOptionalText(input.summary) ?? existing.summary,
+      serializeOptionalMetadata(input.metadata) ?? existing.metadata,
+      now,
+      now,
+      laneId,
+    );
+
+    return this.getPinetLane(laneId)!;
+  }
+
+  setPinetLaneParticipant(input: PinetLaneParticipantUpsertInput): PinetLaneParticipantInfo {
+    const db = this.getDb();
+    const laneId = normalizeLaneId(input.laneId);
+    const agentId = normalizeLaneId(input.agentId);
+    const role = normalizePinetLaneRole(input.role);
+    if (!this.getPinetLane(laneId)) {
+      throw new Error(`Pinet lane not found: ${laneId}`);
+    }
+
+    const now = new Date().toISOString();
+    const existing = db
+      .prepare("SELECT * FROM pinet_lane_participants WHERE lane_id = ? AND agent_id = ?")
+      .get(laneId, agentId) as PinetLaneParticipantRow | undefined;
+
+    if (!existing) {
+      db.prepare(
+        `INSERT INTO pinet_lane_participants (
+           lane_id, agent_id, lane_role, status, summary, metadata,
+           created_at, updated_at, last_activity_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        laneId,
+        agentId,
+        role,
+        normalizeOptionalText(input.status) ?? null,
+        normalizeOptionalText(input.summary) ?? null,
+        serializeOptionalMetadata(input.metadata) ?? null,
+        now,
+        now,
+        now,
+      );
+    } else {
+      db.prepare(
+        `UPDATE pinet_lane_participants
+         SET lane_role = ?,
+             status = ?,
+             summary = ?,
+             metadata = ?,
+             updated_at = ?,
+             last_activity_at = ?
+         WHERE lane_id = ? AND agent_id = ?`,
+      ).run(
+        role,
+        normalizeOptionalText(input.status) ?? existing.status,
+        normalizeOptionalText(input.summary) ?? existing.summary,
+        serializeOptionalMetadata(input.metadata) ?? existing.metadata,
+        now,
+        now,
+        laneId,
+        agentId,
+      );
+    }
+
+    db.prepare(
+      `UPDATE pinet_lanes
+       SET updated_at = ?, last_activity_at = ?
+       WHERE lane_id = ?`,
+    ).run(now, now, laneId);
+
+    const row = db
+      .prepare("SELECT * FROM pinet_lane_participants WHERE lane_id = ? AND agent_id = ?")
+      .get(laneId, agentId) as PinetLaneParticipantRow | undefined;
+    if (!row) {
+      throw new Error(`Failed to update Pinet lane participant ${agentId} for ${laneId}`);
+    }
+    return rowToPinetLaneParticipant(row);
+  }
+
+  getPinetLane(laneId: string): PinetLaneInfo | null {
+    const db = this.getDb();
+    const canonicalLaneId = normalizeLaneId(laneId);
+    const row = db.prepare("SELECT * FROM pinet_lanes WHERE lane_id = ?").get(canonicalLaneId) as
+      | PinetLaneRow
+      | undefined;
+    if (!row) return null;
+    const participantRows = db
+      .prepare("SELECT * FROM pinet_lane_participants WHERE lane_id = ? ORDER BY updated_at DESC")
+      .all(canonicalLaneId) as unknown as PinetLaneParticipantRow[];
+    return rowToPinetLane(row, participantRows.map(rowToPinetLaneParticipant));
+  }
+
+  listPinetLanes(options: PinetLaneListOptions = {}): PinetLaneInfo[] {
+    const db = this.getDb();
+    const clauses: string[] = [];
+    const values: string[] = [];
+    if (options.state) {
+      clauses.push("state = ?");
+      values.push(normalizePinetLaneState(options.state));
+    } else if (!options.includeDone) {
+      clauses.push("state NOT IN ('done', 'cancelled', 'detached')");
+    }
+    const ownerAgentId = normalizeOptionalText(options.ownerAgentId);
+    if (ownerAgentId) {
+      clauses.push("owner_agent_id = ?");
+      values.push(ownerAgentId);
+    }
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const rows = db
+      .prepare(`SELECT * FROM pinet_lanes ${where} ORDER BY updated_at DESC, created_at DESC`)
+      .all(...values) as unknown as PinetLaneRow[];
+    return rows.map((row) => this.getPinetLane(row.lane_id)!);
   }
 
   // ─── Scheduled wake-ups ──────────────────────────────

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -140,6 +140,87 @@ export interface ScheduledWakeupDelivery {
   wakeup: ScheduledWakeupInfo;
   message: BrokerMessage;
 }
+
+export type PinetLaneState =
+  | "planned"
+  | "active"
+  | "blocked"
+  | "review"
+  | "ready"
+  | "done"
+  | "cancelled"
+  | "detached";
+
+export type PinetLaneRole =
+  | "broker"
+  | "coordinator"
+  | "pm"
+  | "lead"
+  | "implementer"
+  | "reviewer"
+  | "second_pass_reviewer"
+  | "observer";
+
+export interface PinetLaneParticipantInfo {
+  laneId: string;
+  agentId: string;
+  role: PinetLaneRole;
+  status: string | null;
+  summary: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+  lastActivityAt: string;
+}
+
+export interface PinetLaneInfo {
+  laneId: string;
+  name: string | null;
+  task: string | null;
+  issueNumber: number | null;
+  prNumber: number | null;
+  threadId: string | null;
+  ownerAgentId: string | null;
+  implementationLeadAgentId: string | null;
+  pmMode: boolean;
+  state: PinetLaneState;
+  summary: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+  lastActivityAt: string;
+  participants: PinetLaneParticipantInfo[];
+}
+
+export interface PinetLaneUpsertInput {
+  laneId: string;
+  name?: string | null;
+  task?: string | null;
+  issueNumber?: number | null;
+  prNumber?: number | null;
+  threadId?: string | null;
+  ownerAgentId?: string | null;
+  implementationLeadAgentId?: string | null;
+  pmMode?: boolean;
+  state?: PinetLaneState;
+  summary?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface PinetLaneParticipantUpsertInput {
+  laneId: string;
+  agentId: string;
+  role: PinetLaneRole;
+  status?: string | null;
+  summary?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface PinetLaneListOptions {
+  state?: PinetLaneState;
+  ownerAgentId?: string;
+  includeDone?: boolean;
+}
 // ─── Routing ──────────────────────────────────────────────
 
 export type RoutingDecision =

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -440,17 +440,19 @@ Only broker prompt content is replaceable. Broker runtime/tool restrictions rema
 
 ### Multi-agent tools
 
-| Tool    | Description                                                                                                         |
-| ------- | ------------------------------------------------------------------------------------------------------------------- |
-| `pinet` | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `schedule`, `agents`) |
+| Tool    | Description                                                                                                                  |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `pinet` | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `schedule`, `agents`, `lanes`) |
 
-Use the dispatcher for all Pinet actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=schedule`, and `pinet action=agents`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
+Use the dispatcher for all Pinet actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=schedule`, `pinet action=agents`, and `pinet action=lanes`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
 
 Dispatcher content defaults to terse CLI-style confirmations/summaries for noisy reads, sends, and agent lists. In default CLI mode, bulky read/agent payloads are also compacted in `data.details` so tool renderers do not surface full message bodies or agent metadata by accident. Pass `args.format="json"` (or `args.f` / `args["-f"]`) for the dispatcher envelope in content with full structured `data.details`, or `args.full=true` / `args["--full"]=true` for verbose text with full structured `data.details`.
 
 Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet action=read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
 
 Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are persisted/stamped as Pinet follow-up mail and surfaced through compact `pinet action=read` pointers rather than direct reminder-body prompts. Wake-up bodies and metadata are treated as mail content only; they do not trigger Pinet remote-control commands such as `/exit`, `/reload`, or structured `pinet:control` JSON.
+
+Durable lane metadata is stored in SQLite and can be inspected/updated with `pinet action=lanes`. PM-mode lanes can record the accountable follower/PM, implementation lead, participant roles (`pm`, `lead`, `implementer`, `reviewer`, `second_pass_reviewer`, etc.), linked issue/PR, state, and summary. The `detached` lane state means a lane is manually supervised by a human; broker/RALPH/status surfaces keep it visible but should not treat it as normal auto-reassignment work without explicit human/broker action.
 
 ### Broker commands
 

--- a/slack-bridge/agent-prompt-guidance.test.ts
+++ b/slack-bridge/agent-prompt-guidance.test.ts
@@ -178,7 +178,7 @@ describe("createAgentPromptGuidance", () => {
       result.systemPrompt.indexOf("TASK WORKFLOW:"),
     );
     expect(result.systemPrompt.indexOf("TASK WORKFLOW:")).toBeLessThan(
-      result.systemPrompt.indexOf("PINET DELEGATION RULES:"),
+      result.systemPrompt.indexOf("HELPER / DELEGATION RULES:"),
     );
   });
 });

--- a/slack-bridge/broker-prompt-loader.test.ts
+++ b/slack-bridge/broker-prompt-loader.test.ts
@@ -221,6 +221,18 @@ describe("packaged default broker prompt", () => {
     expect(defaultPrompt).toContain("{{agentEmoji}} {{agentName}}");
   });
 
+  it("documents consent-gated PM mode and durable lane metadata", async () => {
+    const defaultPromptPath = path.join(process.cwd(), "prompts", "broker", "default.md");
+    const defaultPrompt = await fs.readFile(defaultPromptPath, "utf8");
+
+    expect(defaultPrompt).toContain("PM MODE AWARENESS");
+    expect(defaultPrompt).toContain("consent-gated");
+    expect(defaultPrompt).toContain("nominates an implementation lead");
+    expect(defaultPrompt).toContain("pinet action=lanes");
+    expect(defaultPrompt).toContain("detached` lane means human/manual supervision");
+    expect(defaultPrompt).toContain("do not auto-reassign it as normal broker-managed work");
+  });
+
   it("documents safe repo-scoped follower startup before reporting capacity gaps", async () => {
     const defaultPromptPath = path.join(process.cwd(), "prompts", "broker", "default.md");
     const defaultPrompt = await fs.readFile(defaultPromptPath, "utf8");

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -8,7 +8,15 @@ import type {
   PinetReadResult,
   PinetUnreadThreadSummary,
 } from "@gugu910/pi-pinet-core/pinet-read-formatting";
-import type { ClientAgentInfo, NormalizedMessageContent } from "./types.js";
+import type {
+  ClientAgentInfo,
+  NormalizedMessageContent,
+  PinetLaneInfo,
+  PinetLaneListOptions,
+  PinetLaneParticipantInfo,
+  PinetLaneParticipantUpsertInput,
+  PinetLaneUpsertInput,
+} from "./types.js";
 
 // ─── Types ───────────────────────────────────────────────
 
@@ -51,6 +59,14 @@ export interface ScheduledWakeupInfo {
   threadId: string;
   fireAt: string;
 }
+
+export type {
+  PinetLaneInfo,
+  PinetLaneListOptions,
+  PinetLaneParticipantInfo,
+  PinetLaneParticipantUpsertInput,
+  PinetLaneUpsertInput,
+};
 
 // ─── JSON-RPC types ──────────────────────────────────────
 
@@ -512,6 +528,30 @@ export class BrokerClient {
       threadId: result.threadId,
       fireAt: result.fireAt,
     };
+  }
+
+  async listLanes(options: PinetLaneListOptions = {}): Promise<PinetLaneInfo[]> {
+    return (await this.request("lane.list", {
+      ...(options.state ? { state: options.state } : {}),
+      ...(options.ownerAgentId ? { ownerAgentId: options.ownerAgentId } : {}),
+      ...(typeof options.includeDone === "boolean" ? { includeDone: options.includeDone } : {}),
+    })) as PinetLaneInfo[];
+  }
+
+  async upsertLane(input: PinetLaneUpsertInput): Promise<PinetLaneInfo> {
+    return (await this.request(
+      "lane.upsert",
+      input as unknown as Record<string, unknown>,
+    )) as PinetLaneInfo;
+  }
+
+  async setLaneParticipant(
+    input: PinetLaneParticipantUpsertInput,
+  ): Promise<PinetLaneParticipantInfo> {
+    return (await this.request(
+      "lane.participant",
+      input as unknown as Record<string, unknown>,
+    )) as PinetLaneParticipantInfo;
   }
   // ─── Queries ─────────────────────────────────────────
 

--- a/slack-bridge/broker/control-plane-dashboard.test.ts
+++ b/slack-bridge/broker/control-plane-dashboard.test.ts
@@ -85,6 +85,44 @@ describe("buildBrokerControlPlaneDashboardSnapshot", () => {
           updatedAt: "2026-04-02T16:59:05.000Z",
         },
       ],
+      lanes: [
+        {
+          laneId: "issue-688",
+          name: "PM lane",
+          task: null,
+          issueNumber: 688,
+          prNumber: null,
+          threadId: "a2a:broker:pm",
+          ownerAgentId: "worker-1",
+          implementationLeadAgentId: "worker-1",
+          pmMode: true,
+          state: "active",
+          summary: "coordination active",
+          metadata: null,
+          createdAt: "2026-04-02T16:58:00.000Z",
+          updatedAt: "2026-04-02T17:00:06.000Z",
+          lastActivityAt: "2026-04-02T17:00:06.000Z",
+          participants: [],
+        },
+        {
+          laneId: "issue-123",
+          name: null,
+          task: null,
+          issueNumber: 123,
+          prNumber: null,
+          threadId: null,
+          ownerAgentId: "worker-2",
+          implementationLeadAgentId: null,
+          pmMode: false,
+          state: "detached",
+          summary: "manual supervision",
+          metadata: null,
+          createdAt: "2026-04-02T16:57:00.000Z",
+          updatedAt: "2026-04-02T17:00:07.000Z",
+          lastActivityAt: "2026-04-02T17:00:07.000Z",
+          participants: [],
+        },
+      ],
       recentCycles: [
         {
           startedAt: "2026-04-02T17:00:00.000Z",
@@ -113,5 +151,7 @@ describe("buildBrokerControlPlaneDashboardSnapshot", () => {
     expect(snapshot.roster[0]?.label).toContain("The Broker Otter");
     expect(snapshot.roster[1]?.taskSummary).toContain("#217 PR #221 open");
     expect(snapshot.recentOutcomes).toContain("#202 PR #205 merged");
+    expect(snapshot.activeLanes[0]).toContain("issue-688 [active]");
+    expect(snapshot.detachedLanes[0]).toContain("issue-123 [detached]");
   });
 });

--- a/slack-bridge/broker/control-plane-dashboard.ts
+++ b/slack-bridge/broker/control-plane-dashboard.ts
@@ -7,6 +7,7 @@ import type {
 import { buildAgentDisplayInfo, shortenPath } from "../helpers.js";
 import type { ResolvedTaskAssignment } from "../task-assignments.js";
 import type { BrokerMaintenanceResult } from "./maintenance.js";
+import type { PinetLaneInfo } from "./types.js";
 
 export type BrokerControlPlaneRecentCycle = {
   startedAt: string;
@@ -62,6 +63,8 @@ export interface BrokerControlPlaneDashboardSnapshot {
   };
   activeTasks: string[];
   recentOutcomes: string[];
+  activeLanes: string[];
+  detachedLanes: string[];
   roster: BrokerControlPlaneAgentRow[];
   recentCycles: Array<{
     startedAt: string;
@@ -86,6 +89,7 @@ export interface BuildBrokerControlPlaneDashboardSnapshotInput {
       "agentId" | "issueNumber" | "branch" | "status" | "prNumber" | "updatedAt" | "issueState"
     >
   >;
+  lanes?: PinetLaneInfo[];
   recentCycles: BrokerControlPlaneRecentCycle[];
   cycleStartedAt: string;
   cycleDurationMs: number;
@@ -152,6 +156,17 @@ function formatTaskStatusShort(
     default:
       return `#${assignment.issueNumber} assigned`;
   }
+}
+
+function formatLaneStatusShort(lane: PinetLaneInfo): string {
+  const refs = [
+    lane.issueNumber != null ? `#${lane.issueNumber}` : null,
+    lane.prNumber != null ? `PR #${lane.prNumber}` : null,
+    lane.pmMode ? "PM" : null,
+  ].filter((ref): ref is string => Boolean(ref));
+  const owner = lane.ownerAgentId ? ` owner ${lane.ownerAgentId}` : "";
+  const lead = lane.implementationLeadAgentId ? ` lead ${lane.implementationLeadAgentId}` : "";
+  return `${lane.laneId} [${lane.state}]${refs.length > 0 ? ` (${refs.join(" · ")})` : ""}${owner}${lead}${lane.summary ? ` — ${lane.summary}` : ""}`;
 }
 
 function summarizeAgentTasks(
@@ -248,6 +263,9 @@ export function buildBrokerControlPlaneDashboardSnapshot(
   const sortedAssignments = [...visibleAssignments].sort(
     (left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt),
   );
+  const sortedLanes = [...(input.lanes ?? [])].sort(
+    (left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt),
+  );
   const activeTasks = sortedAssignments
     .filter(
       (assignment) =>
@@ -294,6 +312,16 @@ export function buildBrokerControlPlaneDashboardSnapshot(
     },
     activeTasks,
     recentOutcomes,
+    activeLanes: sortedLanes
+      .filter(
+        (lane) => lane.state !== "done" && lane.state !== "cancelled" && lane.state !== "detached",
+      )
+      .map(formatLaneStatusShort)
+      .slice(0, 8),
+    detachedLanes: sortedLanes
+      .filter((lane) => lane.state === "detached")
+      .map(formatLaneStatusShort)
+      .slice(0, 8),
     roster,
     recentCycles: input.recentCycles.slice(0, 5).map((cycle) => ({
       startedAt: formatTimestamp(cycle.startedAt),

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -90,6 +90,22 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     ]);
   });
 
+  it("rejects invalid lane metadata values through follower RPC", async () => {
+    await client.register("pm-agent", "🧭");
+
+    await expect(
+      client.upsertLane({ laneId: "issue-invalid", state: "bogus" as never }),
+    ).rejects.toThrow("Invalid Pinet lane state");
+    await client.upsertLane({ laneId: "issue-invalid" });
+    await expect(
+      client.setLaneParticipant({
+        laneId: "issue-invalid",
+        agentId: "pm-agent",
+        role: "helper" as never,
+      }),
+    ).rejects.toThrow("Invalid Pinet lane role");
+  });
+
   it("register → send → pollInbox → ack (full path)", async () => {
     // Register two agents
     const reg1 = await client.register("sender-agent", "📤");

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -59,6 +59,37 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     cleanup(dir);
   });
 
+  it("persists lane metadata through follower RPC", async () => {
+    const reg = await client.register("pm-agent", "🧭");
+
+    const lane = await client.upsertLane({
+      laneId: "issue-688",
+      name: "Issue #688 PM lane",
+      issueNumber: 688,
+      ownerAgentId: reg.agentId,
+      pmMode: true,
+      state: "active",
+      summary: "Maintainer-consented PM coordination.",
+    });
+    const participant = await client.setLaneParticipant({
+      laneId: lane.laneId,
+      agentId: reg.agentId,
+      role: "pm",
+      status: "coordinating",
+    });
+
+    expect(participant.agentId).toBe(reg.agentId);
+    expect(participant.role).toBe("pm");
+    await expect(client.listLanes({ ownerAgentId: reg.agentId })).resolves.toEqual([
+      expect.objectContaining({
+        laneId: "issue-688",
+        ownerAgentId: reg.agentId,
+        pmMode: true,
+        participants: [expect.objectContaining({ agentId: reg.agentId, role: "pm" })],
+      }),
+    ]);
+  });
+
   it("register → send → pollInbox → ack (full path)", async () => {
     // Register two agents
     const reg1 = await client.register("sender-agent", "📤");

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -1013,7 +1013,12 @@ export class BrokerSocketServer {
       ...(typeof params.ownerAgentId === "string" ? { ownerAgentId: params.ownerAgentId } : {}),
       ...(typeof params.includeDone === "boolean" ? { includeDone: params.includeDone } : {}),
     };
-    return rpcOk(req.id, this.db.listPinetLanes(options));
+    try {
+      return rpcOk(req.id, this.db.listPinetLanes(options));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return rpcError(req.id, RPC_INVALID_PARAMS, message);
+    }
   }
 
   private handleLaneUpsert(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -18,6 +18,11 @@ import type {
   JsonRpcError,
   MessageAdapter,
   NormalizedMessageContent,
+  PinetLaneListOptions,
+  PinetLaneParticipantUpsertInput,
+  PinetLaneRole,
+  PinetLaneState,
+  PinetLaneUpsertInput,
 } from "./types.js";
 import {
   RPC_PARSE_ERROR,
@@ -497,6 +502,12 @@ export class BrokerSocketServer {
           return this.handleAgentMessage(req, state);
         case "agent.broadcast":
           return this.handleAgentBroadcast(req, state);
+        case "lane.list":
+          return this.handleLaneList(req, state);
+        case "lane.upsert":
+          return this.handleLaneUpsert(req, state);
+        case "lane.participant":
+          return this.handleLaneParticipant(req, state);
         case "schedule.create":
           return this.handleScheduleCreate(req, state);
         case "status.update":
@@ -989,6 +1000,117 @@ export class BrokerSocketServer {
       RPC_INVALID_PARAMS,
       "Broadcast channels are broker-only and cannot be sent by connected clients.",
     );
+  }
+
+  private handleLaneList(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
+    const params = req.params ?? {};
+    const options: PinetLaneListOptions = {
+      ...(typeof params.state === "string" ? { state: params.state as PinetLaneState } : {}),
+      ...(typeof params.ownerAgentId === "string" ? { ownerAgentId: params.ownerAgentId } : {}),
+      ...(typeof params.includeDone === "boolean" ? { includeDone: params.includeDone } : {}),
+    };
+    return rpcOk(req.id, this.db.listPinetLanes(options));
+  }
+
+  private handleLaneUpsert(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
+    const params = req.params ?? {};
+    if (typeof params.laneId !== "string" || params.laneId.trim().length === 0) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "laneId is required");
+    }
+
+    const input: PinetLaneUpsertInput = {
+      laneId: params.laneId,
+      ...(typeof params.name === "string" || params.name === null
+        ? { name: params.name as string | null }
+        : {}),
+      ...(typeof params.task === "string" || params.task === null
+        ? { task: params.task as string | null }
+        : {}),
+      ...(typeof params.issueNumber === "number" || params.issueNumber === null
+        ? { issueNumber: params.issueNumber as number | null }
+        : {}),
+      ...(typeof params.prNumber === "number" || params.prNumber === null
+        ? { prNumber: params.prNumber as number | null }
+        : {}),
+      ...(typeof params.threadId === "string" || params.threadId === null
+        ? { threadId: params.threadId as string | null }
+        : {}),
+      ...(typeof params.ownerAgentId === "string" || params.ownerAgentId === null
+        ? { ownerAgentId: params.ownerAgentId as string | null }
+        : {}),
+      ...(typeof params.implementationLeadAgentId === "string" ||
+      params.implementationLeadAgentId === null
+        ? { implementationLeadAgentId: params.implementationLeadAgentId as string | null }
+        : {}),
+      ...(typeof params.pmMode === "boolean" ? { pmMode: params.pmMode } : {}),
+      ...(typeof params.state === "string" ? { state: params.state as PinetLaneState } : {}),
+      ...(typeof params.summary === "string" || params.summary === null
+        ? { summary: params.summary as string | null }
+        : {}),
+      ...(params.metadata && typeof params.metadata === "object" && !Array.isArray(params.metadata)
+        ? { metadata: params.metadata as Record<string, unknown> }
+        : params.metadata === null
+          ? { metadata: null }
+          : {}),
+    };
+
+    try {
+      const lane = this.db.upsertPinetLane(input);
+      this.db.touchAgentActivity(state.agentId);
+      return rpcOk(req.id, lane);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return rpcError(req.id, RPC_INVALID_PARAMS, message);
+    }
+  }
+
+  private handleLaneParticipant(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
+    const params = req.params ?? {};
+    if (typeof params.laneId !== "string" || params.laneId.trim().length === 0) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "laneId is required");
+    }
+
+    const agentId =
+      typeof params.agentId === "string" && params.agentId.trim().length > 0
+        ? params.agentId
+        : state.agentId;
+    const input: PinetLaneParticipantUpsertInput = {
+      laneId: params.laneId,
+      agentId,
+      role: (typeof params.role === "string" ? params.role : "observer") as PinetLaneRole,
+      ...(typeof params.status === "string" || params.status === null
+        ? { status: params.status as string | null }
+        : {}),
+      ...(typeof params.summary === "string" || params.summary === null
+        ? { summary: params.summary as string | null }
+        : {}),
+      ...(params.metadata && typeof params.metadata === "object" && !Array.isArray(params.metadata)
+        ? { metadata: params.metadata as Record<string, unknown> }
+        : params.metadata === null
+          ? { metadata: null }
+          : {}),
+    };
+
+    try {
+      const participant = this.db.setPinetLaneParticipant(input);
+      this.db.touchAgentActivity(state.agentId);
+      return rpcOk(req.id, participant);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return rpcError(req.id, RPC_INVALID_PARAMS, message);
+    }
   }
 
   private handleScheduleCreate(req: JsonRpcRequest, state: ConnectionState): JsonRpcResponse {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1545,16 +1545,17 @@ describe("buildWorkerPromptGuidelines", () => {
   it("includes Pinet delegation guidance for connected workers", () => {
     const guidelines = buildWorkerPromptGuidelines();
     const joined = guidelines.join(" ");
-    expect(joined).toContain("PINET DELEGATION RULES");
+    expect(joined).toContain("HELPER / DELEGATION RULES");
     expect(joined).toContain("pinet action=agents");
     expect(joined).toContain("pinet action=send");
   });
 
-  it("tells workers not to use the Agent tool for mesh delegation", () => {
+  it("tells workers to prefer local subagents before connected-worker delegation", () => {
     const guidelines = buildWorkerPromptGuidelines();
     const joined = guidelines.join(" ");
-    expect(joined).toContain("do NOT use the Agent tool");
-    expect(joined).toContain("local subagent");
+    expect(joined).toContain("prefer configured local subagents/code-reviewer first");
+    expect(joined).toContain("Do NOT bounce review ownership");
+    expect(joined).toContain("no suitable local subagent is available");
   });
 
   it("requires delegated work to report status back through the thread", () => {
@@ -1571,6 +1572,8 @@ describe("buildWorkerPromptGuidelines", () => {
     expect(joined).toContain("same repo/worktree");
     expect(joined).toContain("maintainer priority/approval");
     expect(joined).toContain("maintainer approval");
+    expect(joined).toContain("PM mode");
+    expect(joined).toContain("pinet action=lanes");
     expect(joined).not.toContain("@gugu91");
   });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1672,12 +1672,16 @@ export function buildWorkerPromptGuidelines(): string[] {
     "- If you received a task in a Slack thread, reply via `slack_send` in that thread.",
     "- Never use the `slack` dispatcher `post_channel` action with a pinet thread ID (e.g. `a2a:...`) — it will fail. Pinet threads are not Slack channels.",
     "",
-    "PINET DELEGATION RULES:",
-    "- When you need another connected agent to take work or parallelize, do NOT use the Agent tool to spawn a local subagent for delegation.",
-    "- Prefer Pinet delegation: first use `pinet action=agents` with the target repo to find a suitable connected worker in the same repo/worktree, then delegate via `pinet action=send`.",
+    "HELPER / DELEGATION RULES:",
+    "- For helper analysis, planning, and review, prefer configured local subagents/code-reviewer first when available. You own the connected Pinet lane and must summarize any local subagent output back in the original Pinet/Slack thread.",
+    "- Do NOT bounce review ownership to another connected worker merely so that worker can invoke a local subagent; invoke the local helper yourself when suitable.",
+    "- Use Pinet delegation to another connected worker only when no suitable local subagent is available, a connected session/worktree is explicitly needed, or the broker has explicitly instructed maintainer-consented PM mode.",
+    "- In PM mode, remain accountable: nominate an implementation lead, delegate implementation, coordinate blockers/status, act as second-pass reviewer, and coordinate merge readiness.",
+    "- Before delegating through Pinet, call `pinet action=agents` with the target repo to find a suitable connected worker in the same repo/worktree, then delegate via `pinet action=send`.",
     "- Keep delegation inside the Pinet or Slack thread so ACKs, blockers, status updates, and final results flow back to the original sender.",
     "- Do not start or delegate extension changes unless the request names a GitHub issue/PR with clear maintainer priority/approval; if missing or unclear, ask first.",
     "- When delegating, include the workflow (`ack/work/ask/report`), the task, issue/PR numbers, maintainer approval, repo/branch/worktree setup, important files, acceptance criteria, and where to reply.",
+    "- Use `pinet action=lanes` to keep PM-mode or complex coordination lane metadata durable when the broker asks you to track lane state/roles.",
   ];
 }
 

--- a/slack-bridge/home-tab.test.ts
+++ b/slack-bridge/home-tab.test.ts
@@ -37,6 +37,8 @@ describe("renderBrokerControlPlaneHomeTabView", () => {
       },
       activeTasks: ["#217 PR #225 open"],
       recentOutcomes: ["#205 PR #205 merged"],
+      activeLanes: ["issue-688 [active] (#688 · PM) owner worker-pm"],
+      detachedLanes: ["issue-123 [detached] (#123) — manual"],
       roster: [
         {
           id: "broker-1",

--- a/slack-bridge/home-tab.test.ts
+++ b/slack-bridge/home-tab.test.ts
@@ -80,6 +80,18 @@ describe("renderBrokerControlPlaneHomeTabView", () => {
         }),
         expect.objectContaining({
           type: "header",
+          text: expect.objectContaining({ text: "Lane metadata" }),
+        }),
+        expect.objectContaining({
+          type: "header",
+          text: expect.objectContaining({ text: "Active/managed lanes" }),
+        }),
+        expect.objectContaining({
+          type: "header",
+          text: expect.objectContaining({ text: "Detached/manual-supervision lanes" }),
+        }),
+        expect.objectContaining({
+          type: "header",
           text: expect.objectContaining({ text: "Recent RALPH cycles" }),
         }),
       ]),
@@ -88,6 +100,8 @@ describe("renderBrokerControlPlaneHomeTabView", () => {
     expect(JSON.stringify(view)).toContain("ghost agents detected: ghost-1");
     expect(JSON.stringify(view)).toContain("🦦 The Broker Otter");
     expect(JSON.stringify(view)).toContain("#217 PR #225 open");
+    expect(JSON.stringify(view)).toContain("issue-688 [active]");
+    expect(JSON.stringify(view)).toContain("issue-123 [detached]");
   });
 });
 

--- a/slack-bridge/home-tab.ts
+++ b/slack-bridge/home-tab.ts
@@ -237,6 +237,17 @@ export function renderBrokerControlPlaneHomeTabView(
       snapshot.recentOutcomes.map((task) => `• ${task}`),
       "No merged or closed PR outcomes tracked yet.",
     ),
+    headerBlock("Lane metadata"),
+    headerBlock("Active/managed lanes"),
+    ...buildLineSections(
+      snapshot.activeLanes.map((lane) => `• ${lane}`),
+      "No active managed lanes tracked.",
+    ),
+    headerBlock("Detached/manual-supervision lanes"),
+    ...buildLineSections(
+      snapshot.detachedLanes.map((lane) => `• ${lane}`),
+      "No detached lanes tracked.",
+    ),
     headerBlock("Recent RALPH cycles"),
     ...buildLineSections(cycleLines, "No recorded RALPH cycles yet."),
     dividerBlock(),

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -19,6 +19,11 @@ import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
 import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
+import type {
+  PinetLaneListOptions,
+  PinetLaneParticipantUpsertInput,
+  PinetLaneUpsertInput,
+} from "./broker/types.js";
 import { dispatchDirectAgentMessage } from "./broker/agent-messaging.js";
 import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
@@ -855,6 +860,46 @@ export default function (pi: ExtensionAPI) {
     listFollowerAgents,
   } = pinetMeshOps;
 
+  async function listPinetLanes(options: PinetLaneListOptions) {
+    if (brokerRole === "broker") {
+      const db = getActiveBrokerDb();
+      if (!db) throw new Error("Broker database is unavailable.");
+      return db.listPinetLanes(options);
+    }
+    if (brokerRole === "follower" && brokerClient?.client) {
+      return await brokerClient.client.listLanes(options);
+    }
+    throw new Error("Pinet is in an unexpected state.");
+  }
+
+  async function upsertPinetLane(input: PinetLaneUpsertInput) {
+    if (brokerRole === "broker") {
+      const db = getActiveBrokerDb();
+      if (!db) throw new Error("Broker database is unavailable.");
+      return db.upsertPinetLane(input);
+    }
+    if (brokerRole === "follower" && brokerClient?.client) {
+      return await brokerClient.client.upsertLane(input);
+    }
+    throw new Error("Pinet is in an unexpected state.");
+  }
+
+  async function setPinetLaneParticipant(input: PinetLaneParticipantUpsertInput) {
+    if (brokerRole === "broker") {
+      const db = getActiveBrokerDb();
+      const selfId = getActiveBrokerSelfId();
+      if (!db) throw new Error("Broker database is unavailable.");
+      return db.setPinetLaneParticipant({
+        ...input,
+        agentId: input.agentId.trim().length > 0 ? input.agentId : (selfId ?? input.agentId),
+      });
+    }
+    if (brokerRole === "follower" && brokerClient?.client) {
+      return await brokerClient.client.setLaneParticipant(input);
+    }
+    throw new Error("Pinet is in an unexpected state.");
+  }
+
   async function readPinetInbox(options: {
     threadId?: string;
     limit?: number;
@@ -1097,6 +1142,9 @@ export default function (pi: ExtensionAPI) {
       readPinetInbox,
       listBrokerAgents,
       listFollowerAgents,
+      listPinetLanes,
+      upsertPinetLane,
+      setPinetLaneParticipant,
     },
     iMessageTools: {
       pinetEnabled: () => pinetEnabled,

--- a/slack-bridge/pinet-control-plane-dashboard.test.ts
+++ b/slack-bridge/pinet-control-plane-dashboard.test.ts
@@ -25,6 +25,44 @@ function createDb() {
     getOwnedThreadCount: (agentId: string) => (agentId === "worker-1" ? 1 : 0),
     getBacklogCount: () => 3,
     listTaskAssignments: () => [],
+    listPinetLanes: () => [
+      {
+        laneId: "issue-688",
+        name: "PM lane",
+        task: null,
+        issueNumber: 688,
+        prNumber: null,
+        threadId: "a2a:broker:pm",
+        ownerAgentId: "worker-1",
+        implementationLeadAgentId: "worker-1",
+        pmMode: true,
+        state: "active" as const,
+        summary: "coordination active",
+        metadata: null,
+        createdAt: "2026-05-02T18:29:00.000Z",
+        updatedAt: "2026-05-02T18:30:00.000Z",
+        lastActivityAt: "2026-05-02T18:30:00.000Z",
+        participants: [],
+      },
+      {
+        laneId: "issue-123",
+        name: null,
+        task: null,
+        issueNumber: 123,
+        prNumber: null,
+        threadId: null,
+        ownerAgentId: "worker-2",
+        implementationLeadAgentId: null,
+        pmMode: false,
+        state: "detached" as const,
+        summary: "manual supervision",
+        metadata: null,
+        createdAt: "2026-05-02T18:28:00.000Z",
+        updatedAt: "2026-05-02T18:30:30.000Z",
+        lastActivityAt: "2026-05-02T18:30:30.000Z",
+        participants: [],
+      },
+    ],
     getMessagesByIds: () => [],
     getRecentRalphCycles: () => [],
   };
@@ -60,6 +98,8 @@ describe("createPinetControlPlaneDashboard", () => {
       assignedBacklogCount: 1,
     });
     expect(snapshot?.roster.map((row) => row.id)).toEqual(["broker-1", "worker-1"]);
+    expect(snapshot?.activeLanes[0]).toContain("issue-688 [active]");
+    expect(snapshot?.detachedLanes[0]).toContain("issue-123 [detached]");
   });
 
   it("returns null when no broker database is active", async () => {

--- a/slack-bridge/pinet-control-plane-dashboard.ts
+++ b/slack-bridge/pinet-control-plane-dashboard.ts
@@ -10,7 +10,7 @@ import {
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
 import type { BrokerMaintenanceResult } from "./broker/maintenance.js";
-import type { TaskAssignmentInfo } from "./broker/types.js";
+import type { PinetLaneInfo, TaskAssignmentInfo } from "./broker/types.js";
 import {
   buildBrokerControlPlaneDashboardSnapshot,
   type BrokerControlPlaneDashboardSnapshot,
@@ -38,6 +38,7 @@ export interface PinetControlPlaneDashboardBrokerDbPort {
   getOwnedThreadCount: (agentId: string) => number;
   getBacklogCount: (status: "pending") => number;
   listTaskAssignments: () => TaskAssignmentInfo[];
+  listPinetLanes: (options?: { includeDone?: boolean }) => PinetLaneInfo[];
   getMessagesByIds: (ids: number[]) => PinetControlPlaneDashboardMessageRecord[];
   getRecentRalphCycles: (limit: number) => BrokerControlPlaneRecentCycle[];
 }
@@ -137,6 +138,7 @@ export function createPinetControlPlaneDashboard(
       evaluationOptions,
       maintenance: deps.getLastMaintenance(),
       assignments: projectedAssignments,
+      lanes: db.listPinetLanes({ includeDone: true }),
       recentCycles: recentRalphCycles,
       cycleStartedAt,
       cycleDurationMs: 0,

--- a/slack-bridge/pinet-home-tabs.test.ts
+++ b/slack-bridge/pinet-home-tabs.test.ts
@@ -149,6 +149,12 @@ describe("createPinetHomeTabs", () => {
       "xoxb-test",
       expect.objectContaining({ user_id: "U456" }),
     );
+    const firstPublishBody = (slack.mock.calls[0] as unknown[] | undefined)?.[2] as
+      | Record<string, unknown>
+      | undefined;
+    expect(JSON.stringify(firstPublishBody)).toContain("Lane metadata");
+    expect(JSON.stringify(firstPublishBody)).toContain("issue-688 [active]");
+    expect(JSON.stringify(firstPublishBody)).toContain("issue-123 [detached]");
     expect(notify).not.toHaveBeenCalled();
   });
 

--- a/slack-bridge/pinet-home-tabs.test.ts
+++ b/slack-bridge/pinet-home-tabs.test.ts
@@ -64,6 +64,8 @@ function createBrokerSnapshot(): BrokerControlPlaneDashboardSnapshot {
     },
     activeTasks: ["#217 PR #225 open"],
     recentOutcomes: ["#205 PR #205 merged"],
+    activeLanes: ["issue-688 [active] (#688 · PM) owner worker-pm"],
+    detachedLanes: ["issue-123 [detached] (#123) — manual"],
     roster: [
       {
         id: "broker-1",

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -597,6 +597,58 @@ describe("registerPinetTools", () => {
     expect(participantResult.details.data.text).toContain("participant worker-pm saved as pm");
   });
 
+  it("passes explicit null clears through the lanes dispatcher", async () => {
+    const upsertPinetLane = vi.fn(createDeps().upsertPinetLane);
+    const setPinetLaneParticipant = vi.fn(createDeps().setPinetLaneParticipant);
+    const tools = registerWithDeps(createDeps({ upsertPinetLane, setPinetLaneParticipant }));
+
+    await tools.get("pinet")?.execute("tool-call-lane-clear", {
+      action: "lanes",
+      args: {
+        op: "upsert",
+        lane_id: "issue-688",
+        pr_number: null,
+        owner_agent: null,
+        implementation_lead: null,
+        summary: null,
+        metadata: null,
+      },
+    });
+    await tools.get("pinet")?.execute("tool-call-participant-clear", {
+      action: "lanes",
+      args: {
+        op: "participant",
+        lane_id: "issue-688",
+        agent_id: "worker-pm",
+        lane_role: "observer",
+        status: null,
+        summary: null,
+        metadata: null,
+      },
+    });
+
+    expect(upsertPinetLane).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneId: "issue-688",
+        prNumber: null,
+        ownerAgentId: null,
+        implementationLeadAgentId: null,
+        summary: null,
+        metadata: null,
+      }),
+    );
+    expect(setPinetLaneParticipant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneId: "issue-688",
+        agentId: "worker-pm",
+        role: "observer",
+        status: null,
+        summary: null,
+        metadata: null,
+      }),
+    );
+  });
+
   it("renders detached lanes only when explicitly included or filtered", async () => {
     const listPinetLanes = vi.fn(async () => [
       {

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -55,6 +55,36 @@ function createDeps(overrides: Partial<RegisterPinetToolsDeps> = {}): RegisterPi
     }),
     listBrokerAgents: () => [makeAgent()],
     listFollowerAgents: async (_includeGhosts: boolean) => [makeAgent({ id: "agent-2" })],
+    listPinetLanes: async () => [],
+    upsertPinetLane: async (input) => ({
+      laneId: input.laneId,
+      name: input.name ?? null,
+      task: input.task ?? null,
+      issueNumber: input.issueNumber ?? null,
+      prNumber: input.prNumber ?? null,
+      threadId: input.threadId ?? null,
+      ownerAgentId: input.ownerAgentId ?? null,
+      implementationLeadAgentId: input.implementationLeadAgentId ?? null,
+      pmMode: input.pmMode ?? false,
+      state: input.state ?? "active",
+      summary: input.summary ?? null,
+      metadata: input.metadata ?? null,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      lastActivityAt: "2026-05-01T00:00:00.000Z",
+      participants: [],
+    }),
+    setPinetLaneParticipant: async (input) => ({
+      laneId: input.laneId,
+      agentId: input.agentId,
+      role: input.role,
+      status: input.status ?? null,
+      summary: input.summary ?? null,
+      metadata: input.metadata ?? null,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      lastActivityAt: "2026-05-01T00:00:00.000Z",
+    }),
   };
 
   return { ...defaults, ...overrides };
@@ -91,7 +121,7 @@ describe("registerPinetTools", () => {
     expect(pinet?.promptSnippet).toContain("Use this compact dispatcher for Pinet actions");
     expect(pinet?.promptSnippet).toContain('args.format="json"');
     expect(JSON.stringify(pinet?.parameters)).toContain(
-      "help, send, read, free, schedule, or agents",
+      "help, send, read, free, schedule, agents, lanes, or help",
     );
   });
 
@@ -395,6 +425,7 @@ describe("registerPinetTools", () => {
         expect.objectContaining({ action: "free", guardrail_tool: "pinet:free" }),
         expect.objectContaining({ action: "schedule", guardrail_tool: "pinet:schedule" }),
         expect.objectContaining({ action: "agents", guardrail_tool: "pinet:agents" }),
+        expect.objectContaining({ action: "lanes", guardrail_tool: "pinet:lanes" }),
       ]),
     );
   });
@@ -512,6 +543,91 @@ describe("registerPinetTools", () => {
     expect(scheduleBrokerWakeup).toHaveBeenCalledWith("2026-04-14T12:05:00.000Z", "check queue");
     expect(result.details.data.text).toBe("Pinet wake-up scheduled for 2026-04-14T12:05:00.000Z.");
     expect(result.details.data.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
+  });
+
+  it("updates durable PM lane metadata through the lanes dispatcher", async () => {
+    const upsertPinetLane = vi.fn(createDeps().upsertPinetLane);
+    const setPinetLaneParticipant = vi.fn(createDeps().setPinetLaneParticipant);
+    const deps = createDeps({ upsertPinetLane, setPinetLaneParticipant });
+    const tools = registerWithDeps(deps);
+
+    const laneResult = (await tools.get("pinet")?.execute("tool-call-lane-upsert", {
+      action: "lanes",
+      args: {
+        op: "upsert",
+        lane_id: "issue-688",
+        issue_number: 688,
+        owner_agent: "worker-pm",
+        implementation_lead: "worker-lead",
+        pm_mode: true,
+        state: "active",
+        summary: "maintainer-consented PM mode",
+        full: true,
+      },
+    })) as {
+      details: { status: string; data: { text: string; details: { lane: { pmMode: boolean } } } };
+    };
+
+    const participantResult = (await tools.get("pinet")?.execute("tool-call-lane-participant", {
+      action: "lanes",
+      args: {
+        op: "participant",
+        lane_id: "issue-688",
+        agent_id: "worker-pm",
+        lane_role: "pm",
+        status: "coordinating",
+      },
+    })) as { details: { status: string; data: { text: string } } };
+
+    expect(upsertPinetLane).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneId: "issue-688",
+        issueNumber: 688,
+        ownerAgentId: "worker-pm",
+        implementationLeadAgentId: "worker-lead",
+        pmMode: true,
+        state: "active",
+      }),
+    );
+    expect(setPinetLaneParticipant).toHaveBeenCalledWith(
+      expect.objectContaining({ laneId: "issue-688", agentId: "worker-pm", role: "pm" }),
+    );
+    expect(laneResult.details.status).toBe("succeeded");
+    expect(laneResult.details.data.details.lane.pmMode).toBe(true);
+    expect(participantResult.details.data.text).toContain("participant worker-pm saved as pm");
+  });
+
+  it("renders detached lanes only when explicitly included or filtered", async () => {
+    const listPinetLanes = vi.fn(async () => [
+      {
+        laneId: "issue-123",
+        name: null,
+        task: null,
+        issueNumber: 123,
+        prNumber: null,
+        threadId: null,
+        ownerAgentId: "worker-human",
+        implementationLeadAgentId: null,
+        pmMode: false,
+        state: "detached" as const,
+        summary: "manual supervision",
+        metadata: null,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+        lastActivityAt: "2026-05-01T00:00:00.000Z",
+        participants: [],
+      },
+    ]);
+    const tools = registerWithDeps(createDeps({ listPinetLanes }));
+
+    const result = (await tools.get("pinet")?.execute("tool-call-lanes-list", {
+      action: "lanes",
+      args: { state: "detached", full: true },
+    })) as { details: { data: { text: string } } };
+
+    expect(listPinetLanes).toHaveBeenCalledWith({ state: "detached" });
+    expect(result.details.data.text).toContain("issue-123 [detached]");
+    expect(result.details.data.text).toContain("manual supervision");
   });
 
   it("renders broker pinet agents output with routing hints and outbound counts", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -23,6 +23,15 @@ import {
 import { isBroadcastChannelTarget } from "./broker/agent-messaging.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import type {
+  PinetLaneInfo,
+  PinetLaneListOptions,
+  PinetLaneParticipantInfo,
+  PinetLaneParticipantUpsertInput,
+  PinetLaneRole,
+  PinetLaneState,
+  PinetLaneUpsertInput,
+} from "./broker/types.js";
 
 export interface PinetToolsAgentRecord {
   emoji: string;
@@ -69,6 +78,11 @@ export interface RegisterPinetToolsDeps {
   readPinetInbox: (options: PinetReadOptions) => Promise<PinetReadResult>;
   listBrokerAgents: () => PinetToolsAgentRecord[];
   listFollowerAgents: (includeGhosts: boolean) => Promise<PinetToolsAgentRecord[]>;
+  listPinetLanes: (options: PinetLaneListOptions) => Promise<PinetLaneInfo[]>;
+  upsertPinetLane: (input: PinetLaneUpsertInput) => Promise<PinetLaneInfo>;
+  setPinetLaneParticipant: (
+    input: PinetLaneParticipantUpsertInput,
+  ) => Promise<PinetLaneParticipantInfo>;
 }
 
 interface PinetAgentsRoutingHint {
@@ -79,7 +93,7 @@ interface PinetAgentsRoutingHint {
   task?: string;
 }
 
-type PinetDispatcherAction = "send" | "read" | "free" | "schedule" | "agents" | "help";
+type PinetDispatcherAction = "send" | "read" | "free" | "schedule" | "agents" | "lanes" | "help";
 type PinetDispatcherErrorClass = "input" | "state" | "runtime" | "network";
 
 type PinetDispatcherStatus = "succeeded" | "failed";
@@ -125,6 +139,19 @@ const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
   free: [{ action: "free", args: { note: "Wrapped up <issue>" } }],
   schedule: [{ action: "schedule", args: { delay: "30m", message: "Check queue state" } }],
   agents: [{ action: "agents", args: { repo: "<repo>", role: "worker", full: true } }],
+  lanes: [
+    { action: "lanes", args: { op: "list", full: true } },
+    {
+      action: "lanes",
+      args: {
+        op: "upsert",
+        lane_id: "issue-688",
+        issue_number: 688,
+        pm_mode: true,
+        state: "active",
+      },
+    },
+  ],
 };
 
 const PINET_OUTPUT_OPTION_PARAMETERS = {
@@ -165,7 +192,15 @@ function normalizeDispatcherAction(value: unknown): PinetDispatcherAction {
     throw new Error("action is required");
   }
 
-  const allowed: PinetDispatcherAction[] = ["help", "send", "read", "free", "schedule", "agents"];
+  const allowed: PinetDispatcherAction[] = [
+    "help",
+    "send",
+    "read",
+    "free",
+    "schedule",
+    "agents",
+    "lanes",
+  ];
   if (!allowed.includes(normalized)) {
     throw new Error(`Unknown Pinet action: ${normalized}`);
   }
@@ -587,6 +622,168 @@ function formatCompactAgentList(agents: AgentDisplayInfo[], hint: PinetAgentsRou
   return `Pinet agents: ${agents.length} visible${hintSuffix}.`;
 }
 
+function formatPinetLaneSummary(lane: PinetLaneInfo): string {
+  const refs = [
+    lane.issueNumber != null ? `#${lane.issueNumber}` : null,
+    lane.prNumber != null ? `PR #${lane.prNumber}` : null,
+    lane.pmMode ? "PM" : null,
+  ].filter((item): item is string => Boolean(item));
+  const participants = lane.participants
+    .slice(0, 4)
+    .map((participant) => `${participant.agentId}:${participant.role}`)
+    .join(", ");
+  return [
+    `- ${lane.laneId} [${lane.state}]${refs.length > 0 ? ` (${refs.join(" · ")})` : ""}`,
+    lane.name ? ` — ${lane.name}` : "",
+    lane.ownerAgentId ? ` owner=${lane.ownerAgentId}` : "",
+    lane.implementationLeadAgentId ? ` lead=${lane.implementationLeadAgentId}` : "",
+    participants ? ` participants=${participants}` : "",
+    lane.summary ? ` — ${lane.summary}` : "",
+  ].join("");
+}
+
+function formatPinetLanes(lanes: PinetLaneInfo[], full: boolean): string {
+  if (lanes.length === 0) return "Pinet lanes: none tracked.";
+  if (!full) return `Pinet lanes: ${lanes.length} tracked.`;
+  return ["Pinet lanes:", ...lanes.map(formatPinetLaneSummary)].join("\n");
+}
+
+function getMaybeString(params: Record<string, unknown>, key: string): string | undefined {
+  const value = params[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function getMaybeNumber(params: Record<string, unknown>, key: string): number | undefined {
+  const value = params[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function getMaybeBoolean(params: Record<string, unknown>, key: string): boolean | undefined {
+  const value = params[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function getMaybeMetadata(
+  params: Record<string, unknown>,
+): Record<string, unknown> | null | undefined {
+  const value = params.metadata;
+  if (value === null) return null;
+  return isRecord(value) ? value : undefined;
+}
+
+function runPinetLanesAction(
+  params: Record<string, unknown>,
+  deps: RegisterPinetToolsDeps,
+  toolName: string,
+  output: PinetOutputOptions,
+): Promise<PinetToolResult> {
+  return (async () => {
+    const op = getMaybeString(params, "op")?.toLowerCase() ?? "list";
+    deps.requireToolPolicy(toolName, undefined, `op=${op} | format=${output.format}`);
+    if (!deps.pinetEnabled()) {
+      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+    }
+
+    if (op === "list") {
+      const options: PinetLaneListOptions = {
+        ...(getMaybeString(params, "state")
+          ? { state: getMaybeString(params, "state") as PinetLaneState }
+          : {}),
+        ...(getMaybeString(params, "owner_agent")
+          ? { ownerAgentId: getMaybeString(params, "owner_agent") }
+          : {}),
+        ...(getMaybeBoolean(params, "include_done") !== undefined
+          ? { includeDone: getMaybeBoolean(params, "include_done") }
+          : {}),
+      };
+      const lanes = await deps.listPinetLanes(options);
+      return {
+        content: [{ type: "text", text: formatPinetLanes(lanes, output.full) }],
+        details: { lanes },
+        compactDetails: { laneCount: lanes.length, lanes: lanes.slice(0, 10) },
+        fullDetails: { lanes },
+      };
+    }
+
+    if (op === "upsert") {
+      const laneId = getMaybeString(params, "lane_id");
+      if (!laneId) throw new Error("lanes op=upsert requires lane_id");
+      const lane = await deps.upsertPinetLane({
+        laneId,
+        ...(getMaybeString(params, "name") ? { name: getMaybeString(params, "name") } : {}),
+        ...(getMaybeString(params, "task") ? { task: getMaybeString(params, "task") } : {}),
+        ...(getMaybeNumber(params, "issue_number") !== undefined
+          ? { issueNumber: getMaybeNumber(params, "issue_number") }
+          : {}),
+        ...(getMaybeNumber(params, "pr_number") !== undefined
+          ? { prNumber: getMaybeNumber(params, "pr_number") }
+          : {}),
+        ...(getMaybeString(params, "thread_id")
+          ? { threadId: getMaybeString(params, "thread_id") }
+          : {}),
+        ...(getMaybeString(params, "owner_agent")
+          ? { ownerAgentId: getMaybeString(params, "owner_agent") }
+          : {}),
+        ...(getMaybeString(params, "implementation_lead")
+          ? { implementationLeadAgentId: getMaybeString(params, "implementation_lead") }
+          : {}),
+        ...(getMaybeBoolean(params, "pm_mode") !== undefined
+          ? { pmMode: getMaybeBoolean(params, "pm_mode") }
+          : {}),
+        ...(getMaybeString(params, "state")
+          ? { state: getMaybeString(params, "state") as PinetLaneState }
+          : {}),
+        ...(getMaybeString(params, "summary")
+          ? { summary: getMaybeString(params, "summary") }
+          : {}),
+        ...(getMaybeMetadata(params) !== undefined ? { metadata: getMaybeMetadata(params) } : {}),
+      });
+      return {
+        content: [{ type: "text", text: `Pinet lane ${lane.laneId} saved (${lane.state}).` }],
+        details: { lane },
+        compactDetails: { laneId: lane.laneId, state: lane.state, pmMode: lane.pmMode },
+        fullDetails: { lane },
+      };
+    }
+
+    if (op === "participant") {
+      const laneId = getMaybeString(params, "lane_id");
+      if (!laneId) throw new Error("lanes op=participant requires lane_id");
+      const agentId = getMaybeString(params, "agent_id") ?? "";
+      const role = (getMaybeString(params, "lane_role") ??
+        getMaybeString(params, "role") ??
+        "observer") as PinetLaneRole;
+      const participant = await deps.setPinetLaneParticipant({
+        laneId,
+        agentId,
+        role,
+        ...(getMaybeString(params, "status") ? { status: getMaybeString(params, "status") } : {}),
+        ...(getMaybeString(params, "summary")
+          ? { summary: getMaybeString(params, "summary") }
+          : {}),
+        ...(getMaybeMetadata(params) !== undefined ? { metadata: getMaybeMetadata(params) } : {}),
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Pinet lane ${participant.laneId} participant ${participant.agentId} saved as ${participant.role}.`,
+          },
+        ],
+        details: { participant },
+        compactDetails: {
+          laneId: participant.laneId,
+          agentId: participant.agentId,
+          role: participant.role,
+        },
+        fullDetails: { participant },
+      };
+    }
+
+    throw new Error("lanes op must be list, upsert, or participant");
+  })();
+}
+
 function runPinetAgentsAction(
   params: Record<string, unknown>,
   deps: RegisterPinetToolsDeps,
@@ -753,16 +950,56 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     execute: (_id, params, output) => runPinetAgentsAction(params, deps, "pinet:agents", output),
   });
 
+  registerAction({
+    name: "lanes",
+    description:
+      "List or update durable Pinet lane metadata for PM-mode and complex coordination visibility.",
+    parameters: Type.Object({
+      op: Type.Optional(Type.String({ description: "Operation: list, upsert, or participant" })),
+      lane_id: Type.Optional(Type.String({ description: "Stable lane id, e.g. issue-688" })),
+      name: Type.Optional(Type.String({ description: "Human-readable lane name" })),
+      task: Type.Optional(Type.String({ description: "Short lane task description" })),
+      issue_number: Type.Optional(Type.Number({ description: "Linked GitHub issue number" })),
+      pr_number: Type.Optional(Type.Number({ description: "Linked GitHub PR number" })),
+      thread_id: Type.Optional(Type.String({ description: "Owning Pinet/Slack thread id" })),
+      owner_agent: Type.Optional(Type.String({ description: "Accountable follower/PM agent id" })),
+      implementation_lead: Type.Optional(
+        Type.String({ description: "Implementation lead agent id" }),
+      ),
+      agent_id: Type.Optional(
+        Type.String({ description: "Participant agent id for op=participant" }),
+      ),
+      lane_role: Type.Optional(
+        Type.String({ description: "Participant role, e.g. pm, lead, reviewer" }),
+      ),
+      pm_mode: Type.Optional(Type.Boolean({ description: "Whether PM mode is enabled" })),
+      state: Type.Optional(
+        Type.String({
+          description:
+            "Lane state: planned, active, blocked, review, ready, done, cancelled, detached",
+        }),
+      ),
+      status: Type.Optional(Type.String({ description: "Participant status" })),
+      summary: Type.Optional(Type.String({ description: "Short lane or participant summary" })),
+      metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+      include_done: Type.Optional(
+        Type.Boolean({ description: "Include done/cancelled/detached lanes in list output" }),
+      ),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
+    }),
+    execute: (_id, params, output) => runPinetLanesAction(params, deps, "pinet:lanes", output),
+  });
+
   pi.registerTool({
     name: "pinet",
     label: "Pinet Dispatcher",
     description:
       "Dispatch Pinet worker operations by action with compact help and schema discovery.",
     promptSnippet:
-      'Use this compact dispatcher for Pinet actions: send, read, free, schedule, agents, and help. Defaults to terse CLI text; pass args.format="json" or args.full=true for explicit detail.',
+      'Use this compact dispatcher for Pinet actions: send, read, free, schedule, agents, lanes, and help. Defaults to terse CLI text; pass args.format="json" or args.full=true for explicit detail.',
     parameters: Type.Object({
       action: Type.String({
-        description: "Action name: help, send, read, free, schedule, or agents.",
+        description: "Action name: help, send, read, free, schedule, agents, lanes, or help.",
       }),
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -653,19 +653,39 @@ function getMaybeString(params: Record<string, unknown>, key: string): string | 
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function getMaybeNumber(params: Record<string, unknown>, key: string): number | undefined {
-  const value = params[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
 function getMaybeBoolean(params: Record<string, unknown>, key: string): boolean | undefined {
   const value = params[key];
   return typeof value === "boolean" ? value : undefined;
 }
 
+function hasParam(params: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(params, key);
+}
+
+function getNullableStringUpdate(
+  params: Record<string, unknown>,
+  key: string,
+): string | null | undefined {
+  if (!hasParam(params, key)) return undefined;
+  const value = params[key];
+  if (value === null) return null;
+  return typeof value === "string" ? value : undefined;
+}
+
+function getNullableNumberUpdate(
+  params: Record<string, unknown>,
+  key: string,
+): number | null | undefined {
+  if (!hasParam(params, key)) return undefined;
+  const value = params[key];
+  if (value === null) return null;
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 function getMaybeMetadata(
   params: Record<string, unknown>,
 ): Record<string, unknown> | null | undefined {
+  if (!hasParam(params, "metadata")) return undefined;
   const value = params.metadata;
   if (value === null) return null;
   return isRecord(value) ? value : undefined;
@@ -710,22 +730,26 @@ function runPinetLanesAction(
       if (!laneId) throw new Error("lanes op=upsert requires lane_id");
       const lane = await deps.upsertPinetLane({
         laneId,
-        ...(getMaybeString(params, "name") ? { name: getMaybeString(params, "name") } : {}),
-        ...(getMaybeString(params, "task") ? { task: getMaybeString(params, "task") } : {}),
-        ...(getMaybeNumber(params, "issue_number") !== undefined
-          ? { issueNumber: getMaybeNumber(params, "issue_number") }
+        ...(getNullableStringUpdate(params, "name") !== undefined
+          ? { name: getNullableStringUpdate(params, "name") }
           : {}),
-        ...(getMaybeNumber(params, "pr_number") !== undefined
-          ? { prNumber: getMaybeNumber(params, "pr_number") }
+        ...(getNullableStringUpdate(params, "task") !== undefined
+          ? { task: getNullableStringUpdate(params, "task") }
           : {}),
-        ...(getMaybeString(params, "thread_id")
-          ? { threadId: getMaybeString(params, "thread_id") }
+        ...(getNullableNumberUpdate(params, "issue_number") !== undefined
+          ? { issueNumber: getNullableNumberUpdate(params, "issue_number") }
           : {}),
-        ...(getMaybeString(params, "owner_agent")
-          ? { ownerAgentId: getMaybeString(params, "owner_agent") }
+        ...(getNullableNumberUpdate(params, "pr_number") !== undefined
+          ? { prNumber: getNullableNumberUpdate(params, "pr_number") }
           : {}),
-        ...(getMaybeString(params, "implementation_lead")
-          ? { implementationLeadAgentId: getMaybeString(params, "implementation_lead") }
+        ...(getNullableStringUpdate(params, "thread_id") !== undefined
+          ? { threadId: getNullableStringUpdate(params, "thread_id") }
+          : {}),
+        ...(getNullableStringUpdate(params, "owner_agent") !== undefined
+          ? { ownerAgentId: getNullableStringUpdate(params, "owner_agent") }
+          : {}),
+        ...(getNullableStringUpdate(params, "implementation_lead") !== undefined
+          ? { implementationLeadAgentId: getNullableStringUpdate(params, "implementation_lead") }
           : {}),
         ...(getMaybeBoolean(params, "pm_mode") !== undefined
           ? { pmMode: getMaybeBoolean(params, "pm_mode") }
@@ -733,8 +757,8 @@ function runPinetLanesAction(
         ...(getMaybeString(params, "state")
           ? { state: getMaybeString(params, "state") as PinetLaneState }
           : {}),
-        ...(getMaybeString(params, "summary")
-          ? { summary: getMaybeString(params, "summary") }
+        ...(getNullableStringUpdate(params, "summary") !== undefined
+          ? { summary: getNullableStringUpdate(params, "summary") }
           : {}),
         ...(getMaybeMetadata(params) !== undefined ? { metadata: getMaybeMetadata(params) } : {}),
       });
@@ -757,9 +781,11 @@ function runPinetLanesAction(
         laneId,
         agentId,
         role,
-        ...(getMaybeString(params, "status") ? { status: getMaybeString(params, "status") } : {}),
-        ...(getMaybeString(params, "summary")
-          ? { summary: getMaybeString(params, "summary") }
+        ...(getNullableStringUpdate(params, "status") !== undefined
+          ? { status: getNullableStringUpdate(params, "status") }
+          : {}),
+        ...(getNullableStringUpdate(params, "summary") !== undefined
+          ? { summary: getNullableStringUpdate(params, "summary") }
           : {}),
         ...(getMaybeMetadata(params) !== undefined ? { metadata: getMaybeMetadata(params) } : {}),
       });
@@ -957,31 +983,74 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     parameters: Type.Object({
       op: Type.Optional(Type.String({ description: "Operation: list, upsert, or participant" })),
       lane_id: Type.Optional(Type.String({ description: "Stable lane id, e.g. issue-688" })),
-      name: Type.Optional(Type.String({ description: "Human-readable lane name" })),
-      task: Type.Optional(Type.String({ description: "Short lane task description" })),
-      issue_number: Type.Optional(Type.Number({ description: "Linked GitHub issue number" })),
-      pr_number: Type.Optional(Type.Number({ description: "Linked GitHub PR number" })),
-      thread_id: Type.Optional(Type.String({ description: "Owning Pinet/Slack thread id" })),
-      owner_agent: Type.Optional(Type.String({ description: "Accountable follower/PM agent id" })),
+      name: Type.Optional(
+        Type.Union([Type.String(), Type.Null()], { description: "Human-readable lane name" }),
+      ),
+      task: Type.Optional(
+        Type.Union([Type.String(), Type.Null()], { description: "Short lane task description" }),
+      ),
+      issue_number: Type.Optional(
+        Type.Union([Type.Number(), Type.Null()], { description: "Linked GitHub issue number" }),
+      ),
+      pr_number: Type.Optional(
+        Type.Union([Type.Number(), Type.Null()], { description: "Linked GitHub PR number" }),
+      ),
+      thread_id: Type.Optional(
+        Type.Union([Type.String(), Type.Null()], { description: "Owning Pinet/Slack thread id" }),
+      ),
+      owner_agent: Type.Optional(
+        Type.Union([Type.String(), Type.Null()], {
+          description: "Accountable follower/PM agent id",
+        }),
+      ),
       implementation_lead: Type.Optional(
-        Type.String({ description: "Implementation lead agent id" }),
+        Type.Union([Type.String(), Type.Null()], { description: "Implementation lead agent id" }),
       ),
       agent_id: Type.Optional(
         Type.String({ description: "Participant agent id for op=participant" }),
       ),
       lane_role: Type.Optional(
-        Type.String({ description: "Participant role, e.g. pm, lead, reviewer" }),
+        Type.Union(
+          [
+            Type.Literal("broker"),
+            Type.Literal("coordinator"),
+            Type.Literal("pm"),
+            Type.Literal("lead"),
+            Type.Literal("implementer"),
+            Type.Literal("reviewer"),
+            Type.Literal("second_pass_reviewer"),
+            Type.Literal("observer"),
+          ],
+          { description: "Participant role" },
+        ),
       ),
       pm_mode: Type.Optional(Type.Boolean({ description: "Whether PM mode is enabled" })),
       state: Type.Optional(
-        Type.String({
-          description:
-            "Lane state: planned, active, blocked, review, ready, done, cancelled, detached",
+        Type.Union(
+          [
+            Type.Literal("planned"),
+            Type.Literal("active"),
+            Type.Literal("blocked"),
+            Type.Literal("review"),
+            Type.Literal("ready"),
+            Type.Literal("done"),
+            Type.Literal("cancelled"),
+            Type.Literal("detached"),
+          ],
+          { description: "Lane state" },
+        ),
+      ),
+      status: Type.Optional(
+        Type.Union([Type.String(), Type.Null()], { description: "Participant status" }),
+      ),
+      summary: Type.Optional(
+        Type.Union([Type.String(), Type.Null()], {
+          description: "Short lane or participant summary",
         }),
       ),
-      status: Type.Optional(Type.String({ description: "Participant status" })),
-      summary: Type.Optional(Type.String({ description: "Short lane or participant summary" })),
-      metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+      metadata: Type.Optional(
+        Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()]),
+      ),
       include_done: Type.Optional(
         Type.Boolean({ description: "Include done/cancelled/detached lanes in list output" }),
       ),

--- a/slack-bridge/prompts/broker/default.md
+++ b/slack-bridge/prompts/broker/default.md
@@ -14,6 +14,8 @@ PRIORITIZED ISSUE GATE: Do not start, assign, or broadcast extension changes unl
 
 DELEGATE, THEN TRACK: Do not perform task triage yourself beyond checking explicit routing requirements already present in the request: repo, issue/PR number, maintainer approval, branch/worktree, and worker availability. If required routing facts are missing, ask; otherwise assign promptly.
 
+PM MODE AWARENESS: For complex or coordination-heavy maintainer-delegated tasks, offer PM mode instead of assuming it. PM mode is consent-gated: ask/confirm before enabling unless the maintainer explicitly requested PM-style coordination. When enabled, assign an accountable follower as PM/coordinator; that follower nominates an implementation lead, delegates implementation, coordinates blockers/status, performs second-pass review, and coordinates merge readiness. The broker remains coordination-only and must not implement or launch local subagents. Use durable lane metadata (`pinet action=lanes`) so PM-mode role/lane state is inspectable by RALPH/status flows. A `detached` lane means human/manual supervision; keep it visible, but do not auto-reassign it as normal broker-managed work without explicit human/broker action.
+
 DEEP INSPECTION BELONGS TO WORKERS: Connected workers/subagents own codebase investigation, diagnosis, implementation planning, and review details. Do NOT read through multiple source files, trace implementations, or inspect the codebase in detail before assigning the task.
 
 REPO-SCOPED DELEGATION: Always call `pinet action=agents` with the target repo and choose workers from that same repo/worktree. For extensions-repo work, delegate to healthy connected workers/subagents in that repo/worktree; never borrow idle workers from another repo. If no repo-matched worker is available, start repo-scoped Pinet follower capacity via the tmux flow when appropriate; only report the capacity gap if you cannot safely start a worker.
@@ -22,7 +24,7 @@ REPO-SCOPED BROADCASTS: New-issue, policy, and routing broadcasts are repository
 
 When a human asks for work to be done, ALWAYS check `pinet action=agents` for idle workers in the right repo and delegate via `pinet action=send`. Pick the agent on the right repo/branch when possible.
 
-If a repo instruction says to use the `code-reviewer` subagent, treat that as work to assign to a connected worker session in the same repo — never the broker itself.
+If a repo instruction says to use the `code-reviewer` subagent, treat that as work for the owning connected worker in the same repo to run locally and summarize back — never the broker itself.
 
 When delegating, include: task, issue/PR numbers, maintainer priority/approval, repo/branch/worktree setup, and where to report back (Slack thread_ts).
 

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -557,6 +557,7 @@ export async function runRalphLoopCycle(
       evaluationOptions,
       maintenance: lastMaintenance,
       assignments: projectedAssignments,
+      lanes: db.listPinetLanes({ includeDone: true }),
       recentCycles: recentRalphCycles,
       cycleStartedAt,
       cycleDurationMs: Date.now() - cycleStartMs,


### PR DESCRIPTION
## Summary
- clarify broker/follower guidance for local subagent preference, consent-gated PM mode, and detached/manual lanes
- add durable SQLite lane/participant metadata (`pinet_lanes`, `pinet_lane_participants`) with `detached` state
- expose lane inspection/update through `pinet action=lanes` plus broker/follower RPC, and surface lanes in control-plane/RALPH snapshots

## Tests
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-slack-bridge test`

Fixes #688
