### PR TITLE
Transfer Slack thread ownership when broker delegates via Pinet

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -761,6 +761,41 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("transfers unread Slack inbox rows and affinity metadata with thread ownership", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-a", "slack", "C123", "agent-a");
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "reply queued before transfer",
+        timestamp: "123.789",
+      });
+
+      const transfer = db.transferThreadOwnership("thread-a", "agent-b");
+
+      expect(transfer).toEqual({ reassignedInboxCount: 1, updatedMessageCount: 1 });
+      expect(db.getThread("thread-a")).toMatchObject({
+        ownerAgent: "agent-b",
+        ownerBinding: "explicit",
+      });
+      expect(db.readInbox("agent-a", { markRead: false }).messages).toEqual([]);
+
+      const read = db.readInbox("agent-b", { markRead: false });
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0].message.body).toBe("reply queued before transfer");
+      expect(read.messages[0].message.metadata).toMatchObject({
+        threadAffinityOwnerAgentId: "agent-b",
+      });
+      expect(read.unreadCountBefore).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
   it("revalidates stale queued Slack rows on read when the owner changes", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -1471,6 +1471,90 @@ export class BrokerDB implements BrokerDBInterface {
     db.prepare(`UPDATE threads SET ${sets.join(", ")} WHERE thread_id = ?`).run(...values);
   }
 
+  transferThreadOwnership(
+    threadId: string,
+    ownerAgent: string,
+  ): { reassignedInboxCount: number; updatedMessageCount: number } {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+    const thread = this.getThread(threadId);
+    if (!thread) {
+      throw new Error(`Unknown thread ${threadId}`);
+    }
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      db.prepare(
+        `UPDATE threads
+         SET owner_agent = ?, owner_binding = 'explicit', updated_at = ?
+         WHERE thread_id = ?`,
+      ).run(ownerAgent, now, threadId);
+
+      const rows = db
+        .prepare(
+          `SELECT i.id AS inbox_id,
+                  i.agent_id AS agent_id,
+                  i.message_id AS message_id,
+                  m.metadata AS metadata
+           FROM inbox i
+           JOIN messages m ON m.id = i.message_id
+           WHERE m.thread_id = ?
+             AND m.source = 'slack'
+             AND m.direction = 'inbound'
+             AND i.read_at IS NULL`,
+        )
+        .all(threadId) as Array<{
+        inbox_id: number;
+        agent_id: string;
+        message_id: number;
+        metadata: string | null;
+      }>;
+
+      let reassignedInboxCount = 0;
+      const updatedMessageIds = new Set<number>();
+      const updateMessageMetadata = db.prepare("UPDATE messages SET metadata = ? WHERE id = ?");
+      const findExistingInbox = db.prepare(
+        "SELECT id FROM inbox WHERE agent_id = ? AND message_id = ?",
+      );
+      const reassignInbox = db.prepare(
+        "UPDATE inbox SET agent_id = ?, delivered = 0 WHERE id = ? AND agent_id = ?",
+      );
+      const markDuplicateRead = db.prepare(
+        "UPDATE inbox SET delivered = 1, read_at = COALESCE(read_at, ?) WHERE id = ?",
+      );
+
+      for (const row of rows) {
+        if (!updatedMessageIds.has(row.message_id)) {
+          const metadata = row.metadata ? parseJsonMetadata(row.metadata) : {};
+          metadata.threadAffinityOwnerAgentId = ownerAgent;
+          updateMessageMetadata.run(JSON.stringify(metadata), row.message_id);
+          updatedMessageIds.add(row.message_id);
+        }
+
+        if (row.agent_id === ownerAgent) {
+          continue;
+        }
+
+        const existing = findExistingInbox.get(ownerAgent, row.message_id) as
+          | { id: number }
+          | undefined;
+        if (existing) {
+          markDuplicateRead.run(now, row.inbox_id);
+          continue;
+        }
+
+        const result = reassignInbox.run(ownerAgent, row.inbox_id, row.agent_id);
+        reassignedInboxCount += Number(result.changes ?? 0);
+      }
+
+      db.exec("COMMIT");
+      return { reassignedInboxCount, updatedMessageCount: updatedMessageIds.size };
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
+  }
+
   claimThread(threadId: string, agentId: string, source = "slack", channel = ""): boolean {
     const db = this.getDb();
     const now = new Date().toISOString();

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -51,10 +51,27 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
     }),
   ];
   let nextMessageId = 1;
