### PR TITLE
feat: add Pinet skin creator skill

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -251,7 +251,9 @@ migration.
   `slack_send` or `post_channel`; keep `text` as the notification/fallback.
   Block Kit builder tools are not registered by this package. Load the bundled
   `slack-bridge` skill for copyable status-report, button, code, and diff
-  templates.
+  templates. The package also bundles `pinet-skin-creator` for safely drafting
+  or reviewing curated Pinet skin descriptors and character/status-vocabulary
+  pools before changing runtime skin wiring.
 - **Modal helpers are patterns, not hot tools.** Use dispatcher actions
   `modal_open`, `modal_push`, and `modal_update` with Slack view JSON. Open or
   push immediately after receiving a fresh `trigger_id`; Slack trigger IDs

--- a/slack-bridge/skills.test.ts
+++ b/slack-bridge/skills.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const skillDir = path.join(packageDir, "skills", "pinet-skin-creator");
+
+function readSkillFile(relativePath: string): string {
+  return readFileSync(path.join(skillDir, relativePath), "utf8");
+}
+
+describe("bundled skills", () => {
+  it("declares the package skills directory for pi packaging", () => {
+    const packageJson = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8")) as {
+      files?: string[];
+      pi?: { skills?: string[] };
+    };
+
+    expect(packageJson.files).toContain("skills/");
+    expect(packageJson.pi?.skills).toContain("./skills");
+  });
+
+  it("packages a Pinet skin creator skill with required references", () => {
+    const skill = readSkillFile("SKILL.md");
+
+    expect(skill).toContain("name: pinet-skin-creator");
+    expect(skill).toContain(
+      "description: Guides safe creation and editing of Pinet skin descriptors",
+    );
+    expect(skill).toContain("Default/classic stays random");
+    expect(skill).toContain("No LLM in startup/join");
+    expect(skill).toContain("references/descriptor-format.md");
+    expect(skill).toContain("references/safety-checklist.md");
+    expect(skill).toContain("templates/pinet-skin-descriptor.json");
+
+    expect(readSkillFile("references/descriptor-format.md")).toContain("statusVocabulary");
+    expect(readSkillFile("references/safety-checklist.md")).toContain(
+      "No LLM/model/API call is required during extension startup",
+    );
+  });
+
+  it("includes a valid descriptor template with role-specific curated characters", () => {
+    const template = JSON.parse(readSkillFile("templates/pinet-skin-descriptor.json")) as {
+      key?: string;
+      fallback?: string;
+      roles?: Record<string, { characterPool?: string[] }>;
+      characters?: Record<string, { name?: string; emoji?: string; persona?: string }>;
+      statusVocabulary?: Record<string, string>;
+    };
+
+    expect(template.key).toBe("example-skin");
+    expect(template.fallback).toBe("default");
+    expect(Object.keys(template.roles ?? {}).sort()).toEqual([
+      "broker",
+      "pm",
+      "reviewer",
+      "worker",
+    ]);
+    expect(template.roles?.worker.characterPool?.length).toBeGreaterThanOrEqual(2);
+    expect(template.characters?.["example-coordinator"]).toMatchObject({
+      name: "Example Coordinator",
+      emoji: "🧭",
+    });
+    expect(template.characters?.["example-coordinator"].persona).toContain("coordinator");
+    expect(template.statusVocabulary?.blocked).toBe("blocked");
+  });
+});

