### PR TITLE
fix(nvim): disable PiComms surface

### DIFF
--- a/.pi/skills/wipe-a2a-comments/SKILL.md
+++ b/.pi/skills/wipe-a2a-comments/SKILL.md
@@ -1,47 +1,34 @@
 ---
 name: wipe-a2a-comments
-description: Wipes all persistent PiComms comments for the current git repository. Use when the user asks to clear/reset/remove all comments.
+description: Deprecated legacy PiComms cleanup note. Use when a user asks to clear/reset/remove old PiComms comments and explain that nvim-bridge now has PiComms disabled.
 ---
 
-# Wipe PiComms Comments
+# Deprecated PiComms Cleanup
 
-Use this skill when the user wants to delete **all** stored PiComms comments in the current repository.
+PiComms is disabled in the active `nvim-bridge` environment. Do **not** call `comment_wipe_all`; that tool is no longer registered by `nvim-bridge`.
 
-## Preferred flow
+## Preferred response
 
-1. Verify the user intent is destructive and explicit.
-2. Call the `comment_wipe_all` tool.
-3. Report how many comments were removed.
-
-## Fallback (if the tool is unavailable)
-
-Run this repo-local reset command:
+1. Explain that Neovim currently syncs editor context only; durable coordination should use Pinet directly.
+2. Do not create or reinitialize `.pi/a2a/comments`.
+3. If the user explicitly wants legacy local artifacts deleted, remove only the legacy comments directory after confirming intent:
 
 ```bash
 bash -lc '
 set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 comments_dir="$repo_root/.pi/a2a/comments"
-removed=0
-if [ -d "$comments_dir/meta" ]; then
-  removed="$(find "$comments_dir/meta" -type f -name "*.json" | wc -l | tr -d " ")"
+if [ -d "$comments_dir" ]; then
+  rm -rf "$comments_dir"
+  echo "Removed legacy PiComms comments directory: $comments_dir"
+else
+  echo "No legacy PiComms comments directory found: $comments_dir"
 fi
-rm -rf "$comments_dir"
-mkdir -p "$comments_dir/items" "$comments_dir/meta"
-updated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-cat > "$comments_dir/index.json" <<EOF
-{
-  "version": 1,
-  "updatedAt": "$updated_at",
-  "comments": []
-}
-EOF
-echo "Wiped PiComms comments in repo: $repo_root"
-echo "Removed comments: $removed"
 '
 ```
 
 ## Notes
 
