### PR TITLE
fix: make RALPH loop cadence configurable

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -146,26 +146,26 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 - `allowedUsers` / `SLACK_ALLOWED_USERS` — allow only specific Slack user IDs
 - `allowAllWorkspaceUsers: true` / `SLACK_ALLOW_ALL_WORKSPACE_USERS=true` — explicit workspace-wide opt-in
 
-| Key                            | Required | Description                                                                                                        |
-| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------ |
-| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                                  |
-| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                       |
-| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true             |
-| `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                              |
-| `defaultChannel`               | no       | Default channel for the `slack` dispatcher `post_channel` action                                                   |
-| `logChannel`                   | no       | Channel for broker activity logs                                                                                   |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                  |
-| `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |
-| `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                             |
-| `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                        |
-| `ralphLoopIntervalMs`          | no       | Broker RALPH maintenance cadence in milliseconds; defaults to `300000` (5 minutes), minimum accepted value `1000`  |
-| `skinTheme`                    | no       | Pinet presentation skin selected at broker startup/reload (`default`, `foundation`, `cosmere`, or free-form)       |
-| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                  |
-| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file            |
-| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                 |
-| `security.readOnly`            | no       | Runtime-block write-capable tools for Slack-triggered turns, including core tools like `bash`, `edit`, and `write` |
-| `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context      |
-| `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                       |
+| Key                            | Required | Description                                                                                                         |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                                   |
+| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                        |
+| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true              |
+| `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                               |
+| `defaultChannel`               | no       | Default channel for the `slack` dispatcher `post_channel` action                                                    |
+| `logChannel`                   | no       | Channel for broker activity logs                                                                                    |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                   |
+| `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                             |
+| `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                              |
+| `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                         |
+| `ralphLoopIntervalMs`          | no       | Broker RALPH maintenance cadence in milliseconds; defaults to `300000` (5 minutes), valid range `1000`-`2147483647` |
+| `skinTheme`                    | no       | Pinet presentation skin selected at broker startup/reload (`default`, `foundation`, `cosmere`, or free-form)        |
+| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                   |
+| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file             |
+| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                  |
+| `security.readOnly`            | no       | Runtime-block write-capable tools for Slack-triggered turns, including core tools like `bash`, `edit`, and `write`  |
+| `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context       |
+| `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                        |
 
 ## Scope carrier model (compatibility-first)
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -129,6 +129,7 @@ Behavior and precedence:
     "logChannel": "#pinet-logs",
     "logLevel": "actions",
     "autoFollow": true,
