### PR TITLE
fix: deliver Slack reaction steering controls

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -1088,7 +1088,7 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
-  it("redelivers read referenced Slack mail when arrow-up makes it steering", () => {
+  it("does not redeliver read referenced Slack mail when arrow-up would make it steering", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);
     try {
@@ -1126,10 +1126,11 @@ describe("BrokerDB message sync identity", () => {
       });
 
       const read = db.readInbox("agent-a", { markRead: false });
-      const redelivered = read.messages.find((item) => item.message.id === original.id);
-      expect(redelivered?.entry).toMatchObject({ delivered: false, readAt: null });
-      expect(redelivered?.message.metadata).toMatchObject({ pinet_mail_class: "steering" });
-      expect(db.getPendingInboxCount("agent-a")).toBeGreaterThanOrEqual(1);
+      expect(read.messages.find((item) => item.message.id === original.id)).toBeUndefined();
+      expect(db.getMessagesByIds([original.id])[0]?.metadata ?? {}).not.toHaveProperty(
+        "pinet_mail_class",
+      );
+      expect(db.getPendingInboxCount("agent-a")).toBe(1);
     } finally {
       db.close();
     }
@@ -1149,10 +1150,7 @@ describe("BrokerDB message sync identity", () => {
         ["agent-a"],
         { channel: "C222", timestamp: "222.333", userId: "U_TARGET" },
       );
-      const originalInboxId = db.getInbox("agent-a")[0]!.entry.id;
-      db.markDelivered([originalInboxId], "agent-a");
-      db.markRead([originalInboxId], "agent-a");
-      db.updateThread("222.222", { ownerAgent: "agent-b" });
+      db.transferThreadOwnership("222.222", "agent-b");
 
       db.queueMessage("agent-b", {
         source: "slack",
@@ -1201,7 +1199,6 @@ describe("BrokerDB message sync identity", () => {
       );
       const originalInboxId = db.getInbox("agent-a")[0]!.entry.id;
       db.markDelivered([originalInboxId], "agent-a");
-      db.markRead([originalInboxId], "agent-a");
 
       db.queueMessage("agent-a", {
         source: "slack",

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -1088,6 +1088,191 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("redelivers read referenced Slack mail when arrow-up makes it steering", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("111.222", "slack", "C123", "agent-a");
+      const original = db.insertMessage(
+        "111.222",
+        "slack",
+        "inbound",
+        "U_TARGET",
+        "This was already handled before escalation.",
+        ["agent-a"],
+        { channel: "C123", timestamp: "111.333", userId: "U_TARGET" },
+      );
+      const originalInboxId = db.getInbox("agent-a")[0]!.entry.id;
+      db.markDelivered([originalInboxId], "agent-a");
+      db.markRead([originalInboxId], "agent-a");
+      expect(db.readInbox("agent-a", { markRead: false }).messages).toHaveLength(0);
+
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "111.222",
+        channel: "C123",
+        userId: "U_REACTOR",
+        userName: "Alice",
+        text: "Reaction trigger from Slack: arrow-up",
+        timestamp: "999.000",
+        metadata: {
+          reactionTrigger: true,
+          reactionName: "arrow_up",
+          reactionAction: "steer",
+          reactorUserId: "U_REACTOR",
+          referencedSource: "slack",
+          referencedExternalId: "C123:111.333",
+        },
+      });
+
+      const read = db.readInbox("agent-a", { markRead: false });
+      const redelivered = read.messages.find((item) => item.message.id === original.id);
+      expect(redelivered?.entry).toMatchObject({ delivered: false, readAt: null });
+      expect(redelivered?.message.metadata).toMatchObject({ pinet_mail_class: "steering" });
+      expect(db.getPendingInboxCount("agent-a")).toBeGreaterThanOrEqual(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("redelivers steering reactions only to the current owner after ownership changes", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("222.222", "slack", "C222", "agent-a");
+      const original = db.insertMessage(
+        "222.222",
+        "slack",
+        "inbound",
+        "U_TARGET",
+        "The current owner should get this after escalation.",
+        ["agent-a"],
+        { channel: "C222", timestamp: "222.333", userId: "U_TARGET" },
+      );
+      const originalInboxId = db.getInbox("agent-a")[0]!.entry.id;
+      db.markDelivered([originalInboxId], "agent-a");
+      db.markRead([originalInboxId], "agent-a");
+      db.updateThread("222.222", { ownerAgent: "agent-b" });
+
+      db.queueMessage("agent-b", {
+        source: "slack",
+        threadId: "222.222",
+        channel: "C222",
+        userId: "U_REACTOR",
+        text: "Reaction trigger from Slack: arrow-up",
+        timestamp: "999.222",
+        metadata: {
+          reactionTrigger: true,
+          reactionName: "arrow_up",
+          reactionAction: "steer",
+          referencedSource: "slack",
+          referencedExternalId: "C222:222.333",
+        },
+      });
+
+      expect(
+        db
+          .readInbox("agent-a", { markRead: false })
+          .messages.find((item) => item.message.id === original.id),
+      ).toBeUndefined();
+      expect(
+        db
+          .readInbox("agent-b", { markRead: false })
+          .messages.find((item) => item.message.id === original.id)?.entry,
+      ).toMatchObject({ delivered: false, readAt: null });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("uses reaction action rather than emoji name for steering redelivery", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("333.000", "slack", "C333", "agent-a");
+      const original = db.insertMessage(
+        "333.000",
+        "slack",
+        "inbound",
+        "U_TARGET",
+        "Escalate only for configured steer actions.",
+        ["agent-a"],
+        { channel: "C333", timestamp: "333.111", userId: "U_TARGET" },
+      );
+      const originalInboxId = db.getInbox("agent-a")[0]!.entry.id;
+      db.markDelivered([originalInboxId], "agent-a");
+      db.markRead([originalInboxId], "agent-a");
+
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "333.000",
+        channel: "C333",
+        userId: "U_REACTOR",
+        text: "Reaction trigger from Slack: custom steer",
+        timestamp: "999.333",
+        metadata: {
+          reactionTrigger: true,
+          reactionName: "eyes",
+          reactionAction: "steer",
+          referencedSource: "slack",
+          referencedExternalId: "C333:333.111",
+        },
+      });
+
+      expect(
+        db
+          .readInbox("agent-a", { markRead: false })
+          .messages.find((item) => item.message.id === original.id)?.message.metadata,
+      ).toMatchObject({ pinet_mail_class: "steering" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not redeliver arrow-up reactions remapped away from steer", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("444.000", "slack", "C444", "agent-a");
+      const original = db.insertMessage(
+        "444.000",
+        "slack",
+        "inbound",
+        "U_TARGET",
+        "Do not escalate when arrow-up is remapped.",
+        ["agent-a"],
+        { channel: "C444", timestamp: "444.111", userId: "U_TARGET" },
+      );
+      const originalInboxId = db.getInbox("agent-a")[0]!.entry.id;
+      db.markDelivered([originalInboxId], "agent-a");
+      db.markRead([originalInboxId], "agent-a");
+
+      db.queueMessage("agent-a", {
+        source: "slack",
+        threadId: "444.000",
+        channel: "C444",
+        userId: "U_REACTOR",
+        text: "Reaction trigger from Slack: remapped arrow-up",
+        timestamp: "999.444",
+        metadata: {
+          reactionTrigger: true,
+          reactionName: "arrow_up",
+          reactionAction: "review",
+          referencedSource: "slack",
+          referencedExternalId: "C444:444.111",
+        },
+      });
+
+      const read = db.readInbox("agent-a", { markRead: false });
+      expect(read.messages.find((item) => item.message.id === original.id)).toBeUndefined();
+      expect(db.getMessagesByIds([original.id])[0]?.metadata ?? {}).not.toHaveProperty(
+        "pinet_mail_class",
+      );
+    } finally {
+      db.close();
+    }
+  });
+
   it("reclassifies delivered durable Slack mail from arrow-up reactions", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -3166,6 +3166,12 @@ export class BrokerDB implements BrokerDBInterface {
         : null);
     if (!externalId) return;
 
+    const referenced = this.getMessageByExternalId(referencedSource, externalId);
+    if (!referenced) return;
+
+    const targetAgentIds = this.getUnreadReactionEscalationTargets(referenced);
+    if (targetAgentIds.length === 0) return;
+
     const reclassified = this.reclassifyMessageByExternalId(
       referencedSource,
       externalId,
@@ -3181,45 +3187,39 @@ export class BrokerDB implements BrokerDBInterface {
       },
     );
     if (reclassified) {
-      this.redeliverReclassifiedReactionMessage(reclassified);
+      this.redeliverReclassifiedReactionMessage(reclassified, targetAgentIds);
     }
   }
 
-  private redeliverReclassifiedReactionMessage(message: BrokerMessage): void {
+  private getUnreadReactionEscalationTargets(message: BrokerMessage): string[] {
     const db = this.getDb();
-    const targetAgentIds = new Set<string>();
     const ownerAgent = this.getThread(message.threadId)?.ownerAgent;
     if (ownerAgent) {
-      targetAgentIds.add(ownerAgent);
-    } else {
-      const existingRecipients = db
-        .prepare("SELECT DISTINCT agent_id FROM inbox WHERE message_id = ?")
-        .all(message.id) as Array<{ agent_id: string }>;
-
-      for (const row of existingRecipients) {
-        if (row.agent_id) {
-          targetAgentIds.add(row.agent_id);
-        }
-      }
+      const row = db
+        .prepare("SELECT 1 FROM inbox WHERE agent_id = ? AND message_id = ? AND read_at IS NULL")
+        .get(ownerAgent, message.id);
+      return row ? [ownerAgent] : [];
     }
 
-    if (targetAgentIds.size === 0) return;
+    const existingUnreadRecipients = db
+      .prepare("SELECT DISTINCT agent_id FROM inbox WHERE message_id = ? AND read_at IS NULL")
+      .all(message.id) as Array<{ agent_id: string }>;
 
-    const now = new Date().toISOString();
-    const insertInbox = db.prepare(
-      `INSERT INTO inbox (agent_id, message_id, delivered, created_at)
-       SELECT ?, ?, 0, ?
-       WHERE NOT EXISTS (
-         SELECT 1 FROM inbox WHERE agent_id = ? AND message_id = ?
-       )`,
-    );
-    const reopenInbox = db.prepare(
-      "UPDATE inbox SET delivered = 0, read_at = NULL WHERE agent_id = ? AND message_id = ?",
+    return existingUnreadRecipients.map((row) => row.agent_id).filter(Boolean);
+  }
+
+  private redeliverReclassifiedReactionMessage(
+    message: BrokerMessage,
+    targetAgentIds: readonly string[],
+  ): void {
+    if (targetAgentIds.length === 0) return;
+
+    const reopenUnreadInbox = this.getDb().prepare(
+      "UPDATE inbox SET delivered = 0 WHERE agent_id = ? AND message_id = ? AND read_at IS NULL",
     );
 
     for (const agentId of targetAgentIds) {
-      insertInbox.run(agentId, message.id, now, agentId, message.id);
-      reopenInbox.run(agentId, message.id);
+      reopenUnreadInbox.run(agentId, message.id);
     }
   }
 
@@ -3376,6 +3376,11 @@ export class BrokerDB implements BrokerDBInterface {
       .prepare("SELECT id FROM messages WHERE source = ? AND external_id = ?")
       .get(source, externalId) as { id?: number } | undefined;
     return typeof row?.id === "number" ? row.id : null;
+  }
+
+  private getMessageByExternalId(source: string, externalId: string): BrokerMessage | null {
+    const messageId = this.getExistingMessageIdForIdentity(source, externalId);
+    return messageId === null ? null : this.getMessageById(messageId);
   }
 
   private getMessageById(messageId: number): BrokerMessage | null {

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -295,10 +295,6 @@ function parseJsonMetadata(value: string | null): Record<string, unknown> {
   }
 }
 
-function isArrowUpReactionName(value: string | null): boolean {
-  return value === "arrow_up" || value === "⬆" || value === "⬆️";
-}
-
 function appendMetadataAudit(
   metadata: Record<string, unknown>,
   key: string,
@@ -3140,8 +3136,12 @@ export class BrokerDB implements BrokerDBInterface {
     const metadata = message.metadata;
     if (!metadata) return;
 
+    if (metadata.reactionTrigger !== true) return;
+
+    const reactionAction = getStringMetadataValue(metadata, ["reactionAction", "reaction_action"]);
+    if (reactionAction !== "steer") return;
+
     const reactionName = getStringMetadataValue(metadata, ["reactionName", "reaction_name"]);
-    if (!isArrowUpReactionName(reactionName)) return;
 
     const referencedSource =
       getStringMetadataValue(metadata, ["referencedSource", "referenced_source"]) ?? message.source;
@@ -3166,15 +3166,61 @@ export class BrokerDB implements BrokerDBInterface {
         : null);
     if (!externalId) return;
 
-    this.reclassifyMessageByExternalId(referencedSource, externalId, "steering", {
-      reason: "slack_reaction_arrow_up",
-      reactionName,
-      reactorUserId: getStringMetadataValue(metadata, ["reactorUserId", "reactor_user_id"]),
-      reactorName: getStringMetadataValue(metadata, ["reactorName", "reactor_name"]),
-      reactionEventTs: getStringMetadataValue(metadata, ["reactionEventTs", "reaction_event_ts"]),
-      referencedThreadId: message.threadId,
-      referencedMessageTs,
-    });
+    const reclassified = this.reclassifyMessageByExternalId(
+      referencedSource,
+      externalId,
+      "steering",
+      {
+        reason: "slack_reaction_arrow_up",
+        reactionName,
+        reactorUserId: getStringMetadataValue(metadata, ["reactorUserId", "reactor_user_id"]),
+        reactorName: getStringMetadataValue(metadata, ["reactorName", "reactor_name"]),
+        reactionEventTs: getStringMetadataValue(metadata, ["reactionEventTs", "reaction_event_ts"]),
+        referencedThreadId: message.threadId,
+        referencedMessageTs,
+      },
+    );
+    if (reclassified) {
+      this.redeliverReclassifiedReactionMessage(reclassified);
+    }
+  }
+
+  private redeliverReclassifiedReactionMessage(message: BrokerMessage): void {
+    const db = this.getDb();
+    const targetAgentIds = new Set<string>();
+    const ownerAgent = this.getThread(message.threadId)?.ownerAgent;
+    if (ownerAgent) {
+      targetAgentIds.add(ownerAgent);
+    } else {
+      const existingRecipients = db
+        .prepare("SELECT DISTINCT agent_id FROM inbox WHERE message_id = ?")
+        .all(message.id) as Array<{ agent_id: string }>;
+
+      for (const row of existingRecipients) {
+        if (row.agent_id) {
+          targetAgentIds.add(row.agent_id);
+        }
+      }
+    }
+
+    if (targetAgentIds.size === 0) return;
+
+    const now = new Date().toISOString();
+    const insertInbox = db.prepare(
+      `INSERT INTO inbox (agent_id, message_id, delivered, created_at)
+       SELECT ?, ?, 0, ?
+       WHERE NOT EXISTS (
+         SELECT 1 FROM inbox WHERE agent_id = ? AND message_id = ?
+       )`,
+    );
+    const reopenInbox = db.prepare(
+      "UPDATE inbox SET delivered = 0, read_at = NULL WHERE agent_id = ? AND message_id = ?",
+    );
+
+    for (const agentId of targetAgentIds) {
+      insertInbox.run(agentId, message.id, now, agentId, message.id);
+      reopenInbox.run(agentId, message.id);
+    }
   }
 
   reclassifyMessageByExternalId(

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -196,7 +196,7 @@ Messages queue while the agent is busy. When the agent finishes, it automaticall
 
 ### Reaction triggers
 
-Configured emoji reactions create structured Pinet requests from the reacted-to Slack message. The default set includes `:arrow_up:` / ⬆️ as `steer`, which marks the referenced message as steering and asks the target agent to treat it as an operator instruction when relevant and safe. Pinet adds ✅ when it accepts the reaction-triggered request. If it cannot process the reaction at all, it adds ❌; check broker logs for the underlying Slack/API error. When Slack cannot return the reacted message text, Pinet still routes the reaction with channel/thread/message IDs so steering reactions do not fail solely because message lookup was unavailable.
+Configured emoji reactions create structured Pinet requests from the reacted-to Slack message. The default set includes `:arrow_up:` / ⬆️ as `steer`, which marks and redelivers the referenced message as steering so the current thread owner sees an unread operator instruction when relevant and safe. The default `:octagonal_sign:` / 🛑 mapping sends an explicit `interrupt` control to the current thread owner; it aborts the active turn when the owner is busy, but does not reload or exit the process. Pinet adds ✅ when it accepts the reaction-triggered request. If it cannot process the reaction at all, it adds ❌; check broker logs for the underlying Slack/API error. When Slack cannot return the reacted message text, Pinet still routes the reaction with channel/thread/message IDs so steering reactions do not fail solely because message lookup was unavailable.
 
 ### Available tools
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1684,6 +1684,196 @@ describe("SlackAdapter — reaction triggers", () => {
     });
   });
 
+  it("routes octagonal-sign reactions as explicit interrupt controls for the thread owner", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.history")) {
+        return mockSlackResponse({
+          messages: [
+            {
+              ts: "111.333",
+              thread_ts: "111.222",
+              text: "Stop the active run",
+              user: "U_TARGET",
+            },
+          ],
+        });
+      }
+
+      if (url.endsWith("/users.info")) {
+        if (parsedBody.user === "U_REACTOR") {
+          return mockSlackResponse({ user: { real_name: "Alice" } });
+        }
+        if (parsedBody.user === "U_TARGET") {
+          return mockSlackResponse({ user: { real_name: "Bob" } });
+        }
+      }
+
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as { onReactionAdded: (evt: Record<string, unknown>) => Promise<void> }
+    ).onReactionAdded({
+      type: "reaction_added",
+      user: "U_REACTOR",
+      reaction: "octagonal_sign",
+      item_user: "U_TARGET",
+      item: {
+        type: "message",
+        channel: "C123",
+        ts: "111.333",
+      },
+      event_ts: "999.000",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        threadId: "111.222",
+        channel: "C123",
+        userId: "U_REACTOR",
+        text: '{"type":"pinet:control","action":"interrupt"}',
+        metadata: expect.objectContaining({
+          type: "pinet:control",
+          action: "interrupt",
+          kind: "pinet_control",
+          command: "interrupt",
+          slackReactionControl: true,
+          reactionTrigger: true,
+          reactionName: "octagonal_sign",
+          reactionAction: "interrupt",
+          referencedExternalId: "C123:111.333",
+        }),
+      }),
+    );
+  });
+
+  it("does not route interrupt controls when Slack cannot identify the reacted message thread", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/conversations.history")) {
+        return mockSlackResponse({ messages: [] });
+      }
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+    });
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as { onReactionAdded: (evt: Record<string, unknown>) => Promise<void> }
+    ).onReactionAdded({
+      type: "reaction_added",
+      user: "U_REACTOR",
+      reaction: "octagonal_sign",
+      item_user: "U_TARGET",
+      item: { type: "message", channel: "C123", ts: "222.333" },
+      event_ts: "999.222",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    const reactionBody = JSON.parse(
+      String(
+        fetchMock.mock.calls.find(([url]) => String(url).endsWith("/reactions.add"))?.[1]?.body ??
+          "{}",
+      ),
+    ) as Record<string, unknown>;
+    expect(reactionBody).toEqual({ channel: "C123", timestamp: "222.333", name: "x" });
+  });
+
+  it("routes custom interrupt reactions even when nonessential author lookup would fail", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.history")) {
+        return mockSlackResponse({
+          messages: [{ ts: "222.333", thread_ts: "222.222", text: "Busy work", user: "U_TARGET" }],
+        });
+      }
+
+      if (url.endsWith("/users.info")) {
+        if (parsedBody.user === "U_REACTOR") {
+          return mockSlackResponse({ user: { real_name: "Alice" } });
+        }
+        throw new Error("author lookup should not be required for interrupt controls");
+      }
+
+      if (url.endsWith("/reactions.add")) {
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      reactionCommands: { rotating_light: "interrupt" },
+    });
+    (adapter as unknown as { botUserId: string | null }).botUserId = "U_BOT";
+
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    await (
+      adapter as unknown as { onReactionAdded: (evt: Record<string, unknown>) => Promise<void> }
+    ).onReactionAdded({
+      type: "reaction_added",
+      user: "U_REACTOR",
+      reaction: "rotating_light",
+      item_user: "U_TARGET",
+      item: { type: "message", channel: "C123", ts: "222.333" },
+      event_ts: "999.222",
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "222.222",
+        text: '{"type":"pinet:control","action":"interrupt"}',
+        metadata: expect.objectContaining({
+          reactionName: "rotating_light",
+          reactionAction: "interrupt",
+          slackReactionControl: true,
+        }),
+      }),
+    );
+  });
+
   it("routes arrow-up steering reactions even when Slack cannot fetch the reacted message", async () => {
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -21,6 +21,8 @@ import {
   callSlackAPI,
   isAbortError,
   buildAllowlist,
+  buildPinetControlMessage,
+  buildPinetControlMetadata,
 } from "../../helpers.js";
 import {
   buildReactionTriggerMessage,
@@ -332,7 +334,13 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     try {
+      const isInterruptReaction = command.action === "interrupt";
       const reactedMessage = await this.fetchMessageByTs(item.channel, item.ts);
+      if (!reactedMessage && isInterruptReaction) {
+        throw new Error(
+          `Unable to identify Slack thread for interrupt reaction ${item.ts} in channel ${item.channel}`,
+        );
+      }
       const reactedMessageFetchStatus = reactedMessage ? "found" : "unavailable";
 
       const threadTs =
@@ -353,19 +361,25 @@ export class SlackAdapter implements MessageAdapter {
         }
       }
 
-      const reactorName = await this.resolveUser(userId);
+      const reactorName = isInterruptReaction
+        ? await this.resolveUser(userId).catch(() => userId)
+        : await this.resolveUser(userId);
       if (this.shuttingDown) return;
       const reactedMessageAuthorId =
         (reactedMessage?.user as string | undefined) ?? (evt.item_user as string | undefined);
-      const reactedMessageAuthor = reactedMessageAuthorId
-        ? await this.resolveUser(reactedMessageAuthorId)
-        : (reactedMessage?.bot_id as string | undefined)
-          ? "bot"
-          : "unknown";
+      const reactedMessageAuthor = isInterruptReaction
+        ? (reactedMessageAuthorId ??
+          ((reactedMessage?.bot_id as string | undefined) ? "bot" : "unknown"))
+        : reactedMessageAuthorId
+          ? await this.resolveUser(reactedMessageAuthorId)
+          : (reactedMessage?.bot_id as string | undefined)
+            ? "bot"
+            : "unknown";
       if (this.shuttingDown) return;
 
-      const reactedMessageText =
-        typeof reactedMessage?.text === "string" && reactedMessage.text.trim().length > 0
+      const reactedMessageText = isInterruptReaction
+        ? "(interrupt control; reacted message text omitted)"
+        : typeof reactedMessage?.text === "string" && reactedMessage.text.trim().length > 0
           ? reactedMessage.text
           : reactedMessage
             ? "(no text)"
@@ -379,21 +393,31 @@ export class SlackAdapter implements MessageAdapter {
         channel: item.channel,
         userId,
         userName: reactorName,
-        text: buildReactionTriggerMessage({
-          reactionName,
-          command,
-          reactorName,
-          channel: item.channel,
-          threadTs,
-          messageTs: item.ts,
-          reactedMessageText,
-          reactedMessageAuthor,
-        }),
+        text: isInterruptReaction
+          ? buildPinetControlMessage("interrupt")
+          : buildReactionTriggerMessage({
+              reactionName,
+              command,
+              reactorName,
+              channel: item.channel,
+              threadTs,
+              messageTs: item.ts,
+              reactedMessageText,
+              reactedMessageAuthor,
+            }),
         timestamp: reactionEventTs,
         metadata: {
           reactionTrigger: true,
           reactionName,
           reactionAction: command.action,
+          ...(isInterruptReaction
+            ? {
+                ...buildPinetControlMetadata("interrupt"),
+                kind: "pinet_control",
+                command: "interrupt",
+                slackReactionControl: true,
+              }
+            : {}),
           reactorUserId: userId,
           reactorName,
           reactionEventTs,

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -862,6 +862,7 @@ describe("formatPinetInboxMessages", () => {
 
 describe("Pinet control helpers", () => {
   it("parses supported control commands", () => {
+    expect(parsePinetControlCommand("interrupt")).toBe("interrupt");
     expect(parsePinetControlCommand("reload")).toBe("reload");
     expect(parsePinetControlCommand("exit")).toBe("exit");
     expect(parsePinetControlCommand("noop")).toBeNull();
@@ -871,6 +872,7 @@ describe("Pinet control helpers", () => {
     expect(getPinetControlCommandFromText('{"type":"pinet:control","action":"reload"}')).toBe(
       "reload",
     );
+    expect(getPinetControlCommandFromText("/interrupt")).toBe("interrupt");
     expect(getPinetControlCommandFromText("/reload")).toBe("reload");
     expect(getPinetControlCommandFromText(" /exit ")).toBe("exit");
     expect(getPinetControlCommandFromText('{"type":"pinet:control","action":"noop"}')).toBe(null);
@@ -884,6 +886,9 @@ describe("Pinet control helpers", () => {
       action: "reload",
     });
     expect(buildPinetControlMessage("reload")).toBe('{"type":"pinet:control","action":"reload"}');
+    expect(buildPinetControlMessage("interrupt")).toBe(
+      '{"type":"pinet:control","action":"interrupt"}',
+    );
   });
 
   it("normalizes outgoing control messages to the structured envelope", () => {
@@ -942,6 +947,48 @@ describe("Pinet control helpers", () => {
         threadId: "a2a:sender:target",
         body: '{"type":"pinet:control","action":"noop"}',
         metadata: { a2a: true },
+      }),
+    ).toBeNull();
+  });
+
+  it("extracts interrupt controls from explicit Slack reaction metadata only", () => {
+    expect(
+      extractPinetControlCommand({
+        threadId: "123.456",
+        body: '{"type":"pinet:control","action":"interrupt"}',
+        metadata: {
+          type: "pinet:control",
+          action: "interrupt",
+          reactionName: "octagonal_sign",
+          reactionAction: "interrupt",
+          slackReactionControl: true,
+        },
+      }),
+    ).toBe("interrupt");
+    expect(
+      extractPinetControlCommand({
+        threadId: "123.456",
+        body: '{"type":"pinet:control","action":"interrupt"}',
+        metadata: {
+          type: "pinet:control",
+          action: "interrupt",
+          reactionName: "rotating_light",
+          reactionAction: "interrupt",
+          slackReactionControl: true,
+        },
+      }),
+    ).toBe("interrupt");
+    expect(
+      extractPinetControlCommand({
+        threadId: "123.456",
+        body: '{"type":"pinet:control","action":"exit"}',
+        metadata: {
+          type: "pinet:control",
+          action: "exit",
+          reactionName: "octagonal_sign",
+          reactionAction: "interrupt",
+          slackReactionControl: true,
+        },
       }),
     ).toBeNull();
   });
@@ -1019,6 +1066,20 @@ describe("Pinet control helpers", () => {
       status: "queued",
       scheduledCommand: "exit",
       ackDisposition: "on_start",
+    });
+  });
+
+  it("treats an interrupt as covered when a stronger command is already running", () => {
+    expect(
+      queuePinetRemoteControl({ currentCommand: "reload", queuedCommand: null }, "interrupt"),
+    ).toMatchObject({
+      currentCommand: "reload",
+      queuedCommand: null,
+      accepted: true,
+      shouldStartNow: false,
+      status: "covered",
+      scheduledCommand: "reload",
+      ackDisposition: "immediate",
     });
   });
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -473,7 +473,7 @@ export function formatPinetInboxMessages(entries: FollowerInboxEntry[]): string 
 
 // ─── Pinet control messages ─────────────────────────────
 
-export type PinetControlCommand = "reload" | "exit";
+export type PinetControlCommand = "interrupt" | "reload" | "exit";
 
 export interface PinetRemoteControlState {
   currentCommand: PinetControlCommand | null;
@@ -489,7 +489,26 @@ export interface PinetRemoteControlRequestResult extends PinetRemoteControlState
 }
 
 export function parsePinetControlCommand(value: unknown): PinetControlCommand | null {
-  return value === "reload" || value === "exit" ? value : null;
+  return value === "interrupt" || value === "reload" || value === "exit" ? value : null;
+}
+
+function comparePinetControlPriority(
+  left: PinetControlCommand,
+  right: PinetControlCommand,
+): number {
+  const priority: Record<PinetControlCommand, number> = {
+    interrupt: 0,
+    reload: 1,
+    exit: 2,
+  };
+  return priority[left] - priority[right];
+}
+
+function higherPriorityPinetControlCommand(
+  left: PinetControlCommand,
+  right: PinetControlCommand,
+): PinetControlCommand {
+  return comparePinetControlPriority(left, right) >= 0 ? left : right;
 }
 
 export function queuePinetRemoteControl(
@@ -520,10 +539,22 @@ export function queuePinetRemoteControl(
     };
   }
 
-  const queuedCommand =
-    state.queuedCommand === "exit" || command === "exit"
-      ? "exit"
-      : (state.queuedCommand ?? command);
+  if (command === "interrupt") {
+    const scheduledCommand = state.queuedCommand ?? state.currentCommand;
+    return {
+      currentCommand: state.currentCommand,
+      queuedCommand: state.queuedCommand,
+      accepted: true,
+      shouldStartNow: false,
+      status: "covered",
+      scheduledCommand,
+      ackDisposition: state.queuedCommand ? "on_start" : "immediate",
+    };
+  }
+
+  const queuedCommand = state.queuedCommand
+    ? higherPriorityPinetControlCommand(state.queuedCommand, command)
+    : command;
 
   const status = queuedCommand === state.queuedCommand ? "covered" : "queued";
 
@@ -628,6 +659,7 @@ function parseLegacyPinetControlCommandFromText(
   text: string | undefined,
 ): PinetControlCommand | null {
   const trimmed = text?.trim();
+  if (trimmed === "/interrupt") return "interrupt";
   if (trimmed === "/reload") return "reload";
   if (trimmed === "/exit") return "exit";
   return null;
@@ -695,11 +727,19 @@ export function extractPinetControlCommand(message: {
   const isAgentToAgent =
     metadata.a2a === true ||
     (typeof message.threadId === "string" && message.threadId.startsWith("a2a:"));
-  if (!isAgentToAgent) return null;
+  const isSlackReactionInterrupt =
+    metadata.slackReactionControl === true && metadata.reactionAction === "interrupt";
 
   const metadataCommand =
     parsePinetControlEnvelope(metadata) ??
     (metadata.kind === "pinet_control" ? parsePinetControlCommand(metadata.command) : null);
+
+  if (isSlackReactionInterrupt) {
+    return metadataCommand === "interrupt" ? "interrupt" : null;
+  }
+
+  if (!isAgentToAgent) return null;
+
   if (metadataCommand) return metadataCommand;
 
   // Backward-compatible fallback for structured JSON or exact slash commands sent over a2a flows.

--- a/slack-bridge/pinet-remote-control-acks.ts
+++ b/slack-bridge/pinet-remote-control-acks.ts
@@ -1,6 +1,7 @@
 import type { PinetControlCommand } from "./helpers.js";
 
 interface PinetRemoteControlAckBuckets {
+  interrupt: Set<number>;
   reload: Set<number>;
   exit: Set<number>;
 }
@@ -23,6 +24,7 @@ export interface PinetRemoteControlAcks {
 
 function createAckBuckets(): PinetRemoteControlAckBuckets {
   return {
+    interrupt: new Set<number>(),
     reload: new Set<number>(),
     exit: new Set<number>(),
   };
@@ -35,8 +37,10 @@ export function createPinetRemoteControlAcks(
   const pendingFollowerControlInboxIds = createAckBuckets();
 
   function resetPendingRemoteControlAcks(): void {
+    pendingBrokerControlInboxIds.interrupt.clear();
     pendingBrokerControlInboxIds.reload.clear();
     pendingBrokerControlInboxIds.exit.clear();
+    pendingFollowerControlInboxIds.interrupt.clear();
     pendingFollowerControlInboxIds.reload.clear();
     pendingFollowerControlInboxIds.exit.clear();
   }

--- a/slack-bridge/pinet-remote-control.test.ts
+++ b/slack-bridge/pinet-remote-control.test.ts
@@ -113,6 +113,23 @@ describe("createPinetRemoteControl", () => {
     );
   });
 
+  it("flushes deferred acks and aborts busy work for interrupt without reloading or exiting", async () => {
+    const { deps, flushDeferredRemoteControlAcks, reloadPinetRuntime } = createDeps();
+    const shutdown = vi.fn();
+    const pinetRemoteControl = createPinetRemoteControl(deps);
+    const { ctx, notify, abort } = createCtx({ idle: false, shutdown });
+
+    pinetRemoteControl.requestRemoteControl("interrupt", ctx);
+    pinetRemoteControl.runRemoteControl("interrupt", ctx);
+    await settleRemoteControl();
+
+    expect(flushDeferredRemoteControlAcks).toHaveBeenCalledWith("interrupt");
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(reloadPinetRuntime).not.toHaveBeenCalled();
+    expect(shutdown).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith("Pinet remote control requested: /interrupt", "warning");
+  });
+
   it("flushes deferred acks, aborts busy work, and reloads the runtime", async () => {
     const { deps, flushDeferredRemoteControlAcks, reloadPinetRuntime } = createDeps();
     const pinetRemoteControl = createPinetRemoteControl(deps);

--- a/slack-bridge/pinet-remote-control.ts
+++ b/slack-bridge/pinet-remote-control.ts
@@ -56,6 +56,10 @@ export function createPinetRemoteControl(deps: PinetRemoteControlDeps): PinetRem
     ctx.ui.notify(`Pinet remote control requested: /${command}`, "warning");
     void (async () => {
       try {
+        if (command === "interrupt") {
+          return;
+        }
+
         if (command === "reload") {
           await deps.reloadPinetRuntime(ctx);
           return;

--- a/slack-bridge/reaction-triggers.test.ts
+++ b/slack-bridge/reaction-triggers.test.ts
@@ -14,6 +14,8 @@ describe("normalizeReactionName", () => {
     expect(normalizeReactionName("memo")).toBe("memo");
     expect(normalizeReactionName("⬆️")).toBe("arrow_up");
     expect(normalizeReactionName(":arrow_up:")).toBe("arrow_up");
+    expect(normalizeReactionName("🛑")).toBe("octagonal_sign");
+    expect(normalizeReactionName(":octagonal_sign:")).toBe("octagonal_sign");
   });
 
   it("throws for unsupported raw emoji input", () => {
@@ -27,6 +29,7 @@ describe("resolveReactionCommands", () => {
     expect(commands.get("memo")?.action).toBe("summarize");
     expect(commands.get("bug")?.action).toBe("file-issue");
     expect(commands.get("arrow_up")?.action).toBe("steer");
+    expect(commands.get("octagonal_sign")?.action).toBe("interrupt");
   });
 
   it("merges custom settings keyed by emoji or alias", () => {
@@ -44,6 +47,7 @@ describe("formatReactionDisplay", () => {
   it("includes both the emoji and Slack reaction name when known", () => {
     expect(formatReactionDisplay("eyes")).toBe("👀 (:eyes:)");
     expect(formatReactionDisplay("arrow_up")).toBe("⬆️ (:arrow_up:)");
+    expect(formatReactionDisplay("octagonal_sign")).toBe("🛑 (:octagonal_sign:)");
   });
 });
 

--- a/slack-bridge/reaction-triggers.ts
+++ b/slack-bridge/reaction-triggers.ts
@@ -33,6 +33,8 @@ const REACTION_ALIASES: Record<string, string> = {
   "⬆️": "arrow_up",
   "⬆": "arrow_up",
   arrow_up: "arrow_up",
+  "🛑": "octagonal_sign",
+  octagonal_sign: "octagonal_sign",
 };
 
 const REACTION_DISPLAY: Record<string, string> = {
@@ -46,6 +48,7 @@ const REACTION_DISPLAY: Record<string, string> = {
   eyes: "👀",
   white_check_mark: "✅",
   arrow_up: "⬆️",
+  octagonal_sign: "🛑",
 };
 
 export const DEFAULT_REACTION_COMMANDS: Record<string, ReactionCommandTemplate> = {
@@ -78,6 +81,11 @@ export const DEFAULT_REACTION_COMMANDS: Record<string, ReactionCommandTemplate> 
     action: "steer",
     prompt:
       "Treat the reacted-to message as steering. Read the durable message context, then prioritize it as an explicit operator instruction if it is relevant and safe.",
+  },
+  octagonal_sign: {
+    action: "interrupt",
+    prompt:
+      "Interrupt the current owner process for the reacted Slack thread. Stop the active turn safely, then read the durable context before deciding whether more work is needed.",
   },
   mag: {
     action: "search",
@@ -112,7 +120,7 @@ export function normalizeReactionName(input: string): string {
   const normalized = normalizeReactionNameOrNull(input);
   if (!normalized) {
     throw new Error(
-      `Unsupported reaction ${JSON.stringify(input)}. Use a Slack reaction name like "eyes" or a supported emoji such as 👀, ✅, 🔄, 📝, 🐛, or ⬆️.`,
+      `Unsupported reaction ${JSON.stringify(input)}. Use a Slack reaction name like "eyes" or a supported emoji such as 👀, ✅, 🔄, 📝, 🐛, ⬆️, or 🛑.`,
     );
   }
   return normalized;
@@ -132,6 +140,8 @@ function buildDefaultPromptForAction(action: string): string {
       return DEFAULT_REACTION_COMMANDS.repeat.prompt;
     case "steer":
       return DEFAULT_REACTION_COMMANDS.arrow_up.prompt;
+    case "interrupt":
+      return DEFAULT_REACTION_COMMANDS.octagonal_sign.prompt;
     case "search":
       return DEFAULT_REACTION_COMMANDS.mag.prompt;
     case "track":

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -308,6 +308,55 @@ describe("single-player-runtime", () => {
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
   });
 
+  it("interrupts busy single-player turns from octagonal-sign reactions", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const abort = vi.fn();
+    const notify = vi.fn();
+    const ctx = {
+      ...createContext(notify),
+      isIdle: () => false,
+      abort,
+    } as unknown as ExtensionContext;
+    const { deps, spies } = createDeps(state, {
+      getReactionCommand: (reactionName) =>
+        reactionName === "octagonal_sign"
+          ? { action: "interrupt", prompt: "Interrupt now." }
+          : undefined,
+      fetchSlackMessageByTs: vi.fn(async () => ({
+        ts: "100.1",
+        text: "busy work",
+        user: "U_TARGET",
+      })),
+      resolveUser: vi.fn(async () => "Alice"),
+    });
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onReactionAdded?.({
+      type: "reaction_added",
+      user: "U_REACTOR",
+      reaction: "octagonal_sign",
+      item: { type: "message", channel: "C123", ts: "100.1" },
+      event_ts: "999.1",
+    });
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(state.inbox).toHaveLength(0);
+    expect(spies.addReaction).toHaveBeenCalledWith("C123", "100.1", "white_check_mark");
+    expect(notify).toHaveBeenCalledWith(
+      "Alice requested an interrupt with :octagonal_sign:",
+      "warning",
+    );
+  });
+
   it("preserves file-share metadata on inbound Slack messages", async () => {
     const state: TestState = {
       threads: new Map(),

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -80,6 +80,20 @@ export interface SinglePlayerRuntimeDeps {
   claimOwnedThread: (threadTs: string, channelId: string, source?: string) => void;
 }
 
+type SinglePlayerControlContext = ExtensionContext & {
+  abort?: () => void;
+};
+
+function interruptSinglePlayerTurn(ctx: ExtensionContext): void {
+  if (ctx.isIdle?.() ?? true) return;
+
+  try {
+    (ctx as SinglePlayerControlContext).abort?.();
+  } catch {
+    /* best effort — interrupt controls must not crash reaction handling */
+  }
+}
+
 export interface SinglePlayerRuntime {
   connect: (ctx: ExtensionContext) => Promise<void>;
   disconnect: () => Promise<void>;
@@ -271,14 +285,18 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     }
 
     try {
+      const isInterruptReaction = command.action === "interrupt";
       const reactedMessage = await deps.fetchSlackMessageByTs(item.channel, item.ts);
       if (!reactedMessage) {
-        throw new Error(`Unable to fetch reacted message ${item.ts} in channel ${item.channel}`);
+        const reason = isInterruptReaction
+          ? "identify Slack thread for interrupt reaction"
+          : "fetch reacted message";
+        throw new Error(`Unable to ${reason} ${item.ts} in channel ${item.channel}`);
       }
 
       const threadTs =
-        (reactedMessage.thread_ts as string | undefined) ??
-        (reactedMessage.ts as string | undefined) ??
+        (reactedMessage?.thread_ts as string | undefined) ??
+        (reactedMessage?.ts as string | undefined) ??
         item.ts;
 
       const threads = deps.getThreads();
@@ -286,7 +304,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         threads.set(threadTs, {
           channelId: item.channel,
           threadTs,
-          userId: (reactedMessage.user as string | undefined) ?? user,
+          userId: (reactedMessage?.user as string | undefined) ?? user,
           source: "slack",
         });
       }
@@ -296,19 +314,29 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         return;
       }
 
-      const reactorName = await deps.resolveUser(user);
+      const reactorName = isInterruptReaction
+        ? await deps.resolveUser(user).catch(() => user)
+        : await deps.resolveUser(user);
       if (shuttingDown) return;
+
+      if (isInterruptReaction) {
+        interruptSinglePlayerTurn(ctx);
+        ctx.ui.notify(`${reactorName} requested an interrupt with :${reactionName}:`, "warning");
+        await deps.addReaction(item.channel, item.ts, "white_check_mark");
+        return;
+      }
+
       const reactedMessageAuthorId =
-        (reactedMessage.user as string | undefined) ?? (evt.item_user as string | undefined);
+        (reactedMessage?.user as string | undefined) ?? (evt.item_user as string | undefined);
       const reactedMessageAuthor = reactedMessageAuthorId
         ? await deps.resolveUser(reactedMessageAuthorId)
-        : (reactedMessage.bot_id as string | undefined)
+        : (reactedMessage?.bot_id as string | undefined)
           ? "bot"
           : "unknown";
       if (shuttingDown) return;
 
       const reactedMessageText =
-        typeof reactedMessage.text === "string" && reactedMessage.text.trim().length > 0
+        typeof reactedMessage?.text === "string" && reactedMessage.text.trim().length > 0
           ? reactedMessage.text
           : "(no text)";
       const reactionMessage = buildReactionTriggerMessage({


### PR DESCRIPTION
## Summary
- route Slack reaction-triggered steering controls through Pinet metadata
- preserve remote-control/interrupt handling for reaction workflows
- add regression coverage across broker schema, Slack adapter, helpers, reaction triggers, and single-player runtime

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pre-push hook passed when branch was pushed

Requested by maintainer follow-up in Slack thread 1778082834.768579.