-- This wipe is **per git repository**.
-- This only affects `.pi/a2a/comments` in the current repo.
+- This is legacy cleanup only.
+- Do not use this as a coordination path; use Pinet lanes, inbox, and Slack/Pinet threads instead.
+- The fuller Neovim-to-Pinet adapter replacement is tracked in GitHub issue #714.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Pi extensions for Slack, Neovim, and Neon Postgres.
 ```
 extensions/
 ├── slack-bridge/    # Pinet — Slack assistant integration (workspace)
-├── nvim-bridge/     # Neovim bridge + PiComms comments (workspace)
+├── nvim-bridge/     # Neovim bridge; PiComms disabled pending Pinet adapter
 ├── neon-psql/       # Neon Postgres CLI (workspace)
 ├── types/           # Shared type declarations (workspace)
 ├── plans/           # Architecture docs
@@ -130,7 +130,7 @@ export default function (pi: ExtensionAPI) {
 ## Key architecture decisions
 
 - **Pinet (slack-bridge)**: Opt-in via `/pinet` command or `autoConnect: true` in settings
-- **PiComms**: SQLite-backed (`node:sqlite`), falls back to JSON files
+- **nvim PiComms**: Disabled in `nvim-bridge`; use Pinet directly while the replacement nvim adapter is tracked in #714
 - **Socket Mode**: Single WebSocket per Slack app token — only one pi session connects
 - **Turborepo**: Per-package lint/typecheck/test with local caching
 - **pnpm workspaces**: Each extension is an independent workspace package

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the [pi coding agent](https://github.com/nicholasgasior/pi-coding-agent).
 
 Current state: the repo has moved from the initial **50+ merged PRs in a
 single day** sprint into a broader Pinet stabilization and docs pass, with a
-broker/follower Slack mesh, persistent PiComms, Slack canvases, scheduled
+broker/follower Slack mesh, durable Pinet lanes/inbox state, Slack canvases, scheduled
 wake-ups, worktree guardrails, checked-in Slack manifest deploy tooling,
 optional mesh auth, and a browser-playwright workspace package for
 interactive browsing and screenshots.
@@ -19,7 +19,7 @@ interactive browsing and screenshots.
 | [`slack-bridge`](slack-bridge/)             | Slack assistant app (Pinet) — broker mesh, inbox, canvases, deploy tooling      |
 | [`slack-api`](slack-api/)                   | Typed Slack Web API client + CLI generated from OpenAPI                         |
 | [`imessage-bridge`](imessage-bridge/)       | macOS/iMessage send-first transport package + readiness helpers                 |
-| [`nvim-bridge`](nvim-bridge/)               | Neovim editor context sync + PiComms persistent comments                        |
+| [`nvim-bridge`](nvim-bridge/)               | Neovim editor context sync; PiComms disabled pending Pinet adapter replacement  |
 | [`neon-psql`](neon-psql/)                   | Config-driven Neon tunnel + `psql` tool                                         |
 | [`types`](types/)                           | Shared ambient type declarations                                                |
 

--- a/nvim-bridge/README.md
+++ b/nvim-bridge/README.md
@@ -1,11 +1,13 @@
 # nvim-bridge
 
-Neovim ↔ pi bridge that sends active editor context (file, viewport, selection) into pi before each agent run, and supports persistent local PiComms comments.
+Neovim ↔ pi bridge that sends active editor context (file, viewport, selection) into pi before each agent run.
+
+PiComms is disabled in this environment while the replacement Pinet-native Neovim adapter is tracked separately in issue #714.
 
 ## How it works
 
-- A pi extension (`index.ts`) starts a Unix socket server.
-- A Neovim plugin (`nvim/**`) sends events to that socket.
+- A pi extension (`index.ts`) starts a same-host Unix socket server.
+- A Neovim plugin (`nvim/**`) sends editor events to that socket.
 - Before each agent run, pi injects context like:
   - current file
   - visible line range
@@ -20,7 +22,7 @@ Neovim ↔ pi bridge that sends active editor context (file, viewport, selection
 
 - The Unix socket under `/tmp/pi-nvim/<hash>.sock` assumes local trust between Neovim and the pi process on the same machine.
 - There is **no peer authentication handshake** on that socket today; the main boundary is host-local access plus the repo/branch-derived socket name.
-- The bridge now tightens the socket directory/socket permissions on a best-effort basis, but that is intentionally narrow hardening rather than a transport redesign.
+- The bridge tightens the socket directory/socket permissions on a best-effort basis, but that is intentionally narrow hardening rather than a transport redesign.
 
 Treat the socket as local editor-control access for the current host, not as a remote-safe transport.
 
@@ -64,8 +66,7 @@ After linking/configuring, restart both so socket + autocommands are initialized
 
 ### Keymaps
 
-This plugin does **not** define global keymaps by default.
-Define mappings in your Neovim config (e.g. lazy `keys` field).
+This plugin does **not** define global keymaps by default. Define mappings in your Neovim config (e.g. lazy `keys` field).
 
 ## Usage
 
@@ -75,46 +76,15 @@ Core bridge commands:
 - `:PiNvimDisable`
 - `:PiNvimStatus`
 
-PiComms commands (stored under `.pi/a2a/comments`):
+Disabled PiComms surface:
 
-- `:PiCommsOpen [thread]` — open the PiComms panel for the current context thread
-- `:PiCommsAdd [thread]` — open the same panel and focus the reply composer for the current context thread
-- `:PiCommsNext` — jump to the next PiComms thread in the current file
-- `:PiCommsClose` — close the PiComms panel
-- `:PiCommsRefresh [thread]` — refresh the open panel from pi
-- `:PiCommsRead` — trigger `/picomms:read`
-- `:PiCommsClean` — trigger `/picomms:clean`
+- no `.pi/a2a/comments` store is initialized by `nvim-bridge`
+- no `comment_add`, `comment_list`, or `comment_wipe_all` tools are registered
+- no `/picomms:*` commands are registered
+- no `:PiComms*` Neovim commands are registered
+- no PiComms panel or line indicators are initialized on startup
 
-Pi slash commands:
-
-- `/picomms:read` — load all repository comments and queue them as guidance for the agent
-- `/picomms:clean` — wipe all repository comments
-
-Inline composer controls:
-
-- panel opens in normal mode
-- `i` → jump into the reply composer and enter insert mode
-- `Enter` → submit comment
-- `Shift-Enter` → newline
-- `q` or `<C-w>q` (normal mode) → close panel
-
-Panel notes:
-
-- `:PiCommsOpen` is the primary entrypoint and resolves the current context thread
-- `:PiCommsAdd` opens the same thread view but focuses the composer area
-- `:PiCommsNext` jumps to the next thread anchor in the current file
-- the panel shows the current thread above and the reply box at the bottom
-- advanced actions stay available as commands: `:PiCommsRefresh`, `:PiCommsClose`, `:PiCommsRead`, `:PiCommsClean`
-
-Line indicators:
-
-- File lines with comment context show a stronger speech-bubble virtual text marker with a count (e.g. `1`, `3`)
-- Range comments mark the start line only
-- Uses virtual text, not sign column, to avoid conflicts with git gutter plugins
-
-Global wipe is also available via skill:
-
-- `/skill:wipe-a2a-comments`
+Use Pinet directly for durable coordination while the replacement Neovim adapter is designed.
 
 ## Development tooling
 

--- a/nvim-bridge/index.test.ts
+++ b/nvim-bridge/index.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { CommentRecord } from "./comments.js";
+import extension from "./index.js";
 import {
   buildPiCommsReadPrompt,
   formatContext,
@@ -32,6 +34,28 @@ function createComment(overrides: Partial<CommentRecord> = {}): CommentRecord {
     ...overrides,
   };
 }
+
+describe("nvim-bridge extension registration", () => {
+  it("registers only the editor bridge surface while PiComms is disabled", () => {
+    const tools: string[] = [];
+    const commands: string[] = [];
+    const events: string[] = [];
+    const pi = {
+      registerTool: vi.fn((definition: { name: string }) => tools.push(definition.name)),
+      registerCommand: vi.fn((name: string) => commands.push(name)),
+      on: vi.fn((name: string) => events.push(name)),
+    } as unknown as ExtensionAPI;
+
+    extension(pi);
+
+    expect(tools).toEqual(["open_in_editor"]);
+    expect(tools).not.toEqual(
+      expect.arrayContaining(["comment_add", "comment_list", "comment_wipe_all"]),
+    );
+    expect(commands).not.toEqual(expect.arrayContaining(["picomms:read", "picomms:clean"]));
+    expect(events).toEqual(["session_start", "before_agent_start", "session_shutdown"]);
+  });
+});
 
 describe("formatContext", () => {
   it("formats the current editor viewport, cursor, and selection", () => {

--- a/nvim-bridge/index.ts
+++ b/nvim-bridge/index.ts
@@ -5,22 +5,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import * as path from "node:path";
-import {
-  createCommentStore,
-  formatCommentPreview,
-  type ICommentStore,
-  type CommentRecord,
-} from "./comments.js";
-import {
-  buildPiCommsReadPrompt,
-  formatContext,
-  parseCommentRpcRequest,
-  parseNvimEvent,
-  toPositiveInteger,
-  type CommentRpcRequest,
-  type EditorState,
-  type NvimEvent,
-} from "./helpers.js";
+import { formatContext, parseNvimEvent, type EditorState, type NvimEvent } from "./helpers.js";
 
 type NvimCommand = { type: "open_file"; file: string; line?: number };
 
@@ -67,38 +52,10 @@ function computeSocketPath(repoInfo: RepoInfo): string {
   return path.join(dir, `${hash}.sock`);
 }
 
-function formatCommentListForTool(result: {
-  threadId: string;
-  total: number;
-  comments: CommentRecord[];
-}): string {
-  if (result.total === 0) {
-    return `No comments in thread "${result.threadId}".`;
-  }
-
-  let text = `Comments in thread "${result.threadId}" (${result.comments.length}/${result.total} shown):`;
-
-  for (const comment of result.comments) {
-    const actor = `${comment.actorType}:${comment.actorId}`;
-    const context = comment.context?.file
-      ? ` (${comment.context.file}` +
-        (comment.context.startLine != null && comment.context.endLine != null
-          ? `:${comment.context.startLine}-${comment.context.endLine}`
-          : "") +
-        ")"
-      : "";
-
-    text += `\n- [${comment.id}] ${actor} @ ${comment.createdAt}${context}\n  ${formatCommentPreview(comment)}`;
-  }
-
-  return text;
-}
-
 export default function (pi: ExtensionAPI) {
   let server: net.Server | null = null;
   let socketPath: string | null = null;
   let dirty = false;
-  let commentStore: ICommentStore | null = null;
   const clients: Set<net.Socket> = new Set();
 
   const editorState: EditorState = {
@@ -133,100 +90,17 @@ export default function (pi: ExtensionAPI) {
     return broadcast(cmd);
   }
 
-  function notifyThreadUpdated(threadId?: string): void {
-    if (!commentStore) return;
-
-    const summary = commentStore.getThreadSummary(threadId);
-    broadcast({
-      type: "comments.updated",
-      payload: {
-        threadId: summary.threadId,
-        total: summary.total,
-        latestId: summary.latestId,
-      },
-    });
-  }
-
-  function notifyAllCommentsWiped(removed: number): void {
-    broadcast({
-      type: "comments.wiped",
-      payload: {
-        removed,
-      },
-    });
-
-    // No threadId on purpose: clients should refresh whichever thread is open.
-    broadcast({
-      type: "comments.updated",
-      payload: {
-        total: 0,
-        latestId: null,
-      },
-    });
-  }
-
-  function notifyCommentUpdated(comment: CommentRecord): void {
-    broadcast({
-      type: "comment.added",
-      payload: { comment },
-    });
-    notifyThreadUpdated(comment.threadId);
-  }
-
-  async function runPiCommsRead(
-    source: "slash" | "panel",
-    options: { isIdle?: boolean } = {},
-  ): Promise<{
-    ok: boolean;
-    message: string;
-  }> {
-    if (!commentStore) {
-      return { ok: false, message: "Comment store is unavailable" };
-    }
-
-    const all = commentStore.listAllComments();
-    if (all.total === 0) {
-      return { ok: false, message: "No PiComms comments found in this repository." };
-    }
-
-    const read = buildPiCommsReadPrompt(editorState, all.comments, all.total);
-
+  function dispatchNvimPrompt(prompt: string): boolean {
     try {
-      if (options.isIdle === false) {
-        pi.sendUserMessage(read.prompt, { deliverAs: "followUp" });
-      } else {
-        pi.sendUserMessage(read.prompt);
+      pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+      return true;
+    } catch {
+      try {
+        pi.sendUserMessage(prompt, { deliverAs: "steer" });
+        return true;
+      } catch {
+        return false;
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to queue PiComms read";
-      return { ok: false, message };
-    }
-
-    const truncationSuffix = read.truncated ? " Prompt was truncated to fit context." : "";
-    return {
-      ok: true,
-      message: `Queued PiComms read from ${source} (${read.included}/${all.total} comments included).${truncationSuffix}`,
-    };
-  }
-
-  async function runPiCommsClean(source: "slash" | "panel" | "tool"): Promise<{
-    ok: boolean;
-    message: string;
-  }> {
-    if (!commentStore) {
-      return { ok: false, message: "Comment store is unavailable" };
-    }
-
-    try {
-      const result = await commentStore.wipeAllComments();
-      notifyAllCommentsWiped(result.removed);
-      return {
-        ok: true,
-        message: `PiComms clean from ${source}: removed ${result.removed} comments in this repository.`,
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to wipe comments";
-      return { ok: false, message };
     }
   }
 
@@ -238,6 +112,8 @@ export default function (pi: ExtensionAPI) {
         editorState.line = event.line;
 
         if (switchedFile) {
+          editorState.visibleStart = null;
+          editorState.visibleEnd = null;
           editorState.selectionStart = null;
           editorState.selectionEnd = null;
         }
@@ -262,78 +138,6 @@ export default function (pi: ExtensionAPI) {
 
       default:
         break;
-    }
-  }
-
-  async function handleCommentRequest(conn: net.Socket, request: CommentRpcRequest): Promise<void> {
-    if (!commentStore) {
-      sendJson(conn, {
-        type: "error",
-        id: request.id,
-        error: {
-          code: "comments_unavailable",
-          message: "Comment storage is not initialized",
-        },
-      });
-      return;
-    }
-
-    try {
-      if (request.type === "comment.list" || request.type === "comment.sync") {
-        const result = commentStore.listComments({
-          threadId: request.payload.threadId,
-          limit: request.payload.limit,
-        });
-
-        sendJson(conn, {
-          type: "ok",
-          id: request.id,
-          result,
-        });
-        return;
-      }
-
-      if (request.type === "comment.list_all") {
-        const result = commentStore.listAllComments({
-          limit: request.payload.limit,
-        });
-
-        sendJson(conn, {
-          type: "ok",
-          id: request.id,
-          result,
-        });
-        return;
-      }
-
-      if (request.type === "comment.add") {
-        const comment = await commentStore.addComment({
-          body: request.payload.body,
-          threadId: request.payload.threadId,
-          actorType: request.payload.actorType ?? "human",
-          actorId: request.payload.actorId,
-          context: request.payload.context,
-        });
-
-        sendJson(conn, {
-          type: "ok",
-          id: request.id,
-          result: { comment },
-        });
-
-        notifyCommentUpdated(comment);
-        return;
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown error";
-      sendJson(conn, {
-        type: "error",
-        id: request.id,
-        error: {
-          code: "comment_request_failed",
-          message,
-        },
-      });
     }
   }
 
@@ -366,147 +170,12 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
-  pi.registerTool({
-    name: "comment_add",
-    label: "Add Comment",
-    description: "Add a markdown PiComms comment in the current git repository",
-    parameters: Type.Object({
-      comment: Type.String({ description: "Markdown comment body" }),
-      thread_id: Type.Optional(Type.String({ description: "Thread id (default: global)" })),
-      actor_type: Type.Optional(
-        Type.String({ description: "Actor type (agent or human). Defaults to agent" }),
-      ),
-      actor_id: Type.Optional(
-        Type.String({
-          description:
-            "Actor identifier (default depends on actor type). Agents default to PI_NICKNAME@tmux or pi@tmux.",
-        }),
-      ),
-      file: Type.Optional(Type.String({ description: "Optional file path for context" })),
-      start_line: Type.Optional(Type.Number({ description: "Optional start line for context" })),
-      end_line: Type.Optional(Type.Number({ description: "Optional end line for context" })),
-    }),
-    async execute(_toolCallId, params) {
-      if (!commentStore) {
-        return {
-          content: [{ type: "text", text: "Comment store is unavailable" }],
-          isError: true,
-        };
-      }
-
-      const hasFile = typeof params.file === "string" && params.file.trim().length > 0;
-
-      try {
-        const comment = await commentStore.addComment({
-          body: params.comment,
-          threadId: params.thread_id,
-          actorType: params.actor_type ?? "agent",
-          actorId: params.actor_id,
-          context: hasFile
-            ? {
-                file: params.file,
-                startLine: toPositiveInteger(params.start_line) ?? undefined,
-                endLine: toPositiveInteger(params.end_line) ?? undefined,
-              }
-            : undefined,
-        });
-
-        notifyCommentUpdated(comment);
-
-        return {
-          content: [
-            { type: "text", text: `Added comment ${comment.id} to thread "${comment.threadId}".` },
-          ],
-          details: { comment },
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to add comment";
-        return {
-          content: [{ type: "text", text: message }],
-          isError: true,
-        };
-      }
-    },
-  });
-
-  pi.registerTool({
-    name: "comment_list",
-    label: "List Comments",
-    description: "List PiComms comments from the current git repository",
-    parameters: Type.Object({
-      thread_id: Type.Optional(Type.String({ description: "Thread id (default: global)" })),
-      limit: Type.Optional(
-        Type.Number({ description: "Maximum number of comments to return (default: 50)" }),
-      ),
-    }),
-    async execute(_toolCallId, params) {
-      if (!commentStore) {
-        return {
-          content: [{ type: "text", text: "Comment store is unavailable" }],
-          isError: true,
-        };
-      }
-
-      const limit = toPositiveInteger(params.limit) ?? 50;
-      const result = commentStore.listComments({
-        threadId: params.thread_id,
-        limit,
-      });
-
-      return {
-        content: [{ type: "text", text: formatCommentListForTool(result) }],
-        details: result,
-      };
-    },
-  });
-
-  pi.registerTool({
-    name: "comment_wipe_all",
-    label: "Wipe All Comments",
-    description: "Delete all persistent PiComms comments in the current git repository",
-    parameters: Type.Object({}),
-    async execute() {
-      const result = await runPiCommsClean("tool");
-      return {
-        content: [{ type: "text", text: result.message }],
-        isError: !result.ok,
-      };
-    },
-  });
-
-  pi.registerCommand("picomms:read", {
-    description: "Read all persistent PiComms comments and queue them for the agent",
-    handler: async (_args, ctx) => {
-      const result = await runPiCommsRead("slash", {
-        isIdle: typeof ctx.isIdle === "function" ? ctx.isIdle() : undefined,
-      });
-      ctx.ui.notify(result.message, result.ok ? "info" : "error");
-    },
-  });
-
-  pi.registerCommand("picomms:clean", {
-    description: "Wipe all persistent PiComms comments in this repository",
-    handler: async (_args, ctx) => {
-      const result = await runPiCommsClean("slash");
-      ctx.ui.notify(result.message, result.ok ? "info" : "error");
-    },
-  });
-
   pi.on("session_start", async (_event, ctx) => {
     const setBridgeStatus = (healthy: boolean) => {
       ctx.ui.setStatus("nvim-bridge", healthy ? "" : "");
     };
 
     const repoInfo = resolveRepoInfo(ctx.cwd);
-    const storageRoot = repoInfo?.repoRoot ?? ctx.cwd;
-
-    try {
-      commentStore = await createCommentStore(storageRoot);
-    } catch (error) {
-      commentStore = null;
-      const message = error instanceof Error ? error.message : "unknown error";
-      console.error(`[nvim-bridge] Failed to initialize comment store: ${message}`);
-    }
 
     if (!repoInfo) {
       socketPath = null;
@@ -516,7 +185,6 @@ export default function (pi: ExtensionAPI) {
 
     socketPath = computeSocketPath(repoInfo);
 
-    // Unlink stale socket if exists.
     try {
       fs.unlinkSync(socketPath);
     } catch {
@@ -542,30 +210,16 @@ export default function (pi: ExtensionAPI) {
 
           try {
             const parsed = JSON.parse(line) as unknown;
-            const request = parseCommentRpcRequest(parsed);
-            if (request) {
-              void handleCommentRequest(conn, request);
-              continue;
-            }
-
             const event = parseNvimEvent(parsed);
             if (!event) continue;
 
             if (event.type === "trigger_agent") {
-              try {
-                pi.sendUserMessage(event.prompt, { deliverAs: "followUp" });
-              } catch {
-                try {
-                  pi.sendUserMessage(event.prompt, { deliverAs: "steer" });
-                } catch {
-                  // Ignore dispatch failures.
-                }
-              }
+              dispatchNvimPrompt(event.prompt);
             } else {
               handleEvent(event);
             }
           } catch {
-            // Ignore malformed JSON
+            // Ignore malformed JSON.
           }
         }
       });
@@ -593,7 +247,6 @@ export default function (pi: ExtensionAPI) {
       if (activeSocketPath) {
         tightenSocketPermissions(activeSocketPath);
       }
-      // Socket is ready, waiting for nvim to connect.
       setBridgeStatus(false);
     });
   });
@@ -639,10 +292,6 @@ export default function (pi: ExtensionAPI) {
       socketPath = null;
     }
 
-    if (commentStore) {
-      commentStore.close();
-      commentStore = null;
-    }
     ctx.ui.setStatus("nvim-bridge", "");
   });
 }

--- a/nvim-bridge/nvim-lua.test.ts
+++ b/nvim-bridge/nvim-lua.test.ts
@@ -13,45 +13,47 @@ function hasNvim(): boolean {
 }
 
 describe("pi-nvim Lua integration", () => {
-  it.skipIf(!hasNvim())(
-    "ignores stale PiComms indicators past the end of a Markdown buffer",
-    () => {
-      const dir = mkdtempSync(path.join(tmpdir(), "pi-nvim-md-"));
-      const markdownPath = path.join(dir, "short.md");
-      writeFileSync(markdownPath, "# Short\n", "utf8");
+  it.skipIf(!hasNvim())("starts on Markdown files without registering PiComms commands", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "pi-nvim-disabled-"));
+    const markdownPath = path.join(dir, "short.md");
+    writeFileSync(markdownPath, "# Short\n", "utf8");
 
-      const pluginRoot = path.join(__dirname, "nvim");
-      const fakeSocket =
-        "package.loaded['pi-nvim.socket'] = { " +
-        "request = function() return { comments = { { context = { " +
-        "file = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':.'), " +
-        "startLine = 99, endLine = 99 " +
-        "} } } }, nil end, " +
-        "on = function() return function() end end " +
-        "}";
+    const pluginRoot = path.join(__dirname, "nvim");
+    const fakeSocket = [
+      "package.loaded['pi-nvim.socket'] = {",
+      "connect = function() end,",
+      "disconnect = function() end,",
+      "invalidate_cache = function() end,",
+      "send = function() return true end,",
+      "is_connected = function() return true end,",
+      "}",
+    ].join(" ");
 
-      try {
-        const result = spawnSync(
-          "nvim",
-          [
-            "--headless",
-            "--clean",
-            "-n",
-            markdownPath,
-            `+set rtp^=${pluginRoot}`,
-            `+lua ${fakeSocket}`,
-            "+lua require('pi-nvim.comments').setup()",
-            "+sleep 300m",
-            "+qa",
-          ],
-          { encoding: "utf8" },
-        );
+    try {
+      const result = spawnSync(
+        "nvim",
+        [
+          "--headless",
+          "--clean",
+          "-n",
+          markdownPath,
+          `+set rtp^=${pluginRoot}`,
+          `+lua ${fakeSocket}`,
+          "+lua require('pi-nvim').setup()",
+          "+lua assert(vim.fn.exists(':PiCommsOpen') == 0)",
+          "+lua assert(vim.fn.exists(':PiCommsAdd') == 0)",
+          "+lua assert(vim.fn.exists(':PiCommsRead') == 0)",
+          "+lua assert(vim.fn.exists(':PiCommsClean') == 0)",
+          "+qa",
+        ],
+        { encoding: "utf8" },
+      );
 
-        expect(result.stderr).not.toContain("Invalid 'line': out of range");
-        expect(result.status).toBe(0);
-      } finally {
-        rmSync(dir, { recursive: true, force: true });
-      }
-    },
-  );
+      expect(result.stderr).not.toContain("Invalid 'line': out of range");
+      expect(result.stderr).not.toContain("Error");
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/nvim-bridge/nvim/lua/pi-nvim/init.lua
+++ b/nvim-bridge/nvim/lua/pi-nvim/init.lua
@@ -1,4 +1,3 @@
-local comments = require('pi-nvim.comments')
 local events = require('pi-nvim.events')
 local socket = require('pi-nvim.socket')
 
@@ -9,124 +8,10 @@ local enabled = false
 function M.setup(_opts)
   enabled = true
 
-  -- Connect socket on startup
+  -- Connect socket on startup.
   socket.connect()
-  comments.setup()
 
-  -- PiComms timeline commands.
-  if vim.fn.exists(':PiCommsOpen') == 0 then
-    vim.api.nvim_create_user_command('PiCommsOpen', function(cmd_opts)
-      if not enabled then
-        vim.notify('pi-nvim: bridge is disabled', vim.log.levels.WARN)
-        return
-      end
-
-      local thread_id = cmd_opts.args ~= '' and cmd_opts.args or nil
-      local has_range = (cmd_opts.range or 0) > 0
-
-      comments.open({
-        thread_id = thread_id,
-        start_line = has_range and cmd_opts.line1 or nil,
-        end_line = has_range and cmd_opts.line2 or nil,
-        focus_composer = false,
-      })
-    end, {
-      desc = 'Open PiComms panel for the current thread',
-      range = true,
-      nargs = '?',
-    })
-  end
-
-  if vim.fn.exists(':PiCommsRefresh') == 0 then
-    vim.api.nvim_create_user_command('PiCommsRefresh', function(cmd_opts)
-      if not enabled then
-        vim.notify('pi-nvim: bridge is disabled', vim.log.levels.WARN)
-        return
-      end
-      local thread_id = cmd_opts.args ~= '' and cmd_opts.args or nil
-      comments.refresh({
-        thread_id = thread_id,
-        open_if_missing = true,
-        focus_composer = false,
-      })
-    end, {
-      desc = 'Refresh PiComms timeline',
-      nargs = '?',
-    })
-  end
-
-  if vim.fn.exists(':PiCommsAdd') == 0 then
-    vim.api.nvim_create_user_command('PiCommsAdd', function(cmd_opts)
-      if not enabled then
-        vim.notify('pi-nvim: bridge is disabled', vim.log.levels.WARN)
-        return
-      end
-
-      local thread_id = cmd_opts.args ~= '' and cmd_opts.args or nil
-      local has_range = (cmd_opts.range or 0) > 0
-
-      comments.open({
-        thread_id = thread_id,
-        start_line = has_range and cmd_opts.line1 or nil,
-        end_line = has_range and cmd_opts.line2 or nil,
-        focus_composer = true,
-      })
-    end, {
-      desc = 'Open PiComms and focus the inline composer',
-      range = true,
-      nargs = '?',
-    })
-  end
-
-  if vim.fn.exists(':PiCommsNext') == 0 then
-    vim.api.nvim_create_user_command('PiCommsNext', function()
-      if not enabled then
-        vim.notify('pi-nvim: bridge is disabled', vim.log.levels.WARN)
-        return
-      end
-      comments.next_thread()
-    end, {
-      desc = 'Jump to the next PiComms thread in this file',
-    })
-  end
-
-  if vim.fn.exists(':PiCommsClose') == 0 then
-    vim.api.nvim_create_user_command('PiCommsClose', function()
-      if not enabled then
-        vim.notify('pi-nvim: bridge is disabled', vim.log.levels.WARN)
-        return
-      end
-      comments.close()
-    end, {
-      desc = 'Close the PiComms panel',
-    })
-  end
-
-  if vim.fn.exists(':PiCommsRead') == 0 then
-    vim.api.nvim_create_user_command('PiCommsRead', function()
-      if not enabled then
-        vim.notify('pi-nvim: bridge is disabled', vim.log.levels.WARN)
-        return
-      end
-      comments.trigger_read()
-    end, {
-      desc = 'Trigger /picomms:read',
-    })
-  end
-
-  if vim.fn.exists(':PiCommsClean') == 0 then
-    vim.api.nvim_create_user_command('PiCommsClean', function()
-      if not enabled then
-        vim.notify('pi-nvim: bridge is disabled', vim.log.levels.WARN)
-        return
-      end
-      comments.trigger_clean()
-    end, {
-      desc = 'Trigger /picomms:clean',
-    })
-  end
-
-  -- BufEnter: send buffer_focus (no debounce)
+  -- BufEnter: send buffer_focus (no debounce).
   vim.api.nvim_create_autocmd('BufEnter', {
     group = vim.api.nvim_create_augroup('PiNvimBufEnter', { clear = true }),
     callback = function()
@@ -137,7 +22,7 @@ function M.setup(_opts)
     end,
   })
 
-  -- WinScrolled: send visible_range (debounced)
+  -- WinScrolled: send visible_range (debounced).
   vim.api.nvim_create_autocmd('WinScrolled', {
     group = vim.api.nvim_create_augroup('PiNvimWinScrolled', { clear = true }),
     callback = function()
@@ -148,7 +33,7 @@ function M.setup(_opts)
     end,
   })
 
-  -- CursorMoved: send selection in visual mode (debounced)
+  -- CursorMoved: send selection in visual mode (debounced).
   vim.api.nvim_create_autocmd('CursorMoved', {
     group = vim.api.nvim_create_augroup('PiNvimCursorMoved', { clear = true }),
     callback = function()
@@ -159,7 +44,7 @@ function M.setup(_opts)
     end,
   })
 
-  -- DirChanged / FocusGained: invalidate cached git info and reconnect
+  -- DirChanged / FocusGained: invalidate cached git info and reconnect.
   vim.api.nvim_create_autocmd({ 'DirChanged', 'FocusGained' }, {
     group = vim.api.nvim_create_augroup('PiNvimDirChanged', { clear = true }),
     callback = function()
@@ -179,7 +64,6 @@ end
 function M.enable()
   enabled = true
   socket.connect()
-  comments.setup()
 end
 
 function M.disable()

--- a/nvim-bridge/package.json
+++ b/nvim-bridge/package.json
@@ -2,7 +2,7 @@
   "name": "@gugu910/pi-nvim-bridge",
   "version": "0.1.0",
   "type": "module",
-  "description": "Neovim bridge for pi — editor context sync and PiComms persistent comments",
+  "description": "Neovim bridge for pi — editor context sync (PiComms disabled)",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary\n- disable PiComms in the nvim bridge runtime: no comment store init, comment tools, /picomms commands, or :PiComms commands\n- keep editor context sync and open_in_editor intact\n- update docs and legacy cleanup skill to point at Pinet/direct tracking instead of live PiComms\n- file #714 to track the fuller PiComms→Pinet nvim adapter replacement\n\n## Validation\n- pnpm --filter @gugu910/pi-nvim-bridge lint\n- pnpm --filter @gugu910/pi-nvim-bridge typecheck\n- pnpm --filter @gugu910/pi-nvim-bridge test\n- pnpm format:check:lua\n- pnpm prepush