### PR TITLE
Update Pi package namespace to @earendil-works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Each extension is a workspace package with a `package.json` that declares the
 `pi` manifest and an `index.ts` entry point:
 
 ```typescript
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
   // Register tools, commands, event handlers

--- a/browser-playwright/index.ts
+++ b/browser-playwright/index.ts
@@ -2,8 +2,8 @@ import { mkdir } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { StringEnum, Type } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { StringEnum, Type } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   assessUrl,
   buildInstallInstructions,

--- a/browser-playwright/package.json
+++ b/browser-playwright/package.json
@@ -29,12 +29,12 @@
     "playwright": "^1.52.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*"
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@mariozechner/pi-ai": "^0.65.2",
-    "@mariozechner/pi-coding-agent": "^0.65.2",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "@types/node": "^22.13.1",
     "typescript": "^5.9.3"
   }

--- a/neon-psql/index.ts
+++ b/neon-psql/index.ts
@@ -4,16 +4,16 @@ import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { StringEnum } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   formatSize,
   getAgentDir,
   truncateHead,
-} from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 
 import {

--- a/neon-psql/query-execution.ts
+++ b/neon-psql/query-execution.ts
@@ -3,7 +3,7 @@ import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { TruncationResult } from "@mariozechner/pi-coding-agent";
+import type { TruncationResult } from "@earendil-works/pi-coding-agent";
 
 import { isReadOnlyQuery, type SourceValues } from "./helpers.js";
 

--- a/nvim-bridge/index.test.ts
+++ b/nvim-bridge/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { CommentRecord } from "./comments.js";
 import extension from "./index.js";
 import {

--- a/nvim-bridge/index.ts
+++ b/nvim-bridge/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import * as crypto from "node:crypto";
 import { execSync } from "node:child_process";

--- a/openai-execution-shaping/index.ts
+++ b/openai-execution-shaping/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { loadConfig } from "./config.js";
 import {
   buildAutoContinueMessage,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         version: 22.19.11
       eslint:
         specifier: ^9.19.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@2.7.0)
       globals:
         specifier: ^15.14.0
         version: 15.15.0
@@ -36,10 +36,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.22.0
-        version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.11)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2))
+        version: 4.1.2(@types/node@22.19.11)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.7.0)(yaml@2.8.2))
 
   broker-core:
     dependencies:
@@ -53,12 +53,12 @@ importers:
         specifier: ^1.52.0
         version: 1.59.1
     devDependencies:
-      "@mariozechner/pi-ai":
-        specifier: ^0.65.2
-        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
-      "@mariozechner/pi-coding-agent":
-        specifier: ^0.65.2
-        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-ai":
+        specifier: ^0.74.0
+        version: 0.74.0(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-coding-agent":
+        specifier: ^0.74.0
+        version: 0.74.0(ws@8.20.0)(zod@4.3.6)
       "@types/node":
         specifier: ^22.13.1
         version: 22.19.11
@@ -122,10 +122,10 @@ importers:
   transport-core: {}
 
 packages:
-  "@anthropic-ai/sdk@0.73.0":
+  "@anthropic-ai/sdk@0.91.1":
     resolution:
       {
-        integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==,
+        integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==,
       }
     hasBin: true
     peerDependencies:
@@ -400,6 +400,36 @@ packages:
         integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==,
       }
 
+  "@earendil-works/pi-agent-core@0.74.0":
+    resolution:
+      {
+        integrity: sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@earendil-works/pi-ai@0.74.0":
+    resolution:
+      {
+        integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==,
+      }
+    engines: { node: ">=20.0.0" }
+    hasBin: true
+
+  "@earendil-works/pi-coding-agent@0.74.0":
+    resolution:
+      {
+        integrity: sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==,
+      }
+    engines: { node: ">=20.6.0" }
+    hasBin: true
+
+  "@earendil-works/pi-tui@0.74.0":
+    resolution:
+      {
+        integrity: sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==,
+      }
+    engines: { node: ">=20.0.0" }
+
   "@emnapi/core@1.9.1":
     resolution:
       {
@@ -618,54 +648,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@mariozechner/clipboard@0.3.2":
+  "@mariozechner/clipboard@0.3.5":
     resolution:
       {
-        integrity: sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==,
+        integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==,
       }
     engines: { node: ">= 10" }
 
-  "@mariozechner/jiti@2.6.5":
+  "@mistralai/mistralai@2.2.1":
     resolution:
       {
-        integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==,
-      }
-    hasBin: true
-
-  "@mariozechner/pi-agent-core@0.65.2":
-    resolution:
-      {
-        integrity: sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@mariozechner/pi-ai@0.65.2":
-    resolution:
-      {
-        integrity: sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==,
-      }
-    engines: { node: ">=20.0.0" }
-    hasBin: true
-
-  "@mariozechner/pi-coding-agent@0.65.2":
-    resolution:
-      {
-        integrity: sha512-/rpFzPQ+CishxrSwJHSSRZBQHHWy2K3Rbu/iV0HcMq/hl9cSI2ygpwjVTRbPW+NuP1tHxVV3AMxz69VLAs5Ztg==,
-      }
-    engines: { node: ">=20.6.0" }
-    hasBin: true
-
-  "@mariozechner/pi-tui@0.65.2":
-    resolution:
-      {
-        integrity: sha512-LBPbIBASjCF4QLrc/dwmPdBzVMsbkDhzmBIAFgglX5rZBnGRppB7ekSA+1kb5pdxDpDn8IbxJX+bl7ZaeqZqxw==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@mistralai/mistralai@1.14.1":
-    resolution:
-      {
-        integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==,
+        integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==,
       }
 
   "@napi-rs/wasm-runtime@1.1.2":
@@ -1534,27 +1527,10 @@ packages:
       }
     engines: { node: ">= 14" }
 
-  ajv-formats@3.0.1:
-    resolution:
-      {
-        integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==,
-      }
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.12.6:
     resolution:
       {
         integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
-      }
-
-  ajv@8.18.0:
-    resolution:
-      {
-        integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
       }
 
   ansi-escapes@7.3.0:
@@ -2109,12 +2085,6 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
-  fast-uri@3.1.0:
-    resolution:
-      {
-        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
-      }
-
   fast-xml-builder@1.1.5:
     resolution:
       {
@@ -2511,10 +2481,10 @@ packages:
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
       }
 
-  jiti@2.6.1:
+  jiti@2.7.0:
     resolution:
       {
-        integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
       }
     hasBin: true
 
@@ -2548,12 +2518,6 @@ packages:
     resolution:
       {
         integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
-      }
-
-  json-schema-traverse@1.0.0:
-    resolution:
-      {
-        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
       }
 
   json-stable-stringify-without-jsonify@1.0.1:
@@ -3200,13 +3164,6 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  require-from-string@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
-      }
-    engines: { node: ">=0.10.0" }
-
   resolve-from@4.0.0:
     resolution:
       {
@@ -3342,12 +3299,6 @@ packages:
     resolution:
       {
         integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
-      }
-
-  std-env@3.10.0:
-    resolution:
-      {
-        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
       }
 
   std-env@4.0.0:
@@ -3514,6 +3465,12 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
+  typebox@1.1.38:
+    resolution:
+      {
+        integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==,
+      }
+
   typescript-eslint@8.55.0:
     resolution:
       {
@@ -3557,6 +3514,13 @@ packages:
       {
         integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
       }
+
+  uuid@14.0.0:
+    resolution:
+      {
+        integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==,
+      }
+    hasBin: true
 
   vite@8.0.3:
     resolution:
@@ -3749,13 +3713,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  yoctocolors@2.1.2:
-    resolution:
-      {
-        integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
-      }
-    engines: { node: ">=18" }
-
   zod-to-json-schema@3.25.2:
     resolution:
       {
@@ -3771,7 +3728,7 @@ packages:
       }
 
 snapshots:
-  "@anthropic-ai/sdk@0.73.0(zod@4.3.6)":
+  "@anthropic-ai/sdk@0.91.1(zod@4.3.6)":
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -4189,6 +4146,85 @@ snapshots:
 
   "@borewit/text-codec@0.2.2": {}
 
+  "@earendil-works/pi-agent-core@0.74.0(ws@8.20.0)(zod@4.3.6)":
+    dependencies:
+      "@earendil-works/pi-ai": 0.74.0(ws@8.20.0)(zod@4.3.6)
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - "@modelcontextprotocol/sdk"
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  "@earendil-works/pi-ai@0.74.0(ws@8.20.0)(zod@4.3.6)":
+    dependencies:
+      "@anthropic-ai/sdk": 0.91.1(zod@4.3.6)
+      "@aws-sdk/client-bedrock-runtime": 3.1034.0
+      "@google/genai": 1.50.1
+      "@mistralai/mistralai": 2.2.1
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      typebox: 1.1.38
+      undici: 7.25.0
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - "@modelcontextprotocol/sdk"
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  "@earendil-works/pi-coding-agent@0.74.0(ws@8.20.0)(zod@4.3.6)":
+    dependencies:
+      "@earendil-works/pi-agent-core": 0.74.0(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-ai": 0.74.0(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-tui": 0.74.0
+      "@silvia-odwyer/photon-node": 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.4
+      extract-zip: 2.0.1
+      file-type: 21.3.4
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      jiti: 2.7.0
+      marked: 15.0.12
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.1.2
+      typebox: 1.1.38
+      undici: 7.25.0
+      uuid: 14.0.0
+      yaml: 2.8.2
+    optionalDependencies:
+      "@mariozechner/clipboard": 0.3.5
+    transitivePeerDependencies:
+      - "@modelcontextprotocol/sdk"
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  "@earendil-works/pi-tui@0.74.0":
+    dependencies:
+      "@types/mime-types": 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.4.0
+      marked: 15.0.12
+      mime-types: 3.0.2
+    optionalDependencies:
+      koffi: 2.16.1
+
   "@emnapi/core@1.9.1":
     dependencies:
       "@emnapi/wasi-threads": 1.2.0
@@ -4205,9 +4241,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))":
+  "@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.7.0))":
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.2": {}
@@ -4305,7 +4341,7 @@ snapshots:
   "@mariozechner/clipboard-win32-x64-msvc@0.3.2":
     optional: true
 
-  "@mariozechner/clipboard@0.3.2":
+  "@mariozechner/clipboard@0.3.5":
     optionalDependencies:
       "@mariozechner/clipboard-darwin-arm64": 0.3.2
       "@mariozechner/clipboard-darwin-universal": 0.3.2
@@ -4319,91 +4355,7 @@ snapshots:
       "@mariozechner/clipboard-win32-x64-msvc": 0.3.2
     optional: true
 
-  "@mariozechner/jiti@2.6.5":
-    dependencies:
-      std-env: 3.10.0
-      yoctocolors: 2.1.2
-
-  "@mariozechner/pi-agent-core@0.65.2(ws@8.20.0)(zod@4.3.6)":
-    dependencies:
-      "@mariozechner/pi-ai": 0.65.2(ws@8.20.0)(zod@4.3.6)
-    transitivePeerDependencies:
-      - "@modelcontextprotocol/sdk"
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  "@mariozechner/pi-ai@0.65.2(ws@8.20.0)(zod@4.3.6)":
-    dependencies:
-      "@anthropic-ai/sdk": 0.73.0(zod@4.3.6)
-      "@aws-sdk/client-bedrock-runtime": 3.1034.0
-      "@google/genai": 1.50.1
-      "@mistralai/mistralai": 1.14.1
-      "@sinclair/typebox": 0.34.49
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      undici: 7.25.0
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - "@modelcontextprotocol/sdk"
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  "@mariozechner/pi-coding-agent@0.65.2(ws@8.20.0)(zod@4.3.6)":
-    dependencies:
-      "@mariozechner/jiti": 2.6.5
-      "@mariozechner/pi-agent-core": 0.65.2(ws@8.20.0)(zod@4.3.6)
-      "@mariozechner/pi-ai": 0.65.2(ws@8.20.0)(zod@4.3.6)
-      "@mariozechner/pi-tui": 0.65.2
-      "@silvia-odwyer/photon-node": 0.3.4
-      ajv: 8.18.0
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1
-      file-type: 21.3.4
-      glob: 13.0.6
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.1.2
-      undici: 7.25.0
-      yaml: 2.8.2
-    optionalDependencies:
-      "@mariozechner/clipboard": 0.3.2
-    transitivePeerDependencies:
-      - "@modelcontextprotocol/sdk"
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  "@mariozechner/pi-tui@0.65.2":
-    dependencies:
-      "@types/mime-types": 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.4.0
-      marked: 15.0.12
-      mime-types: 3.0.2
-    optionalDependencies:
-      koffi: 2.16.1
-
-  "@mistralai/mistralai@1.14.1":
+  "@mistralai/mistralai@2.2.1":
     dependencies:
       ws: 8.20.0
       zod: 4.3.6
@@ -4883,15 +4835,15 @@ snapshots:
       "@types/node": 22.19.11
     optional: true
 
-  "@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)":
+  "@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       "@typescript-eslint/scope-manager": 8.55.0
-      "@typescript-eslint/type-utils": 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      "@typescript-eslint/type-utils": 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       "@typescript-eslint/visitor-keys": 8.55.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -4899,14 +4851,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)":
+  "@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)":
     dependencies:
       "@typescript-eslint/scope-manager": 8.55.0
       "@typescript-eslint/types": 8.55.0
       "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
       "@typescript-eslint/visitor-keys": 8.55.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4929,13 +4881,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  "@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)":
+  "@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)":
     dependencies:
       "@typescript-eslint/types": 8.55.0
       "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      "@typescript-eslint/utils": 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4958,13 +4910,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)":
+  "@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2(jiti@2.7.0))
       "@typescript-eslint/scope-manager": 8.55.0
       "@typescript-eslint/types": 8.55.0
       "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4983,13 +4935,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2))":
+  "@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.7.0)(yaml@2.8.2))":
     dependencies:
       "@vitest/spy": 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.7.0)(yaml@2.8.2)
 
   "@vitest/pretty-format@4.1.2":
     dependencies:
@@ -5023,23 +4975,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
-
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.18.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -5252,9 +5193,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint@9.39.2(jiti@2.7.0):
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2(jiti@2.7.0))
       "@eslint-community/regexpp": 4.12.2
       "@eslint/config-array": 0.21.1
       "@eslint/config-helpers": 0.4.2
@@ -5289,7 +5230,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5340,8 +5281,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-uri@3.1.0: {}
 
   fast-xml-builder@1.1.5:
     dependencies:
@@ -5567,8 +5506,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jiti@2.6.1:
-    optional: true
+  jiti@2.7.0: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -5586,8 +5524,6 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
-
-  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5939,8 +5875,6 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2: {}
-
   resolve-from@4.0.0: {}
 
   restore-cursor@5.1.0:
@@ -6020,8 +5954,6 @@ snapshots:
     optional: true
 
   stackback@0.0.2: {}
-
-  std-env@3.10.0: {}
 
   std-env@4.0.0: {}
 
@@ -6114,13 +6046,15 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typebox@1.1.38: {}
+
+  typescript-eslint@8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      "@typescript-eslint/parser": 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      "@typescript-eslint/eslint-plugin": 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      "@typescript-eslint/utils": 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -6137,7 +6071,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2):
+  uuid@14.0.0: {}
+
+  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.7.0)(yaml@2.8.2):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -6147,16 +6083,16 @@ snapshots:
     optionalDependencies:
       "@types/node": 22.19.11
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       yaml: 2.8.2
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  vitest@4.1.2(@types/node@22.19.11)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2)):
+  vitest@4.1.2(@types/node@22.19.11)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.7.0)(yaml@2.8.2)):
     dependencies:
       "@vitest/expect": 4.1.2
-      "@vitest/mocker": 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2))
+      "@vitest/mocker": 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.7.0)(yaml@2.8.2))
       "@vitest/pretty-format": 4.1.2
       "@vitest/runner": 4.1.2
       "@vitest/snapshot": 4.1.2
@@ -6173,7 +6109,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@22.19.11)(jiti@2.7.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 22.19.11
@@ -6231,8 +6167,6 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
-
-  yoctocolors@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:

--- a/slack-bridge/agent-completion-runtime.test.ts
+++ b/slack-bridge/agent-completion-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   createAgentCompletionRuntime,
   type AgentCompletionRuntimeDeps,

--- a/slack-bridge/agent-completion-runtime.ts
+++ b/slack-bridge/agent-completion-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 interface AgentCompletionThreadState {
   channelId: string;

--- a/slack-bridge/agent-event-runtime.test.ts
+++ b/slack-bridge/agent-event-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createAgentEventRuntime, type AgentEventRuntimeDeps } from "./agent-event-runtime.js";
 
 function createDeps(overrides: Partial<AgentEventRuntimeDeps> = {}) {

--- a/slack-bridge/agent-event-runtime.ts
+++ b/slack-bridge/agent-event-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentCompletionRuntime } from "./agent-completion-runtime.js";
 import type { AgentPromptGuidance } from "./agent-prompt-guidance.js";
 import {

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   type InboxMessage,
   type PinetControlCommand,

--- a/slack-bridge/command-registration-runtime.test.ts
+++ b/slack-bridge/command-registration-runtime.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { PinetCommandsDeps } from "./pinet-commands.js";
 import { createCommandRegistrationRuntime } from "./command-registration-runtime.js";
 

--- a/slack-bridge/command-registration-runtime.ts
+++ b/slack-bridge/command-registration-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerPinetCommands, type PinetCommandsDeps } from "./pinet-commands.js";
 
 export interface CommandRegistrationRuntimeDeps {

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   type FollowerRuntimeDiagnostic,
   type FollowerThreadState,

--- a/slack-bridge/imessage-tools.test.ts
+++ b/slack-bridge/imessage-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Broker } from "./broker/index.js";
 import {
   registerIMessageTools,

--- a/slack-bridge/imessage-tools.ts
+++ b/slack-bridge/imessage-tools.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { NormalizedMessageContent } from "@gugu910/pi-transport-core";
 import { Type } from "@sinclair/typebox";
 import {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DatabaseSync } from "node:sqlite";
 import { BrokerClient } from "./broker/client.js";
 import * as brokerModule from "./broker/index.js";

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createGitContextCache, probeGitBranch, probeGitContext } from "./git-metadata.js";
 import {
   type FollowerRuntimeDiagnostic,

--- a/slack-bridge/persisted-runtime-state.test.ts
+++ b/slack-bridge/persisted-runtime-state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { buildPinetOwnerToken } from "./helpers.js";
 import {
   createPersistedRuntimeState,

--- a/slack-bridge/persisted-runtime-state.ts
+++ b/slack-bridge/persisted-runtime-state.ts
@@ -1,5 +1,5 @@
 import * as os from "node:os";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   buildPinetOwnerToken,
   resolveAgentStableId,

--- a/slack-bridge/pinet-agent-status.test.ts
+++ b/slack-bridge/pinet-agent-status.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import {
   createPinetAgentStatus,

--- a/slack-bridge/pinet-agent-status.ts
+++ b/slack-bridge/pinet-agent-status.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
 
 export type PinetAgentStatusValue = "working" | "idle";

--- a/slack-bridge/pinet-commands.test.ts
+++ b/slack-bridge/pinet-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   formatPinetCommandHelp,
   registerPinetCommands,

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { parseScheduledWakeupDelay } from "@gugu910/pi-pinet-core/scheduled-wakeups";
 import {
   generateAgentName,

--- a/slack-bridge/pinet-home-tabs.test.ts
+++ b/slack-bridge/pinet-home-tabs.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
 import {

--- a/slack-bridge/pinet-home-tabs.ts
+++ b/slack-bridge/pinet-home-tabs.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
 import { probeGitBranch } from "./git-metadata.js";
 import {

--- a/slack-bridge/pinet-registration-gate.test.ts
+++ b/slack-bridge/pinet-registration-gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
 
 function createContext(

--- a/slack-bridge/pinet-registration-gate.ts
+++ b/slack-bridge/pinet-registration-gate.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { isLikelyLocalSubagentContext } from "./helpers.js";
 
 const PINET_REGISTRATION_BLOCK_REASON =

--- a/slack-bridge/pinet-remote-control.test.ts
+++ b/slack-bridge/pinet-remote-control.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import {
   createPinetRemoteControl,

--- a/slack-bridge/pinet-remote-control.ts
+++ b/slack-bridge/pinet-remote-control.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   finishPinetRemoteControl,
   queuePinetRemoteControl,

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   registerPinetTools,
   type PinetToolsAgentRecord,

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -14,7 +14,7 @@ import {
   parseScheduledWakeupDelay,
   resolveScheduledWakeupFireAt,
 } from "@gugu910/pi-pinet-core/scheduled-wakeups";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import {
   buildAgentDisplayInfo,

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   applyTrackedAssignmentIdleReplyStalls,
   buildTrackedAssignmentReplyNudgeMessage,

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -1,5 +1,5 @@
 import * as os from "node:os";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   type RalphLoopAgentWorkload,
   type RalphLoopEvaluationOptions,

--- a/slack-bridge/runtime-agent-context.test.ts
+++ b/slack-bridge/runtime-agent-context.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   buildPinetOwnerToken,
   buildPinetSkinAssignment,

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { GitContext } from "./git-metadata.js";
 import {
   buildAllowlist,

--- a/slack-bridge/session-ui-runtime.test.ts
+++ b/slack-bridge/session-ui-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createSessionUiRuntime, type SessionUiRuntimeDeps } from "./session-ui-runtime.js";
 
 function createContext(

--- a/slack-bridge/session-ui-runtime.ts
+++ b/slack-bridge/session-ui-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 const AUTO_DRAIN_INTERRUPT_SUPPRESSION_MS = 1_500;
 const AUTO_DRAIN_IDLE_RETRY_MS = 250;

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SlackSocketModeClientConfig } from "./slack-access.js";
 import {

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { agentOwnsThread, type InboxMessage, normalizeOwnedThreads } from "./helpers.js";
 import {
   buildReactionTriggerMessage,

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerSlackTools, type SlackPinetDeliveryInput } from "./slack-tools.js";
 import type { InboxMessage } from "./helpers.js";
 import type { SlackResult } from "./slack-api.js";

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -1,5 +1,9 @@
 import os from "node:os";
-import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { InboxMessage } from "./helpers.js";
 import type { SlackResult } from "./slack-api.js";

--- a/slack-bridge/tool-registration-runtime.test.ts
+++ b/slack-bridge/tool-registration-runtime.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { RegisterIMessageToolsDeps } from "./imessage-tools.js";
 import type { RegisterPinetToolsDeps } from "./pinet-tools.js";
 import type { RegisterSlackToolsDeps } from "./slack-tools.js";

--- a/slack-bridge/tool-registration-runtime.ts
+++ b/slack-bridge/tool-registration-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerIMessageTools, type RegisterIMessageToolsDeps } from "./imessage-tools.js";
 import { registerPinetTools, type RegisterPinetToolsDeps } from "./pinet-tools.js";
 import { registerSlackTools, type RegisterSlackToolsDeps } from "./slack-tools.js";

--- a/types/pi-ai.d.ts
+++ b/types/pi-ai.d.ts
@@ -1,4 +1,4 @@
-declare module "@mariozechner/pi-ai" {
+declare module "@earendil-works/pi-ai" {
   import type { TSchema } from "@sinclair/typebox";
 
   export function StringEnum(values: readonly string[], options?: Record<string, unknown>): TSchema;

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -1,4 +1,4 @@
-declare module "@mariozechner/pi-coding-agent" {
+declare module "@earendil-works/pi-coding-agent" {
   export interface TruncationResult {
     content: string;
     truncated: boolean;

--- a/types/pi-tui.d.ts
+++ b/types/pi-tui.d.ts
@@ -1,4 +1,4 @@
-declare module "@mariozechner/pi-tui" {
+declare module "@earendil-works/pi-tui" {
   export class Text {
     constructor(text: string, x: number, y: number);
   }


### PR DESCRIPTION
Pi packages have moved from `@mariozechner/*` to `@earendil-works/*`. This updates extension imports, local ambient type declarations, docs examples, and package metadata/lockfile accordingly.\n\nValidation:\n- `pnpm typecheck`\n- `pnpm test`