### PR TITLE
fix(nvim-bridge): ignore stale PiComms indicator lines

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Install StyLua
         run: npm install --global @johnnymorganz/stylua-bin@2.0.2
 
+      - name: Install Neovim
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y neovim
+
       - name: Run quality checks
         run: pnpm check
 

--- a/nvim-bridge/nvim-lua.test.ts
+++ b/nvim-bridge/nvim-lua.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function hasNvim(): boolean {
+  const result = spawnSync("nvim", ["--version"], { encoding: "utf8" });
+  return result.status === 0;
+}
+
+describe("pi-nvim Lua integration", () => {
+  it.skipIf(!hasNvim())(
+    "ignores stale PiComms indicators past the end of a Markdown buffer",
+    () => {
+      const dir = mkdtempSync(path.join(tmpdir(), "pi-nvim-md-"));
+      const markdownPath = path.join(dir, "short.md");
+      writeFileSync(markdownPath, "# Short\n", "utf8");
+
+      const pluginRoot = path.join(__dirname, "nvim");
+      const fakeSocket =
+        "package.loaded['pi-nvim.socket'] = { " +
+        "request = function() return { comments = { { context = { " +
+        "file = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':.'), " +
+        "startLine = 99, endLine = 99 " +
+        "} } } }, nil end, " +
+        "on = function() return function() end end " +
+        "}";
+
+      try {
+        const result = spawnSync(
+          "nvim",
+          [
+            "--headless",
+            "--clean",
+            "-n",
+            markdownPath,
+            `+set rtp^=${pluginRoot}`,
+            `+lua ${fakeSocket}`,
+            "+lua require('pi-nvim.comments').setup()",
+            "+sleep 300m",
+            "+qa",
+          ],
+          { encoding: "utf8" },
+        );
+
+        expect(result.stderr).not.toContain("Invalid 'line': out of range");
+        expect(result.status).toBe(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/nvim-bridge/nvim/lua/pi-nvim/comments.lua
+++ b/nvim-bridge/nvim/lua/pi-nvim/comments.lua
@@ -443,9 +443,11 @@ local function apply_indicators_to_buffer(bufnr)
   end
   table.sort(line_numbers)
 
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+
   for _, line in ipairs(line_numbers) do
     local count = lines[line]
-    if type(count) == 'number' and count > 0 and line >= 1 then
+    if type(count) == 'number' and count > 0 and line >= 1 and line <= line_count then
       vim.api.nvim_buf_set_extmark(bufnr, indicator_ns, line - 1, 0, {
         virt_text = { { indicator_text(count), 'PiCommsIndicator' } },
         virt_text_pos = 'eol',


### PR DESCRIPTION
## Summary\n- skip PiComms indicator extmarks when saved comment context lines are past the current buffer length\n- add a headless Neovim regression test for opening a short Markdown buffer with stale indicator data\n\n## Validation\n- pnpm --filter @gugu910/pi-nvim-bridge lint\n- pnpm --filter @gugu910/pi-nvim-bridge typecheck\n- pnpm --filter @gugu910/pi-nvim-bridge test\n- pnpm format:check:lua\n- manual headless nvim repro before/after