### PR TITLE
cleanup: remove legacy Pinet command aliases

### DIFF
--- a/imessage-bridge/README.md
+++ b/imessage-bridge/README.md
@@ -33,7 +33,7 @@ That means outbound sends can work even when the local Messages database is unav
 
 Treat this as explicit local outbound power, not as a remote-safe transport or a generic policy-enforced messaging surface.
 
-In the current repo bring-up path, enable the adapter with `slack-bridge.imessage.enabled: true` and start the broker runtime with `/pinet-start`.
+In the current repo bring-up path, enable the adapter with `slack-bridge.imessage.enabled: true` and start the broker runtime with `/pinet start`.
 
 ## What stays in this package
 

--- a/plans/677-md-backed-broker-prompt.md
+++ b/plans/677-md-backed-broker-prompt.md
@@ -87,7 +87,7 @@ Do not let broker prompt MD change follower behavior.
    - only the explicitly listed non-replaceable tool/protocol guardrails remain in code and append after loaded MD.
 5. Update `createAgentPromptGuidance` to load broker MD only when `getBrokerRole() === "broker"`.
 6. Leave follower path unchanged.
-7. Pick up prompt changes on `/pinet-start` / runtime reload; no per-turn hot reload is needed for the first slice.
+7. Pick up prompt changes on `/pinet start` / runtime reload; no per-turn hot reload is needed for the first slice.
 8. Document the conventional MD paths and package fallback behavior in `slack-bridge/README.md`.
 
 ## Tests
@@ -105,4 +105,4 @@ Do not let broker prompt MD change follower behavior.
 - Workspace-local override precedes user-local override for slice 1; repo/workspace intent wins before private user preference.
 - Do not add a second gitignored workspace-private filename yet.
 - Copy bundled default MD into `dist/prompts/**` and publish it; do not rely on a TS-string fallback for the normal packaged default path.
-- Reloading on `/pinet-start` / runtime restart is enough for slice 1; no per-turn hot reload is needed.
+- Reloading on `/pinet start` / runtime restart is enough for slice 1; no per-turn hot reload is needed.

--- a/plans/slack-split-proposal.md
+++ b/plans/slack-split-proposal.md
@@ -65,7 +65,7 @@ It directly wires:
 - agent prompt / agent event runtime
 - Pinet home tabs and control-plane canvas surfaces
 - tool registration (`slack`, `pinet`, `imessage`)
-- command registration (`/pinet-*`)
+- command registration (`/pinet <action>`)
 
 `index.ts` imports **35 local modules** today. That confirms the runtime has been modularized, but the package boundary is still tangled.
 

--- a/plans/test-policy.md
+++ b/plans/test-policy.md
@@ -42,10 +42,10 @@ No PR is merge-ready if any of these fail.
 
 Run after merge into target branch:
 
-1. `pinet-start` / `pinet-follow` start paths
-2. Security guardrail path (`/pinet-status`, `slack` dispatcher action `confirm_action` if applicable)
+1. `/pinet start` / `/pinet follow` start paths
+2. Security guardrail path (`/pinet status`, `slack` dispatcher action `confirm_action` if applicable)
 3. Reconnect path (follow mode) and message drain behavior in a real environment
-4. Worker visibility check (`pinet-status`) for status/CWD/active-work context
+4. Worker visibility check (`/pinet status`) for status/CWD/active-work context
 
 ## Test quality standards
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -370,14 +370,12 @@ The `canvas_comments_read` dispatcher action is intentionally narrow:
 
 ### Slash commands
 
-| Command            | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| `/pinet <action>`  | Unified Pinet command surface; run `/pinet help` for usage |
-| `/pinet status`    | Show connection status, threads, and agent identity        |
-| `/pinet rename`    | Change the agent's display name                            |
-| `/pinet logs`      | Show recent broker activity log entries                    |
-| `/pinet-*` aliases | Backwards-compatible aliases for legacy command names      |
-| `/slack-logs`      | Legacy alias for recent Slack bridge/Pinet activity logs   |
+| Command           | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `/pinet <action>` | Unified Pinet command surface; run `/pinet help` for usage |
+| `/pinet status`   | Show connection status, threads, and agent identity        |
+| `/pinet rename`   | Change the agent's display name                            |
+| `/pinet logs`     | Show recent broker activity log entries                    |
 
 ## Runtime modes
 
