### PR TITLE
Refine Slack canvas fallback recovery

### DIFF
--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1594,6 +1594,54 @@ describe("registerSlackTools", () => {
     );
   });
 
+  it("does not bookmark private file URLs as fallback canvas permalinks", async () => {
+    const { slack, tools, setFilesInfoResponse } = setup();
+    setFilesInfoResponse({
+      ok: true,
+      file: {
+        id: "F_FALLBACK_PRIVATE",
+        title: "Private URL only",
+        url_private: "https://files.slack.com/files-pri/T/F_FALLBACK_PRIVATE/download/doc",
+      },
+      comments: [],
+      response_metadata: { next_cursor: "" },
+    } as SlackResult);
+
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "conversations.canvases.create") {
+          throw new Error("Slack conversations.canvases.create: canvas_tab_creation_failed");
+        }
+        if (method === "canvases.create") {
+          return { ok: true, token, body, canvas_id: "F_FALLBACK_PRIVATE" } as SlackResult;
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    const result = await tools.get("slack_canvas_create")!.execute("tool-canvas-create-private", {
+      kind: "channel",
+      channel: "proj-alpha",
+      title: "Private URL only",
+      markdown: "# Review",
+    });
+
+    expect(slack.mock.calls.some(([method]) => method === "bookmarks.add")).toBe(false);
+    expect(result.content?.[0]?.text).toContain("Slack did not expose a permalink");
+    expect(result.details).toEqual(
+      expect.not.objectContaining({
+        permalink: "https://files.slack.com/files-pri/T/F_FALLBACK_PRIVATE/download/doc",
+      }),
+    );
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        canvas_id: "F_FALLBACK_PRIVATE",
+        bookmark_status: "skipped",
+      }),
+    );
+  });
+
   it("guides channel canvas updates toward fallback canvas IDs when Slack exposes no channel canvas", async () => {
     const { tools } = setup();
 
@@ -1602,7 +1650,7 @@ describe("registerSlackTools", () => {
         channel: "proj-alpha",
         markdown: "## Update",
       }),
-    ).rejects.toThrow("use the standalone fallback canvas_id returned by canvas_create");
+    ).rejects.toThrow("canvas_create will auto-create and bookmark a standalone fallback");
   });
 
   it("validates a direct canvas id before reading its comments", async () => {
@@ -1822,6 +1870,77 @@ describe("registerSlackTools", () => {
     const details = (result as { details: Record<string, unknown> }).details;
     expect(details.channel_id).toBe("C_PROJ");
     expect(details.canvas_id).toBeNull();
+  });
+
+  it("falls back and bookmarks a standalone project canvas when channel tab creation fails", async () => {
+    const { slack, tools, setFilesInfoResponse } = setup();
+    setFilesInfoResponse({
+      ok: true,
+      file: {
+        id: "F_PROJECT_FALLBACK",
+        title: "Beta RFC",
+        permalink: "https://example.slack.com/docs/T/F_PROJECT_FALLBACK",
+      },
+      comments: [],
+      response_metadata: { next_cursor: "" },
+    } as SlackResult);
+
+    const originalSlack = slack.getMockImplementation()!;
+    slack.mockImplementation(
+      async (method: string, token: string, body?: Record<string, unknown>) => {
+        if (method === "conversations.canvases.create") {
+          throw new Error("Slack conversations.canvases.create: canvas_tab_creation_failed");
+        }
+        if (method === "canvases.create") {
+          return { ok: true, token, body, canvas_id: "F_PROJECT_FALLBACK" } as SlackResult;
+        }
+        return originalSlack(method, token, body);
+      },
+    );
+
+    const result = await tools.get("slack_project_create")!.execute("tool-proj-fallback", {
+      name: "proj-beta",
+      canvas_title: "Beta RFC",
+      canvas_markdown: "# Beta",
+    });
+
+    expect(slack).toHaveBeenCalledWith(
+      "canvases.create",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel_id: "C_PROJ",
+        title: "Beta RFC",
+      }),
+    );
+    expect(slack).toHaveBeenCalledWith("files.info", "xoxb-initial", {
+      file: "F_PROJECT_FALLBACK",
+    });
+    expect(slack).toHaveBeenCalledWith(
+      "bookmarks.add",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel_id: "C_PROJ",
+        title: "Beta RFC",
+        link: "https://example.slack.com/docs/T/F_PROJECT_FALLBACK",
+      }),
+    );
+    expect(result.content?.[0]?.text).toContain("Created standalone fallback RFC canvas");
+    expect(result.content?.[0]?.text).toContain("canvas_id=F_PROJECT_FALLBACK");
+
+    const details = (result as { details: Record<string, unknown> }).details;
+    expect(details).toEqual(
+      expect.objectContaining({
+        channel_id: "C_PROJ",
+        canvas_id: "F_PROJECT_FALLBACK",
+        canvas_kind: "standalone",
+        canvas_fallback: true,
+        canvas_fallback_reason: "canvas_tab_creation_failed",
+        bookmark_status: "added",
+        bookmark_id: "Bk123",
+        permalink: "https://example.slack.com/docs/T/F_PROJECT_FALLBACK",
+        next_action: "canvas_update canvas_id=F_PROJECT_FALLBACK",
+      }),
+    );
   });
 
   it("classifies raw upload 403 responses as input when no proxy marker is present", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -690,11 +690,7 @@ function extractSlackCanvasPermalink(response: Record<string, unknown>): string 
   if (canvasLink) return canvasLink;
 
   const file = asSlackObject(response.file);
-  return (
-    asTrimmedSlackString(file?.permalink) ??
-    asTrimmedSlackString(file?.url_private) ??
-    asTrimmedSlackString(file?.url)
-  );
+  return asTrimmedSlackString(file?.permalink);
 }
 
 function isPiAgentSlackMessage(
@@ -997,6 +993,111 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     },
   });
 