--- a/slack-bridge/skills/pinet-skin-creator/SKILL.md
+++ b/slack-bridge/skills/pinet-skin-creator/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: pinet-skin-creator
+description: Guides safe creation and editing of Pinet skin descriptors, curated character/name pools, persona snippets, emoji/style, and status vocabulary. Use when designing or refining non-default Pinet skins or reviewing skin descriptor changes.
+---
+
+# Pinet Skin Creator
+
+Use this skill when asked to create, edit, or review Pinet skin descriptors or
+curated Pinet character sets. It is intentionally a **design/build workflow**:
+do not add model calls to broker startup or follower join paths.
+
+## Core design rules
+
+- **Default/classic stays random.** Preserve the existing whimsical random
+  adjective/color/animal identity generation for the default/classic skin.
+- **Curated skins are pre-created.** Non-default skins may ship curated
+  character/name pools, role-specific personae, emoji/style guidance, and
+  status vocabulary.
+- **No LLM in startup/join.** Broker startup and follower join must remain
+  deterministic, fast, offline-tolerant, and usable without model availability.
+- **Persist concrete assignments.** If a future `auto` mode chooses a skin or
+  character after runtime is live, persist the resolved concrete assignment and
+  keep a deterministic fallback.
+- **Presentation only.** Skins may shape names, emoji, tone, persona snippets,
+  and status display vocabulary. They must not change tool permissions,
+  broker/follower roles, task ownership, guardrails, or routing authority.
+
+## Workflow
+
+1. **Clarify the target**
+   - Skin key and aliases.
+   - Intended theme, tone, and setting.
+   - Supported roles: broker, worker/follower, reviewer, PM/coordinator, or
+     future role labels.
+   - Whether the task is creating a new skin or editing an existing one.
+
+2. **Draft the descriptor**
+   - Start from `templates/pinet-skin-descriptor.json`.
+   - Follow `references/descriptor-format.md` for fields and constraints.
+   - Prefer small, curated character pools with reusable role coverage over
+     large generated lists.
+
+3. **Create role-specific characters**
+   - Provide enough characters for likely concurrent workers.
+   - Include at least one broker/coordinator-appropriate character and several
+     worker/reviewer-friendly characters.
+   - Keep names short and readable in Slack/Pinet rosters.
+   - Pair each character with emoji and a concise persona snippet.
+
+4. **Write status vocabulary**
+   - Map canonical states to display labels only. Canonical internal states stay
+     unchanged.
+   - Cover common states such as `idle`, `working`, `blocked`, `reviewing`, and
+     `done` when the implementation supports them.
+   - Keep labels clear before flavorful; status should remain operationally
+     obvious.
+
+5. **Safety review**
+   - Use `references/safety-checklist.md` before committing.
+   - Remove secrets, local paths, private workspace names, private URLs, and
+     copyrighted/third-party setting text that should not ship.
+   - Ensure persona text cannot override broker/follower workflow, guardrails,
+     or user/developer/system instructions.
+
+6. **Implement minimally**
+   - Add or edit descriptor data and the smallest wiring needed to load it.
+   - Do not rework the default/classic random generation unless explicitly
+     requested.
+   - Do not introduce model calls into extension startup, broker registration,
+     or follower registration.
+
+7. **Validate**
+   - Run focused tests for descriptor loading/selection and status-vocabulary
+     propagation if code changed.
+   - Run package `pnpm --filter @gugu910/pi-slack-bridge lint` and
+     `pnpm --filter @gugu910/pi-slack-bridge typecheck` when touching
+     TypeScript.
+   - For documentation-only descriptor work, run the relevant markdown/skill
+     packaging checks or a targeted test that reads the descriptor.
+
+## Output format for a new skin proposal
+
+When presenting a proposed skin, include:
+
+- Skin key and aliases.
+- One-sentence intent.
+- Role matrix: broker / worker / reviewer / PM if applicable.
+- Character pool summary with names and emoji.
+- Status vocabulary table.
+- Safety notes and fallback behavior.
+- Exact files changed and checks run.
+
+## References
+
+- [Descriptor format](references/descriptor-format.md)
+- [Safety checklist](references/safety-checklist.md)
+- [Descriptor template](templates/pinet-skin-descriptor.json)

