### PR TITLE
fix(pinet): default dispatcher output to compact CLI

### DIFF
--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -180,6 +180,7 @@ describe("registerPinetTools", () => {
     expect(pinet?.promptSnippet).toContain("lanes, ports, reload");
     expect(pinet?.promptSnippet).not.toContain("skin");
     expect(pinet?.promptSnippet).toContain('args.format="json"');
+    expect(pinet?.promptSnippet).toContain("fill context quickly");
     expect(JSON.stringify(pinet?.parameters)).toContain(
       "help, send, read, free, schedule, agents, lanes, ports, reload, or exit",
     );
@@ -214,14 +215,19 @@ describe("registerPinetTools", () => {
     });
   });
 
-  it("rejects the removed dispatcher skin action", async () => {
+  it("rejects the removed dispatcher skin action with compact CLI text by default", async () => {
     const tools = registerWithDeps(createDeps());
 
     const result = (await tools.get("pinet")?.execute("tool-call-1", {
       action: "skin",
       args: { theme: "foundation" },
-    })) as { details: { status: string; errors: Array<{ message: string }> } };
+    })) as {
+      content: Array<{ text: string }>;
+      details: { status: string; errors: Array<{ message: string }> };
+    };
 
+    expect(result.content[0]?.text).toContain("Pinet failed: Unknown Pinet action: skin");
+    expect(result.content[0]?.text).not.toContain('"errors"');
     expect(result.details.status).toBe("failed");
     expect(result.details.errors[0]?.message).toBe("Unknown Pinet action: skin");
   });
@@ -501,7 +507,7 @@ describe("registerPinetTools", () => {
     expect(envelope.data.full_details).toBeUndefined();
   });
 
