### PR TITLE
feat: unify Pinet command surface

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -370,12 +370,14 @@ The `canvas_comments_read` dispatcher action is intentionally narrow:
 
 ### Slash commands
 
-| Command         | Description                                         |
-| --------------- | --------------------------------------------------- |
-| `/pinet-status` | Show connection status, threads, and agent identity |
-| `/pinet-rename` | Change the agent's display name                     |
-| `/pinet-logs`   | Show recent broker activity log entries             |
-| `/slack-logs`   | Show recent Slack bridge log entries                |
+| Command            | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| `/pinet <action>`  | Unified Pinet command surface; run `/pinet help` for usage |
+| `/pinet status`    | Show connection status, threads, and agent identity        |
+| `/pinet rename`    | Change the agent's display name                            |
+| `/pinet logs`      | Show recent broker activity log entries                    |
+| `/pinet-*` aliases | Backwards-compatible aliases for legacy command names      |
+| `/slack-logs`      | Legacy alias for recent Slack bridge/Pinet activity logs   |
 
 ## Runtime modes
 
@@ -394,7 +396,7 @@ Startup selection:
 - `autoConnect` is a legacy compatibility alias for `runtimeMode: "single"`.
 - `autoFollow` is a legacy compatibility alias for `runtimeMode: "follower"` when a broker socket is available.
 - explicit `runtimeMode` wins over the legacy flags.
-- `/pinet-start` and `/pinet-follow` still switch the live session into broker/follower runtimes explicitly.
+- `/pinet start` and `/pinet follow` still switch the live session into broker/follower runtimes explicitly.
 
 ## Scope carriers (compatibility-first)
 
@@ -415,13 +417,13 @@ Pinet supports a broker/follower architecture for coordinating multiple pi agent
 **Broker** (one per mesh — coordinates routing and health):
 
 ```
-/pinet-start
+/pinet start
 ```
 
 **Follower** (workers that connect to the broker):
 
 ```
-/pinet-follow
+/pinet follow
 ```
 
 Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": true`) to auto-connect when a broker is running.
@@ -436,15 +438,15 @@ Broker coordination policy is loaded from Markdown rather than a settings select
 
 Invalid higher-priority files (unsafe symlink/path escape, unreadable file, oversized content, invalid UTF-8/binary-looking content, or empty file) emit a concise warning and fall through to lower-priority candidates. Warnings identify only the candidate kind and reason; prompt bodies and private paths are not echoed.
 
-Only broker prompt content is replaceable. Broker runtime/tool restrictions remain code-owned and are appended after the loaded MD prompt, including the forbidden local `Agent` path and broker `edit`/`write` blocking. Followers keep append-only worker guidance and do not load broker prompt MD. Prompt changes are picked up on `/pinet-start` / runtime restart; this slice does not hot-reload per turn.
+Only broker prompt content is replaceable. Broker runtime/tool restrictions remain code-owned and are appended after the loaded MD prompt, including the forbidden local `Agent` path and broker `edit`/`write` blocking. Followers keep append-only worker guidance and do not load broker prompt MD. Prompt changes are picked up on `/pinet start` / runtime restart; this slice does not hot-reload per turn.
 
 ### Multi-agent tools
 