+  type SlackCanvasFallbackResult = {
+    canvasId: string;
+    permalink?: string;
+    permalinkLookupError?: string;
+    bookmarkId?: string;
+    bookmarkStatus: "added" | "skipped" | "failed";
+    bookmarkError?: string;
+  };
+
+  async function createStandaloneCanvasFallback(input: {
+    channelId: string;
+    channelLabel: string;
+    title?: string;
+    markdown?: string;
+  }): Promise<SlackCanvasFallbackResult> {
+    const fallbackRequest = buildSlackCanvasCreateRequest({
+      kind: "standalone",
+      title: input.title,
+      markdown: input.markdown,
+      channelId: input.channelId,
+    });
+
+    let fallbackResponse: SlackResult;
+    try {
+      fallbackResponse = await slack(fallbackRequest.method, getBotToken(), fallbackRequest.body);
+    } catch (fallbackErr) {
+      const fallbackMessage =
+        fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+      throw new Error(
+        `Slack channel canvas creation failed with canvas_tab_creation_failed, and standalone fallback creation also failed: ${fallbackMessage}. To recover manually, create a standalone canvas with channel=${input.channelLabel} and update/share it by canvas_id.`,
+      );
+    }
+
+    const fallbackCanvasId = asTrimmedSlackString(fallbackResponse.canvas_id);
+    if (!fallbackCanvasId) {
+      throw new Error(
+        `Slack channel canvas creation failed with canvas_tab_creation_failed, and standalone fallback creation did not return a canvas_id. To recover manually, create a standalone canvas with channel=${input.channelLabel} and update/share it by canvas_id.`,
+      );
+    }
+
+    let permalink = extractSlackCanvasPermalink(fallbackResponse);
+    let permalinkLookupError: string | undefined;
+    if (!permalink) {
+      try {
+        const fileInfo = await slack("files.info", getBotToken(), { file: fallbackCanvasId });
+        permalink = extractSlackCanvasPermalink(fileInfo);
+      } catch (permalinkErr) {
+        permalinkLookupError =
+          permalinkErr instanceof Error ? permalinkErr.message : String(permalinkErr);
+      }
+    }
+
+    let bookmarkId: string | undefined;
+    let bookmarkStatus: "added" | "skipped" | "failed" = "skipped";
+    let bookmarkError: string | undefined;
+    if (permalink) {
+      try {
+        const title =
+          input.title && input.title.trim().length > 0
+            ? input.title.trim()
+            : `Canvas ${fallbackCanvasId}`;
+        const bookmarkResponse = await slack("bookmarks.add", getBotToken(), {
+          channel_id: input.channelId,
+          title,
+          type: "link",
+          link: normalizeSlackBookmarkUrl(permalink),
+          emoji: ":memo:",
+        });
+        const bookmark = asSlackObject(bookmarkResponse.bookmark);
+        bookmarkId = asTrimmedSlackString(bookmark?.id);
+        bookmarkStatus = "added";
+      } catch (bookmarkErr) {
+        bookmarkStatus = "failed";
+        bookmarkError = bookmarkErr instanceof Error ? bookmarkErr.message : String(bookmarkErr);
+      }
+    }
+
+    return {
+      canvasId: fallbackCanvasId,
+      bookmarkStatus,
+      ...(permalink ? { permalink } : {}),
+      ...(permalinkLookupError ? { permalinkLookupError } : {}),
+      ...(bookmarkId ? { bookmarkId } : {}),
+      ...(bookmarkError ? { bookmarkError } : {}),
+    };
+  }
+
+  function buildStandaloneCanvasFallbackBookmarkSummary(input: {
+    channelLabel: string;
+    canvasId: string;
+    permalink?: string;
+    permalinkLookupError?: string;
+    bookmarkId?: string;
+    bookmarkStatus: "added" | "skipped" | "failed";
+    bookmarkError?: string;
+  }): string {
+    if (input.bookmarkStatus === "added") {
+      return ` Bookmarked it in ${input.channelLabel}${input.bookmarkId ? ` as ${input.bookmarkId}` : ""}.`;
+    }
+    if (input.permalink) {
+      return ` Could not bookmark it automatically${input.bookmarkError ? ` (${input.bookmarkError})` : ""}; add ${input.permalink} as a channel bookmark if you need a durable channel link.`;
+    }
+    return ` Slack did not expose a permalink${input.permalinkLookupError ? ` (${input.permalinkLookupError})` : ""}; use canvas_id=${input.canvasId} directly or add a bookmark manually once you have the canvas URL.`;
+  }
+
   async function resolveCanvasTarget(
     canvasId: string | undefined,
     channel: string | undefined,
@@ -1016,7 +1117,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     const resolvedCanvasId = extractSlackChannelCanvasId(info);
     if (!resolvedCanvasId) {
       throw new Error(
-        `Slack did not expose a channel canvas ID in conversations.info for ${channelInput}. Provide canvas_id directly. If channel canvas tab creation failed earlier, use the standalone fallback canvas_id returned by canvas_create; otherwise create a standalone fallback with canvas_create kind='standalone' channel='${channelInput}' and update it by canvas_id.`,
+        `Slack did not expose a channel canvas ID in conversations.info for ${channelInput}. Provide canvas_id directly. If channel canvas tab creation failed earlier, use the standalone fallback canvas_id returned by canvas_create. Otherwise run canvas_create with kind='channel' and channel='${channelInput}'; if Slack rejects channel tab creation, canvas_create will auto-create and bookmark a standalone fallback. Use kind='standalone' only when you intentionally want to skip the channel-tab attempt.`,
       );
     }
 
@@ -2300,6 +2401,9 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       // 4. Create the channel canvas with the RFC/spec
       const canvasTitle = params.canvas_title?.trim() || `${channel.name} RFC`;
       let canvasId: string | null = null;
+      let canvasKind: "channel" | "standalone" | null = null;
+      let canvasFallback: SlackCanvasFallbackResult | null = null;
+      let canvasFailure: string | null = null;
       try {
         const canvasRequest = buildSlackCanvasCreateRequest({
           kind: "channel",
@@ -2309,16 +2413,49 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         });
         const canvasResponse = await slack(canvasRequest.method, getBotToken(), canvasRequest.body);
         canvasId = canvasResponse.canvas_id as string;
-      } catch {
-        // Canvas creation failure is non-fatal — the channel is still usable
+        canvasKind = "channel";
+      } catch (err) {
+        if (
+          isSlackMethodError(err, "conversations.canvases.create", "canvas_tab_creation_failed")
+        ) {
+          try {
+            canvasFallback = await createStandaloneCanvasFallback({
+              channelId: channel.id,
+              channelLabel: `#${channel.name}`,
+              title: canvasTitle,
+              markdown: params.canvas_markdown,
+            });
+            canvasId = canvasFallback.canvasId;
+            canvasKind = "standalone";
+          } catch (fallbackErr) {
+            canvasFailure =
+              fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+          }
+        } else {
+          // Canvas creation failure is non-fatal — the channel is still usable
+          canvasFailure = err instanceof Error ? err.message : String(err);
+        }
       }
 
       const parts = [`Created project channel #${channel.name} (${channel.id})`];
-      if (canvasId) {
+      if (canvasId && canvasKind === "standalone" && canvasFallback) {
+        const bookmarkSummary = buildStandaloneCanvasFallbackBookmarkSummary({
+          channelLabel: `#${channel.name}`,
+          canvasId,
+          permalink: canvasFallback.permalink,
+          permalinkLookupError: canvasFallback.permalinkLookupError,
+          bookmarkId: canvasFallback.bookmarkId,
+          bookmarkStatus: canvasFallback.bookmarkStatus,
+          bookmarkError: canvasFallback.bookmarkError,
+        });
+        parts.push(
+          `Slack could not create the project channel canvas tab (canvas_tab_creation_failed). Created standalone fallback RFC canvas: ${canvasId} — "${canvasTitle}".${bookmarkSummary} Use canvas_update with canvas_id=${canvasId} for future updates.`,
+        );
+      } else if (canvasId) {
         parts.push(`RFC canvas: ${canvasId} — "${canvasTitle}"`);
       } else {
         parts.push(
-          "Canvas creation failed — create it manually with the slack dispatcher action canvas_create.",
+          `Canvas creation failed${canvasFailure ? ` (${canvasFailure})` : ""} — retry with canvas_create kind='channel' channel='#${channel.name}' so the Slack bridge can auto-create/bookmark a standalone fallback if Slack rejects channel tab creation.`,
         );
       }
       if (botInvited) {
@@ -2332,7 +2469,25 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           channel_name: channel.name,
           canvas_id: canvasId,
           canvas_title: canvasTitle,
+          canvas_kind: canvasKind,
           bot_invited: botInvited,
+          ...(canvasFallback
+            ? {
+                canvas_fallback: true,
+                canvas_fallback_reason: "canvas_tab_creation_failed",
+                bookmark_status: canvasFallback.bookmarkStatus,
+                next_action: `canvas_update canvas_id=${canvasFallback.canvasId}`,
+                ...(canvasFallback.permalink ? { permalink: canvasFallback.permalink } : {}),
+                ...(canvasFallback.bookmarkId ? { bookmark_id: canvasFallback.bookmarkId } : {}),
+                ...(canvasFallback.bookmarkError
+                  ? { bookmark_error: canvasFallback.bookmarkError }
+                  : {}),
+                ...(canvasFallback.permalinkLookupError
+                  ? { permalink_lookup_error: canvasFallback.permalinkLookupError }
+                  : {}),
+              }
+            : {}),
+          ...(canvasFailure ? { canvas_error: canvasFailure } : {}),
         },
       };
     },
