### PR TITLE
Fix Slack channel canvas fallback

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -273,9 +273,12 @@ migration.
   when Slack returns `invalid_arguments`, preserving syntax highlighting for
   supported types while avoiding hard failures on unsupported snippet types.
 - **Canvases are long-lived docs.** `canvas_create` creates standalone or
-  channel canvases; `canvas_update` can append, prepend, replace the whole
-  canvas, or replace a matched section; `canvas_comments_read` is read-only and
-  limited to verified canvas targets.
+  channel canvases. If Slack rejects channel tab creation with
+  `canvas_tab_creation_failed`, it falls back to a standalone canvas attached to
+  the channel, attempts to bookmark the canvas URL, and returns the fallback
+  `canvas_id` for future `canvas_update` calls. `canvas_update` can append,
+  prepend, replace the whole canvas, or replace a matched section;
+  `canvas_comments_read` is read-only and limited to verified canvas targets.
 - **Scheduling, pins, and bookmarks are durable affordances.** Use `schedule`
   for delayed reminders instead of waiting; use `pin` for important thread
   messages; use `bookmark` for persistent channel-header links to repos,

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -239,6 +239,11 @@ Create/update a channel canvas:
 }
 ```
 
+If Slack returns `canvas_tab_creation_failed`, `canvas_create` creates a
+standalone fallback attached to the channel, attempts to add a channel bookmark,
+and returns the fallback `canvas_id`. Use that `canvas_id` for later
+`canvas_update` calls if Slack still does not expose a channel canvas ID.
+
 Append to a canvas:
 
 ```json

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1521,6 +1521,90 @@ describe("registerSlackTools", () => {
     });
   });
 