-| Tool    | Description                                                                                                                  |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `pinet` | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `schedule`, `agents`, `lanes`) |
+| Tool    | Description                                                                                                                                            |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pinet` | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `schedule`, `agents`, `lanes`, `reload`, `exit`, `skin`) |
 
-Use the dispatcher for all Pinet actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=schedule`, `pinet action=agents`, and `pinet action=lanes`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
+Use the dispatcher for Pinet tool actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=schedule`, `pinet action=agents`, `pinet action=lanes`, `pinet action=reload`, `pinet action=exit`, and `pinet action=skin`. Use slash commands for UI lifecycle transitions: `/pinet start`, `/pinet follow`, and `/pinet unfollow`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
 
 Dispatcher content defaults to terse CLI-style confirmations/summaries for noisy reads, sends, and agent lists. In default CLI mode, bulky read/agent payloads are also compacted in `data.details` so tool renderers do not surface full message bodies or agent metadata by accident. Pass `args.format="json"` (or `args.f` / `args["-f"]`) for the dispatcher envelope in content with full structured `data.details`, or `args.full=true` / `args["--full"]=true` for verbose text with full structured `data.details`.
 
@@ -454,21 +456,23 @@ Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are per
 
 Durable lane metadata is stored in SQLite and can be inspected/updated with `pinet action=lanes`. PM-mode lanes can record the accountable follower/PM, implementation lead, participant roles (`pm`, `lead`, `implementer`, `reviewer`, `second_pass_reviewer`, etc.), linked issue/PR, state, and summary. The `detached` lane state means a lane is manually supervised by a human; broker/RALPH/status surfaces keep it visible but should not treat it as normal auto-reassignment work without explicit human/broker action.
 
-### Broker commands
+### Pinet command surface
+
+Use `/pinet <action> [args]` for mesh lifecycle and broker operations. Legacy aliases such as `/pinet-start`, `/pinet-follow`, `/pinet-free`, and `/pinet-skin` remain registered for compatibility.
 
 | Command                 | Description                                     |
 | ----------------------- | ----------------------------------------------- |
-| `/pinet-start`          | Start as the mesh broker                        |
-| `/pinet-follow`         | Connect as a follower worker                    |
-| `/pinet-unfollow`       | Disconnect from the broker                      |
-| `/pinet-reload <agent>` | Ask another agent to reload                     |
-| `/pinet-exit <agent>`   | Ask another agent to exit                       |
-| `/pinet-free`           | Mark this agent as idle                         |
-| `/pinet-skin <theme>`   | Change the mesh presentation skin (broker only) |
+| `/pinet start`          | Start as the mesh broker                        |
+| `/pinet follow`         | Connect as a follower worker                    |
+| `/pinet unfollow`       | Disconnect from the broker                      |
+| `/pinet reload <agent>` | Ask another agent to reload                     |
+| `/pinet exit <agent>`   | Ask another agent to exit                       |
+| `/pinet free`           | Mark this agent as idle                         |
+| `/pinet skin <theme>`   | Change the mesh presentation skin (broker only) |
 
 ### Pinet skins
 
-`/pinet-skin <theme>` updates mesh presentation only: names, emoji palette, persona/tone guidance, and optional display vocabulary for statuses. Core roles and states stay skin-neutral (`broker`, `worker`, `idle`, `working`, routing, repo, and guardrails are not redefined by skins).
+`/pinet skin <theme>` updates mesh presentation only: names, emoji palette, persona/tone guidance, and optional display vocabulary for statuses. Core roles and states stay skin-neutral (`broker`, `worker`, `idle`, `working`, routing, repo, and guardrails are not redefined by skins).
 
 Built-in skins:
 

--- a/slack-bridge/broker-prompt-loader.test.ts
+++ b/slack-bridge/broker-prompt-loader.test.ts
@@ -239,7 +239,7 @@ describe("packaged default broker prompt", () => {
 
     expect(defaultPrompt).toContain("Use tmux only to launch repo-scoped Pinet follower workers");
     expect(defaultPrompt).toContain("create a tmux session in the target repo");
-    expect(defaultPrompt).toContain("/pinet-follow");
+    expect(defaultPrompt).toContain("/pinet follow");
     expect(defaultPrompt).toContain(
       "only report the capacity gap if you cannot safely start a worker",
     );

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -145,6 +145,9 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("pinet:send")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:schedule")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:free")).toBe(true);
+    expect(WRITE_TOOLS.has("pinet:reload")).toBe(true);
+    expect(WRITE_TOOLS.has("pinet:exit")).toBe(true);
+    expect(WRITE_TOOLS.has("pinet:skin")).toBe(true);
     expect(WRITE_TOOLS.has("pinet_message")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:read")).toBe(true);
     expect(READ_ONLY_TOOLS.has("pinet:agents")).toBe(true);
@@ -153,12 +156,18 @@ describe("isToolBlocked", () => {
     expect(READ_ONLY_TOOLS.has("pinet:send")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:schedule")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:free")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("pinet:reload")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("pinet:exit")).toBe(false);
+    expect(READ_ONLY_TOOLS.has("pinet:skin")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet_message")).toBe(false);
   });
 
   it("classifies Pinet dispatcher and legacy policy names for readOnly checks", () => {
     const g: SecurityGuardrails = { readOnly: true };
     expect(isToolBlocked("pinet:send", g)).toBe(true);
+    expect(isToolBlocked("pinet:reload", g)).toBe(true);
+    expect(isToolBlocked("pinet:exit", g)).toBe(true);
+    expect(isToolBlocked("pinet:skin", g)).toBe(true);
     expect(isToolBlocked("pinet_message", g)).toBe(true);
     expect(isToolBlocked("pinet_send", g)).toBe(true);
     expect(isToolBlocked("pinet:read", g)).toBe(false);

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -55,6 +55,9 @@ export const WRITE_TOOLS = new Set([
   "pinet:schedule",
   "pinet:send",
   "pinet:free",
+  "pinet:reload",
+  "pinet:exit",
+  "pinet:skin",
 ]);
 
 /**

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1706,7 +1706,7 @@ describe("buildWorkerPromptGuidelines", () => {
     const guidelines = buildWorkerPromptGuidelines();
     const joined = guidelines.join(" ");
     expect(joined).toContain("pinet action=free");
-    expect(joined).toContain("/pinet-free");
+    expect(joined).toContain("/pinet free");
     expect(joined).toContain("idle/free");
   });
 
@@ -3526,13 +3526,13 @@ describe("buildFollowerRuntimeDiagnostic", () => {
       kind: "broker_disconnect",
       state: "reconnecting",
       reason: "broker disconnected",
-      nextStep: "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+      nextStep: "Wait for automatic reconnect. If it does not recover, run /pinet follow.",
     });
     expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
       "reconnecting — broker disconnected",
     );
     expect(formatFollowerRuntimeDiagnosticNextStep(diagnostic)).toBe(
-      "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+      "Wait for automatic reconnect. If it does not recover, run /pinet follow.",
     );
   });
 
@@ -3548,7 +3548,7 @@ describe("buildFollowerRuntimeDiagnostic", () => {
       reason: "inbox polling failed",
       detail: "Request timed out: pollInbox",
       nextStep:
-        "Watch the next poll cycle. If failures continue, inspect the broker and run /pinet-follow.",
+        "Watch the next poll cycle. If failures continue, inspect the broker and run /pinet follow.",
     });
     expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
       "degraded — inbox polling failed (Request timed out: pollInbox)",
@@ -3566,7 +3566,7 @@ describe("buildFollowerRuntimeDiagnostic", () => {
       reason: "registration refresh failed after reconnect",
       detail: "refresh failed once",
       nextStep:
-        "Follower kept the last registered identity. If status or ownership looks stale, run /pinet-follow.",
+        "Follower kept the last registered identity. If status or ownership looks stale, run /pinet follow.",
     });
     expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
       "degraded — registration refresh failed after reconnect (refresh failed once)",
@@ -3583,7 +3583,7 @@ describe("buildFollowerRuntimeDiagnostic", () => {
       state: "error",
       reason: "automatic reconnect stopped",
       detail: 'Agent name "Reserved Crane" is already reserved.',
-      nextStep: "Fix the reported error, then run /pinet-follow to retry.",
+      nextStep: "Fix the reported error, then run /pinet follow to retry.",
     });
     expect(formatFollowerRuntimeDiagnosticHealth(diagnostic)).toBe(
       'error — automatic reconnect stopped (Agent name "Reserved Crane" is already reserved.)',

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1694,7 +1694,7 @@ export function buildWorkerPromptGuidelines(): string[] {
     "2. Do the work.",
     "3. If you hit a blocker, report it immediately and ask for what you need — blocked work must be visible so it can be unblocked or reassigned.",
     "4. When done, report the outcome (what changed, branch/PR, test results) — the sender needs closure and next steps.",
-    "5. When you have finished all assigned work and are waiting for more, call `pinet action=free` (or `/pinet-free`) to mark yourself idle/free for the broker.",
+    "5. When you have finished all assigned work and are waiting for more, call `pinet action=free` (or `/pinet free`) to mark yourself idle/free for the broker.",
     "Always reply where the task came from.",
     "If a Pinet thread explicitly says things like 'no further replies are needed', 'hard stop', or 'stay free/quiet unless a new task appears', treat it as a terminal closeout. Do NOT send another acknowledgement unless you have a real blocker, a materially new finding, or a genuinely new task arrives in that thread.",
     "",
@@ -2269,7 +2269,7 @@ export function buildFollowerRuntimeDiagnostic(
       kind,
       state: "reconnecting",
       reason: "broker disconnected",
-      nextStep: "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+      nextStep: "Wait for automatic reconnect. If it does not recover, run /pinet follow.",
       ...(detail ? { detail } : {}),
     };
   }
@@ -2281,8 +2281,8 @@ export function buildFollowerRuntimeDiagnostic(
       state: connected ? "degraded" : "reconnecting",
       reason: "inbox polling failed",
       nextStep: connected
-        ? "Watch the next poll cycle. If failures continue, inspect the broker and run /pinet-follow."
-        : "Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+        ? "Watch the next poll cycle. If failures continue, inspect the broker and run /pinet follow."
+        : "Wait for automatic reconnect. If it does not recover, run /pinet follow.",
       ...(detail ? { detail } : {}),
     };
   }
@@ -2293,7 +2293,7 @@ export function buildFollowerRuntimeDiagnostic(
       state: "degraded",
       reason: "registration refresh failed after reconnect",
       nextStep:
-        "Follower kept the last registered identity. If status or ownership looks stale, run /pinet-follow.",
+        "Follower kept the last registered identity. If status or ownership looks stale, run /pinet follow.",
       ...(detail ? { detail } : {}),
     };
   }
@@ -2302,7 +2302,7 @@ export function buildFollowerRuntimeDiagnostic(
     kind,
     state: "error",
     reason: "automatic reconnect stopped",
-    nextStep: "Fix the reported error, then run /pinet-follow to retry.",
+    nextStep: "Fix the reported error, then run /pinet follow to retry.",
     ...(detail ? { detail } : {}),
   };
 }

--- a/slack-bridge/home-tab.ts
+++ b/slack-bridge/home-tab.ts
@@ -300,7 +300,7 @@ export function renderStandalonePinetHomeTabView(
         text: [
           "• Open the *Messages* tab and start a conversation with Pinet.",
           "• Mention Pinet in a channel to continue work in-thread.",
-          '• Use `runtimeMode: "single"` for local Slack-only mode, or `/pinet-start` and `/pinet-follow` for mesh runtimes.',
+          '• Use `runtimeMode: "single"` for local Slack-only mode, or `/pinet start` and `/pinet follow` for mesh runtimes.',
         ].join("\n"),
       }),
     ],

--- a/slack-bridge/imessage-tools.ts
+++ b/slack-bridge/imessage-tools.ts
@@ -68,7 +68,7 @@ export function registerIMessageTools(pi: ExtensionAPI, deps: RegisterIMessageTo
       );
 
       if (!deps.pinetEnabled()) {
-        throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+        throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
       }
 
       const recipient = normalizeIMessageRecipient(params.to);
@@ -99,7 +99,7 @@ export function registerIMessageTools(pi: ExtensionAPI, deps: RegisterIMessageTo
         }
         if (!broker.adapters.some((candidate) => candidate.name === "imessage")) {
           throw new Error(
-            "iMessage adapter is not enabled or not ready on the active broker. Set slack-bridge.imessage.enabled: true and restart /pinet-start.",
+            "iMessage adapter is not enabled or not ready on the active broker. Set slack-bridge.imessage.enabled: true and restart /pinet start.",
           );
         }
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2508,7 +2508,7 @@ describe("slack-bridge Pinet reconnect", () => {
     );
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Next step: Wait for automatic reconnect. If it does not recover, run /pinet-follow.",
+        "Next step: Wait for automatic reconnect. If it does not recover, run /pinet follow.",
       ),
       "info",
     );
@@ -2694,7 +2694,7 @@ describe("slack-bridge Pinet reconnect", () => {
     );
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Next step: Follower kept the last registered identity. If status or ownership looks stale, run /pinet-follow.",
+        "Next step: Follower kept the last registered identity. If status or ownership looks stale, run /pinet follow.",
       ),
       "info",
     );
@@ -2893,7 +2893,7 @@ describe("slack-bridge Pinet reconnect", () => {
       );
       expect(notify).toHaveBeenCalledWith(
         expect.stringContaining(
-          "Next step: Fix the reported error, then run /pinet-follow to retry.",
+          "Next step: Fix the reported error, then run /pinet follow to retry.",
         ),
         "info",
       );
@@ -3026,7 +3026,7 @@ describe("slack-bridge Pinet reconnect", () => {
       );
       expect(notify).toHaveBeenCalledWith(
         expect.stringContaining(
-          "Next step: Watch the next poll cycle. If failures continue, inspect the broker and run /pinet-follow.",
+          "Next step: Watch the next poll cycle. If failures continue, inspect the broker and run /pinet follow.",
         ),
         "info",
       );

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1145,6 +1145,7 @@ export default function (pi: ExtensionAPI) {
       listPinetLanes,
       upsertPinetLane,
       setPinetLaneParticipant,
+      applyMeshSkin,
     },
     iMessageTools: {
       pinetEnabled: () => pinetEnabled,
@@ -1329,7 +1330,7 @@ export default function (pi: ExtensionAPI) {
       });
       setExtStatus(ctx, "error");
       ctx.ui.notify(
-        `Pinet reconnect stopped: ${msg(error)} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet-follow to retry.`,
+        `Pinet reconnect stopped: ${msg(error)} Update slack-bridge.agentName/agentEmoji or PI_NICKNAME, or clear the explicit identity request, then run /pinet follow to retry.`,
         "error",
       );
     },

--- a/slack-bridge/pinet-agent-status.test.ts
+++ b/slack-bridge/pinet-agent-status.test.ts
@@ -125,6 +125,6 @@ describe("createPinetAgentStatus", () => {
 
     await expect(
       pinetAgentStatus.signalAgentFree(undefined, { requirePinet: true }),
-    ).rejects.toThrow("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+    ).rejects.toThrow("Pinet is not running. Use /pinet start or /pinet follow first.");
   });
 });

--- a/slack-bridge/pinet-agent-status.ts
+++ b/slack-bridge/pinet-agent-status.ts
@@ -68,7 +68,7 @@ export function createPinetAgentStatus(deps: PinetAgentStatusDeps): PinetAgentSt
   ): Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }> {
     const pinetEnabled = deps.getPinetEnabled();
     if (!pinetEnabled && options.requirePinet) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
 
     const maintenanceCtx = ctx ?? deps.getExtensionContext() ?? undefined;

--- a/slack-bridge/pinet-commands.test.ts
+++ b/slack-bridge/pinet-commands.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  formatPinetCommandHelp,
+  registerPinetCommands,
+  type PinetCommandsDeps,
+} from "./pinet-commands.js";
+import type { SlackBridgeSettings } from "./helpers.js";
+import type { SlackScopeDiagnostics } from "./slack-scope-diagnostics.js";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
+
+type CommandDefinition = {
+  description?: string;
+  handler: (args: string, ctx: ExtensionContext) => Promise<void> | void;
+};
+
+function createContext(): { ctx: ExtensionContext; notify: ReturnType<typeof vi.fn> } {
+  const notify = vi.fn();
+  const ctx = {
+    hasUI: true,
+    isIdle: () => true,
+    ui: {
+      notify,
+      theme: { fg: (_color: string, text: string) => text },
+      setStatus: vi.fn(),
+    },
+  } as unknown as ExtensionContext;
+
+  return { ctx, notify };
+}
+
+function createDeps(overrides: Partial<PinetCommandsDeps> = {}): PinetCommandsDeps {
+  const settings: SlackBridgeSettings = {};
+  const slackScopeDiagnostics: SlackScopeDiagnostics = {
+    status: "not_checked",
+    checkedAt: null,
+    summary: "unchecked",
+    surfaces: [],
+    missingScopes: [],
+    results: [],
+  };
+
+  const defaults: PinetCommandsDeps = {
+    pinetEnabled: () => true,
+    pinetRegistrationBlocked: () => false,
+    runtimeMode: () => "single" as SlackBridgeRuntimeMode,
+    runtimeConnected: () => true,
+    brokerRole: () => "broker",
+    agentName: () => "Slate Chalk Otter",
+    agentEmoji: () => "🦦",
+    agentOwnerToken: () => "owner-token",
+    agentPersonality: () => null,
+    agentAliases: () => new Set<string>(),
+    botUserId: () => "U123",
+    activeSkinTheme: () => null,
+    lastDmChannel: () => null,
+    followerRuntimeDiagnostic: () => null,
+    threads: () => new Map<string, { owner?: string }>(),
+    allowedUsers: () => null,
+    inboxLength: () => 0,
+    recentActivityLogEntries: () => [],
+    slackScopeDiagnostics: () => slackScopeDiagnostics,
+    settings: () => settings,
+    lastBrokerMaintenance: () => null,
+    getBrokerControlPlaneHomeTabViewerIds: () => [],
+    lastBrokerControlPlaneHomeTabRefreshAt: () => null,
+    lastBrokerControlPlaneHomeTabError: () => null,
+    getPinetRegistrationBlockReason: () => "blocked",
+    connectAsBroker: async () => {},
+    connectAsFollower: async () => {},
+    reloadPinetRuntime: async () => {},
+    disconnectFollower: async () => ({ unregisterError: null }),
+    sendPinetAgentMessage: async (target) => ({ messageId: 1, target }),
+    signalAgentFree: async () => ({ queuedInboxCount: 0, drainedQueuedInbox: false }),
+    applyMeshSkin: (themeInput) => ({ theme: themeInput.trim(), updatedAgents: ["agent-1"] }),
+    applyLocalAgentIdentity: () => {},
+    setExtStatus: () => {},
+    setExtCtx: () => {},
+  };
+
+  return { ...defaults, ...overrides };
+}
+
+function registerCommands(deps: PinetCommandsDeps): Map<string, CommandDefinition> {
+  const commands = new Map<string, CommandDefinition>();
+  const pi = {
+    registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
+      commands.set(name, definition);
+    }),
+  } as unknown as ExtensionAPI;
+
+  registerPinetCommands(pi, deps);
+  return commands;
+}
+
+describe("registerPinetCommands", () => {
+  it("registers the unified /pinet command while preserving legacy aliases", () => {
+    const commands = registerCommands(createDeps());
+
+    expect(commands.has("pinet")).toBe(true);
+    expect(commands.has("pinet-start")).toBe(true);
+    expect(commands.has("pinet-follow")).toBe(true);
+    expect(commands.has("pinet-free")).toBe(true);
+    expect(commands.has("pinet-skin")).toBe(true);
+  });
+
+  it("shows help for the unified command", async () => {
+    const commands = registerCommands(createDeps());
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Usage: /pinet <action> [args]"),
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("/pinet start"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("/pinet skin <theme>"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("/pinet-start"), "info");
+  });
+
+  it("routes /pinet reload through the existing remote-control message path", async () => {
+    const sendPinetAgentMessage = vi.fn(async (target: string, body: string) => ({
+      messageId: 42,
+      target: `${target}:${body}`,
+    }));
+    const commands = registerCommands(createDeps({ sendPinetAgentMessage }));
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("reload GoldenOtter", ctx);
+
+    expect(sendPinetAgentMessage).toHaveBeenCalledWith("GoldenOtter", "/reload");
+    expect(notify).toHaveBeenCalledWith("Sent /reload to GoldenOtter:/reload", "info");
+  });
+
+  it("keeps legacy usage text on legacy aliases", async () => {
+    const commands = registerCommands(createDeps());
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet-reload")?.handler("", ctx);
+
+    expect(notify).toHaveBeenCalledWith("Usage: /pinet-reload <agent-name-or-id>", "warning");
+  });
+
+  it("runs free and skin from the unified command", async () => {
+    const signalAgentFree = vi.fn(async () => ({ queuedInboxCount: 0, drainedQueuedInbox: false }));
+    const applyMeshSkin = vi.fn((themeInput: string) => ({
+      theme: themeInput.trim(),
+      updatedAgents: ["agent-1", "agent-2"],
+    }));
+    const commands = registerCommands(createDeps({ signalAgentFree, applyMeshSkin }));
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("free", ctx);
+    await commands.get("pinet")?.handler("skin slate chalk", ctx);
+
+    expect(signalAgentFree).toHaveBeenCalledWith(ctx, { requirePinet: true });
+    expect(applyMeshSkin).toHaveBeenCalledWith("slate chalk");
+    expect(notify).toHaveBeenCalledWith(
+      "Marked 🦦 Slate Chalk Otter idle/free for new work.",
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith('Applied mesh skin "slate chalk" to 2 agents.', "info");
+  });
+});
+
+describe("formatPinetCommandHelp", () => {
+  it("documents the consolidated primary actions", () => {
+    const help = formatPinetCommandHelp();
+
+    expect(help).toContain("/pinet start");
+    expect(help).toContain("/pinet follow");
+    expect(help).toContain("/pinet reload <agent>");
+    expect(help).toContain("/pinet exit <agent>");
+    expect(help).toContain("/pinet free");
+    expect(help).toContain("/pinet skin <theme>");
+  });
+});

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -71,6 +71,94 @@ export interface PinetCommandsDeps {
   setExtCtx: (ctx: ExtensionContext) => void;
 }
 
+export type PinetCommandAction =
+  | "start"
+  | "follow"
+  | "unfollow"
+  | "reload"
+  | "exit"
+  | "free"
+  | "skin"
+  | "status"
+  | "logs"
+  | "rename";
+
+interface ParsedPinetCommandAction {
+  action: PinetCommandAction;
+  args: string;
+}
+
+const PINET_PRIMARY_COMMANDS: Array<{
+  action: PinetCommandAction;
+  args: string;
+  description: string;
+}> = [
+  { action: "start", args: "", description: "Start as the mesh broker" },
+  { action: "follow", args: "", description: "Connect as a follower worker" },
+  { action: "unfollow", args: "", description: "Disconnect from the broker" },
+  { action: "reload", args: "<agent>", description: "Ask another agent to reload" },
+  { action: "exit", args: "<agent>", description: "Ask another agent to exit" },
+  { action: "free", args: "", description: "Mark this agent as idle" },
+  { action: "skin", args: "<theme>", description: "Change the mesh presentation skin" },
+];
+
+const PINET_SECONDARY_COMMANDS: Array<{
+  action: PinetCommandAction;
+  args: string;
+  description: string;
+}> = [
+  { action: "status", args: "", description: "Show Pinet status" },
+  { action: "logs", args: "", description: "Show recent broker activity logs" },
+  { action: "rename", args: "[name]", description: "Rename this Pinet agent" },
+];
+
+const PINET_LEGACY_COMMANDS: Array<{
+  name: string;
+  action: PinetCommandAction;
+  description: string;
+}> = [
+  {
+    name: "pinet-start",
+    action: "start",
+    description:
+      "Start Pinet as the broker (Slack connection + message routing, or reload the active broker)",
+  },
+  {
+    name: "pinet-follow",
+    action: "follow",
+    description: "Connect to an existing Pinet broker as a follower",
+  },
+  {
+    name: "pinet-unfollow",
+    action: "unfollow",
+    description: "Disconnect from the Pinet broker and keep working locally",
+  },
+  {
+    name: "pinet-reload",
+    action: "reload",
+    description: "Tell a connected Pinet agent to reload itself",
+  },
+  {
+    name: "pinet-exit",
+    action: "exit",
+    description: "Tell a connected Pinet agent to exit gracefully",
+  },
+  {
+    name: "pinet-free",
+    action: "free",
+    description: "Mark this Pinet agent idle/free for new work",
+  },
+  {
+    name: "pinet-skin",
+    action: "skin",
+    description: "Regenerate the mesh naming/personality skin from a theme",
+  },
+  { name: "pinet-status", action: "status", description: "Show Pinet status" },
+  { name: "pinet-logs", action: "logs", description: "Show recent broker activity log entries" },
+  { name: "slack-logs", action: "logs", description: "Show recent broker activity log entries" },
+  { name: "pinet-rename", action: "rename", description: "Rename this Pinet agent" },
+];
+
 // ─── Registration ────────────────────────────────────────
 
 function abortCurrentTurnBeforeBrokerReload(ctx: ExtensionContext): void {
@@ -85,294 +173,426 @@ function abortCurrentTurnBeforeBrokerReload(ctx: ExtensionContext): void {
   }
 }
 
-export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps): void {
-  pi.registerCommand("pinet-start", {
-    description:
-      "Start Pinet as the broker (Slack connection + message routing, or reload the active broker)",
-    handler: async (_args, ctx) => {
-      if (deps.pinetRegistrationBlocked()) {
-        ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
-        return;
-      }
-      deps.setExtCtx(ctx);
+export function formatPinetCommandHelp(): string {
+  const lines = [
+    "Usage: /pinet <action> [args]",
+    "",
+    "Primary actions:",
+    ...PINET_PRIMARY_COMMANDS.map((command) =>
+      formatPinetCommandHelpLine(command.action, command.args, command.description),
+    ),
+    "",
+    "Other actions:",
+    ...PINET_SECONDARY_COMMANDS.map((command) =>
+      formatPinetCommandHelpLine(command.action, command.args, command.description),
+    ),
+    "",
+    "Legacy aliases such as /pinet-start, /pinet-follow, /pinet-free, and /pinet-skin remain supported.",
+  ];
 
-      if (deps.runtimeMode() === "broker") {
-        try {
-          abortCurrentTurnBeforeBrokerReload(ctx);
-          ctx.ui.notify("Pinet broker already running — reloading current runtime", "info");
-          await deps.reloadPinetRuntime(ctx);
-        } catch (err) {
-          ctx.ui.notify(`Pinet broker reload failed: ${errorMsg(err)}`, "error");
-          deps.setExtStatus(ctx, "error");
-        }
-        return;
-      }
+  return lines.join("\n");
+}
 
-      try {
-        await deps.connectAsBroker(ctx);
-      } catch (err) {
-        ctx.ui.notify(`Pinet broker failed: ${errorMsg(err)}`, "error");
-        deps.setExtStatus(ctx, "error");
-      }
-    },
-  });
+function formatPinetCommandHelpLine(
+  action: PinetCommandAction,
+  args: string,
+  description: string,
+): string {
+  const command = args ? `/pinet ${action} ${args}` : `/pinet ${action}`;
+  return `• ${command} — ${description}`;
+}
 
-  pi.registerCommand("pinet-follow", {
-    description: "Connect to an existing Pinet broker as a follower",
-    handler: async (_args, ctx) => {
-      if (deps.pinetRegistrationBlocked()) {
-        ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
-        return;
-      }
-      if (deps.runtimeMode() === "follower") {
-        ctx.ui.notify("Pinet already running (follower)", "info");
-        return;
-      }
-      deps.setExtCtx(ctx);
+function parsePinetCommandAction(args: string): ParsedPinetCommandAction | null {
+  const trimmed = args.trim();
+  if (!trimmed || trimmed === "?" || trimmed === "-h" || trimmed === "--help") {
+    return null;
+  }
 
-      try {
-        await deps.connectAsFollower(ctx);
-        ctx.ui.notify(`${deps.agentEmoji()} ${deps.agentName()} — following broker`, "info");
-      } catch (err) {
-        ctx.ui.notify(`Pinet follow failed: ${errorMsg(err)}`, "error");
-        deps.setExtStatus(ctx, "error");
-      }
-    },
-  });
+  const [rawAction = "", ...rest] = trimmed.split(/\s+/);
+  const action = normalizePinetCommandAction(rawAction);
+  if (!action) {
+    return null;
+  }
 
-  pi.registerCommand("pinet-unfollow", {
-    description: "Disconnect from the Pinet broker and keep working locally",
-    handler: async (_args, ctx) => {
-      if (deps.runtimeMode() !== "follower" || deps.brokerRole() == null) {
-        ctx.ui.notify("Pinet is not running as a follower.", "info");
-        return;
-      }
-
-      if (deps.brokerRole() !== "follower") {
-        ctx.ui.notify(
-          "Pinet is running as broker; /pinet-unfollow only applies to followers.",
-          "warning",
-        );
-        return;
-      }
-
-      const { unregisterError } = await deps.disconnectFollower(ctx);
-      if (unregisterError) {
-        ctx.ui.notify(
-          `Pinet follower disconnected locally, but broker deregistration failed: ${unregisterError}`,
-          "warning",
-        );
-        return;
-      }
-
-      ctx.ui.notify(
-        `${deps.agentEmoji()} ${deps.agentName()} — disconnected from broker; local session still running`,
-        "info",
-      );
-    },
-  });
-
-  pi.registerCommand("pinet-reload", {
-    description: "Tell a connected Pinet agent to reload itself",
-    handler: async (args, ctx) => {
-      const target = args.trim();
-      if (!target) {
-        ctx.ui.notify("Usage: /pinet-reload <agent-name-or-id>", "warning");
-        return;
-      }
-
-      try {
-        const result = await deps.sendPinetAgentMessage(target, "/reload");
-        ctx.ui.notify(`Sent /reload to ${result.target}`, "info");
-      } catch (err) {
-        ctx.ui.notify(`Pinet reload failed: ${errorMsg(err)}`, "error");
-      }
-    },
-  });
-
-  pi.registerCommand("pinet-exit", {
-    description: "Tell a connected Pinet agent to exit gracefully",
-    handler: async (args, ctx) => {
-      const target = args.trim();
-      if (!target) {
-        ctx.ui.notify("Usage: /pinet-exit <agent-name-or-id>", "warning");
-        return;
-      }
-
-      try {
-        const result = await deps.sendPinetAgentMessage(target, "/exit");
-        ctx.ui.notify(`Sent /exit to ${result.target}`, "info");
-      } catch (err) {
-        ctx.ui.notify(`Pinet exit failed: ${errorMsg(err)}`, "error");
-      }
-    },
-  });
-
-  pi.registerCommand("pinet-free", {
-    description: "Mark this Pinet agent idle/free for new work",
-    handler: async (_args, ctx) => {
-      if (!deps.pinetEnabled()) {
-        ctx.ui.notify(
-          "Pinet mesh runtime is not active. Use /pinet-start or /pinet-follow.",
-          "info",
-        );
-        return;
-      }
-
-      try {
-        const result = await deps.signalAgentFree(ctx, { requirePinet: true });
-        const suffix = result.drainedQueuedInbox
-          ? ` Processing ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? "" : "s"} now.`
-          : result.queuedInboxCount > 0
-            ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`
-            : "";
-        ctx.ui.notify(
-          `Marked ${deps.agentEmoji()} ${deps.agentName()} idle/free for new work.${suffix}`,
-          "info",
-        );
-      } catch (err) {
-        ctx.ui.notify(`Pinet free failed: ${errorMsg(err)}`, "error");
-      }
-    },
-  });
-
-  pi.registerCommand("pinet-skin", {
-    description: "Regenerate the mesh naming/personality skin from a theme",
-    handler: async (args, ctx) => {
-      if (!deps.pinetEnabled() || deps.brokerRole() == null) {
-        ctx.ui.notify(
-          "Pinet mesh runtime is not active. Use /pinet-start or /pinet-follow.",
-          "info",
-        );
-        return;
-      }
-      if (deps.brokerRole() !== "broker") {
-        ctx.ui.notify("/pinet-skin can only run on the active broker.", "warning");
-        return;
-      }
-
-      try {
-        const result = deps.applyMeshSkin(args);
-        ctx.ui.notify(
-          `Applied mesh skin "${result.theme}" to ${result.updatedAgents.length} agent${result.updatedAgents.length === 1 ? "" : "s"}.`,
-          "info",
-        );
-      } catch (err) {
-        ctx.ui.notify(`Pinet skin failed: ${errorMsg(err)}`, "error");
-      }
-    },
-  });
-
-  pi.registerCommand("pinet-status", {
-    description: "Show Pinet status",
-    handler: async (_args, ctx) => {
-      const mode = deps.runtimeMode();
-      const ownedCount = [...deps.threads().values()].filter((t) =>
-        agentOwnsThread(t.owner, deps.agentName(), deps.agentAliases(), deps.agentOwnerToken()),
-      ).length;
-      const users = deps.allowedUsers();
-      const s = deps.settings();
-      const allowlistInfo = describeSlackUserAccess(users, {
-        allowAllWorkspaceUsers: resolveAllowAllWorkspaceUsers(
-          s,
-          process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
-        ),
-      });
-      const defaultChInfo = s.defaultChannel
-        ? `Default channel: ${s.defaultChannel}`
-        : "Default channel: none";
-      const activityLogInfo = s.logChannel
-        ? `Activity log: ${s.logChannel} (${s.logLevel ?? "actions"})`
-        : "Activity log: disabled";
-      const guardrailsInfo = `Guardrails: ${formatRuntimeGuardrailsPosture(s.security ?? {})}`;
-      const runtimeDiagnostic = deps.followerRuntimeDiagnostic();
-      const runtimeHealthInfo = `Runtime health: ${formatFollowerRuntimeDiagnosticHealth(runtimeDiagnostic)}`;
-      const runtimeNextStepInfo = `Next step: ${formatFollowerRuntimeDiagnosticNextStep(runtimeDiagnostic)}`;
-      const slackToolHealthInfo = `Slack tool health: ${formatSlackScopeDiagnosticsStatus(deps.slackScopeDiagnostics())}`;
-      const lbm = deps.lastBrokerMaintenance();
-      const brokerHealthInfo =
-        mode === "broker" && lbm
-          ? [
-              `Pending backlog: ${lbm.pendingBacklogCount}`,
-              `Last maintenance: assigned ${lbm.assignedBacklogCount}, reaped ${lbm.reapedAgentIds.length}, repaired ${lbm.repairedThreadClaims}`,
-              ...(lbm.anomalies.length > 0 ? [`Health: ${lbm.anomalies.join("; ")}`] : []),
-            ]
-          : [];
-      const brokerHomeTabInfo =
-        mode === "broker"
-          ? [
-              `Home tab viewers: ${deps.getBrokerControlPlaneHomeTabViewerIds().length}`,
-              ...(deps.lastBrokerControlPlaneHomeTabRefreshAt()
-                ? [`Home tab refreshed: ${deps.lastBrokerControlPlaneHomeTabRefreshAt()}`]
-                : []),
-              ...(deps.lastBrokerControlPlaneHomeTabError()
-                ? [`Home tab status: ${deps.lastBrokerControlPlaneHomeTabError()}`]
-                : []),
-            ]
-          : [];
-      ctx.ui.notify(
-        [
-          `Mode: ${mode}`,
-          `Agent: ${deps.agentEmoji()} ${deps.agentName()}`,
-          `Bot: ${deps.botUserId() ?? "unknown"}`,
-          `Connection: ${deps.runtimeConnected() ? "connected" : "disconnected"}`,
-          runtimeHealthInfo,
-          runtimeNextStepInfo,
-          `Skin: ${deps.activeSkinTheme() ?? "(legacy/manual)"}`,
-          ...(deps.agentPersonality() ? [`Persona: ${deps.agentPersonality()}`] : []),
-          `Threads: ${deps.threads().size} (${ownedCount} owned by ${deps.agentName()})`,
-          `DM channel: ${deps.lastDmChannel() ?? "none yet"}`,
-          allowlistInfo,
-          guardrailsInfo,
-          defaultChInfo,
-          activityLogInfo,
-          slackToolHealthInfo,
-          ...brokerHealthInfo,
-          ...brokerHomeTabInfo,
-        ].join("\n"),
-        "info",
-      );
-    },
-  });
-
-  const showActivityLogs = async (_args: string, ctx: ExtensionContext) => {
-    const s = deps.settings();
-    const channelInfo = s.logChannel ? `${s.logChannel} (${s.logLevel ?? "actions"})` : "disabled";
-    ctx.ui.notify(
-      [
-        `Activity log channel: ${channelInfo}`,
-        formatRecentActivityLogEntries(deps.recentActivityLogEntries(10)),
-      ].join("\n\n"),
-      s.logChannel ? "info" : "warning",
-    );
+  return {
+    action,
+    args: rest.join(" ").trim(),
   };
+}
 
