### PR TITLE
fix(pinet): preserve skin identity on resume

### DIFF
--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
 import {
+  applyBrokerSelfSkinIdentity,
+  buildBrokerSelfRegistrationMetadata,
   createBrokerRuntime,
+  resolveBrokerRegistrationSkinAssignment,
   resolveConfiguredBrokerSkinTheme,
   shouldRouteKnownSlackThread,
   type BrokerRuntimeDeps,
@@ -19,6 +22,7 @@ function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDe
     setBrokerStableId: vi.fn(),
     getActiveSkinTheme: () => null,
     setActiveSkinTheme: vi.fn(),
+    setSkinIdentityRole: vi.fn(),
     setAgentOwnerToken: vi.fn(),
     getAgentMetadata: vi.fn(async () => ({})),
     applyLocalAgentIdentity: vi.fn(),
@@ -124,6 +128,132 @@ describe("broker-runtime", () => {
     expect(resolveConfiguredBrokerSkinTheme({ skinTheme: "foundation" })).toBe("foundation");
     expect(resolveConfiguredBrokerSkinTheme({ skinTheme: "classic" })).toBe("default");
     expect(resolveConfiguredBrokerSkinTheme({})).toBe("default");
+  });
+
+  it("preserves follower-provided skin identity metadata for blank registrations", () => {
+    const assignment = resolveBrokerRegistrationSkinAssignment({
+      theme: "cosmere",
+      role: "worker",
+      seed: "stable-id-that-would-pick-a-different-character",
+      requestedName: "",
+      metadata: {
+        skinTheme: "cosmere",
+        skinIdentity: { name: "Drehy Wave", emoji: "🐦", role: "worker" },
+        personality: "Nods, fixes, moves on; warmly competent.",
+      },
+    });
+
+    expect(assignment.name).toBe("Drehy Wave");
+    expect(assignment.emoji).toBe("🐦");
+    expect(assignment.personality).toBe("Nods, fixes, moves on; warmly competent.");
+  });
+
+  it("preserves follower-provided free-form skin identity metadata for matching roles", () => {
+    const assignment = resolveBrokerRegistrationSkinAssignment({
+      theme: "custom nebula",
+      role: "worker",
+      seed: "stable-id-that-would-pick-a-generated-freeform-name",
+      requestedName: "",
+      metadata: {
+        skinTheme: "custom nebula",
+        skinIdentity: { name: "Persisted Nebula Worker", emoji: "🌈", role: "worker" },
+        personality: "Custom free-form worker persona.",
+      },
+    });
+
+    expect(assignment.name).toBe("Persisted Nebula Worker");
+    expect(assignment.emoji).toBe("🌈");
+    expect(assignment.personality).toBe("Custom free-form worker persona.");
+  });
+
+  it("ignores follower-provided skin identity metadata for a different role", () => {
+    const assignment = resolveBrokerRegistrationSkinAssignment({
+      theme: "cosmere",
+      role: "worker",
+      seed: "stable-id-that-would-pick-a-different-character",
+      requestedName: "",
+      metadata: {
+        skinTheme: "cosmere",
+        skinIdentity: { name: "Sazed Keeper", emoji: "📚", role: "broker" },
+      },
+    });
+
+    expect(assignment.name).not.toBe("Sazed Keeper");
+  });
+
+  it("ignores follower-provided skin identity metadata without role provenance", () => {
+    const assignment = resolveBrokerRegistrationSkinAssignment({
+      theme: "cosmere",
+      role: "worker",
+      seed: "stable-id-that-would-pick-a-different-character",
+      requestedName: "",
+      metadata: {
+        skinTheme: "cosmere",
+        skinIdentity: { name: "Drehy Wave", emoji: "🐦" },
+      },
+    });
+
+    expect(assignment.name).not.toBe("Drehy Wave");
+  });
+
+  it("ignores follower-provided skin identity metadata for explicit registrations", () => {
+    const assignment = resolveBrokerRegistrationSkinAssignment({
+      theme: "cosmere",
+      role: "worker",
+      seed: "stable-id-that-would-pick-a-different-character",
+      requestedName: "Explicit Worker",
+      metadata: {
+        skinTheme: "cosmere",
+        skinIdentity: { name: "Drehy Wave", emoji: "🐦" },
+      },
+    });
+
+    expect(assignment.name).not.toBe("Drehy Wave");
+  });
+
+  it("records broker role provenance when applying broker self skin identity", () => {
+    const deps = createDeps();
+
+    applyBrokerSelfSkinIdentity(
+      deps,
+      { name: "Sazed Keeper", emoji: "📚" },
+      "Careful, indexed, and observant.",
+    );
+
+    expect(deps.applyLocalAgentIdentity).toHaveBeenCalledWith(
+      "Sazed Keeper",
+      "📚",
+      "Careful, indexed, and observant.",
+      "broker",
+    );
+    expect(deps.setSkinIdentityRole).not.toHaveBeenCalled();
+  });
+
+  it("overrides stale local skin identity metadata for broker self registration", async () => {
+    const deps = createDeps({
+      getAgentMetadata: vi.fn(async () => ({
+        role: "broker",
+        skinIdentity: { name: "Drehy Wave", emoji: "🐦", role: "worker" },
+      })),
+      buildSkinMetadata: vi.fn((metadata, personality) => ({
+        ...metadata,
+        skinTheme: "cosmere",
+        personality,
+      })),
+    });
+
+    await expect(
+      buildBrokerSelfRegistrationMetadata(deps, {
+        name: "Sazed Keeper",
+        emoji: "📚",
+        personality: "Careful, indexed, and observant.",
+      }),
+    ).resolves.toMatchObject({
+      role: "broker",
+      skinTheme: "cosmere",
+      personality: "Careful, indexed, and observant.",
+      skinIdentity: { name: "Sazed Keeper", emoji: "📚", role: "broker" },
+    });
   });
 
   it("clears transient Home tab observability state on disconnect", async () => {

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -8,6 +8,7 @@ import {
   buildPinetOwnerToken,
   buildPinetSkinAssignment,
   DEFAULT_PINET_SKIN_THEME,
+  normalizePinetSkinIdentityMetadata,
   normalizePinetSkinTheme,
   resolvePinetMeshAuth,
   syncBrokerInboxEntries,
@@ -66,9 +67,15 @@ export interface BrokerRuntimeDeps {
   setBrokerStableId: (stableId: string) => void;
   getActiveSkinTheme: () => string | null;
   setActiveSkinTheme: (theme: string) => void;
+  setSkinIdentityRole: (role: "broker" | "worker" | null) => void;
   setAgentOwnerToken: (ownerToken: string) => void;
   getAgentMetadata: (role: "broker" | "worker") => Promise<Record<string, unknown>>;
-  applyLocalAgentIdentity: (name: string, emoji: string, personality: string | null) => void;
+  applyLocalAgentIdentity: (
+    name: string,
+    emoji: string,
+    personality: string | null,
+    skinIdentityRole?: "broker" | "worker" | null,
+  ) => void;
   buildSkinMetadata: (
     metadata: Record<string, unknown> | undefined,
     personality: string,
@@ -142,6 +149,74 @@ function normalizeOptionalSetting(value: string | null | undefined): string | nu
 
 export function resolveConfiguredBrokerSkinTheme(settings: SlackBridgeSettings): string {
   return normalizePinetSkinTheme(settings.skinTheme) ?? DEFAULT_PINET_SKIN_THEME;
+}
+
+export function resolveBrokerRegistrationSkinAssignment(input: {
+  theme: string;
+  role: "broker" | "worker";
+  seed: string;
+  requestedName?: string;
+  metadata?: Record<string, unknown>;
+}): {
+  name: string;
+  emoji: string;
+  personality: string;
+  statusVocabulary?: PinetSkinStatusVocabulary;
+} {
+  const assignment = buildPinetSkinAssignment({
+    theme: input.theme,
+    role: input.role,
+    seed: input.seed,
+  });
+  const metadataSkinIdentity = normalizePinetSkinIdentityMetadata(input.metadata?.skinIdentity);
+  const preservedSkinIdentity =
+    input.requestedName?.trim().length === 0 &&
+    input.metadata?.skinTheme === input.theme &&
+    metadataSkinIdentity?.role === input.role
+      ? metadataSkinIdentity
+      : null;
+  const personality =
+    preservedSkinIdentity && typeof input.metadata?.personality === "string"
+      ? input.metadata.personality
+      : assignment.personality;
+
+  return {
+    name: preservedSkinIdentity?.name ?? assignment.name,
+    emoji: preservedSkinIdentity?.emoji ?? assignment.emoji,
+    personality,
+    ...(assignment.statusVocabulary ? { statusVocabulary: assignment.statusVocabulary } : {}),
+  };
+}
+
+export function applyBrokerSelfSkinIdentity(
+  deps: Pick<BrokerRuntimeDeps, "applyLocalAgentIdentity">,
+  agent: { name: string; emoji: string },
+  personality: string,
+): void {
+  deps.applyLocalAgentIdentity(agent.name, agent.emoji, personality, "broker");
+}
+
+export async function buildBrokerSelfRegistrationMetadata(
+  deps: Pick<BrokerRuntimeDeps, "getAgentMetadata" | "buildSkinMetadata">,
+  assignment: {
+    name: string;
+    emoji: string;
+    personality: string;
+    statusVocabulary?: PinetSkinStatusVocabulary;
+  },
+): Promise<Record<string, unknown>> {
+  return {
+    ...deps.buildSkinMetadata(
+      await deps.getAgentMetadata("broker"),
+      assignment.personality,
+      assignment.statusVocabulary,
+    ),
+    skinIdentity: {
+      name: assignment.name,
+      emoji: assignment.emoji,
+      role: "broker",
+    },
+  };
 }
 
 export interface BrokerRuntime {
@@ -614,10 +689,12 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         broker.db.setSetting("pinet.skinTheme", activeSkinTheme);
         broker.server.setAgentRegistrationResolver((registration) => {
           const theme = deps.getActiveSkinTheme() ?? DEFAULT_PINET_SKIN_THEME;
-          const assignment = buildPinetSkinAssignment({
+          const assignment = resolveBrokerRegistrationSkinAssignment({
             theme,
             role: deps.getMeshRoleFromMetadata(registration.metadata, "worker"),
             seed: registration.stableId ?? registration.agentId,
+            requestedName: registration.name,
+            metadata: registration.metadata,
           });
           return {
             name: assignment.name,
@@ -640,15 +717,11 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
           selfAssignment.name,
           selfAssignment.emoji,
           process.pid,
-          deps.buildSkinMetadata(
-            await deps.getAgentMetadata("broker"),
-            selfAssignment.personality,
-            selfAssignment.statusVocabulary,
-          ),
+          await buildBrokerSelfRegistrationMetadata(deps, selfAssignment),
           brokerStableId,
         );
         selfId = selfAgent.id;
-        deps.applyLocalAgentIdentity(selfAgent.name, selfAgent.emoji, selfAssignment.personality);
+        applyBrokerSelfSkinIdentity(deps, selfAgent, selfAssignment.personality);
 
         const brokerSelfId = selfId;
         adapter.onInbound((message) => {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -3371,6 +3371,59 @@ function buildBuiltInPinetSkinAssignment(options: {
   };
 }
 
+export interface PinetSkinIdentityMetadata {
+  name: string;
+  emoji: string;
+  role?: PinetSkinRole;
+}
+
+export function normalizePinetSkinIdentityMetadata(
+  value: unknown,
+): PinetSkinIdentityMetadata | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const name = asString(record.name);
+  const emoji = asString(record.emoji);
+  if (!name || !emoji) return null;
+
+  const role = asString(record.role);
+  return {
+    name,
+    emoji,
+    ...(role === "broker" || role === "worker" ? { role } : {}),
+  };
+}
+
+export function isPinetSkinIdentityCompatible(options: {
+  theme: string;
+  role: PinetSkinRole;
+  name: string;
+  emoji: string;
+}): boolean {
+  const normalizedTheme = normalizePinetSkinTheme(options.theme) ?? DEFAULT_PINET_SKIN_THEME;
+  const builtInProfile = getBuiltInPinetSkinProfile(normalizedTheme);
+  if (!builtInProfile) {
+    return true;
+  }
+
+  const roleDescriptor = builtInProfile.roles[options.role];
+  const rolePool = roleDescriptor.characterPool;
+  for (const characterId of rolePool) {
+    const character = builtInProfile.characters[characterId];
+    if (!character || character.emoji !== options.emoji) {
+      continue;
+    }
+    const names =
+      character.aliases && character.aliases.length > 0 ? character.aliases : [character.name];
+    if (names.includes(options.name)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function buildPinetSkinAssignment(options: {
   theme: string;
   role: PinetSkinRole;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -117,6 +117,7 @@ export default function (pi: ExtensionAPI) {
   let agentOwnerToken = buildPinetOwnerToken(agentStableId);
   let activeSkinTheme: string | null = null;
   let agentPersonality: string | null = null;
+  let skinIdentityRole: "broker" | "worker" | null = null;
   const agentAliases = new Set<string>();
   // Security guardrails
   let guardrails: SecurityGuardrails = settings.security ?? {};
@@ -181,6 +182,10 @@ export default function (pi: ExtensionAPI) {
     getAgentPersonality: () => agentPersonality,
     setAgentPersonality: (personality) => {
       agentPersonality = personality;
+    },
+    getSkinIdentityRole: () => skinIdentityRole,
+    setSkinIdentityRole: (role) => {
+      skinIdentityRole = role;
     },
     agentAliases,
     setAgentOwnerToken: (ownerToken) => {
@@ -290,6 +295,10 @@ export default function (pi: ExtensionAPI) {
     getAgentPersonality: () => agentPersonality,
     setAgentPersonality: (personality) => {
       agentPersonality = personality;
+    },
+    getSkinIdentityRole: () => skinIdentityRole,
+    setSkinIdentityRole: (role) => {
+      skinIdentityRole = role;
     },
     getAgentAliases: () => agentAliases,
     getThreads: () => threads,
@@ -614,6 +623,9 @@ export default function (pi: ExtensionAPI) {
     getActiveSkinTheme: () => activeSkinTheme,
     setActiveSkinTheme: (theme) => {
       activeSkinTheme = theme;
+    },
+    setSkinIdentityRole: (role) => {
+      skinIdentityRole = role;
     },
     setAgentOwnerToken: (ownerToken) => {
       agentOwnerToken = ownerToken;

--- a/slack-bridge/persisted-runtime-state.test.ts
+++ b/slack-bridge/persisted-runtime-state.test.ts
@@ -17,6 +17,7 @@ interface MutableRuntimeState {
   brokerRole: "broker" | "follower" | null;
   activeSkinTheme: string | null;
   agentPersonality: string | null;
+  skinIdentityRole: "broker" | "worker" | null;
   agentOwnerToken: string;
 }
 
@@ -39,6 +40,7 @@ function createDeps(
     brokerRole: null,
     activeSkinTheme: "cobalt",
     agentPersonality: "steady",
+    skinIdentityRole: "worker",
     agentOwnerToken: "owner:current",
     ...overrides.state,
   };
@@ -95,6 +97,10 @@ function createDeps(
     setAgentPersonality: (personality) => {
       state.agentPersonality = personality;
     },
+    getSkinIdentityRole: () => state.skinIdentityRole,
+    setSkinIdentityRole: (role) => {
+      state.skinIdentityRole = role;
+    },
     agentAliases,
     setAgentOwnerToken: (ownerToken) => {
       state.agentOwnerToken = ownerToken;
@@ -150,6 +156,7 @@ describe("createPersistedRuntimeState", () => {
         brokerRole: "broker",
         activeSkinTheme: "oceanic",
         agentPersonality: "calm",
+        skinIdentityRole: "broker",
       },
       threads: new Map([
         [
@@ -191,6 +198,7 @@ describe("createPersistedRuntimeState", () => {
       lastPinetRole: "broker",
       activeSkinTheme: "oceanic",
       agentPersonality: "calm",
+      skinIdentityRole: "broker",
       agentAliases: ["Cobalt", "Crane"],
     });
   });
@@ -287,6 +295,7 @@ describe("createPersistedRuntimeState", () => {
     expect(state.agentOwnerToken).toBe(buildPinetOwnerToken("broker-stable-saved"));
     expect(state.activeSkinTheme).toBe("midnight");
     expect(state.agentPersonality).toBe("observant");
+    expect(state.skinIdentityRole).toBe("broker");
     expect([...agentAliases]).toEqual(["Saved Alias", "Night Crane"]);
 
     expect(threads.get("100.1")?.owner).toBe("owner:current");
@@ -334,6 +343,7 @@ describe("createPersistedRuntimeState", () => {
       lastPinetRole: "worker",
       activeSkinTheme: "midnight",
       agentPersonality: "observant",
+      skinIdentityRole: "broker",
       agentAliases: ["Saved Alias", "Night Crane"],
     });
   });

--- a/slack-bridge/persisted-runtime-state.ts
+++ b/slack-bridge/persisted-runtime-state.ts
@@ -20,6 +20,7 @@ export interface PersistedState {
   lastPinetRole?: "broker" | "worker";
   activeSkinTheme?: string | null;
   agentPersonality?: string | null;
+  skinIdentityRole?: "broker" | "worker" | null;
   agentAliases?: string[];
 }
 
@@ -48,6 +49,8 @@ export interface PersistedRuntimeStateDeps {
   setActiveSkinTheme: (theme: string | null) => void;
   getAgentPersonality: () => string | null;
   setAgentPersonality: (personality: string | null) => void;
+  getSkinIdentityRole: () => "broker" | "worker" | null;
+  setSkinIdentityRole: (role: "broker" | "worker" | null) => void;
   agentAliases: Set<string>;
   setAgentOwnerToken: (ownerToken: string) => void;
   getSettings: () => SlackBridgeSettings;
@@ -80,6 +83,7 @@ export function createPersistedRuntimeState(
         lastPinetRole: deps.getBrokerRole() === "broker" ? "broker" : "worker",
         activeSkinTheme: deps.getActiveSkinTheme(),
         agentPersonality: deps.getAgentPersonality(),
+        skinIdentityRole: deps.getSkinIdentityRole(),
         agentAliases: [...deps.agentAliases],
       } satisfies PersistedState);
     } catch (error) {
@@ -135,6 +139,7 @@ export function createPersistedRuntimeState(
           : (ctx.sessionManager.getSessionFile() ?? agentStableId);
       deps.setActiveSkinTheme(savedState?.activeSkinTheme ?? null);
       deps.setAgentPersonality(savedState?.agentPersonality ?? null);
+      deps.setSkinIdentityRole(savedState?.skinIdentityRole ?? (savedState ? restoredRole : null));
       deps.agentAliases.clear();
       for (const alias of savedState?.agentAliases ?? []) {
         if (alias) {

--- a/slack-bridge/runtime-agent-context.test.ts
+++ b/slack-bridge/runtime-agent-context.test.ts
@@ -33,6 +33,7 @@ interface MutableRuntimeAgentState {
   agentOwnerToken: string;
   activeSkinTheme: string | null;
   agentPersonality: string | null;
+  skinIdentityRole: "broker" | "worker" | null;
 }
 
 function createContext(
@@ -86,6 +87,7 @@ function createDeps(
     agentOwnerToken: buildPinetOwnerToken("agent-stable-current"),
     activeSkinTheme: null,
     agentPersonality: null,
+    skinIdentityRole: null,
     ...overrides.state,
   };
   const threads =
@@ -164,6 +166,10 @@ function createDeps(
     getAgentPersonality: () => state.agentPersonality,
     setAgentPersonality: (personality) => {
       state.agentPersonality = personality;
+    },
+    getSkinIdentityRole: () => state.skinIdentityRole,
+    setSkinIdentityRole: (role) => {
+      state.skinIdentityRole = role;
     },
     getAgentAliases: () => agentAliases,
     getThreads: () => threads,
@@ -300,6 +306,7 @@ describe("createRuntimeAgentContext", () => {
     expect(state.agentName).toBe("Obsidian Coral Goose");
     expect(state.agentEmoji).toBe("🪿");
     expect(state.agentPersonality).toBe("observant");
+    expect(state.skinIdentityRole).toBeNull();
     expect([...agentAliases]).toEqual(["Cobalt Olive Crane"]);
     expect(threads.get("100.1")?.owner).toBe(state.agentOwnerToken);
     expect(threads.get("200.1")?.owner).toBe("someone-else");
@@ -366,6 +373,138 @@ describe("createRuntimeAgentContext", () => {
     expect(state.agentPersonality).toBe(expectedSkin.personality);
   });
 
+  it("preserves persisted skin identity when refreshing the same configured skin", () => {
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "slack-bridge": {
+          skinTheme: "cosmere",
+        },
+      }),
+    );
+
+    const { deps, state } = createDeps({
+      state: {
+        activeSkinTheme: "cosmere",
+        agentName: "Drehy Wave",
+        agentEmoji: "🐦",
+        agentPersonality: "Nods, fixes, moves on; warmly competent.",
+        skinIdentityRole: "worker",
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    runtimeAgentContext.refreshSettings();
+
+    expect(state.activeSkinTheme).toBe("cosmere");
+    expect(state.agentName).toBe("Drehy Wave");
+    expect(state.agentEmoji).toBe("🐦");
+    expect(state.agentPersonality).toBe("Nods, fixes, moves on; warmly competent.");
+  });
+
+  it("preserves same-role free-form skin identity when refreshing the same skin", () => {
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "slack-bridge": {
+          skinTheme: "custom nebula",
+        },
+      }),
+    );
+
+    const { deps, state } = createDeps({
+      state: {
+        activeSkinTheme: "custom nebula",
+        skinIdentityRole: "worker",
+        agentName: "Persisted Nebula Worker",
+        agentEmoji: "🌈",
+        agentPersonality: "Custom free-form worker persona.",
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    runtimeAgentContext.refreshSettings();
+
+    expect(state.agentName).toBe("Persisted Nebula Worker");
+    expect(state.agentEmoji).toBe("🌈");
+    expect(state.agentPersonality).toBe("Custom free-form worker persona.");
+    expect(state.skinIdentityRole).toBe("worker");
+  });
+
+  it("does not preserve manual same-role local identity edits as skin provenance", () => {
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "slack-bridge": {
+          skinTheme: "custom nebula",
+        },
+      }),
+    );
+
+    const { deps, state } = createDeps({
+      state: {
+        activeSkinTheme: "custom nebula",
+        skinIdentityRole: "worker",
+        agentName: "Persisted Nebula Worker",
+        agentEmoji: "🌈",
+        agentPersonality: "Custom free-form worker persona.",
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    runtimeAgentContext.applyLocalAgentIdentity("Manual Local Rename", "📝", "manual");
+    runtimeAgentContext.refreshSettings();
+
+    expect(state.agentName).not.toBe("Manual Local Rename");
+    expect(state.agentEmoji).not.toBe("📝");
+    expect(state.skinIdentityRole).toBe("worker");
+  });
+
+  it("does not preserve a broker skin identity when refreshing as a worker", () => {
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "slack-bridge": {
+          skinTheme: "cosmere",
+        },
+      }),
+    );
+
+    const sessionFile = "/tmp/runtime-agent-context-session.json";
+    const brokerSkin = buildPinetSkinAssignment({
+      theme: "cosmere",
+      role: "broker",
+      seed: "broker-stable-current",
+    });
+    const expectedWorkerSkin = buildPinetSkinAssignment({
+      theme: "cosmere",
+      role: "worker",
+      seed: sessionFile,
+    });
+    const { deps, state } = createDeps({
+      extensionContext: createContext(sessionFile),
+      state: {
+        brokerRole: null,
+        activeSkinTheme: "cosmere",
+        agentName: brokerSkin.name,
+        agentEmoji: brokerSkin.emoji,
+        agentPersonality: brokerSkin.personality,
+        skinIdentityRole: "broker",
+      },
+    });
+    const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+    runtimeAgentContext.refreshSettings();
+
+    expect(state.agentName).toBe(expectedWorkerSkin.name);
+    expect(state.agentEmoji).toBe(expectedWorkerSkin.emoji);
+    expect(state.agentPersonality).toBe(expectedWorkerSkin.personality);
+  });
+
   it("clears stale active skin when skinTheme is removed from settings", () => {
     fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
     fs.writeFileSync(
@@ -412,6 +551,7 @@ describe("createRuntimeAgentContext", () => {
         agentOwnerToken: "owner:stale",
         activeSkinTheme: "midnight",
         agentPersonality: "steady",
+        skinIdentityRole: "broker",
       },
       agentAliases: new Set(["Saved Alias", "Saved Crane"]),
     });
@@ -430,6 +570,7 @@ describe("createRuntimeAgentContext", () => {
     state.agentEmoji = "🪿";
     state.activeSkinTheme = null;
     state.agentPersonality = null;
+    state.skinIdentityRole = null;
     agentAliases.clear();
     agentAliases.add("Mutated Alias");
 
@@ -451,6 +592,7 @@ describe("createRuntimeAgentContext", () => {
     expect(state.agentEmoji).toBe("🦩");
     expect(state.activeSkinTheme).toBe("midnight");
     expect(state.agentPersonality).toBe("steady");
+    expect(state.skinIdentityRole).toBe("broker");
     expect(state.agentOwnerToken).toBe(buildPinetOwnerToken(state.brokerStableId));
     expect([...agentAliases]).toEqual(["Saved Alias"]);
   });
@@ -473,6 +615,7 @@ describe("createRuntimeAgentContext", () => {
       state: {
         activeSkinTheme: "midnight",
         agentPersonality: "observant",
+        skinIdentityRole: "broker",
       },
       gitContext: {
         cwd: workerDir,
@@ -500,6 +643,11 @@ describe("createRuntimeAgentContext", () => {
       branch: "feat/runtime-agent-context",
       role: "broker",
       skinTheme: "midnight",
+      skinIdentity: {
+        name: "Cobalt Olive Crane",
+        emoji: "🦩",
+        role: "broker",
+      },
       personality: "observant",
       skinStatusVocabulary: {
         idle: "standing by",

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -10,9 +10,11 @@ import {
   buildPinetSkinAssignment,
   buildSlackCompatibilityScope,
   getSlackUserAccessWarning,
+  isPinetSkinIdentityCompatible,
   isUserAllowed as checkUserAllowed,
   loadSettings as loadSettingsFromFile,
   normalizeOwnedThreads,
+  normalizePinetSkinIdentityMetadata,
   normalizePinetSkinTheme,
   resolveRuntimeAgentIdentity,
   shortenPath,
@@ -42,6 +44,7 @@ export interface ReloadableRuntimeSnapshot {
   agentEmoji: string;
   activeSkinTheme: string | null;
   agentPersonality: string | null;
+  skinIdentityRole: RuntimeAgentRole | null;
   agentAliases: string[];
 }
 
@@ -74,6 +77,8 @@ export interface RuntimeAgentContextDeps {
   setActiveSkinTheme: (theme: string | null) => void;
   getAgentPersonality: () => string | null;
   setAgentPersonality: (personality: string | null) => void;
+  getSkinIdentityRole: () => RuntimeAgentRole | null;
+  setSkinIdentityRole: (role: RuntimeAgentRole | null) => void;
   getAgentAliases: () => Set<string>;
   getThreads: () => Map<string, SinglePlayerThreadInfo>;
   getExtensionContext: () => ExtensionContext | null;
@@ -103,6 +108,7 @@ export interface RuntimeAgentContext {
     nextName: string,
     nextEmoji: string,
     nextPersonality: string | null,
+    skinIdentityRole?: RuntimeAgentRole | null,
   ) => void;
   refreshSettings: () => void;
   snapshotReloadableRuntime: () => ReloadableRuntimeSnapshot;
@@ -235,12 +241,14 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     nextName: string,
     nextEmoji: string,
     nextPersonality: string | null,
+    skinRole?: RuntimeAgentRole | null,
   ): void {
     const previousName = deps.getAgentName();
     if (
       previousName === nextName &&
       deps.getAgentEmoji() === nextEmoji &&
-      (deps.getAgentPersonality() ?? null) === (nextPersonality ?? null)
+      (deps.getAgentPersonality() ?? null) === (nextPersonality ?? null) &&
+      deps.getSkinIdentityRole() === (skinRole ?? null)
     ) {
       return;
     }
@@ -248,6 +256,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     deps.setAgentName(nextName);
     deps.setAgentEmoji(nextEmoji);
     deps.setAgentPersonality(nextPersonality ?? null);
+    deps.setSkinIdentityRole(skinRole ?? null);
     rememberAgentAlias(previousName);
     normalizeOwnedThreads(
       deps.getThreads().values(),
@@ -276,15 +285,42 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     deps.setReactionCommands(resolveReactionCommands(settings.reactionCommands));
     deps.setSecurityPrompt(buildSecurityPrompt(guardrails));
     const configuredSkinTheme = normalizePinetSkinTheme(settings.skinTheme);
+    const previousSkinTheme = deps.getActiveSkinTheme();
+    const previousSkinIdentity = {
+      name: deps.getAgentName().trim(),
+      emoji: deps.getAgentEmoji().trim(),
+      personality: deps.getAgentPersonality(),
+    };
     deps.setActiveSkinTheme(configuredSkinTheme);
 
     const role = deps.getBrokerRole() === "broker" ? "broker" : "worker";
     const identitySeed = getIdentitySeedForRole(role);
     const skinIdentity = resolveSkinAssignment(role, identitySeed);
     if (skinIdentity) {
+      if (
+        configuredSkinTheme &&
+        previousSkinTheme === configuredSkinTheme &&
+        deps.getSkinIdentityRole() === role &&
+        previousSkinIdentity.name &&
+        previousSkinIdentity.emoji &&
+        isPinetSkinIdentityCompatible({
+          theme: configuredSkinTheme,
+          role,
+          name: previousSkinIdentity.name,
+          emoji: previousSkinIdentity.emoji,
+        })
+      ) {
+        deps.setAgentName(previousSkinIdentity.name);
+        deps.setAgentEmoji(previousSkinIdentity.emoji);
+        deps.setAgentPersonality(previousSkinIdentity.personality ?? skinIdentity.personality);
+        deps.setSkinIdentityRole(role);
+        return;
+      }
+
       deps.setAgentName(skinIdentity.name);
       deps.setAgentEmoji(skinIdentity.emoji);
       deps.setAgentPersonality(skinIdentity.personality);
+      deps.setSkinIdentityRole(role);
       return;
     }
 
@@ -298,6 +334,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     deps.setAgentName(refreshedIdentity.name);
     deps.setAgentEmoji(refreshedIdentity.emoji);
     deps.setAgentPersonality(null);
+    deps.setSkinIdentityRole(null);
   }
 
   function snapshotReloadableRuntime(): ReloadableRuntimeSnapshot {
@@ -313,6 +350,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
       agentEmoji: deps.getAgentEmoji(),
       activeSkinTheme: deps.getActiveSkinTheme(),
       agentPersonality: deps.getAgentPersonality(),
+      skinIdentityRole: deps.getSkinIdentityRole(),
       agentAliases: [...deps.getAgentAliases()],
     };
   }
@@ -329,6 +367,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     deps.setAgentEmoji(snapshot.agentEmoji);
     deps.setActiveSkinTheme(snapshot.activeSkinTheme);
     deps.setAgentPersonality(snapshot.agentPersonality);
+    deps.setSkinIdentityRole(snapshot.skinIdentityRole);
     deps.setAgentOwnerToken(
       buildPinetOwnerToken(
         getStableIdForRole(deps.getBrokerRole() === "broker" ? "broker" : "worker"),
@@ -387,6 +426,15 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     ];
 
     const skinAssignment = resolveSkinAssignment(role, getIdentitySeedForRole(role));
+    const skinIdentityRole = deps.getSkinIdentityRole();
+    const activeSkinIdentity =
+      deps.getActiveSkinTheme() && skinIdentityRole
+        ? {
+            name: deps.getAgentName(),
+            emoji: deps.getAgentEmoji(),
+            role: skinIdentityRole,
+          }
+        : null;
     const brokerManaged = role === "worker" && process.env.PINET_BROKER_MANAGED === "1";
     const brokerManagedMetadata = brokerManaged
       ? {
@@ -408,6 +456,7 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
       scope,
       ...brokerManagedMetadata,
       ...(deps.getActiveSkinTheme() ? { skinTheme: deps.getActiveSkinTheme() } : {}),
+      ...(activeSkinIdentity ? { skinIdentity: activeSkinIdentity } : {}),
       ...(deps.getAgentPersonality() ? { personality: deps.getAgentPersonality() } : {}),
       ...(skinAssignment?.statusVocabulary
         ? { skinStatusVocabulary: skinAssignment.statusVocabulary }
@@ -460,10 +509,14 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     metadata?: Record<string, unknown> | null;
   }): void {
     deps.setActiveSkinTheme(asStringValue(registration.metadata?.skinTheme) ?? null);
+    const registrationSkinIdentity = normalizePinetSkinIdentityMetadata(
+      registration.metadata?.skinIdentity,
+    );
     applyLocalAgentIdentity(
       registration.name,
       registration.emoji,
       asStringValue(registration.metadata?.personality) ?? null,
+      deps.getActiveSkinTheme() ? (registrationSkinIdentity?.role ?? null) : null,
     );
   }
 


### PR DESCRIPTION
## Summary
- preserve already-persisted skin name/emoji when refreshing the same configured Pinet skin
- include the current skin identity in follower metadata so broker resume/follow registration can keep it
- make broker blank-registration skin assignment honor that preserved identity instead of recomputing from a different seed
- add regressions for local refresh and broker registration identity preservation

## Root cause
On resume/follow, the local runtime could restore `agentName`/`agentEmoji` from session state, but `refreshSettings()` recomputed skin identity from the runtime seed. Broker registration also independently resolved blank follower registrations from `stableId`. Those seeds can differ from the original skin assignment seed, so a resumed stable session could keep the same agent/name context while receiving a different skin emoji/character assignment.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge test -- runtime-agent-context.test.ts broker-runtime.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test` — 10 packages successful

Fixes #718