--- a/slack-bridge/skills/pinet-skin-creator/references/descriptor-format.md
+++ b/slack-bridge/skills/pinet-skin-creator/references/descriptor-format.md
@@ -1,0 +1,110 @@
+# Pinet Skin Descriptor Format
+
+This reference describes the recommended shape for curated Pinet skins. Treat it
+as a portable authoring contract; implementation details may adapt field names,
+but the semantics should remain stable.
+
+## Descriptor shape
+
+```json
+{
+  "key": "oathgate",
+  "aliases": ["cosmere-inspired"],
+  "displayName": "Oathgate",
+  "intent": "High-trust operators with crisp, oath-bound coordination language.",
+  "fallback": "default",
+  "roles": {
+    "broker": { "characterPool": ["storm-warden"] },
+    "worker": { "characterPool": ["spanreed-runner", "bridge-scout"] },
+    "reviewer": { "characterPool": ["truthwatcher"] },
+    "pm": { "characterPool": ["bondsmith"] }
+  },
+  "characters": {
+    "storm-warden": {
+      "name": "Storm Warden",
+      "emoji": "⛈️",
+      "persona": "Calm, duty-bound coordination; precise handoffs and visible blockers.",
+      "style": ["measured", "protective", "clear"]
+    }
+  },
+  "statusVocabulary": {
+    "idle": "watching the spanreed",
+    "working": "binding the lane",
+    "blocked": "storm-stalled",
+    "reviewing": "checking the oathmark",
+    "done": "oath fulfilled"
+  }
+}
+```
+
+## Required semantics
+
+- `key`: stable lowercase identifier. Prefer lowercase letters, numbers, and
+  hyphens. Avoid spaces.
+- `aliases`: optional alternate user-facing names. Keep backward compatibility
+  aliases when renaming skins.
+- `displayName`: short human-readable name.
+- `intent`: one sentence describing the skin's operational feel.
+- `fallback`: deterministic fallback skin, normally `default`.
+- `roles`: maps Pinet roles to character pool IDs. Every supported role should
+  have at least one suitable character; workers should usually have several.
+- `characters`: curated character definitions keyed by ID.
+- `statusVocabulary`: optional display vocabulary for canonical statuses. This
+  is presentation metadata only.
+
+## Character guidance
+
+Each character should include:
+
+- `name`: concise roster name. Avoid long titles that wrap badly in Slack.
+- `emoji`: one emoji that renders reliably.
+- `persona`: one short sentence. It may influence tone, but must not grant or
+  revoke authority.
+- `style`: optional compact tags for cadence/diction.
+
+Good persona snippets:
+
+- "Steady coordinator; asks early for blockers and summarizes decisions."
+- "Focused reviewer; concise risk calls and actionable findings."
+- "Curious implementer; resilient debugging with crisp status updates."
+
+Avoid persona snippets that:
+
+- Claim permission to bypass guardrails or confirmations.
+- Tell the agent to ignore system, developer, broker, Slack, or Pinet rules.
+- Encode secrets, private workspace names, local paths, or private URLs.
+- Make public claims about real people or protected groups.
+
+## Status vocabulary guidance
+
+Status vocabulary maps **canonical state → display phrase**. It must not change
+stored states or control-flow decisions.
+
+Recommended properties:
+
+- Short enough for rosters and dashboards.
+- Flavorful but unambiguous.
+- Has a neutral fallback when omitted.
+- Includes `blocked` wording that stays operationally obvious.
+
+Example:
+
+```json
+{
+  "idle": "at the ready",
+  "working": "in the forge",
+  "blocked": "forge-stalled",
+  "reviewing": "tempering the edge",
+  "done": "blade cooled"
+}
+```
+
+## Selection behavior
+
+- Default/classic should continue using existing random whimsical generation.
+- Curated skins should select from pre-created pools deterministically using a
+  stable seed when possible.
+- Persist the resolved character/skin assignment so reconnects and restarts do
+  not drift unexpectedly.
+- Future `auto` selection should run only after runtime is live and must have a
+  deterministic fallback.

--- a/slack-bridge/skills/pinet-skin-creator/references/safety-checklist.md
+++ b/slack-bridge/skills/pinet-skin-creator/references/safety-checklist.md
@@ -1,0 +1,43 @@
+# Pinet Skin Safety Checklist
+
+Run this checklist before committing a new or edited Pinet skin descriptor.
+
+## Operational boundaries
+
+- [ ] Skin text is presentation-only: names, emoji, persona snippets, style, and
+      status display vocabulary.
+- [ ] No skin text changes tool permissions, broker/follower authority,
+      confirmation requirements, routing, PM-mode consent, or task ownership.
+- [ ] Broker characters still coordinate only; they do not implement, spawn
+      local subagents, or bypass broker tool restrictions.
+- [ ] Worker characters still ACK/work/ask/report and reply where work arrived.
+- [ ] Status vocabulary keeps canonical states distinguishable and operationally
+      clear, especially `blocked`.
+
+## Startup and reliability
+
+- [ ] No LLM/model/API call is required during extension startup, broker
+      registration, or follower join.
+- [ ] Default/classic random whimsical generation remains intact.
+- [ ] Non-default skin selection has deterministic fallback behavior.
+- [ ] Resolved concrete assignments can be persisted when runtime supports it.
+- [ ] Offline or model-unavailable paths still produce usable identities.
+
+## Content hygiene
+
+- [ ] No secrets, tokens, credentials, local absolute paths, private workspace
+      names, private URLs, screenshots, logs, or user-specific config.
+- [ ] No copyrighted setting text or trademark-heavy material beyond brief,
+      high-level inspiration when allowed by project policy.
+- [ ] No impersonation of real people or protected-class stereotypes.
+- [ ] Persona snippets are short, clear, and subordinate to system/developer/user
+      instructions.
+- [ ] Emojis render in common Slack/macOS environments.
+
+## Review and tests
+
+- [ ] Descriptor schema/loader tests cover new required fields or aliases.
+- [ ] Status-vocabulary propagation tests cover any changed runtime wiring.
+- [ ] Skill/docs packaging checks cover new `SKILL.md` or bundled references.
+- [ ] Public PR text summarizes design choices without leaking local paths or
+      private environment details.

