### PR TITLE
pinet: surface pending inbox after thread transfer

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -963,6 +963,34 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("stamps post-transfer Slack follow-ups with the new thread owner", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("thread-a", "slack", "C123", "agent-a");
+      db.transferThreadOwnership("thread-a", "agent-b");
+
+      db.queueMessage("agent-b", {
+        source: "slack",
+        threadId: "thread-a",
+        channel: "C123",
+        userId: "U1",
+        text: "reply after transfer",
+        timestamp: "124.000",
+      });
+
+      const read = db.readInbox("agent-b", { markRead: false });
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0].message.body).toBe("reply after transfer");
+      expect(read.messages[0].message.metadata).toMatchObject({
+        threadAffinityOwnerAgentId: "agent-b",
+      });
+      expect(db.getPendingInboxCount("agent-b")).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
   it("revalidates stale queued Slack rows on read when the owner changes", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);
@@ -977,6 +1005,8 @@ describe("BrokerDB message sync identity", () => {
         timestamp: "123.789",
       });
       db.updateThread("thread-a", { ownerAgent: "agent-b" });
+
+      expect(db.getPendingInboxCount("agent-a")).toBe(0);
 
       const read = db.readInbox("agent-a", { markRead: false });
 

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -2485,11 +2485,14 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   getPendingInboxCount(agentId: string): number {
-    const db = this.getDb();
-    const row = db
-      .prepare("SELECT COUNT(*) AS count FROM inbox WHERE agent_id = ? AND delivered = 0")
-      .get(agentId) as { count: number };
-    return row.count;
+    return this.withTransaction(() => {
+      this.dropStaleSlackInboxRows(agentId);
+      const db = this.getDb();
+      const row = db
+        .prepare("SELECT COUNT(*) AS count FROM inbox WHERE agent_id = ? AND delivered = 0")
+        .get(agentId) as { count: number };
+      return row.count;
+    });
   }
 
   getOwnedThreadCount(agentId: string): number {

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -18,6 +18,7 @@ export interface AgentInfo {
   idleSince?: string | null;
   lastActivity?: string | null;
   outboundCount?: number;
+  pendingInboxCount?: number;
 }
 
 export type ClientAgentInfo = Omit<AgentInfo, "stableId">;

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -432,7 +432,9 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(names).toEqual(["agent-alpha", "agent-beta"]);
     expect(agents.every((agent) => !("stableId" in agent))).toBe(true);
     expect(agents.find((agent) => agent.name === "agent-alpha")?.outboundCount).toBe(1);
+    expect(agents.find((agent) => agent.name === "agent-alpha")?.pendingInboxCount).toBe(0);
     expect(agents.find((agent) => agent.name === "agent-beta")?.outboundCount).toBe(0);
+    expect(agents.find((agent) => agent.name === "agent-beta")?.pendingInboxCount).toBe(1);
 
     client2.disconnect();
   });

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -909,7 +909,10 @@ export class BrokerSocketServer {
     const params = req.params ?? {};
     const includeDisconnected = params.includeDisconnected === true;
     const agents = (includeDisconnected ? this.db.getAllAgents() : this.db.getAgents()).map(
-      toClientAgentInfo,
+      (agent) => ({
+        ...toClientAgentInfo(agent),
+        pendingInboxCount: this.db.getPendingInboxCount(agent.id),
+      }),
     );
     return rpcOk(req.id, agents);
   }

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -1935,6 +1935,32 @@ describe("formatAgentList", () => {
     );
   });
 
+  it("includes pending inbox counts when present", () => {
+    const agents: AgentDisplayInfo[] = [
+      {
+        emoji: "📬",
+        name: "Mailbox Spren",
+        id: "agent-1",
+        status: "idle",
+        metadata: null,
+        pendingInboxCount: 1,
+      },
+      {
+        emoji: "📭",
+        name: "Empty Spren",
+        id: "agent-2",
+        status: "idle",
+        metadata: null,
+        pendingInboxCount: 0,
+      },
+    ];
+
+    const result = formatAgentList(agents, homedir);
+
+    expect(result).toContain("pending inbox: 1 queued item");
+    expect(result).not.toContain("pending inbox: 0");
+  });
+
   it("includes pid when present", () => {
     const agents: AgentDisplayInfo[] = [
       {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -908,6 +908,7 @@ export interface AgentDisplayInfo {
   idleDuration?: string | null;
   lastActivityAge?: string | null;
   outboundCount?: number | null;
+  pendingInboxCount?: number | null;
   capabilityTags?: string[];
   routingScore?: number;
   routingReasons?: string[];
@@ -927,6 +928,7 @@ export interface AgentVisibilityInput {
   idleSince?: string | null;
   lastActivity?: string | null;
   outboundCount?: number | null;
+  pendingInboxCount?: number | null;
 }
 
 export interface AgentVisibilityOptions {
@@ -1240,6 +1242,7 @@ export function buildAgentDisplayInfo(
     idleDuration: formatAge(idleDurationMs),
     lastActivityAge: formatAge(lastActivityAgeMs),
     outboundCount: agent.outboundCount ?? null,
+    pendingInboxCount: agent.pendingInboxCount ?? null,
     capabilityTags,
   };
 }
@@ -2491,6 +2494,10 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
 
       if (a.outboundCount != null) {
         line += `\n   outbound: ${a.outboundCount} this session`;
+      }
+
+      if (a.pendingInboxCount != null && a.pendingInboxCount > 0) {
+        line += `\n   pending inbox: ${a.pendingInboxCount} queued item${a.pendingInboxCount === 1 ? "" : "s"}`;
       }
 
       const tags = (a.capabilityTags ?? []).slice(0, 6);

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -123,6 +123,7 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
     agentId,
     message,
   }));
+  const getPendingInboxCount = vi.fn((agentId: string) => (agentId === "worker-1" ? 2 : 0));
   const logActivity = vi.fn((_entry: ActivityLogEntry) => undefined);
 
   const db: PinetMeshOpsBrokerDbPort = {
@@ -131,6 +132,7 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
     createThread,
     insertMessage,
     getAllAgents: () => agents,
+    getPendingInboxCount,
     transferThreadOwnership,
     recordTaskAssignment,
     scheduleWakeup,
@@ -159,6 +161,7 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
     insertedMessages,
     recordTaskAssignment,
     scheduleWakeup,
+    getPendingInboxCount,
     logActivity,
   };
 }
@@ -180,6 +183,7 @@ function createFollowerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
       disconnectedAt: null,
       resumableUntil: null,
       outboundCount: 2,
+      pendingInboxCount: 4,
     },
   ]);
   const followerClient: PinetMeshOpsFollowerClientPort = {
@@ -408,6 +412,7 @@ describe("createPinetMeshOps", () => {
           status: "idle",
           name: "Worker One",
           outboundCount: 3,
+          pendingInboxCount: 2,
         }),
         expect.objectContaining({ id: "worker-2", status: "idle", name: "Worker Two" }),
       ]),