@@ -458,7 +456,7 @@ Durable lane metadata is stored in SQLite and can be inspected/updated with `pin
 
 ### Pinet command surface
 
-Use `/pinet <action> [args]` for mesh lifecycle and broker operations. Legacy aliases such as `/pinet-start`, `/pinet-follow`, `/pinet-free`, and `/pinet-skin` remain registered for compatibility.
+Use `/pinet <action> [args]` for mesh lifecycle and broker operations.
 
 | Command                 | Description                                     |
 | ----------------------- | ----------------------------------------------- |
@@ -493,7 +491,7 @@ Free-form themes are still accepted as deterministic legacy/custom presentation 
 
 - **User access**: Slack access is default-deny. Set `allowedUsers` for a narrow allowlist, or `allowAllWorkspaceUsers: true` only if you explicitly want workspace-wide access
 - **Tool guardrails**: `security.readOnly`, `security.requireConfirmation`, and `security.blockedTools` are runtime-enforced for Slack-triggered turns, including core tools such as `bash`, `edit`, and `write`
-- **Guardrail posture**: If Slack/Pinet access is enabled for admitted users and `security.readOnly`, `security.blockedTools`, and `security.requireConfirmation` are all effectively empty (`readOnly !== true` and both arrays are absent or empty), the bridge emits a startup/runtime warning and `/pinet-status` shows `Guardrails: empty (warn-first posture; behavior unchanged)`. This is visibility-only: it does **not** auto-enable `readOnly`, block startup, or require an acknowledgement flow.
+- **Guardrail posture**: If Slack/Pinet access is enabled for admitted users and `security.readOnly`, `security.blockedTools`, and `security.requireConfirmation` are all effectively empty (`readOnly !== true` and both arrays are absent or empty), the bridge emits a startup/runtime warning and `/pinet status` shows `Guardrails: empty (warn-first posture; behavior unchanged)`. This is visibility-only: it does **not** auto-enable `readOnly`, block startup, or require an acknowledgement flow.
 - **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` (or `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH`) to require a shared secret; leave them unset to disable shared-secret auth. Configured followers fail closed on missing secret files or older/no-auth brokers rather than silently downgrading.
 
 Find Slack user IDs: click a user's profile → **More** → **Copy member ID**.

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -172,9 +172,9 @@ describe("slack-bridge top-level shutdown", () => {
     expect(tools.has("pinet_free")).toBe(false);
     expect(tools.has("pinet_schedule")).toBe(false);
     expect(tools.has("pinet_agents")).toBe(false);
-    expect(commands.has("pinet-start")).toBe(true);
-    expect(commands.has("pinet-free")).toBe(true);
-    expect(commands.has("pinet-skin")).toBe(true);
+    expect(commands.has("pinet-start")).toBe(false);
+    expect(commands.has("pinet-free")).toBe(false);
+    expect(commands.has("pinet-skin")).toBe(false);
 
     await sessionStart?.({}, ctx);
 
@@ -319,7 +319,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
     const slackDispatcher = tools.get("slack");
 
     expect(sessionStart).toBeDefined();
@@ -328,7 +328,7 @@ describe("slack-bridge top-level shutdown", () => {
     expect(slackDispatcher).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     expect(brokerRuntimes).toHaveLength(1);
     brokerRuntimes[0]!.db.registerAgent("sender", "Sender", "📤", 202);
@@ -379,7 +379,7 @@ describe("slack-bridge top-level shutdown", () => {
     );
   });
 
-  it("reloads the active broker runtime when /pinet-start runs twice", async () => {
+  it("reloads the active broker runtime when /pinet start runs twice", async () => {
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
@@ -469,15 +469,15 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
+    await pinetStart?.handler("start", ctx);
 
     expect(startBrokerSpy).toHaveBeenCalledTimes(2);
     expect(brokerRuntimes).toHaveLength(2);
@@ -491,7 +491,7 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionShutdown?.({}, ctx);
   });
 
-  it("aborts the current turn before reloading broker runtime from /pinet-start", async () => {
+  it("aborts the current turn before reloading broker runtime from /pinet start", async () => {
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
@@ -583,15 +583,15 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
+    await pinetStart?.handler("start", ctx);
 
     expect(abort).toHaveBeenCalledTimes(1);
     expect(startBrokerSpy).toHaveBeenCalledTimes(2);
@@ -605,7 +605,7 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionShutdown?.({}, ctx);
   });
 
-  it("restores the previous broker runtime if /pinet-start reload fails", async () => {
+  it("restores the previous broker runtime if /pinet start reload fails", async () => {
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
@@ -701,18 +701,18 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
     notify.mockClear();
     setStatus.mockClear();
 
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     expect(startBrokerSpy).toHaveBeenCalledTimes(3);
     expect(brokerRuntimes).toHaveLength(2);
@@ -809,7 +809,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
     const beforeAgentStart = events.get("before_agent_start") as
       | ((
           event: { systemPrompt: string },
@@ -823,7 +823,7 @@ describe("slack-bridge top-level shutdown", () => {
     expect(beforeAgentStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
     expect(startBrokerSpy).toHaveBeenCalledTimes(1);
 
     const sentinelSystemPrompt = "SENTINEL ROOT PROMPT";
@@ -972,7 +972,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
     const imessageSendTool = tools.get("imessage_send");
 
     expect(sessionStart).toBeDefined();
@@ -981,7 +981,7 @@ describe("slack-bridge top-level shutdown", () => {
     expect(imessageSendTool).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     const result = await imessageSendTool!.execute("tool-call-1", {
       to: "chat:alice",
@@ -1116,14 +1116,14 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     expect(createAdapterSpy).not.toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith(
@@ -1286,7 +1286,7 @@ describe("slack-bridge top-level shutdown", () => {
     expect(setStatus).toHaveBeenCalled();
   });
 
-  it("starts explicit single runtime mode on session start and reports it in pinet-status", async () => {
+  it("starts explicit single runtime mode on session start and reports it in /pinet status", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
     fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { runtimeMode: "single" } }));
@@ -1342,7 +1342,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStatus = commands.get("pinet-status");
+    const pinetStatus = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -1357,7 +1357,7 @@ describe("slack-bridge top-level shutdown", () => {
     );
     expect(FakeWebSocket.instances).toHaveLength(1);
 
-    await pinetStatus?.handler("", ctx);
+    await pinetStatus?.handler("status", ctx);
 
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: single"), "info");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
@@ -1371,7 +1371,7 @@ describe("slack-bridge top-level shutdown", () => {
     expect(firstSocket.close).toHaveBeenCalled();
   });
 
-  it("warns on default-deny Slack access at startup and reports it in pinet-status", async () => {
+  it("warns on default-deny Slack access at startup and reports it in /pinet status", async () => {
     const originalAllowedUsersEnv = process.env.SLACK_ALLOWED_USERS;
     const originalAllowAllEnv = process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
     delete process.env.SLACK_ALLOWED_USERS;
@@ -1432,7 +1432,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStatus = commands.get("pinet-status");
+    const pinetStatus = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -1460,7 +1460,7 @@ describe("slack-bridge top-level shutdown", () => {
       ),
     ).toBe(false);
 
-    await pinetStatus?.handler("", ctx);
+    await pinetStatus?.handler("status", ctx);
 
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -1493,7 +1493,7 @@ describe("slack-bridge top-level shutdown", () => {
     }
   });
 
-  it("warns when admitted users have effectively empty guardrails and reports the posture in pinet-status", async () => {
+  it("warns when admitted users have effectively empty guardrails and reports the posture in /pinet status", async () => {
     const originalAllowedUsersEnv = process.env.SLACK_ALLOWED_USERS;
     const originalAllowAllEnv = process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS;
     delete process.env.SLACK_ALLOWED_USERS;
@@ -1562,7 +1562,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStatus = commands.get("pinet-status");
+    const pinetStatus = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -1581,7 +1581,7 @@ describe("slack-bridge top-level shutdown", () => {
       "warning",
     );
 
-    await pinetStatus?.handler("", ctx);
+    await pinetStatus?.handler("status", ctx);
 
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("Guardrails: empty (warn-first posture; behavior unchanged)"),
@@ -1721,7 +1721,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStatus = commands.get("pinet-status");
+    const pinetStatus = commands.get("pinet");
 
     await sessionStart?.({}, ctx);
     await vi.waitFor(() => {
@@ -1732,7 +1732,7 @@ describe("slack-bridge top-level shutdown", () => {
         "warning",
       );
     });
-    await pinetStatus?.handler("", ctx);
+    await pinetStatus?.handler("status", ctx);
 
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -1842,7 +1842,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -1852,7 +1852,7 @@ describe("slack-bridge top-level shutdown", () => {
     await Promise.resolve();
     expect(FakeWebSocket.instances).toHaveLength(1);
 
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     const firstSocket = FakeWebSocket.instances[0];
     expect(firstSocket).toBeDefined();
@@ -2281,7 +2281,7 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -2296,7 +2296,7 @@ describe("slack-bridge top-level shutdown", () => {
         ),
       ).toBe(true);
 
-      await pinetStart?.handler("", ctx);
+      await pinetStart?.handler("start", ctx);
       await startup;
 
       await vi.advanceTimersByTimeAsync(5_001);
@@ -2464,8 +2464,8 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const follow = commands.get("pinet-follow");
-    const pinetStatus = commands.get("pinet-status");
+    const follow = commands.get("pinet");
+    const pinetStatus = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -2473,7 +2473,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(pinetStatus).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await follow?.handler("", ctx);
+    await follow?.handler("follow", ctx);
 
     expect(registerCalls).toHaveLength(1);
     expect(disconnectHandler).toBeTypeOf("function");
@@ -2497,7 +2497,7 @@ describe("slack-bridge Pinet reconnect", () => {
     runDisconnect();
 
     notify.mockClear();
-    await pinetStatus?.handler("", ctx);
+    await pinetStatus?.handler("status", ctx);
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("Connection: disconnected"),
       "info",
@@ -2527,7 +2527,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(notify).toHaveBeenCalledWith("Pinet broker reconnected", "info");
 
     notify.mockClear();
-    await pinetStatus?.handler("", ctx);
+    await pinetStatus?.handler("status", ctx);
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Runtime health: healthy"), "info");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Next step: None."), "info");
@@ -2648,8 +2648,8 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const follow = commands.get("pinet-follow");
-    const pinetStatus = commands.get("pinet-status");
+    const follow = commands.get("pinet");
+    const pinetStatus = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -2657,7 +2657,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(pinetStatus).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await follow?.handler("", ctx);
+    await follow?.handler("follow", ctx);
 
     expect(registerAttempt).toBe(1);
     expect(disconnectHandler).toBeTypeOf("function");
@@ -2683,7 +2683,7 @@ describe("slack-bridge Pinet reconnect", () => {
     });
 
     notify.mockClear();
-    await pinetStatus?.handler("", ctx);
+    await pinetStatus?.handler("status", ctx);
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: follower"), "info");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
     expect(notify).toHaveBeenCalledWith(
@@ -2827,8 +2827,8 @@ describe("slack-bridge Pinet reconnect", () => {
 
       const sessionStart = events.get("session_start");
       const sessionShutdown = events.get("session_shutdown");
-      const follow = commands.get("pinet-follow");
-      const pinetStatus = commands.get("pinet-status");
+      const follow = commands.get("pinet");
+      const pinetStatus = commands.get("pinet");
 
       expect(sessionStart).toBeDefined();
       expect(sessionShutdown).toBeDefined();
@@ -2836,7 +2836,7 @@ describe("slack-bridge Pinet reconnect", () => {
       expect(pinetStatus).toBeDefined();
 
       await sessionStart?.({}, ctx);
-      await follow?.handler("", ctx);
+      await follow?.handler("follow", ctx);
 
       expect(registerCalls).toHaveLength(1);
       expect(registerCalls[0]?.name).toBe("Reserved Crane");
@@ -2879,7 +2879,7 @@ describe("slack-bridge Pinet reconnect", () => {
       expect(setStatus).toHaveBeenCalledWith("slack-bridge", expect.stringContaining("✗"));
 
       notify.mockClear();
-      await pinetStatus?.handler("", ctx);
+      await pinetStatus?.handler("status", ctx);
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: off"), "info");
       expect(notify).toHaveBeenCalledWith(
         expect.stringContaining("Connection: disconnected"),
@@ -2898,13 +2898,13 @@ describe("slack-bridge Pinet reconnect", () => {
         "info",
       );
 
-      await follow?.handler("", ctx);
+      await follow?.handler("follow", ctx);
       expect(connect).toHaveBeenCalledTimes(2);
       expect(registerCalls).toHaveLength(2);
       expect(registerCalls[1]?.name).toBe("Reserved Crane");
 
       notify.mockClear();
-      await pinetStatus?.handler("", ctx);
+      await pinetStatus?.handler("status", ctx);
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: follower"), "info");
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
       expect(notify).toHaveBeenCalledWith(
@@ -2922,7 +2922,7 @@ describe("slack-bridge Pinet reconnect", () => {
     }
   });
 
-  it("surfaces follower poll failures in pinet-status and clears them after recovery", async () => {
+  it("surfaces follower poll failures in /pinet status and clears them after recovery", async () => {
     vi.useFakeTimers();
 
     const commands = new Map<string, CommandDefinition>();
@@ -2999,8 +2999,8 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const follow = commands.get("pinet-follow");
-    const pinetStatus = commands.get("pinet-status");
+    const follow = commands.get("pinet");
+    const pinetStatus = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -3009,13 +3009,13 @@ describe("slack-bridge Pinet reconnect", () => {
 
     try {
       await sessionStart?.({}, ctx);
-      await follow?.handler("", ctx);
+      await follow?.handler("follow", ctx);
 
       await vi.advanceTimersByTimeAsync(2_000);
       expect(pollAttempt).toBe(1);
 
       notify.mockClear();
-      await pinetStatus?.handler("", ctx);
+      await pinetStatus?.handler("status", ctx);
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mode: follower"), "info");
       expect(notify).toHaveBeenCalledWith(expect.stringContaining("Connection: connected"), "info");
       expect(notify).toHaveBeenCalledWith(
@@ -3035,7 +3035,7 @@ describe("slack-bridge Pinet reconnect", () => {
       expect(pollAttempt).toBe(2);
 
       notify.mockClear();
-      await pinetStatus?.handler("", ctx);
+      await pinetStatus?.handler("status", ctx);
       expect(notify).toHaveBeenCalledWith(
         expect.stringContaining("Runtime health: healthy"),
         "info",
@@ -3123,7 +3123,7 @@ describe("slack-bridge Pinet reconnect", () => {
         ctx,
         sessionStart: events.get("session_start"),
         sessionShutdown: events.get("session_shutdown"),
-        follow: commands.get("pinet-follow"),
+        follow: commands.get("pinet"),
       };
     }
 
@@ -3132,7 +3132,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(first.sessionShutdown).toBeDefined();
     expect(first.follow).toBeDefined();
     await first.sessionStart?.({}, first.ctx);
-    await first.follow?.handler("", first.ctx);
+    await first.follow?.handler("follow", first.ctx);
     await first.sessionShutdown?.({}, first.ctx);
 
     const second = buildFollowerRuntime("/tmp/slack-bridge-worker-b.json", "worker-leaf-b");
@@ -3140,7 +3140,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(second.sessionShutdown).toBeDefined();
     expect(second.follow).toBeDefined();
     await second.sessionStart?.({}, second.ctx);
-    await second.follow?.handler("", second.ctx);
+    await second.follow?.handler("follow", second.ctx);
     await second.sessionShutdown?.({}, second.ctx);
 
     expect(registerCalls).toHaveLength(2);
@@ -3253,7 +3253,7 @@ describe("slack-bridge Pinet reconnect", () => {
         ctx,
         sessionStart: events.get("session_start"),
         sessionShutdown: events.get("session_shutdown"),
-        pinetStart: commands.get("pinet-start"),
+        pinetStart: commands.get("pinet"),
         getPersistedState: () => persistedState,
       };
     }
@@ -3263,7 +3263,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(first.sessionShutdown).toBeDefined();
     expect(first.pinetStart).toBeDefined();
     await first.sessionStart?.({}, first.ctx);
-    await first.pinetStart?.handler("", first.ctx);
+    await first.pinetStart?.handler("start", first.ctx);
     const initialBrokerIdentity = readBrokerIdentity(startedDbs[0]!);
     await first.sessionShutdown?.({}, first.ctx);
 
@@ -3278,7 +3278,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(second.sessionShutdown).toBeDefined();
     expect(second.pinetStart).toBeDefined();
     await second.sessionStart?.({}, second.ctx);
-    await second.pinetStart?.handler("", second.ctx);
+    await second.pinetStart?.handler("start", second.ctx);
     const reloadedBrokerIdentity = readBrokerIdentity(startedDbs[1]!);
 
     expect(reloadedBrokerIdentity).toEqual(initialBrokerIdentity);
@@ -3380,7 +3380,7 @@ describe("slack-bridge Pinet reconnect", () => {
         ctx,
         sessionStart: events.get("session_start"),
         sessionShutdown: events.get("session_shutdown"),
-        pinetStart: commands.get("pinet-start"),
+        pinetStart: commands.get("pinet"),
       };
     }
 
@@ -3392,7 +3392,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(first.sessionShutdown).toBeDefined();
     expect(first.pinetStart).toBeDefined();
     await first.sessionStart?.({}, first.ctx);
-    await first.pinetStart?.handler("", first.ctx);
+    await first.pinetStart?.handler("start", first.ctx);
     const initialBrokerIdentity = readBrokerIdentity(startedDbs[0]!);
     await first.sessionShutdown?.({}, first.ctx);
 
@@ -3404,7 +3404,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(second.sessionShutdown).toBeDefined();
     expect(second.pinetStart).toBeDefined();
     await second.sessionStart?.({}, second.ctx);
-    await second.pinetStart?.handler("", second.ctx);
+    await second.pinetStart?.handler("start", second.ctx);
     const restartedBrokerIdentity = readBrokerIdentity(startedDbs[1]!);
 
     expect(restartedBrokerIdentity).toEqual(initialBrokerIdentity);
@@ -3501,14 +3501,14 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const follow = commands.get("pinet-follow");
+    const follow = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(follow).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await follow?.handler("", ctx);
+    await follow?.handler("follow", ctx);
 
     expect(claimThread).not.toHaveBeenCalled();
     expect(reconnectHandler).toBeTypeOf("function");
@@ -3634,7 +3634,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const follow = commands.get("pinet-follow");
+    const follow = commands.get("pinet");
     const pinet = tools.get("pinet");
 
     expect(sessionStart).toBeDefined();
@@ -3644,7 +3644,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
     try {
       await sessionStart?.({}, ctx);
-      await follow?.handler("", ctx);
+      await follow?.handler("follow", ctx);
 
       await vi.advanceTimersByTimeAsync(2_000);
       await vi.waitFor(() => {
@@ -3783,7 +3783,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const follow = commands.get("pinet-follow");
+    const follow = commands.get("pinet");
     const agentEnd = events.get("agent_end");
 
     expect(sessionStart).toBeDefined();
@@ -3793,7 +3793,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
     try {
       await sessionStart?.({}, ctx);
-      await follow?.handler("", ctx);
+      await follow?.handler("follow", ctx);
 
       await vi.advanceTimersByTimeAsync(2_000);
       await vi.waitFor(() => {
@@ -3934,7 +3934,7 @@ describe("slack-bridge Pinet reconnect", () => {
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
     const agentEnd = events.get("agent_end");
-    const follow = commands.get("pinet-follow");
+    const follow = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
@@ -3943,7 +3943,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
     try {
       await sessionStart?.({}, ctx);
-      await follow?.handler("", ctx);
+      await follow?.handler("follow", ctx);
 
       await vi.advanceTimersByTimeAsync(2_000);
       expect(sendUserMessage).not.toHaveBeenCalled();
@@ -4039,7 +4039,7 @@ describe("slack-bridge Pinet reconnect", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const follow = commands.get("pinet-follow");
+    const follow = commands.get("pinet");
     const pinet = tools.get("pinet");
 
     expect(sessionStart).toBeDefined();
@@ -4048,7 +4048,7 @@ describe("slack-bridge Pinet reconnect", () => {
     expect(pinet).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await follow?.handler("", ctx);
+    await follow?.handler("follow", ctx);
     await pinet?.execute("tool-call-1", {
       action: "send",
       args: {
@@ -4217,14 +4217,14 @@ describe("slack-bridge broker startup backlog recovery", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     const inspectDb = new DatabaseSync(dbPath);
     const backlog = inspectDb
@@ -4362,14 +4362,14 @@ describe("slack-bridge broker startup backlog recovery", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     restartedDb.registerAgent("sender", "Sender", "📤", 202);
     restartedDb.createThread("a2a:sender:broker-prev", "agent", "", "sender");
@@ -4624,19 +4624,19 @@ describe("slack-bridge broker startup backlog recovery", () => {
 
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
-    const pinetStart = commands.get("pinet-start");
+    const pinetStart = commands.get("pinet");
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     expect(startBrokerSpy).toHaveBeenCalledTimes(1);
     inspectHealthyBrokerState();
 
-    await pinetStart?.handler("", ctx);
+    await pinetStart?.handler("start", ctx);
 
     expect(startBrokerSpy).toHaveBeenCalledTimes(2);
     expect(brokerRuntimes).toHaveLength(2);

--- a/slack-bridge/pinet-commands.test.ts
+++ b/slack-bridge/pinet-commands.test.ts
@@ -94,14 +94,14 @@ function registerCommands(deps: PinetCommandsDeps): Map<string, CommandDefinitio
 }
 
 describe("registerPinetCommands", () => {
-  it("registers the unified /pinet command while preserving legacy aliases", () => {
+  it("registers only the unified /pinet command", () => {
     const commands = registerCommands(createDeps());
 
     expect(commands.has("pinet")).toBe(true);
-    expect(commands.has("pinet-start")).toBe(true);
-    expect(commands.has("pinet-follow")).toBe(true);
-    expect(commands.has("pinet-free")).toBe(true);
-    expect(commands.has("pinet-skin")).toBe(true);
+    expect(commands.has("pinet-start")).toBe(false);
+    expect(commands.has("pinet-follow")).toBe(false);
+    expect(commands.has("pinet-free")).toBe(false);
+    expect(commands.has("pinet-skin")).toBe(false);
   });
 
   it("shows help for the unified command", async () => {
@@ -116,7 +116,7 @@ describe("registerPinetCommands", () => {
     );
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("/pinet start"), "info");
     expect(notify).toHaveBeenCalledWith(expect.stringContaining("/pinet skin <theme>"), "info");
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining("/pinet-start"), "info");
+    expect(notify).not.toHaveBeenCalledWith(expect.stringContaining("/pinet-start"), "info");
   });
 
   it("routes /pinet reload through the existing remote-control message path", async () => {
@@ -133,13 +133,13 @@ describe("registerPinetCommands", () => {
     expect(notify).toHaveBeenCalledWith("Sent /reload to GoldenOtter:/reload", "info");
   });
 
-  it("keeps legacy usage text on legacy aliases", async () => {
+  it("uses unified usage text for action arguments", async () => {
     const commands = registerCommands(createDeps());
     const { ctx, notify } = createContext();
 
-    await commands.get("pinet-reload")?.handler("", ctx);
+    await commands.get("pinet")?.handler("reload", ctx);
 
-    expect(notify).toHaveBeenCalledWith("Usage: /pinet-reload <agent-name-or-id>", "warning");
+    expect(notify).toHaveBeenCalledWith("Usage: /pinet reload <agent-name-or-id>", "warning");
   });
 
   it("runs free and skin from the unified command", async () => {

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -112,53 +112,6 @@ const PINET_SECONDARY_COMMANDS: Array<{
   { action: "rename", args: "[name]", description: "Rename this Pinet agent" },
 ];
 
-const PINET_LEGACY_COMMANDS: Array<{
-  name: string;
-  action: PinetCommandAction;
-  description: string;
-}> = [
-  {
-    name: "pinet-start",
-    action: "start",
-    description:
-      "Start Pinet as the broker (Slack connection + message routing, or reload the active broker)",
-  },
-  {
-    name: "pinet-follow",
-    action: "follow",
-    description: "Connect to an existing Pinet broker as a follower",
-  },
-  {
-    name: "pinet-unfollow",
-    action: "unfollow",
-    description: "Disconnect from the Pinet broker and keep working locally",
-  },
-  {
-    name: "pinet-reload",
-    action: "reload",
-    description: "Tell a connected Pinet agent to reload itself",
-  },
-  {
-    name: "pinet-exit",
-    action: "exit",
-    description: "Tell a connected Pinet agent to exit gracefully",
-  },
-  {
-    name: "pinet-free",
-    action: "free",
-    description: "Mark this Pinet agent idle/free for new work",
-  },
-  {
-    name: "pinet-skin",
-    action: "skin",
-    description: "Regenerate the mesh naming/personality skin from a theme",
-  },
-  { name: "pinet-status", action: "status", description: "Show Pinet status" },
-  { name: "pinet-logs", action: "logs", description: "Show recent broker activity log entries" },
-  { name: "slack-logs", action: "logs", description: "Show recent broker activity log entries" },
-  { name: "pinet-rename", action: "rename", description: "Rename this Pinet agent" },
-];
-
 // ─── Registration ────────────────────────────────────────
 
 function abortCurrentTurnBeforeBrokerReload(ctx: ExtensionContext): void {
@@ -186,8 +139,6 @@ export function formatPinetCommandHelp(): string {
     ...PINET_SECONDARY_COMMANDS.map((command) =>
       formatPinetCommandHelpLine(command.action, command.args, command.description),
     ),
-    "",
-    "Legacy aliases such as /pinet-start, /pinet-follow, /pinet-free, and /pinet-skin remain supported.",
   ];
 
   return lines.join("\n");
@@ -221,11 +172,7 @@ function parsePinetCommandAction(args: string): ParsedPinetCommandAction | null 
 }
 
 function normalizePinetCommandAction(rawAction: string): PinetCommandAction | null {
-  const normalized = rawAction
-    .trim()
-    .replace(/^\//, "")
-    .replace(/^pinet[:-]/, "")
-    .toLowerCase();
+  const normalized = rawAction.trim().replace(/^\//, "").toLowerCase();
 
   switch (normalized) {
     case "start":
@@ -321,15 +268,6 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
       await runPinetCommandAction(deps, parsed.action, parsed.args, ctx);
     },
   });
-
-  for (const command of PINET_LEGACY_COMMANDS) {
-    pi.registerCommand(command.name, {
-      description: `${command.description} (alias for /pinet ${command.action})`,
-      handler: async (args, ctx) => {
-        await runPinetCommandAction(deps, command.action, args, ctx, `/${command.name}`);
-      },
-    });
-  }
 }
 
 async function runPinetStart(deps: PinetCommandsDeps, ctx: ExtensionContext): Promise<void> {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -803,7 +803,7 @@ function runPinetLanesAction(
     const op = getMaybeString(params, "op")?.toLowerCase() ?? "list";
     deps.requireToolPolicy(toolName, undefined, `op=${op} | format=${output.format}`);
     if (!deps.pinetEnabled()) {
-      throw new Error("Pinet is not running. Use /pinet-start or /pinet-follow first.");
+      throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
 
     if (op === "list") {


### PR DESCRIPTION
## Summary
- Closes #701
- Remove the legacy `/pinet-*` and `/slack-logs` slash-command registrations so `/pinet <action>` is the single advertised command surface.
- Update help text, README/planning docs, and tests to use `/pinet <action>` examples.
- Update the remaining runtime error copy that pointed at `/pinet-start` / `/pinet-follow`.

## Checks
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- pre-push `pnpm lint && pnpm typecheck && pnpm test`