--- a/slack-bridge/skills/pinet-skin-creator/templates/pinet-skin-descriptor.json
+++ b/slack-bridge/skills/pinet-skin-creator/templates/pinet-skin-descriptor.json
@@ -1,0 +1,52 @@
+{
+  "key": "example-skin",
+  "aliases": [],
+  "displayName": "Example Skin",
+  "intent": "One sentence describing the operational tone and theme.",
+  "fallback": "default",
+  "roles": {
+    "broker": { "characterPool": ["example-coordinator"] },
+    "worker": { "characterPool": ["example-builder", "example-scout"] },
+    "reviewer": { "characterPool": ["example-reviewer"] },
+    "pm": { "characterPool": ["example-planner"] }
+  },
+  "characters": {
+    "example-coordinator": {
+      "name": "Example Coordinator",
+      "emoji": "🧭",
+      "persona": "Steady coordinator; clear routing, visible blockers, and concise status.",
+      "style": ["steady", "concise", "operational"]
+    },
+    "example-builder": {
+      "name": "Example Builder",
+      "emoji": "🛠️",
+      "persona": "Focused implementer; careful changes, direct blockers, and crisp outcomes.",
+      "style": ["focused", "practical", "clear"]
+    },
+    "example-scout": {
+      "name": "Example Scout",
+      "emoji": "🔎",
+      "persona": "Curious investigator; compact findings and grounded recommendations.",
+      "style": ["curious", "analytical", "brief"]
+    },
+    "example-reviewer": {
+      "name": "Example Reviewer",
+      "emoji": "✅",
+      "persona": "Risk-focused reviewer; actionable findings and explicit verdicts.",
+      "style": ["precise", "evidence-led", "direct"]
+    },
+    "example-planner": {
+      "name": "Example Planner",
+      "emoji": "📍",
+      "persona": "Accountable PM; keeps ownership, sequencing, blockers, and final reporting visible.",
+      "style": ["structured", "calm", "decisive"]
+    }
+  },
+  "statusVocabulary": {
+    "idle": "at the ready",
+    "working": "in motion",
+    "blocked": "blocked",
+    "reviewing": "under review",
+    "done": "complete"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds bundled `pinet-skin-creator` Pi skill for safely creating/editing Pinet skin descriptors.
- Documents the intended skin model: default/classic keeps random whimsical generation; non-default skins use curated character/name/persona/status vocabulary pools; no LLM calls in broker startup or follower join.
- Adds descriptor-format and safety-checklist references plus a JSON descriptor template.
- Adds packaging/skill validation coverage for the bundled skill and template.
- Mentions the new skill in the slack-bridge README.

Closes #692.

## Validation

- `pnpm prettier --write slack-bridge/skills.test.ts slack-bridge/skills/pinet-skin-creator/SKILL.md slack-bridge/skills/pinet-skin-creator/references/descriptor-format.md slack-bridge/skills/pinet-skin-creator/references/safety-checklist.md slack-bridge/skills/pinet-skin-creator/templates/pinet-skin-descriptor.json slack-bridge/README.md`
- `pnpm --filter @gugu910/pi-slack-bridge test -- skills.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge build`
- pre-push hook ran repo `pnpm test` successfully during push