+    "ralphLoopIntervalMs": 300000,
     "meshSecretPath": "/Users/alice/.config/pi/pinet.secret",
     "suggestedPrompts": [{ "title": "Status", "message": "What are you working on?" }],
     "security": {
@@ -157,6 +158,7 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                            |
 | `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                             |
 | `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                        |
+| `ralphLoopIntervalMs`          | no       | Broker RALPH maintenance cadence in milliseconds; defaults to `300000` (5 minutes), minimum accepted value `1000`  |
 | `skinTheme`                    | no       | Pinet presentation skin selected at broker startup/reload (`default`, `foundation`, `cosmere`, or free-form)       |
 | `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                  |
 | `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file            |
@@ -491,7 +493,7 @@ Free-form themes are still accepted as deterministic legacy/custom presentation 
 
 ### How it works
 
-- The **broker** runs Slack Socket Mode, routes messages to agents, and monitors health via the RALPH loop
+- The **broker** runs Slack Socket Mode, routes messages to agents, and monitors health via the RALPH loop. The loop defaults to every 5 minutes and can be configured with `ralphLoopIntervalMs` under `slack-bridge` settings.
 - **Followers** connect to the broker over a local Unix socket, poll for work, and report results
 - Agents can optionally authenticate using a shared local secret (`meshSecret` or `meshSecretPath`); when both are unset, mesh auth is disabled
 - Thread ownership is first-responder-wins — the first agent to reply claims the thread

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -443,6 +443,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
       refreshHomeTabs: (ctx, snapshot, refreshedAt) =>
         deps.refreshHomeTabs(ctx, snapshot, refreshedAt),
       getLastMaintenance: () => lastBrokerMaintenance,
+      getSettings: () => deps.getSettings(),
       buildControlPlaneDashboardSnapshot: (input) => deps.buildControlPlaneDashboardSnapshot(input),
       setLastHomeTabSnapshot: (snapshot) => {
         lastBrokerControlPlaneHomeTabSnapshot = snapshot;

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -46,6 +46,7 @@ import {
   buildRalphLoopStatusMessage,
   shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_INTERVAL_MS,
+  MAX_RALPH_LOOP_INTERVAL_MS,
   resolveRalphLoopIntervalMs,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -2366,6 +2367,9 @@ describe("RALPH loop defaults", () => {
     expect(resolveRalphLoopIntervalMs({ ralphLoopIntervalMs: Number.NaN })).toBe(
       DEFAULT_RALPH_LOOP_INTERVAL_MS,
     );
+    expect(
+      resolveRalphLoopIntervalMs({ ralphLoopIntervalMs: MAX_RALPH_LOOP_INTERVAL_MS + 1 }),
+    ).toBe(DEFAULT_RALPH_LOOP_INTERVAL_MS);
   });
 });
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -45,6 +45,7 @@ import {
   buildRalphLoopFollowUpMessage,
   buildRalphLoopStatusMessage,
   shouldDeliverRalphLoopFollowUp,
+  DEFAULT_RALPH_LOOP_INTERVAL_MS,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
   isRalphNudgeEntry,
@@ -2345,6 +2346,12 @@ describe("rankAgentsForRouting", () => {
 });
 
 // ─── Ralph loop helpers ────────────────────────────────
+
+describe("RALPH loop defaults", () => {
+  it("runs the broker maintenance loop every two minutes by default", () => {
+    expect(DEFAULT_RALPH_LOOP_INTERVAL_MS).toBe(2 * 60_000);
+  });
+});
 
 describe("evaluateRalphLoopCycle", () => {
   it("flags ghost agents, nudges idle agents with work, and reports self-repair anomalies", () => {

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -46,6 +46,7 @@ import {
   buildRalphLoopStatusMessage,
   shouldDeliverRalphLoopFollowUp,
   DEFAULT_RALPH_LOOP_INTERVAL_MS,
+  resolveRalphLoopIntervalMs,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
   isRalphNudgeEntry,
@@ -138,6 +139,7 @@ describe("loadSettings", () => {
         appToken: "xapp-test",
         runtimeMode: "single",
         autoConnect: true,
+        ralphLoopIntervalMs: 120000,
         allowedUsers: ["U123"],
         allowAllWorkspaceUsers: false,
         defaultChannel: "C456",
@@ -151,6 +153,7 @@ describe("loadSettings", () => {
     expect(result.appToken).toBe("xapp-test");
     expect(result.runtimeMode).toBe("single");
     expect(result.autoConnect).toBe(true);
+    expect(result.ralphLoopIntervalMs).toBe(120000);
     expect(result.allowedUsers).toEqual(["U123"]);
     expect(result.allowAllWorkspaceUsers).toBe(false);
     expect(result.defaultChannel).toBe("C456");
@@ -2348,8 +2351,21 @@ describe("rankAgentsForRouting", () => {
 // ─── Ralph loop helpers ────────────────────────────────
 
 describe("RALPH loop defaults", () => {
-  it("runs the broker maintenance loop every two minutes by default", () => {
-    expect(DEFAULT_RALPH_LOOP_INTERVAL_MS).toBe(2 * 60_000);
+  it("runs the broker maintenance loop every five minutes by default", () => {
+    expect(DEFAULT_RALPH_LOOP_INTERVAL_MS).toBe(5 * 60_000);
+  });
+
+  it("accepts a configured broker maintenance loop interval", () => {
+    expect(resolveRalphLoopIntervalMs({ ralphLoopIntervalMs: 120_000 })).toBe(120_000);
+  });
+
+  it("falls back to the default for invalid configured intervals", () => {
+    expect(resolveRalphLoopIntervalMs({ ralphLoopIntervalMs: 0 })).toBe(
+      DEFAULT_RALPH_LOOP_INTERVAL_MS,
+    );
+    expect(resolveRalphLoopIntervalMs({ ralphLoopIntervalMs: Number.NaN })).toBe(
+      DEFAULT_RALPH_LOOP_INTERVAL_MS,
+    );
   });
 });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1346,7 +1346,7 @@ export function rankAgentsForRouting(
   return ranked.sort(compareRouting);
 }
 
-export const DEFAULT_RALPH_LOOP_INTERVAL_MS = 30_000;
+export const DEFAULT_RALPH_LOOP_INTERVAL_MS = 2 * 60_000;
 export const DEFAULT_RALPH_LOOP_IDLE_WITH_WORK_THRESHOLD_MS = 60_000;
 export const DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS = 5 * 60_000;
 export const DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS = 60_000;

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -33,6 +33,7 @@ export interface SlackBridgeSettings {
   brokerPrompt?: string;
   autoConnect?: boolean;
   autoFollow?: boolean;
+  ralphLoopIntervalMs?: number;
   skinTheme?: string;
   agentName?: string;
   agentEmoji?: string;
@@ -1346,11 +1347,22 @@ export function rankAgentsForRouting(
   return ranked.sort(compareRouting);
 }
 
-export const DEFAULT_RALPH_LOOP_INTERVAL_MS = 2 * 60_000;
+export const DEFAULT_RALPH_LOOP_INTERVAL_MS = 5 * 60_000;
 export const DEFAULT_RALPH_LOOP_IDLE_WITH_WORK_THRESHOLD_MS = 60_000;
 export const DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS = 5 * 60_000;
 export const DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS = 60_000;
 export const DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS = 5 * 60_000;
+export const MIN_RALPH_LOOP_INTERVAL_MS = 1_000;
+
+export function resolveRalphLoopIntervalMs(settings: SlackBridgeSettings = {}): number {
+  const configured = settings.ralphLoopIntervalMs;
+  if (!Number.isFinite(configured) || configured == null) {
+    return DEFAULT_RALPH_LOOP_INTERVAL_MS;
+  }
+
+  const intervalMs = Math.trunc(configured);
+  return intervalMs >= MIN_RALPH_LOOP_INTERVAL_MS ? intervalMs : DEFAULT_RALPH_LOOP_INTERVAL_MS;
+}
 
 export interface RalphLoopAgentWorkload extends AgentVisibilityInput {
   lastSeen?: string;

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1353,6 +1353,7 @@ export const DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS = 5 * 60_000;
 export const DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS = 60_000;
 export const DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS = 5 * 60_000;
 export const MIN_RALPH_LOOP_INTERVAL_MS = 1_000;
+export const MAX_RALPH_LOOP_INTERVAL_MS = 2_147_483_647;
 
 export function resolveRalphLoopIntervalMs(settings: SlackBridgeSettings = {}): number {
   const configured = settings.ralphLoopIntervalMs;
@@ -1361,7 +1362,11 @@ export function resolveRalphLoopIntervalMs(settings: SlackBridgeSettings = {}): 
   }
 
   const intervalMs = Math.trunc(configured);
-  return intervalMs >= MIN_RALPH_LOOP_INTERVAL_MS ? intervalMs : DEFAULT_RALPH_LOOP_INTERVAL_MS;
+  if (intervalMs < MIN_RALPH_LOOP_INTERVAL_MS || intervalMs > MAX_RALPH_LOOP_INTERVAL_MS) {
+    return DEFAULT_RALPH_LOOP_INTERVAL_MS;
+  }
+
+  return intervalMs;
 }
 
 export interface RalphLoopAgentWorkload extends AgentVisibilityInput {

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -78,6 +78,26 @@ describe("startRalphLoop", () => {
       setIntervalSpy.mockRestore();
     }
   });
+
+  it("falls back before scheduling oversized intervals that Node would overflow", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const state = createRalphLoopState();
+
+    try {
+      startRalphLoop({} as ExtensionContext, state, {
+        ...createLoopDeps(),
+        getSettings: () => ({ ralphLoopIntervalMs: 3_000_000_000 }),
+      });
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        DEFAULT_RALPH_LOOP_INTERVAL_MS,
+      );
+    } finally {
+      stopRalphLoop(state);
+      setIntervalSpy.mockRestore();
+    }
+  });
 });
 
 describe("hydrateRalphLoopReportedGhosts", () => {

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -1,11 +1,37 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
   applyTrackedAssignmentIdleReplyStalls,
   buildTrackedAssignmentReplyNudgeMessage,
   createRalphLoopState,
   hydrateRalphLoopReportedGhosts,
+  startRalphLoop,
+  stopRalphLoop,
+  type RalphLoopDeps,
 } from "./ralph-loop.js";
-import { rewriteRalphLoopGhostAnomalies } from "./helpers.js";
+import { DEFAULT_RALPH_LOOP_INTERVAL_MS, rewriteRalphLoopGhostAnomalies } from "./helpers.js";
+
+function createLoopDeps(overrides: Partial<RalphLoopDeps> = {}): RalphLoopDeps {
+  return {
+    getBrokerDb: () => null,
+    getBrokerAgentId: () => null,
+    heartbeatTimerActive: () => true,
+    maintenanceTimerActive: () => true,
+    runMaintenance: vi.fn(),
+    sendMaintenanceMessage: vi.fn(),
+    trySendFollowUp: vi.fn(),
+    logActivity: vi.fn(),
+    formatTrackedAgent: vi.fn((agentId: string) => agentId),
+    summarizeTrackedAssignmentStatus: vi.fn(() => ({ summary: "assigned", tone: "info" })),
+    refreshHomeTabs: vi.fn(async () => undefined),
+    getLastMaintenance: vi.fn(() => null),
+    buildControlPlaneDashboardSnapshot: vi.fn((input) => input as never),
+    setLastHomeTabSnapshot: vi.fn(),
+    getLastHomeTabError: vi.fn(() => null),
+    setLastHomeTabError: vi.fn(),
+    ...overrides,
+  };
+}
 
 function buildEvaluation(ghostAgentIds: string[]) {
   return {
@@ -17,6 +43,42 @@ function buildEvaluation(ghostAgentIds: string[]) {
       ghostAgentIds.length > 0 ? [`ghost agents detected: ${ghostAgentIds.join(", ")}`] : [],
   };
 }
+
+describe("startRalphLoop", () => {
+  it("uses the configured RALPH loop interval for the broker timer", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const state = createRalphLoopState();
+
+    try {
+      startRalphLoop({} as ExtensionContext, state, {
+        ...createLoopDeps(),
+        getSettings: () => ({ ralphLoopIntervalMs: 123_000 }),
+      });
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 123_000);
+    } finally {
+      stopRalphLoop(state);
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("uses the five-minute default when no interval is configured", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const state = createRalphLoopState();
+
+    try {
+      startRalphLoop({} as ExtensionContext, state, createLoopDeps());
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        DEFAULT_RALPH_LOOP_INTERVAL_MS,
+      );
+    } finally {
+      stopRalphLoop(state);
+      setIntervalSpy.mockRestore();
+    }
+  });
+});
 
 describe("hydrateRalphLoopReportedGhosts", () => {
   it("hydrates the latest persisted ghost ids into a fresh state", () => {

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -4,6 +4,7 @@ import {
   type RalphLoopAgentWorkload,
   type RalphLoopEvaluationOptions,
   type RalphLoopEvaluationResult,
+  type SlackBridgeSettings,
   evaluateRalphLoopCycle,
   rewriteRalphLoopGhostAnomalies,
   buildAgentDisplayInfo,
@@ -13,7 +14,7 @@ import {
   buildRalphLoopStatusMessage,
   shouldDeliverRalphLoopFollowUp,
   filterAgentsForMeshVisibility,
-  DEFAULT_RALPH_LOOP_INTERVAL_MS,
+  resolveRalphLoopIntervalMs,
   DEFAULT_RALPH_LOOP_NUDGE_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_FOLLOW_UP_COOLDOWN_MS,
   DEFAULT_RALPH_LOOP_STUCK_WORKING_THRESHOLD_MS,
@@ -202,6 +203,7 @@ export interface RalphLoopDeps {
     refreshedAt: string,
   ) => Promise<void>;
   getLastMaintenance: () => BrokerMaintenanceResult | null;
+  getSettings?: () => SlackBridgeSettings;
 
   // Snapshot builder
   buildControlPlaneDashboardSnapshot: (
@@ -599,9 +601,10 @@ export function startRalphLoop(
   deps: RalphLoopDeps,
 ): void {
   stopRalphLoop(state);
+  const intervalMs = resolveRalphLoopIntervalMs(deps.getSettings?.() ?? {});
   state.timer = setInterval(() => {
     void runRalphLoopCycle(ctx, state, deps);
-  }, DEFAULT_RALPH_LOOP_INTERVAL_MS);
+  }, intervalMs);
   state.timer.unref?.();
   void runRalphLoopCycle(ctx, state, deps);
 }


### PR DESCRIPTION
## Summary
- make the broker RALPH loop interval configurable via `slack-bridge.ralphLoopIntervalMs`
- default the interval to 5 minutes (`300000` ms) and fall back to that default for invalid, too-small, or Node timer-overflow values
- wire runtime settings into `startRalphLoop` and document the setting/valid range
- add regression coverage for settings loading, interval resolution, timer wiring, and oversized interval fallback

## Tests
- pnpm --filter @gugu910/pi-slack-bridge test -- helpers.test.ts ralph-loop.test.ts
- pnpm --filter @gugu910/pi-slack-bridge lint
- pnpm --filter @gugu910/pi-slack-bridge typecheck
- pre-push hook: pnpm lint && pnpm typecheck && pnpm test