### PR TITLE
Fix Neon Pi SDK peer dependencies

### DIFF
--- a/neon-psql/package.json
+++ b/neon-psql/package.json
@@ -41,7 +41,15 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
   "devDependencies": {
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@sinclair/typebox": "^0.34.49"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,15 @@ importers:
 
   neon-psql:
     devDependencies:
+      "@earendil-works/pi-ai":
+        specifier: ^0.74.0
+        version: 0.74.0(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-coding-agent":
+        specifier: ^0.74.0
+        version: 0.74.0(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-tui":
+        specifier: ^0.74.0
+        version: 0.74.0
       "@sinclair/typebox":
         specifier: ^0.34.49
         version: 0.34.49


### PR DESCRIPTION
Follow-up to #740. Local runtime smoke testing found that the built Neon package imports `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` but did not declare the Pi SDK packages. This adds them as peer dependencies per Pi package docs and as dev dependencies for local/package smoke tests.\n\nValidation:\n- `pnpm install --frozen-lockfile`\n- `pnpm --filter @gugu910/pi-neon-psql run build`\n- `node -e "import('./neon-psql/dist/index.js')..."`\n- `pnpm typecheck`\n- `pnpm test`\n- Pi 0.74 package smoke via `npm exec @earendil-works/pi-coding-agent@0.74.0 -- pi -e <worktree> --list-models` with temp `PI_CODING_AGENT_DIR`