### PR TITLE
fix(slack): add dispatcher message update action

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -218,6 +218,7 @@ Cold Slack actions live behind the `slack` dispatcher:
 | `upload`               | Upload files, snippets, or diffs into Slack                                       |
 | `schedule`             | Schedule a message for later delivery                                             |
 | `post_channel`         | Post to a channel (by name or ID)                                                 |
+| `update`               | Update an existing bot-posted Slack message by channel and message timestamp      |
 | `delete`               | Delete a bot-posted message or an entire thread                                   |
 | `read_channel`         | Read channel history or a thread in a channel                                     |
 | `create_channel`       | Create a new Slack channel                                                        |
@@ -252,10 +253,11 @@ migration.
 - **Channel posting is explicit.** `post_channel` posts to a named channel or
   channel ID. When `channel` is omitted, it first resolves a provided
   `thread_ts` to a tracked thread channel, then falls back to `defaultChannel`
-  from settings. `slack_send` is intentionally narrower and resolves the
-  current tracked assistant thread/DM context.
+  from settings. `update` edits an existing message and requires the exact
+  `channel` plus message `ts`. `slack_send` is intentionally narrower and
+  resolves the current tracked assistant thread/DM context.
 - **Rich messages use Block Kit JSON.** Pass `blocks` directly to
-  `slack_send` or `post_channel`; keep `text` as the notification/fallback.
+  `slack_send`, `post_channel`, or `update`; keep `text` as the notification/fallback.
   Block Kit builder tools are not registered by this package. Load the bundled
   `slack-bridge` skill for copyable status-report, button, code, and diff
   templates. The package also bundles `pinet-skin-creator` for safely drafting

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -254,8 +254,10 @@ migration.
   channel ID. When `channel` is omitted, it first resolves a provided
   `thread_ts` to a tracked thread channel, then falls back to `defaultChannel`
   from settings. `update` edits an existing message and requires the exact
-  `channel` plus message `ts`. `slack_send` is intentionally narrower and
-  resolves the current tracked assistant thread/DM context.
+  `channel` plus message `ts`; include the root `thread_ts` as the approval
+  context when guardrails require `slack:update` confirmation for a threaded
+  reply. `slack_send` is intentionally narrower and resolves the current
+  tracked assistant thread/DM context.
 - **Rich messages use Block Kit JSON.** Pass `blocks` directly to
   `slack_send`, `post_channel`, or `update`; keep `text` as the notification/fallback.
   Block Kit builder tools are not registered by this package. Load the bundled

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -48,7 +48,7 @@ should use the colon form.
 
 ## Action quick map
 
-- Thread/channel messaging: `post_channel`, `read`, `read_channel`, `export`
+- Thread/channel messaging: `post_channel`, `update`, `read`, `read_channel`, `export`
 - Lightweight acknowledgement: `react`
 - Files/snippets: `upload`
 - Time-based follow-up: `schedule`
@@ -63,7 +63,7 @@ should use the colon form.
 ## Block Kit patterns
 
 No Block Kit builder tool is registered. Build the JSON inline and pass it to
-`slack_send` or `slack` action `post_channel` as `blocks`.
+`slack_send`, `slack` action `post_channel`, or `slack` action `update` as `blocks`.
 
 ### Status report
 

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -49,6 +49,8 @@ should use the colon form.
 ## Action quick map
 
 - Thread/channel messaging: `post_channel`, `update`, `read`, `read_channel`, `export`
+  - For guarded `update` calls on threaded replies, pass both the message `ts`
+    to edit and the root `thread_ts` as the confirmation context.
 - Lightweight acknowledgement: `react`
 - Files/snippets: `upload`
 - Time-based follow-up: `schedule`

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -103,7 +103,7 @@ describe("registerSlackTools", () => {
         } as SlackResult;
       }
 
