### PR TITLE
Add generic PM2 process manager extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "./slack-bridge/index.ts",
       "./nvim-bridge/index.ts",
       "./neon-psql/index.ts",
+      "./pm2-processes/index.ts",
       "./browser-playwright/index.ts"
     ]
   },

--- a/pm2-processes/LICENSE
+++ b/pm2-processes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pm2-processes/README.md
+++ b/pm2-processes/README.md
@@ -1,0 +1,58 @@
+# pi-pm2-processes
+
+Generic Pi extension for managing project-local PM2 processes declared in a PM2 ecosystem config.
+
+## Configuration discovery
+
+The extension manages only apps declared by the active PM2 config. Discovery order:
+
+1. `PI_PM2_CONFIG=/absolute/or/relative/ecosystem.config.cjs`
+2. `pm2-processes.configPath` in `.pi/settings.json` or `~/.pi/agent/settings.json`
+3. `.pi/pm2/ecosystem.config.cjs`
+4. `ecosystem.config.js`, `ecosystem.config.cjs`, `ecosystem.config.json` in the current workspace
+
+Optional metadata can live at `.pi/pm2/metadata.json`, `PI_PM2_METADATA`, or `pm2-processes.metadataPath`:
+
+```json
+{
+  "apps": {
+    "backend": { "url": "http://localhost:8000/health" },
+    "frontend": { "url": "http://localhost:3000" }
+  }
+}
+```
+
+## Slash command
+
+```text
+/pm2                  # default status/config summary
+/pm2 status [app|all]
+/pm2 start [app|all]
+/pm2 restart [app|all]
+/pm2 stop [app|all]
+/pm2 logs <app> [--lines N]
+/pm2 urls
+/pm2 config
+```
+
+## Agent tool
+
+`pm2_process` accepts:
+
+```ts
+{
+  action: "status" | "start" | "restart" | "stop" | "logs" | "urls" | "config";
+  target?: string; // declared app name, or "all" where supported
+  lines?: number;
+}
+```
+
+Safety properties:
+
+- no arbitrary shell command input
+- exact app-name allowlist from the PM2 ecosystem config
+- `all` is expanded to exact declared app names for mutations
+- no `pm2 stop all`, `delete`, or `kill`
+- log output is bounded by configured line/byte limits
+- config output lists app names and paths, not environment values
+- PM2 owns the long-running processes independently of Pi

--- a/pm2-processes/dist/ecosystem.js
+++ b/pm2-processes/dist/ecosystem.js
@@ -1,8 +1,6 @@
 import * as fs from "node:fs";
