### PR TITLE
feat: add compaction worker extension

### DIFF
--- a/compaction-worker/LICENSE
+++ b/compaction-worker/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/compaction-worker/README.md
+++ b/compaction-worker/README.md
@@ -39,6 +39,13 @@ Add settings under `compaction-worker` in `.pi/settings.json` or `~/.pi/agent/se
 
 Use `/compaction-worker-status` to inspect the active model, matched profile, thresholds, and prepared-summary state.
 
+Profile matching is deterministic: exact model matches win over globs, more specific globs win over broader globs, and declaration order is only used as the final tie-breaker.
+
+Additional guardrail knobs are available when you need to coordinate with Pi's built-in compaction threshold:
+
+- `builtinReserveTokens` (default `16384`) mirrors the host built-in reserve used to detect the built-in threshold.
+- `builtinSkipMarginPercent` (default `0`) can reserve a small percentage band before that built-in threshold where this worker stands down and lets Pi's built-in compaction path win. Keep this at `0` unless you explicitly want that handoff band.
+
 ## Boundaries
 
 This is an extension-side proactive policy. Pi core still owns built-in auto-compaction and overflow recovery thresholds. If a prepared summary is stale, divergent, expired, or incompatible with the current model/profile, the extension generates a live summary or falls back to Pi default compaction.

--- a/compaction-worker/README.md
+++ b/compaction-worker/README.md
@@ -1,0 +1,44 @@
+# Pi Compaction Worker
+
+Opt-in Pi extension for model-aware custom compaction.
+
+It provides an extension-first slice for issue #595:
+
+- resolves per-model/profile compaction budgets;
+- starts a side summary job at a configurable prepare threshold;
+- triggers compaction at a later threshold;
+- validates prepared summaries against the current session/branch before use;
+- falls back to live custom compaction, then Pi default compaction, on any failure.
+
+The extension is disabled by default.
+
+## Configuration
+
+Add settings under `compaction-worker` in `.pi/settings.json` or `~/.pi/agent/settings.json`:
+
+```jsonc
+{
+  "compaction-worker": {
+    "enabled": true,
+    "prepareAtPercent": 60,
+    "triggerAtPercent": 75,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 20000,
+    "summaryModels": ["google/gemini-2.5-flash"],
+    "profiles": {
+      "opus": {
+        "match": "anthropic/claude-opus-*",
+        "prepareAtPercent": 55,
+        "triggerAtPercent": 70,
+        "keepRecentTokens": 100000,
+      },
+    },
+  },
+}
+```
+
+Use `/compaction-worker-status` to inspect the active model, matched profile, thresholds, and prepared-summary state.
+
+## Boundaries
+
+This is an extension-side proactive policy. Pi core still owns built-in auto-compaction and overflow recovery thresholds. If a prepared summary is stale, divergent, expired, or incompatible with the current model/profile, the extension generates a live summary or falls back to Pi default compaction.

--- a/compaction-worker/config.ts
+++ b/compaction-worker/config.ts
@@ -1,0 +1,60 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { join } from "node:path";
+import {
+  CONFIG_ENV,
+  SETTINGS_KEY,
+  resolveBaseConfig,
+  type RawCompactionWorkerConfig,
+  type ResolvedBaseConfig,
+} from "./helpers.js";
+
+export interface LoadConfigOptions {
+  cwd?: string;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+function parseJsonFile(filePath: string): unknown | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[${SETTINGS_KEY}] Failed to parse config ${filePath}: ${message}`);
+    return null;
+  }
+}
+
+function readSettingsConfig(
+  settingsPath: string,
+): { path: string; raw: RawCompactionWorkerConfig } | null {
+  if (!fs.existsSync(settingsPath)) return null;
+  const parsed = parseJsonFile(settingsPath);
+  if (!parsed || typeof parsed !== "object") return null;
+  const raw = (parsed as Record<string, unknown>)[SETTINGS_KEY];
+  if (!raw || typeof raw !== "object") return null;
+  return {
+    path: `${settingsPath}#${SETTINGS_KEY}`,
+    raw: raw as RawCompactionWorkerConfig,
+  };
+}
+
+export function loadConfig(options: LoadConfigOptions = {}): ResolvedBaseConfig {
+  const cwd = options.cwd ?? process.cwd();
+  const agentDir = options.agentDir ?? join(os.homedir(), ".pi", "agent");
+  const env = options.env ?? process.env;
+
+  const explicitSettingsPath = env[CONFIG_ENV];
+  if (explicitSettingsPath) {
+    const explicit = readSettingsConfig(explicitSettingsPath);
+    if (explicit) return resolveBaseConfig(explicit.raw, explicit.path);
+  }
+
+  const projectSettings = readSettingsConfig(join(cwd, ".pi", "settings.json"));
+  if (projectSettings) return resolveBaseConfig(projectSettings.raw, projectSettings.path);
+
+  const globalSettings = readSettingsConfig(join(agentDir, "settings.json"));
+  if (globalSettings) return resolveBaseConfig(globalSettings.raw, globalSettings.path);
+
+  return resolveBaseConfig(null, null);
+}

--- a/compaction-worker/eslint.config.mjs
+++ b/compaction-worker/eslint.config.mjs
@@ -1,0 +1,3 @@
+import rootConfig from "../eslint.config.mjs";
+
+export default [...rootConfig];

--- a/compaction-worker/helpers.test.ts
+++ b/compaction-worker/helpers.test.ts
@@ -51,6 +51,42 @@ describe("compaction-worker policy resolution", () => {
     expect(policy.keepRecentTokens).toBe(33_000);
     expect(policy.summaryModels).toEqual(["google/gemini-2.5-flash"]);
   });