+  it("falls back and bookmarks a standalone canvas when channel canvas tab creation fails", async () => {
+    const { slack, tools, setFilesInfoResponse } = setup();
+    setFilesInfoResponse({
+      ok: true,
+      file: {
+        id: "F_FALLBACK",
+        title: "Agent Vault setup spike review",
+        permalink: "https://example.slack.com/docs/T/F_FALLBACK",
+      },
+      comments: [],
+      response_metadata: { next_cursor: "" },
+    } as SlackResult);
+
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "conversations.canvases.create") {
+          throw new Error("Slack conversations.canvases.create: canvas_tab_creation_failed");
+        }
+        if (method === "canvases.create") {
+          return { ok: true, token, body, canvas_id: "F_FALLBACK" } as SlackResult;
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    const result = await tools.get("slack_canvas_create")!.execute("tool-canvas-create-1", {
+      kind: "channel",
+      channel: "proj-alpha",
+      title: "Agent Vault setup spike review",
+      markdown: "# Review",
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "conversations.canvases.create",
+      "xoxb-initial",
+      expect.objectContaining({ channel_id: "resolved:proj-alpha" }),
+    );
+    expect(slack).toHaveBeenCalledWith(
+      "canvases.create",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel_id: "resolved:proj-alpha",
+        title: "Agent Vault setup spike review",
+      }),
+    );
+    expect(slack).toHaveBeenCalledWith("files.info", "xoxb-initial", { file: "F_FALLBACK" });
+    expect(slack).toHaveBeenCalledWith(
+      "bookmarks.add",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel_id: "resolved:proj-alpha",
+        title: "Agent Vault setup spike review",
+        link: "https://example.slack.com/docs/T/F_FALLBACK",
+      }),
+    );
+    expect(result.content?.[0]?.text).toContain("Created standalone fallback canvas F_FALLBACK");
+    expect(result.content?.[0]?.text).toContain("canvas_id=F_FALLBACK");
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        canvas_id: "F_FALLBACK",
+        kind: "standalone",
+        requested_kind: "channel",
+        channel: "resolved:proj-alpha",
+        fallback: true,
+        fallback_reason: "canvas_tab_creation_failed",
+        bookmark_status: "added",
+        bookmark_id: "Bk123",
+        permalink: "https://example.slack.com/docs/T/F_FALLBACK",
+      }),
+    );
+  });
+
+  it("guides channel canvas updates toward fallback canvas IDs when Slack exposes no channel canvas", async () => {
+    const { tools } = setup();
+
+    await expect(
+      tools.get("slack_canvas_update")!.execute("tool-canvas-update-missing-1", {
+        channel: "proj-alpha",
+        markdown: "## Update",
+      }),
+    ).rejects.toThrow("use the standalone fallback canvas_id returned by canvas_create");
+  });
+
   it("validates a direct canvas id before reading its comments", async () => {
     const { slack, tools, setFilesInfoResponse, setResolveUser } = setup();
     setResolveUser(async (userId) => (userId === "U123" ? "Alice" : userId));

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -207,6 +207,10 @@ const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
   ],
   canvas_create: [
     { action: "canvas_create", args: { title: "Launch notes", markdown: "# Launch" } },
+    {
+      action: "canvas_create",
+      args: { kind: "channel", channel: "#project", title: "Runbook", markdown: "# Runbook" },
+    },
   ],
   canvas_update: [
     {
@@ -659,6 +663,40 @@ function normalizeSlackBookmarkUrl(url: string): string {
   return parsed.toString();
 }
 
+function asSlackObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asTrimmedSlackString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function extractSlackCanvasPermalink(response: Record<string, unknown>): string | undefined {
+  const direct =
+    asTrimmedSlackString(response.permalink) ??
+    asTrimmedSlackString(response.url) ??
+    asTrimmedSlackString(response.link);
+  if (direct) return direct;
+
+  const canvas = asSlackObject(response.canvas);
+  const canvasLink =
+    asTrimmedSlackString(canvas?.permalink) ??
+    asTrimmedSlackString(canvas?.url) ??
+    asTrimmedSlackString(canvas?.link);
+  if (canvasLink) return canvasLink;
+
+  const file = asSlackObject(response.file);
+  return (
+    asTrimmedSlackString(file?.permalink) ??
+    asTrimmedSlackString(file?.url_private) ??
+    asTrimmedSlackString(file?.url)
+  );
+}
+
 function isPiAgentSlackMessage(
   message: Record<string, unknown>,
   botUserId: string | null,
@@ -978,7 +1016,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     const resolvedCanvasId = extractSlackChannelCanvasId(info);
     if (!resolvedCanvasId) {
       throw new Error(
-        `Slack did not expose a channel canvas ID in conversations.info for ${channelInput}. Provide canvas_id directly.`,
+        `Slack did not expose a channel canvas ID in conversations.info for ${channelInput}. Provide canvas_id directly. If channel canvas tab creation failed earlier, use the standalone fallback canvas_id returned by canvas_create; otherwise create a standalone fallback with canvas_create kind='standalone' channel='${channelInput}' and update it by canvas_id.`,
       );
     }
 
@@ -2995,9 +3033,9 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     name: "slack_canvas_create",
     label: "Slack Canvas Create",
     description:
-      "Create a Slack canvas with markdown content, either standalone or as a channel canvas.",
+      "Create a Slack canvas with markdown content, either standalone or as a channel canvas. If Slack cannot create a channel canvas tab, creates a standalone channel-attached fallback and bookmarks it when possible.",
     promptSnippet:
-      "Create a Slack canvas for long-lived documentation. Use standalone canvases for shared docs and kind='channel' for a channel's main canvas.",
+      "Create a Slack canvas for long-lived documentation. Use standalone canvases for shared docs and kind='channel' for a channel's main canvas; channel tab failures fall back to a standalone canvas plus bookmark when possible.",
     parameters: Type.Object({
       title: Type.Optional(Type.String({ description: "Canvas title" })),
       markdown: Type.Optional(
@@ -3009,7 +3047,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         Type.String({ description: "Channel name or ID to attach the canvas to" }),
       ),
       kind: Type.Optional(
-        Type.String({ description: "Canvas kind: 'standalone' (default) or 'channel'" }),
+        Type.String({
+          description:
+            "Canvas kind: 'standalone' (default) or 'channel'. Channel canvas tab failures fall back to a standalone canvas and return its canvas_id.",
+        }),
       ),
     }),
     async execute(_id, params) {
@@ -3056,7 +3097,110 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         rememberChannel(channelInput.replace(/^#/, ""), channelId);
       }
 
-      const response = await slack(request.method, getBotToken(), request.body);
+      let response: SlackResult;
+      try {
+        response = await slack(request.method, getBotToken(), request.body);
+      } catch (err) {
+        if (
+          request.kind !== "channel" ||
+          !channelId ||
+          !isSlackMethodError(err, "conversations.canvases.create", "canvas_tab_creation_failed")
+        ) {
+          throw err;
+        }
+
+        const fallbackRequest = buildSlackCanvasCreateRequest({
+          kind: "standalone",
+          title: params.title,
+          markdown: params.markdown,
+          channelId,
+        });
+        let fallbackResponse: SlackResult;
+        try {
+          fallbackResponse = await slack(
+            fallbackRequest.method,
+            getBotToken(),
+            fallbackRequest.body,
+          );
+        } catch (fallbackErr) {
+          const fallbackMessage =
+            fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+          throw new Error(
+            `Slack channel canvas creation failed with canvas_tab_creation_failed, and standalone fallback creation also failed: ${fallbackMessage}. To recover manually, create a standalone canvas with channel=${channelInput ?? channelId} and update/share it by canvas_id.`,
+          );
+        }
+
+        const fallbackCanvasId = fallbackResponse.canvas_id as string;
+        let permalink = extractSlackCanvasPermalink(fallbackResponse);
+        let permalinkLookupError: string | undefined;
+        if (!permalink) {
+          try {
+            const fileInfo = await slack("files.info", getBotToken(), { file: fallbackCanvasId });
+            permalink = extractSlackCanvasPermalink(fileInfo);
+          } catch (permalinkErr) {
+            permalinkLookupError =
+              permalinkErr instanceof Error ? permalinkErr.message : String(permalinkErr);
+          }
+        }
+
+        let bookmarkId: string | undefined;
+        let bookmarkStatus: "added" | "skipped" | "failed" = "skipped";
+        let bookmarkError: string | undefined;
+        if (permalink) {
+          try {
+            const title =
+              typeof params.title === "string" && params.title.trim().length > 0
+                ? params.title.trim()
+                : `Canvas ${fallbackCanvasId}`;
+            const bookmarkResponse = await slack("bookmarks.add", getBotToken(), {
+              channel_id: channelId,
+              title,
+              type: "link",
+              link: normalizeSlackBookmarkUrl(permalink),
+              emoji: ":memo:",
+            });
+            const bookmark = asSlackObject(bookmarkResponse.bookmark);
+            bookmarkId = asTrimmedSlackString(bookmark?.id);
+            bookmarkStatus = "added";
+          } catch (bookmarkErr) {
+            bookmarkStatus = "failed";
+            bookmarkError =
+              bookmarkErr instanceof Error ? bookmarkErr.message : String(bookmarkErr);
+          }
+        }
+
+        const channelLabel = channelInput ?? channelId;
+        const bookmarkSummary =
+          bookmarkStatus === "added"
+            ? ` Bookmarked it in ${channelLabel}${bookmarkId ? ` as ${bookmarkId}` : ""}.`
+            : permalink
+              ? ` Could not bookmark it automatically${bookmarkError ? ` (${bookmarkError})` : ""}; add ${permalink} as a channel bookmark if you need a durable channel link.`
+              : ` Slack did not expose a permalink${permalinkLookupError ? ` (${permalinkLookupError})` : ""}; use canvas_id=${fallbackCanvasId} directly or add a bookmark manually once you have the canvas URL.`;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Slack could not create a channel canvas tab for ${channelLabel} (canvas_tab_creation_failed). Created standalone fallback canvas ${fallbackCanvasId} attached to ${channelLabel}.${bookmarkSummary} Use canvas_update with canvas_id=${fallbackCanvasId} for future updates. Initial content: ${getSlackCanvasSummary(params.markdown)}`,
+            },
+          ],
+          details: {
+            canvas_id: fallbackCanvasId,
+            kind: "standalone",
+            requested_kind: "channel",
+            channel: channelId,
+            fallback: true,
+            fallback_reason: "canvas_tab_creation_failed",
+            bookmark_status: bookmarkStatus,
+            next_action: `canvas_update canvas_id=${fallbackCanvasId}`,
+            ...(permalink ? { permalink } : {}),
+            ...(bookmarkId ? { bookmark_id: bookmarkId } : {}),
+            ...(bookmarkError ? { bookmark_error: bookmarkError } : {}),
+            ...(permalinkLookupError ? { permalink_lookup_error: permalinkLookupError } : {}),
+          },
+        };
+      }
+
       const canvasId = response.canvas_id as string;
       const channelLabel = channelInput ?? channelId;
       const targetSummary =
@@ -3090,7 +3234,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     parameters: Type.Object({
       canvas_id: Type.Optional(Type.String({ description: "Canvas ID to update" })),
       channel: Type.Optional(
-        Type.String({ description: "Channel name or ID whose channel canvas should be updated" }),
+        Type.String({
+          description:
+            "Channel name or ID whose channel canvas should be updated. If Slack does not expose a channel canvas ID, provide the standalone fallback canvas_id returned by canvas_create.",
+        }),
       ),
       markdown: Type.String({ description: "Canvas content in markdown" }),
       mode: Type.Optional(


### PR DESCRIPTION
## Summary
- fall back from `canvas_tab_creation_failed` channel canvas tab creation to a standalone canvas attached to the channel
- look up the fallback canvas permalink and add a channel bookmark when possible
- return clearer fallback `canvas_id`/next-action details and improve channel-update guidance when Slack exposes no channel canvas ID
- document the canvas fallback behavior in README and Slack bridge skill help

Fixes #697

## Tests
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm prepush`