### PR TITLE
Add /oathgate Pinet agent picker

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -384,12 +384,15 @@ The `canvas_comments_read` dispatcher action is intentionally narrow:
 
 ### Slash commands
 
-| Command           | Description                                                |
-| ----------------- | ---------------------------------------------------------- |
-| `/pinet <action>` | Unified Pinet command surface; run `/pinet help` for usage |
-| `/pinet status`   | Show connection status, threads, and agent identity        |
-| `/pinet rename`   | Change the agent's display name                            |
-| `/pinet logs`     | Show recent broker activity log entries                    |
+| Command           | Description                                                                                   |
+| ----------------- | --------------------------------------------------------------------------------------------- |
+| `/pinet <action>` | Unified Pinet command surface; run `/pinet help` for usage                                    |
+| `/pinet status`   | Show connection status, threads, and agent identity                                           |
+| `/pinet rename`   | Change the agent's display name                                                               |
+| `/pinet logs`     | Show recent broker activity log entries                                                       |
+| `/oathgate`       | Broker-only safe Pinet agent picker/context browser for copying an agent name into Slack chat |
+
+`/oathgate` opens a compact modal listing visible Pinet agents with safe routing context such as status, repo/branch, relative worktree hint, workload, and active lane reference. It intentionally does not send or route messages from the modal; copy/paste the selected agent name into chat instead. Raw stable ids, absolute local paths, full metadata blobs, and private prompt contents must not appear in the Slack-visible picker.
 
 ## Runtime modes
 

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -52,6 +52,7 @@ import {
 } from "./ralph-loop.js";
 import { TtlCache } from "./ttl-cache.js";
 import { createBrokerGhostReaper } from "./broker/ghost-reaper.js";
+import { buildOathgateAgentSummaries, buildOathgateModalView } from "./oathgate.js";
 
 export interface BrokerRuntimeConnectResult {
   botUserId: string | null;
@@ -578,6 +579,18 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         },
         onAppHomeOpened: async ({ userId }) => {
           await deps.onAppHomeOpened(userId, ctx);
+        },
+        onOathgateCommand: () => {
+          const agents = broker.db.getAllAgents().map((agent) => ({
+            ...agent,
+            pendingInboxCount: broker.db.getPendingInboxCount(agent.id),
+            ownedThreadCount: broker.db.getOwnedThreadCount(agent.id),
+          }));
+          const summaries = buildOathgateAgentSummaries({
+            agents,
+            lanes: broker.db.listPinetLanes({ includeDone: false }),
+          });
+          return buildOathgateModalView({ agents: summaries });
         },
       });
       let selfId: string | null = null;

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -77,6 +77,33 @@ describe("parseSocketFrame", () => {
     });
   });
 