+
+  it("prefers exact and more specific profile matches over broad globs", () => {
+    const base = resolveBaseConfig({
+      enabled: true,
+      profiles: {
+        broad: {
+          match: "anthropic/*",
+          reserveTokens: 10_000,
+        },
+        opus: {
+          match: "anthropic/claude-opus-*",
+          reserveTokens: 60_000,
+        },
+        exact: {
+          match: "anthropic/claude-opus-4",
+          reserveTokens: 90_000,
+        },
+      },
+    });
+
+    const exactPolicy = resolveEffectivePolicy(base, {
+      provider: "anthropic",
+      id: "claude-opus-4",
+      contextWindow: 1_000_000,
+    });
+    const specificGlobPolicy = resolveEffectivePolicy(base, {
+      provider: "anthropic",
+      id: "claude-opus-4-1",
+      contextWindow: 1_000_000,
+    });
+
+    expect(exactPolicy.matchedProfile).toBe("exact");
+    expect(exactPolicy.reserveTokens).toBe(90_000);
+    expect(specificGlobPolicy.matchedProfile).toBe("opus");
+    expect(specificGlobPolicy.reserveTokens).toBe(60_000);
+  });
 });
 
 describe("compaction-worker runtime decisions", () => {
@@ -89,6 +125,49 @@ describe("compaction-worker runtime decisions", () => {
         nowMs: 100,
       }),
     ).toEqual({ action: "compact", reason: "trigger-threshold-live", usePrepared: false });
+  });
+
+  it("does not suppress large-context custom reserve triggers by default", () => {
+    const largeContextPolicy = resolveEffectivePolicy(
+      resolveBaseConfig({
+        enabled: true,
+        reserveTokens: 65_536,
+        builtinReserveTokens: 16_384,
+      }),
+      { provider: "anthropic", id: "claude-opus-4", contextWindow: 1_000_000 },
+    );
+
+    expect(largeContextPolicy.builtinSkipMarginPercent).toBe(0);
+    expect(largeContextPolicy.triggerAtTokens).toBe(934_464);
+    expect(
+      decideRuntimeAction({
+        usage: { tokens: 934_464, contextWindow: 1_000_000 },
+        policy: largeContextPolicy,
+        prepared: undefined,
+        inFlight: false,
+        nowMs: 100,
+      }),
+    ).toEqual({ action: "compact", reason: "trigger-threshold-live", usePrepared: false });
+  });
+
+  it("applies cooldown only when the current runtime supplies a recent compaction time", () => {
+    const input = {
+      usage: { tokens: 220, contextWindow: 1_000 },
+      policy,
+      prepared: undefined,
+      inFlight: false,
+      nowMs: 100,
+    };
+
+    expect(decideRuntimeAction({ ...input, lastCompactAtMs: 95 })).toEqual({
+      action: "none",
+      reason: "cooldown",
+    });
+    expect(decideRuntimeAction(input)).toEqual({
+      action: "compact",
+      reason: "trigger-threshold-live",
+      usePrepared: false,
+    });
   });
 
   it("triggers live compaction at the trigger threshold without a ready summary", () => {

--- a/compaction-worker/helpers.test.ts
+++ b/compaction-worker/helpers.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideRuntimeAction,
+  extractFileListDetails,
+  resolveBaseConfig,
+  resolveEffectivePolicy,
+  validatePreparedRecord,
+  type PreparedCompactionRecord,
+} from "./helpers.js";
+
+describe("compaction-worker policy resolution", () => {
+  it("resolves default reserve threshold from model context window", () => {
+    const base = resolveBaseConfig({ enabled: true, reserveTokens: 10_000 });
+    const policy = resolveEffectivePolicy(base, {
+      provider: "anthropic",
+      id: "claude-sonnet",
+      contextWindow: 200_000,
+    });
+
+    expect(policy.enabled).toBe(true);
+    expect(policy.modelKey).toBe("anthropic/claude-sonnet");
+    expect(policy.triggerAtTokens).toBe(190_000);
+    expect(policy.keepRecentTokens).toBe(20_000);
+  });
+
+  it("uses glob profile overrides without resetting omitted default fields", () => {
+    const base = resolveBaseConfig({
+      enabled: true,
+      keepRecentTokens: 33_000,
+      summaryModels: ["google/gemini-2.5-flash"],
+      profiles: {
+        opus: {
+          match: "anthropic/claude-opus-*",
+          prepareAtPercent: 55,
+          triggerAtPercent: 70,
+          reserveTokens: 50_000,
+        },
+      },
+    });
+
+    const policy = resolveEffectivePolicy(base, {
+      provider: "anthropic",
+      id: "claude-opus-4",
+      contextWindow: 1_000_000,
+    });
+
+    expect(policy.matchedProfile).toBe("opus");
+    expect(policy.prepareAtTokens).toBe(550_000);
+    expect(policy.triggerAtTokens).toBe(700_000);
+    expect(policy.reserveTokens).toBe(50_000);
+    expect(policy.keepRecentTokens).toBe(33_000);
+    expect(policy.summaryModels).toEqual(["google/gemini-2.5-flash"]);
+  });
+});
+
+describe("compaction-worker runtime decisions", () => {
+  const policy = resolveEffectivePolicy(
+    resolveBaseConfig({
+      enabled: true,
+      prepareAtTokens: 100,
+      triggerAtTokens: 200,
+      cooldownMs: 10,
+      builtinReserveTokens: 100,
+      builtinSkipMarginPercent: 0,
+    }),
+    { provider: "test", id: "model", contextWindow: 1_000 },
+  );
+
+  it("starts prepare after the prepare threshold", () => {
+    expect(
+      decideRuntimeAction({
+        usage: { tokens: 120, contextWindow: 1_000 },
+        policy,
+        prepared: undefined,
+        inFlight: false,
+        nowMs: 100,
+      }),
+    ).toEqual({ action: "prepare", reason: "prepare-threshold" });
+  });
+
+  it("honors an explicit zero built-in skip margin", () => {
+    expect(policy.builtinSkipMarginPercent).toBe(0);
+    expect(
+      decideRuntimeAction({
+        usage: { tokens: 880, contextWindow: 1_000 },
+        policy,
+        prepared: undefined,
+        inFlight: false,
+        nowMs: 100,
+      }),
+    ).toEqual({ action: "compact", reason: "trigger-threshold-live", usePrepared: false });
+  });
+
+  it("triggers live compaction at the trigger threshold without a ready summary", () => {
+    expect(
+      decideRuntimeAction({
+        usage: { tokens: 220, contextWindow: 1_000 },
+        policy,
+        prepared: undefined,
+        inFlight: false,
+        nowMs: 100,
+      }),
+    ).toEqual({ action: "compact", reason: "trigger-threshold-live", usePrepared: false });
+  });
+
+  it("triggers prepared compaction at the trigger threshold with a ready summary", () => {
+    const prepared: PreparedCompactionRecord = {
+      schemaVersion: 1,
+      status: "ready",
+      jobId: "job",
+      cwd: "/repo",
+      modelKey: "test/model",
+      policyHash: policy.policyHash,
+      createdAt: new Date(0).toISOString(),
+      summary: "summary",
+    };
+
+    expect(
+      decideRuntimeAction({
+        usage: { tokens: 220, contextWindow: 1_000 },
+        policy,
+        prepared,
+        inFlight: false,
+        nowMs: 100,
+      }),
+    ).toEqual({ action: "compact", reason: "trigger-threshold-ready", usePrepared: true });
+  });
+});
+
+describe("compaction detail helpers", () => {
+  it("extracts top-level file lists from worker details", () => {
+    expect(
+      extractFileListDetails({
+        kind: "compaction-worker",
+        readFiles: ["README.md"],
+        modifiedFiles: ["compaction-worker/index.ts"],
+      }),
+    ).toEqual({ readFiles: ["README.md"], modifiedFiles: ["compaction-worker/index.ts"] });
+  });
+
+  it("can read nested legacy Pi detail payloads", () => {
+    expect(
+      extractFileListDetails({
+        kind: "compaction-worker",
+        details: {
+          readFiles: ["old-read.ts"],
+          modifiedFiles: ["old-edit.ts"],
+        },
+      }),
+    ).toEqual({ readFiles: ["old-read.ts"], modifiedFiles: ["old-edit.ts"] });
+  });
+});
+
+describe("prepared record validation", () => {
+  const policy = resolveEffectivePolicy(
+    resolveBaseConfig({ enabled: true, triggerAtTokens: 200, maxPreparedAgeMs: 60_000 }),
+    { provider: "test", id: "model", contextWindow: 1_000 },
+  );
+
+  function readyRecord(
+    overrides: Partial<PreparedCompactionRecord> = {},
+  ): PreparedCompactionRecord {
+    return {
+      schemaVersion: 1,
+      status: "ready",
+      jobId: "job",
+      sessionId: "session",
+      sessionFile: "/tmp/session.jsonl",
+      cwd: "/repo",
+      modelKey: "test/model",
+      policyHash: policy.policyHash,
+      createdAt: new Date(1_000).toISOString(),
+      firstKeptEntryId: "b",
+      leafIdCovered: "c",
+      previousCompactionId: "a",
+      summary: "summary",
+      ...overrides,
+    };
+  }
+
+  const branchEntries = [
+    { id: "a", type: "compaction" },
+    { id: "b", type: "message" },
+    { id: "c", type: "message" },
+    { id: "d", type: "message" },
+  ];
+
+  it("accepts a ready record that covers an ancestor of the current branch", () => {
+    expect(
+      validatePreparedRecord(readyRecord(), {
+        identity: { sessionId: "session", sessionFile: "/tmp/session.jsonl", cwd: "/repo" },
+        policy,
+        branchEntries,
+        nowMs: 2_000,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects records for divergent branches", () => {
+    expect(
+      validatePreparedRecord(readyRecord({ leafIdCovered: "missing" }), {
+        identity: { sessionId: "session", sessionFile: "/tmp/session.jsonl", cwd: "/repo" },
+        policy,
+        branchEntries,
+        nowMs: 2_000,
+      }),
+    ).toEqual({ ok: false, reason: "covered-leaf-not-ancestor" });
+  });
+
+  it("rejects records after another compaction changed the boundary", () => {
+    expect(
+      validatePreparedRecord(readyRecord(), {
+        identity: { sessionId: "session", sessionFile: "/tmp/session.jsonl", cwd: "/repo" },
+        policy,
+        branchEntries: [...branchEntries, { id: "e", type: "compaction" }],
+        nowMs: 2_000,
+      }),
+    ).toEqual({ ok: false, reason: "compaction-boundary-changed" });
+  });
+});

--- a/compaction-worker/helpers.test.ts
+++ b/compaction-worker/helpers.test.ts
@@ -141,13 +141,44 @@ describe("compaction-worker runtime decisions", () => {
     expect(largeContextPolicy.triggerAtTokens).toBe(934_464);
     expect(
       decideRuntimeAction({
-        usage: { tokens: 934_464, contextWindow: 1_000_000 },
+        usage: { tokens: 990_000, contextWindow: 1_000_000 },
         policy: largeContextPolicy,
         prepared: undefined,
         inFlight: false,
         nowMs: 100,
       }),
     ).toEqual({ action: "compact", reason: "trigger-threshold-live", usePrepared: false });
+  });
+
+  it("stands down near Pi's built-in threshold only when a positive skip margin is configured", () => {
+    const skipPolicy = resolveEffectivePolicy(
+      resolveBaseConfig({
+        enabled: true,
+        reserveTokens: 65_536,
+        builtinReserveTokens: 16_384,
+        builtinSkipMarginPercent: 2,
+      }),
+      { provider: "anthropic", id: "claude-opus-4", contextWindow: 1_000_000 },
+    );
+
+    expect(
+      decideRuntimeAction({
+        usage: { tokens: 970_000, contextWindow: 1_000_000 },
+        policy: skipPolicy,
+        prepared: undefined,
+        inFlight: false,
+        nowMs: 100,
+      }),
+    ).toEqual({ action: "none", reason: "near-built-in-threshold" });
+    expect(
+      decideRuntimeAction({
+        usage: { tokens: 970_000 },
+        policy: skipPolicy,
+        prepared: undefined,
+        inFlight: false,
+        nowMs: 100,
+      }),
+    ).toEqual({ action: "none", reason: "near-built-in-threshold" });
   });
 
   it("applies cooldown only when the current runtime supplies a recent compaction time", () => {

--- a/compaction-worker/helpers.ts
+++ b/compaction-worker/helpers.ts
@@ -1,0 +1,499 @@
+export const SETTINGS_KEY = "compaction-worker";
+export const CONFIG_ENV = "PI_COMPACTION_WORKER_SETTINGS";
+
+const DEFAULT_SUMMARY_MODELS = ["google/gemini-2.5-flash"] as const;
+const DEFAULT_KEEP_RECENT_TOKENS = 20_000;
+const DEFAULT_RESERVE_TOKENS = 16_384;
+const DEFAULT_COOLDOWN_MS = 60_000;
+const DEFAULT_MAX_PREPARED_AGE_MS = 30 * 60_000;
+const DEFAULT_BUILTIN_SKIP_MARGIN_PERCENT = 5;
+
+export interface ModelLike {
+  provider?: string;
+  id?: string;
+  contextWindow?: number;
+}
+
+export interface UsageLike {
+  tokens: number;
+  contextWindow?: number;
+}
+
+export interface ThresholdConfig {
+  tokens?: number;
+  percent?: number;
+}
+
+export interface RawCompactionWorkerRule {
+  match?: string | string[];
+  prepareAtTokens?: number;
+  prepareAtPercent?: number;
+  triggerAtTokens?: number;
+  triggerAtPercent?: number;
+  reserveTokens?: number;
+  keepRecentTokens?: number;
+  summaryModels?: string[];
+  summaryMaxTokens?: number;
+  cooldownMs?: number;
+  maxPreparedAgeMs?: number;
+  builtinReserveTokens?: number;
+  builtinSkipMarginPercent?: number;
+}
+
+export interface RawCompactionWorkerConfig extends RawCompactionWorkerRule {
+  enabled?: boolean;
+  quiet?: boolean;
+  showStatus?: boolean;
+  profiles?: Record<string, RawCompactionWorkerRule>;
+}
+
+export interface ResolvedBaseConfig {
+  enabled: boolean;
+  quiet: boolean;
+  showStatus: boolean;
+  defaultRule: ResolvedRule;
+  rawDefault: RawCompactionWorkerRule;
+  profiles: Record<string, ResolvedProfile>;
+  sourcePath: string | null;
+}
+
+export interface ResolvedProfile {
+  name: string;
+  matches: string[];
+  raw: RawCompactionWorkerRule;
+}
+
+export interface ResolvedRule {
+  prepareAt?: ThresholdConfig;
+  triggerAt?: ThresholdConfig;
+  reserveTokens: number;
+  keepRecentTokens: number;
+  summaryModels: string[];
+  summaryMaxTokens?: number;
+  cooldownMs: number;
+  maxPreparedAgeMs: number;
+  builtinReserveTokens: number;
+  builtinSkipMarginPercent: number;
+}
+
+export interface EffectivePolicy extends ResolvedRule {
+  enabled: boolean;
+  quiet: boolean;
+  showStatus: boolean;
+  modelKey: string;
+  matchedProfile?: string;
+  prepareAtTokens?: number;
+  triggerAtTokens?: number;
+  policyHash: string;
+  sourcePath: string | null;
+}
+
+export type PreparedStatus = "pending" | "ready" | "failed" | "stale" | "used";
+
+export interface PreparedCompactionRecord {
+  schemaVersion: 1;
+  status: PreparedStatus;
+  jobId: string;
+  sessionId?: string;
+  sessionFile?: string;
+  cwd: string;
+  modelKey: string;
+  matchedProfile?: string;
+  policyHash: string;
+  createdAt: string;
+  completedAt?: string;
+  firstKeptEntryId?: string;
+  leafIdCovered?: string;
+  previousCompactionId?: string;
+  summary?: string;
+  tokensBeforeAtPrepare?: number;
+  summaryModel?: string;
+  details?: unknown;
+  failure?: string;
+  invalidationReason?: string;
+}
+
+export interface SessionIdentity {
+  sessionId?: string;
+  sessionFile?: string;
+  cwd: string;
+}
+
+export interface EntryLike {
+  id?: string;
+  type?: string;
+}
+
+export interface FileListDetails {
+  readFiles: string[];
+  modifiedFiles: string[];
+}
+
+export interface RuntimeDecisionInput {
+  usage: UsageLike | undefined;
+  policy: EffectivePolicy;
+  prepared: PreparedCompactionRecord | undefined;
+  inFlight: boolean;
+  nowMs: number;
+  lastCompactAtMs?: number;
+}
+
+export type RuntimeDecision =
+  | { action: "none"; reason: string }
+  | { action: "prepare"; reason: string }
+  | { action: "compact"; reason: string; usePrepared: boolean };
+
+export function modelKey(model: ModelLike | undefined): string {
+  const provider = model?.provider?.trim();
+  const id = model?.id?.trim();
+  if (!provider || !id) return "unknown";
+  return `${provider}/${id}`;
+}
+
+export function parseModelSelector(selector: string): { provider: string; id: string } | undefined {
+  const trimmed = selector.trim();
+  if (!trimmed) return undefined;
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0 || slash === trimmed.length - 1) return undefined;
+  return {
+    provider: trimmed.slice(0, slash),
+    id: trimmed.slice(slash + 1),
+  };
+}
+
+export function resolveBaseConfig(
+  raw: RawCompactionWorkerConfig | null | undefined,
+  sourcePath: string | null = null,
+): ResolvedBaseConfig {
+  return {
+    enabled: raw?.enabled === true,
+    quiet: raw?.quiet === true,
+    showStatus: raw?.showStatus !== false,
+    defaultRule: resolveRule(raw),
+    rawDefault: raw ?? {},
+    profiles: resolveProfiles(raw?.profiles),
+    sourcePath,
+  };
+}
+
+export function resolveEffectivePolicy(
+  base: ResolvedBaseConfig,
+  model: ModelLike | undefined,
+  usage?: UsageLike,
+): EffectivePolicy {
+  const key = modelKey(model);
+  const matched = findMatchingProfile(base.profiles, key);
+  const merged = matched
+    ? resolveRule(mergeRawRules(base.rawDefault, matched.raw))
+    : base.defaultRule;
+  const contextWindow = usage?.contextWindow ?? model?.contextWindow;
+  const prepareAtTokens = resolveThreshold(merged.prepareAt, contextWindow);
+  const explicitTrigger = resolveThreshold(merged.triggerAt, contextWindow);
+  const triggerAtTokens =
+    explicitTrigger ?? resolveReserveThreshold(contextWindow, merged.reserveTokens);
+  const effective: EffectivePolicy = {
+    ...merged,
+    enabled: base.enabled,
+    quiet: base.quiet,
+    showStatus: base.showStatus,
+    modelKey: key,
+    matchedProfile: matched?.name,
+    prepareAtTokens,
+    triggerAtTokens,
+    policyHash: hashPolicy({
+      key,
+      matchedProfile: matched?.name,
+      rule: merged,
+      prepareAtTokens,
+      triggerAtTokens,
+    }),
+    sourcePath: base.sourcePath,
+  };
+  return effective;
+}
+
+export function decideRuntimeAction(input: RuntimeDecisionInput): RuntimeDecision {
+  const { usage, policy, prepared, inFlight, nowMs, lastCompactAtMs } = input;
+  if (!policy.enabled) return { action: "none", reason: "disabled" };
+  if (!usage || !Number.isFinite(usage.tokens))
+    return { action: "none", reason: "usage-unavailable" };
+  if (inFlight) return { action: "none", reason: "in-flight" };
+  if (lastCompactAtMs !== undefined && nowMs - lastCompactAtMs < policy.cooldownMs) {
+    return { action: "none", reason: "cooldown" };
+  }
+
+  const currentTokens = usage.tokens;
+  const ready = prepared?.status === "ready" && !!prepared.summary;
+  if (policy.triggerAtTokens !== undefined && currentTokens >= policy.triggerAtTokens) {
+    if (isNearBuiltinThreshold(usage, policy)) {
+      return { action: "none", reason: "near-built-in-threshold" };
+    }
+    return {
+      action: "compact",
+      reason: ready ? "trigger-threshold-ready" : "trigger-threshold-live",
+      usePrepared: ready,
+    };
+  }
+
+  if (policy.prepareAtTokens !== undefined && currentTokens >= policy.prepareAtTokens) {
+    if (
+      !prepared ||
+      prepared.status === "failed" ||
+      prepared.status === "stale" ||
+      prepared.status === "used"
+    ) {
+      return { action: "prepare", reason: "prepare-threshold" };
+    }
+    return { action: "none", reason: `prepared-${prepared.status}` };
+  }
+
+  return { action: "none", reason: "below-threshold" };
+}
+
+export function validatePreparedRecord(
+  record: PreparedCompactionRecord | undefined,
+  options: {
+    identity: SessionIdentity;
+    policy: EffectivePolicy;
+    branchEntries: EntryLike[];
+    nowMs: number;
+  },
+): { ok: true } | { ok: false; reason: string } {
+  if (!record) return { ok: false, reason: "missing" };
+  if (record.status !== "ready") return { ok: false, reason: `not-ready:${record.status}` };
+  if (!record.summary?.trim()) return { ok: false, reason: "empty-summary" };
+  if (!record.firstKeptEntryId) return { ok: false, reason: "missing-first-kept" };
+  if (!record.leafIdCovered) return { ok: false, reason: "missing-covered-leaf" };
+  if (record.cwd !== options.identity.cwd) return { ok: false, reason: "cwd-mismatch" };
+  if (
+    record.sessionId &&
+    options.identity.sessionId &&
+    record.sessionId !== options.identity.sessionId
+  ) {
+    return { ok: false, reason: "session-id-mismatch" };
+  }
+  if (
+    record.sessionFile &&
+    options.identity.sessionFile &&
+    record.sessionFile !== options.identity.sessionFile
+  ) {
+    return { ok: false, reason: "session-file-mismatch" };
+  }
+  if (record.modelKey !== options.policy.modelKey) return { ok: false, reason: "model-mismatch" };
+  if (record.policyHash !== options.policy.policyHash)
+    return { ok: false, reason: "policy-mismatch" };
+  const createdAtMs = Date.parse(record.createdAt);
+  if (!Number.isFinite(createdAtMs)) return { ok: false, reason: "invalid-created-at" };
+  if (options.nowMs - createdAtMs > options.policy.maxPreparedAgeMs)
+    return { ok: false, reason: "expired" };
+
+  const firstKeptIndex = options.branchEntries.findIndex(
+    (entry) => entry.id === record.firstKeptEntryId,
+  );
+  if (firstKeptIndex < 0) return { ok: false, reason: "first-kept-not-on-branch" };
+  const coveredIndex = options.branchEntries.findIndex(
+    (entry) => entry.id === record.leafIdCovered,
+  );
+  if (coveredIndex < 0) return { ok: false, reason: "covered-leaf-not-ancestor" };
+  if (firstKeptIndex > coveredIndex) return { ok: false, reason: "invalid-coverage-order" };
+
+  const latestCompaction = findLatestCompactionId(options.branchEntries);
+  if ((latestCompaction ?? undefined) !== (record.previousCompactionId ?? undefined)) {
+    return { ok: false, reason: "compaction-boundary-changed" };
+  }
+
+  return { ok: true };
+}
+
+export function findLatestCompactionId(entries: EntryLike[]): string | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.type === "compaction" && entry.id) return entry.id;
+  }
+  return undefined;
+}
+
+export function extractFileListDetails(details: unknown): FileListDetails {
+  const direct = extractFileListDetailsFromRecord(toRecord(details));
+  if (direct.readFiles.length > 0 || direct.modifiedFiles.length > 0) return direct;
+  const nested = toRecord(details)?.details;
+  return extractFileListDetailsFromRecord(toRecord(nested));
+}
+
+function resolveProfiles(
+  rawProfiles: Record<string, RawCompactionWorkerRule> | undefined,
+): Record<string, ResolvedProfile> {
+  const result: Record<string, ResolvedProfile> = {};
+  if (!rawProfiles) return result;
+  for (const [name, raw] of Object.entries(rawProfiles)) {
+    const matches = normalizeMatches(raw.match);
+    if (matches.length === 0) continue;
+    result[name] = {
+      name,
+      matches,
+      raw,
+    };
+  }
+  return result;
+}
+
+function resolveRule(raw: RawCompactionWorkerRule | null | undefined): ResolvedRule {
+  return {
+    prepareAt: resolveThresholdConfig(raw?.prepareAtTokens, raw?.prepareAtPercent),
+    triggerAt: resolveThresholdConfig(raw?.triggerAtTokens, raw?.triggerAtPercent),
+    reserveTokens: normalizePositiveInt(raw?.reserveTokens, DEFAULT_RESERVE_TOKENS),
+    keepRecentTokens: normalizePositiveInt(raw?.keepRecentTokens, DEFAULT_KEEP_RECENT_TOKENS),
+    summaryModels: normalizeStringArray(raw?.summaryModels, [...DEFAULT_SUMMARY_MODELS]),
+    summaryMaxTokens: normalizeOptionalPositiveInt(raw?.summaryMaxTokens),
+    cooldownMs: normalizePositiveInt(raw?.cooldownMs, DEFAULT_COOLDOWN_MS),
+    maxPreparedAgeMs: normalizePositiveInt(raw?.maxPreparedAgeMs, DEFAULT_MAX_PREPARED_AGE_MS),
+    builtinReserveTokens: normalizePositiveInt(raw?.builtinReserveTokens, DEFAULT_RESERVE_TOKENS),
+    builtinSkipMarginPercent: normalizeSkipPercent(
+      raw?.builtinSkipMarginPercent,
+      DEFAULT_BUILTIN_SKIP_MARGIN_PERCENT,
+    ),
+  };
+}
+
+function mergeRawRules(
+  base: RawCompactionWorkerRule,
+  override: RawCompactionWorkerRule,
+): RawCompactionWorkerRule {
+  return {
+    ...base,
+    ...override,
+    match: override.match,
+  };
+}
+
+function findMatchingProfile(
+  profiles: Record<string, ResolvedProfile>,
+  key: string,
+): ResolvedProfile | undefined {
+  const normalized = key.toLowerCase();
+  for (const profile of Object.values(profiles)) {
+    if (profile.matches.some((pattern) => globMatch(pattern, normalized))) return profile;
+  }
+  return undefined;
+}
+
+function normalizeMatches(match: string | string[] | undefined): string[] {
+  const values = Array.isArray(match) ? match : match ? [match] : [];
+  return values.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0);
+}
+
+function globMatch(pattern: string, value: string): boolean {
+  if (pattern === value) return true;
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`, "i").test(value);
+}
+
+function resolveThresholdConfig(
+  tokens: number | undefined,
+  percent: number | undefined,
+): ThresholdConfig | undefined {
+  const normalizedTokens = normalizeOptionalPositiveInt(tokens);
+  if (normalizedTokens !== undefined) return { tokens: normalizedTokens };
+  const normalizedPercent = normalizeOptionalPercent(percent);
+  if (normalizedPercent !== undefined) return { percent: normalizedPercent };
+  return undefined;
+}
+
+function resolveThreshold(
+  threshold: ThresholdConfig | undefined,
+  contextWindow: number | undefined,
+): number | undefined {
+  if (!threshold) return undefined;
+  if (threshold.tokens !== undefined) return threshold.tokens;
+  if (threshold.percent === undefined) return undefined;
+  const window = normalizeOptionalPositiveInt(contextWindow);
+  if (window === undefined) return undefined;
+  return Math.floor((window * threshold.percent) / 100);
+}
+
+function resolveReserveThreshold(
+  contextWindow: number | undefined,
+  reserveTokens: number,
+): number | undefined {
+  const window = normalizeOptionalPositiveInt(contextWindow);
+  if (window === undefined) return undefined;
+  return Math.max(0, window - reserveTokens);
+}
+
+function isNearBuiltinThreshold(usage: UsageLike, policy: EffectivePolicy): boolean {
+  const contextWindow = normalizeOptionalPositiveInt(usage.contextWindow);
+  if (contextWindow === undefined) return false;
+  const builtinThreshold = Math.max(0, contextWindow - policy.builtinReserveTokens);
+  const marginTokens = Math.floor((contextWindow * policy.builtinSkipMarginPercent) / 100);
+  return usage.tokens >= builtinThreshold - marginTokens;
+}
+
+function normalizePositiveInt(value: number | undefined, fallback: number): number {
+  const normalized = normalizeOptionalPositiveInt(value);
+  return normalized ?? fallback;
+}
+
+function normalizeOptionalPositiveInt(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  return Math.floor(value);
+}
+
+function normalizeOptionalPercent(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0 || value >= 100)
+    return undefined;
+  return value;
+}
+
+function normalizeSkipPercent(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value >= 100)
+    return fallback;
+  return value;
+}
+
+function normalizeStringArray(value: string[] | undefined, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return fallback;
+  const normalized = value.map((item) => item.trim()).filter((item) => item.length > 0);
+  return normalized.length > 0 ? normalized : fallback;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function extractFileListDetailsFromRecord(
+  record: Record<string, unknown> | undefined,
+): FileListDetails {
+  return {
+    readFiles: normalizeStringList(record?.readFiles),
+    modifiedFiles: normalizeStringList(record?.modifiedFiles),
+  };
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`).join(",")}}`;
+}
+
+function hashPolicy(value: unknown): string {
+  const text = stableStringify(value);
+  let hash = 2166136261;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/compaction-worker/helpers.ts
+++ b/compaction-worker/helpers.ts
@@ -6,7 +6,7 @@ const DEFAULT_KEEP_RECENT_TOKENS = 20_000;
 const DEFAULT_RESERVE_TOKENS = 16_384;
 const DEFAULT_COOLDOWN_MS = 60_000;
 const DEFAULT_MAX_PREPARED_AGE_MS = 30 * 60_000;
-const DEFAULT_BUILTIN_SKIP_MARGIN_PERCENT = 5;
+const DEFAULT_BUILTIN_SKIP_MARGIN_PERCENT = 0;
 
 export interface ModelLike {
   provider?: string;
@@ -371,10 +371,50 @@ function findMatchingProfile(
   key: string,
 ): ResolvedProfile | undefined {
   const normalized = key.toLowerCase();
-  for (const profile of Object.values(profiles)) {
-    if (profile.matches.some((pattern) => globMatch(pattern, normalized))) return profile;
-  }
-  return undefined;
+  let best: { profile: ResolvedProfile; rank: ProfileMatchRank } | undefined;
+
+  Object.values(profiles).forEach((profile, profileIndex) => {
+    profile.matches.forEach((pattern, patternIndex) => {
+      if (!globMatch(pattern, normalized)) return;
+      const rank = profileMatchRank(pattern, profileIndex, patternIndex);
+      if (!best || compareProfileMatchRank(rank, best.rank) > 0) {
+        best = { profile, rank };
+      }
+    });
+  });
+
+  return best?.profile;
+}
+
+interface ProfileMatchRank {
+  exact: boolean;
+  literalLength: number;
+  wildcardCount: number;
+  profileIndex: number;
+  patternIndex: number;
+}
+
+function profileMatchRank(
+  pattern: string,
+  profileIndex: number,
+  patternIndex: number,
+): ProfileMatchRank {
+  const wildcardCount = [...pattern].filter((char) => char === "*" || char === "?").length;
+  return {
+    exact: wildcardCount === 0,
+    literalLength: pattern.replaceAll("*", "").replaceAll("?", "").length,
+    wildcardCount,
+    profileIndex,
+    patternIndex,
+  };
+}
+
+function compareProfileMatchRank(left: ProfileMatchRank, right: ProfileMatchRank): number {
+  if (left.exact !== right.exact) return left.exact ? 1 : -1;
+  if (left.literalLength !== right.literalLength) return left.literalLength - right.literalLength;
+  if (left.wildcardCount !== right.wildcardCount) return right.wildcardCount - left.wildcardCount;
+  if (left.profileIndex !== right.profileIndex) return right.profileIndex - left.profileIndex;
+  return right.patternIndex - left.patternIndex;
 }
 
 function normalizeMatches(match: string | string[] | undefined): string[] {

--- a/compaction-worker/helpers.ts
+++ b/compaction-worker/helpers.ts
@@ -82,6 +82,7 @@ export interface EffectivePolicy extends ResolvedRule {
   showStatus: boolean;
   modelKey: string;
   matchedProfile?: string;
+  contextWindowTokens?: number;
   prepareAtTokens?: number;
   triggerAtTokens?: number;
   policyHash: string;
@@ -186,11 +187,13 @@ export function resolveEffectivePolicy(
   const merged = matched
     ? resolveRule(mergeRawRules(base.rawDefault, matched.raw))
     : base.defaultRule;
-  const contextWindow = usage?.contextWindow ?? model?.contextWindow;
-  const prepareAtTokens = resolveThreshold(merged.prepareAt, contextWindow);
-  const explicitTrigger = resolveThreshold(merged.triggerAt, contextWindow);
+  const contextWindowTokens = normalizeOptionalPositiveInt(
+    usage?.contextWindow ?? model?.contextWindow,
+  );
+  const prepareAtTokens = resolveThreshold(merged.prepareAt, contextWindowTokens);
+  const explicitTrigger = resolveThreshold(merged.triggerAt, contextWindowTokens);
   const triggerAtTokens =
-    explicitTrigger ?? resolveReserveThreshold(contextWindow, merged.reserveTokens);
+    explicitTrigger ?? resolveReserveThreshold(contextWindowTokens, merged.reserveTokens);
   const effective: EffectivePolicy = {
     ...merged,
     enabled: base.enabled,
@@ -198,6 +201,7 @@ export function resolveEffectivePolicy(
     showStatus: base.showStatus,
     modelKey: key,
     matchedProfile: matched?.name,
+    contextWindowTokens,
     prepareAtTokens,
     triggerAtTokens,
     policyHash: hashPolicy({
@@ -464,7 +468,9 @@ function resolveReserveThreshold(
 }
 
 function isNearBuiltinThreshold(usage: UsageLike, policy: EffectivePolicy): boolean {
-  const contextWindow = normalizeOptionalPositiveInt(usage.contextWindow);
+  if (policy.builtinSkipMarginPercent <= 0) return false;
+  const contextWindow =
+    normalizeOptionalPositiveInt(usage.contextWindow) ?? policy.contextWindowTokens;
   if (contextWindow === undefined) return false;
   const builtinThreshold = Math.max(0, contextWindow - policy.builtinReserveTokens);
   const marginTokens = Math.floor((contextWindow * policy.builtinSkipMarginPercent) / 100);

--- a/compaction-worker/index.test.ts
+++ b/compaction-worker/index.test.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  CompactOptions,
+  ExtensionAPI,
+  ExtensionContext,
+  SessionBeforeCompactEvent,
+} from "@mariozechner/pi-coding-agent";
+import compactionWorkerExtension from "./index.js";
+
+type RegisteredHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+function createMockPi(): { pi: ExtensionAPI; handlers: Record<string, RegisteredHandler> } {
+  const handlers: Record<string, RegisteredHandler> = {};
+  const pi = {
+    on(event: string, handler: RegisteredHandler): void {
+      handlers[event] = handler;
+    },
+    registerCommand(): void {},
+    registerTool(): void {},
+    registerMessageRenderer(): void {},
+    sendUserMessage(): void {},
+    sendMessage(): void {},
+    appendEntry(): void {},
+  } as unknown as ExtensionAPI;
+  return { pi, handlers };
+}
+
+function writeConfig(cwd: string): void {
+  writeFileSync(
+    join(cwd, ".pi", "settings.json"),
+    JSON.stringify({
+      "compaction-worker": {
+        enabled: true,
+        triggerAtTokens: 200,
+        summaryModels: ["test/missing-summary-model"],
+        cooldownMs: 1,
+      },
+    }),
+  );
+}
+
+function createPreparation(): SessionBeforeCompactEvent["preparation"] {
+  return {
+    firstKeptEntryId: "entry-1",
+    messagesToSummarize: [],
+    turnPrefixMessages: [],
+    isSplitTurn: false,
+    tokensBefore: 150,
+    fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+    settings: { enabled: true, reserveTokens: 1, keepRecentTokens: 1 },
+  };
+}
+
+function createContext(cwd: string, compactCalls: CompactOptions[]): ExtensionContext {
+  return {
+    cwd,
+    hasUI: false,
+    ui: {
+      theme: {},
+      notify(): void {},
+      setStatus(): void {},
+    },
+    model: { provider: "test", id: "model", contextWindow: 1_000 },
+    modelRegistry: {
+      find(): unknown | undefined {
+        return undefined;
+      },
+      async getApiKeyAndHeaders(): Promise<{ ok: boolean; error: string }> {
+        return { ok: false, error: "unavailable" };
+      },
+    },
+    sessionManager: {
+      getEntries: () => [],
+      getBranch: () => [],
+      getLeafId: () => "entry-1",
+      getSessionId: () => "session-1",
+      getSessionFile: () => join(cwd, "session.jsonl"),
+    },
+    getContextUsage: () => ({ tokens: 250, contextWindow: 1_000 }),
+    compact(options?: CompactOptions): void {
+      compactCalls.push(options ?? {});
+    },
+  } as unknown as ExtensionContext;
+}
+
+describe("compaction-worker extension runtime lifecycle", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears failed session_before_compact in-flight state before the next agent_end decision", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "compaction-worker-test-"));
+    tempDirs.push(cwd);
+    mkdirSync(join(cwd, ".pi"));
+    writeConfig(cwd);
+
+    const { pi, handlers } = createMockPi();
+    const compactCalls: CompactOptions[] = [];
+    const ctx = createContext(cwd, compactCalls);
+    compactionWorkerExtension(pi);
+
+    const beforeCompact = handlers.session_before_compact;
+    const agentEnd = handlers.agent_end;
+    expect(beforeCompact).toBeDefined();
+    expect(agentEnd).toBeDefined();
+
+    const event: SessionBeforeCompactEvent = {
+      type: "session_before_compact",
+      preparation: createPreparation(),
+      branchEntries: [],
+      signal: new AbortController().signal,
+    };
+
+    await beforeCompact(event, ctx);
+    await agentEnd({}, ctx);
+
+    expect(compactCalls).toHaveLength(1);
+  });
+});

--- a/compaction-worker/index.ts
+++ b/compaction-worker/index.ts
@@ -1,0 +1,504 @@
+import {
+  compact as generateCompaction,
+  type CompactionResult,
+  type CompactionSettings,
+  type ExtensionAPI,
+  type ExtensionContext,
+  type SessionBeforeCompactEvent,
+  type SessionEntry,
+} from "@mariozechner/pi-coding-agent";
+import { loadConfig } from "./config.js";
+import {
+  decideRuntimeAction,
+  extractFileListDetails,
+  findLatestCompactionId,
+  parseModelSelector,
+  resolveEffectivePolicy,
+  validatePreparedRecord,
+  type EffectivePolicy,
+  type ModelLike,
+  type PreparedCompactionRecord,
+  type SessionIdentity,
+  type UsageLike,
+} from "./helpers.js";
+import { buildPreparationFromBranch } from "./retention.js";
+
+const STATUS_ID = "compaction-worker";
+const CUSTOM_INSTRUCTIONS =
+  "Create a precise coding-session compaction summary. Preserve exact file paths, commands, failing tests, decisions, blockers, and next steps. Do not continue the conversation.";
+
+interface AuthResult {
+  ok: boolean;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  error?: string;
+}
+
+type SummaryModel = unknown;
+
+interface CompatibleModelRegistry {
+  find(provider: string, id: string): SummaryModel | undefined;
+  getApiKeyAndHeaders(model: SummaryModel): Promise<AuthResult>;
+}
+
+interface CompatibleSessionManager {
+  getEntries(): SessionEntry[];
+  getBranch(): SessionEntry[];
+  getLeafId(): string | undefined;
+  getSessionId?: () => string | undefined;
+  getSessionFile(): string | undefined;
+}
+
+interface CompatibleContext extends ExtensionContext {
+  model?: ModelLike;
+  modelRegistry: CompatibleModelRegistry;
+  sessionManager: CompatibleSessionManager;
+  getContextUsage(): UsageLike | undefined;
+  compact(options?: {
+    customInstructions?: string;
+    onComplete?: (result: CompactionResult) => void;
+    onError?: (error: Error) => void;
+  }): void;
+}
+
+interface WorkerRuntime {
+  prepared?: PreparedCompactionRecord;
+  inFlight?: "prepare" | "compact" | "session_before_compact";
+  lastCompactAtMs?: number;
+  activeAbort?: AbortController;
+  lastStatus?: string;
+}
+
+interface ResolvedSummaryModel {
+  selector: string;
+  model: SummaryModel;
+  apiKey?: string;
+  headers?: Record<string, string>;
+}
+
+function asContext(ctx: ExtensionContext): CompatibleContext {
+  return ctx as CompatibleContext;
+}
+
+function sessionIdentity(ctx: CompatibleContext): SessionIdentity {
+  return {
+    sessionId: ctx.sessionManager.getSessionId?.(),
+    sessionFile: ctx.sessionManager.getSessionFile?.(),
+    cwd: ctx.cwd,
+  };
+}
+
+function compactionSettings(policy: EffectivePolicy): CompactionSettings {
+  return {
+    enabled: true,
+    reserveTokens: policy.reserveTokens,
+    keepRecentTokens: policy.keepRecentTokens,
+  };
+}
+
+function notify(
+  ctx: CompatibleContext,
+  policy: EffectivePolicy,
+  message: string,
+  level: string = "info",
+): void {
+  if (policy.quiet || !ctx.hasUI) return;
+  ctx.ui.notify(message, level);
+}
+
+function statusLine(policy: EffectivePolicy, runtime: WorkerRuntime): string {
+  if (!policy.enabled) return "compaction-worker: off";
+  const bits = [
+    `compaction-worker: ${runtime.inFlight ?? runtime.prepared?.status ?? "idle"}`,
+    policy.matchedProfile ? `profile=${policy.matchedProfile}` : undefined,
+    `model=${policy.modelKey}`,
+    policy.prepareAtTokens ? `prepare=${policy.prepareAtTokens.toLocaleString()}t` : undefined,
+    policy.triggerAtTokens ? `trigger=${policy.triggerAtTokens.toLocaleString()}t` : undefined,
+  ].filter((bit): bit is string => bit !== undefined);
+  return bits.join(" ");
+}
+
+function updateStatus(
+  ctx: CompatibleContext,
+  policy: EffectivePolicy,
+  runtime: WorkerRuntime,
+): void {
+  if (!ctx.hasUI || !policy.showStatus) return;
+  const next = statusLine(policy, runtime);
+  if (next === runtime.lastStatus) return;
+  runtime.lastStatus = next;
+  ctx.ui.setStatus(STATUS_ID, next);
+}
+
+async function resolveSummaryModel(
+  ctx: CompatibleContext,
+  policy: EffectivePolicy,
+): Promise<ResolvedSummaryModel | undefined> {
+  const failures: string[] = [];
+  for (const selector of policy.summaryModels) {
+    const parsed = parseModelSelector(selector);
+    if (!parsed) {
+      failures.push(`${selector}: expected provider/model`);
+      continue;
+    }
+    const model = ctx.modelRegistry.find(parsed.provider, parsed.id);
+    if (!model) {
+      failures.push(`${selector}: model not found`);
+      continue;
+    }
+    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+    if (!auth.ok) {
+      failures.push(`${selector}: ${auth.error ?? "auth failed"}`);
+      continue;
+    }
+    return { selector, model, apiKey: auth.apiKey, headers: auth.headers };
+  }
+  notify(
+    ctx,
+    policy,
+    `Compaction worker could not resolve a summary model (${failures.join("; ")}). Falling back to Pi default compaction.`,
+    "warning",
+  );
+  return undefined;
+}
+
+function isExternalCustomInstructions(customInstructions: string | undefined): boolean {
+  const trimmed = customInstructions?.trim();
+  return !!trimmed && trimmed !== CUSTOM_INSTRUCTIONS;
+}
+
+function buildCustomInstructions(customInstructions: string | undefined): string {
+  const trimmed = customInstructions?.trim();
+  if (!trimmed || trimmed === CUSTOM_INSTRUCTIONS) return CUSTOM_INSTRUCTIONS;
+  return `${CUSTOM_INSTRUCTIONS}\n\nAdditional compaction instructions from the caller:\n${trimmed}`;
+}
+
+async function runCompactionSummary(
+  preparation: SessionBeforeCompactEvent["preparation"],
+  ctx: CompatibleContext,
+  policy: EffectivePolicy,
+  signal: AbortSignal,
+  customInstructions?: string,
+): Promise<{ result: CompactionResult; summaryModel: string } | undefined> {
+  const resolved = await resolveSummaryModel(ctx, policy);
+  if (!resolved) return undefined;
+  const result = await generateCompaction(
+    preparation,
+    resolved.model,
+    resolved.apiKey ?? "",
+    resolved.headers,
+    buildCustomInstructions(customInstructions),
+    signal,
+  );
+  if (!result.summary.trim()) throw new Error("summary model returned an empty compaction summary");
+  return { result, summaryModel: resolved.selector };
+}
+
+function prepareWithPolicy(
+  branchEntries: SessionEntry[],
+  fallback: SessionBeforeCompactEvent["preparation"] | undefined,
+  policy: EffectivePolicy,
+): SessionBeforeCompactEvent["preparation"] | undefined {
+  return (
+    buildPreparationFromBranch(branchEntries, compactionSettings(policy), fallback?.tokensBefore) ??
+    fallback
+  );
+}
+
+function startPrepareJob(
+  ctx: CompatibleContext,
+  policy: EffectivePolicy,
+  runtime: WorkerRuntime,
+): void {
+  const branchEntries = ctx.sessionManager.getBranch();
+  const identity = sessionIdentity(ctx);
+  const fallbackLeafId = branchEntries[branchEntries.length - 1]?.id;
+  const leafId =
+    ctx.sessionManager.getLeafId() ??
+    (typeof fallbackLeafId === "string" ? fallbackLeafId : undefined);
+  const previousCompactionId = findLatestCompactionId(branchEntries);
+  const jobId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const abort = new AbortController();
+  runtime.activeAbort?.abort();
+  runtime.activeAbort = abort;
+  runtime.inFlight = "prepare";
+  runtime.prepared = {
+    schemaVersion: 1,
+    status: "pending",
+    jobId,
+    ...identity,
+    modelKey: policy.modelKey,
+    matchedProfile: policy.matchedProfile,
+    policyHash: policy.policyHash,
+    createdAt: new Date().toISOString(),
+    leafIdCovered: leafId,
+    previousCompactionId,
+  };
+  updateStatus(ctx, policy, runtime);
+
+  void (async () => {
+    try {
+      const preparation = prepareWithPolicy(branchEntries, undefined, policy);
+      if (!preparation) throw new Error("session branch is not ready for compaction");
+      const generated = await runCompactionSummary(preparation, ctx, policy, abort.signal);
+      if (!generated) throw new Error("no summary model was available");
+      if (runtime.prepared?.jobId !== jobId) return;
+      runtime.prepared = {
+        ...runtime.prepared,
+        status: "ready",
+        completedAt: new Date().toISOString(),
+        firstKeptEntryId: generated.result.firstKeptEntryId,
+        summary: generated.result.summary,
+        tokensBeforeAtPrepare: generated.result.tokensBefore,
+        summaryModel: generated.summaryModel,
+        details: generated.result.details,
+      };
+      notify(ctx, policy, "Compaction worker prepared a summary for the next threshold.");
+    } catch (error) {
+      if (abort.signal.aborted) return;
+      const message = error instanceof Error ? error.message : String(error);
+      if (runtime.prepared?.jobId === jobId) {
+        runtime.prepared = {
+          ...runtime.prepared,
+          status: "failed",
+          completedAt: new Date().toISOString(),
+          failure: message,
+        };
+      }
+      notify(ctx, policy, `Compaction worker prepare failed: ${message}`, "warning");
+    } finally {
+      if (runtime.prepared?.jobId === jobId) {
+        runtime.inFlight = undefined;
+        updateStatus(ctx, policy, runtime);
+      }
+    }
+  })();
+}
+
+function triggerCompaction(
+  ctx: CompatibleContext,
+  policy: EffectivePolicy,
+  runtime: WorkerRuntime,
+  reason: string,
+): void {
+  runtime.inFlight = "compact";
+  updateStatus(ctx, policy, runtime);
+  notify(ctx, policy, `Compaction worker triggering compaction (${reason}).`);
+  ctx.compact({
+    customInstructions: CUSTOM_INSTRUCTIONS,
+    onComplete: () => {
+      runtime.inFlight = undefined;
+      runtime.lastCompactAtMs = Date.now();
+      runtime.prepared = undefined;
+      updateStatus(ctx, policy, runtime);
+    },
+    onError: (error) => {
+      runtime.inFlight = undefined;
+      notify(ctx, policy, `Compaction worker trigger failed: ${error.message}`, "error");
+      updateStatus(ctx, policy, runtime);
+    },
+  });
+}
+
+function buildDetails(
+  policy: EffectivePolicy,
+  mode: "prepared" | "live",
+  summaryModel: string | undefined,
+  details: unknown,
+): Record<string, unknown> {
+  const fileLists = extractFileListDetails(details);
+  return {
+    kind: "compaction-worker",
+    mode,
+    modelKey: policy.modelKey,
+    matchedProfile: policy.matchedProfile,
+    policyHash: policy.policyHash,
+    prepareAtTokens: policy.prepareAtTokens,
+    triggerAtTokens: policy.triggerAtTokens,
+    keepRecentTokens: policy.keepRecentTokens,
+    reserveTokens: policy.reserveTokens,
+    summaryModel,
+    generatedAt: new Date().toISOString(),
+    readFiles: fileLists.readFiles,
+    modifiedFiles: fileLists.modifiedFiles,
+    details,
+  };
+}
+
+export default function compactionWorkerExtension(pi: ExtensionAPI) {
+  const runtime: WorkerRuntime = {};
+
+  function loadPolicy(ctx: CompatibleContext): EffectivePolicy {
+    return resolveEffectivePolicy(loadConfig({ cwd: ctx.cwd }), ctx.model, ctx.getContextUsage());
+  }
+
+  pi.registerCommand("compaction-worker-status", {
+    description: "Show compaction worker policy and prepared-summary status",
+    handler: async (_args, rawCtx) => {
+      const ctx = asContext(rawCtx);
+      const policy = loadPolicy(ctx);
+      const lines = [
+        "Compaction worker",
+        `enabled: ${policy.enabled ? "yes" : "no"}`,
+        `source: ${policy.sourcePath ?? "defaults"}`,
+        `model: ${policy.modelKey}`,
+        `profile: ${policy.matchedProfile ?? "default"}`,
+        `prepareAt: ${policy.prepareAtTokens?.toLocaleString() ?? "not configured"}`,
+        `triggerAt: ${policy.triggerAtTokens?.toLocaleString() ?? "not available"}`,
+        `keepRecentTokens: ${policy.keepRecentTokens.toLocaleString()}`,
+        `summaryModels: ${policy.summaryModels.join(", ")}`,
+        `state: ${runtime.inFlight ?? runtime.prepared?.status ?? "idle"}`,
+        runtime.prepared?.firstKeptEntryId
+          ? `prepared.firstKeptEntryId: ${runtime.prepared.firstKeptEntryId}`
+          : undefined,
+        runtime.prepared?.failure ? `prepared.failure: ${runtime.prepared.failure}` : undefined,
+      ].filter((line): line is string => line !== undefined);
+      ctx.ui.notify(lines.join("\n"));
+    },
+  });
+
+  pi.on("agent_end", async (_event, rawCtx) => {
+    const ctx = asContext(rawCtx);
+    const policy = loadPolicy(ctx);
+    updateStatus(ctx, policy, runtime);
+
+    const decision = decideRuntimeAction({
+      usage: ctx.getContextUsage(),
+      policy,
+      prepared: runtime.prepared,
+      inFlight: runtime.inFlight !== undefined,
+      nowMs: Date.now(),
+      lastCompactAtMs: runtime.lastCompactAtMs,
+    });
+
+    if (decision.action === "prepare") {
+      startPrepareJob(ctx, policy, runtime);
+      return;
+    }
+    if (decision.action === "compact") {
+      triggerCompaction(ctx, policy, runtime, decision.reason);
+    }
+  });
+
+  pi.on("session_before_compact", async (event, rawCtx) => {
+    const ctx = asContext(rawCtx);
+    const policy = loadPolicy(ctx);
+    if (!policy.enabled) return undefined;
+
+    runtime.inFlight = "session_before_compact";
+    updateStatus(ctx, policy, runtime);
+
+    const validation = validatePreparedRecord(runtime.prepared, {
+      identity: sessionIdentity(ctx),
+      policy,
+      branchEntries: event.branchEntries,
+      nowMs: Date.now(),
+    });
+
+    const hasExternalInstructions = isExternalCustomInstructions(event.customInstructions);
+
+    if (
+      !hasExternalInstructions &&
+      validation.ok &&
+      runtime.prepared?.summary &&
+      runtime.prepared.firstKeptEntryId
+    ) {
+      const prepared = runtime.prepared;
+      prepared.status = "used";
+      return {
+        compaction: {
+          summary: prepared.summary,
+          firstKeptEntryId: prepared.firstKeptEntryId,
+          tokensBefore: event.preparation.tokensBefore,
+          details: buildDetails(policy, "prepared", prepared.summaryModel, prepared.details),
+        },
+      };
+    }
+
+    if (hasExternalInstructions && runtime.prepared?.status === "ready") {
+      notify(
+        ctx,
+        policy,
+        "Prepared compaction summary bypassed because this compaction supplied custom instructions; generating a live summary.",
+        "info",
+      );
+    } else if (!validation.ok && runtime.prepared?.status === "ready") {
+      runtime.prepared.status = "stale";
+      runtime.prepared.invalidationReason = validation.reason;
+      notify(
+        ctx,
+        policy,
+        `Prepared compaction summary is stale (${validation.reason}); generating a live summary.`,
+        "warning",
+      );
+    }
+
+    try {
+      const preparation = prepareWithPolicy(event.branchEntries, event.preparation, policy);
+      if (!preparation) return undefined;
+      const generated = await runCompactionSummary(
+        preparation,
+        ctx,
+        policy,
+        event.signal,
+        event.customInstructions,
+      );
+      if (!generated) return undefined;
+      return {
+        compaction: {
+          summary: generated.result.summary,
+          firstKeptEntryId: generated.result.firstKeptEntryId,
+          tokensBefore: generated.result.tokensBefore,
+          details: buildDetails(policy, "live", generated.summaryModel, generated.result.details),
+        },
+      };
+    } catch (error) {
+      if (!event.signal.aborted) {
+        const message = error instanceof Error ? error.message : String(error);
+        notify(
+          ctx,
+          policy,
+          `Compaction worker live summary failed: ${message}. Falling back to Pi default compaction.`,
+          "error",
+        );
+      }
+      return undefined;
+    }
+  });
+
+  pi.on("session_compact", async (_event, rawCtx) => {
+    const ctx = asContext(rawCtx);
+    const policy = loadPolicy(ctx);
+    runtime.inFlight = undefined;
+    runtime.lastCompactAtMs = Date.now();
+    runtime.prepared = undefined;
+    updateStatus(ctx, policy, runtime);
+  });
+
+  pi.on("session_start", async (_event, rawCtx) => {
+    const ctx = asContext(rawCtx);
+    runtime.activeAbort?.abort();
+    runtime.activeAbort = undefined;
+    runtime.inFlight = undefined;
+    runtime.prepared = undefined;
+    updateStatus(ctx, loadPolicy(ctx), runtime);
+  });
+
+  pi.on("session_tree", async (_event, rawCtx) => {
+    const ctx = asContext(rawCtx);
+    runtime.activeAbort?.abort();
+    runtime.activeAbort = undefined;
+    runtime.inFlight = undefined;
+    runtime.prepared = undefined;
+    updateStatus(ctx, loadPolicy(ctx), runtime);
+  });
+
+  pi.on("session_shutdown", async (_event, rawCtx) => {
+    const ctx = asContext(rawCtx);
+    runtime.activeAbort?.abort();
+    runtime.activeAbort = undefined;
+    runtime.inFlight = undefined;
+    runtime.prepared = undefined;
+    ctx.ui.setStatus(STATUS_ID, undefined);
+  });
+}

--- a/compaction-worker/index.ts
+++ b/compaction-worker/index.ts
@@ -481,6 +481,7 @@ export default function compactionWorkerExtension(pi: ExtensionAPI) {
     runtime.activeAbort = undefined;
     runtime.inFlight = undefined;
     runtime.prepared = undefined;
+    runtime.lastCompactAtMs = undefined;
     updateStatus(ctx, loadPolicy(ctx), runtime);
   });
 
@@ -490,6 +491,7 @@ export default function compactionWorkerExtension(pi: ExtensionAPI) {
     runtime.activeAbort = undefined;
     runtime.inFlight = undefined;
     runtime.prepared = undefined;
+    runtime.lastCompactAtMs = undefined;
     updateStatus(ctx, loadPolicy(ctx), runtime);
   });
 

--- a/compaction-worker/index.ts
+++ b/compaction-worker/index.ts
@@ -1,7 +1,6 @@
 import {
   compact as generateCompaction,
   type CompactionResult,
-  type CompactionSettings,
   type ExtensionAPI,
   type ExtensionContext,
   type SessionBeforeCompactEvent,
@@ -34,7 +33,10 @@ interface AuthResult {
   error?: string;
 }
 
-type SummaryModel = unknown;
+type SummaryModel = Parameters<typeof generateCompaction>[1];
+type HookCompactionSettings = SessionBeforeCompactEvent["preparation"]["settings"];
+type SessionBeforeCompactResult = { cancel?: boolean; compaction?: CompactionResult };
+type NotificationLevel = "info" | "warning" | "error";
 
 interface CompatibleModelRegistry {
   find(provider: string, id: string): SummaryModel | undefined;
@@ -49,7 +51,13 @@ interface CompatibleSessionManager {
   getSessionFile(): string | undefined;
 }
 
-interface CompatibleContext extends ExtensionContext {
+interface CompatibleContext {
+  cwd: string;
+  hasUI: boolean;
+  ui: {
+    notify(message: string, level?: NotificationLevel): void;
+    setStatus(id: string, value?: string): void;
+  };
   model?: ModelLike;
   modelRegistry: CompatibleModelRegistry;
   sessionManager: CompatibleSessionManager;
@@ -77,7 +85,7 @@ interface ResolvedSummaryModel {
 }
 
 function asContext(ctx: ExtensionContext): CompatibleContext {
-  return ctx as CompatibleContext;
+  return ctx as unknown as CompatibleContext;
 }
 
 function sessionIdentity(ctx: CompatibleContext): SessionIdentity {
@@ -88,7 +96,7 @@ function sessionIdentity(ctx: CompatibleContext): SessionIdentity {
   };
 }
 
-function compactionSettings(policy: EffectivePolicy): CompactionSettings {
+function compactionSettings(policy: EffectivePolicy): HookCompactionSettings {
   return {
     enabled: true,
     reserveTokens: policy.reserveTokens,
@@ -100,7 +108,7 @@ function notify(
   ctx: CompatibleContext,
   policy: EffectivePolicy,
   message: string,
-  level: string = "info",
+  level: NotificationLevel = "info",
 ): void {
   if (policy.quiet || !ctx.hasUI) return;
   ctx.ui.notify(message, level);
@@ -128,6 +136,17 @@ function updateStatus(
   if (next === runtime.lastStatus) return;
   runtime.lastStatus = next;
   ctx.ui.setStatus(STATUS_ID, next);
+}
+
+function finishSessionBeforeCompact(
+  ctx: CompatibleContext,
+  policy: EffectivePolicy,
+  runtime: WorkerRuntime,
+  previousInFlight: WorkerRuntime["inFlight"],
+): void {
+  if (runtime.inFlight !== "session_before_compact") return;
+  runtime.inFlight = previousInFlight;
+  updateStatus(ctx, policy, runtime);
 }
 
 async function resolveSummaryModel(
@@ -380,89 +399,105 @@ export default function compactionWorkerExtension(pi: ExtensionAPI) {
     }
   });
 
-  pi.on("session_before_compact", async (event, rawCtx) => {
+  const onSessionBeforeCompact = pi.on as unknown as (
+    event: "session_before_compact",
+    handler: (
+      event: SessionBeforeCompactEvent,
+      ctx: ExtensionContext,
+    ) => Promise<SessionBeforeCompactResult | undefined>,
+  ) => void;
+
+  onSessionBeforeCompact("session_before_compact", async (event, rawCtx) => {
     const ctx = asContext(rawCtx);
     const policy = loadPolicy(ctx);
     if (!policy.enabled) return undefined;
 
+    const previousInFlight = runtime.inFlight;
     runtime.inFlight = "session_before_compact";
     updateStatus(ctx, policy, runtime);
 
-    const validation = validatePreparedRecord(runtime.prepared, {
-      identity: sessionIdentity(ctx),
-      policy,
-      branchEntries: event.branchEntries,
-      nowMs: Date.now(),
-    });
-
-    const hasExternalInstructions = isExternalCustomInstructions(event.customInstructions);
-
-    if (
-      !hasExternalInstructions &&
-      validation.ok &&
-      runtime.prepared?.summary &&
-      runtime.prepared.firstKeptEntryId
-    ) {
-      const prepared = runtime.prepared;
-      prepared.status = "used";
-      return {
-        compaction: {
-          summary: prepared.summary,
-          firstKeptEntryId: prepared.firstKeptEntryId,
-          tokensBefore: event.preparation.tokensBefore,
-          details: buildDetails(policy, "prepared", prepared.summaryModel, prepared.details),
-        },
-      };
-    }
-
-    if (hasExternalInstructions && runtime.prepared?.status === "ready") {
-      notify(
-        ctx,
-        policy,
-        "Prepared compaction summary bypassed because this compaction supplied custom instructions; generating a live summary.",
-        "info",
-      );
-    } else if (!validation.ok && runtime.prepared?.status === "ready") {
-      runtime.prepared.status = "stale";
-      runtime.prepared.invalidationReason = validation.reason;
-      notify(
-        ctx,
-        policy,
-        `Prepared compaction summary is stale (${validation.reason}); generating a live summary.`,
-        "warning",
-      );
-    }
-
     try {
-      const preparation = prepareWithPolicy(event.branchEntries, event.preparation, policy);
-      if (!preparation) return undefined;
-      const generated = await runCompactionSummary(
-        preparation,
-        ctx,
+      const validation = validatePreparedRecord(runtime.prepared, {
+        identity: sessionIdentity(ctx),
         policy,
-        event.signal,
-        event.customInstructions,
-      );
-      if (!generated) return undefined;
-      return {
-        compaction: {
-          summary: generated.result.summary,
-          firstKeptEntryId: generated.result.firstKeptEntryId,
-          tokensBefore: generated.result.tokensBefore,
-          details: buildDetails(policy, "live", generated.summaryModel, generated.result.details),
-        },
-      };
-    } catch (error) {
-      if (!event.signal.aborted) {
-        const message = error instanceof Error ? error.message : String(error);
+        branchEntries: event.branchEntries,
+        nowMs: Date.now(),
+      });
+
+      const hasExternalInstructions = isExternalCustomInstructions(event.customInstructions);
+
+      if (
+        !hasExternalInstructions &&
+        validation.ok &&
+        runtime.prepared?.summary &&
+        runtime.prepared.firstKeptEntryId
+      ) {
+        const prepared = runtime.prepared;
+        const summary = prepared.summary;
+        const firstKeptEntryId = prepared.firstKeptEntryId;
+        if (!summary || !firstKeptEntryId) return undefined;
+        prepared.status = "used";
+        return {
+          compaction: {
+            summary,
+            firstKeptEntryId,
+            tokensBefore: event.preparation.tokensBefore,
+            details: buildDetails(policy, "prepared", prepared.summaryModel, prepared.details),
+          },
+        };
+      }
+
+      if (hasExternalInstructions && runtime.prepared?.status === "ready") {
         notify(
           ctx,
           policy,
-          `Compaction worker live summary failed: ${message}. Falling back to Pi default compaction.`,
-          "error",
+          "Prepared compaction summary bypassed because this compaction supplied custom instructions; generating a live summary.",
+          "info",
+        );
+      } else if (!validation.ok && runtime.prepared?.status === "ready") {
+        runtime.prepared.status = "stale";
+        runtime.prepared.invalidationReason = validation.reason;
+        notify(
+          ctx,
+          policy,
+          `Prepared compaction summary is stale (${validation.reason}); generating a live summary.`,
+          "warning",
         );
       }
-      return undefined;
+
+      try {
+        const preparation = prepareWithPolicy(event.branchEntries, event.preparation, policy);
+        if (!preparation) return undefined;
+        const generated = await runCompactionSummary(
+          preparation,
+          ctx,
+          policy,
+          event.signal,
+          event.customInstructions,
+        );
+        if (!generated) return undefined;
+        return {
+          compaction: {
+            summary: generated.result.summary,
+            firstKeptEntryId: generated.result.firstKeptEntryId,
+            tokensBefore: generated.result.tokensBefore,
+            details: buildDetails(policy, "live", generated.summaryModel, generated.result.details),
+          },
+        };
+      } catch (error) {
+        if (!event.signal.aborted) {
+          const message = error instanceof Error ? error.message : String(error);
+          notify(
+            ctx,
+            policy,
+            `Compaction worker live summary failed: ${message}. Falling back to Pi default compaction.`,
+            "error",
+          );
+        }
+        return undefined;
+      }
+    } finally {
+      finishSessionBeforeCompact(ctx, policy, runtime, previousInFlight);
     }
   });
 

--- a/compaction-worker/package.json
+++ b/compaction-worker/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@gugu910/pi-compaction-worker",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Opt-in Pi extension for model-aware custom compaction with prepare/commit thresholds",
+  "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gugu91/extensions.git",
+    "directory": "compaction-worker"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "dist/"
+  ],
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "scripts": {
+    "build": "node ../scripts/build-package.mjs",
+    "prepack": "pnpm run build",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {}
+}

--- a/compaction-worker/package.json
+++ b/compaction-worker/package.json
@@ -38,5 +38,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.65.2"
+  }
 }

--- a/compaction-worker/retention.ts
+++ b/compaction-worker/retention.ts
@@ -1,0 +1,148 @@
+import {
+  buildSessionContext,
+  findCutPoint,
+  type CompactionPreparation,
+  type CompactionSettings,
+  type FileOperations,
+  type SessionEntry,
+} from "@mariozechner/pi-coding-agent";
+import { extractFileListDetails } from "./helpers.js";
+
+export function buildPreparationFromBranch(
+  branchEntries: SessionEntry[],
+  settings: CompactionSettings,
+  tokensBefore: number = 0,
+): CompactionPreparation | undefined {
+  if (branchEntries.length === 0) return undefined;
+  if (branchEntries[branchEntries.length - 1]?.type === "compaction") return undefined;
+
+  const prevCompactionIndex = findPreviousCompactionIndex(branchEntries);
+  const previousCompaction =
+    prevCompactionIndex >= 0 ? branchEntries[prevCompactionIndex] : undefined;
+  const previousSummary =
+    previousCompaction?.type === "compaction"
+      ? getStringProperty(previousCompaction, "summary")
+      : undefined;
+  let boundaryStart = 0;
+
+  if (previousCompaction?.type === "compaction") {
+    const firstKeptEntryId = getStringProperty(previousCompaction, "firstKeptEntryId");
+    const firstKeptEntryIndex = firstKeptEntryId
+      ? branchEntries.findIndex((entry) => entry.id === firstKeptEntryId)
+      : -1;
+    boundaryStart = firstKeptEntryIndex >= 0 ? firstKeptEntryIndex : prevCompactionIndex + 1;
+  }
+
+  const cutPoint = findCutPoint(
+    branchEntries,
+    boundaryStart,
+    branchEntries.length,
+    settings.keepRecentTokens,
+  );
+  const firstKeptEntry = branchEntries[cutPoint.firstKeptEntryIndex];
+  const firstKeptEntryId = typeof firstKeptEntry?.id === "string" ? firstKeptEntry.id : undefined;
+  if (!firstKeptEntryId) return undefined;
+
+  const historyEnd = cutPoint.isSplitTurn ? cutPoint.turnStartIndex : cutPoint.firstKeptEntryIndex;
+  if (historyEnd < boundaryStart) return undefined;
+
+  const messagesToSummarize = collectMessagesFromRange(branchEntries, boundaryStart, historyEnd);
+  const turnPrefixMessages = cutPoint.isSplitTurn
+    ? collectMessagesFromRange(branchEntries, cutPoint.turnStartIndex, cutPoint.firstKeptEntryIndex)
+    : [];
+
+  return {
+    firstKeptEntryId,
+    messagesToSummarize,
+    turnPrefixMessages,
+    isSplitTurn: cutPoint.isSplitTurn,
+    tokensBefore,
+    previousSummary,
+    fileOps: buildFileOperations(
+      messagesToSummarize,
+      turnPrefixMessages,
+      branchEntries,
+      prevCompactionIndex,
+    ),
+    settings,
+  };
+}
+
+function findPreviousCompactionIndex(entries: SessionEntry[]): number {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (entries[index]?.type === "compaction") return index;
+  }
+  return -1;
+}
+
+function collectMessagesFromRange(
+  entries: SessionEntry[],
+  start: number,
+  end: number,
+): CompactionPreparation["messagesToSummarize"] {
+  if (start < 0 || end <= start) return [];
+  return buildSessionContext(entries.slice(start, end)).messages;
+}
+
+function buildFileOperations(
+  messagesToSummarize: CompactionPreparation["messagesToSummarize"],
+  turnPrefixMessages: CompactionPreparation["turnPrefixMessages"],
+  entries: SessionEntry[],
+  prevCompactionIndex: number,
+): FileOperations {
+  const fileOps: FileOperations = {
+    read: new Set<string>(),
+    written: new Set<string>(),
+    edited: new Set<string>(),
+  };
+
+  if (prevCompactionIndex >= 0) {
+    const previousCompaction = entries[prevCompactionIndex];
+    const details =
+      previousCompaction?.type === "compaction"
+        ? getRecordProperty(previousCompaction, "details")
+        : undefined;
+    const fileLists = extractFileListDetails(details);
+    for (const path of fileLists.readFiles) fileOps.read.add(path);
+    for (const path of fileLists.modifiedFiles) fileOps.edited.add(path);
+  }
+
+  for (const message of messagesToSummarize) extractFileOpsFromMessage(message, fileOps);
+  for (const message of turnPrefixMessages) extractFileOpsFromMessage(message, fileOps);
+
+  return fileOps;
+}
+
+function extractFileOpsFromMessage(message: unknown, fileOps: FileOperations): void {
+  if (!message || typeof message !== "object") return;
+  const role = "role" in message ? message.role : undefined;
+  if (role !== "assistant") return;
+  const content = "content" in message ? message.content : undefined;
+  if (!Array.isArray(content)) return;
+
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const type = "type" in block ? block.type : undefined;
+    if (type !== "toolCall") continue;
+    const args = "arguments" in block ? block.arguments : undefined;
+    if (!args || typeof args !== "object") continue;
+    const path = "path" in args && typeof args.path === "string" ? args.path : undefined;
+    if (!path) continue;
+    const name = "name" in block ? block.name : undefined;
+    if (name === "read") fileOps.read.add(path);
+    if (name === "write") fileOps.written.add(path);
+    if (name === "edit") fileOps.edited.add(path);
+  }
+}
+
+function getStringProperty(value: SessionEntry, key: string): string | undefined {
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === "string" ? raw : undefined;
+}
+
+function getRecordProperty(value: SessionEntry, key: string): Record<string, unknown> | undefined {
+  const raw = (value as Record<string, unknown>)[key];
+  return raw && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : undefined;
+}

--- a/compaction-worker/retention.ts
+++ b/compaction-worker/retention.ts
@@ -1,12 +1,14 @@
 import {
   buildSessionContext,
   findCutPoint,
-  type CompactionPreparation,
-  type CompactionSettings,
   type FileOperations,
+  type SessionBeforeCompactEvent,
   type SessionEntry,
 } from "@mariozechner/pi-coding-agent";
 import { extractFileListDetails } from "./helpers.js";
+
+type CompactionPreparation = SessionBeforeCompactEvent["preparation"];
+type CompactionSettings = CompactionPreparation["settings"];
 
 export function buildPreparationFromBranch(
   branchEntries: SessionEntry[],
@@ -136,12 +138,12 @@ function extractFileOpsFromMessage(message: unknown, fileOps: FileOperations): v
 }
 
 function getStringProperty(value: SessionEntry, key: string): string | undefined {
-  const raw = (value as Record<string, unknown>)[key];
+  const raw = (value as unknown as Record<string, unknown>)[key];
   return typeof raw === "string" ? raw : undefined;
 }
 
 function getRecordProperty(value: SessionEntry, key: string): Record<string, unknown> | undefined {
-  const raw = (value as Record<string, unknown>)[key];
+  const raw = (value as unknown as Record<string, unknown>)[key];
   return raw && typeof raw === "object" && !Array.isArray(raw)
     ? (raw as Record<string, unknown>)
     : undefined;

--- a/compaction-worker/tsconfig.json
+++ b/compaction-worker/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["**/*.ts", "../types/**/*.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  compaction-worker: {}
+
   imessage-bridge:
     dependencies:
       "@gugu910/pi-transport-core":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,11 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
-  compaction-worker: {}
+  compaction-worker:
+    devDependencies:
+      "@mariozechner/pi-coding-agent":
+        specifier: ^0.65.2
+        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
 
   imessage-bridge:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,18 @@ importers:
   transport-core: {}
 
 packages:
+  "@anthropic-ai/sdk@0.73.0":
+    resolution:
+      {
+        integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==,
+      }
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   "@anthropic-ai/sdk@0.91.1":
     resolution:
       {
@@ -669,6 +681,53 @@ packages:
         integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==,
       }
     engines: { node: ">= 10" }
+
+  "@mariozechner/jiti@2.6.5":
+    resolution:
+      {
+        integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==,
+      }
+    hasBin: true
+
+  "@mariozechner/pi-agent-core@0.65.2":
+    resolution:
+      {
+        integrity: sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: please use @earendil-works/pi-agent-core instead going forward
+
+  "@mariozechner/pi-ai@0.65.2":
+    resolution:
+      {
+        integrity: sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: please use @earendil-works/pi-ai instead going forward
+    hasBin: true
+
+  "@mariozechner/pi-coding-agent@0.65.2":
+    resolution:
+      {
+        integrity: sha512-/rpFzPQ+CishxrSwJHSSRZBQHHWy2K3Rbu/iV0HcMq/hl9cSI2ygpwjVTRbPW+NuP1tHxVV3AMxz69VLAs5Ztg==,
+      }
+    engines: { node: ">=20.6.0" }
+    deprecated: please use @earendil-works/pi-coding-agent instead going forward
+    hasBin: true
+
+  "@mariozechner/pi-tui@0.65.2":
+    resolution:
+      {
+        integrity: sha512-LBPbIBASjCF4QLrc/dwmPdBzVMsbkDhzmBIAFgglX5rZBnGRppB7ekSA+1kb5pdxDpDn8IbxJX+bl7ZaeqZqxw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: please use @earendil-works/pi-tui instead going forward
+
+  "@mistralai/mistralai@1.14.1":
+    resolution:
+      {
+        integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==,
+      }
 
   "@mistralai/mistralai@2.2.1":
     resolution:
@@ -1542,10 +1601,27 @@ packages:
       }
     engines: { node: ">= 14" }
 
+  ajv-formats@3.0.1:
+    resolution:
+      {
+        integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==,
+      }
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution:
       {
         integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+      }
+
+  ajv@8.20.0:
+    resolution:
+      {
+        integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
   ansi-escapes@7.3.0:
@@ -2100,6 +2176,12 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
+  fast-uri@3.1.2:
+    resolution:
+      {
+        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+      }
+
   fast-xml-builder@1.1.5:
     resolution:
       {
@@ -2533,6 +2615,12 @@ packages:
     resolution:
       {
         integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
+
+  json-schema-traverse@1.0.0:
+    resolution:
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
       }
 
   json-stable-stringify-without-jsonify@1.0.1:
@@ -3179,6 +3267,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  require-from-string@2.0.2:
+    resolution:
+      {
+        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+      }
+    engines: { node: ">=0.10.0" }
+
   resolve-from@4.0.0:
     resolution:
       {
@@ -3314,6 +3409,12 @@ packages:
     resolution:
       {
         integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
+
+  std-env@3.10.0:
+    resolution:
+      {
+        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
       }
 
   std-env@4.0.0:
@@ -3728,6 +3829,13 @@ packages:
       }
     engines: { node: ">=10" }
 
+  yoctocolors@2.1.2:
+    resolution:
+      {
+        integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
+      }
+    engines: { node: ">=18" }
+
   zod-to-json-schema@3.25.2:
     resolution:
       {
@@ -3743,6 +3851,12 @@ packages:
       }
 
 snapshots:
+  "@anthropic-ai/sdk@0.73.0(zod@4.3.6)":
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
   "@anthropic-ai/sdk@0.91.1(zod@4.3.6)":
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -4370,6 +4484,99 @@ snapshots:
       "@mariozechner/clipboard-win32-x64-msvc": 0.3.2
     optional: true
 
+  "@mariozechner/jiti@2.6.5":
+    dependencies:
+      std-env: 3.10.0
+      yoctocolors: 2.1.2
+
+  "@mariozechner/pi-agent-core@0.65.2(ws@8.20.0)(zod@4.3.6)":
+    dependencies:
+      "@mariozechner/pi-ai": 0.65.2(ws@8.20.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - "@modelcontextprotocol/sdk"
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  "@mariozechner/pi-ai@0.65.2(ws@8.20.0)(zod@4.3.6)":
+    dependencies:
+      "@anthropic-ai/sdk": 0.73.0(zod@4.3.6)
+      "@aws-sdk/client-bedrock-runtime": 3.1034.0
+      "@google/genai": 1.50.1
+      "@mistralai/mistralai": 1.14.1
+      "@sinclair/typebox": 0.34.49
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.25.0
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - "@modelcontextprotocol/sdk"
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  "@mariozechner/pi-coding-agent@0.65.2(ws@8.20.0)(zod@4.3.6)":
+    dependencies:
+      "@mariozechner/jiti": 2.6.5
+      "@mariozechner/pi-agent-core": 0.65.2(ws@8.20.0)(zod@4.3.6)
+      "@mariozechner/pi-ai": 0.65.2(ws@8.20.0)(zod@4.3.6)
+      "@mariozechner/pi-tui": 0.65.2
+      "@silvia-odwyer/photon-node": 0.3.4
+      ajv: 8.20.0
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.4
+      extract-zip: 2.0.1
+      file-type: 21.3.4
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.1.2
+      undici: 7.25.0
+      yaml: 2.8.2
+    optionalDependencies:
+      "@mariozechner/clipboard": 0.3.5
+    transitivePeerDependencies:
+      - "@modelcontextprotocol/sdk"
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  "@mariozechner/pi-tui@0.65.2":
+    dependencies:
+      "@types/mime-types": 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.4.0
+      marked: 15.0.12
+      mime-types: 3.0.2
+    optionalDependencies:
+      koffi: 2.16.1
+
+  "@mistralai/mistralai@1.14.1":
+    dependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   "@mistralai/mistralai@2.2.1":
     dependencies:
       ws: 8.20.0
@@ -4990,12 +5197,23 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -5297,6 +5515,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.2: {}
+
   fast-xml-builder@1.1.5:
     dependencies:
       path-expression-matcher: 1.5.0
@@ -5539,6 +5759,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5890,6 +6112,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   restore-cursor@5.1.0:
@@ -5969,6 +6193,8 @@ snapshots:
     optional: true
 
   stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   std-env@4.0.0: {}
 
@@ -6182,6 +6408,8 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ packages:
   - nvim-bridge
   - neon-psql
   - openai-execution-shaping
+  - compaction-worker

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -73,6 +73,13 @@ const packageConfigs = {
     vendorDirs: [],
     importRewrites: [],
   },
+  "compaction-worker": {
+    excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
+    excludeFiles: new Set(),
+    excludePrefixes: [],
+    vendorDirs: [],
+    importRewrites: [],
+  },
 };
 
 const config = packageConfigs[packageName];

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -35,7 +35,29 @@ declare module "@earendil-works/pi-coding-agent" {
     getEntries(): SessionEntry[];
     getBranch(): SessionEntry[];
     getLeafId(): string | undefined;
+    getSessionId?(): string | undefined;
     getSessionFile(): string | undefined;
+  }
+
+  export interface ModelRegistry {
+    find(provider: string, id: string): any | undefined;
+    getApiKeyAndHeaders(model: any): Promise<{
+      ok: boolean;
+      apiKey?: string;
+      headers?: Record<string, string>;
+      error?: string;
+    }>;
+  }
+
+  export interface ContextUsage {
+    tokens: number;
+    contextWindow?: number;
+  }
+
+  export interface CompactOptions {
+    customInstructions?: string;
+    onComplete?: (result: CompactionResult) => void;
+    onError?: (error: Error) => void;
   }
 
   export interface ExtensionContext {
@@ -44,6 +66,10 @@ declare module "@earendil-works/pi-coding-agent" {
     isIdle?: () => boolean;
     ui: ExtensionUI;
     sessionManager: SessionManager;
+    model?: { provider?: string; id?: string; contextWindow?: number };
+    modelRegistry: ModelRegistry;
+    getContextUsage(): ContextUsage | undefined;
+    compact(options?: CompactOptions): void;
   }
 
   export interface ToolUpdate {
@@ -73,6 +99,78 @@ declare module "@earendil-works/pi-coding-agent" {
     description?: string;
     handler: (args: string, ctx: ExtensionContext) => Promise<void> | void;
   }
+
+  export interface CompactionSettings {
+    enabled: boolean;
+    reserveTokens: number;
+    keepRecentTokens: number;
+  }
+
+  export interface FileOperations {
+    read: Set<string>;
+    written: Set<string>;
+    edited: Set<string>;
+  }
+
+  export interface CompactionPreparation {
+    firstKeptEntryId: string;
+    messagesToSummarize: any[];
+    turnPrefixMessages: any[];
+    isSplitTurn: boolean;
+    tokensBefore: number;
+    previousSummary?: string;
+    fileOps: FileOperations;
+    settings: CompactionSettings;
+  }
+
+  export interface CompactionResult<T = unknown> {
+    summary: string;
+    firstKeptEntryId: string;
+    tokensBefore: number;
+    details?: T;
+  }
+
+  export interface SessionBeforeCompactEvent {
+    type: "session_before_compact";
+    preparation: CompactionPreparation;
+    branchEntries: SessionEntry[];
+    customInstructions?: string;
+    signal: AbortSignal;
+  }
+
+  export interface SessionContext {
+    messages: any[];
+    thinkingLevel?: string;
+    model?: { provider: string; modelId: string } | null;
+  }
+
+  export interface CutPointResult {
+    firstKeptEntryIndex: number;
+    turnStartIndex: number;
+    isSplitTurn: boolean;
+  }
+
+  export function buildSessionContext(
+    entries: SessionEntry[],
+    leafId?: string | null,
+  ): SessionContext;
+
+  export function findCutPoint(
+    entries: SessionEntry[],
+    startIndex: number,
+    endIndex: number,
+    keepRecentTokens: number,
+  ): CutPointResult;
+
+  export function compact(
+    preparation: CompactionPreparation,
+    model: any,
+    apiKey: string,
+    headers?: Record<string, string>,
+    customInstructions?: string,
+    signal?: AbortSignal,
+    thinkingLevel?: any,
+  ): Promise<CompactionResult>;
 
   export interface ExtensionAPI {
     on(event: string, handler: (event: any, ctx: ExtensionContext) => any): void;


### PR DESCRIPTION
## Summary
- add a new opt-in `@gugu910/pi-compaction-worker` Pi package for custom/model-aware compaction
- support exact/glob profile matching, prepare/trigger thresholds, side summary preparation, live custom fallback, stale prepared-summary validation, and `/compaction-worker-status`
- rebuild compaction preparation with exported Pi utilities (`findCutPoint`, `buildSessionContext`) so per-profile `keepRecentTokens` can control the kept boundary without private Pi imports

## Testing
- `pnpm prepush`
- `pnpm --filter @gugu910/pi-compaction-worker build`

Refs #595