@@ -3109,94 +3264,45 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           throw err;
         }
 
-        const fallbackRequest = buildSlackCanvasCreateRequest({
-          kind: "standalone",
+        const channelLabel = channelInput ?? channelId;
+        const fallback = await createStandaloneCanvasFallback({
+          channelId,
+          channelLabel,
           title: params.title,
           markdown: params.markdown,
-          channelId,
         });
-        let fallbackResponse: SlackResult;
-        try {
-          fallbackResponse = await slack(
-            fallbackRequest.method,
-            getBotToken(),
-            fallbackRequest.body,
-          );
-        } catch (fallbackErr) {
-          const fallbackMessage =
-            fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
-          throw new Error(
-            `Slack channel canvas creation failed with canvas_tab_creation_failed, and standalone fallback creation also failed: ${fallbackMessage}. To recover manually, create a standalone canvas with channel=${channelInput ?? channelId} and update/share it by canvas_id.`,
-          );
-        }
-
-        const fallbackCanvasId = fallbackResponse.canvas_id as string;
-        let permalink = extractSlackCanvasPermalink(fallbackResponse);
-        let permalinkLookupError: string | undefined;
-        if (!permalink) {
-          try {
-            const fileInfo = await slack("files.info", getBotToken(), { file: fallbackCanvasId });
-            permalink = extractSlackCanvasPermalink(fileInfo);
-          } catch (permalinkErr) {
-            permalinkLookupError =
-              permalinkErr instanceof Error ? permalinkErr.message : String(permalinkErr);
-          }
-        }
-
-        let bookmarkId: string | undefined;
-        let bookmarkStatus: "added" | "skipped" | "failed" = "skipped";
-        let bookmarkError: string | undefined;
-        if (permalink) {
-          try {
-            const title =
-              typeof params.title === "string" && params.title.trim().length > 0
-                ? params.title.trim()
-                : `Canvas ${fallbackCanvasId}`;
-            const bookmarkResponse = await slack("bookmarks.add", getBotToken(), {
-              channel_id: channelId,
-              title,
-              type: "link",
-              link: normalizeSlackBookmarkUrl(permalink),
-              emoji: ":memo:",
-            });
-            const bookmark = asSlackObject(bookmarkResponse.bookmark);
-            bookmarkId = asTrimmedSlackString(bookmark?.id);
-            bookmarkStatus = "added";
-          } catch (bookmarkErr) {
-            bookmarkStatus = "failed";
-            bookmarkError =
-              bookmarkErr instanceof Error ? bookmarkErr.message : String(bookmarkErr);
-          }
-        }
-
-        const channelLabel = channelInput ?? channelId;
-        const bookmarkSummary =
-          bookmarkStatus === "added"
-            ? ` Bookmarked it in ${channelLabel}${bookmarkId ? ` as ${bookmarkId}` : ""}.`
-            : permalink
-              ? ` Could not bookmark it automatically${bookmarkError ? ` (${bookmarkError})` : ""}; add ${permalink} as a channel bookmark if you need a durable channel link.`
-              : ` Slack did not expose a permalink${permalinkLookupError ? ` (${permalinkLookupError})` : ""}; use canvas_id=${fallbackCanvasId} directly or add a bookmark manually once you have the canvas URL.`;
+        const bookmarkSummary = buildStandaloneCanvasFallbackBookmarkSummary({
+          channelLabel,
+          canvasId: fallback.canvasId,
+          permalink: fallback.permalink,
+          permalinkLookupError: fallback.permalinkLookupError,
+          bookmarkId: fallback.bookmarkId,
+          bookmarkStatus: fallback.bookmarkStatus,
+          bookmarkError: fallback.bookmarkError,
+        });
 
         return {
           content: [
             {
               type: "text",
-              text: `Slack could not create a channel canvas tab for ${channelLabel} (canvas_tab_creation_failed). Created standalone fallback canvas ${fallbackCanvasId} attached to ${channelLabel}.${bookmarkSummary} Use canvas_update with canvas_id=${fallbackCanvasId} for future updates. Initial content: ${getSlackCanvasSummary(params.markdown)}`,
+              text: `Slack could not create a channel canvas tab for ${channelLabel} (canvas_tab_creation_failed). Created standalone fallback canvas ${fallback.canvasId} attached to ${channelLabel}.${bookmarkSummary} Use canvas_update with canvas_id=${fallback.canvasId} for future updates. Initial content: ${getSlackCanvasSummary(params.markdown)}`,
             },
           ],
           details: {
-            canvas_id: fallbackCanvasId,
+            canvas_id: fallback.canvasId,
             kind: "standalone",
             requested_kind: "channel",
             channel: channelId,
             fallback: true,
             fallback_reason: "canvas_tab_creation_failed",
-            bookmark_status: bookmarkStatus,
-            next_action: `canvas_update canvas_id=${fallbackCanvasId}`,
-            ...(permalink ? { permalink } : {}),
-            ...(bookmarkId ? { bookmark_id: bookmarkId } : {}),
-            ...(bookmarkError ? { bookmark_error: bookmarkError } : {}),
-            ...(permalinkLookupError ? { permalink_lookup_error: permalinkLookupError } : {}),
+            bookmark_status: fallback.bookmarkStatus,
+            next_action: `canvas_update canvas_id=${fallback.canvasId}`,
+            ...(fallback.permalink ? { permalink: fallback.permalink } : {}),
+            ...(fallback.bookmarkId ? { bookmark_id: fallback.bookmarkId } : {}),
+            ...(fallback.bookmarkError ? { bookmark_error: fallback.bookmarkError } : {}),
+            ...(fallback.permalinkLookupError
+              ? { permalink_lookup_error: fallback.permalinkLookupError }
+              : {}),
           },
         };
       }


### PR DESCRIPTION
## Summary
- preserve and rebase the recovered `fix/canvas-fallback-697` branch onto current `main`
- avoid treating Slack `url_private` / private file URLs as bookmarkable canvas permalinks
- reuse the standalone canvas fallback/bookmark helper for `project_create` channel canvas tab failures
- improve channel-canvas update guidance toward fallback canvas IDs

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge test` — 74 files, 1270 tests passed
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test` — 10 packages successful

## Notes
- Original remote branch commit `4c00654` was backed up locally as `backup/fix-canvas-fallback-697-pre-rebase` before rebasing.
- Issue #697 is already closed by earlier canvas fallback work (#702); this PR carries the remaining recovery branch refinements.