-      if (method === "chat.delete") {
+      if (method === "chat.delete" || method === "chat.update") {
         return {
           ok: true,
           token,
@@ -288,6 +288,7 @@ describe("registerSlackTools", () => {
       "create_channel",
       "project_create",
       "post_channel",
+      "update",
       "delete",
       "pin",
       "bookmark",
@@ -1132,6 +1133,73 @@ describe("registerSlackTools", () => {
     expect(clearPendingAttention).toHaveBeenCalledWith("123.456");
   });
 
+  it("updates Slack messages through the dispatcher", async () => {
+    const { registeredTools, slack, requireToolPolicy } = setup();
+    const dispatcher = registeredTools.get("slack")!;
+
+    const response = await dispatcher.execute("tool-update", {
+      action: "update",
+      args: {
+        channel: "#deployments",
+        ts: "1712345678.000200",
+        text: "Deploy complete",
+        blocks: [{ type: "section", text: { type: "mrkdwn", text: "Deploy complete" } }],
+      },
+    });
+    const envelope = response.details as SlackDispatcherEnvelope;
+
+    expect(envelope.status).toBe("succeeded");
+    expect(envelope.data).toMatchObject({
+      text: "Updated Slack message 1712345678.000200 in channel #deployments.",
+      details: {
+        channel: "resolved:#deployments",
+        ts: "1712345678.000200",
+        blocksCount: 1,
+      },
+    });
+    expect(slack).toHaveBeenCalledWith("chat.update", "xoxb-initial", {
+      channel: "resolved:#deployments",
+      ts: "1712345678.000200",
+      text: "Deploy complete",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "Deploy complete" } }],
+    });
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "slack:update",
+      "1712345678.000200",
+      "channel=#deployments | ts=1712345678.000200 | text=Deploy complete | blocks=1",
+    );
+  });
+
+  it("documents Slack update dispatcher schema and validates required payload", async () => {
+    const { registeredTools, slack } = setup();
+    const dispatcher = registeredTools.get("slack")!;
+
+    const help = await dispatcher.execute("tool-help-update", {
+      action: "help",
+      args: { topic: "update" },
+    });
+    const helpEnvelope = help.details as SlackDispatcherEnvelope;
+    expect(helpEnvelope.data).toMatchObject({
+      action: "update",
+      guardrail_tool: "slack:update",
+      examples: [expect.objectContaining({ action: "update" })],
+    });
+    expect(JSON.stringify(helpEnvelope.data)).toContain("chat.update");
+    expect(JSON.stringify(helpEnvelope.data)).toContain("channel");
+    expect(JSON.stringify(helpEnvelope.data)).toContain("ts");
+
+    const missingPayload = await dispatcher.execute("tool-update-missing-payload", {
+      action: "update",
+      args: { channel: "#deployments", ts: "1712345678.000200" },
+    });
+    const missingEnvelope = missingPayload.details as SlackDispatcherEnvelope;
+    expect(missingEnvelope.status).toBe("failed");
+    expect(missingEnvelope.errors[0]?.message).toBe(
+      "Provide text or blocks to update the Slack message.",
+    );
+    expect(slack).not.toHaveBeenCalledWith("chat.update", expect.any(String), expect.any(Object));
+  });
+
   it("includes blocks when slack_post_channel posts a rich message", async () => {
     const { slack, tools } = setup();
 
@@ -1375,6 +1443,7 @@ describe("registerSlackTools", () => {
     expect(catalogEnvelope.status).toBe("succeeded");
     expect(catalogResponse.content?.[0]?.text).toContain('"status": "succeeded"');
     expect(catalogResponse.content?.[0]?.text).toContain('"action": "post_channel"');
+    expect(catalogResponse.content?.[0]?.text).toContain('"action": "update"');
 
     const schemaResponse = await dispatcher.execute("tool-help-topic", {
       action: "help",

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerSlackTools, type SlackPinetDeliveryInput } from "./slack-tools.js";
+import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
 import type { InboxMessage } from "./helpers.js";
 import type { SlackResult } from "./slack-api.js";
 
@@ -39,7 +40,19 @@ function unwrapSlackDispatcherResponse(response: ToolResponse): ToolResponse {
 }
 
 describe("registerSlackTools", () => {
-  function setup() {
+  function setup(
+    options: {
+      requireToolPolicy?: (toolName: string, threadTs: string | undefined, action: string) => void;
+      registerConfirmationRequest?: (
+        threadTs: string,
+        tool: string,
+        action: string,
+      ) => {
+        status: "created" | "refreshed" | "conflict";
+        conflict?: { toolPattern: string; action: string };
+      };
+    } = {},
+  ) {
     const tools = new Map<string, ToolDefinition>();
     const pi = {
       registerTool: vi.fn((definition: ToolDefinition) => {
@@ -233,7 +246,14 @@ describe("registerSlackTools", () => {
       null;
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
-    const requireToolPolicy = vi.fn();
+    const requireToolPolicy = vi.fn(
+      options.requireToolPolicy ??
+        ((_toolName: string, _threadTs: string | undefined, _action: string) => {}),
+    );
+    const registerConfirmationRequest = vi.fn(
+      options.registerConfirmationRequest ??
+        ((_threadTs: string, _tool: string, _action: string) => ({ status: "created" as const })),
+    );
     let pinetDeliveryAvailable = false;
     const sendPinetSlackMessage = vi.fn(async (input: SlackPinetDeliveryInput) => ({
       adapter: "slack",
@@ -263,7 +283,7 @@ describe("registerSlackTools", () => {
       resolveChannel: async (nameOrId) => `resolved:${nameOrId}`,
       rememberChannel: () => {},
       requireToolPolicy,
-      registerConfirmationRequest: () => ({ status: "created" }),
+      registerConfirmationRequest,
       getBotUserId: () => "U_BOT",
       pinetDelivery: {
         isAvailable: () => pinetDeliveryAvailable,
@@ -1201,6 +1221,61 @@ describe("registerSlackTools", () => {
       "1712345678.000100",
       "channel=#deployments | thread_ts=1712345678.000100 | ts=1712345678.000200 | text=Threaded reply updated | blocks=0",
     );
+  });
+
+  it("allows confirmation-gated updates to threaded replies after approval in the root thread", async () => {
+    const policy = createThreadConfirmationPolicy({
+      getGuardrails: () => ({ requireConfirmation: ["slack:update"] }),
+    });
+    const { registeredTools, slack, setResolveThreadChannel } = setup({
+      requireToolPolicy: policy.requireToolPolicy,
+      registerConfirmationRequest: policy.registerRequest,
+    });
+    setResolveThreadChannel(async () => "C_DEPLOY");
+    const dispatcher = registeredTools.get("slack")!;
+    const updateArgs = {
+      channel: "#deployments",
+      thread_ts: "1712345678.000100",
+      ts: "1712345678.000200",
+      text: "Threaded reply updated",
+    };
+    const actionString =
+      "channel=#deployments | thread_ts=1712345678.000100 | ts=1712345678.000200 | text=Threaded reply updated | blocks=0";
+
+    const blocked = await dispatcher.execute("tool-update-needs-confirm", {
+      action: "update",
+      args: updateArgs,
+    });
+    const blockedEnvelope = blocked.details as SlackDispatcherEnvelope;
+    expect(blockedEnvelope.status).toBe("failed");
+    expect(blockedEnvelope.errors[0]?.message).toContain(
+      'Call slack with action "confirm_action" in thread 1712345678.000100',
+    );
+    expect(slack).not.toHaveBeenCalledWith("chat.update", expect.any(String), expect.any(Object));
+
+    const confirm = await dispatcher.execute("tool-confirm-update", {
+      action: "confirm_action",
+      args: {
+        thread_ts: "1712345678.000100",
+        tool: "slack:update",
+        action: actionString,
+      },
+    });
+    const confirmEnvelope = confirm.details as SlackDispatcherEnvelope;
+    expect(confirmEnvelope.status).toBe("succeeded");
+    expect(policy.consumeReply("1712345678.000100", "yes")).toEqual({ approved: true });
+
+    const approved = await dispatcher.execute("tool-update-approved", {
+      action: "update",
+      args: updateArgs,
+    });
+    const approvedEnvelope = approved.details as SlackDispatcherEnvelope;
+    expect(approvedEnvelope.status).toBe("succeeded");
+    expect(slack).toHaveBeenCalledWith("chat.update", "xoxb-initial", {
+      channel: "resolved:#deployments",
+      ts: "1712345678.000200",
+      text: "Threaded reply updated",
+    });
   });
 
   it("documents Slack update dispatcher schema and validates required payload", async () => {

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1170,6 +1170,39 @@ describe("registerSlackTools", () => {
     );
   });
 
+  it("uses the root thread as confirmation context when updating threaded replies", async () => {
+    const { registeredTools, slack, requireToolPolicy } = setup();
+    const dispatcher = registeredTools.get("slack")!;
+    requireToolPolicy.mockImplementation((toolName, threadTs) => {
+      if (toolName === "slack:update" && threadTs !== "1712345678.000100") {
+        throw new Error(`confirmation checked against wrong thread: ${String(threadTs)}`);
+      }
+    });
+
+    const response = await dispatcher.execute("tool-update-threaded-reply", {
+      action: "update",
+      args: {
+        channel: "#deployments",
+        thread_ts: "1712345678.000100",
+        ts: "1712345678.000200",
+        text: "Threaded reply updated",
+      },
+    });
+    const envelope = response.details as SlackDispatcherEnvelope;
+
+    expect(envelope.status).toBe("succeeded");
+    expect(slack).toHaveBeenCalledWith("chat.update", "xoxb-initial", {
+      channel: "resolved:#deployments",
+      ts: "1712345678.000200",
+      text: "Threaded reply updated",
+    });
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "slack:update",
+      "1712345678.000100",
+      "channel=#deployments | thread_ts=1712345678.000100 | ts=1712345678.000200 | text=Threaded reply updated | blocks=0",
+    );
+  });
+
   it("documents Slack update dispatcher schema and validates required payload", async () => {
     const { registeredTools, slack } = setup();
     const dispatcher = registeredTools.get("slack")!;
@@ -1182,10 +1215,13 @@ describe("registerSlackTools", () => {
     expect(helpEnvelope.data).toMatchObject({
       action: "update",
       guardrail_tool: "slack:update",
-      examples: [expect.objectContaining({ action: "update" })],
     });
+    expect((helpEnvelope.data as { examples: unknown[] }).examples).toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "update" })]),
+    );
     expect(JSON.stringify(helpEnvelope.data)).toContain("chat.update");
     expect(JSON.stringify(helpEnvelope.data)).toContain("channel");
+    expect(JSON.stringify(helpEnvelope.data)).toContain("thread_ts");
     expect(JSON.stringify(helpEnvelope.data)).toContain("ts");
 
     const missingPayload = await dispatcher.execute("tool-update-missing-payload", {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -170,6 +170,12 @@ const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
       args: { channel: "#deployments", text: "Deploy complete" },
     },
   ],
+  update: [
+    {
+      action: "update",
+      args: { channel: "#deployments", ts: "1712345678.000200", text: "Deploy complete" },
+    },
+  ],
   read_channel: [{ action: "read_channel", args: { channel: "#deployments", limit: 20 } }],
   confirm_action: [
     {
@@ -920,7 +926,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     name: "slack",
     label: "Slack",
     description:
-      "Dispatcher for non-hot Slack actions: react, read, upload, schedule, presence, export, post_channel, read_channel, confirm_action, delete, pin, bookmark, create_channel, project_create, canvas_comments_read, canvas_create, canvas_update, modal_open, modal_push, modal_update, and help. Use slack_inbox and slack_send for hot-path inbox/reply work.",
+      "Dispatcher for non-hot Slack actions: react, read, upload, schedule, presence, export, post_channel, update, read_channel, confirm_action, delete, pin, bookmark, create_channel, project_create, canvas_comments_read, canvas_create, canvas_update, modal_open, modal_push, modal_update, and help. Use slack_inbox and slack_send for hot-path inbox/reply work.",
     promptSnippet:
       "Run non-hot Slack actions through a compact dispatcher. Use action='help' for the action catalogue or args.topic for a specific schema. Defaults to compact cli output; pass args.format='json' (or args.response_format='json' when the action owns format) or args.full=true for structured/full details.",
     promptGuidelines: [
@@ -932,7 +938,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     parameters: Type.Object({
       action: Type.String({
         description:
-          "Action name: help | react | read | upload | schedule | presence | export | post_channel | read_channel | confirm_action | delete | pin | bookmark | create_channel | project_create | canvas_comments_read | canvas_create | canvas_update | modal_open | modal_push | modal_update",
+          "Action name: help | react | read | upload | schedule | presence | export | post_channel | update | read_channel | confirm_action | delete | pin | bookmark | create_channel | project_create | canvas_comments_read | canvas_create | canvas_update | modal_open | modal_push | modal_update",
       }),
       args: Type.Optional(
         Type.Record(Type.String(), Type.Unknown(), {
@@ -2411,6 +2417,71 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           ...(delivery.adapter ? { adapter: delivery.adapter } : {}),
           ...(delivery.messageId ? { messageId: delivery.messageId } : {}),
           ...(delivery.fallbackReason ? { fallbackReason: delivery.fallbackReason } : {}),
+        },
+      };
+    },
+  });
+
+  registerSlackAction({
+    name: "slack_update",
+    label: "Slack Update Message",
+    description:
+      "Update an existing Slack message by channel and message timestamp using chat.update.",
+    promptSnippet:
+      "Update a Slack message previously posted by the bot. Provide the channel and exact message ts plus text and/or blocks.",
+    parameters: Type.Object({
+      channel: Type.String({ description: "Channel name or ID containing the message to update" }),
+      ts: Type.String({ description: "Message timestamp (ts) of the Slack message to update" }),
+      text: Type.Optional(Type.String({ description: "Updated message text (Slack markdown)" })),
+      blocks: Type.Optional(
+        Type.Array(Type.Record(Type.String(), Type.Unknown()), {
+          description: "Optional replacement Slack Block Kit blocks JSON array",
+        }),
+      ),
+    }),
+    async execute(id, params) {
+      const channelInput = typeof params.channel === "string" ? params.channel.trim() : "";
+      const ts = typeof params.ts === "string" ? params.ts.trim() : "";
+      const text = typeof params.text === "string" ? params.text : undefined;
+      const blocks =
+        params.blocks === undefined ? undefined : normalizeSlackBlocksInput(params.blocks);
+
+      if (!channelInput) {
+        throw new Error("channel is required.");
+      }
+      if (!ts) {
+        throw new Error("ts is required.");
+      }
+      if ((text == null || text.length === 0) && (!blocks || blocks.length === 0)) {
+        throw new Error("Provide text or blocks to update the Slack message.");
+      }
+
+      requireToolPolicy(
+        id,
+        ts,
+        `channel=${channelInput} | ts=${ts} | text=${text ?? ""} | blocks=${summarizeSlackBlocksForPolicy(blocks)}`,
+      );
+
+      const channelId = await resolveChannel(channelInput);
+      const body: Record<string, unknown> = {
+        channel: channelId,
+        ts,
+        ...(text != null ? { text } : {}),
+        ...(blocks ? { blocks } : {}),
+      };
+      const response = await slack("chat.update", getBotToken(), body);
+      const updatedTs = typeof response.ts === "string" ? response.ts : ts;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Updated Slack message ${updatedTs} in channel ${channelInput}.`,
+          },
+        ],
+        details: {
+          channel: channelId,
+          ts: updatedTs,
+          blocksCount: blocks?.length ?? 0,
         },
       };
     },

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -175,6 +175,15 @@ const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
       action: "update",
       args: { channel: "#deployments", ts: "1712345678.000200", text: "Deploy complete" },
     },
+    {
+      action: "update",
+      args: {
+        channel: "#deployments",
+        thread_ts: "1712345678.000100",
+        ts: "1712345678.000200",
+        text: "Threaded reply updated",
+      },
+    },
   ],
   read_channel: [{ action: "read_channel", args: { channel: "#deployments", limit: 20 } }],
   confirm_action: [
@@ -2432,6 +2441,12 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     parameters: Type.Object({
       channel: Type.String({ description: "Channel name or ID containing the message to update" }),
       ts: Type.String({ description: "Message timestamp (ts) of the Slack message to update" }),
+      thread_ts: Type.Optional(
+        Type.String({
+          description:
+            "Root thread timestamp to use for confirmation context when updating a threaded reply. chat.update still targets ts.",
+        }),
+      ),
       text: Type.Optional(Type.String({ description: "Updated message text (Slack markdown)" })),
       blocks: Type.Optional(
         Type.Array(Type.Record(Type.String(), Type.Unknown()), {
@@ -2443,6 +2458,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       const channelInput = typeof params.channel === "string" ? params.channel.trim() : "";
       const ts = typeof params.ts === "string" ? params.ts.trim() : "";
       const text = typeof params.text === "string" ? params.text : undefined;
+      const threadTs =
+        typeof params.thread_ts === "string" && params.thread_ts.trim().length > 0
+          ? params.thread_ts.trim()
+          : undefined;
       const blocks =
         params.blocks === undefined ? undefined : normalizeSlackBlocksInput(params.blocks);
 
@@ -2456,11 +2475,14 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         throw new Error("Provide text or blocks to update the Slack message.");
       }
 
-      requireToolPolicy(
-        id,
-        ts,
-        `channel=${channelInput} | ts=${ts} | text=${text ?? ""} | blocks=${summarizeSlackBlocksForPolicy(blocks)}`,
-      );
+      const policyAction = [
+        `channel=${channelInput}`,
+        ...(threadTs ? [`thread_ts=${threadTs}`] : []),
+        `ts=${ts}`,
+        `text=${text ?? ""}`,
+        `blocks=${summarizeSlackBlocksForPolicy(blocks)}`,
+      ].join(" | ");
+      requireToolPolicy(id, threadTs ?? ts, policyAction);
 
       const channelId = await resolveChannel(channelInput);
       const body: Record<string, unknown> = {
@@ -2481,6 +2503,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         details: {
           channel: channelId,
           ts: updatedTs,
+          ...(threadTs ? { thread_ts: threadTs } : {}),
           blocksCount: blocks?.length ?? 0,
         },
       };


### PR DESCRIPTION
## Summary
- Fixes #730.
- Adds a compact Slack dispatcher `update` action backed by Slack `chat.update`.
- Requires explicit `channel` and message `ts`, plus `text` and/or replacement Block Kit `blocks`.
- Exposes action-specific help/schema/examples with guardrail name `slack:update`.
- Updates README and bundled Slack bridge skill quick-map/docs.

## Token-footprint / progressive discovery
The action is added to the existing compact Slack dispatcher catalog only by name/summary. Detailed args remain discoverable via `slack action=help args.topic=update`, preserving progressive discovery and avoiding a new hot-path tool schema.

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge test -- slack-tools.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

No merge performed.