@@ -418,6 +423,7 @@ describe("createPinetMeshOps", () => {
         status: "idle",
         name: "Worker Two",
         outboundCount: 2,
+        pendingInboxCount: 4,
       }),
     ]);
     expect(follower.listAgents).toHaveBeenCalledWith(true);

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -21,6 +21,7 @@ export interface PinetMeshOpsAgentRecord {
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
   outboundCount?: number;
+  pendingInboxCount?: number;
 }
 
 export interface PinetMeshOpsRecordedAssignment {
@@ -36,6 +37,7 @@ export interface PinetMeshOpsTransferableThread {
 
 export interface PinetMeshOpsBrokerDbPort extends AgentMessageStorage {
   getAllAgents: () => AgentInfo[];
+  getPendingInboxCount: (agentId: string) => number;
   getThread: (threadId: string) => PinetMeshOpsTransferableThread | null;
   transferThreadOwnership: (
     threadId: string,
@@ -309,6 +311,7 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
       disconnectedAt: agent.disconnectedAt,
       resumableUntil: agent.resumableUntil,
       outboundCount: agent.outboundCount,
+      pendingInboxCount: db.getPendingInboxCount(agent.id),
     }));
   }
 
@@ -330,6 +333,7 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
       disconnectedAt: agent.disconnectedAt,
       resumableUntil: agent.resumableUntil,
       outboundCount: agent.outboundCount,
+      pendingInboxCount: agent.pendingInboxCount,
     }));
   }
 

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -879,11 +879,11 @@ describe("registerPinetTools", () => {
     expect(result.details.data.text).toContain("manual supervision");
   });
 
-  it("renders broker pinet agents output with routing hints and outbound counts", async () => {
+  it("renders broker pinet agents output with routing hints, outbound counts, and pending inbox", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
 
-    const listBrokerAgents = vi.fn(() => [makeAgent({ outboundCount: 3 })]);
+    const listBrokerAgents = vi.fn(() => [makeAgent({ outboundCount: 3, pendingInboxCount: 2 })]);
     const deps = createDeps({ listBrokerAgents });
     const tools = registerWithDeps(deps);
 
@@ -911,6 +911,7 @@ describe("registerPinetTools", () => {
     );
     expect(result.details.data.text).toContain("Golden Chalk Rabbit");
     expect(result.details.data.text).toContain("outbound: 3 this session");
+    expect(result.details.data.text).toContain("pending inbox: 2 queued items");
     expect(result.details.data.details.hint).toEqual({
       repo: "extensions",
       branch: undefined,

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -50,6 +50,7 @@ export interface PinetToolsAgentRecord {
   disconnectedAt?: string | null;
   resumableUntil?: string | null;
   outboundCount?: number;
+  pendingInboxCount?: number;
 }
 
 export interface RegisterPinetToolsDeps {
@@ -698,6 +699,9 @@ function buildCompactAgentDetails(
         launchSource: agent.metadata?.launchSource ?? null,
         tmuxSession: agent.metadata?.tmuxSession ?? null,
         routingScore: agent.routingScore ?? null,
+        ...(agent.pendingInboxCount != null && agent.pendingInboxCount > 0
+          ? { pendingInboxCount: agent.pendingInboxCount }
+          : {}),
         capabilityTags: capabilityTags.slice(0, 4),
         capabilityCount: capabilityTags.length,
       };


### PR DESCRIPTION
## Summary
- verified transferred Slack follow-ups keep the new thread owner affinity in broker-core regression coverage
- surface broker-visible per-agent pending inbox counts in `pinet agents --full` output/details
- include pending counts in mesh ops agent records so stalled handoff deliveries are inspectable

## Investigation note
Live broker DB inspection showed the reported transferred thread was explicitly owned by Drehy and two post-transfer follow-ups were queued to Drehy with matching thread-affinity metadata. This PR preserves that routing behavior with a regression and makes the pending queued state visible to brokers.

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge test -- pinet-mesh-ops.test.ts pinet-tools.test.ts helpers.test.ts`
- `pnpm --filter @gugu910/pi-broker-core test -- schema.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm lint && pnpm typecheck && pnpm test`

Fixes #722
