### PR TITLE
Fix Pi Git package install

### DIFF
--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -43,6 +43,6 @@
     "test": "vitest run *.test.ts"
   },
   "dependencies": {
-    "@gugu910/pi-transport-core": "workspace:*"
+    "@gugu910/pi-transport-core": "file:../transport-core"
   }
 }

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -32,6 +32,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gugu910/pi-transport-core": "workspace:*"
+    "@gugu910/pi-transport-core": "file:../transport-core"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "build": "turbo run build",
+    "build:packages": "node ./scripts/build-all.mjs",
     "test": "turbo run test",
     "deploy:slack": "node --experimental-strip-types ./slack-bridge/deploy-manifest.ts",
     "check": "pnpm lint && pnpm typecheck && pnpm format:check",
     "prepush": "pnpm lint && pnpm typecheck && pnpm test",
     "lint-staged": "lint-staged",
-    "prepare": "husky"
+    "prepare": "node ./scripts/prepare.mjs",
+    "postinstall": "node ./scripts/build-all.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs,json,md,yml,yaml}": "prettier --write",
@@ -43,8 +45,22 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.5.1",
     "turbo": "^2.5.4",
-    "typescript": "^5.7.3",
     "typescript-eslint": "^8.22.0",
     "vitest": "^4.1.2"
+  },
+  "workspaces": [
+    "transport-core",
+    "broker-core",
+    "browser-playwright",
+    "pinet-core",
+    "slack-bridge",
+    "slack-api",
+    "imessage-bridge",
+    "nvim-bridge",
+    "neon-psql",
+    "openai-execution-shaping"
+  ],
+  "dependencies": {
+    "typescript": "^5.7.3"
   }
 }

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -34,7 +34,7 @@
     "test": "vitest run *.test.ts"
   },
   "dependencies": {
-    "@gugu910/pi-broker-core": "workspace:*",
-    "@gugu910/pi-transport-core": "workspace:*"
+    "@gugu910/pi-broker-core": "file:../broker-core",
+    "@gugu910/pi-transport-core": "file:../transport-core"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 importers:
   .:
+    dependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
     devDependencies:
       "@eslint/js":
         specifier: ^9.19.0
@@ -31,9 +35,6 @@ importers:
       turbo:
         specifier: ^2.5.4
         version: 2.9.3
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
       typescript-eslint:
         specifier: ^8.22.0
         version: 8.55.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
@@ -44,7 +45,7 @@ importers:
   broker-core:
     dependencies:
       "@gugu910/pi-transport-core":
-        specifier: workspace:*
+        specifier: file:../transport-core
         version: link:../transport-core
 
   browser-playwright:
@@ -69,7 +70,7 @@ importers:
   imessage-bridge:
     dependencies:
       "@gugu910/pi-transport-core":
-        specifier: workspace:*
+        specifier: file:../transport-core
         version: link:../transport-core
 
   neon-psql:
@@ -98,10 +99,10 @@ importers:
   pinet-core:
     dependencies:
       "@gugu910/pi-broker-core":
-        specifier: workspace:*
+        specifier: file:../broker-core
         version: link:../broker-core
       "@gugu910/pi-transport-core":
-        specifier: workspace:*
+        specifier: file:../transport-core
         version: link:../transport-core
 
   slack-api:
@@ -113,16 +114,16 @@ importers:
   slack-bridge:
     dependencies:
       "@gugu910/pi-broker-core":
-        specifier: workspace:*
+        specifier: file:../broker-core
         version: link:../broker-core
       "@gugu910/pi-imessage-bridge":
-        specifier: workspace:*
+        specifier: file:../imessage-bridge
         version: link:../imessage-bridge
       "@gugu910/pi-pinet-core":
-        specifier: workspace:*
+        specifier: file:../pinet-core
         version: link:../pinet-core
       "@gugu910/pi-transport-core":
-        specifier: workspace:*
+        specifier: file:../transport-core
         version: link:../transport-core
       "@sinclair/typebox":
         specifier: ^0.34.49

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Keep this in dependency order so package exports that point at dist/*.js are
+// available before downstream packages are imported by pi from a Git checkout.
+const packages = [
+  "transport-core",
+  "broker-core",
+  "pinet-core",
+  "imessage-bridge",
+  "slack-api",
+  "nvim-bridge",
+  "neon-psql",
+  "openai-execution-shaping",
+  "slack-bridge",
+];
+
+for (const workspace of packages) {
+  const result = spawnSync(process.execPath, ["../scripts/build-package.mjs"], {
+    cwd: path.join(repoRoot, workspace),
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+// pi installs Git packages with `npm install --omit=dev`, so dev-only tools like
+// husky are intentionally unavailable there. Keep local developer installs
+// convenient without making production/package installs fail.
+if (process.env.NODE_ENV === "production" || process.env.npm_config_omit?.includes("dev")) {
+  process.exit(0);
+}
+
+const huskyLookup = spawnSync("sh", ["-c", "command -v husky >/dev/null 2>&1"]);
+if (huskyLookup.status !== 0) {
+  process.exit(0);
+}
+
+const result = spawnSync("husky", { stdio: "inherit", shell: true });
+process.exit(result.status ?? 0);

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -44,10 +44,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gugu910/pi-broker-core": "workspace:*",
-    "@gugu910/pi-imessage-bridge": "workspace:*",
-    "@gugu910/pi-pinet-core": "workspace:*",
-    "@gugu910/pi-transport-core": "workspace:*",
+    "@gugu910/pi-broker-core": "file:../broker-core",
+    "@gugu910/pi-imessage-bridge": "file:../imessage-bridge",
+    "@gugu910/pi-pinet-core": "file:../pinet-core",
+    "@gugu910/pi-transport-core": "file:../transport-core",
     "@sinclair/typebox": "^0.34.49"
   }
 }


### PR DESCRIPTION
## Summary
- make the monorepo installable via Pi's default Git package path (`npm install --omit=dev`)
- add npm workspaces and npm-compatible local workspace dependency specs
- replace the dev-only Husky prepare failure with a production-safe prepare shim
- add a postinstall build path that emits package dist files needed by workspace package exports

## Why
`pi install git:github.com/gugu91/extensions` currently fails because Pi runs `npm install --omit=dev`; the root `prepare` script calls `husky`, which is dev-only, and the repo also needs dist files built for workspace package exports.

## Verification
- clean clone + overlay patch: `npm install --omit=dev` succeeds
- `node -e "import('./slack-bridge/dist/index.js')..."` succeeds
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- pre-push hook ran full `pnpm lint && pnpm typecheck && pnpm test` successfully
