### PR TITLE
Fix arrow_up steering reaction fallback

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -194,6 +194,10 @@ User opens Pinet in Slack sidebar
 
 Messages queue while the agent is busy. When the agent finishes, it automatically drains the inbox and responds.
 
+### Reaction triggers
+
+Configured emoji reactions create structured Pinet requests from the reacted-to Slack message. The default set includes `:arrow_up:` / ⬆️ as `steer`, which marks the referenced message as steering and asks the target agent to treat it as an operator instruction when relevant and safe. Pinet adds ✅ when it accepts the reaction-triggered request. If it cannot process the reaction at all, it adds ❌; check broker logs for the underlying Slack/API error. When Slack cannot return the reacted message text, Pinet still routes the reaction with channel/thread/message IDs so steering reactions do not fail solely because message lookup was unavailable.
+
 ### Available tools
 
 Slack-bridge uses progressive disclosure to keep the per-turn tool surface

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1683,6 +1683,89 @@ describe("SlackAdapter — reaction triggers", () => {
       name: "white_check_mark",
     });
   });
+
+  it("routes arrow-up steering reactions even when Slack cannot fetch the reacted message", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.history")) {
+        return mockSlackResponse({ messages: [] });
+      }
+
+      if (url.endsWith("/users.info")) {
+        if (parsedBody.user === "U_REACTOR") {
+          return mockSlackResponse({ user: { real_name: "Alice" } });
+        }
+        if (parsedBody.user === "U_TARGET") {
+          return mockSlackResponse({ user: { real_name: "Bob" } });
+        }
+      }
+
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as { onReactionAdded: (evt: Record<string, unknown>) => Promise<void> }
+    ).onReactionAdded({
+      type: "reaction_added",
+      user: "U_REACTOR",
+      reaction: "arrow_up",
+      item_user: "U_TARGET",
+      item: {
+        type: "message",
+        channel: "C123",
+        ts: "111.333",
+      },
+      event_ts: "999.000",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        threadId: "111.333",
+        channel: "C123",
+        userId: "U_REACTOR",
+        userName: "Alice",
+        timestamp: "999.000",
+        metadata: expect.objectContaining({
+          reactionTrigger: true,
+          reactionName: "arrow_up",
+          reactionAction: "steer",
+          reactedMessageFetchStatus: "unavailable",
+          referencedMessageTs: "111.333",
+          reactedMessageAuthor: "Bob",
+          reactedMessageAuthorId: "U_TARGET",
+        }),
+      }),
+    );
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("- action: steer");
+    expect(handler.mock.calls[0]?.[0]?.text).toContain("message text unavailable");
+
+    const reactionBodies = fetchMock.mock.calls
+      .filter(([url]) => String(url).endsWith("/reactions.add"))
+      .map(([, init]) => JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+    expect(reactionBodies).toEqual([
+      { channel: "C123", timestamp: "111.333", name: "white_check_mark" },
+    ]);
+  });
 });
 
 describe("SlackAdapter — send", () => {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -333,20 +333,18 @@ export class SlackAdapter implements MessageAdapter {
 
     try {
       const reactedMessage = await this.fetchMessageByTs(item.channel, item.ts);
-      if (!reactedMessage) {
-        throw new Error(`Unable to fetch reacted message ${item.ts} in channel ${item.channel}`);
-      }
+      const reactedMessageFetchStatus = reactedMessage ? "found" : "unavailable";
 
       const threadTs =
-        (reactedMessage.thread_ts as string | undefined) ??
-        (reactedMessage.ts as string | undefined) ??
+        (reactedMessage?.thread_ts as string | undefined) ??
+        (reactedMessage?.ts as string | undefined) ??
         item.ts;
 
       if (!this.getThread(threadTs)) {
         this.threads.set(threadTs, {
           channelId: item.channel,
           threadTs,
-          userId: (reactedMessage.user as string | undefined) ?? userId,
+          userId: (reactedMessage?.user as string | undefined) ?? userId,
         });
         try {
           this.config.rememberKnownThread?.(threadTs, item.channel, null);
@@ -358,18 +356,20 @@ export class SlackAdapter implements MessageAdapter {
       const reactorName = await this.resolveUser(userId);
       if (this.shuttingDown) return;
       const reactedMessageAuthorId =
-        (reactedMessage.user as string | undefined) ?? (evt.item_user as string | undefined);
+        (reactedMessage?.user as string | undefined) ?? (evt.item_user as string | undefined);
       const reactedMessageAuthor = reactedMessageAuthorId
         ? await this.resolveUser(reactedMessageAuthorId)
-        : (reactedMessage.bot_id as string | undefined)
+        : (reactedMessage?.bot_id as string | undefined)
           ? "bot"
           : "unknown";
       if (this.shuttingDown) return;
 
       const reactedMessageText =
-        typeof reactedMessage.text === "string" && reactedMessage.text.trim().length > 0
+        typeof reactedMessage?.text === "string" && reactedMessage.text.trim().length > 0
           ? reactedMessage.text
-          : "(no text)";
+          : reactedMessage
+            ? "(no text)"
+            : "(message text unavailable; Slack did not return the reacted message, so use the channel/thread/message ids for context)";
 
       const threadInfo = this.getThread(threadTs);
       const reactionEventTs = (evt.event_ts as string | undefined) ?? item.ts;
@@ -402,6 +402,7 @@ export class SlackAdapter implements MessageAdapter {
           referencedThreadTs: threadTs,
           referencedMessageTs: item.ts,
           referencedExternalId: `${item.channel}:${item.ts}`,
+          reactedMessageFetchStatus,
           reactedMessageAuthor,
           ...(reactedMessageAuthorId ? { reactedMessageAuthorId } : {}),
         },


### PR DESCRIPTION
## Summary
- Fixes #720.
- Allows `:arrow_up:` steering reaction triggers to enqueue even when Slack cannot return the reacted message text.
- Records fallback metadata/context and acknowledges accepted steering with ✅ instead of generic ❌.
- Documents reaction feedback behavior.

## Validation
Reported by Glyphward:
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test` (74 files / 1269 tests)
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`

No merge without maintainer approval.