-  it("routes action-dispatched help through the dispatcher", async () => {
+  it("routes action-dispatched help through the dispatcher with compact CLI text by default", async () => {
     const tools = registerWithDeps(createDeps());
 
     const result = (await tools.get("pinet")?.execute("tool-call-dispatch-help", {
@@ -517,6 +523,9 @@ describe("registerPinetTools", () => {
       };
     };
 
+    expect(result.content[0]?.text).toContain("Pinet actions:");
+    expect(result.content[0]?.text).toContain("send");
+    expect(result.content[0]?.text).not.toContain('"args_schema"');
     expect(result.details.status).toBe("succeeded");
     expect(result.details.data.note).toContain("Use args.topic");
     expect(result.details.data.actions).toEqual(
@@ -530,6 +539,59 @@ describe("registerPinetTools", () => {
         expect.objectContaining({ action: "ports", guardrail_tool: "pinet:ports" }),
       ]),
     );
+  });
+
+  it("preserves explicit JSON output for action-dispatched help", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-dispatch-help-json", {
+      action: "help",
+      args: { format: "json" },
+    })) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain('"status": "succeeded"');
+    expect(result.content[0]?.text).toContain('"args_schema"');
+  });
+
+  it("preserves explicit full output for action-dispatched help", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-dispatch-help-full", {
+      action: "help",
+      args: { full: true },
+    })) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain('"status": "succeeded"');
+    expect(result.content[0]?.text).toContain('"args_schema"');
+  });
+
+  it("preserves valid structured help output flags when a sibling output flag is invalid", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const jsonResult = (await tools.get("pinet")?.execute("tool-call-help-json-invalid-full", {
+      action: "help",
+      args: { format: "json", full: "true" },
+    })) as { content: Array<{ text: string }> };
+    const fullResult = (await tools.get("pinet")?.execute("tool-call-help-full-invalid-format", {
+      action: "help",
+      args: { format: "yaml", full: true },
+    })) as { content: Array<{ text: string }> };
+
+    expect(jsonResult.content[0]?.text).toContain('"status": "failed"');
+    expect(jsonResult.content[0]?.text).toContain('"full must be a boolean when provided."');
+    expect(fullResult.content[0]?.text).toContain('"status": "failed"');
+    expect(fullResult.content[0]?.text).toContain('"format must be');
+  });
+
+  it("warns compact help topic callers that JSON/full output can fill context quickly", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-dispatch-help-topic", {
+      action: "help",
+      args: { topic: "read" },
+    })) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain("JSON/full output can fill context quickly");
   });
 
   it("routes action-dispatched port lease acquire", async () => {
@@ -583,6 +645,79 @@ describe("registerPinetTools", () => {
 
     expect(result.details.status).toBe("failed");
     expect(result.details.errors[0]?.message).toContain("Unknown Pinet action: pinet_send");
+  });
+
+  it("preserves explicit JSON output for dispatcher errors", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-error-json", {
+      action: "skin",
+      args: { theme: "foundation", format: "json" },
+    })) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain('"status": "failed"');
+    expect(result.content[0]?.text).toContain('"errors"');
+  });
+
+  it("preserves explicit full output for dispatcher errors", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-error-full", {
+      action: "skin",
+      args: { theme: "foundation", full: true },
+    })) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain('"status": "failed"');
+    expect(result.content[0]?.text).toContain('"errors"');
+  });
+
+  it("preserves explicit full output for action runtime errors", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-runtime-error-full", {
+      action: "send",
+      args: { message: "dispatch now", full: true },
+    })) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain('"status": "failed"');
+    expect(result.content[0]?.text).toContain('"to is required"');
+  });
+
+  it("preserves valid structured action output flags when a sibling output flag is invalid", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const jsonResult = (await tools.get("pinet")?.execute("tool-call-send-json-invalid-full", {
+      action: "send",
+      args: { to: "alpha", message: "dispatch now", format: "json", full: "true" },
+    })) as { content: Array<{ text: string }> };
+    const fullResult = (await tools.get("pinet")?.execute("tool-call-send-full-invalid-format", {
+      action: "send",
+      args: { to: "alpha", message: "dispatch now", format: "yaml", full: true },
+    })) as { content: Array<{ text: string }> };
+
+    expect(jsonResult.content[0]?.text).toContain('"status": "failed"');
+    expect(jsonResult.content[0]?.text).toContain('"full must be a boolean when provided."');
+    expect(fullResult.content[0]?.text).toContain('"status": "failed"');
+    expect(fullResult.content[0]?.text).toContain('"format must be');
+  });
+
+  it("reports invalid output options as compact CLI text by default", async () => {
+    const tools = registerWithDeps(createDeps());
+
+    const result = (await tools.get("pinet")?.execute("tool-call-invalid-output", {
+      action: "send",
+      args: { to: "alpha", message: "dispatch now", full: "true" },
+    })) as {
+      content: Array<{ text: string }>;
+      details: { status: string; errors: Array<{ message: string }> };
+    };
+
+    expect(result.content[0]?.text).toContain(
+      "Pinet failed: full must be a boolean when provided.",
+    );
+    expect(result.content[0]?.text).not.toContain('"errors"');
+    expect(result.details.status).toBe("failed");
+    expect(result.details.errors[0]?.message).toBe("full must be a boolean when provided.");
   });
 
   it("routes action-dispatched pinet send", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -313,17 +313,87 @@ function buildPinetDispatcherEnvelope(
   return { status, data, errors, warnings };
 }
 
+function formatPinetHelpCliText(data: Record<string, unknown>): string | null {
+  const actions = Array.isArray(data.actions)
+    ? data.actions
+        .map((action) =>
+          isRecord(action) && typeof action.action === "string" ? action.action : null,
+        )
+        .filter((action): action is string => Boolean(action))
+    : [];
+  if (actions.length > 0) {
+    const note = typeof data.note === "string" && data.note.trim() ? ` ${data.note.trim()}` : "";
+    return `Pinet actions: ${actions.join(", ")}.${note}`;
+  }
+
+  if (typeof data.action === "string") {
+    const description =
+      typeof data.description === "string" && data.description.trim()
+        ? ` — ${data.description.trim()}`
+        : "";
+    return `Pinet ${data.action}${description}. Use args.format="json" or args.full=true for schema/details; JSON/full output can fill context quickly.`;
+  }
+
+  return null;
+}
+
 function getPinetEnvelopeCliText(envelope: PinetDispatcherEnvelope): string {
   if (envelope.status === "succeeded" && isRecord(envelope.data)) {
     const text = envelope.data.text;
     if (typeof text === "string" && text.length > 0) return text;
+
+    const helpText = formatPinetHelpCliText(envelope.data);
+    if (helpText) return helpText;
+
+    const action = typeof envelope.data.action === "string" ? ` ${envelope.data.action}` : "";
+    return `Pinet${action} succeeded. Use args.format="json" or args.full=true for details; JSON/full output can fill context quickly.`;
   }
-  return JSON.stringify(envelope, null, 2);
+
+  const errors = envelope.errors.map((error) => error.message).filter(Boolean);
+  const hints = Array.from(
+    new Set(envelope.errors.map((error) => error.hint).filter((hint) => hint.length > 0)),
+  );
+  if (errors.length > 0) {
+    return `Pinet ${envelope.status}: ${errors.join("; ")}${hints.length > 0 ? ` Hint: ${hints.join(" ")}` : ""}`;
+  }
+
+  return `Pinet ${envelope.status}. Use args.format="json" or args.full=true for details; JSON/full output can fill context quickly.`;
+}
+
+function getTolerantPinetOutputOptions(value: unknown): PinetOutputOptions {
+  if (!isRecord(value)) return { format: "cli", full: false };
+
+  const rawFormat = value.format ?? value.f ?? value["-f"];
+  const normalizedFormat = rawFormat == null ? "cli" : String(rawFormat).trim().toLowerCase();
+  const format = normalizedFormat === "json" ? "json" : "cli";
+  const rawFull = value.full ?? value["--full"];
+  return { format, full: rawFull === true };
+}
+
+function getOptionalPinetOutputOptions(value: unknown): PinetOutputOptions {
+  if (!isRecord(value)) return { format: "cli", full: false };
+  try {
+    return normalizePinetOutputOptions(value);
+  } catch {
+    return getTolerantPinetOutputOptions(value);
+  }
+}
+
+function shouldRenderStructuredPinetEnvelope(
+  envelope: PinetDispatcherEnvelope,
+  output: PinetOutputOptions,
+): boolean {
+  if (output.format === "json") return true;
+  if (!output.full) return false;
+  if (envelope.status === "failed") return true;
+  if (!isRecord(envelope.data)) return true;
+  const text = envelope.data.text;
+  return typeof text !== "string" || text.length === 0;
 }
 
 function wrapDispatcherEnvelope(
   envelope: PinetDispatcherEnvelope,
-  output: PinetOutputOptions = { format: "json", full: true },
+  output: PinetOutputOptions = { format: "cli", full: false },
 ): {
   content: Array<{ type: "text"; text: string }>;
   details: PinetDispatcherEnvelope;
@@ -332,10 +402,9 @@ function wrapDispatcherEnvelope(
     content: [
       {
         type: "text",
-        text:
-          output.format === "json"
-            ? JSON.stringify(envelope, null, 2)
-            : getPinetEnvelopeCliText(envelope),
+        text: shouldRenderStructuredPinetEnvelope(envelope, output)
+          ? JSON.stringify(envelope, null, 2)
+          : getPinetEnvelopeCliText(envelope),
       },
     ],
     details: envelope,
@@ -1381,7 +1450,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     label: "Pinet Dispatcher",
     description: "Dispatch Pinet operations by action with compact help and schema discovery.",
     promptSnippet:
-      'Use this compact dispatcher for Pinet actions: send, read, free, schedule, agents, lanes, ports, reload, exit, and help. Use /pinet start, /pinet follow, and /pinet unfollow for TUI lifecycle changes. Defaults to terse CLI text; pass args.format="json" or args.full=true for explicit detail.',
+      'Use this compact dispatcher for Pinet actions: send, read, free, schedule, agents, lanes, ports, reload, exit, and help. Use /pinet start, /pinet follow, and /pinet unfollow for TUI lifecycle changes. Defaults to terse CLI text; pass args.format="json" or args.full=true for explicit detail, but avoid JSON/full unless needed because it can fill context quickly.',
     parameters: Type.Object({
       action: Type.String({
         description:
@@ -1390,7 +1459,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {
           description:
-            'Action arguments. Add format="cli"|"json" (or f/"-f") and full=true (or "--full": true) for explicit presentation control. Default cli keeps data.details compact; format="json" or full=true exposes full structured details.',
+            'Action arguments. Add format="cli"|"json" (or f/"-f") and full=true (or "--full": true) for explicit presentation control. Default cli keeps data.details compact; format="json" or full=true exposes full structured details and can fill context quickly, so use it only when needed.',
         }),
       ),
     }),
@@ -1408,6 +1477,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
               hint: 'Use action="help" to inspect supported actions.',
             },
           ]),