-  pi.registerCommand("pinet-logs", {
-    description: "Show recent broker activity log entries",
-    handler: showActivityLogs,
-  });
+function normalizePinetCommandAction(rawAction: string): PinetCommandAction | null {
+  const normalized = rawAction
+    .trim()
+    .replace(/^\//, "")
+    .replace(/^pinet[:-]/, "")
+    .toLowerCase();
 
-  pi.registerCommand("slack-logs", {
-    description: "Show recent broker activity log entries",
-    handler: showActivityLogs,
-  });
+  switch (normalized) {
+    case "start":
+    case "broker":
+      return "start";
+    case "follow":
+    case "worker":
+      return "follow";
+    case "unfollow":
+    case "disconnect":
+      return "unfollow";
+    case "reload":
+      return "reload";
+    case "exit":
+      return "exit";
+    case "free":
+    case "idle":
+      return "free";
+    case "skin":
+      return "skin";
+    case "status":
+      return "status";
+    case "logs":
+    case "log":
+      return "logs";
+    case "rename":
+      return "rename";
+    case "help":
+      return null;
+    default:
+      return null;
+  }
+}
 
-  pi.registerCommand("pinet-rename", {
-    description: "Rename this Pinet agent",
+export async function runPinetCommandAction(
+  deps: PinetCommandsDeps,
+  action: PinetCommandAction,
+  args: string,
+  ctx: ExtensionContext,
+  usageCommand = `/pinet ${action}`,
+): Promise<void> {
+  switch (action) {
+    case "start":
+      await runPinetStart(deps, ctx);
+      return;
+    case "follow":
+      await runPinetFollow(deps, ctx);
+      return;
+    case "unfollow":
+      await runPinetUnfollow(deps, ctx);
+      return;
+    case "reload":
+      await runPinetReload(deps, args, ctx, usageCommand);
+      return;
+    case "exit":
+      await runPinetExit(deps, args, ctx, usageCommand);
+      return;
+    case "free":
+      await runPinetFree(deps, ctx);
+      return;
+    case "skin":
+      runPinetSkin(deps, args, ctx, usageCommand);
+      return;
+    case "status":
+      runPinetStatus(deps, ctx);
+      return;
+    case "logs":
+      runPinetLogs(deps, ctx);
+      return;
+    case "rename":
+      runPinetRename(deps, args, ctx);
+      return;
+  }
+}
+
+export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps): void {
+  pi.registerCommand("pinet", {
+    description:
+      "Unified Pinet command surface: start, follow, unfollow, reload, exit, free, skin, status, logs, rename",
     handler: async (args, ctx) => {
-      const newName = args.trim();
-      if (!newName) {
-        const fresh = generateAgentName(
-          undefined,
-          deps.runtimeMode() === "broker" ? "broker" : "worker",
-        );
-        deps.applyLocalAgentIdentity(fresh.name, fresh.emoji, deps.agentPersonality());
-      } else {
-        deps.applyLocalAgentIdentity(newName, deps.agentEmoji(), deps.agentPersonality());
+      const parsed = parsePinetCommandAction(args);
+      if (!parsed) {
+        const trimmed = args.trim();
+        const tone =
+          trimmed && !["help", "?", "-h", "--help"].includes(trimmed.toLowerCase())
+            ? "warning"
+            : "info";
+        const prefix = tone === "warning" ? `Unknown Pinet action: ${trimmed}\n\n` : "";
+        ctx.ui.notify(`${prefix}${formatPinetCommandHelp()}`, tone);
+        return;
       }
-      ctx.ui.notify(`${deps.agentEmoji()} Agent renamed to: ${deps.agentName()}`, "info");
+
+      await runPinetCommandAction(deps, parsed.action, parsed.args, ctx);
     },
   });
+
+  for (const command of PINET_LEGACY_COMMANDS) {
+    pi.registerCommand(command.name, {
+      description: `${command.description} (alias for /pinet ${command.action})`,
+      handler: async (args, ctx) => {
+        await runPinetCommandAction(deps, command.action, args, ctx, `/${command.name}`);
+      },
+    });
+  }
+}
+
+async function runPinetStart(deps: PinetCommandsDeps, ctx: ExtensionContext): Promise<void> {
+  if (deps.pinetRegistrationBlocked()) {
+    ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
+    return;
+  }
+  deps.setExtCtx(ctx);
+
+  if (deps.runtimeMode() === "broker") {
+    try {
+      abortCurrentTurnBeforeBrokerReload(ctx);
+      ctx.ui.notify("Pinet broker already running — reloading current runtime", "info");
+      await deps.reloadPinetRuntime(ctx);
+    } catch (err) {
+      ctx.ui.notify(`Pinet broker reload failed: ${errorMsg(err)}`, "error");
+      deps.setExtStatus(ctx, "error");
+    }
+    return;
+  }
+
+  try {
+    await deps.connectAsBroker(ctx);
+  } catch (err) {
+    ctx.ui.notify(`Pinet broker failed: ${errorMsg(err)}`, "error");
+    deps.setExtStatus(ctx, "error");
+  }
+}
+
+async function runPinetFollow(deps: PinetCommandsDeps, ctx: ExtensionContext): Promise<void> {
+  if (deps.pinetRegistrationBlocked()) {
+    ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
+    return;
+  }
+  if (deps.runtimeMode() === "follower") {
+    ctx.ui.notify("Pinet already running (follower)", "info");
+    return;
+  }
+  deps.setExtCtx(ctx);
+
+  try {
+    await deps.connectAsFollower(ctx);
+    ctx.ui.notify(`${deps.agentEmoji()} ${deps.agentName()} — following broker`, "info");
+  } catch (err) {
+    ctx.ui.notify(`Pinet follow failed: ${errorMsg(err)}`, "error");
+    deps.setExtStatus(ctx, "error");
+  }
+}
+
+async function runPinetUnfollow(deps: PinetCommandsDeps, ctx: ExtensionContext): Promise<void> {
+  if (deps.runtimeMode() !== "follower" || deps.brokerRole() == null) {
+    ctx.ui.notify("Pinet is not running as a follower.", "info");
+    return;
+  }
+
+  if (deps.brokerRole() !== "follower") {
+    ctx.ui.notify(
+      "Pinet is running as broker; /pinet unfollow only applies to followers.",
+      "warning",
+    );
+    return;
+  }
+
+  const { unregisterError } = await deps.disconnectFollower(ctx);
+  if (unregisterError) {
+    ctx.ui.notify(
+      `Pinet follower disconnected locally, but broker deregistration failed: ${unregisterError}`,
+      "warning",
+    );
+    return;
+  }
+
+  ctx.ui.notify(
+    `${deps.agentEmoji()} ${deps.agentName()} — disconnected from broker; local session still running`,
+    "info",
+  );
+}
+
+async function runPinetReload(
+  deps: PinetCommandsDeps,
+  args: string,
+  ctx: ExtensionContext,
+  usageCommand: string,
+): Promise<void> {
+  const target = args.trim();
+  if (!target) {
+    ctx.ui.notify(`Usage: ${usageCommand} <agent-name-or-id>`, "warning");
+    return;
+  }
+
+  try {
+    const result = await deps.sendPinetAgentMessage(target, "/reload");
+    ctx.ui.notify(`Sent /reload to ${result.target}`, "info");
+  } catch (err) {
+    ctx.ui.notify(`Pinet reload failed: ${errorMsg(err)}`, "error");
+  }
+}
+
+async function runPinetExit(
+  deps: PinetCommandsDeps,
+  args: string,
+  ctx: ExtensionContext,
+  usageCommand: string,
+): Promise<void> {
+  const target = args.trim();
+  if (!target) {
+    ctx.ui.notify(`Usage: ${usageCommand} <agent-name-or-id>`, "warning");
+    return;
+  }
+
+  try {
+    const result = await deps.sendPinetAgentMessage(target, "/exit");
+    ctx.ui.notify(`Sent /exit to ${result.target}`, "info");
+  } catch (err) {
+    ctx.ui.notify(`Pinet exit failed: ${errorMsg(err)}`, "error");
+  }
+}
+
+async function runPinetFree(deps: PinetCommandsDeps, ctx: ExtensionContext): Promise<void> {
+  if (!deps.pinetEnabled()) {
+    ctx.ui.notify("Pinet mesh runtime is not active. Use /pinet start or /pinet follow.", "info");
+    return;
+  }
+
+  try {
+    const result = await deps.signalAgentFree(ctx, { requirePinet: true });
+    const suffix = result.drainedQueuedInbox
+      ? ` Processing ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? "" : "s"} now.`
+      : result.queuedInboxCount > 0
+        ? ` ${result.queuedInboxCount} queued inbox item${result.queuedInboxCount === 1 ? " remains" : "s remain"}.`
+        : "";
+    ctx.ui.notify(
+      `Marked ${deps.agentEmoji()} ${deps.agentName()} idle/free for new work.${suffix}`,
+      "info",
+    );
+  } catch (err) {
+    ctx.ui.notify(`Pinet free failed: ${errorMsg(err)}`, "error");
+  }
+}
+
+function runPinetSkin(
+  deps: PinetCommandsDeps,
+  args: string,
+  ctx: ExtensionContext,
+  usageCommand: string,
+): void {
+  if (!deps.pinetEnabled() || deps.brokerRole() == null) {
+    ctx.ui.notify("Pinet mesh runtime is not active. Use /pinet start or /pinet follow.", "info");
+    return;
+  }
+  if (deps.brokerRole() !== "broker") {
+    ctx.ui.notify("/pinet skin can only run on the active broker.", "warning");
+    return;
+  }
+  if (!args.trim()) {
+    ctx.ui.notify(`Usage: ${usageCommand} <theme>`, "warning");
+    return;
+  }
+
+  try {
+    const result = deps.applyMeshSkin(args);
+    ctx.ui.notify(
+      `Applied mesh skin "${result.theme}" to ${result.updatedAgents.length} agent${result.updatedAgents.length === 1 ? "" : "s"}.`,
+      "info",
+    );
+  } catch (err) {
+    ctx.ui.notify(`Pinet skin failed: ${errorMsg(err)}`, "error");
+  }
+}
+
+function runPinetStatus(deps: PinetCommandsDeps, ctx: ExtensionContext): void {
+  const mode = deps.runtimeMode();
+  const ownedCount = [...deps.threads().values()].filter((t) =>
+    agentOwnsThread(t.owner, deps.agentName(), deps.agentAliases(), deps.agentOwnerToken()),
+  ).length;
+  const users = deps.allowedUsers();
+  const s = deps.settings();
+  const allowlistInfo = describeSlackUserAccess(users, {
+    allowAllWorkspaceUsers: resolveAllowAllWorkspaceUsers(
+      s,
+      process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS,
+    ),
+  });
+  const defaultChInfo = s.defaultChannel
+    ? `Default channel: ${s.defaultChannel}`
+    : "Default channel: none";
+  const activityLogInfo = s.logChannel
+    ? `Activity log: ${s.logChannel} (${s.logLevel ?? "actions"})`
+    : "Activity log: disabled";
+  const guardrailsInfo = `Guardrails: ${formatRuntimeGuardrailsPosture(s.security ?? {})}`;
+  const runtimeDiagnostic = deps.followerRuntimeDiagnostic();
+  const runtimeHealthInfo = `Runtime health: ${formatFollowerRuntimeDiagnosticHealth(runtimeDiagnostic)}`;
+  const runtimeNextStepInfo = `Next step: ${formatFollowerRuntimeDiagnosticNextStep(runtimeDiagnostic)}`;
+  const slackToolHealthInfo = `Slack tool health: ${formatSlackScopeDiagnosticsStatus(deps.slackScopeDiagnostics())}`;
+  const lbm = deps.lastBrokerMaintenance();
+  const brokerHealthInfo =
+    mode === "broker" && lbm
+      ? [
+          `Pending backlog: ${lbm.pendingBacklogCount}`,
+          `Last maintenance: assigned ${lbm.assignedBacklogCount}, reaped ${lbm.reapedAgentIds.length}, repaired ${lbm.repairedThreadClaims}`,
+          ...(lbm.anomalies.length > 0 ? [`Health: ${lbm.anomalies.join("; ")}`] : []),
+        ]
+      : [];
+  const brokerHomeTabInfo =
+    mode === "broker"
+      ? [
+          `Home tab viewers: ${deps.getBrokerControlPlaneHomeTabViewerIds().length}`,
+          ...(deps.lastBrokerControlPlaneHomeTabRefreshAt()
+            ? [`Home tab refreshed: ${deps.lastBrokerControlPlaneHomeTabRefreshAt()}`]
+            : []),
+          ...(deps.lastBrokerControlPlaneHomeTabError()
+            ? [`Home tab status: ${deps.lastBrokerControlPlaneHomeTabError()}`]
+            : []),
+        ]
+      : [];
+  ctx.ui.notify(
+    [
+      `Mode: ${mode}`,
+      `Agent: ${deps.agentEmoji()} ${deps.agentName()}`,
+      `Bot: ${deps.botUserId() ?? "unknown"}`,
+      `Connection: ${deps.runtimeConnected() ? "connected" : "disconnected"}`,
+      runtimeHealthInfo,
+      runtimeNextStepInfo,
+      `Skin: ${deps.activeSkinTheme() ?? "(legacy/manual)"}`,
+      ...(deps.agentPersonality() ? [`Persona: ${deps.agentPersonality()}`] : []),
+      `Threads: ${deps.threads().size} (${ownedCount} owned by ${deps.agentName()})`,
+      `DM channel: ${deps.lastDmChannel() ?? "none yet"}`,
+      allowlistInfo,
+      guardrailsInfo,
+      defaultChInfo,
+      activityLogInfo,
+      slackToolHealthInfo,
+      ...brokerHealthInfo,
+      ...brokerHomeTabInfo,
+    ].join("\n"),
+    "info",
+  );
+}
+
+function runPinetLogs(deps: PinetCommandsDeps, ctx: ExtensionContext): void {
+  const s = deps.settings();
+  const channelInfo = s.logChannel ? `${s.logChannel} (${s.logLevel ?? "actions"})` : "disabled";
+  ctx.ui.notify(
+    [
+      `Activity log channel: ${channelInfo}`,
+      formatRecentActivityLogEntries(deps.recentActivityLogEntries(10)),
+    ].join("\n\n"),
+    s.logChannel ? "info" : "warning",
+  );
+}
+
+function runPinetRename(deps: PinetCommandsDeps, args: string, ctx: ExtensionContext): void {
+  const newName = args.trim();
+  if (!newName) {
+    const fresh = generateAgentName(
+      undefined,
+      deps.runtimeMode() === "broker" ? "broker" : "worker",
+    );
+    deps.applyLocalAgentIdentity(fresh.name, fresh.emoji, deps.agentPersonality());
+  } else {
+    deps.applyLocalAgentIdentity(newName, deps.agentEmoji(), deps.agentPersonality());
+  }
+  ctx.ui.notify(`${deps.agentEmoji()} Agent renamed to: ${deps.agentName()}`, "info");
 }
 
 function errorMsg(err: unknown): string {

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -134,7 +134,7 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
     metadata?: Record<string, unknown>,
   ): Promise<{ messageId: number; target: string }> {
     if (!deps.getPinetEnabled()) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
 
     if (isBroadcastChannelTarget(targetRef)) {

--- a/slack-bridge/pinet-skin.test.ts
+++ b/slack-bridge/pinet-skin.test.ts
@@ -82,7 +82,7 @@ describe("createPinetMeshSkin", () => {
     const pinetMeshSkin = createPinetMeshSkin(deps);
 
     expect(() => pinetMeshSkin.applyMeshSkin("cyberpunk neon")).toThrow(
-      "/pinet-skin can only run on the active broker.",
+      "/pinet skin can only run on the active broker.",
     );
   });
 
@@ -90,7 +90,7 @@ describe("createPinetMeshSkin", () => {
     const { deps } = createDeps();
     const pinetMeshSkin = createPinetMeshSkin(deps);
 
-    expect(() => pinetMeshSkin.applyMeshSkin("   ")).toThrow("Usage: /pinet-skin <theme>");
+    expect(() => pinetMeshSkin.applyMeshSkin("   ")).toThrow("Usage: /pinet skin <theme>");
   });
 
   it("requires the broker identity to be available", () => {

--- a/slack-bridge/pinet-skin.ts
+++ b/slack-bridge/pinet-skin.ts
@@ -72,12 +72,12 @@ export function createPinetMeshSkin(deps: PinetMeshSkinDeps): PinetMeshSkin {
     const db = deps.getActiveBrokerDb();
     const selfId = deps.getActiveBrokerSelfId();
     if (deps.getBrokerRole() !== "broker" || !db) {
-      throw new Error("/pinet-skin can only run on the active broker.");
+      throw new Error("/pinet skin can only run on the active broker.");
     }
 
     const theme = normalizePinetSkinTheme(themeInput);
     if (!theme) {
-      throw new Error("Usage: /pinet-skin <theme>");
+      throw new Error("Usage: /pinet skin <theme>");
     }
 
     if (!selfId) {

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -85,6 +85,10 @@ function createDeps(overrides: Partial<RegisterPinetToolsDeps> = {}): RegisterPi
       updatedAt: "2026-05-01T00:00:00.000Z",
       lastActivityAt: "2026-05-01T00:00:00.000Z",
     }),
+    applyMeshSkin: (themeInput: string) => ({
+      theme: themeInput.trim(),
+      updatedAgents: ["agent-1"],
+    }),
   };
 
   return { ...defaults, ...overrides };
@@ -119,10 +123,63 @@ describe("registerPinetTools", () => {
     const pinet = tools.get("pinet");
 
     expect(pinet?.promptSnippet).toContain("Use this compact dispatcher for Pinet actions");
+    expect(pinet?.promptSnippet).toContain("reload, exit, skin");
     expect(pinet?.promptSnippet).toContain('args.format="json"');
     expect(JSON.stringify(pinet?.parameters)).toContain(
-      "help, send, read, free, schedule, agents, lanes, or help",
+      "help, send, read, free, schedule, agents, lanes, reload, exit, or skin",
     );
+  });
+
+  it("routes reload and exit through the dispatcher remote-control actions", async () => {
+    const sendPinetAgentMessage = vi.fn(async (target: string, body: string) => ({
+      messageId: body === "/reload" ? 31 : 32,
+      target,
+    }));
+    const deps = createDeps({ sendPinetAgentMessage });
+    const tools = registerWithDeps(deps);
+
+    const reload = (await tools.get("pinet")?.execute("tool-call-1", {
+      action: "reload",
+      args: { target: "Golden Chalk Rabbit" },
+    })) as { details: { data: { details: { command: string; target: string } } } };
+    const exit = (await tools.get("pinet")?.execute("tool-call-2", {
+      action: "exit",
+      args: { target: "Golden Chalk Rabbit" },
+    })) as { details: { data: { details: { command: string; target: string } } } };
+
+    expect(sendPinetAgentMessage).toHaveBeenCalledWith("Golden Chalk Rabbit", "/reload");
+    expect(sendPinetAgentMessage).toHaveBeenCalledWith("Golden Chalk Rabbit", "/exit");
+    expect(reload.details.data.details).toMatchObject({
+      command: "/reload",
+      target: "Golden Chalk Rabbit",
+    });
+    expect(exit.details.data.details).toMatchObject({
+      command: "/exit",
+      target: "Golden Chalk Rabbit",
+    });
+  });
+
+  it("applies broker mesh skins through the dispatcher skin action", async () => {
+    const applyMeshSkin = vi.fn((themeInput: string) => ({
+      theme: themeInput.trim(),
+      updatedAgents: ["agent-1", "agent-2"],
+    }));
+    const deps = createDeps({ applyMeshSkin });
+    const tools = registerWithDeps(deps);
+
+    const result = (await tools.get("pinet")?.execute("tool-call-1", {
+      action: "skin",
+      args: { theme: "foundation" },
+    })) as {
+      details: { data: { text: string; details: { theme: string; updatedAgents: string[] } } };
+    };
+
+    expect(applyMeshSkin).toHaveBeenCalledWith("foundation");
+    expect(result.details.data.text).toBe('Applied mesh skin "foundation" to 2 agents.');
+    expect(result.details.data.details).toEqual({
+      theme: "foundation",
+      updatedAgents: ["agent-1", "agent-2"],
+    });
   });
 
   it("uses the broker broadcast path for broadcast dispatcher send targets", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -84,6 +84,7 @@ export interface RegisterPinetToolsDeps {
   setPinetLaneParticipant: (
     input: PinetLaneParticipantUpsertInput,
   ) => Promise<PinetLaneParticipantInfo>;
+  applyMeshSkin: (themeInput: string) => { theme: string; updatedAgents: string[] };
 }
 
 interface PinetAgentsRoutingHint {
@@ -94,7 +95,17 @@ interface PinetAgentsRoutingHint {
   task?: string;
 }
 
-type PinetDispatcherAction = "send" | "read" | "free" | "schedule" | "agents" | "lanes" | "help";
+type PinetDispatcherAction =
+  | "send"
+  | "read"
+  | "free"
+  | "schedule"
+  | "agents"
+  | "lanes"
+  | "reload"
+  | "exit"
+  | "skin"
+  | "help";
 type PinetDispatcherErrorClass = "input" | "state" | "runtime" | "network";
 
 type PinetDispatcherStatus = "succeeded" | "failed";
@@ -153,6 +164,9 @@ const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
       },
     },
   ],
+  reload: [{ action: "reload", args: { target: "@worker" } }],
+  exit: [{ action: "exit", args: { target: "@worker" } }],
+  skin: [{ action: "skin", args: { theme: "foundation" } }],
 };
 
 const PINET_OUTPUT_OPTION_PARAMETERS = {
@@ -201,6 +215,9 @@ function normalizeDispatcherAction(value: unknown): PinetDispatcherAction {
     "schedule",
     "agents",
     "lanes",
+    "reload",
+    "exit",
+    "skin",
   ];
   if (!allowed.includes(normalized)) {
     throw new Error(`Unknown Pinet action: ${normalized}`);
@@ -239,7 +256,12 @@ function classifyPinetError(message: string): PinetDispatcherError {
     };
   }
 
-  if (message.includes("thread_id must be") || message.includes("message is required")) {
+  if (
+    message.includes("thread_id must be") ||
+    message.includes("message is required") ||
+    message.includes("target is required") ||
+    message.includes("theme is required")
+  ) {
     return {
       class: "input",
       message,
@@ -471,7 +493,7 @@ function runPinetReadAction(
     );
 
     if (!deps.pinetEnabled()) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
 
     const options: PinetReadOptions = {
@@ -538,6 +560,59 @@ function runPinetFreeAction(
   })();
 }
 
+function runPinetRemoteControlAction(
+  params: Record<string, unknown>,
+  deps: RegisterPinetToolsDeps,
+  toolName: string,
+  command: "/reload" | "/exit",
+): Promise<PinetToolResult> {
+  return (async () => {
+    const target = typeof params.target === "string" ? params.target.trim() : "";
+    if (!target) {
+      throw new Error("target is required");
+    }
+
+    deps.requireToolPolicy(toolName, undefined, `target=${target}`);
+
+    const result = await deps.sendPinetAgentMessage(target, command);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Sent ${command} to ${result.target}.`,
+        },
+      ],
+      details: { messageId: result.messageId, target: result.target, command },
+    };
+  })();
+}
+
+function runPinetSkinAction(
+  params: Record<string, unknown>,
+  deps: RegisterPinetToolsDeps,
+  toolName: string,
+): Promise<PinetToolResult> {
+  return (async () => {
+    const theme = typeof params.theme === "string" ? params.theme.trim() : "";
+    if (!theme) {
+      throw new Error("theme is required");
+    }
+
+    deps.requireToolPolicy(toolName, undefined, `theme=${theme}`);
+
+    const result = deps.applyMeshSkin(theme);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Applied mesh skin "${result.theme}" to ${result.updatedAgents.length} agent${result.updatedAgents.length === 1 ? "" : "s"}.`,
+        },
+      ],
+      details: { theme: result.theme, updatedAgents: result.updatedAgents },
+    };
+  })();
+}
+
 function runPinetScheduleAction(
   params: Record<string, unknown>,
   deps: RegisterPinetToolsDeps,
@@ -556,7 +631,7 @@ function runPinetScheduleAction(
     );
 
     if (!deps.pinetEnabled()) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
     if (!message) {
       throw new Error("message is required");
@@ -865,7 +940,7 @@ function runPinetAgentsAction(
     );
 
     if (!deps.pinetEnabled()) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
 
     const includeGhosts = true;
@@ -972,6 +1047,38 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
     execute: (_id, params, output) => runPinetFreeAction(params, deps, "pinet:free", output),
+  });
+
+  registerAction({
+    name: "reload",
+    description: "Ask another connected Pinet agent to reload itself.",
+    parameters: Type.Object({
+      target: Type.String({ description: "Target agent name or ID" }),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
+    }),
+    execute: (_id, params, _output) =>
+      runPinetRemoteControlAction(params, deps, "pinet:reload", "/reload"),
+  });
+
+  registerAction({
+    name: "exit",
+    description: "Ask another connected Pinet agent to exit gracefully.",
+    parameters: Type.Object({
+      target: Type.String({ description: "Target agent name or ID" }),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
+    }),
+    execute: (_id, params, _output) =>
+      runPinetRemoteControlAction(params, deps, "pinet:exit", "/exit"),
+  });
+
+  registerAction({
+    name: "skin",
+    description: "Change the mesh presentation skin from the active broker runtime.",
+    parameters: Type.Object({
+      theme: Type.String({ description: "Skin theme, e.g. default, foundation, or cosmere" }),
+      ...PINET_OUTPUT_OPTION_PARAMETERS,
+    }),
+    execute: (_id, params, _output) => runPinetSkinAction(params, deps, "pinet:skin"),
   });
 
   registerAction({
@@ -1095,13 +1202,13 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
   pi.registerTool({
     name: "pinet",
     label: "Pinet Dispatcher",
-    description:
-      "Dispatch Pinet worker operations by action with compact help and schema discovery.",
+    description: "Dispatch Pinet operations by action with compact help and schema discovery.",
     promptSnippet:
-      'Use this compact dispatcher for Pinet actions: send, read, free, schedule, agents, lanes, and help. Defaults to terse CLI text; pass args.format="json" or args.full=true for explicit detail.',
+      'Use this compact dispatcher for Pinet actions: send, read, free, schedule, agents, lanes, reload, exit, skin, and help. Use /pinet start, /pinet follow, and /pinet unfollow for TUI lifecycle changes. Defaults to terse CLI text; pass args.format="json" or args.full=true for explicit detail.',
     parameters: Type.Object({
       action: Type.String({
-        description: "Action name: help, send, read, free, schedule, agents, lanes, or help.",
+        description:
+          "Action name: help, send, read, free, schedule, agents, lanes, reload, exit, or skin.",
       }),
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {

--- a/slack-bridge/prompts/broker/default.md
+++ b/slack-bridge/prompts/broker/default.md
@@ -28,7 +28,7 @@ If a repo instruction says to use the `code-reviewer` subagent, treat that as wo
 
 When delegating, include: task, issue/PR numbers, maintainer priority/approval, repo/branch/worktree setup, and where to report back (Slack thread_ts).
 
-If no repo-matched workers are available and new capacity is needed, you may spin up a worker as broker infrastructure: create a tmux session in the target repo, launch `pi`, run `/pinet-follow`, wait for the worker in `pinet action=agents`, then delegate via `pinet action=send`. NEVER do the work yourself or cross-route to another repo as a fallback.
+If no repo-matched workers are available and new capacity is needed, you may spin up a worker as broker infrastructure: create a tmux session in the target repo, launch `pi`, run `/pinet follow`, wait for the worker in `pinet action=agents`, then delegate via `pinet action=send`. NEVER do the work yourself or cross-route to another repo as a fallback.
 
 WORKTREE RULE: The main repo checkout must ALWAYS stay on the `main` branch. NEVER run `git checkout <branch>` or `git switch <branch>` in the main checkout.
 


### PR DESCRIPTION
## Summary
- add unified `/pinet <action>` slash command for start/follow/unfollow/reload/exit/free/skin plus status/logs/rename
- keep legacy `/pinet-*` aliases registered for backwards compatibility
- extend the `pinet` dispatcher with reload/exit/skin actions and guard new mutating actions under read-only policy
- refresh user-facing docs/help strings to prefer `/pinet ...`

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

## Review
- local code-reviewer approved after guardrail fix