-import { createRequire } from "node:module";
 import { extname, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
-import { readFile, stat } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 function isRecord(value) {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -11,27 +9,10 @@ function unwrapDefault(value) {
         return value.default;
     return value;
 }
-async function importEcosystem(configPath) {
-    const absolutePath = resolve(configPath);
-    const extension = extname(absolutePath).toLowerCase();
-    if (extension === ".json") {
-        return JSON.parse(await readFile(absolutePath, "utf8"));
-    }
-    const require = createRequire(import.meta.url);
-    try {
-        const resolved = require.resolve(absolutePath);
-        delete require.cache[resolved];
-        return require(resolved);
-    }
-    catch (error) {
-        const code = isRecord(error) && typeof error.code === "string" ? error.code : undefined;
-        if (code !== "ERR_REQUIRE_ESM")
-            throw error;
-        const stats = await stat(absolutePath);
-        return import(`${pathToFileURL(absolutePath).href}?mtime=${stats.mtimeMs}`);
-    }
+async function readJsonEcosystem(configPath) {
+    return JSON.parse(await readFile(configPath, "utf8"));
 }
-function extractAppArray(raw) {
+function extractJsonAppArray(raw) {
     const value = unwrapDefault(raw);
     if (Array.isArray(value))
         return value;
@@ -40,7 +21,7 @@ function extractAppArray(raw) {
         if (Array.isArray(ecosystem.apps))
             return ecosystem.apps;
     }
-    throw new Error("PM2 ecosystem config must export an apps array or { apps: [...] }");
+    throw new Error("PM2 ecosystem config must declare an apps array or { apps: [...] }");
 }
 function validateAppName(name, index) {
     if (typeof name !== "string" || name.trim().length === 0) {
@@ -51,6 +32,275 @@ function validateAppName(name, index) {
         throw new Error(`PM2 app name '${trimmed}' is not allowed; use exact non-wildcard names`);
     }
     return trimmed;
+}
+function isIdentifierStart(char) {
+    return char !== undefined && /[A-Za-z_$]/.test(char);
+}
+function isIdentifierPart(char) {
+    return char !== undefined && /[A-Za-z0-9_$-]/.test(char);
+}
+function isBoundary(source, index) {
+    return !isIdentifierPart(source[index]);
+}
+function skipWhitespace(source, index) {
+    let cursor = index;
+    while (cursor < source.length && /\s/.test(source[cursor] ?? ""))
+        cursor += 1;
+    return cursor;
+}
+function skipLineComment(source, index) {
+    const newline = source.indexOf("\n", index + 2);
+    return newline === -1 ? source.length : newline + 1;
+}
+function skipBlockComment(source, index) {
+    const end = source.indexOf("*/", index + 2);
+    return end === -1 ? source.length : end + 2;
+}
+function readQuotedString(source, start) {
+    const quote = source[start];
+    let cursor = start + 1;
+    let value = "";
+    while (cursor < source.length) {
+        const char = source[cursor];
+        if (char === quote)
+            return { value, end: cursor + 1 };
+        if (char === "\\") {
+            const next = source[cursor + 1];
+            if (next === undefined)
+                break;
+            if (next === "n")
+                value += "\n";
+            else if (next === "r")
+                value += "\r";
+            else if (next === "t")
+                value += "\t";
+            else if (next === "b")
+                value += "\b";
+            else if (next === "f")
+                value += "\f";
+            else if (next === "v")
+                value += "\v";
+            else if (next === "0")
+                value += "\0";
+            else if (next === "x" && /^[0-9a-fA-F]{2}$/.test(source.slice(cursor + 2, cursor + 4))) {
+                value += String.fromCharCode(Number.parseInt(source.slice(cursor + 2, cursor + 4), 16));
+                cursor += 2;
+            }
+            else if (next === "u" && /^[0-9a-fA-F]{4}$/.test(source.slice(cursor + 2, cursor + 6))) {
+                value += String.fromCharCode(Number.parseInt(source.slice(cursor + 2, cursor + 6), 16));
+                cursor += 4;
+            }
+            else {
+                value += next;
+            }
+            cursor += 2;
+            continue;
+        }
+        if (quote === "`" && char === "$" && source[cursor + 1] === "{") {
+            throw new Error("dynamic template expressions are not supported for PM2 app names");
+        }
+        value += char;
+        cursor += 1;
+    }
+    throw new Error("unterminated string literal while reading PM2 ecosystem config");
+}
+function skipQuotedString(source, start) {
+    const quote = source[start];
+    let cursor = start + 1;
+    while (cursor < source.length) {
+        const char = source[cursor];
+        if (char === "\\") {
+            cursor += 2;
+            continue;
+        }
+        if (char === quote)
+            return cursor + 1;
+        cursor += 1;
+    }
+    throw new Error("unterminated string literal while reading PM2 ecosystem config");
+}
+function findAppsArraySource(source) {
+    let cursor = 0;
+    while (cursor < source.length) {
+        const char = source[cursor];
+        const next = source[cursor + 1];
+        if (char === "/" && next === "/") {
+            cursor = skipLineComment(source, cursor);
+            continue;
+        }
+        if (char === "/" && next === "*") {
+            cursor = skipBlockComment(source, cursor);
+            continue;
+        }
+        if (char === "'" || char === '"' || char === "`") {
+            cursor = skipQuotedString(source, cursor);
+            continue;
+        }
+        if (source.startsWith("apps", cursor) &&
+            isBoundary(source, cursor - 1) &&
+            isBoundary(source, cursor + "apps".length)) {
+            let afterName = skipWhitespace(source, cursor + "apps".length);
+            if (source[afterName] === ":" || source[afterName] === "=") {
+                afterName = skipWhitespace(source, afterName + 1);
+                if (source[afterName] === "[")
+                    return scanArraySource(source, afterName);
+            }
+        }
+        cursor += 1;
+    }
+    throw new Error("PM2 ecosystem config apps array could not be discovered without executing JavaScript; use a static apps: [...] declaration or JSON config");
+}
+function scanArraySource(source, start) {
+    let cursor = start;
+    let depth = 0;
+    while (cursor < source.length) {
+        const char = source[cursor];
+        const next = source[cursor + 1];
+        if (char === "/" && next === "/") {
+            cursor = skipLineComment(source, cursor);
+            continue;
+        }
+        if (char === "/" && next === "*") {
+            cursor = skipBlockComment(source, cursor);
+            continue;
+        }
+        if (char === "'" || char === '"' || char === "`") {
+            cursor = skipQuotedString(source, cursor);
+            continue;
+        }
+        if (char === "[")
+            depth += 1;
+        if (char === "]") {
+            depth -= 1;
+            if (depth === 0)
+                return source.slice(start + 1, cursor);
+        }
+        cursor += 1;
+    }
+    throw new Error("unterminated apps array in PM2 ecosystem config");
+}
+function splitTopLevelObjectSources(arraySource) {
+    const objects = [];
+    let cursor = 0;
+    let objectStart;
+    let depth = 0;
+    while (cursor < arraySource.length) {
+        const char = arraySource[cursor];
+        const next = arraySource[cursor + 1];
+        if (char === "/" && next === "/") {
+            cursor = skipLineComment(arraySource, cursor);
+            continue;
+        }
+        if (char === "/" && next === "*") {
+            cursor = skipBlockComment(arraySource, cursor);
+            continue;
+        }
+        if (char === "'" || char === '"' || char === "`") {
+            cursor = skipQuotedString(arraySource, cursor);
+            continue;
+        }
+        if (char === "{") {
+            if (depth === 0)
+                objectStart = cursor;
+            depth += 1;
+        }
+        else if (char === "}") {
+            depth -= 1;
+            if (depth === 0 && objectStart !== undefined) {
+                objects.push(arraySource.slice(objectStart, cursor + 1));
+                objectStart = undefined;
+            }
+            if (depth < 0)
+                throw new Error("unbalanced object literal in PM2 apps array");
+        }
+        cursor += 1;
+    }
+    if (depth !== 0)
+        throw new Error("unterminated object literal in PM2 apps array");
+    if (objects.length === 0)
+        throw new Error("PM2 apps array must contain object literals");
+    return objects;
+}
+function readIdentifier(source, start) {
+    if (!isIdentifierStart(source[start]))
+        return null;
+    let cursor = start + 1;
+    while (isIdentifierPart(source[cursor]))
+        cursor += 1;
+    return { value: source.slice(start, cursor), end: cursor };
+}
+function skipValue(source, start) {
+    let cursor = start;
+    let depth = 0;
+    while (cursor < source.length) {
+        const char = source[cursor];
+        const next = source[cursor + 1];
+        if (char === "/" && next === "/") {
+            cursor = skipLineComment(source, cursor);
+            continue;
+        }
+        if (char === "/" && next === "*") {
+            cursor = skipBlockComment(source, cursor);
+            continue;
+        }
+        if (char === "'" || char === '"' || char === "`") {
+            cursor = skipQuotedString(source, cursor);
+            continue;
+        }
+        if (char === "{" || char === "[" || char === "(")
+            depth += 1;
+        else if (char === "}" || char === "]" || char === ")") {
+            if (depth === 0)
+                return cursor;
+            depth -= 1;
+        }
+        else if (char === "," && depth === 0)
+            return cursor + 1;
+        cursor += 1;
+    }
+    return cursor;
+}
+function extractTopLevelName(objectSource, index) {
+    let cursor = 1;
+    const end = objectSource.length - 1;
+    while (cursor < end) {
+        cursor = skipWhitespace(objectSource, cursor);
+        if (objectSource[cursor] === ",") {
+            cursor += 1;
+            continue;
+        }
+        let key = null;
+        const char = objectSource[cursor];
+        if (char === "'" || char === '"' || char === "`") {
+            key = readQuotedString(objectSource, cursor);
+        }
+        else {
+            key = readIdentifier(objectSource, cursor);
+        }
+        if (!key) {
+            cursor += 1;
+            continue;
+        }
+        const colon = skipWhitespace(objectSource, key.end);
+        if (objectSource[colon] !== ":") {
+            cursor = skipValue(objectSource, key.end);
+            continue;
+        }
+        const valueStart = skipWhitespace(objectSource, colon + 1);
+        if (key.value === "name") {
+            const quote = objectSource[valueStart];
+            if (quote !== "'" && quote !== '"' && quote !== "`") {
+                throw new Error(`PM2 app at index ${index} must declare a static string name`);
+            }
+            return validateAppName(readQuotedString(objectSource, valueStart).value, index);
+        }
+        cursor = skipValue(objectSource, valueStart);
+    }
+    throw new Error(`PM2 app at index ${index} must declare a non-empty string name`);
+}
+function extractStaticJsAppNames(source) {
+    const arraySource = findAppsArraySource(source);
+    return splitTopLevelObjectSources(arraySource).map((objectSource, index) => extractTopLevelName(objectSource, index));
 }
 function parseMetadata(metadataPath) {
     if (!metadataPath)
@@ -81,17 +331,28 @@ function parseMetadata(metadataPath) {
         return {};
     }
 }
+async function loadAppNames(configPath) {
+    const absolutePath = resolve(configPath);
+    const extension = extname(absolutePath).toLowerCase();
+    if (extension === ".json") {
+        return extractJsonAppArray(await readJsonEcosystem(absolutePath)).map((rawApp, index) => {
+            if (!isRecord(rawApp)) {
+                throw new Error(`PM2 app at index ${index} must be an object`);
+            }
+            return validateAppName(rawApp.name, index);
+        });
+    }
+    if (![".js", ".cjs", ".mjs"].includes(extension)) {
+        throw new Error(`Unsupported PM2 ecosystem config extension '${extension || "none"}'`);
+    }
+    return extractStaticJsAppNames(await readFile(absolutePath, "utf8"));
+}
 export async function loadDeclaredApps(configPath, metadataPath) {
-    const raw = await importEcosystem(configPath);
-    const appArray = extractAppArray(raw);
+    const appNames = await loadAppNames(configPath);
     const metadata = parseMetadata(metadataPath);
     const seen = new Set();
     const apps = [];
-    appArray.forEach((rawApp, index) => {
-        if (!isRecord(rawApp)) {
-            throw new Error(`PM2 app at index ${index} must be an object`);
-        }
-        const name = validateAppName(rawApp.name, index);
+    appNames.forEach((name) => {
         if (seen.has(name))
             throw new Error(`Duplicate PM2 app name in ecosystem config: ${name}`);
         seen.add(name);

--- a/pm2-processes/dist/ecosystem.js
+++ b/pm2-processes/dist/ecosystem.js
@@ -1,0 +1,106 @@
+import * as fs from "node:fs";
+import { createRequire } from "node:module";
+import { extname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { readFile, stat } from "node:fs/promises";
+function isRecord(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function unwrapDefault(value) {
+    if (isRecord(value) && "default" in value)
+        return value.default;
+    return value;
+}
+async function importEcosystem(configPath) {
+    const absolutePath = resolve(configPath);
+    const extension = extname(absolutePath).toLowerCase();
+    if (extension === ".json") {
+        return JSON.parse(await readFile(absolutePath, "utf8"));
+    }
+    const require = createRequire(import.meta.url);
+    try {
+        const resolved = require.resolve(absolutePath);
+        delete require.cache[resolved];
+        return require(resolved);
+    }
+    catch (error) {
+        const code = isRecord(error) && typeof error.code === "string" ? error.code : undefined;
+        if (code !== "ERR_REQUIRE_ESM")
+            throw error;
+        const stats = await stat(absolutePath);
+        return import(`${pathToFileURL(absolutePath).href}?mtime=${stats.mtimeMs}`);
+    }
+}
+function extractAppArray(raw) {
+    const value = unwrapDefault(raw);
+    if (Array.isArray(value))
+        return value;
+    if (isRecord(value)) {
+        const ecosystem = value;
+        if (Array.isArray(ecosystem.apps))
+            return ecosystem.apps;
+    }
+    throw new Error("PM2 ecosystem config must export an apps array or { apps: [...] }");
+}
+function validateAppName(name, index) {
+    if (typeof name !== "string" || name.trim().length === 0) {
+        throw new Error(`PM2 app at index ${index} must declare a non-empty string name`);
+    }
+    const trimmed = name.trim();
+    if (trimmed === "all" || trimmed.includes("*")) {
+        throw new Error(`PM2 app name '${trimmed}' is not allowed; use exact non-wildcard names`);
+    }
+    return trimmed;
+}
+function parseMetadata(metadataPath) {
+    if (!metadataPath)
+        return {};
+    try {
+        const parsed = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+        if (!isRecord(parsed))
+            return {};
+        const apps = isRecord(parsed.apps) ? parsed.apps : parsed;
+        const result = {};
+        for (const [name, raw] of Object.entries(apps)) {
+            if (!isRecord(raw))
+                continue;
+            const url = typeof raw.url === "string" && raw.url.trim() ? raw.url.trim() : undefined;
+            const readinessUrl = typeof raw.readinessUrl === "string" && raw.readinessUrl.trim()
+                ? raw.readinessUrl.trim()
+                : typeof raw.healthUrl === "string" && raw.healthUrl.trim()
+                    ? raw.healthUrl.trim()
+                    : undefined;
+            const description = typeof raw.description === "string" && raw.description.trim()
+                ? raw.description.trim()
+                : undefined;
+            result[name] = { url, readinessUrl, description };
+        }
+        return result;
+    }
+    catch {
+        return {};
+    }
+}
+export async function loadDeclaredApps(configPath, metadataPath) {
+    const raw = await importEcosystem(configPath);
+    const appArray = extractAppArray(raw);
+    const metadata = parseMetadata(metadataPath);
+    const seen = new Set();
+    const apps = [];
+    appArray.forEach((rawApp, index) => {
+        if (!isRecord(rawApp)) {
+            throw new Error(`PM2 app at index ${index} must be an object`);
+        }
+        const name = validateAppName(rawApp.name, index);
+        if (seen.has(name))
+            throw new Error(`Duplicate PM2 app name in ecosystem config: ${name}`);
+        seen.add(name);
+        apps.push({ name, metadata: metadata[name] });
+    });
+    if (apps.length === 0)
+        throw new Error("PM2 ecosystem config declares no apps");
+    return apps;
+}
+export function getAllowedAppNames(apps) {
+    return apps.map((app) => app.name);
+}

--- a/pm2-processes/dist/helpers.js
+++ b/pm2-processes/dist/helpers.js
@@ -1,0 +1,78 @@
+import { Buffer } from "node:buffer";
+export function normalizeTarget(target, apps, options) {
+    const requested = target?.trim() || (options.defaultAll ? "all" : undefined);
+    if (!requested)
+        throw new Error("A target app name is required for this PM2 action");
+    if (requested === "all") {
+        if (!options.allowAll)
+            throw new Error("Target 'all' is not supported for this PM2 action");
+        return { targetLabel: "all", names: apps.map((app) => app.name) };
+    }
+    const app = apps.find((candidate) => candidate.name === requested);
+    if (!app) {
+        const allowed = apps.map((candidate) => candidate.name).join(", ");
+        throw new Error(`Unknown PM2 app '${requested}'. Allowed targets: ${allowed}`);
+    }
+    return { targetLabel: app.name, names: [app.name] };
+}
+export function normalizeLines(lines, defaultLines, maxLines) {
+    if (lines === undefined || !Number.isFinite(lines))
+        return defaultLines;
+    return Math.min(maxLines, Math.max(1, Math.floor(lines)));
+}
+export function truncateTail(text, maxBytes, maxLines) {
+    const normalized = text.replace(/\r\n/g, "\n");
+    const lines = normalized.split("\n");
+    const tailLines = lines.slice(Math.max(0, lines.length - maxLines)).join("\n");
+    const buffer = Buffer.from(tailLines, "utf8");
+    const truncatedByLines = lines.length > maxLines;
+    if (buffer.byteLength <= maxBytes) {
+        return { text: tailLines, truncated: truncatedByLines };
+    }
+    const slice = buffer.subarray(Math.max(0, buffer.byteLength - maxBytes)).toString("utf8");
+    const firstNewline = slice.indexOf("\n");
+    const safeSlice = firstNewline >= 0 ? slice.slice(firstNewline + 1) : slice;
+    return { text: safeSlice, truncated: true };
+}
+export function formatBytes(bytes) {
+    if (bytes === undefined || !Number.isFinite(bytes))
+        return "n/a";
+    if (bytes < 1024)
+        return `${bytes}B`;
+    if (bytes < 1024 * 1024)
+        return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+export function formatUptime(startedAt, now = Date.now()) {
+    if (!startedAt || !Number.isFinite(startedAt))
+        return "n/a";
+    const seconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+    if (seconds < 60)
+        return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60)
+        return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24)
+        return `${hours}h${minutes % 60}m`;
+    const days = Math.floor(hours / 24);
+    return `${days}d${hours % 24}h`;
+}
+export function buildPlainTable(headers, rows) {
+    const widths = headers.map((header, column) => Math.max(header.length, ...rows.map((row) => row[column]?.length ?? 0)));
+    const renderRow = (row) => row
+        .map((cell, column) => cell.padEnd(widths[column] ?? cell.length))
+        .join("  ")
+        .trimEnd();
+    return [
+        renderRow(headers),
+        renderRow(widths.map((width) => "-".repeat(width))),
+        ...rows.map(renderRow),
+    ].join("\n");
+}
+export function summarizeCommandOutput(stdout, stderr, maxBytes) {
+    const combined = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
+    if (!combined)
+        return "(no output)";
+    return truncateTail(combined, maxBytes, 200).text;
+}

--- a/pm2-processes/dist/helpers.js
+++ b/pm2-processes/dist/helpers.js
@@ -20,6 +20,14 @@ export function normalizeLines(lines, defaultLines, maxLines) {
         return defaultLines;
     return Math.min(maxLines, Math.max(1, Math.floor(lines)));
 }
+export function redactSensitiveText(text) {
+    return text
+        .replace(/(\bAuthorization\s*[:=]\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[REDACTED]")
+        .replace(/(\b(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth|client[_-]?secret)\b\s*[:=]\s*)([^\s"'`]+)/gi, "$1[REDACTED]")
+        .replace(/(\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|AUTH)[A-Z0-9_]*\s*=\s*)([^\s"'`]+)/g, "$1[REDACTED]")
+        .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[REDACTED]")
+        .replace(/([?&](?:password|passwd|pwd|secret|token|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth|client[_-]?secret)=)([^&\s]+)/gi, "$1[REDACTED]");
+}
 export function truncateTail(text, maxBytes, maxLines) {
     const normalized = text.replace(/\r\n/g, "\n");
     const lines = normalized.split("\n");
@@ -74,5 +82,5 @@ export function summarizeCommandOutput(stdout, stderr, maxBytes) {
     const combined = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
     if (!combined)
         return "(no output)";
-    return truncateTail(combined, maxBytes, 200).text;
+    return truncateTail(redactSensitiveText(combined), maxBytes, 200).text;
 }

--- a/pm2-processes/dist/index.js
+++ b/pm2-processes/dist/index.js
@@ -1,0 +1,113 @@
+import { StringEnum } from "@mariozechner/pi-ai";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "@sinclair/typebox";
+import { loadDeclaredApps } from "./ecosystem.js";
+import {} from "./helpers.js";
+import { CliPm2Runner, executePm2Action } from "./pm2.js";
+import { loadSettings } from "./settings.js";
+const PM2_ACTIONS = ["status", "start", "restart", "stop", "logs", "urls", "config"];
+const Pm2ProcessParams = Type.Object({
+    action: StringEnum(PM2_ACTIONS, {
+        description: "PM2 action to run against declared apps only.",
+    }),
+    target: Type.Optional(Type.String({
+        description: "Declared app name, or 'all' for status/start/restart/stop. Required for logs.",
+    })),
+    lines: Type.Optional(Type.Number({
+        description: "Line count for logs; clamped to configured safe limits.",
+    })),
+});
+function parseCommandArgs(args) {
+    const tokens = args.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0)
+        return null;
+    const action = tokens[0];
+    if (!PM2_ACTIONS.includes(action)) {
+        throw new Error(`Unknown /pm2 action '${tokens[0]}'. Expected: ${PM2_ACTIONS.join(", ")}`);
+    }
+    let target;
+    let lines;
+    for (let index = 1; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        if (token === "--lines") {
+            const value = tokens[index + 1];
+            if (!value)
+                throw new Error("/pm2 logs --lines requires a number");
+            lines = Number(value);
+            index += 1;
+            continue;
+        }
+        if (token?.startsWith("--lines=")) {
+            lines = Number(token.slice("--lines=".length));
+            continue;
+        }
+        if (!target) {
+            target = token;
+            continue;
+        }
+        throw new Error(`Unexpected /pm2 argument '${token}'`);
+    }
+    return { action, target, lines };
+}
+function formatWarnings(warnings) {
+    return warnings.length > 0
+        ? `\n\nWarnings:\n${warnings.map((warning) => `- ${warning}`).join("\n")}`
+        : "";
+}
+async function prepare(cwd) {
+    const settings = loadSettings({ cwd, agentDir: getAgentDir() });
+    if (!settings.configPath) {
+        return { settings, apps: [], runner: new CliPm2Runner(settings.pm2Bin) };
+    }
+    const apps = await loadDeclaredApps(settings.configPath, settings.metadataPath);
+    return { settings, apps, runner: new CliPm2Runner(settings.pm2Bin) };
+}
+async function runPm2(input, ctx, signal) {
+    const { settings, apps, runner } = await prepare(ctx.cwd);
+    const result = await executePm2Action(input, apps, settings, runner, signal);
+    return `${result.text}${formatWarnings(result.warnings)}`;
+}
+async function showPm2Menu(ctx) {
+    const { settings } = await prepare(ctx.cwd);
+    return settings.configPath ? { action: "status", target: "all" } : { action: "config" };
+}
+export default function pm2ProcessesExtension(pi) {
+    pi.registerTool({
+        name: "pm2_process",
+        label: "PM2 Process",
+        description: "Manage project-local PM2 apps declared in the active ecosystem config. Actions are bounded and app-name allowlisted.",
+        promptSnippet: "Manage declared PM2 apps via status/start/restart/stop/logs/urls/config without arbitrary shell commands.",
+        promptGuidelines: [
+            "Use pm2_process for project PM2 process lifecycle tasks instead of starting long-running processes with bash.",
+            "pm2_process only accepts exact declared app names or all where supported; do not use PM2 wildcards or delete/kill actions.",
+        ],
+        parameters: Pm2ProcessParams,
+        async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+            const text = await runPm2(params, ctx, signal);
+            return {
+                content: [{ type: "text", text }],
+                details: { action: params.action, target: params.target },
+            };
+        },
+        renderCall(args, theme) {
+            return new Text(`${theme.fg("toolTitle", theme.bold("pm2_process"))} ${args.action ?? ""} ${args.target ?? ""}`.trim(), 0, 0);
+        },
+    });
+    pi.registerCommand("pm2", {
+        description: "Manage PM2 apps declared in the active ecosystem config",
+        handler: async (args, ctx) => {
+            try {
+                const parsed = parseCommandArgs(args) ?? (await showPm2Menu(ctx));
+                if (!parsed)
+                    return;
+                const text = await runPm2(parsed, ctx);
+                ctx.ui.notify(text, "info");
+            }
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                ctx.ui.notify(`PM2 error: ${message}`, "error");
+            }
+        },
+    });
+}

--- a/pm2-processes/dist/index.js
+++ b/pm2-processes/dist/index.js
@@ -55,21 +55,38 @@ function formatWarnings(warnings) {
         ? `\n\nWarnings:\n${warnings.map((warning) => `- ${warning}`).join("\n")}`
         : "";
 }
-async function prepare(cwd) {
+async function prepare(cwd, options) {
     const settings = loadSettings({ cwd, agentDir: getAgentDir() });
-    if (!settings.configPath) {
-        return { settings, apps: [], runner: new CliPm2Runner(settings.pm2Bin) };
+    const runner = new CliPm2Runner(settings.pm2Bin);
+    if (!settings.configPath)
+        return { settings, apps: [], runner };
+    try {
+        const apps = await loadDeclaredApps(settings.configPath, settings.metadataPath);
+        return { settings, apps, runner };
     }
-    const apps = await loadDeclaredApps(settings.configPath, settings.metadataPath);
-    return { settings, apps, runner: new CliPm2Runner(settings.pm2Bin) };
+    catch (error) {
+        if (!options.tolerateAppDiscoveryErrors)
+            throw error;
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+            settings: {
+                ...settings,
+                diagnostics: [...settings.diagnostics, `PM2 app discovery skipped: ${message}`],
+            },
+            apps: [],
+            runner,
+        };
+    }
 }
 async function runPm2(input, ctx, signal) {
-    const { settings, apps, runner } = await prepare(ctx.cwd);
+    const { settings, apps, runner } = await prepare(ctx.cwd, {
+        tolerateAppDiscoveryErrors: input.action === "config",
+    });
     const result = await executePm2Action(input, apps, settings, runner, signal);
     return `${result.text}${formatWarnings(result.warnings)}`;
 }
 async function showPm2Menu(ctx) {
-    const { settings } = await prepare(ctx.cwd);
+    const settings = loadSettings({ cwd: ctx.cwd, agentDir: getAgentDir() });
     return settings.configPath ? { action: "status", target: "all" } : { action: "config" };
 }
 export default function pm2ProcessesExtension(pi) {

--- a/pm2-processes/dist/pm2.js
+++ b/pm2-processes/dist/pm2.js
@@ -1,8 +1,17 @@
 import { spawn } from "node:child_process";
 import net from "node:net";
-import { buildPlainTable, formatBytes, formatUptime, normalizeLines, normalizeTarget, summarizeCommandOutput, truncateTail, } from "./helpers.js";
+import { buildPlainTable, formatBytes, formatUptime, normalizeLines, normalizeTarget, redactSensitiveText, summarizeCommandOutput, truncateTail, } from "./helpers.js";
 function isRecord(value) {
     return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function appendBoundedTail(current, chunk, maxBytes) {
+    const combined = Buffer.concat([Buffer.from(current, "utf8"), Buffer.from(chunk, "utf8")]);
+    if (combined.byteLength <= maxBytes)
+        return { text: current + chunk, truncated: false };
+    return {
+        text: combined.subarray(combined.byteLength - maxBytes).toString("utf8"),
+        truncated: true,
+    };
 }
 export class CliPm2Runner {
     pm2Bin;
@@ -14,8 +23,11 @@ export class CliPm2Runner {
             const child = spawn(this.pm2Bin, args, { stdio: ["ignore", "pipe", "pipe"] });
             let stdout = "";
             let stderr = "";
+            let stdoutTruncated = false;
+            let stderrTruncated = false;
             let settled = false;
             let timedOut = false;
+            const maxBytes = options.maxBytes ?? 50_000;
             const timeout = options.timeoutMs
                 ? setTimeout(() => {
                     timedOut = true;
@@ -31,10 +43,14 @@ export class CliPm2Runner {
             child.stdout?.setEncoding("utf8");
             child.stderr?.setEncoding("utf8");
             child.stdout?.on("data", (chunk) => {
-                stdout += chunk;
+                const next = appendBoundedTail(stdout, chunk, maxBytes);
+                stdout = next.text;
+                stdoutTruncated = stdoutTruncated || next.truncated;
             });
             child.stderr?.on("data", (chunk) => {
-                stderr += chunk;
+                const next = appendBoundedTail(stderr, chunk, maxBytes);
+                stderr = next.text;
+                stderrTruncated = stderrTruncated || next.truncated;
             });
             child.once("error", (error) => {
                 if (settled)
@@ -52,7 +68,7 @@ export class CliPm2Runner {
                 if (timeout)
                     clearTimeout(timeout);
                 options.signal?.removeEventListener("abort", abort);
-                resolve({ stdout, stderr, code, timedOut });
+                resolve({ stdout, stderr, code, timedOut, stdoutTruncated, stderrTruncated });
             });
         });
     }
@@ -84,7 +100,11 @@ function parsePm2List(stdout) {
     });
 }
 async function getDeclaredStatuses(apps, runner, settings, signal) {
-    const result = await runner.run(["jlist"], { signal, timeoutMs: settings.commandTimeoutMs });
+    const result = await runner.run(["jlist"], {
+        signal,
+        timeoutMs: settings.commandTimeoutMs,
+        maxBytes: settings.maxBytes,
+    });
     if (result.timedOut)
         throw new Error(`pm2 jlist timed out after ${settings.commandTimeoutMs}ms`);
     if (result.code !== 0) {
@@ -126,7 +146,11 @@ async function runMutation(action, names, settings, runner, signal) {
         throw new Error("No PM2 config file is active");
     for (const name of names) {
         const args = action === "stop" ? ["stop", name] : [action, settings.configPath, "--only", name];
-        const result = await runner.run(args, { signal, timeoutMs: settings.commandTimeoutMs });
+        const result = await runner.run(args, {
+            signal,
+            timeoutMs: settings.commandTimeoutMs,
+            maxBytes: settings.maxBytes,
+        });
         if (result.timedOut)
             throw new Error(`pm2 ${action} ${name} timed out after ${settings.commandTimeoutMs}ms`);
         if (result.code !== 0) {
@@ -228,14 +252,16 @@ export async function executePm2Action(input, apps, settings, runner, signal) {
         const result = await runner.run(["logs", target.names[0] ?? "", "--lines", String(lines), "--nostream", "--raw"], {
             signal,
             timeoutMs: settings.commandTimeoutMs,
+            maxBytes: settings.maxBytes,
         });
         if (result.timedOut)
             throw new Error(`pm2 logs ${target.targetLabel} timed out after ${settings.commandTimeoutMs}ms`);
         if (result.code !== 0) {
             throw new Error(`pm2 logs ${target.targetLabel} failed: ${summarizeCommandOutput(result.stdout, result.stderr, settings.maxBytes)}`);
         }
-        const truncated = truncateTail([result.stdout, result.stderr].filter(Boolean).join("\n"), settings.maxBytes, lines);
-        const suffix = truncated.truncated
+        const truncated = truncateTail(redactSensitiveText([result.stdout, result.stderr].filter(Boolean).join("\n")), settings.maxBytes, lines);
+        const wasCapturedTruncated = result.stdoutTruncated === true || result.stderrTruncated === true;
+        const suffix = truncated.truncated || wasCapturedTruncated
             ? `\n\n[logs truncated to ${lines} lines / ${settings.maxBytes} bytes]`
             : "";
         return {
@@ -244,7 +270,7 @@ export async function executePm2Action(input, apps, settings, runner, signal) {
                 action: input.action,
                 target: target.targetLabel,
                 lines,
-                truncated: truncated.truncated,
+                truncated: truncated.truncated || wasCapturedTruncated,
             },
             warnings: [],
         };

--- a/pm2-processes/dist/pm2.js
+++ b/pm2-processes/dist/pm2.js
@@ -1,0 +1,277 @@
+import { spawn } from "node:child_process";
+import net from "node:net";
+import { buildPlainTable, formatBytes, formatUptime, normalizeLines, normalizeTarget, summarizeCommandOutput, truncateTail, } from "./helpers.js";
+function isRecord(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+export class CliPm2Runner {
+    pm2Bin;
+    constructor(pm2Bin) {
+        this.pm2Bin = pm2Bin;
+    }
+    run(args, options = {}) {
+        return new Promise((resolve, reject) => {
+            const child = spawn(this.pm2Bin, args, { stdio: ["ignore", "pipe", "pipe"] });
+            let stdout = "";
+            let stderr = "";
+            let settled = false;
+            let timedOut = false;
+            const timeout = options.timeoutMs
+                ? setTimeout(() => {
+                    timedOut = true;
+                    child.kill("SIGTERM");
+                    setTimeout(() => child.kill("SIGKILL"), 1_000).unref();
+                }, options.timeoutMs)
+                : undefined;
+            const abort = () => {
+                timedOut = true;
+                child.kill("SIGTERM");
+            };
+            options.signal?.addEventListener("abort", abort, { once: true });
+            child.stdout?.setEncoding("utf8");
+            child.stderr?.setEncoding("utf8");
+            child.stdout?.on("data", (chunk) => {
+                stdout += chunk;
+            });
+            child.stderr?.on("data", (chunk) => {
+                stderr += chunk;
+            });
+            child.once("error", (error) => {
+                if (settled)
+                    return;
+                settled = true;
+                if (timeout)
+                    clearTimeout(timeout);
+                options.signal?.removeEventListener("abort", abort);
+                reject(error);
+            });
+            child.once("close", (code) => {
+                if (settled)
+                    return;
+                settled = true;
+                if (timeout)
+                    clearTimeout(timeout);
+                options.signal?.removeEventListener("abort", abort);
+                resolve({ stdout, stderr, code, timedOut });
+            });
+        });
+    }
+}
+function parsePm2List(stdout) {
+    const parsed = JSON.parse(stdout || "[]");
+    if (!Array.isArray(parsed))
+        throw new Error("pm2 jlist did not return a JSON array");
+    return parsed.flatMap((item) => {
+        if (!isRecord(item))
+            return [];
+        const name = typeof item.name === "string" ? item.name : undefined;
+        if (!name)
+            return [];
+        const env = isRecord(item.pm2_env) ? item.pm2_env : {};
+        const monit = isRecord(item.monit) ? item.monit : {};
+        return [
+            {
+                name,
+                status: typeof env.status === "string" ? env.status : "unknown",
+                pid: typeof item.pid === "number" ? item.pid : undefined,
+                pmId: typeof item.pm_id === "number" ? item.pm_id : undefined,
+                cpu: typeof monit.cpu === "number" ? monit.cpu : undefined,
+                memory: typeof monit.memory === "number" ? monit.memory : undefined,
+                restarts: typeof env.restart_time === "number" ? env.restart_time : undefined,
+                uptime: formatUptime(typeof env.pm_uptime === "number" ? env.pm_uptime : undefined),
+            },
+        ];
+    });
+}
+async function getDeclaredStatuses(apps, runner, settings, signal) {
+    const result = await runner.run(["jlist"], { signal, timeoutMs: settings.commandTimeoutMs });
+    if (result.timedOut)
+        throw new Error(`pm2 jlist timed out after ${settings.commandTimeoutMs}ms`);
+    if (result.code !== 0) {
+        throw new Error(`pm2 jlist failed: ${summarizeCommandOutput(result.stdout, result.stderr, settings.maxBytes)}`);
+    }
+    const running = parsePm2List(result.stdout);
+    return apps.map((app) => {
+        const match = running.find((process) => process.name === app.name);
+        return {
+            name: app.name,
+            status: match?.status ?? "stopped",
+            pid: match?.pid,
+            pmId: match?.pmId,
+            cpu: match?.cpu,
+            memory: match?.memory,
+            restarts: match?.restarts,
+            uptime: match?.uptime,
+            url: app.metadata?.url,
+        };
+    });
+}
+function renderStatusTable(statuses) {
+    if (statuses.length === 0)
+        return "No declared PM2 apps matched.";
+    return buildPlainTable(["app", "status", "pid", "cpu", "mem", "restarts", "uptime", "url"], statuses.map((status) => [
+        status.name,
+        status.status,
+        status.pid === undefined ? "-" : String(status.pid),
+        status.cpu === undefined ? "-" : `${status.cpu}%`,
+        formatBytes(status.memory),
+        status.restarts === undefined ? "-" : String(status.restarts),
+        status.uptime ?? "n/a",
+        status.url ?? "-",
+    ]));
+}
+async function runMutation(action, names, settings, runner, signal) {
+    const outputs = [];
+    if (!settings.configPath)
+        throw new Error("No PM2 config file is active");
+    for (const name of names) {
+        const args = action === "stop" ? ["stop", name] : [action, settings.configPath, "--only", name];
+        const result = await runner.run(args, { signal, timeoutMs: settings.commandTimeoutMs });
+        if (result.timedOut)
+            throw new Error(`pm2 ${action} ${name} timed out after ${settings.commandTimeoutMs}ms`);
+        if (result.code !== 0) {
+            throw new Error(`pm2 ${action} ${name} failed: ${summarizeCommandOutput(result.stdout, result.stderr, settings.maxBytes)}`);
+        }
+        outputs.push(`pm2 ${action} ${name}: ${summarizeCommandOutput(result.stdout, result.stderr, 2_000)}`);
+    }
+    return outputs;
+}
+function renderConfig(apps, settings) {
+    const metadata = settings.metadataPath
+        ? `${settings.metadataPath} (${settings.metadataSource})`
+        : "none";
+    return [
+        `PM2 config: ${settings.configPath ?? "not found"}`,
+        `Config source: ${settings.configSource ?? "none"}`,
+        `Metadata: ${metadata}`,
+        `PM2 binary: ${settings.pm2Bin}`,
+        `Allowed apps: ${apps.map((app) => app.name).join(", ") || "none"}`,
+        `Log limits: default ${settings.defaultLines} lines, max ${settings.maxLines} lines / ${settings.maxBytes} bytes`,
+    ].join("\n");
+}
+function renderUrls(apps) {
+    const rows = apps
+        .filter((app) => app.metadata?.url || app.metadata?.readinessUrl)
+        .map((app) => [app.name, app.metadata?.url ?? "-", app.metadata?.readinessUrl ?? "-"]);
+    if (rows.length === 0)
+        return "No PM2 app URLs configured. Add .pi/pm2/metadata.json with app URL metadata.";
+    return buildPlainTable(["app", "url", "readiness"], rows);
+}
+function localhostPortFromUrl(url) {
+    if (!url)
+        return null;
+    try {
+        const parsed = new URL(url);
+        if (!["localhost", "127.0.0.1", "::1"].includes(parsed.hostname))
+            return null;
+        if (parsed.port)
+            return Number(parsed.port);
+        return parsed.protocol === "https:" ? 443 : parsed.protocol === "http:" ? 80 : null;
+    }
+    catch {
+        return null;
+    }
+}
+async function canConnectLocalPort(port, timeoutMs) {
+    return new Promise((resolve) => {
+        const socket = net.createConnection({ host: "127.0.0.1", port });
+        const timeout = setTimeout(() => {
+            socket.destroy();
+            resolve(false);
+        }, timeoutMs);
+        socket.once("connect", () => {
+            clearTimeout(timeout);
+            socket.destroy();
+            resolve(true);
+        });
+        socket.once("error", () => {
+            clearTimeout(timeout);
+            socket.destroy();
+            resolve(false);
+        });
+    });
+}
+async function collectPortWarnings(apps, names, statuses, settings) {
+    const warnings = [];
+    for (const app of apps.filter((candidate) => names.includes(candidate.name))) {
+        const status = statuses.find((candidate) => candidate.name === app.name)?.status;
+        if (status === "online")
+            continue;
+        const port = localhostPortFromUrl(app.metadata?.url ?? app.metadata?.readinessUrl);
+        if (!port)
+            continue;
+        if (await canConnectLocalPort(port, Math.min(settings.readinessTimeoutMs, 1_000))) {
+            warnings.push(`Port ${port} for ${app.name} appears to be in use while PM2 does not report the app online; not killing unrelated processes.`);
+        }
+    }
+    return warnings;
+}
+export async function executePm2Action(input, apps, settings, runner, signal) {
+    if (!settings.enabled)
+        throw new Error("pm2-processes is disabled by settings");
+    if (input.action === "config") {
+        return {
+            text: renderConfig(apps, settings),
+            details: { action: input.action, settings },
+            warnings: settings.diagnostics,
+        };
+    }
+    if (!settings.configPath) {
+        throw new Error(`No PM2 config file found. Searched:\n${settings.searchedConfigPaths.join("\n")}`);
+    }
+    if (input.action === "urls") {
+        return { text: renderUrls(apps), details: { action: input.action, apps }, warnings: [] };
+    }
+    if (input.action === "logs") {
+        const target = normalizeTarget(input.target, apps, { defaultAll: false, allowAll: false });
+        const lines = normalizeLines(input.lines, settings.defaultLines, settings.maxLines);
+        const result = await runner.run(["logs", target.names[0] ?? "", "--lines", String(lines), "--nostream", "--raw"], {
+            signal,
+            timeoutMs: settings.commandTimeoutMs,
+        });
+        if (result.timedOut)
+            throw new Error(`pm2 logs ${target.targetLabel} timed out after ${settings.commandTimeoutMs}ms`);
+        if (result.code !== 0) {
+            throw new Error(`pm2 logs ${target.targetLabel} failed: ${summarizeCommandOutput(result.stdout, result.stderr, settings.maxBytes)}`);
+        }
+        const truncated = truncateTail([result.stdout, result.stderr].filter(Boolean).join("\n"), settings.maxBytes, lines);
+        const suffix = truncated.truncated
+            ? `\n\n[logs truncated to ${lines} lines / ${settings.maxBytes} bytes]`
+            : "";
+        return {
+            text: `Logs for ${target.targetLabel}:\n${truncated.text || "(no log output)"}${suffix}`,
+            details: {
+                action: input.action,
+                target: target.targetLabel,
+                lines,
+                truncated: truncated.truncated,
+            },
+            warnings: [],
+        };
+    }
+    const target = normalizeTarget(input.target, apps, { defaultAll: true, allowAll: true });
+    if (input.action === "status") {
+        const statuses = await getDeclaredStatuses(apps, runner, settings, signal);
+        const selected = statuses.filter((status) => target.names.includes(status.name));
+        return {
+            text: renderStatusTable(selected),
+            details: { action: input.action, target: target.targetLabel, statuses: selected },
+            warnings: [],
+        };
+    }
+    const beforeStatuses = await getDeclaredStatuses(apps, runner, settings, signal);
+    const warnings = await collectPortWarnings(apps, target.names, beforeStatuses, settings);
+    const mutationOutput = await runMutation(input.action, target.names, settings, runner, signal);
+    const afterStatuses = await getDeclaredStatuses(apps, runner, settings, signal);
+    const selected = afterStatuses.filter((status) => target.names.includes(status.name));
+    return {
+        text: [`PM2 ${input.action} ${target.targetLabel} complete.`, renderStatusTable(selected)].join("\n\n"),
+        details: {
+            action: input.action,
+            target: target.targetLabel,
+            outputs: mutationOutput,
+            statuses: selected,
+        },
+        warnings,
+    };
+}

--- a/pm2-processes/dist/settings.js
+++ b/pm2-processes/dist/settings.js
@@ -1,0 +1,132 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+export const SETTINGS_KEY = "pm2-processes";
+const DEFAULT_CONFIG_CANDIDATES = [
+    join(".pi", "pm2", "ecosystem.config.cjs"),
+    "ecosystem.config.js",
+    "ecosystem.config.cjs",
+    "ecosystem.config.json",
+];
+function readJsonFile(filePath) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, "utf8"));
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { __pm2ProcessesParseError: `Failed to parse ${filePath}: ${message}` };
+    }
+}
+function readSettingsConfig(settingsPath) {
+    if (!fs.existsSync(settingsPath))
+        return null;
+    const parsed = readJsonFile(settingsPath);
+    if (!parsed || typeof parsed !== "object")
+        return null;
+    if ("__pm2ProcessesParseError" in parsed) {
+        return {
+            pathLabel: settingsPath,
+            raw: {},
+        };
+    }
+    const raw = parsed[SETTINGS_KEY];
+    if (!raw || typeof raw !== "object")
+        return null;
+    return {
+        pathLabel: `${settingsPath}#${SETTINGS_KEY}`,
+        raw: raw,
+    };
+}
+function resolvePath(cwd, input) {
+    return isAbsolute(input) ? input : resolve(cwd, input);
+}
+function cleanString(value) {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+}
+function cleanPositiveInt(value, fallback, min, max) {
+    if (!Number.isFinite(value) || value === undefined)
+        return fallback;
+    return Math.min(max, Math.max(min, Math.floor(value)));
+}
+function collectSettings(cwd, agentDir) {
+    const globalSettings = readSettingsConfig(join(agentDir, "settings.json"));
+    const projectSettings = readSettingsConfig(join(cwd, ".pi", "settings.json"));
+    return [globalSettings, projectSettings].filter((source) => source !== null);
+}
+function mergeSettings(sources) {
+    return sources.reduce((merged, source) => ({ ...merged, ...source.raw }), {});
+}
+function resolveExistingFile(cwd, candidates) {
+    const searched = [];
+    const diagnostics = [];
+    for (const candidate of candidates) {
+        const absolutePath = resolvePath(cwd, candidate.path);
+        searched.push(absolutePath);
+        if (fs.existsSync(absolutePath)) {
+            return { configPath: absolutePath, configSource: candidate.source, searched, diagnostics };
+        }
+        diagnostics.push(`PM2 config candidate not found: ${absolutePath} (${candidate.source})`);
+    }
+    return { searched, diagnostics };
+}
+export function loadSettings(options = {}) {
+    const cwd = options.cwd ?? process.cwd();
+    const agentDir = options.agentDir ?? join(os.homedir(), ".pi", "agent");
+    const env = options.env ?? process.env;
+    const sources = collectSettings(cwd, agentDir);
+    const merged = mergeSettings(sources);
+    const diagnostics = [];
+    const explicitEnvConfig = cleanString(env.PI_PM2_CONFIG);
+    const settingsConfig = cleanString(merged.configPath);
+    const candidates = [];
+    if (explicitEnvConfig)
+        candidates.push({ path: explicitEnvConfig, source: "env:PI_PM2_CONFIG" });
+    else if (settingsConfig)
+        candidates.push({ path: settingsConfig, source: "settings:configPath" });
+    else {
+        for (const candidate of DEFAULT_CONFIG_CANDIDATES) {
+            candidates.push({ path: candidate, source: `default:${candidate}` });
+        }
+    }
+    const discovered = resolveExistingFile(cwd, candidates);
+    diagnostics.push(...discovered.diagnostics);
+    const metadataEnv = cleanString(env.PI_PM2_METADATA);
+    const metadataSetting = cleanString(merged.metadataPath);
+    const defaultMetadata = join(cwd, ".pi", "pm2", "metadata.json");
+    let metadataPath;
+    let metadataSource;
+    if (metadataEnv) {
+        metadataPath = resolvePath(cwd, metadataEnv);
+        metadataSource = "env:PI_PM2_METADATA";
+    }
+    else if (metadataSetting) {
+        metadataPath = resolvePath(cwd, metadataSetting);
+        metadataSource = "settings:metadataPath";
+    }
+    else if (fs.existsSync(defaultMetadata)) {
+        metadataPath = defaultMetadata;
+        metadataSource = "default:.pi/pm2/metadata.json";
+    }
+    if (metadataPath && !fs.existsSync(metadataPath)) {
+        diagnostics.push(`PM2 metadata file not found: ${metadataPath} (${metadataSource ?? "unknown"})`);
+        metadataPath = undefined;
+        metadataSource = undefined;
+    }
+    return {
+        enabled: merged.enabled ?? true,
+        configPath: discovered.configPath,
+        configSource: discovered.configSource,
+        metadataPath,
+        metadataSource,
+        pm2Bin: cleanString(env.PI_PM2_BIN) ?? cleanString(merged.pm2Bin) ?? "pm2",
+        defaultLines: cleanPositiveInt(merged.defaultLines, 80, 1, 2000),
+        maxLines: cleanPositiveInt(merged.maxLines, 300, 1, 5000),
+        maxBytes: cleanPositiveInt(merged.maxBytes, 50_000, 1_000, 500_000),
+        commandTimeoutMs: cleanPositiveInt(merged.commandTimeoutMs, 15_000, 1_000, 120_000),
+        readinessTimeoutMs: cleanPositiveInt(merged.readinessTimeoutMs, 1_500, 100, 30_000),
+        settingsSources: sources.map((source) => source.pathLabel),
+        searchedConfigPaths: discovered.searched,
+        diagnostics,
+    };
+}

--- a/pm2-processes/dist/settings.js
+++ b/pm2-processes/dist/settings.js
@@ -10,31 +10,33 @@ const DEFAULT_CONFIG_CANDIDATES = [
 ];
 function readJsonFile(filePath) {
     try {
-        return JSON.parse(fs.readFileSync(filePath, "utf8"));
+        return { value: JSON.parse(fs.readFileSync(filePath, "utf8")) };
     }
     catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return { __pm2ProcessesParseError: `Failed to parse ${filePath}: ${message}` };
+        return { diagnostic: `Failed to parse ${filePath}: ${message}` };
     }
 }
 function readSettingsConfig(settingsPath) {
     if (!fs.existsSync(settingsPath))
         return null;
     const parsed = readJsonFile(settingsPath);
-    if (!parsed || typeof parsed !== "object")
-        return null;
-    if ("__pm2ProcessesParseError" in parsed) {
+    if (parsed.diagnostic) {
         return {
             pathLabel: settingsPath,
             raw: {},
+            diagnostics: [parsed.diagnostic],
         };
     }
-    const raw = parsed[SETTINGS_KEY];
+    if (!parsed.value || typeof parsed.value !== "object")
+        return null;
+    const raw = parsed.value[SETTINGS_KEY];
     if (!raw || typeof raw !== "object")
         return null;
     return {
         pathLabel: `${settingsPath}#${SETTINGS_KEY}`,
         raw: raw,
+        diagnostics: [],
     };
 }
 function resolvePath(cwd, input) {
@@ -76,7 +78,7 @@ export function loadSettings(options = {}) {
     const env = options.env ?? process.env;
     const sources = collectSettings(cwd, agentDir);
     const merged = mergeSettings(sources);
-    const diagnostics = [];
+    const diagnostics = sources.flatMap((source) => source.diagnostics);
     const explicitEnvConfig = cleanString(env.PI_PM2_CONFIG);
     const settingsConfig = cleanString(merged.configPath);
     const candidates = [];

--- a/pm2-processes/ecosystem.test.ts
+++ b/pm2-processes/ecosystem.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadDeclaredApps } from "./ecosystem.js";
+
+let tmpDirs: string[] = [];
+
+function makeTmp(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "pm2-ecosystem-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+  tmpDirs = [];
+});
+
+describe("loadDeclaredApps", () => {
+  it("loads declared app names and metadata", async () => {
+    const dir = makeTmp();
+    const configPath = path.join(dir, "ecosystem.config.cjs");
+    const metadataPath = path.join(dir, "metadata.json");
+    writeFileSync(configPath, "module.exports = { apps: [{ name: 'api' }, { name: 'web' }] };\n");
+    writeFileSync(
+      metadataPath,
+      JSON.stringify({ apps: { api: { url: "http://localhost:3001/health" } } }),
+    );
+
+    const apps = await loadDeclaredApps(configPath, metadataPath);
+
+    expect(apps).toEqual([
+      {
+        name: "api",
+        metadata: {
+          url: "http://localhost:3001/health",
+          readinessUrl: undefined,
+          description: undefined,
+        },
+      },
+      { name: "web", metadata: undefined },
+    ]);
+  });
+
+  it("rejects duplicate names", async () => {
+    const dir = makeTmp();
+    const configPath = path.join(dir, "ecosystem.config.cjs");
+    writeFileSync(configPath, "module.exports = { apps: [{ name: 'api' }, { name: 'api' }] };\n");
+
+    await expect(loadDeclaredApps(configPath)).rejects.toThrow("Duplicate PM2 app name");
+  });
+
+  it("requires explicit app names", async () => {
+    const dir = makeTmp();
+    const configPath = path.join(dir, "ecosystem.config.cjs");
+    writeFileSync(configPath, "module.exports = { apps: [{ script: 'server.js' }] };\n");
+
+    await expect(loadDeclaredApps(configPath)).rejects.toThrow(
+      "must declare a non-empty string name",
+    );
+  });
+});

--- a/pm2-processes/ecosystem.test.ts
+++ b/pm2-processes/ecosystem.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -61,5 +61,28 @@ describe("loadDeclaredApps", () => {
     await expect(loadDeclaredApps(configPath)).rejects.toThrow(
       "must declare a non-empty string name",
     );
+  });
+
+  it("does not execute JavaScript ecosystem files while discovering apps", async () => {
+    const dir = makeTmp();
+    const configPath = path.join(dir, "ecosystem.config.cjs");
+    const sideEffectPath = path.join(dir, "side-effect.txt");
+    writeFileSync(
+      configPath,
+      `const fs = require("node:fs");\nfs.writeFileSync(${JSON.stringify(sideEffectPath)}, "executed");\nmodule.exports = { apps: [{ name: "api" }] };\n`,
+    );
+
+    await expect(loadDeclaredApps(configPath)).resolves.toEqual([
+      { name: "api", metadata: undefined },
+    ]);
+    expect(existsSync(sideEffectPath)).toBe(false);
+  });
+
+  it("rejects dynamic app names instead of executing workspace config", async () => {
+    const dir = makeTmp();
+    const configPath = path.join(dir, "ecosystem.config.cjs");
+    writeFileSync(configPath, "module.exports = { apps: [{ name: process.env.APP_NAME }] };\n");
+
+    await expect(loadDeclaredApps(configPath)).rejects.toThrow("static string name");
   });
 });

--- a/pm2-processes/ecosystem.ts
+++ b/pm2-processes/ecosystem.ts
@@ -1,8 +1,6 @@
 import * as fs from "node:fs";
-import { createRequire } from "node:module";
 import { extname, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
-import { readFile, stat } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 
 export interface AppMetadata {
   url?: string;
@@ -19,6 +17,8 @@ interface LoadedEcosystem {
   apps?: unknown;
 }
 
+type Quote = "'" | '"' | "`";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -28,34 +28,18 @@ function unwrapDefault(value: unknown): unknown {
   return value;
 }
 
-async function importEcosystem(configPath: string): Promise<unknown> {
-  const absolutePath = resolve(configPath);
-  const extension = extname(absolutePath).toLowerCase();
-  if (extension === ".json") {
-    return JSON.parse(await readFile(absolutePath, "utf8")) as unknown;
-  }
-
-  const require = createRequire(import.meta.url);
-  try {
-    const resolved = require.resolve(absolutePath);
-    delete require.cache[resolved];
-    return require(resolved) as unknown;
-  } catch (error) {
-    const code = isRecord(error) && typeof error.code === "string" ? error.code : undefined;
-    if (code !== "ERR_REQUIRE_ESM") throw error;
-    const stats = await stat(absolutePath);
-    return import(`${pathToFileURL(absolutePath).href}?mtime=${stats.mtimeMs}`) as Promise<unknown>;
-  }
+async function readJsonEcosystem(configPath: string): Promise<unknown> {
+  return JSON.parse(await readFile(configPath, "utf8")) as unknown;
 }
 
-function extractAppArray(raw: unknown): unknown[] {
+function extractJsonAppArray(raw: unknown): unknown[] {
   const value = unwrapDefault(raw);
   if (Array.isArray(value)) return value;
   if (isRecord(value)) {
     const ecosystem = value as LoadedEcosystem;
     if (Array.isArray(ecosystem.apps)) return ecosystem.apps;
   }
-  throw new Error("PM2 ecosystem config must export an apps array or { apps: [...] }");
+  throw new Error("PM2 ecosystem config must declare an apps array or { apps: [...] }");
 }
 
 function validateAppName(name: unknown, index: number): string {
@@ -67,6 +51,272 @@ function validateAppName(name: unknown, index: number): string {
     throw new Error(`PM2 app name '${trimmed}' is not allowed; use exact non-wildcard names`);
   }
   return trimmed;
+}
+
+function isIdentifierStart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z_$]/.test(char);
+}
+
+function isIdentifierPart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9_$-]/.test(char);
+}
+
+function isBoundary(source: string, index: number): boolean {
+  return !isIdentifierPart(source[index]);
+}
+
+function skipWhitespace(source: string, index: number): number {
+  let cursor = index;
+  while (cursor < source.length && /\s/.test(source[cursor] ?? "")) cursor += 1;
+  return cursor;
+}
+
+function skipLineComment(source: string, index: number): number {
+  const newline = source.indexOf("\n", index + 2);
+  return newline === -1 ? source.length : newline + 1;
+}
+
+function skipBlockComment(source: string, index: number): number {
+  const end = source.indexOf("*/", index + 2);
+  return end === -1 ? source.length : end + 2;
+}
+
+function readQuotedString(source: string, start: number): { value: string; end: number } {
+  const quote = source[start] as Quote;
+  let cursor = start + 1;
+  let value = "";
+  while (cursor < source.length) {
+    const char = source[cursor];
+    if (char === quote) return { value, end: cursor + 1 };
+    if (char === "\\") {
+      const next = source[cursor + 1];
+      if (next === undefined) break;
+      if (next === "n") value += "\n";
+      else if (next === "r") value += "\r";
+      else if (next === "t") value += "\t";
+      else if (next === "b") value += "\b";
+      else if (next === "f") value += "\f";
+      else if (next === "v") value += "\v";
+      else if (next === "0") value += "\0";
+      else if (next === "x" && /^[0-9a-fA-F]{2}$/.test(source.slice(cursor + 2, cursor + 4))) {
+        value += String.fromCharCode(Number.parseInt(source.slice(cursor + 2, cursor + 4), 16));
+        cursor += 2;
+      } else if (next === "u" && /^[0-9a-fA-F]{4}$/.test(source.slice(cursor + 2, cursor + 6))) {
+        value += String.fromCharCode(Number.parseInt(source.slice(cursor + 2, cursor + 6), 16));
+        cursor += 4;
+      } else {
+        value += next;
+      }
+      cursor += 2;
+      continue;
+    }
+    if (quote === "`" && char === "$" && source[cursor + 1] === "{") {
+      throw new Error("dynamic template expressions are not supported for PM2 app names");
+    }
+    value += char;
+    cursor += 1;
+  }
+  throw new Error("unterminated string literal while reading PM2 ecosystem config");
+}
+
+function skipQuotedString(source: string, start: number): number {
+  const quote = source[start];
+  let cursor = start + 1;
+  while (cursor < source.length) {
+    const char = source[cursor];
+    if (char === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (char === quote) return cursor + 1;
+    cursor += 1;
+  }
+  throw new Error("unterminated string literal while reading PM2 ecosystem config");
+}
+
+function findAppsArraySource(source: string): string {
+  let cursor = 0;
+  while (cursor < source.length) {
+    const char = source[cursor];
+    const next = source[cursor + 1];
+    if (char === "/" && next === "/") {
+      cursor = skipLineComment(source, cursor);
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      cursor = skipBlockComment(source, cursor);
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      cursor = skipQuotedString(source, cursor);
+      continue;
+    }
+    if (
+      source.startsWith("apps", cursor) &&
+      isBoundary(source, cursor - 1) &&
+      isBoundary(source, cursor + "apps".length)
+    ) {
+      let afterName = skipWhitespace(source, cursor + "apps".length);
+      if (source[afterName] === ":" || source[afterName] === "=") {
+        afterName = skipWhitespace(source, afterName + 1);
+        if (source[afterName] === "[") return scanArraySource(source, afterName);
+      }
+    }
+    cursor += 1;
+  }
+  throw new Error(
+    "PM2 ecosystem config apps array could not be discovered without executing JavaScript; use a static apps: [...] declaration or JSON config",
+  );
+}
+
+function scanArraySource(source: string, start: number): string {
+  let cursor = start;
+  let depth = 0;
+  while (cursor < source.length) {
+    const char = source[cursor];
+    const next = source[cursor + 1];
+    if (char === "/" && next === "/") {
+      cursor = skipLineComment(source, cursor);
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      cursor = skipBlockComment(source, cursor);
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      cursor = skipQuotedString(source, cursor);
+      continue;
+    }
+    if (char === "[") depth += 1;
+    if (char === "]") {
+      depth -= 1;
+      if (depth === 0) return source.slice(start + 1, cursor);
+    }
+    cursor += 1;
+  }
+  throw new Error("unterminated apps array in PM2 ecosystem config");
+}
+
+function splitTopLevelObjectSources(arraySource: string): string[] {
+  const objects: string[] = [];
+  let cursor = 0;
+  let objectStart: number | undefined;
+  let depth = 0;
+
+  while (cursor < arraySource.length) {
+    const char = arraySource[cursor];
+    const next = arraySource[cursor + 1];
+    if (char === "/" && next === "/") {
+      cursor = skipLineComment(arraySource, cursor);
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      cursor = skipBlockComment(arraySource, cursor);
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      cursor = skipQuotedString(arraySource, cursor);
+      continue;
+    }
+    if (char === "{") {
+      if (depth === 0) objectStart = cursor;
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0 && objectStart !== undefined) {
+        objects.push(arraySource.slice(objectStart, cursor + 1));
+        objectStart = undefined;
+      }
+      if (depth < 0) throw new Error("unbalanced object literal in PM2 apps array");
+    }
+    cursor += 1;
+  }
+
+  if (depth !== 0) throw new Error("unterminated object literal in PM2 apps array");
+  if (objects.length === 0) throw new Error("PM2 apps array must contain object literals");
+  return objects;
+}
+
+function readIdentifier(source: string, start: number): { value: string; end: number } | null {
+  if (!isIdentifierStart(source[start])) return null;
+  let cursor = start + 1;
+  while (isIdentifierPart(source[cursor])) cursor += 1;
+  return { value: source.slice(start, cursor), end: cursor };
+}
+
+function skipValue(source: string, start: number): number {
+  let cursor = start;
+  let depth = 0;
+  while (cursor < source.length) {
+    const char = source[cursor];
+    const next = source[cursor + 1];
+    if (char === "/" && next === "/") {
+      cursor = skipLineComment(source, cursor);
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      cursor = skipBlockComment(source, cursor);
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      cursor = skipQuotedString(source, cursor);
+      continue;
+    }
+    if (char === "{" || char === "[" || char === "(") depth += 1;
+    else if (char === "}" || char === "]" || char === ")") {
+      if (depth === 0) return cursor;
+      depth -= 1;
+    } else if (char === "," && depth === 0) return cursor + 1;
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function extractTopLevelName(objectSource: string, index: number): string {
+  let cursor = 1;
+  const end = objectSource.length - 1;
+  while (cursor < end) {
+    cursor = skipWhitespace(objectSource, cursor);
+    if (objectSource[cursor] === ",") {
+      cursor += 1;
+      continue;
+    }
+
+    let key: { value: string; end: number } | null = null;
+    const char = objectSource[cursor];
+    if (char === "'" || char === '"' || char === "`") {
+      key = readQuotedString(objectSource, cursor);
+    } else {
+      key = readIdentifier(objectSource, cursor);
+    }
+    if (!key) {
+      cursor += 1;
+      continue;
+    }
+
+    const colon = skipWhitespace(objectSource, key.end);
+    if (objectSource[colon] !== ":") {
+      cursor = skipValue(objectSource, key.end);
+      continue;
+    }
+    const valueStart = skipWhitespace(objectSource, colon + 1);
+    if (key.value === "name") {
+      const quote = objectSource[valueStart];
+      if (quote !== "'" && quote !== '"' && quote !== "`") {
+        throw new Error(`PM2 app at index ${index} must declare a static string name`);
+      }
+      return validateAppName(readQuotedString(objectSource, valueStart).value, index);
+    }
+    cursor = skipValue(objectSource, valueStart);
+  }
+  throw new Error(`PM2 app at index ${index} must declare a non-empty string name`);
+}
+
+function extractStaticJsAppNames(source: string): string[] {
+  const arraySource = findAppsArraySource(source);
+  return splitTopLevelObjectSources(arraySource).map((objectSource, index) =>
+    extractTopLevelName(objectSource, index),
+  );
 }
 
 function parseMetadata(metadataPath: string | undefined): Record<string, AppMetadata> {
@@ -97,21 +347,34 @@ function parseMetadata(metadataPath: string | undefined): Record<string, AppMeta
   }
 }
 
+async function loadAppNames(configPath: string): Promise<string[]> {
+  const absolutePath = resolve(configPath);
+  const extension = extname(absolutePath).toLowerCase();
+  if (extension === ".json") {
+    return extractJsonAppArray(await readJsonEcosystem(absolutePath)).map((rawApp, index) => {
+      if (!isRecord(rawApp)) {
+        throw new Error(`PM2 app at index ${index} must be an object`);
+      }
+      return validateAppName(rawApp.name, index);
+    });
+  }
+
+  if (![".js", ".cjs", ".mjs"].includes(extension)) {
+    throw new Error(`Unsupported PM2 ecosystem config extension '${extension || "none"}'`);
+  }
+  return extractStaticJsAppNames(await readFile(absolutePath, "utf8"));
+}
+
 export async function loadDeclaredApps(
   configPath: string,
   metadataPath?: string,
 ): Promise<DeclaredPm2App[]> {
-  const raw = await importEcosystem(configPath);
-  const appArray = extractAppArray(raw);
+  const appNames = await loadAppNames(configPath);
   const metadata = parseMetadata(metadataPath);
   const seen = new Set<string>();
   const apps: DeclaredPm2App[] = [];
 
-  appArray.forEach((rawApp, index) => {
-    if (!isRecord(rawApp)) {
-      throw new Error(`PM2 app at index ${index} must be an object`);
-    }
-    const name = validateAppName(rawApp.name, index);
+  appNames.forEach((name) => {
     if (seen.has(name)) throw new Error(`Duplicate PM2 app name in ecosystem config: ${name}`);
     seen.add(name);
     apps.push({ name, metadata: metadata[name] });

--- a/pm2-processes/ecosystem.ts
+++ b/pm2-processes/ecosystem.ts
@@ -1,0 +1,126 @@
+import * as fs from "node:fs";
+import { createRequire } from "node:module";
+import { extname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { readFile, stat } from "node:fs/promises";
+
+export interface AppMetadata {
+  url?: string;
+  readinessUrl?: string;
+  description?: string;
+}
+
+export interface DeclaredPm2App {
+  name: string;
+  metadata?: AppMetadata;
+}
+
+interface LoadedEcosystem {
+  apps?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function unwrapDefault(value: unknown): unknown {
+  if (isRecord(value) && "default" in value) return value.default;
+  return value;
+}
+
+async function importEcosystem(configPath: string): Promise<unknown> {
+  const absolutePath = resolve(configPath);
+  const extension = extname(absolutePath).toLowerCase();
+  if (extension === ".json") {
+    return JSON.parse(await readFile(absolutePath, "utf8")) as unknown;
+  }
+
+  const require = createRequire(import.meta.url);
+  try {
+    const resolved = require.resolve(absolutePath);
+    delete require.cache[resolved];
+    return require(resolved) as unknown;
+  } catch (error) {
+    const code = isRecord(error) && typeof error.code === "string" ? error.code : undefined;
+    if (code !== "ERR_REQUIRE_ESM") throw error;
+    const stats = await stat(absolutePath);
+    return import(`${pathToFileURL(absolutePath).href}?mtime=${stats.mtimeMs}`) as Promise<unknown>;
+  }
+}
+
+function extractAppArray(raw: unknown): unknown[] {
+  const value = unwrapDefault(raw);
+  if (Array.isArray(value)) return value;
+  if (isRecord(value)) {
+    const ecosystem = value as LoadedEcosystem;
+    if (Array.isArray(ecosystem.apps)) return ecosystem.apps;
+  }
+  throw new Error("PM2 ecosystem config must export an apps array or { apps: [...] }");
+}
+
+function validateAppName(name: unknown, index: number): string {
+  if (typeof name !== "string" || name.trim().length === 0) {
+    throw new Error(`PM2 app at index ${index} must declare a non-empty string name`);
+  }
+  const trimmed = name.trim();
+  if (trimmed === "all" || trimmed.includes("*")) {
+    throw new Error(`PM2 app name '${trimmed}' is not allowed; use exact non-wildcard names`);
+  }
+  return trimmed;
+}
+
+function parseMetadata(metadataPath: string | undefined): Record<string, AppMetadata> {
+  if (!metadataPath) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as unknown;
+    if (!isRecord(parsed)) return {};
+    const apps = isRecord(parsed.apps) ? parsed.apps : parsed;
+    const result: Record<string, AppMetadata> = {};
+    for (const [name, raw] of Object.entries(apps)) {
+      if (!isRecord(raw)) continue;
+      const url = typeof raw.url === "string" && raw.url.trim() ? raw.url.trim() : undefined;
+      const readinessUrl =
+        typeof raw.readinessUrl === "string" && raw.readinessUrl.trim()
+          ? raw.readinessUrl.trim()
+          : typeof raw.healthUrl === "string" && raw.healthUrl.trim()
+            ? raw.healthUrl.trim()
+            : undefined;
+      const description =
+        typeof raw.description === "string" && raw.description.trim()
+          ? raw.description.trim()
+          : undefined;
+      result[name] = { url, readinessUrl, description };
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+export async function loadDeclaredApps(
+  configPath: string,
+  metadataPath?: string,
+): Promise<DeclaredPm2App[]> {
+  const raw = await importEcosystem(configPath);
+  const appArray = extractAppArray(raw);
+  const metadata = parseMetadata(metadataPath);
+  const seen = new Set<string>();
+  const apps: DeclaredPm2App[] = [];
+
+  appArray.forEach((rawApp, index) => {
+    if (!isRecord(rawApp)) {
+      throw new Error(`PM2 app at index ${index} must be an object`);
+    }
+    const name = validateAppName(rawApp.name, index);
+    if (seen.has(name)) throw new Error(`Duplicate PM2 app name in ecosystem config: ${name}`);
+    seen.add(name);
+    apps.push({ name, metadata: metadata[name] });
+  });
+
+  if (apps.length === 0) throw new Error("PM2 ecosystem config declares no apps");
+  return apps;
+}
+
+export function getAllowedAppNames(apps: DeclaredPm2App[]): string[] {
+  return apps.map((app) => app.name);
+}

--- a/pm2-processes/eslint.config.mjs
+++ b/pm2-processes/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../eslint.config.mjs";

--- a/pm2-processes/helpers.test.ts
+++ b/pm2-processes/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeLines, normalizeTarget, truncateTail } from "./helpers.js";
+import { normalizeLines, normalizeTarget, redactSensitiveText, truncateTail } from "./helpers.js";
 
 const apps = [{ name: "api" }, { name: "web" }];
 
@@ -33,5 +33,15 @@ describe("pm2 helpers", () => {
   it("truncates tail by lines", () => {
     const result = truncateTail("one\ntwo\nthree", 1_000, 2);
     expect(result).toEqual({ text: "two\nthree", truncated: true });
+  });
+
+  it("redacts secret-looking output", () => {
+    expect(
+      redactSensitiveText(
+        "TOKEN=abc123 password: hunter2 Authorization: Bearer secret https://x.test?a=1&token=leak",
+      ),
+    ).toBe(
+      "TOKEN=[REDACTED] password: [REDACTED] Authorization: Bearer [REDACTED] https://x.test?a=1&token=[REDACTED]",
+    );
   });
 });

--- a/pm2-processes/helpers.test.ts
+++ b/pm2-processes/helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeLines, normalizeTarget, truncateTail } from "./helpers.js";
+
+const apps = [{ name: "api" }, { name: "web" }];
+
+describe("pm2 helpers", () => {
+  it("expands all to exact declared app names", () => {
+    expect(normalizeTarget("all", apps, { defaultAll: true, allowAll: true })).toEqual({
+      targetLabel: "all",
+      names: ["api", "web"],
+    });
+  });
+
+  it("rejects undeclared app names", () => {
+    expect(() => normalizeTarget("db", apps, { defaultAll: false, allowAll: false })).toThrow(
+      "Unknown PM2 app 'db'",
+    );
+  });
+
+  it("requires explicit target when defaultAll is false", () => {
+    expect(() => normalizeTarget(undefined, apps, { defaultAll: false, allowAll: false })).toThrow(
+      "target app name is required",
+    );
+  });
+
+  it("clamps requested log lines", () => {
+    expect(normalizeLines(undefined, 80, 300)).toBe(80);
+    expect(normalizeLines(0, 80, 300)).toBe(1);
+    expect(normalizeLines(999, 80, 300)).toBe(300);
+  });
+
+  it("truncates tail by lines", () => {
+    const result = truncateTail("one\ntwo\nthree", 1_000, 2);
+    expect(result).toEqual({ text: "two\nthree", truncated: true });
+  });
+});

--- a/pm2-processes/helpers.ts
+++ b/pm2-processes/helpers.ts
@@ -1,0 +1,102 @@
+import { Buffer } from "node:buffer";
+
+import type { DeclaredPm2App } from "./ecosystem.js";
+
+export type Pm2Action = "status" | "start" | "restart" | "stop" | "logs" | "urls" | "config";
+
+export interface TargetResolution {
+  targetLabel: string;
+  names: string[];
+}
+
+export function normalizeTarget(
+  target: string | undefined,
+  apps: DeclaredPm2App[],
+  options: { defaultAll: boolean; allowAll: boolean },
+): TargetResolution {
+  const requested = target?.trim() || (options.defaultAll ? "all" : undefined);
+  if (!requested) throw new Error("A target app name is required for this PM2 action");
+
+  if (requested === "all") {
+    if (!options.allowAll) throw new Error("Target 'all' is not supported for this PM2 action");
+    return { targetLabel: "all", names: apps.map((app) => app.name) };
+  }
+
+  const app = apps.find((candidate) => candidate.name === requested);
+  if (!app) {
+    const allowed = apps.map((candidate) => candidate.name).join(", ");
+    throw new Error(`Unknown PM2 app '${requested}'. Allowed targets: ${allowed}`);
+  }
+
+  return { targetLabel: app.name, names: [app.name] };
+}
+
+export function normalizeLines(
+  lines: number | undefined,
+  defaultLines: number,
+  maxLines: number,
+): number {
+  if (lines === undefined || !Number.isFinite(lines)) return defaultLines;
+  return Math.min(maxLines, Math.max(1, Math.floor(lines)));
+}
+
+export function truncateTail(
+  text: string,
+  maxBytes: number,
+  maxLines: number,
+): { text: string; truncated: boolean } {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  const tailLines = lines.slice(Math.max(0, lines.length - maxLines)).join("\n");
+  const buffer = Buffer.from(tailLines, "utf8");
+  const truncatedByLines = lines.length > maxLines;
+  if (buffer.byteLength <= maxBytes) {
+    return { text: tailLines, truncated: truncatedByLines };
+  }
+
+  const slice = buffer.subarray(Math.max(0, buffer.byteLength - maxBytes)).toString("utf8");
+  const firstNewline = slice.indexOf("\n");
+  const safeSlice = firstNewline >= 0 ? slice.slice(firstNewline + 1) : slice;
+  return { text: safeSlice, truncated: true };
+}
+
+export function formatBytes(bytes: number | undefined): string {
+  if (bytes === undefined || !Number.isFinite(bytes)) return "n/a";
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+
+export function formatUptime(startedAt: number | undefined, now = Date.now()): string {
+  if (!startedAt || !Number.isFinite(startedAt)) return "n/a";
+  const seconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h${minutes % 60}m`;
+  const days = Math.floor(hours / 24);
+  return `${days}d${hours % 24}h`;
+}
+
+export function buildPlainTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, column) =>
+    Math.max(header.length, ...rows.map((row) => row[column]?.length ?? 0)),
+  );
+  const renderRow = (row: string[]): string =>
+    row
+      .map((cell, column) => cell.padEnd(widths[column] ?? cell.length))
+      .join("  ")
+      .trimEnd();
+  return [
+    renderRow(headers),
+    renderRow(widths.map((width) => "-".repeat(width))),
+    ...rows.map(renderRow),
+  ].join("\n");
+}
+
+export function summarizeCommandOutput(stdout: string, stderr: string, maxBytes: number): string {
+  const combined = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
+  if (!combined) return "(no output)";
+  return truncateTail(combined, maxBytes, 200).text;
+}

--- a/pm2-processes/helpers.ts
+++ b/pm2-processes/helpers.ts
@@ -40,6 +40,24 @@ export function normalizeLines(
   return Math.min(maxLines, Math.max(1, Math.floor(lines)));
 }
 
+export function redactSensitiveText(text: string): string {
+  return text
+    .replace(/(\bAuthorization\s*[:=]\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[REDACTED]")
+    .replace(
+      /(\b(?:password|passwd|pwd|secret|token|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth|client[_-]?secret)\b\s*[:=]\s*)([^\s"'`]+)/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /(\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|AUTH)[A-Z0-9_]*\s*=\s*)([^\s"'`]+)/g,
+      "$1[REDACTED]",
+    )
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[REDACTED]")
+    .replace(
+      /([?&](?:password|passwd|pwd|secret|token|api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth|client[_-]?secret)=)([^&\s]+)/gi,
+      "$1[REDACTED]",
+    );
+}
+
 export function truncateTail(
   text: string,
   maxBytes: number,
@@ -98,5 +116,5 @@ export function buildPlainTable(headers: string[], rows: string[][]): string {
 export function summarizeCommandOutput(stdout: string, stderr: string, maxBytes: number): string {
   const combined = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
   if (!combined) return "(no output)";
-  return truncateTail(combined, maxBytes, 200).text;
+  return truncateTail(redactSensitiveText(combined), maxBytes, 200).text;
 }

--- a/pm2-processes/index.ts
+++ b/pm2-processes/index.ts
@@ -77,17 +77,33 @@ function formatWarnings(warnings: string[]): string {
     : "";
 }
 
-async function prepare(cwd: string): Promise<{
+async function prepare(
+  cwd: string,
+  options: { tolerateAppDiscoveryErrors: boolean },
+): Promise<{
   settings: ResolvedSettings;
   apps: DeclaredPm2App[];
   runner: Pm2Runner;
 }> {
   const settings = loadSettings({ cwd, agentDir: getAgentDir() });
-  if (!settings.configPath) {
-    return { settings, apps: [], runner: new CliPm2Runner(settings.pm2Bin) };
+  const runner = new CliPm2Runner(settings.pm2Bin);
+  if (!settings.configPath) return { settings, apps: [], runner };
+
+  try {
+    const apps = await loadDeclaredApps(settings.configPath, settings.metadataPath);
+    return { settings, apps, runner };
+  } catch (error) {
+    if (!options.tolerateAppDiscoveryErrors) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      settings: {
+        ...settings,
+        diagnostics: [...settings.diagnostics, `PM2 app discovery skipped: ${message}`],
+      },
+      apps: [],
+      runner,
+    };
   }
-  const apps = await loadDeclaredApps(settings.configPath, settings.metadataPath);
-  return { settings, apps, runner: new CliPm2Runner(settings.pm2Bin) };
 }
 
 async function runPm2(
@@ -95,13 +111,15 @@ async function runPm2(
   ctx: ExtensionContext,
   signal?: AbortSignal,
 ): Promise<string> {
-  const { settings, apps, runner } = await prepare(ctx.cwd);
+  const { settings, apps, runner } = await prepare(ctx.cwd, {
+    tolerateAppDiscoveryErrors: input.action === "config",
+  });
   const result = await executePm2Action(input, apps, settings, runner, signal);
   return `${result.text}${formatWarnings(result.warnings)}`;
 }
 
 async function showPm2Menu(ctx: ExtensionContext): Promise<Pm2ProcessInput> {
-  const { settings } = await prepare(ctx.cwd);
+  const settings = loadSettings({ cwd: ctx.cwd, agentDir: getAgentDir() });
   return settings.configPath ? { action: "status", target: "all" } : { action: "config" };
 }
 

--- a/pm2-processes/index.ts
+++ b/pm2-processes/index.ts
@@ -1,0 +1,151 @@
+import { StringEnum } from "@mariozechner/pi-ai";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "@sinclair/typebox";
+
+import { loadDeclaredApps, type DeclaredPm2App } from "./ecosystem.js";
+import { type Pm2Action } from "./helpers.js";
+import { CliPm2Runner, executePm2Action, type Pm2Runner } from "./pm2.js";
+import { loadSettings, type ResolvedSettings } from "./settings.js";
+
+const PM2_ACTIONS = ["status", "start", "restart", "stop", "logs", "urls", "config"] as const;
+
+const Pm2ProcessParams = Type.Object({
+  action: StringEnum(PM2_ACTIONS, {
+    description: "PM2 action to run against declared apps only.",
+  }),
+  target: Type.Optional(
+    Type.String({
+      description: "Declared app name, or 'all' for status/start/restart/stop. Required for logs.",
+    }),
+  ),
+  lines: Type.Optional(
+    Type.Number({
+      description: "Line count for logs; clamped to configured safe limits.",
+    }),
+  ),
+});
+
+type Pm2ProcessInput = {
+  action: Pm2Action;
+  target?: string;
+  lines?: number;
+};
+
+type ThemeLike = {
+  fg: (name: string, value: string) => string;
+  bold: (value: string) => string;
+};
+
+function parseCommandArgs(args: string): Pm2ProcessInput | null {
+  const tokens = args.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  const action = tokens[0] as Pm2Action;
+  if (!PM2_ACTIONS.includes(action)) {
+    throw new Error(`Unknown /pm2 action '${tokens[0]}'. Expected: ${PM2_ACTIONS.join(", ")}`);
+  }
+
+  let target: string | undefined;
+  let lines: number | undefined;
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--lines") {
+      const value = tokens[index + 1];
+      if (!value) throw new Error("/pm2 logs --lines requires a number");
+      lines = Number(value);
+      index += 1;
+      continue;
+    }
+    if (token?.startsWith("--lines=")) {
+      lines = Number(token.slice("--lines=".length));
+      continue;
+    }
+    if (!target) {
+      target = token;
+      continue;
+    }
+    throw new Error(`Unexpected /pm2 argument '${token}'`);
+  }
+
+  return { action, target, lines };
+}
+
+function formatWarnings(warnings: string[]): string {
+  return warnings.length > 0
+    ? `\n\nWarnings:\n${warnings.map((warning) => `- ${warning}`).join("\n")}`
+    : "";
+}
+
+async function prepare(cwd: string): Promise<{
+  settings: ResolvedSettings;
+  apps: DeclaredPm2App[];
+  runner: Pm2Runner;
+}> {
+  const settings = loadSettings({ cwd, agentDir: getAgentDir() });
+  if (!settings.configPath) {
+    return { settings, apps: [], runner: new CliPm2Runner(settings.pm2Bin) };
+  }
+  const apps = await loadDeclaredApps(settings.configPath, settings.metadataPath);
+  return { settings, apps, runner: new CliPm2Runner(settings.pm2Bin) };
+}
+
+async function runPm2(
+  input: Pm2ProcessInput,
+  ctx: ExtensionContext,
+  signal?: AbortSignal,
+): Promise<string> {
+  const { settings, apps, runner } = await prepare(ctx.cwd);
+  const result = await executePm2Action(input, apps, settings, runner, signal);
+  return `${result.text}${formatWarnings(result.warnings)}`;
+}
+
+async function showPm2Menu(ctx: ExtensionContext): Promise<Pm2ProcessInput> {
+  const { settings } = await prepare(ctx.cwd);
+  return settings.configPath ? { action: "status", target: "all" } : { action: "config" };
+}
+
+export default function pm2ProcessesExtension(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "pm2_process",
+    label: "PM2 Process",
+    description:
+      "Manage project-local PM2 apps declared in the active ecosystem config. Actions are bounded and app-name allowlisted.",
+    promptSnippet:
+      "Manage declared PM2 apps via status/start/restart/stop/logs/urls/config without arbitrary shell commands.",
+    promptGuidelines: [
+      "Use pm2_process for project PM2 process lifecycle tasks instead of starting long-running processes with bash.",
+      "pm2_process only accepts exact declared app names or all where supported; do not use PM2 wildcards or delete/kill actions.",
+    ],
+    parameters: Pm2ProcessParams,
+    async execute(_toolCallId, params: Pm2ProcessInput, signal, _onUpdate, ctx) {
+      const text = await runPm2(params, ctx, signal);
+      return {
+        content: [{ type: "text", text }],
+        details: { action: params.action, target: params.target },
+      };
+    },
+    renderCall(args: Partial<Pm2ProcessInput>, theme: ThemeLike) {
+      return new Text(
+        `${theme.fg("toolTitle", theme.bold("pm2_process"))} ${args.action ?? ""} ${args.target ?? ""}`.trim(),
+        0,
+        0,
+      );
+    },
+  });
+
+  pi.registerCommand("pm2", {
+    description: "Manage PM2 apps declared in the active ecosystem config",
+    handler: async (args, ctx) => {
+      try {
+        const parsed = parseCommandArgs(args) ?? (await showPm2Menu(ctx));
+        if (!parsed) return;
+        const text = await runPm2(parsed, ctx);
+        ctx.ui.notify(text, "info");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        ctx.ui.notify(`PM2 error: ${message}`, "error");
+      }
+    },
+  });
+}

--- a/pm2-processes/package.json
+++ b/pm2-processes/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "devDependencies": {
+  "dependencies": {
     "@sinclair/typebox": "^0.34.49"
   }
 }

--- a/pm2-processes/package.json
+++ b/pm2-processes/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@gugu910/pi-pm2-processes",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Generic PM2 process manager extension for pi",
+  "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gugu91/extensions.git",
+    "directory": "pm2-processes"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "dist/"
+  ],
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "scripts": {
+    "build": "node ../scripts/build-package.mjs",
+    "prepack": "pnpm run build",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.49"
+  }
+}

--- a/pm2-processes/pm2.test.ts
+++ b/pm2-processes/pm2.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeclaredPm2App } from "./ecosystem.js";
+import { executePm2Action, type CommandResult, type Pm2Runner } from "./pm2.js";
+import type { ResolvedSettings } from "./settings.js";
+
+class FakeRunner implements Pm2Runner {
+  readonly calls: string[][] = [];
+
+  async run(args: string[]): Promise<CommandResult> {
+    this.calls.push(args);
+    if (args[0] === "jlist") {
+      return {
+        stdout: JSON.stringify([
+          {
+            name: "api",
+            pid: 123,
+            pm_id: 0,
+            pm2_env: { status: "online", restart_time: 2, pm_uptime: Date.now() - 10_000 },
+            monit: { cpu: 1, memory: 2048 },
+          },
+        ]),
+        stderr: "",
+        code: 0,
+        timedOut: false,
+      };
+    }
+    if (args[0] === "logs") {
+      return { stdout: "line1\nline2\nline3", stderr: "", code: 0, timedOut: false };
+    }
+    return { stdout: "ok", stderr: "", code: 0, timedOut: false };
+  }
+}
+
+const settings: ResolvedSettings = {
+  enabled: true,
+  configPath: "/repo/ecosystem.config.cjs",
+  configSource: "test",
+  pm2Bin: "pm2",
+  defaultLines: 2,
+  maxLines: 10,
+  maxBytes: 10_000,
+  commandTimeoutMs: 1_000,
+  readinessTimeoutMs: 100,
+  settingsSources: [],
+  searchedConfigPaths: ["/repo/ecosystem.config.cjs"],
+  diagnostics: [],
+};
+
+const apps: DeclaredPm2App[] = [{ name: "api" }, { name: "web" }];
+
+describe("executePm2Action", () => {
+  it("renders status for declared apps even before they are running", async () => {
+    const runner = new FakeRunner();
+    const result = await executePm2Action(
+      { action: "status", target: "all" },
+      apps,
+      settings,
+      runner,
+    );
+
+    expect(result.text).toContain("api");
+    expect(result.text).toContain("web");
+    expect(result.text).toContain("stopped");
+    expect(runner.calls).toEqual([["jlist"]]);
+  });
+
+  it("expands stop all into exact app-name commands", async () => {
+    const runner = new FakeRunner();
+    await executePm2Action({ action: "stop", target: "all" }, apps, settings, runner);
+
+    expect(runner.calls).toContainEqual(["stop", "api"]);
+    expect(runner.calls).toContainEqual(["stop", "web"]);
+    expect(runner.calls).not.toContainEqual(["stop", "all"]);
+  });
+
+  it("starts via ecosystem config with --only exact app name", async () => {
+    const runner = new FakeRunner();
+    await executePm2Action({ action: "start", target: "api" }, apps, settings, runner);
+
+    expect(runner.calls).toContainEqual(["start", "/repo/ecosystem.config.cjs", "--only", "api"]);
+  });
+
+  it("requires logs target to be a single declared app", async () => {
+    const runner = new FakeRunner();
+
+    await expect(
+      executePm2Action({ action: "logs", target: "all" }, apps, settings, runner),
+    ).rejects.toThrow("Target 'all' is not supported");
+  });
+
+  it("shows config diagnostics before a PM2 config has been created", async () => {
+    const runner = new FakeRunner();
+    const result = await executePm2Action(
+      { action: "config" },
+      [],
+      {
+        ...settings,
+        configPath: undefined,
+        configSource: undefined,
+        searchedConfigPaths: ["/repo/.pi/pm2/ecosystem.config.cjs"],
+      },
+      runner,
+    );
+
+    expect(result.text).toContain("PM2 config: not found");
+    expect(result.text).toContain("Allowed apps: none");
+    expect(runner.calls).toEqual([]);
+  });
+});

--- a/pm2-processes/pm2.test.ts
+++ b/pm2-processes/pm2.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { DeclaredPm2App } from "./ecosystem.js";
-import { executePm2Action, type CommandResult, type Pm2Runner } from "./pm2.js";
+import { CliPm2Runner, executePm2Action, type CommandResult, type Pm2Runner } from "./pm2.js";
 import type { ResolvedSettings } from "./settings.js";
 
 class FakeRunner implements Pm2Runner {
@@ -26,7 +26,12 @@ class FakeRunner implements Pm2Runner {
       };
     }
     if (args[0] === "logs") {
-      return { stdout: "line1\nline2\nline3", stderr: "", code: 0, timedOut: false };
+      return {
+        stdout: "line1\nTOKEN=abc123\nline3",
+        stderr: "",
+        code: 0,
+        timedOut: false,
+      };
     }
     return { stdout: "ok", stderr: "", code: 0, timedOut: false };
   }
@@ -87,6 +92,30 @@ describe("executePm2Action", () => {
     await expect(
       executePm2Action({ action: "logs", target: "all" }, apps, settings, runner),
     ).rejects.toThrow("Target 'all' is not supported");
+  });
+
+  it("redacts PM2 log output before returning it", async () => {
+    const runner = new FakeRunner();
+    const result = await executePm2Action(
+      { action: "logs", target: "api" },
+      apps,
+      settings,
+      runner,
+    );
+
+    expect(result.text).toContain("TOKEN=[REDACTED]");
+    expect(result.text).not.toContain("abc123");
+  });
+
+  it("bounds CLI output capture while preserving the tail", async () => {
+    const runner = new CliPm2Runner(process.execPath);
+    const result = await runner.run(["-e", "process.stdout.write('a'.repeat(2000) + 'TAIL')"], {
+      maxBytes: 16,
+      timeoutMs: 1_000,
+    });
+
+    expect(result.stdout).toBe("aaaaaaaaaaaaTAIL");
+    expect(result.stdoutTruncated).toBe(true);
   });
 
   it("shows config diagnostics before a PM2 config has been created", async () => {

--- a/pm2-processes/pm2.ts
+++ b/pm2-processes/pm2.ts
@@ -8,6 +8,7 @@ import {
   formatUptime,
   normalizeLines,
   normalizeTarget,
+  redactSensitiveText,
   summarizeCommandOutput,
   truncateTail,
   type Pm2Action,
@@ -19,12 +20,14 @@ export interface CommandResult {
   stderr: string;
   code: number | null;
   timedOut: boolean;
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
 }
 
 export interface Pm2Runner {
   run(
     args: string[],
-    options?: { signal?: AbortSignal; timeoutMs?: number },
+    options?: { signal?: AbortSignal; timeoutMs?: number; maxBytes?: number },
   ): Promise<CommandResult>;
 }
 
@@ -56,19 +59,35 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function appendBoundedTail(
+  current: string,
+  chunk: string,
+  maxBytes: number,
+): { text: string; truncated: boolean } {
+  const combined = Buffer.concat([Buffer.from(current, "utf8"), Buffer.from(chunk, "utf8")]);
+  if (combined.byteLength <= maxBytes) return { text: current + chunk, truncated: false };
+  return {
+    text: combined.subarray(combined.byteLength - maxBytes).toString("utf8"),
+    truncated: true,
+  };
+}
+
 export class CliPm2Runner implements Pm2Runner {
   constructor(private readonly pm2Bin: string) {}
 
   run(
     args: string[],
-    options: { signal?: AbortSignal; timeoutMs?: number } = {},
+    options: { signal?: AbortSignal; timeoutMs?: number; maxBytes?: number } = {},
   ): Promise<CommandResult> {
     return new Promise((resolve, reject) => {
       const child = spawn(this.pm2Bin, args, { stdio: ["ignore", "pipe", "pipe"] });
       let stdout = "";
       let stderr = "";
+      let stdoutTruncated = false;
+      let stderrTruncated = false;
       let settled = false;
       let timedOut = false;
+      const maxBytes = options.maxBytes ?? 50_000;
       const timeout = options.timeoutMs
         ? setTimeout(() => {
             timedOut = true;
@@ -86,10 +105,14 @@ export class CliPm2Runner implements Pm2Runner {
       child.stdout?.setEncoding("utf8");
       child.stderr?.setEncoding("utf8");
       child.stdout?.on("data", (chunk: string) => {
-        stdout += chunk;
+        const next = appendBoundedTail(stdout, chunk, maxBytes);
+        stdout = next.text;
+        stdoutTruncated = stdoutTruncated || next.truncated;
       });
       child.stderr?.on("data", (chunk: string) => {
-        stderr += chunk;
+        const next = appendBoundedTail(stderr, chunk, maxBytes);
+        stderr = next.text;
+        stderrTruncated = stderrTruncated || next.truncated;
       });
       child.once("error", (error) => {
         if (settled) return;
@@ -103,7 +126,7 @@ export class CliPm2Runner implements Pm2Runner {
         settled = true;
         if (timeout) clearTimeout(timeout);
         options.signal?.removeEventListener("abort", abort);
-        resolve({ stdout, stderr, code, timedOut });
+        resolve({ stdout, stderr, code, timedOut, stdoutTruncated, stderrTruncated });
       });
     });
   }
@@ -139,7 +162,11 @@ async function getDeclaredStatuses(
   settings: ResolvedSettings,
   signal?: AbortSignal,
 ): Promise<Pm2ProcessStatus[]> {
-  const result = await runner.run(["jlist"], { signal, timeoutMs: settings.commandTimeoutMs });
+  const result = await runner.run(["jlist"], {
+    signal,
+    timeoutMs: settings.commandTimeoutMs,
+    maxBytes: settings.maxBytes,
+  });
   if (result.timedOut) throw new Error(`pm2 jlist timed out after ${settings.commandTimeoutMs}ms`);
   if (result.code !== 0) {
     throw new Error(
@@ -191,7 +218,11 @@ async function runMutation(
   if (!settings.configPath) throw new Error("No PM2 config file is active");
   for (const name of names) {
     const args = action === "stop" ? ["stop", name] : [action, settings.configPath, "--only", name];
-    const result = await runner.run(args, { signal, timeoutMs: settings.commandTimeoutMs });
+    const result = await runner.run(args, {
+      signal,
+      timeoutMs: settings.commandTimeoutMs,
+      maxBytes: settings.maxBytes,
+    });
     if (result.timedOut)
       throw new Error(`pm2 ${action} ${name} timed out after ${settings.commandTimeoutMs}ms`);
     if (result.code !== 0) {
@@ -317,6 +348,7 @@ export async function executePm2Action(
       {
         signal,
         timeoutMs: settings.commandTimeoutMs,
+        maxBytes: settings.maxBytes,
       },
     );
     if (result.timedOut)
@@ -329,20 +361,22 @@ export async function executePm2Action(
       );
     }
     const truncated = truncateTail(
-      [result.stdout, result.stderr].filter(Boolean).join("\n"),
+      redactSensitiveText([result.stdout, result.stderr].filter(Boolean).join("\n")),
       settings.maxBytes,
       lines,
     );
-    const suffix = truncated.truncated
-      ? `\n\n[logs truncated to ${lines} lines / ${settings.maxBytes} bytes]`
-      : "";
+    const wasCapturedTruncated = result.stdoutTruncated === true || result.stderrTruncated === true;
+    const suffix =
+      truncated.truncated || wasCapturedTruncated
+        ? `\n\n[logs truncated to ${lines} lines / ${settings.maxBytes} bytes]`
+        : "";
     return {
       text: `Logs for ${target.targetLabel}:\n${truncated.text || "(no log output)"}${suffix}`,
       details: {
         action: input.action,
         target: target.targetLabel,
         lines,
-        truncated: truncated.truncated,
+        truncated: truncated.truncated || wasCapturedTruncated,
       },
       warnings: [],
     };

--- a/pm2-processes/pm2.ts
+++ b/pm2-processes/pm2.ts
@@ -1,0 +1,379 @@
+import { spawn } from "node:child_process";
+import net from "node:net";
+
+import type { DeclaredPm2App } from "./ecosystem.js";
+import {
+  buildPlainTable,
+  formatBytes,
+  formatUptime,
+  normalizeLines,
+  normalizeTarget,
+  summarizeCommandOutput,
+  truncateTail,
+  type Pm2Action,
+} from "./helpers.js";
+import type { ResolvedSettings } from "./settings.js";
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  timedOut: boolean;
+}
+
+export interface Pm2Runner {
+  run(
+    args: string[],
+    options?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<CommandResult>;
+}
+
+export interface Pm2ProcessStatus {
+  name: string;
+  status: string;
+  pid?: number;
+  pmId?: number;
+  cpu?: number;
+  memory?: number;
+  restarts?: number;
+  uptime?: string;
+  url?: string;
+}
+
+export interface Pm2ActionResult {
+  text: string;
+  details: Record<string, unknown>;
+  warnings: string[];
+}
+
+export interface ExecuteActionInput {
+  action: Pm2Action;
+  target?: string;
+  lines?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class CliPm2Runner implements Pm2Runner {
+  constructor(private readonly pm2Bin: string) {}
+
+  run(
+    args: string[],
+    options: { signal?: AbortSignal; timeoutMs?: number } = {},
+  ): Promise<CommandResult> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.pm2Bin, args, { stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      let timedOut = false;
+      const timeout = options.timeoutMs
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGTERM");
+            setTimeout(() => child.kill("SIGKILL"), 1_000).unref();
+          }, options.timeoutMs)
+        : undefined;
+
+      const abort = (): void => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      };
+
+      options.signal?.addEventListener("abort", abort, { once: true });
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.once("error", (error) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        options.signal?.removeEventListener("abort", abort);
+        reject(error);
+      });
+      child.once("close", (code) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        options.signal?.removeEventListener("abort", abort);
+        resolve({ stdout, stderr, code, timedOut });
+      });
+    });
+  }
+}
+
+function parsePm2List(stdout: string): Pm2ProcessStatus[] {
+  const parsed = JSON.parse(stdout || "[]") as unknown;
+  if (!Array.isArray(parsed)) throw new Error("pm2 jlist did not return a JSON array");
+  return parsed.flatMap((item): Pm2ProcessStatus[] => {
+    if (!isRecord(item)) return [];
+    const name = typeof item.name === "string" ? item.name : undefined;
+    if (!name) return [];
+    const env = isRecord(item.pm2_env) ? item.pm2_env : {};
+    const monit = isRecord(item.monit) ? item.monit : {};
+    return [
+      {
+        name,
+        status: typeof env.status === "string" ? env.status : "unknown",
+        pid: typeof item.pid === "number" ? item.pid : undefined,
+        pmId: typeof item.pm_id === "number" ? item.pm_id : undefined,
+        cpu: typeof monit.cpu === "number" ? monit.cpu : undefined,
+        memory: typeof monit.memory === "number" ? monit.memory : undefined,
+        restarts: typeof env.restart_time === "number" ? env.restart_time : undefined,
+        uptime: formatUptime(typeof env.pm_uptime === "number" ? env.pm_uptime : undefined),
+      },
+    ];
+  });
+}
+
+async function getDeclaredStatuses(
+  apps: DeclaredPm2App[],
+  runner: Pm2Runner,
+  settings: ResolvedSettings,
+  signal?: AbortSignal,
+): Promise<Pm2ProcessStatus[]> {
+  const result = await runner.run(["jlist"], { signal, timeoutMs: settings.commandTimeoutMs });
+  if (result.timedOut) throw new Error(`pm2 jlist timed out after ${settings.commandTimeoutMs}ms`);
+  if (result.code !== 0) {
+    throw new Error(
+      `pm2 jlist failed: ${summarizeCommandOutput(result.stdout, result.stderr, settings.maxBytes)}`,
+    );
+  }
+  const running = parsePm2List(result.stdout);
+  return apps.map((app) => {
+    const match = running.find((process) => process.name === app.name);
+    return {
+      name: app.name,
+      status: match?.status ?? "stopped",
+      pid: match?.pid,
+      pmId: match?.pmId,
+      cpu: match?.cpu,
+      memory: match?.memory,
+      restarts: match?.restarts,
+      uptime: match?.uptime,
+      url: app.metadata?.url,
+    };
+  });
+}
+
+function renderStatusTable(statuses: Pm2ProcessStatus[]): string {
+  if (statuses.length === 0) return "No declared PM2 apps matched.";
+  return buildPlainTable(
+    ["app", "status", "pid", "cpu", "mem", "restarts", "uptime", "url"],
+    statuses.map((status) => [
+      status.name,
+      status.status,
+      status.pid === undefined ? "-" : String(status.pid),
+      status.cpu === undefined ? "-" : `${status.cpu}%`,
+      formatBytes(status.memory),
+      status.restarts === undefined ? "-" : String(status.restarts),
+      status.uptime ?? "n/a",
+      status.url ?? "-",
+    ]),
+  );
+}
+
+async function runMutation(
+  action: "start" | "restart" | "stop",
+  names: string[],
+  settings: ResolvedSettings,
+  runner: Pm2Runner,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const outputs: string[] = [];
+  if (!settings.configPath) throw new Error("No PM2 config file is active");
+  for (const name of names) {
+    const args = action === "stop" ? ["stop", name] : [action, settings.configPath, "--only", name];
+    const result = await runner.run(args, { signal, timeoutMs: settings.commandTimeoutMs });
+    if (result.timedOut)
+      throw new Error(`pm2 ${action} ${name} timed out after ${settings.commandTimeoutMs}ms`);
+    if (result.code !== 0) {
+      throw new Error(
+        `pm2 ${action} ${name} failed: ${summarizeCommandOutput(result.stdout, result.stderr, settings.maxBytes)}`,
+      );
+    }
+    outputs.push(
+      `pm2 ${action} ${name}: ${summarizeCommandOutput(result.stdout, result.stderr, 2_000)}`,
+    );
+  }
+  return outputs;
+}
+
+function renderConfig(apps: DeclaredPm2App[], settings: ResolvedSettings): string {
+  const metadata = settings.metadataPath
+    ? `${settings.metadataPath} (${settings.metadataSource})`
+    : "none";
+  return [
+    `PM2 config: ${settings.configPath ?? "not found"}`,
+    `Config source: ${settings.configSource ?? "none"}`,
+    `Metadata: ${metadata}`,
+    `PM2 binary: ${settings.pm2Bin}`,
+    `Allowed apps: ${apps.map((app) => app.name).join(", ") || "none"}`,
+    `Log limits: default ${settings.defaultLines} lines, max ${settings.maxLines} lines / ${settings.maxBytes} bytes`,
+  ].join("\n");
+}
+
+function renderUrls(apps: DeclaredPm2App[]): string {
+  const rows = apps
+    .filter((app) => app.metadata?.url || app.metadata?.readinessUrl)
+    .map((app) => [app.name, app.metadata?.url ?? "-", app.metadata?.readinessUrl ?? "-"]);
+  if (rows.length === 0)
+    return "No PM2 app URLs configured. Add .pi/pm2/metadata.json with app URL metadata.";
+  return buildPlainTable(["app", "url", "readiness"], rows);
+}
+
+function localhostPortFromUrl(url: string | undefined): number | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (!["localhost", "127.0.0.1", "::1"].includes(parsed.hostname)) return null;
+    if (parsed.port) return Number(parsed.port);
+    return parsed.protocol === "https:" ? 443 : parsed.protocol === "http:" ? 80 : null;
+  } catch {
+    return null;
+  }
+}
+
+async function canConnectLocalPort(port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      resolve(false);
+    }, timeoutMs);
+    socket.once("connect", () => {
+      clearTimeout(timeout);
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      clearTimeout(timeout);
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function collectPortWarnings(
+  apps: DeclaredPm2App[],
+  names: string[],
+  statuses: Pm2ProcessStatus[],
+  settings: ResolvedSettings,
+): Promise<string[]> {
+  const warnings: string[] = [];
+  for (const app of apps.filter((candidate) => names.includes(candidate.name))) {
+    const status = statuses.find((candidate) => candidate.name === app.name)?.status;
+    if (status === "online") continue;
+    const port = localhostPortFromUrl(app.metadata?.url ?? app.metadata?.readinessUrl);
+    if (!port) continue;
+    if (await canConnectLocalPort(port, Math.min(settings.readinessTimeoutMs, 1_000))) {
+      warnings.push(
+        `Port ${port} for ${app.name} appears to be in use while PM2 does not report the app online; not killing unrelated processes.`,
+      );
+    }
+  }
+  return warnings;
+}
+
+export async function executePm2Action(
+  input: ExecuteActionInput,
+  apps: DeclaredPm2App[],
+  settings: ResolvedSettings,
+  runner: Pm2Runner,
+  signal?: AbortSignal,
+): Promise<Pm2ActionResult> {
+  if (!settings.enabled) throw new Error("pm2-processes is disabled by settings");
+
+  if (input.action === "config") {
+    return {
+      text: renderConfig(apps, settings),
+      details: { action: input.action, settings },
+      warnings: settings.diagnostics,
+    };
+  }
+
+  if (!settings.configPath) {
+    throw new Error(
+      `No PM2 config file found. Searched:\n${settings.searchedConfigPaths.join("\n")}`,
+    );
+  }
+
+  if (input.action === "urls") {
+    return { text: renderUrls(apps), details: { action: input.action, apps }, warnings: [] };
+  }
+
+  if (input.action === "logs") {
+    const target = normalizeTarget(input.target, apps, { defaultAll: false, allowAll: false });
+    const lines = normalizeLines(input.lines, settings.defaultLines, settings.maxLines);
+    const result = await runner.run(
+      ["logs", target.names[0] ?? "", "--lines", String(lines), "--nostream", "--raw"],
+      {
+        signal,
+        timeoutMs: settings.commandTimeoutMs,
+      },
+    );
+    if (result.timedOut)
+      throw new Error(
+        `pm2 logs ${target.targetLabel} timed out after ${settings.commandTimeoutMs}ms`,
+      );
+    if (result.code !== 0) {
+      throw new Error(
+        `pm2 logs ${target.targetLabel} failed: ${summarizeCommandOutput(result.stdout, result.stderr, settings.maxBytes)}`,
+      );
+    }
+    const truncated = truncateTail(
+      [result.stdout, result.stderr].filter(Boolean).join("\n"),
+      settings.maxBytes,
+      lines,
+    );
+    const suffix = truncated.truncated
+      ? `\n\n[logs truncated to ${lines} lines / ${settings.maxBytes} bytes]`
+      : "";
+    return {
+      text: `Logs for ${target.targetLabel}:\n${truncated.text || "(no log output)"}${suffix}`,
+      details: {
+        action: input.action,
+        target: target.targetLabel,
+        lines,
+        truncated: truncated.truncated,
+      },
+      warnings: [],
+    };
+  }
+
+  const target = normalizeTarget(input.target, apps, { defaultAll: true, allowAll: true });
+  if (input.action === "status") {
+    const statuses = await getDeclaredStatuses(apps, runner, settings, signal);
+    const selected = statuses.filter((status) => target.names.includes(status.name));
+    return {
+      text: renderStatusTable(selected),
+      details: { action: input.action, target: target.targetLabel, statuses: selected },
+      warnings: [],
+    };
+  }
+
+  const beforeStatuses = await getDeclaredStatuses(apps, runner, settings, signal);
+  const warnings = await collectPortWarnings(apps, target.names, beforeStatuses, settings);
+  const mutationOutput = await runMutation(input.action, target.names, settings, runner, signal);
+  const afterStatuses = await getDeclaredStatuses(apps, runner, settings, signal);
+  const selected = afterStatuses.filter((status) => target.names.includes(status.name));
+  return {
+    text: [`PM2 ${input.action} ${target.targetLabel} complete.`, renderStatusTable(selected)].join(
+      "\n\n",
+    ),
+    details: {
+      action: input.action,
+      target: target.targetLabel,
+      outputs: mutationOutput,
+      statuses: selected,
+    },
+    warnings,
+  };
+}

--- a/pm2-processes/settings.test.ts
+++ b/pm2-processes/settings.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadSettings } from "./settings.js";
+
+let tmpDirs: string[] = [];
+
+function makeTmp(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "pm2-processes-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+  tmpDirs = [];
+});
+
+describe("loadSettings", () => {
+  it("discovers project-local default ecosystem config", () => {
+    const cwd = makeTmp();
+    const configPath = path.join(cwd, ".pi", "pm2", "ecosystem.config.cjs");
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "module.exports = { apps: [] };\n");
+
+    const settings = loadSettings({ cwd, agentDir: makeTmp(), env: {} });
+
+    expect(settings.configPath).toBe(configPath);
+    expect(settings.configSource).toBe("default:.pi/pm2/ecosystem.config.cjs");
+  });
+
+  it("uses PI_PM2_CONFIG before defaults", () => {
+    const cwd = makeTmp();
+    const explicit = path.join(cwd, "custom.config.cjs");
+    writeFileSync(explicit, "module.exports = { apps: [] };\n");
+    const defaultConfig = path.join(cwd, "ecosystem.config.cjs");
+    writeFileSync(defaultConfig, "module.exports = { apps: [] };\n");
+
+    const settings = loadSettings({ cwd, agentDir: makeTmp(), env: { PI_PM2_CONFIG: explicit } });
+
+    expect(settings.configPath).toBe(explicit);
+    expect(settings.configSource).toBe("env:PI_PM2_CONFIG");
+  });
+
+  it("merges global and project settings with project precedence", () => {
+    const cwd = makeTmp();
+    const agentDir = makeTmp();
+    const globalConfig = path.join(cwd, "global.config.cjs");
+    const projectConfig = path.join(cwd, "project.config.cjs");
+    writeFileSync(globalConfig, "module.exports = { apps: [] };\n");
+    writeFileSync(projectConfig, "module.exports = { apps: [] };\n");
+    mkdirSync(path.join(agentDir), { recursive: true });
+    mkdirSync(path.join(cwd, ".pi"), { recursive: true });
+    writeFileSync(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({ "pm2-processes": { configPath: globalConfig, maxLines: 42 } }),
+    );
+    writeFileSync(
+      path.join(cwd, ".pi", "settings.json"),
+      JSON.stringify({ "pm2-processes": { configPath: projectConfig } }),
+    );
+
+    const settings = loadSettings({ cwd, agentDir, env: {} });
+
+    expect(settings.configPath).toBe(projectConfig);
+    expect(settings.maxLines).toBe(42);
+    expect(settings.settingsSources).toHaveLength(2);
+  });
+});

--- a/pm2-processes/settings.test.ts
+++ b/pm2-processes/settings.test.ts
@@ -69,4 +69,17 @@ describe("loadSettings", () => {
     expect(settings.maxLines).toBe(42);
     expect(settings.settingsSources).toHaveLength(2);
   });
+
+  it("surfaces malformed settings files in diagnostics", () => {
+    const cwd = makeTmp();
+    const agentDir = makeTmp();
+    mkdirSync(path.join(cwd, ".pi"), { recursive: true });
+    writeFileSync(path.join(cwd, ".pi", "settings.json"), "{ not json");
+
+    const settings = loadSettings({ cwd, agentDir, env: {} });
+
+    expect(settings.diagnostics.some((diagnostic) => diagnostic.includes("Failed to parse"))).toBe(
+      true,
+    );
+  });
 });

--- a/pm2-processes/settings.ts
+++ b/pm2-processes/settings.ts
@@ -1,0 +1,199 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+export const SETTINGS_KEY = "pm2-processes";
+
+const DEFAULT_CONFIG_CANDIDATES = [
+  join(".pi", "pm2", "ecosystem.config.cjs"),
+  "ecosystem.config.js",
+  "ecosystem.config.cjs",
+  "ecosystem.config.json",
+] as const;
+
+export interface FileConfig {
+  enabled?: boolean;
+  configPath?: string;
+  metadataPath?: string;
+  pm2Bin?: string;
+  defaultLines?: number;
+  maxLines?: number;
+  maxBytes?: number;
+  commandTimeoutMs?: number;
+  readinessTimeoutMs?: number;
+}
+
+export interface ResolvedSettings {
+  enabled: boolean;
+  configPath?: string;
+  configSource?: string;
+  metadataPath?: string;
+  metadataSource?: string;
+  pm2Bin: string;
+  defaultLines: number;
+  maxLines: number;
+  maxBytes: number;
+  commandTimeoutMs: number;
+  readinessTimeoutMs: number;
+  settingsSources: string[];
+  searchedConfigPaths: string[];
+  diagnostics: string[];
+}
+
+export interface LoadSettingsOptions {
+  cwd?: string;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+interface RawSettingsSource {
+  pathLabel: string;
+  raw: FileConfig;
+}
+
+function readJsonFile(filePath: string): unknown | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { __pm2ProcessesParseError: `Failed to parse ${filePath}: ${message}` };
+  }
+}
+
+function readSettingsConfig(settingsPath: string): RawSettingsSource | null {
+  if (!fs.existsSync(settingsPath)) return null;
+  const parsed = readJsonFile(settingsPath);
+  if (!parsed || typeof parsed !== "object") return null;
+  if ("__pm2ProcessesParseError" in parsed) {
+    return {
+      pathLabel: settingsPath,
+      raw: {},
+    };
+  }
+
+  const raw = (parsed as Record<string, unknown>)[SETTINGS_KEY];
+  if (!raw || typeof raw !== "object") return null;
+  return {
+    pathLabel: `${settingsPath}#${SETTINGS_KEY}`,
+    raw: raw as FileConfig,
+  };
+}
+
+function resolvePath(cwd: string, input: string): string {
+  return isAbsolute(input) ? input : resolve(cwd, input);
+}
+
+function cleanString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function cleanPositiveInt(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (!Number.isFinite(value) || value === undefined) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function collectSettings(cwd: string, agentDir: string): RawSettingsSource[] {
+  const globalSettings = readSettingsConfig(join(agentDir, "settings.json"));
+  const projectSettings = readSettingsConfig(join(cwd, ".pi", "settings.json"));
+  return [globalSettings, projectSettings].filter(
+    (source): source is RawSettingsSource => source !== null,
+  );
+}
+
+function mergeSettings(sources: RawSettingsSource[]): FileConfig {
+  return sources.reduce<FileConfig>((merged, source) => ({ ...merged, ...source.raw }), {});
+}
+
+function resolveExistingFile(
+  cwd: string,
+  candidates: Array<{ path: string; source: string }>,
+): {
+  configPath?: string;
+  configSource?: string;
+  searched: string[];
+  diagnostics: string[];
+} {
+  const searched: string[] = [];
+  const diagnostics: string[] = [];
+
+  for (const candidate of candidates) {
+    const absolutePath = resolvePath(cwd, candidate.path);
+    searched.push(absolutePath);
+    if (fs.existsSync(absolutePath)) {
+      return { configPath: absolutePath, configSource: candidate.source, searched, diagnostics };
+    }
+    diagnostics.push(`PM2 config candidate not found: ${absolutePath} (${candidate.source})`);
+  }
+
+  return { searched, diagnostics };
+}
+
+export function loadSettings(options: LoadSettingsOptions = {}): ResolvedSettings {
+  const cwd = options.cwd ?? process.cwd();
+  const agentDir = options.agentDir ?? join(os.homedir(), ".pi", "agent");
+  const env = options.env ?? process.env;
+  const sources = collectSettings(cwd, agentDir);
+  const merged = mergeSettings(sources);
+  const diagnostics: string[] = [];
+
+  const explicitEnvConfig = cleanString(env.PI_PM2_CONFIG);
+  const settingsConfig = cleanString(merged.configPath);
+  const candidates: Array<{ path: string; source: string }> = [];
+  if (explicitEnvConfig) candidates.push({ path: explicitEnvConfig, source: "env:PI_PM2_CONFIG" });
+  else if (settingsConfig) candidates.push({ path: settingsConfig, source: "settings:configPath" });
+  else {
+    for (const candidate of DEFAULT_CONFIG_CANDIDATES) {
+      candidates.push({ path: candidate, source: `default:${candidate}` });
+    }
+  }
+
+  const discovered = resolveExistingFile(cwd, candidates);
+  diagnostics.push(...discovered.diagnostics);
+
+  const metadataEnv = cleanString(env.PI_PM2_METADATA);
+  const metadataSetting = cleanString(merged.metadataPath);
+  const defaultMetadata = join(cwd, ".pi", "pm2", "metadata.json");
+  let metadataPath: string | undefined;
+  let metadataSource: string | undefined;
+  if (metadataEnv) {
+    metadataPath = resolvePath(cwd, metadataEnv);
+    metadataSource = "env:PI_PM2_METADATA";
+  } else if (metadataSetting) {
+    metadataPath = resolvePath(cwd, metadataSetting);
+    metadataSource = "settings:metadataPath";
+  } else if (fs.existsSync(defaultMetadata)) {
+    metadataPath = defaultMetadata;
+    metadataSource = "default:.pi/pm2/metadata.json";
+  }
+
+  if (metadataPath && !fs.existsSync(metadataPath)) {
+    diagnostics.push(
+      `PM2 metadata file not found: ${metadataPath} (${metadataSource ?? "unknown"})`,
+    );
+    metadataPath = undefined;
+    metadataSource = undefined;
+  }
+
+  return {
+    enabled: merged.enabled ?? true,
+    configPath: discovered.configPath,
+    configSource: discovered.configSource,
+    metadataPath,
+    metadataSource,
+    pm2Bin: cleanString(env.PI_PM2_BIN) ?? cleanString(merged.pm2Bin) ?? "pm2",
+    defaultLines: cleanPositiveInt(merged.defaultLines, 80, 1, 2000),
+    maxLines: cleanPositiveInt(merged.maxLines, 300, 1, 5000),
+    maxBytes: cleanPositiveInt(merged.maxBytes, 50_000, 1_000, 500_000),
+    commandTimeoutMs: cleanPositiveInt(merged.commandTimeoutMs, 15_000, 1_000, 120_000),
+    readinessTimeoutMs: cleanPositiveInt(merged.readinessTimeoutMs, 1_500, 100, 30_000),
+    settingsSources: sources.map((source) => source.pathLabel),
+    searchedConfigPaths: discovered.searched,
+    diagnostics,
+  };
+}

--- a/pm2-processes/settings.ts
+++ b/pm2-processes/settings.ts
@@ -49,33 +49,36 @@ export interface LoadSettingsOptions {
 interface RawSettingsSource {
   pathLabel: string;
   raw: FileConfig;
+  diagnostics: string[];
 }
 
-function readJsonFile(filePath: string): unknown | null {
+function readJsonFile(filePath: string): { value?: unknown; diagnostic?: string } {
   try {
-    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+    return { value: JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return { __pm2ProcessesParseError: `Failed to parse ${filePath}: ${message}` };
+    return { diagnostic: `Failed to parse ${filePath}: ${message}` };
   }
 }
 
 function readSettingsConfig(settingsPath: string): RawSettingsSource | null {
   if (!fs.existsSync(settingsPath)) return null;
   const parsed = readJsonFile(settingsPath);
-  if (!parsed || typeof parsed !== "object") return null;
-  if ("__pm2ProcessesParseError" in parsed) {
+  if (parsed.diagnostic) {
     return {
       pathLabel: settingsPath,
       raw: {},
+      diagnostics: [parsed.diagnostic],
     };
   }
+  if (!parsed.value || typeof parsed.value !== "object") return null;
 
-  const raw = (parsed as Record<string, unknown>)[SETTINGS_KEY];
+  const raw = (parsed.value as Record<string, unknown>)[SETTINGS_KEY];
   if (!raw || typeof raw !== "object") return null;
   return {
     pathLabel: `${settingsPath}#${SETTINGS_KEY}`,
     raw: raw as FileConfig,
+    diagnostics: [],
   };
 }
 
@@ -140,7 +143,7 @@ export function loadSettings(options: LoadSettingsOptions = {}): ResolvedSetting
   const env = options.env ?? process.env;
   const sources = collectSettings(cwd, agentDir);
   const merged = mergeSettings(sources);
-  const diagnostics: string[] = [];
+  const diagnostics = sources.flatMap((source) => source.diagnostics);
 
   const explicitEnvConfig = cleanString(env.PI_PM2_CONFIG);
   const settingsConfig = cleanString(merged.configPath);

--- a/pm2-processes/tsconfig.json
+++ b/pm2-processes/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.ts", "../types/**/*.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,12 @@ importers:
         specifier: ^0.34.49
         version: 0.34.49
 
+  pm2-processes:
+    devDependencies:
+      "@sinclair/typebox":
+        specifier: ^0.34.49
+        version: 0.34.49
+
   nvim-bridge:
     devDependencies:
       "@sinclair/typebox":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,12 +78,6 @@ importers:
         specifier: ^0.34.49
         version: 0.34.49
 
-  pm2-processes:
-    devDependencies:
-      "@sinclair/typebox":
-        specifier: ^0.34.49
-        version: 0.34.49
-
   nvim-bridge:
     devDependencies:
       "@sinclair/typebox":
@@ -100,6 +94,12 @@ importers:
       "@gugu910/pi-transport-core":
         specifier: workspace:*
         version: link:../transport-core
+
+  pm2-processes:
+    dependencies:
+      "@sinclair/typebox":
+        specifier: ^0.34.49
+        version: 0.34.49
 
   slack-api:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,5 @@ packages:
   - imessage-bridge
   - nvim-bridge
   - neon-psql
+  - pm2-processes
   - openai-execution-shaping

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -59,6 +59,13 @@ const packageConfigs = {
     vendorDirs: [],
     importRewrites: [],
   },
+  "pm2-processes": {
+    excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
+    excludeFiles: new Set(["vitest.config.ts"]),
+    excludePrefixes: [],
+    vendorDirs: [],
+    importRewrites: [],
+  },
   "slack-api": {
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
     excludeFiles: new Set(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "pinet-core/**/*.ts",
     "nvim-bridge/**/*.ts",
     "neon-psql/**/*.ts",
+    "pm2-processes/**/*.ts",
     "slack-api/**/*.ts",
     "slack-bridge/**/*.ts",
     "types/**/*.d.ts",


### PR DESCRIPTION
## Summary
- add a generic `pm2-processes` Pi extension for config-driven PM2 app management
- expose bounded `/pm2` commands and a narrow agent tool for status/start/restart/stop/logs/urls/config
- include config discovery, app-name safety checks, bounded output, and tests

## Tests
- Not run by this follow-up; PR creation only from existing branch `fix/issue-685` (`5e395b3`).

Fixes #685