+          getOptionalPinetOutputOptions(params.args),
         );
       }
 
@@ -1426,6 +1496,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
                 hint: 'Use format="cli" or format="json" and full as a boolean.',
               },
             ]),
+            getTolerantPinetOutputOptions(args),
           );
         }
         return wrapDispatcherEnvelope(
@@ -1445,6 +1516,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
               hint: 'Use action="help" to inspect supported actions.',
             },
           ]),
+          getOptionalPinetOutputOptions(params.args),
         );
       }
 
@@ -1458,6 +1530,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
               hint: "Pass a JSON object as args.",
             },
           ]),
+          getOptionalPinetOutputOptions(params.args),
         );
       }
 
@@ -1474,6 +1547,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
               hint: 'Use format="cli" or format="json" and full as a boolean.',
             },
           ]),
+          getTolerantPinetOutputOptions(params.args),
         );
       }
 
@@ -1494,6 +1568,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
         const message = getErrorMessage(error);
         return wrapDispatcherEnvelope(
           buildPinetDispatcherEnvelope("failed", null, [classifyPinetError(message)]),
+          output,
         );
       }
     },


### PR DESCRIPTION
## Summary
- Fixes #726.
- Changes the Pinet dispatcher wrapper to default fallback/help/error responses to compact CLI text instead of pretty-printing the full JSON envelope.
- Keeps normal action output compact by default while preserving full structured envelopes when callers explicitly pass `format=json` / `f=json` or request full details.
- Adds user-facing guidance that JSON/full output can fill context quickly and should be used only when needed.

## Root cause
The Pinet dispatcher had compact action results for normal read/send paths, but its envelope wrapper defaulted to `{ format: "json", full: true }` and fell back to `JSON.stringify(envelope, null, 2)` whenever the envelope had no top-level `data.text`. That made help, unknown-action, invalid-argument, and runtime-error paths emit large JSON blocks by default.

## Token-footprint / default-output tradeoff
Default human-facing Pinet output now favors terse CLI summaries for scanability and lower Slack/Pinet token footprint. Structured data is still available through tool `details` and through explicit `format=json` / `full=true` requests, so automation and debugging can opt into verbosity intentionally. JSON/full output can fill context quickly, so the prompt/schema/help guidance now warns callers to reserve it for cases that actually need full structured details.

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge test -- pinet-tools.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`