+  it("extracts slash command payloads", () => {
+    const frame = JSON.stringify({
+      type: "slash_commands",
+      payload: {
+        command: "/oathgate",
+        text: "",
+        trigger_id: "trigger-1",
+        user_id: "U123",
+        channel_id: "C123",
+        channel_name: "ops",
+        team_id: "T123",
+        response_url: "https://hooks.slack.test/response",
+      },
+    });
+    const result = parseSocketFrame(frame);
+    expect(result?.slashCommand).toEqual({
+      command: "/oathgate",
+      text: "",
+      triggerId: "trigger-1",
+      userId: "U123",
+      channelId: "C123",
+      channelName: "ops",
+      teamId: "T123",
+      responseUrl: "https://hooks.slack.test/response",
+    });
+  });
+
   it("does not extract event from non-events_api types", () => {
     const frame = JSON.stringify({
       type: "hello",
@@ -979,6 +1006,82 @@ describe("SlackAdapter", () => {
     expect(handler).toHaveBeenCalledTimes(1);
     expect(resolveUserSpy).toHaveBeenCalledTimes(1);
     expect(addReactionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens /oathgate modal from slash command payloads", async () => {
+    const onOathgateCommand = vi.fn(() => ({
+      type: "modal",
+      title: { type: "plain_text", text: "Oathgate" },
+      blocks: [],
+    }));
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onOathgateCommand,
+    });
+    const callSlack = vi
+      .spyOn(
+        adapter as unknown as {
+          callSlack: (
+            method: string,
+            token: string,
+            body?: Record<string, unknown>,
+          ) => Promise<Record<string, unknown>>;
+        },
+        "callSlack",
+      )
+      .mockResolvedValue({ ok: true });
+
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({})),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      onSlashCommand: (event) =>
+        (
+          adapter as unknown as {
+            onSlashCommand: (input: {
+              command: string;
+              text: string;
+              triggerId: string;
+              userId: string;
+              channelId: string;
+            }) => Promise<void>;
+          }
+        ).onSlashCommand(event),
+    });
+
+    await (
+      client as unknown as {
+        handleFrame: (raw: string) => Promise<void>;
+      }
+    ).handleFrame(
+      JSON.stringify({
+        envelope_id: "env-oathgate",
+        type: "slash_commands",
+        payload: {
+          command: "/oathgate",
+          text: "",
+          trigger_id: "trigger-1",
+          user_id: "U123",
+          channel_id: "C123",
+        },
+      }),
+    );
+
+    expect(onOathgateCommand).toHaveBeenCalledWith({
+      command: "/oathgate",
+      text: "",
+      triggerId: "trigger-1",
+      userId: "U123",
+      channelId: "C123",
+    });
+    expect(callSlack).toHaveBeenCalledWith("views.open", "xoxb-test-token", {
+      trigger_id: "trigger-1",
+      view: {
+        type: "modal",
+        title: { type: "plain_text", text: "Oathgate" },
+        blocks: [],
+      },
+    });
   });
 
   it("emits normalized block action payloads with structured metadata", async () => {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -13,6 +13,7 @@ import {
   setSlackSuggestedPrompts,
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
+  type ParsedSlashCommand,
   type ParsedThreadContextChanged,
   type ParsedThreadStarted,
 } from "../../slack-access.js";
@@ -66,6 +67,10 @@ export interface SlackAdapterConfig {
   ) => void;
   /** Best-effort callback for Home tab opens. */
   onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
+  /** Build the /oathgate modal view from current broker state. */
+  onOathgateCommand?: (
+    event: ParsedSlashCommand,
+  ) => Promise<Record<string, unknown>> | Record<string, unknown>;
 }
 
 interface SlackThreadInfo {
@@ -145,6 +150,7 @@ export class SlackAdapter implements MessageAdapter {
       onMemberJoinedChannel: (event) => this.onMemberJoined(event),
       onAppHomeOpened: (event) => this.onAppHomeOpened(event),
       onInteractive: (event) => this.emitInteractiveInbound(event),
+      onSlashCommand: (event) => this.onSlashCommand(event),
       onError: (error) => {
         if (!isAbortError(error)) {
           console.error(`[slack-adapter] Socket Mode: ${errorMsg(error)}`);
@@ -478,6 +484,22 @@ export class SlackAdapter implements MessageAdapter {
       ...(isChannelMention ? { isChannelMention: true } : {}),
       ...(metadata ? { metadata } : {}),
     });
+  }
+
+  private async onSlashCommand(command: ParsedSlashCommand): Promise<void> {
+    if (command.command !== "/oathgate") return;
+    if (!isSlackUserAllowed(this.allowlist, command.userId)) return;
+    if (!this.config.onOathgateCommand) return;
+
+    try {
+      const view = await this.config.onOathgateCommand(command);
+      await this.callSlack("views.open", this.config.botToken, {
+        trigger_id: command.triggerId,
+        view,
+      });
+    } catch (error) {
+      console.error(`[slack-adapter] /oathgate failed: ${errorMsg(error)}`);
+    }
   }
 
   private async emitInteractiveInbound(normalized: {

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -14,6 +14,11 @@ features:
   assistant_view:
     assistant_description: Pi coding agent
     suggested_prompts: []
+  slash_commands:
+    - command: /oathgate
+      description: Browse visible Pinet agents and copy an agent name into chat
+      usage_hint: ""
+      should_escape: false
 oauth_config:
   scopes:
     bot:
@@ -23,6 +28,7 @@ oauth_config:
       - channels:history
       - channels:read
       - chat:write
+      - commands
       - files:read
       - files:write
       - bookmarks:read

--- a/slack-bridge/oathgate.test.ts
+++ b/slack-bridge/oathgate.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { buildOathgateAgentSummaries, buildOathgateModalView } from "./oathgate.js";
+import type { OathgateAgentInput } from "./oathgate.js";
+
+function makeAgent(overrides: Partial<OathgateAgentInput> = {}): OathgateAgentInput {
+  return {
+    id: "agent-1",
+    stableId: "/raw/session/path/should-not-show",
+    name: "Fearspren",
+    emoji: "😱",
+    pid: 1234,
+    connectedAt: "2026-05-07T10:00:00.000Z",
+    lastSeen: "2026-05-07T10:00:00.000Z",
+    lastHeartbeat: "2026-05-07T10:00:00.000Z",
+    metadata: {
+      cwd: "/Users/will/extensions/.worktrees/oathgate-agent-picker/slack-bridge",
+      repoRoot: "/Users/will/extensions",
+      repo: "extensions",
+      branch: "fix/oathgate-agent-picker-734",
+      rawSecret: "do-not-show",
+      capabilities: {
+        role: "worker",
+        repo: "extensions",
+        repoRoot: "/Users/will/extensions",
+        branch: "fix/oathgate-agent-picker-734",
+      },
+    },
+    status: "idle",
+    disconnectedAt: null,
+    resumableUntil: null,
+    idleSince: "2026-05-07T09:59:00.000Z",
+    lastActivity: "2026-05-07T09:58:00.000Z",
+    pendingInboxCount: 2,
+    ownedThreadCount: 1,
+    ...overrides,
+  };
+}
+
+describe("oathgate", () => {
+  it("builds safe agent summaries without raw stable ids or absolute cwd", () => {
+    const summaries = buildOathgateAgentSummaries({
+      now: Date.parse("2026-05-07T10:00:00.000Z"),
+      homedir: "/Users/will",
+      agents: [makeAgent()],
+      lanes: [
+        {
+          laneId: "oathgate-agent-picker",
+          name: "Oathgate picker",
+          task: null,
+          issueNumber: 734,
+          prNumber: null,
+          threadId: "1778062718.438539",
+          ownerAgentId: "agent-1",
+          implementationLeadAgentId: null,
+          pmMode: false,
+          state: "active",
+          summary: "raw details should not be needed",
+          metadata: { worktree: "/Users/will/extensions/.worktrees/oathgate-agent-picker" },
+          createdAt: "2026-05-07T09:00:00.000Z",
+          updatedAt: "2026-05-07T09:59:00.000Z",
+          lastActivityAt: "2026-05-07T09:59:00.000Z",
+          participants: [],
+        },
+      ],
+    });
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      copyText: "Fearspren",
+      repo: "extensions",
+      branch: "fix/oathgate-agent-picker-734",
+      worktreeHint: ".worktrees/oathgate-agent-picker/slack-bridge",
+      workload: "2 inbox / 1 thread",
+      lane: "Oathgate picker [active] (#734)",
+    });
+    expect(JSON.stringify(summaries)).not.toContain("/Users/will/extensions");
+    expect(JSON.stringify(summaries)).not.toContain("stable");
+    expect(JSON.stringify(summaries)).not.toContain("do-not-show");
+  });
+
+  it("renders a modal with copyable agent names and no composer", () => {
+    const summaries = buildOathgateAgentSummaries({
+      now: Date.parse("2026-05-07T10:00:00.000Z"),
+      homedir: "/Users/will",
+      agents: [makeAgent()],
+    });
+    const view = buildOathgateModalView({ agents: summaries });
+    const rendered = JSON.stringify(view);
+
+    expect(view.callback_id).toBe("oathgate.agent_picker");
+    expect(rendered).toContain("Pick an agent name to copy/paste into chat");
+    expect(rendered).toContain("`Fearspren`");
+    expect(rendered).toContain("static_select");
+    expect(rendered).not.toContain("plain_text_input");
+  });
+});

--- a/slack-bridge/oathgate.test.ts
+++ b/slack-bridge/oathgate.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { buildOathgateAgentSummaries, buildOathgateModalView } from "./oathgate.js";
 import type { OathgateAgentInput } from "./oathgate.js";
@@ -76,6 +77,69 @@ describe("oathgate", () => {
     expect(JSON.stringify(summaries)).not.toContain("/Users/will/extensions");
     expect(JSON.stringify(summaries)).not.toContain("stable");
     expect(JSON.stringify(summaries)).not.toContain("do-not-show");
+  });
+
+  it("escapes metadata and lane values rendered as mrkdwn", () => {
+    const summaries = buildOathgateAgentSummaries({
+      now: Date.parse("2026-05-07T10:00:00.000Z"),
+      homedir: "/Users/will",
+      agents: [
+        makeAgent({
+          name: "Fear<@U123>&`tick`",
+          metadata: {
+            cwd: "/Users/will/extensions/.worktrees/oathgate-agent-picker",
+            repoRoot: "/Users/will/extensions",
+            repo: "ext<&>",
+            branch: "feat/<@U999>&danger",
+            capabilities: {
+              role: "worker",
+              repo: "ext<&>",
+              branch: "feat/<@U999>&danger",
+            },
+          },
+        }),
+      ],
+      lanes: [
+        {
+          laneId: "lane-1",
+          name: "Lane <@U777> & raw",
+          task: null,
+          issueNumber: 734,
+          prNumber: null,
+          threadId: "1778062718.438539",
+          ownerAgentId: "agent-1",
+          implementationLeadAgentId: null,
+          pmMode: false,
+          state: "active",
+          summary: null,
+          metadata: {},
+          createdAt: "2026-05-07T09:00:00.000Z",
+          updatedAt: "2026-05-07T09:59:00.000Z",
+          lastActivityAt: "2026-05-07T09:59:00.000Z",
+          participants: [],
+        },
+      ],
+    });
+    const view = buildOathgateModalView({ agents: summaries });
+    const mrkdwnTexts = (view.blocks as Array<{ text?: { type: string; text: string } }>)
+      .map((block) => block.text)
+      .filter((text): text is { type: string; text: string } => text?.type === "mrkdwn")
+      .map((text) => text.text)
+      .join("\n");
+
+    expect(mrkdwnTexts).toContain("Fear&lt;@U123&gt;&amp;'tick'");
+    expect(mrkdwnTexts).toContain("ext&lt;&amp;&gt;");
+    expect(mrkdwnTexts).toContain("feat/&lt;@U999&gt;&amp;danger");
+    expect(mrkdwnTexts).toContain("Lane &lt;@U777&gt; &amp; raw");
+    expect(mrkdwnTexts).not.toContain("<@U");
+  });
+
+  it("ships Slack manifest support for /oathgate", () => {
+    const manifest = readFileSync(new URL("./manifest.yaml", import.meta.url), "utf8");
+
+    expect(manifest).toContain("slash_commands:");
+    expect(manifest).toContain("command: /oathgate");
+    expect(manifest).toContain("- commands");
   });
 
   it("renders a modal with copyable agent names and no composer", () => {

--- a/slack-bridge/oathgate.ts
+++ b/slack-bridge/oathgate.ts
@@ -1,0 +1,288 @@
+import * as path from "node:path";
+import { buildAgentDisplayInfo, filterAgentsForMeshVisibility } from "./helpers.js";
+import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
+import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
+import type { AgentInfo, PinetLaneInfo } from "./broker/types.js";
+
+export interface OathgateAgentInput extends AgentInfo {
+  pendingInboxCount?: number;
+  ownedThreadCount?: number;
+}
+
+export interface OathgateAgentSummary {
+  agentId: string;
+  copyText: string;
+  label: string;
+  status: "working" | "idle";
+  health: string;
+  role: string;
+  repo: string | null;
+  branch: string | null;
+  worktreeHint: string | null;
+  activity: string;
+  workload: string;
+  lane: string | null;
+}
+
+export interface BuildOathgateAgentSummariesInput {
+  agents: OathgateAgentInput[];
+  lanes?: PinetLaneInfo[];
+  now?: number;
+  homedir?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function stripControlChars(value: string): string {
+  return [...value]
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || code === 127 ? " " : char;
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function escapeCodeSpan(value: string): string {
+  return stripControlChars(value).replace(/`/g, "'");
+}
+
+function plainText(
+  value: string,
+  maxLength = 75,
+): { type: "plain_text"; text: string; emoji: true } {
+  return {
+    type: "plain_text",
+    text: truncateText(stripControlChars(value), maxLength),
+    emoji: true,
+  };
+}
+
+function mrkdwnText(value: string): { type: "mrkdwn"; text: string } {
+  return { type: "mrkdwn", text: value };
+}
+
+function pathHintFromMetadata(
+  metadata: Record<string, unknown> | null,
+  homedir: string,
+): string | null {
+  const cwd = asString(metadata?.cwd);
+  if (!cwd) return null;
+
+  const repoRoot =
+    asString(metadata?.repoRoot) ?? asString(asRecord(metadata?.capabilities)?.repoRoot);
+  if (repoRoot) {
+    const relative = path.relative(repoRoot, cwd);
+    if (relative === "") return "repo root";
+    if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+      return truncateText(relative, 48);
+    }
+  }
+
+  const normalizedHome = homedir.endsWith(path.sep) ? homedir : `${homedir}${path.sep}`;
+  if (cwd.startsWith(normalizedHome)) {
+    const relativeHome = cwd.slice(normalizedHome.length);
+    const worktreeIndex = relativeHome.split(path.sep).indexOf(".worktrees");
+    if (worktreeIndex >= 0) {
+      const parts = relativeHome.split(path.sep).slice(worktreeIndex, worktreeIndex + 2);
+      return truncateText(parts.join("/"), 48);
+    }
+  }
+
+  const base = path.basename(cwd);
+  return base ? truncateText(base, 48) : null;
+}
+
+function laneMatchesAgent(lane: PinetLaneInfo, agentId: string): boolean {
+  return (
+    lane.ownerAgentId === agentId ||
+    lane.implementationLeadAgentId === agentId ||
+    lane.participants.some((participant) => participant.agentId === agentId)
+  );
+}
+
+function formatLane(lane: PinetLaneInfo): string {
+  const refs = [
+    lane.issueNumber != null ? `#${lane.issueNumber}` : null,
+    lane.prNumber != null ? `PR #${lane.prNumber}` : null,
+  ].filter((ref): ref is string => Boolean(ref));
+  const name = lane.name ?? lane.laneId;
+  return truncateText(`${name} [${lane.state}]${refs.length ? ` (${refs.join(" · ")})` : ""}`, 72);
+}
+
+function getRole(metadata: Record<string, unknown> | null): string {
+  const capabilities = asRecord(metadata?.capabilities);
+  return asString(capabilities?.role) ?? asString(metadata?.role) ?? "worker";
+}
+
+function getRepo(metadata: Record<string, unknown> | null): string | null {
+  const capabilities = asRecord(metadata?.capabilities);
+  return asString(capabilities?.repo) ?? asString(metadata?.repo);
+}
+
+function getBranch(metadata: Record<string, unknown> | null): string | null {
+  const capabilities = asRecord(metadata?.capabilities);
+  return asString(capabilities?.branch) ?? asString(metadata?.branch);
+}
+
+function summarizeWorkload(agent: OathgateAgentInput): string {
+  const parts = [
+    `${agent.pendingInboxCount ?? 0} inbox`,
+    `${agent.ownedThreadCount ?? 0} thread${agent.ownedThreadCount === 1 ? "" : "s"}`,
+  ];
+  return parts.join(" / ");
+}
+
+export function buildOathgateAgentSummaries(
+  input: BuildOathgateAgentSummariesInput,
+): OathgateAgentSummary[] {
+  const now = input.now ?? Date.now();
+  const homedir = input.homedir ?? process.env.HOME ?? "";
+  const visibleAgents = filterAgentsForMeshVisibility(input.agents, {
+    now,
+    includeGhosts: true,
+    recentDisconnectWindowMs: DEFAULT_HEARTBEAT_TIMEOUT_MS * 2,
+  });
+  const activeLanes = (input.lanes ?? []).filter(
+    (lane) => lane.state !== "done" && lane.state !== "cancelled" && lane.state !== "detached",
+  );
+
+  return visibleAgents
+    .map((agent) => {
+      const display = buildAgentDisplayInfo(agent, {
+        now,
+        heartbeatTimeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
+        heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+      });
+      const metadata = asRecord(agent.metadata);
+      const matchingLane = [...activeLanes]
+        .filter((lane) => laneMatchesAgent(lane, agent.id))
+        .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))[0];
+      const repo = getRepo(metadata);
+      const branch = getBranch(metadata);
+      const role = getRole(metadata);
+      const health = display.health ?? "unknown";
+      return {
+        agentId: agent.id,
+        copyText: agent.name,
+        label: `${agent.emoji} ${agent.name}`,
+        status: agent.status,
+        health,
+        role,
+        repo,
+        branch,
+        worktreeHint: pathHintFromMetadata(metadata, homedir),
+        activity: display.lastActivityAge
+          ? `last active ${display.lastActivityAge}`
+          : "activity n/a",
+        workload: summarizeWorkload(agent),
+        lane: matchingLane ? formatLane(matchingLane) : null,
+      } satisfies OathgateAgentSummary;
+    })
+    .sort((left, right) => {
+      const leftGhost = left.health === "ghost" ? 1 : 0;
+      const rightGhost = right.health === "ghost" ? 1 : 0;
+      if (leftGhost !== rightGhost) return leftGhost - rightGhost;
+      if (left.status !== right.status) return left.status === "idle" ? -1 : 1;
+      return left.copyText.localeCompare(right.copyText);
+    });
+}
+
+function formatAgentDescription(agent: OathgateAgentSummary): string {
+  const location = [agent.repo, agent.branch]
+    .filter((part): part is string => Boolean(part))
+    .join("/");
+  return [agent.status, agent.health, location || agent.role, agent.worktreeHint]
+    .filter((part): part is string => Boolean(part))
+    .join(" · ");
+}
+
+function formatAgentListLine(agent: OathgateAgentSummary): string {
+  const context = [
+    `${agent.status}/${agent.health}`,
+    agent.repo,
+    agent.branch,
+    agent.worktreeHint ? `cwd:${agent.worktreeHint}` : null,
+    agent.lane,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" · ");
+  return `• \`${escapeCodeSpan(agent.copyText)}\` — ${context || agent.role}`;
+}
+
+export function buildOathgateModalView(input: {
+  agents: OathgateAgentSummary[];
+  commandText?: string | null;
+}): Record<string, unknown> {
+  const visibleAgents = input.agents.slice(0, 100);
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: "section",
+      text: mrkdwnText(
+        "Pick an agent name to copy/paste into chat. `/oathgate` v1 only shows safe routing context; it does not send or route messages for you.",
+      ),
+    },
+  ];
+
+  if (visibleAgents.length > 0) {
+    blocks.push({
+      type: "section",
+      text: mrkdwnText("Use the picker to inspect agents, then copy the name from the list below."),
+      accessory: {
+        type: "static_select",
+        action_id: "oathgate_agent_select",
+        placeholder: plainText("Select an agent"),
+        options: visibleAgents.map((agent) => ({
+          text: plainText(agent.label),
+          value: agent.agentId,
+          description: plainText(formatAgentDescription(agent)),
+        })),
+      },
+    });
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "section",
+      text: mrkdwnText(visibleAgents.slice(0, 12).map(formatAgentListLine).join("\n")),
+    });
+    if (input.agents.length > 12) {
+      blocks.push({
+        type: "context",
+        elements: [
+          mrkdwnText(
+            `Showing 12 of ${input.agents.length} agents in the copy list; use the picker for the rest.`,
+          ),
+        ],
+      });
+    }
+  } else {
+    blocks.push({
+      type: "section",
+      text: mrkdwnText(
+        "No visible Pinet agents are available right now. Start the broker mesh with `/pinet start`, then try `/oathgate` again.",
+      ),
+    });
+  }
+
+  return {
+    type: "modal",
+    callback_id: "oathgate.agent_picker",
+    title: plainText("Oathgate", 24),
+    close: plainText("Close", 24),
+    private_metadata: JSON.stringify({ workflow: "oathgate.agent_picker" }),
+    blocks,
+  };
+}

--- a/slack-bridge/oathgate.ts
+++ b/slack-bridge/oathgate.ts
@@ -57,8 +57,15 @@ function stripControlChars(value: string): string {
     .trim();
 }
 
+function escapeSlackMrkdwn(value: string): string {
+  return stripControlChars(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 function escapeCodeSpan(value: string): string {
-  return stripControlChars(value).replace(/`/g, "'");
+  return escapeSlackMrkdwn(value).replace(/`/g, "'");
 }
 
 function plainText(
@@ -221,7 +228,7 @@ function formatAgentListLine(agent: OathgateAgentSummary): string {
   ]
     .filter((part): part is string => Boolean(part))
     .join(" · ");
-  return `• \`${escapeCodeSpan(agent.copyText)}\` — ${context || agent.role}`;
+  return `• \`${escapeCodeSpan(agent.copyText)}\` — ${escapeSlackMrkdwn(context || agent.role)}`;
 }
 
 export function buildOathgateModalView(input: {
@@ -259,13 +266,13 @@ export function buildOathgateModalView(input: {
       text: mrkdwnText(visibleAgents.slice(0, 12).map(formatAgentListLine).join("\n")),
     });
     if (input.agents.length > 12) {
+      const overflowText =
+        input.agents.length > visibleAgents.length
+          ? `Showing 12 of ${input.agents.length} agents in the copy list and the first ${visibleAgents.length} in the picker; narrow the mesh view and retry to see more.`
+          : `Showing 12 of ${input.agents.length} agents in the copy list; use the picker for the rest.`;
       blocks.push({
         type: "context",
-        elements: [
-          mrkdwnText(
-            `Showing 12 of ${input.agents.length} agents in the copy list; use the picker for the rest.`,
-          ),
-        ],
+        elements: [mrkdwnText(overflowText)],
       });
     }
   } else {

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -5,6 +5,7 @@ import {
   normalizeReactionName,
   type ReactionCommandTemplate,
 } from "./reaction-triggers.js";
+import { buildOathgateModalView } from "./oathgate.js";
 import type { SlackInteractiveInboxEvent } from "./slack-block-kit.js";
 import type { SlackToolsThreadContextPort } from "./slack-tools.js";
 import {
@@ -14,6 +15,7 @@ import {
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
   type ParsedThreadContextChanged,
+  type ParsedSlashCommand,
   type ParsedThreadStarted,
   type SlackAccessSet,
   type SlackCall,
@@ -111,6 +113,20 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       agentAliases: deps.getAgentAliases(),
       agentOwnerToken: deps.getAgentOwnerToken(),
     };
+  }
+
+  async function onSlashCommand(command: ParsedSlashCommand): Promise<void> {
+    if (command.command !== "/oathgate") return;
+    if (!deps.isUserAllowed(command.userId)) return;
+
+    try {
+      await deps.slack("views.open", deps.getBotToken(), {
+        trigger_id: command.triggerId,
+        view: buildOathgateModalView({ agents: [] }),
+      });
+    } catch (error) {
+      console.error(`[slack-bridge] /oathgate fallback failed: ${deps.formatError(error)}`);
+    }
   }
 
   function trackOwnedThread(threadTs: string, channelId: string, source = "slack"): void {
@@ -530,6 +546,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         },
         onInteractive: (event: SlackInteractiveInboxEvent) =>
           queueInteractiveInboxEvent(event, ctx),
+        onSlashCommand,
       });
 
       slackSocket = socket;

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -74,12 +74,24 @@ export function buildSlackThreadRuntimeScope(input: {
   );
 }
 
+export interface ParsedSlashCommand {
+  command: string;
+  text: string;
+  triggerId: string;
+  userId: string;
+  channelId: string;
+  channelName?: string;
+  teamId?: string;
+  responseUrl?: string;
+}
+
 export interface ParsedEnvelope {
   envelopeId?: string;
   type: string;
   dedupKey?: string;
   event?: Record<string, unknown>;
   interactivePayload?: Record<string, unknown>;
+  slashCommand?: ParsedSlashCommand;
 }
 
 export function isSlackUserAllowed(allowlist: Set<string> | null, userId: string): boolean {
@@ -111,6 +123,29 @@ export function parseSocketFrame(raw: string): ParsedEnvelope | null {
     const interactivePayload = extractSlackInteractivePayloadFromEnvelope(data);
     if (interactivePayload) {
       result.interactivePayload = interactivePayload;
+    }
+    if (data.type === "slash_commands") {
+      const payload = data.payload as Record<string, unknown> | undefined;
+      const command = typeof payload?.command === "string" ? payload.command : null;
+      const triggerId = typeof payload?.trigger_id === "string" ? payload.trigger_id : null;
+      const userId = typeof payload?.user_id === "string" ? payload.user_id : null;
+      const channelId = typeof payload?.channel_id === "string" ? payload.channel_id : null;
+      if (command && triggerId && userId && channelId) {
+        result.slashCommand = {
+          command,
+          text: typeof payload?.text === "string" ? payload.text : "",
+          triggerId,
+          userId,
+          channelId,
+          ...(typeof payload?.channel_name === "string"
+            ? { channelName: payload.channel_name }
+            : {}),
+          ...(typeof payload?.team_id === "string" ? { teamId: payload.team_id } : {}),
+          ...(typeof payload?.response_url === "string"
+            ? { responseUrl: payload.response_url }
+            : {}),
+        };
+      }
     }
     return result;
   } catch {
@@ -510,6 +545,7 @@ export interface SlackSocketModeClientConfig {
   onMemberJoinedChannel?: (event: { channel: string; isSelf: boolean }) => Promise<void> | void;
   onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
   onInteractive?: (event: SlackInteractiveInboxEvent) => Promise<void> | void;
+  onSlashCommand?: (event: ParsedSlashCommand) => Promise<void> | void;
 }
 
 export class SlackSocketModeClient {
@@ -624,6 +660,11 @@ export class SlackSocketModeClient {
         if (normalized) {
           await this.config.onInteractive?.(normalized);
         }
+        return;
+      }
+
+      if (envelope.slashCommand) {
+        await this.config.onSlashCommand?.(envelope.slashCommand);
         return;
       }
 

--- a/slack-bridge/slack-socket-dedup.ts
+++ b/slack-bridge/slack-socket-dedup.ts
@@ -169,6 +169,16 @@ export function extractSlackSocketDedupKey(frame: Record<string, unknown>): stri
     return payload?.event ? extractSlackEventDedupKey(payload.event) : null;
   }
 
+  if (frame.type === "slash_commands") {
+    const payload = frame.payload as Record<string, unknown> | undefined;
+    const triggerId = asNonEmptyString(payload?.trigger_id);
+    const command = asNonEmptyString(payload?.command);
+    const userId = asNonEmptyString(payload?.user_id);
+    return triggerId && command
+      ? ["slash_commands", command, userId ?? "", triggerId].join(":")
+      : null;
+  }
+
   const interactivePayload = extractSlackInteractivePayloadFromEnvelope(frame);
   return interactivePayload ? extractSlackInteractiveDedupKey(interactivePayload) : null;
 }


### PR DESCRIPTION
## Summary
- Closes #734 by adding `/oathgate` Socket Mode slash-command handling.
- Opens a compact Slack modal that lists visible Pinet agents with safe routing context and copyable names.
- Keeps v1 read-only/context-only: no modal message composer and no direct route/send action.
- Redacts risky internals from Slack-visible UI by using repo/branch, relative worktree hints, status/health/workload, and active lane refs instead of raw stable IDs, absolute paths, or metadata blobs.
- Adds broker modal support plus single-player/no-broker fallback modal.

## Tests
- `pnpm --filter @gugu910/pi-slack-bridge test -- oathgate.test.ts broker/adapters/slack.test.ts single-player-runtime.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`

No merge without Will approval.