-  const threads = new Map<string, { threadId: string }>();
+  const threads = new Map<
+    string,
+    {
+      threadId: string;
+      source?: string;
+      channel?: string;
+      ownerAgent?: string | null;
+      ownerBinding?: "explicit" | null;
+    }
+  >();
   const insertedMessages: BrokerMessage[] = [];
-  const createThread = vi.fn((threadId: string) => {
-    threads.set(threadId, { threadId });
+  const createThread = vi.fn(
+    (threadId: string, source: string, channel: string, ownerAgent: string | null) => {
+      threads.set(threadId, { threadId, source, channel, ownerAgent, ownerBinding: null });
+    },
+  );
+  const transferThreadOwnership = vi.fn((threadId: string, ownerAgent: string) => {
+    const existing = threads.get(threadId);
+    if (!existing) throw new Error(`Unknown thread ${threadId}`);
+    threads.set(threadId, { ...existing, ownerAgent, ownerBinding: "explicit" });
+    return { reassignedInboxCount: 2, updatedMessageCount: 1 };
   });
   const insertMessage = vi.fn(
     (
@@ -114,6 +131,7 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
     createThread,
     insertMessage,
     getAllAgents: () => agents,
+    transferThreadOwnership,
     recordTaskAssignment,
     scheduleWakeup,
   };
@@ -136,6 +154,7 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
     db,
     agents,
     createThread,
+    transferThreadOwnership,
     insertMessage,
     insertedMessages,
     recordTaskAssignment,
@@ -245,6 +264,82 @@ describe("createPinetMeshOps", () => {
         tone: "info",
       }),
     );
+  });
+
+  it("transfers broker thread ownership to the direct recipient when requested", async () => {
+    const { deps, insertedMessages, logActivity, transferThreadOwnership } = createBrokerDeps();
+    const db = deps.getActiveBrokerDb();
+    db?.createThread("1777798507.674009", "slack", "C123", "broker-1");
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    const result = await pinetMeshOps.sendPinetAgentMessage("worker-1", "please report back", {
+      threadOwnershipTransfer: { mode: "transfer", threadId: "1777798507.674009" },
+    });
+
+    expect(result).toEqual({
+      messageId: 1,
+      target: "Worker One",
+      transferredThreadId: "1777798507.674009",
+    });
+    expect(transferThreadOwnership).toHaveBeenCalledWith("1777798507.674009", "worker-1");
+    expect(insertedMessages[0]?.metadata).toMatchObject({
+      threadOwnershipTransfer: { mode: "transfer", threadId: "1777798507.674009" },
+      senderAgent: "Broker Crane",
+      a2a: true,
+    });
+    expect(logActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "thread_transfer",
+        title: "Thread ownership transferred",
+        summary: "Transferred 1777798507.674009 to 🦊 Worker One.",
+      }),
+    );
+  });
+
+  it("rejects unknown thread ownership transfer requests before dispatch", async () => {
+    const { deps, insertMessage, transferThreadOwnership } = createBrokerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    await expect(
+      pinetMeshOps.sendPinetAgentMessage("worker-1", "please report back", {
+        threadOwnershipTransfer: { mode: "transfer", threadId: "missing-thread" },
+      }),
+    ).rejects.toThrow("Cannot transfer unknown thread missing-thread.");
+
+    expect(insertMessage).not.toHaveBeenCalled();
+    expect(transferThreadOwnership).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-Slack thread ownership transfer requests", async () => {
+    const { deps, insertMessage, transferThreadOwnership } = createBrokerDeps();
+    const db = deps.getActiveBrokerDb();
+    db?.createThread("a2a:broker-1:worker-1", "agent", "", "broker-1");
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    await expect(
+      pinetMeshOps.sendPinetAgentMessage("worker-1", "please report back", {
+        threadOwnershipTransfer: { mode: "transfer", threadId: "a2a:broker-1:worker-1" },
+      }),
+    ).rejects.toThrow("Thread a2a:broker-1:worker-1 is not a transferable Slack thread.");
+
+    expect(insertMessage).not.toHaveBeenCalled();
+    expect(transferThreadOwnership).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-Slack transport ownership transfer requests", async () => {
+    const { deps, insertMessage, transferThreadOwnership } = createBrokerDeps();
+    const db = deps.getActiveBrokerDb();
+    db?.createThread("imessage:chat:alice", "imessage", "chat:alice", "broker-1");
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    await expect(
+      pinetMeshOps.sendPinetAgentMessage("worker-1", "please report back", {
+        threadOwnershipTransfer: { mode: "transfer", threadId: "imessage:chat:alice" },
+      }),
+    ).rejects.toThrow("Thread imessage:chat:alice is not a transferable Slack thread.");
+
+    expect(insertMessage).not.toHaveBeenCalled();
+    expect(transferThreadOwnership).not.toHaveBeenCalled();
   });
 
   it("routes follower direct messages through the follower client", async () => {

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -28,8 +28,19 @@ export interface PinetMeshOpsRecordedAssignment {
   branch: string | null;
 }
 
+export interface PinetMeshOpsTransferableThread {
+  threadId: string;
+  source?: string;
+  channel?: string;
+}
+
 export interface PinetMeshOpsBrokerDbPort extends AgentMessageStorage {
   getAllAgents: () => AgentInfo[];
+  getThread: (threadId: string) => PinetMeshOpsTransferableThread | null;
+  transferThreadOwnership: (
+    threadId: string,
+    ownerAgent: string,
+  ) => { reassignedInboxCount: number; updatedMessageCount: number };
   recordTaskAssignment: (
     agentId: string,
     issueNumber: number,
@@ -74,7 +85,7 @@ export interface PinetMeshOps {
     target: string,
     body: string,
     metadata?: Record<string, unknown>,
-  ) => Promise<{ messageId: number; target: string }>;
+  ) => Promise<{ messageId: number; target: string; transferredThreadId?: string }>;
   sendPinetBroadcastMessage: (
     channel: string,
     body: string,
@@ -106,6 +117,16 @@ function prepareOutgoingPinetAgentMessage(
   return { body, metadata };
 }
 
+function getThreadOwnershipTransferId(metadata?: Record<string, unknown>): string | null {
+  const transfer = metadata?.threadOwnershipTransfer;
+  if (!transfer || typeof transfer !== "object" || Array.isArray(transfer)) {
+    return null;
+  }
+
+  const threadId = (transfer as Record<string, unknown>).threadId;
+  return typeof threadId === "string" && threadId.trim().length > 0 ? threadId.trim() : null;
+}
+
 export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
   async function sendPinetAgentMessage(
     targetRef: string,
@@ -133,6 +154,15 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
         throw new Error("Broker agent identity is unavailable.");
       }
 
+      const transferThreadId = getThreadOwnershipTransferId(finalMetadata);
+      const transferThread = transferThreadId ? db.getThread(transferThreadId) : null;
+      if (transferThreadId && !transferThread) {
+        throw new Error(`Cannot transfer unknown thread ${transferThreadId}.`);
+      }
+      if (transferThread && (transferThread.source !== "slack" || !transferThread.channel)) {
+        throw new Error(`Thread ${transferThreadId} is not a transferable Slack thread.`);
+      }
+
       const result = dispatchDirectAgentMessage(db, {
         senderAgentId: selfId,
         senderAgentName: deps.getAgentName(),
@@ -140,6 +170,23 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
         body: finalBody,
         metadata: finalMetadata,
       });
+
+      if (transferThreadId) {
+        const transfer = db.transferThreadOwnership(transferThreadId, result.target.id);
+        deps.logActivity({
+          kind: "thread_transfer",
+          level: "actions",
+          title: "Thread ownership transferred",
+          summary: `Transferred ${transferThreadId} to ${deps.formatTrackedAgent(result.target.id)}.`,
+          fields: [
+            { label: "Worker", value: deps.formatTrackedAgent(result.target.id) },
+            { label: "Thread", value: transferThreadId },
+            { label: "A2A message", value: result.messageId },
+            { label: "Reassigned inbox rows", value: transfer.reassignedInboxCount },
+          ],
+          tone: "info",
+        });
+      }
 
       const recordedAssignments: PinetMeshOpsRecordedAssignment[] = [];
       for (const assignment of extractTaskAssignmentsFromMessage(body)) {
@@ -173,7 +220,11 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
         });
       }
 
-      return { messageId: result.messageId, target: result.target.name };
+      return {
+        messageId: result.messageId,
+        target: result.target.name,
+        ...(transferThreadId ? { transferredThreadId: transferThreadId } : {}),
+      };
     }
 
     if (deps.getBrokerRole() === "follower") {

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -34,7 +34,7 @@ function createDeps(overrides: Partial<RegisterPinetToolsDeps> = {}): RegisterPi
     pinetEnabled: () => true,
     brokerRole: () => "broker",
     requireToolPolicy: () => {},
-    sendPinetAgentMessage: async (target, _body) => ({ messageId: 17, target }),
+    sendPinetAgentMessage: async (target, _body, _metadata) => ({ messageId: 17, target }),
     sendPinetBroadcastMessage: (channel) => ({
       channel,
       messageIds: [11, 12],
@@ -435,6 +435,59 @@ describe("registerPinetTools", () => {
     expect(result.details.data.action).toBe("send");
     expect(result.details.data.text).toBe("Pinet message sent to alpha.");
     expect(result.content[0]?.text).toContain('"status": "succeeded"');
+  });
+
+  it("passes broker thread ownership transfers through pinet send metadata", async () => {
+    const sendPinetAgentMessage = vi.fn(async (_to: string, _message: string) => ({
+      messageId: 41,
+      target: "alpha",
+      transferredThreadId: "1777798507.674009",
+    }));
+    const deps = createDeps({ sendPinetAgentMessage });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-dispatch-send-transfer", {
+      action: "send",
+      args: {
+        to: "alpha",
+        message: "dispatch now",
+        transfer_thread_id: "1777798507.674009",
+        format: "json",
+      },
+    })) as {
+      details: { status: string; data: { text: string; details: Record<string, unknown> } };
+    };
+
+    expect(sendPinetAgentMessage).toHaveBeenCalledWith("alpha", "dispatch now", {
+      threadOwnershipTransfer: { mode: "transfer", threadId: "1777798507.674009" },
+    });
+    expect(result.details.status).toBe("succeeded");
+    expect(result.details.data.text).toBe(
+      "Pinet message sent to alpha; transferred thread 1777798507.674009.",
+    );
+    expect(result.details.data.details.transferredThreadId).toBe("1777798507.674009");
+  });
+
+  it("rejects follower thread ownership transfers", async () => {
+    const sendPinetAgentMessage = vi.fn(async (_to: string, _message: string) => ({
+      messageId: 41,
+      target: "alpha",
+    }));
+    const deps = createDeps({ brokerRole: () => "follower", sendPinetAgentMessage });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-dispatch-send-transfer-follower", {
+      action: "send",
+      args: {
+        to: "alpha",
+        message: "dispatch now",
+        transfer_thread_id: "1777798507.674009",
+      },
+    })) as { details: { status: string; errors: Array<{ message: string }> } };
+
+    expect(result.details.status).toBe("failed");
+    expect(result.details.errors[0]?.message).toContain("transfer_thread_id is broker-only");
+    expect(sendPinetAgentMessage).not.toHaveBeenCalled();
   });
 
   it("honors explicit full output for pinet send", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -45,7 +45,8 @@ export interface RegisterPinetToolsDeps {
   sendPinetAgentMessage: (
     target: string,
     body: string,
-  ) => Promise<{ messageId: number; target: string }>;
+    metadata?: Record<string, unknown>,
+  ) => Promise<{ messageId: number; target: string; transferredThreadId?: string }>;
   sendPinetBroadcastMessage: (
     channel: string,
     body: string,
@@ -348,6 +349,10 @@ function runPinetSendAction(
   return (async () => {
     const to = typeof params.to === "string" ? params.to.trim() : "";
     const message = typeof params.message === "string" ? params.message : "";
+    const transferThreadId =
+      typeof params.transfer_thread_id === "string" && params.transfer_thread_id.trim().length > 0
+        ? params.transfer_thread_id.trim()
+        : undefined;
 
     if (!to) {
       throw new Error("to is required");
@@ -356,7 +361,21 @@ function runPinetSendAction(
       throw new Error("message is required");
     }
 
-    deps.requireToolPolicy(toolName, undefined, `to=${to} | message=${message}`);
+    deps.requireToolPolicy(
+      toolName,
+      undefined,
+      `to=${to} | message=${message}${transferThreadId ? ` | transfer_thread_id=${transferThreadId}` : ""}`,
+    );
+
+    if (transferThreadId && deps.brokerRole() !== "broker") {
+      throw new Error("transfer_thread_id is broker-only and requires the broker role.");
+    }
+
+    if (transferThreadId && isBroadcastChannelTarget(to)) {
+      throw new Error(
+        "transfer_thread_id requires a direct agent target, not a broadcast channel.",
+      );
+    }
 
     if (deps.brokerRole() === "broker" && isBroadcastChannelTarget(to)) {
       const result = deps.sendPinetBroadcastMessage(to, message);
@@ -380,17 +399,25 @@ function runPinetSendAction(
       };
     }
 
-    const result = await deps.sendPinetAgentMessage(to, message);
+    const result = transferThreadId
+      ? await deps.sendPinetAgentMessage(to, message, {
+          threadOwnershipTransfer: { mode: "transfer", threadId: transferThreadId },
+        })
+      : await deps.sendPinetAgentMessage(to, message);
     return {
       content: [
         {
           type: "text",
           text: output.full
-            ? `Message sent to ${result.target} (id: ${result.messageId}).`
-            : `Pinet message sent to ${result.target}.`,
+            ? `Message sent to ${result.target} (id: ${result.messageId})${result.transferredThreadId ? ` and transferred thread ${result.transferredThreadId}` : ""}.`
+            : `Pinet message sent to ${result.target}${result.transferredThreadId ? `; transferred thread ${result.transferredThreadId}` : ""}.`,
         },
       ],
-      details: { messageId: result.messageId, target: result.target },
+      details: {
+        messageId: result.messageId,
+        target: result.target,
+        ...(result.transferredThreadId ? { transferredThreadId: result.transferredThreadId } : {}),
+      },
     };
   })();
 }
@@ -676,6 +703,12 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
           "Target agent name/ID, or a broker-only broadcast channel like #extensions. Avoid #all for repo-specific issue/policy announcements.",
       }),
       message: Type.String({ description: "Message body" }),
+      transfer_thread_id: Type.Optional(
+        Type.String({
+          description:
+            "Broker-only: transfer ownership of this existing Slack thread to the direct recipient after delivery (for example a Slack thread_ts).",
+        }),
+      ),
       ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
     execute: (_id, params, output) => runPinetSendAction(params, deps, "pinet:send", output),


### PR DESCRIPTION
## Summary
- add broker-only `transfer_thread_id` support to `pinet send`
- transfer the existing Slack thread owner to the direct recipient with an explicit binding
- migrate unread Slack inbox rows and affinity metadata during transfer
- reject unknown, agent, and non-Slack thread IDs before dispatch

Fixes #696

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## Review
- code-reviewer subagent final verdict: approved