### PR TITLE
Fix Slack message_replied thread reply ingress

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -537,6 +537,190 @@ describe("classifyMessage", () => {
     }
   });
 
+  it("accepts message_replied updates with embedded reply bodies in broker-known threads", () => {
+    const isKnownThread = (ts: string) => ts === "500.600";
+    const evt = {
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.701",
+        replies: [
+          { user: "U0", ts: "500.650", text: "older reply" },
+          { user: "U1", ts: "500.701", text: "embedded follow up" },
+        ],
+      },
+    };
+
+    const result = classifyMessage(evt, botId, emptyTracked, isKnownThread);
+
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.threadTs).toBe("500.600");
+      expect(result.messageTs).toBe("500.701");
+      expect(result.userId).toBe("U1");
+      expect(result.text).toBe("embedded follow up");
+      expect(result.metadata).toEqual({ slackSubtype: "message_replied" });
+    }
+  });
+
+  it("accepts message_replied updates with block-only embedded reply bodies", () => {
+    const isKnownThread = (ts: string) => ts === "500.600";
+    const evt = {
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.701",
+        replies: [
+          {
+            user: "U1",
+            ts: "500.701",
+            blocks: [
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: "Block follow up" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const result = classifyMessage(evt, botId, emptyTracked, isKnownThread);
+
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.threadTs).toBe("500.600");
+      expect(result.messageTs).toBe("500.701");
+      expect(result.userId).toBe("U1");
+      expect(result.text).toBe(
+        "(Slack message had no plain-text body)\n\nSlack message context:\n- Block follow up",
+      );
+    }
+  });
+
+  it("rejects stale embedded replies when latest_reply is missing from the payload", () => {
+    const isKnownThread = (ts: string) => ts === "500.600";
+    const evt = {
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.702",
+        replies: [{ user: "U1", ts: "500.701", text: "stale embedded reply" }],
+      },
+    };
+
+    expect(classifyMessage(evt, botId, emptyTracked, isKnownThread)).toEqual({ relevant: false });
+  });
+
+  it("inherits root channel_type for direct wrapper message_replied payloads", () => {
+    const evt = {
+      type: "message",
+      subtype: "message_replied",
+      user: "U1",
+      text: "direct wrapper reply",
+      channel: "D1",
+      thread_ts: "500.600",
+      ts: "500.701",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "D1",
+        channel_type: "im",
+        thread_ts: "500.600",
+        ts: "500.600",
+      },
+    };
+
+    const result = classifyMessage(evt, botId, emptyTracked);
+
+    expect(result.relevant).toBe(true);
+    if (result.relevant) {
+      expect(result.threadTs).toBe("500.600");
+      expect(result.messageTs).toBe("500.701");
+      expect(result.isDM).toBe(true);
+      expect(result.text).toBe("direct wrapper reply");
+    }
+  });
+
+  it("rejects message_replied updates without an embedded reply body", () => {
+    const isKnownThread = (ts: string) => ts === "500.600";
+    const evt = {
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.701",
+        replies: [{ user: "U1", ts: "500.701" }],
+      },
+    };
+
+    expect(classifyMessage(evt, botId, emptyTracked, isKnownThread)).toEqual({ relevant: false });
+  });
+
+  it("rejects message_replied updates in unknown threads without @mention", () => {
+    const isKnownThread = () => false;
+    const evt = {
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "600.700",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "600.700",
+        ts: "600.700",
+        latest_reply: "600.800",
+        replies: [{ user: "U1", ts: "600.800", text: "random reply" }],
+      },
+    };
+
+    expect(classifyMessage(evt, botId, emptyTracked, isKnownThread)).toEqual({ relevant: false });
+  });
+
   it("rejects thread replies in unknown threads without @mention", () => {
     const isKnownThread = () => false;
     const evt = {
@@ -1368,6 +1552,418 @@ describe("SlackAdapter — allowlist filtering", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("hydrates partial message_replied payloads when latest_reply is not embedded", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.replies")) {
+        expect(parsedBody).toMatchObject({
+          channel: "C1",
+          ts: "500.600",
+          oldest: "500.702",
+          latest: "500.702",
+        });
+        return mockSlackResponse({
+          messages: [
+            {
+              type: "message",
+              user: "U_ALLOWED",
+              text: "fresh reply from API",
+              channel: "C1",
+              thread_ts: "500.600",
+              ts: "500.702",
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "C1", timestamp: "500.702", name: "eyes" });
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: (threadTs) => threadTs === "500.600",
+      getKnownThread: (threadTs) =>
+        threadTs === "500.600" ? { channelId: "C1", context: null } : null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.702",
+        replies: [{ user: "U_STALE", ts: "500.701", text: "stale embedded reply" }],
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        threadId: "500.600",
+        channel: "C1",
+        userId: "U_ALLOWED",
+        userName: "Alice Example",
+        text: "fresh reply from API",
+        timestamp: "500.702",
+      }),
+    );
+  });
+
+  it("hydrates body-less message_replied events when message already represents the reply", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.replies")) {
+        expect(parsedBody).toMatchObject({
+          channel: "C1",
+          ts: "800.100",
+          oldest: "800.200",
+          latest: "800.200",
+        });
+        return mockSlackResponse({
+          messages: [
+            {
+              type: "message",
+              user: "U_ALLOWED",
+              text: "reply body from API",
+              channel: "C1",
+              thread_ts: "800.100",
+              ts: "800.200",
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "C1", timestamp: "800.200", name: "eyes" });
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: (threadTs) => threadTs === "800.100",
+      getKnownThread: (threadTs) =>
+        threadTs === "800.100" ? { channelId: "C1", context: null } : null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "800.100",
+      message: {
+        type: "message",
+        user: "U_ALLOWED",
+        channel: "C1",
+        thread_ts: "800.100",
+        ts: "800.200",
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        threadId: "800.100",
+        channel: "C1",
+        userId: "U_ALLOWED",
+        userName: "Alice Example",
+        text: "reply body from API",
+        timestamp: "800.200",
+      }),
+    );
+  });
+
+  it("deduplicates normal threaded messages and matching message_replied updates", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "C1", timestamp: "900.200", name: "eyes" });
+        return mockSlackResponse();
+      }
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: (threadTs) => threadTs === "900.100",
+      getKnownThread: (threadTs) =>
+        threadTs === "900.100" ? { channelId: "C1", context: null } : null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      user: "U_ALLOWED",
+      text: "copy once",
+      channel: "C1",
+      channel_type: "channel",
+      thread_ts: "900.100",
+      ts: "900.200",
+    });
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "900.100",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "900.100",
+        ts: "900.100",
+        latest_reply: "900.200",
+        replies: [{ user: "U_ALLOWED", ts: "900.200" }],
+      },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "900.100",
+        channel: "C1",
+        userId: "U_ALLOWED",
+        text: "copy once",
+        timestamp: "900.200",
+      }),
+    );
+  });
+
+  it("does not hydrate embedded-body message_replied updates already known to be irrelevant", async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error("embedded irrelevant message_replied should not call Slack APIs");
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: () => false,
+      getKnownThread: () => null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "700.100",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "700.100",
+        ts: "700.100",
+        latest_reply: "700.200",
+        replies: [{ user: "U_ALLOWED", ts: "700.200", text: "random reply" }],
+      },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not hydrate body-less message_replied updates for unknown channel threads", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      throw new Error(`unexpected Slack API call: ${String(input)}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: () => false,
+      getKnownThread: () => null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "700.100",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "700.100",
+        ts: "700.100",
+        latest_reply: "700.200",
+        replies: [{ user: "U_ALLOWED", ts: "700.200" }],
+      },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses hydrated message_replied legacy threaded DMs without durable context", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.replies")) {
+        expect(parsedBody).toMatchObject({
+          channel: "D1",
+          ts: "1.1",
+          oldest: "1.2",
+          latest: "1.2",
+        });
+        return mockSlackResponse({
+          messages: [
+            {
+              type: "message",
+              user: "U_ALLOWED",
+              text: "legacy reply after restart",
+              channel: "D1",
+              channel_type: "im",
+              thread_ts: "1.1",
+              ts: "1.2",
+            },
+          ],
+        });
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: () => false,
+      getKnownThread: (threadTs) =>
+        threadTs === "1.1" ? { channelId: "D1", context: null } : null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "D1",
+      ts: "1.1",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "D1",
+        channel_type: "im",
+        thread_ts: "1.1",
+        ts: "1.1",
+        latest_reply: "1.2",
+        replies: [{ user: "U_ALLOWED", ts: "1.2" }],
+      },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    const endpoints = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(endpoints).toEqual(["https://slack.com/api/conversations.replies"]);
+  });
+
   it("rehydrates known Slack thread context into inbound scope after cache eviction", async () => {
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);
@@ -1469,6 +2065,184 @@ describe("SlackAdapter — allowlist filtering", () => {
             compatibilityKey: "default",
           },
         },
+      }),
+    );
+  });
+
+  it("emits inbound mail for message_replied updates in broker-known Slack threads", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "C1", timestamp: "500.701", name: "eyes" });
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: (threadTs) => threadTs === "500.600",
+      getKnownThread: (threadTs) =>
+        threadTs === "500.600" ? { channelId: "C1", context: null } : null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.701",
+        replies: [{ user: "U_ALLOWED", ts: "500.701", text: "copy" }],
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      source: "slack",
+      threadId: "500.600",
+      channel: "C1",
+      userId: "U_ALLOWED",
+      userName: "Alice Example",
+      text: "copy",
+      timestamp: "500.701",
+      metadata: { slackSubtype: "message_replied" },
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "C1",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    });
+  });
+
+  it("hydrates message_replied updates from conversations.replies when Slack omits body", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const rawBody = typeof init?.body === "string" ? init.body : "";
+      const parsedBody = rawBody.startsWith("{")
+        ? (JSON.parse(rawBody) as Record<string, unknown>)
+        : Object.fromEntries(new URLSearchParams(rawBody));
+
+      if (url.endsWith("/conversations.replies")) {
+        expect(parsedBody).toMatchObject({
+          channel: "C1",
+          ts: "500.600",
+          oldest: "500.701",
+          latest: "500.701",
+        });
+        return mockSlackResponse({
+          messages: [
+            {
+              type: "message",
+              user: "U_ROOT",
+              text: "thread root",
+              channel: "C1",
+              thread_ts: "500.600",
+              ts: "500.600",
+            },
+            {
+              type: "message",
+              user: "U_ALLOWED",
+              text: "copy from API",
+              channel: "C1",
+              thread_ts: "500.600",
+              ts: "500.701",
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/users.info")) {
+        expect(parsedBody.user).toBe("U_ALLOWED");
+        return mockSlackResponse({ user: { real_name: "Alice Example" } });
+      }
+      if (url.endsWith("/reactions.add")) {
+        expect(parsedBody).toEqual({ channel: "C1", timestamp: "500.701", name: "eyes" });
+        return mockSlackResponse();
+      }
+
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowAllWorkspaceUsers: true,
+      isKnownThread: (threadTs) => threadTs === "500.600",
+      getKnownThread: (threadTs) =>
+        threadTs === "500.600" ? { channelId: "C1", context: null } : null,
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+
+    const adapterPort = adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+    adapterPort.botUserId = "U_BOT";
+
+    await adapterPort.onMessage({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.701",
+        replies: [{ user: "U_ALLOWED", ts: "500.701" }],
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        threadId: "500.600",
+        channel: "C1",
+        userId: "U_ALLOWED",
+        userName: "Alice Example",
+        text: "copy from API",
+        timestamp: "500.701",
+        metadata: { slackSubtype: "message_replied" },
       }),
     );
   });

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -3,6 +3,8 @@ import {
   buildSlackThreadRuntimeScope,
   classifyMessage,
   clearSlackThreadStatus,
+  getSlackMessageRepliedHydrationTarget,
+  hydrateSlackMessageRepliedEvent,
   extractAppHomeOpened,
   extractThreadContextChanged,
   extractThreadStarted,
@@ -11,6 +13,7 @@ import {
   removeSlackReaction,
   resolveSlackUserName,
   setSlackSuggestedPrompts,
+  shouldHydrateSlackMessageRepliedEvent,
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
   type ParsedThreadContextChanged,
@@ -82,6 +85,12 @@ export const SLACK_THREAD_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 export const SLACK_PENDING_ATTENTION_MAX_THREADS = 1000;
 export const SLACK_PENDING_ATTENTION_TTL_MS = 2 * 60 * 60 * 1000;
 export const SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD = 50;
+export const SLACK_INBOUND_MESSAGE_DEDUP_MAX_SIZE = 10_000;
+export const SLACK_INBOUND_MESSAGE_DEDUP_TTL_MS = 10 * 60 * 1000;
+
+function buildSlackInboundMessageDedupKey(channel: string, messageTs: string): string {
+  return `slack-inbound-message:${channel}:${messageTs}`;
+}
 
 export class SlackAdapter implements MessageAdapter {
   readonly name = "slack";
@@ -103,6 +112,10 @@ export class SlackAdapter implements MessageAdapter {
   private readonly processedSocketDeliveries = new TtlSet<string>({
     maxSize: SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
     ttlMs: SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
+  });
+  private readonly processedInboundMessages = new TtlSet<string>({
+    maxSize: SLACK_INBOUND_MESSAGE_DEDUP_MAX_SIZE,
+    ttlMs: SLACK_INBOUND_MESSAGE_DEDUP_TTL_MS,
   });
   private readonly pendingEyes: TtlCache<string, { channel: string; messageTs: string }[]>;
 
@@ -446,22 +459,49 @@ export class SlackAdapter implements MessageAdapter {
   private async onMessage(evt: Record<string, unknown>): Promise<void> {
     if (this.shuttingDown) return;
 
-    const classified = classifyMessage(
+    let classified = classifyMessage(
       evt,
       this.botUserId,
       this.getTrackedThreadIds(),
       this.config.isKnownThread,
     );
+    if (
+      !classified.relevant &&
+      shouldHydrateSlackMessageRepliedEvent(evt, (threadTs) =>
+        Boolean(this.threads.get(threadTs) || this.config.isKnownThread?.(threadTs)),
+      )
+    ) {
+      const hydrationTarget = getSlackMessageRepliedHydrationTarget(evt);
+      if (
+        hydrationTarget &&
+        this.processedInboundMessages.has(
+          buildSlackInboundMessageDedupKey(hydrationTarget.channel, hydrationTarget.replyTs),
+        )
+      ) {
+        return;
+      }
+
+      const hydratedEvent = await hydrateSlackMessageRepliedEvent({
+        evt,
+        slack: this.callSlack.bind(this),
+        token: this.config.botToken,
+      });
+      if (this.shuttingDown) return;
+      if (hydratedEvent) {
+        classified = classifyMessage(
+          hydratedEvent,
+          this.botUserId,
+          this.getTrackedThreadIds(),
+          this.config.isKnownThread,
+        );
+      }
+    }
     if (!classified.relevant) return;
 
     const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs, metadata } =
       classified;
 
-    if (
-      isDM &&
-      typeof evt.thread_ts === "string" &&
-      this.shouldSuppressLegacyThreadedDm(threadTs)
-    ) {
+    if (isDM && messageTs !== threadTs && this.shouldSuppressLegacyThreadedDm(threadTs)) {
       return;
     }
 
@@ -474,6 +514,10 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     if (!isSlackUserAllowed(this.allowlist, userId)) return;
+
+    const inboundDedupKey = buildSlackInboundMessageDedupKey(channel, messageTs);
+    if (this.processedInboundMessages.has(inboundDedupKey)) return;
+    this.processedInboundMessages.add(inboundDedupKey);
 
     void this.addReaction(channel, messageTs, "eyes");
     const pending = this.pendingEyes.get(threadTs) ?? [];

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -357,6 +357,247 @@ describe("single-player-runtime", () => {
     );
   });
 
+  it("hydrates body-less message_replied replies before single-player classification", async () => {
+    const state: TestState = {
+      threads: new Map([
+        [
+          "500.600",
+          {
+            channelId: "C1",
+            threadTs: "500.600",
+            userId: "U_ROOT",
+            source: "slack",
+            owner: "owner:crane",
+          },
+        ],
+      ]),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const slack = vi.fn(async (method: string, _token: string, body?: Record<string, unknown>) => {
+      if (method === "conversations.replies") {
+        expect(body).toMatchObject({
+          channel: "C1",
+          ts: "500.600",
+          oldest: "500.701",
+          latest: "500.701",
+        });
+        return {
+          ok: true,
+          messages: [
+            {
+              type: "message",
+              user: "U_SENDER",
+              text: "copy from API",
+              channel: "C1",
+              thread_ts: "500.600",
+              ts: "500.701",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+    const { deps, spies } = createDeps(state, { slack });
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "500.600",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "500.600",
+        ts: "500.600",
+        latest_reply: "500.701",
+        replies: [{ user: "U_SENDER", ts: "500.701" }],
+      },
+    });
+
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith({
+      channel: "C1",
+      threadTs: "500.600",
+      userId: "U_SENDER",
+      text: "copy from API",
+      timestamp: "500.701",
+      metadata: { slackSubtype: "message_replied" },
+      scope: {
+        workspace: {
+          provider: "slack",
+          source: "compatibility",
+          compatibilityKey: "default",
+          channelId: "C1",
+        },
+        instance: {
+          source: "compatibility",
+          compatibilityKey: "default",
+        },
+      },
+    });
+    expect(spies.addReaction).toHaveBeenCalledWith("C1", "500.701", "eyes");
+  });
+
+  it("hydrates body-less message_replied when message already represents the reply", async () => {
+    const state: TestState = {
+      threads: new Map([
+        [
+          "800.100",
+          {
+            channelId: "C1",
+            threadTs: "800.100",
+            userId: "U_ROOT",
+            source: "slack",
+            owner: "owner:crane",
+          },
+        ],
+      ]),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const slack = vi.fn(async (method: string, _token: string, body?: Record<string, unknown>) => {
+      if (method === "conversations.replies") {
+        expect(body).toMatchObject({
+          channel: "C1",
+          ts: "800.100",
+          oldest: "800.200",
+          latest: "800.200",
+        });
+        return {
+          ok: true,
+          messages: [
+            {
+              type: "message",
+              user: "U_SENDER",
+              text: "reply body from API",
+              channel: "C1",
+              thread_ts: "800.100",
+              ts: "800.200",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+    const { deps, spies } = createDeps(state, { slack });
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "800.100",
+      message: {
+        type: "message",
+        user: "U_SENDER",
+        channel: "C1",
+        thread_ts: "800.100",
+        ts: "800.200",
+      },
+    });
+
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C1",
+        threadTs: "800.100",
+        userId: "U_SENDER",
+        text: "reply body from API",
+        timestamp: "800.200",
+        metadata: { slackSubtype: "message_replied" },
+      }),
+    );
+  });
+
+  it("deduplicates normal threaded messages and matching message_replied updates", async () => {
+    const state: TestState = {
+      threads: new Map([
+        [
+          "900.100",
+          {
+            channelId: "C1",
+            threadTs: "900.100",
+            userId: "U_ROOT",
+            source: "slack",
+            owner: "owner:crane",
+          },
+        ],
+      ]),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const ctx = createContext();
+    const { deps, spies } = createDeps(state);
+    const runtime = createSinglePlayerRuntime(deps);
+
+    await runtime.connect(ctx);
+
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    await socketConfig?.onMessage?.({
+      type: "message",
+      user: "U_SENDER",
+      text: "copy once",
+      channel: "C1",
+      channel_type: "channel",
+      thread_ts: "900.100",
+      ts: "900.200",
+    });
+    await socketConfig?.onMessage?.({
+      type: "message",
+      subtype: "message_replied",
+      hidden: true,
+      channel: "C1",
+      channel_type: "channel",
+      ts: "900.100",
+      message: {
+        type: "message",
+        user: "U_ROOT",
+        text: "thread root",
+        channel: "C1",
+        thread_ts: "900.100",
+        ts: "900.100",
+        latest_reply: "900.200",
+        replies: [{ user: "U_SENDER", ts: "900.200" }],
+      },
+    });
+
+    expect(spies.slack).not.toHaveBeenCalledWith(
+      "conversations.replies",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(spies.pushInboxMessage).toHaveBeenCalledTimes(1);
+    expect(spies.pushInboxMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C1",
+        threadTs: "900.100",
+        userId: "U_SENDER",
+        text: "copy once",
+        timestamp: "900.200",
+      }),
+    );
+  });
+
   it("preserves file-share metadata on inbound Slack messages", async () => {
     const state: TestState = {
       threads: new Map(),

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -10,6 +10,9 @@ import type { SlackToolsThreadContextPort } from "./slack-tools.js";
 import {
   buildSlackThreadRuntimeScope,
   classifyMessage,
+  getSlackMessageRepliedHydrationTarget,
+  hydrateSlackMessageRepliedEvent,
+  shouldHydrateSlackMessageRepliedEvent,
   resolveSlackThreadOwnerHint,
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
@@ -106,6 +109,10 @@ export interface SinglePlayerRuntime {
 }
 
 type SinglePlayerThreadOwnershipResult = "continue" | "skip" | "shutdown";
+
+function buildSlackInboundMessageDedupKey(channel: string, messageTs: string): string {
+  return `slack-inbound-message:${channel}:${messageTs}`;
+}
 
 export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): SinglePlayerRuntime {
   let slackSocket: SlackSocketModeClient | null = null;
@@ -378,7 +385,31 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     if (shuttingDown) return;
 
     const threads = deps.getThreads();
-    const classified = classifyMessage(evt, getCurrentBotUserId(), new Set(threads.keys()));
+    let classified = classifyMessage(evt, getCurrentBotUserId(), new Set(threads.keys()));
+    if (
+      !classified.relevant &&
+      shouldHydrateSlackMessageRepliedEvent(evt, (threadTs) => threads.has(threadTs))
+    ) {
+      const hydrationTarget = getSlackMessageRepliedHydrationTarget(evt);
+      if (
+        hydrationTarget &&
+        deps.dedup.has(
+          buildSlackInboundMessageDedupKey(hydrationTarget.channel, hydrationTarget.replyTs),
+        )
+      ) {
+        return;
+      }
+
+      const hydratedEvent = await hydrateSlackMessageRepliedEvent({
+        evt,
+        slack: deps.slack,
+        token: deps.getBotToken(),
+      });
+      if (shuttingDown) return;
+      if (hydratedEvent) {
+        classified = classifyMessage(hydratedEvent, getCurrentBotUserId(), new Set(threads.keys()));
+      }
+    }
     if (!classified.relevant) return;
 
     const { threadTs, channel, userId, text, isDM, isChannelMention, messageTs, metadata } =
@@ -406,6 +437,10 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       deps.setLastDmChannel(channel);
     }
     deps.persistState();
+
+    const inboundDedupKey = buildSlackInboundMessageDedupKey(channel, messageTs);
+    if (deps.dedup.has(inboundDedupKey)) return;
+    deps.dedup.add(inboundDedupKey);
 
     const confirmationResult = deps.consumeConfirmationReply(threadTs, text);
     const messageText =

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -215,6 +215,249 @@ export type MessageClassification =
       metadata?: Record<string, unknown>;
     };
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function hasSlackMessageBody(evt: Record<string, unknown> | null): boolean {
+  if (!evt) return false;
+  const text = asNonEmptyString(evt.text);
+  if (text && text.trim().length > 0) return true;
+  return buildSlackInboundMessageText("", evt).trim().length > 0;
+}
+
+export function selectLatestThreadReply(
+  rootMessage: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  const replies = Array.isArray(rootMessage?.replies)
+    ? rootMessage.replies.filter(
+        (reply): reply is Record<string, unknown> =>
+          typeof reply === "object" && reply !== null && !Array.isArray(reply),
+      )
+    : [];
+  if (replies.length === 0) return null;
+
+  const latestReplyTs = asNonEmptyString(rootMessage?.latest_reply);
+  if (latestReplyTs) {
+    return replies.find((reply) => reply.ts === latestReplyTs) ?? null;
+  }
+
+  return replies[replies.length - 1] ?? null;
+}
+
+function normalizeMessageRepliedEvent(
+  evt: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const rootMessage = asRecord(evt.message);
+  const channel = asNonEmptyString(evt.channel) ?? asNonEmptyString(rootMessage?.channel);
+  const channelType =
+    asNonEmptyString(evt.channel_type) ?? asNonEmptyString(rootMessage?.channel_type);
+
+  if (rootMessage) {
+    const rootThreadTs =
+      asNonEmptyString(rootMessage.thread_ts) ??
+      asNonEmptyString(rootMessage.ts) ??
+      asNonEmptyString(evt.thread_ts);
+
+    // Some Slack transports provide the actual reply as `message` even though
+    // the wrapper subtype is `message_replied`. Keep that shape first.
+    if (
+      asNonEmptyString(rootMessage.thread_ts) &&
+      rootMessage.thread_ts !== rootMessage.ts &&
+      asNonEmptyString(rootMessage.user) &&
+      asNonEmptyString(rootMessage.ts) &&
+      hasSlackMessageBody(rootMessage)
+    ) {
+      return {
+        ...rootMessage,
+        type: "message",
+        subtype: "message_replied",
+        ...(channel ? { channel } : {}),
+        ...(channelType ? { channel_type: channelType } : {}),
+      };
+    }
+
+    const latestReply = selectLatestThreadReply(rootMessage);
+    if (latestReply && rootThreadTs) {
+      const replyEvent: Record<string, unknown> = {
+        ...latestReply,
+        type: "message",
+        subtype: "message_replied",
+        thread_ts: rootThreadTs,
+        ...(channel ? { channel } : {}),
+        ...(channelType ? { channel_type: channelType } : {}),
+      };
+
+      if (
+        asNonEmptyString(replyEvent.user) &&
+        asNonEmptyString(replyEvent.ts) &&
+        hasSlackMessageBody(replyEvent)
+      ) {
+        return replyEvent;
+      }
+    }
+  }
+
+  // Fallback for adapters that put the reply fields directly on the wrapper.
+  if (
+    asNonEmptyString(evt.thread_ts) &&
+    asNonEmptyString(evt.user) &&
+    asNonEmptyString(evt.ts) &&
+    hasSlackMessageBody(evt)
+  ) {
+    return {
+      ...evt,
+      type: "message",
+      subtype: "message_replied",
+      ...(channel ? { channel } : {}),
+      ...(channelType ? { channel_type: channelType } : {}),
+    };
+  }
+
+  return null;
+}
+
+export function messageRepliedEventHasUsableBody(evt: Record<string, unknown>): boolean {
+  if (evt.subtype !== "message_replied") return false;
+
+  const rootMessage = asRecord(evt.message);
+  if (
+    rootMessage &&
+    asNonEmptyString(rootMessage.thread_ts) &&
+    rootMessage.thread_ts !== rootMessage.ts
+  ) {
+    return hasSlackMessageBody(rootMessage);
+  }
+
+  const latestReply = selectLatestThreadReply(rootMessage);
+  return hasSlackMessageBody(latestReply) || hasSlackMessageBody(evt);
+}
+
+export function getSlackMessageRepliedThreadTs(evt: Record<string, unknown>): string | null {
+  if (evt.subtype !== "message_replied") return null;
+  const rootMessage = asRecord(evt.message);
+  return (
+    asNonEmptyString(rootMessage?.thread_ts) ??
+    asNonEmptyString(rootMessage?.ts) ??
+    asNonEmptyString(evt.thread_ts) ??
+    asNonEmptyString(evt.ts)
+  );
+}
+
+export interface SlackMessageRepliedHydrationTarget {
+  channel: string;
+  threadTs: string;
+  replyTs: string;
+}
+
+export function shouldHydrateSlackMessageRepliedEvent(
+  evt: Record<string, unknown>,
+  isKnownThread: (threadTs: string) => boolean,
+): boolean {
+  if (evt.subtype !== "message_replied" || messageRepliedEventHasUsableBody(evt)) return false;
+
+  const threadTs = getSlackMessageRepliedThreadTs(evt);
+  if (threadTs && isKnownThread(threadTs)) return true;
+
+  const rootMessage = asRecord(evt.message);
+  const channelType =
+    asNonEmptyString(evt.channel_type) ?? asNonEmptyString(rootMessage?.channel_type);
+  return channelType === "im";
+}
+
+export function getSlackMessageRepliedHydrationTarget(
+  evt: Record<string, unknown>,
+): SlackMessageRepliedHydrationTarget | null {
+  if (evt.subtype !== "message_replied") return null;
+
+  const rootMessage = asRecord(evt.message);
+  const channel = asNonEmptyString(evt.channel) ?? asNonEmptyString(rootMessage?.channel);
+  const threadTs =
+    asNonEmptyString(rootMessage?.thread_ts) ??
+    asNonEmptyString(rootMessage?.ts) ??
+    asNonEmptyString(evt.thread_ts);
+  if (!channel || !threadTs) return null;
+
+  const latestReply = selectLatestThreadReply(rootMessage);
+  const rootMessageIsReply =
+    asNonEmptyString(rootMessage?.thread_ts) && rootMessage?.thread_ts !== rootMessage?.ts;
+  const replyTs =
+    (rootMessageIsReply ? asNonEmptyString(rootMessage?.ts) : null) ??
+    asNonEmptyString(rootMessage?.latest_reply) ??
+    asNonEmptyString(latestReply?.ts) ??
+    asNonEmptyString(evt.ts);
+  if (!replyTs || replyTs === threadTs) return null;
+
+  return { channel, threadTs, replyTs };
+}
+
+function describeSlackHydrationError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function hydrateSlackMessageRepliedEvent(input: {
+  evt: Record<string, unknown>;
+  slack: SlackCall;
+  token: string;
+}): Promise<Record<string, unknown> | null> {
+  const { evt, slack, token } = input;
+  const target = getSlackMessageRepliedHydrationTarget(evt);
+  if (!target) return null;
+
+  const { channel, threadTs, replyTs } = target;
+  const rootMessage = asRecord(evt.message);
+
+  try {
+    const response = await slack("conversations.replies", token, {
+      channel,
+      ts: threadTs,
+      oldest: replyTs,
+      latest: replyTs,
+      inclusive: true,
+      limit: 1,
+    });
+    const messages = (response.messages as Record<string, unknown>[]) ?? [];
+    const fetchedReply = messages.find((message) => message.ts === replyTs) ?? null;
+    if (!fetchedReply) return null;
+
+    const channelType =
+      asNonEmptyString(evt.channel_type) ??
+      asNonEmptyString(rootMessage?.channel_type) ??
+      asNonEmptyString(fetchedReply.channel_type);
+
+    return {
+      ...fetchedReply,
+      type: "message",
+      subtype: "message_replied",
+      channel,
+      thread_ts: threadTs,
+      ...(channelType ? { channel_type: channelType } : {}),
+    };
+  } catch (error) {
+    console.warn(
+      `[slack-access] failed to hydrate message_replied reply channel=${channel} thread_ts=${threadTs} reply_ts=${replyTs}: ${describeSlackHydrationError(error)}`,
+    );
+    return null;
+  }
+}
+
+function normalizeSlackMessageEvent(evt: Record<string, unknown>): Record<string, unknown> | null {
+  const subtype = asNonEmptyString(evt.subtype);
+  if (subtype === "message_replied") {
+    return normalizeMessageRepliedEvent(evt);
+  }
+  if (subtype === null || subtype === "file_share") {
+    return evt;
+  }
+  return null;
+}
+
 /**
  * Classify an incoming Slack message event. Determines whether the
  * message is relevant (DM, known thread, or bot mention) and
@@ -226,15 +469,15 @@ export function classifyMessage(
   trackedThreadIds: Set<string>,
   isKnownThread?: (threadTs: string) => boolean,
 ): MessageClassification {
-  const subtype = typeof evt.subtype === "string" ? evt.subtype : undefined;
-  const allowsSubtype = subtype === undefined || subtype === "file_share";
-  if (!allowsSubtype || evt.bot_id) return { relevant: false };
+  const normalizedEvent = normalizeSlackMessageEvent(evt);
+  if (!normalizedEvent || normalizedEvent.bot_id) return { relevant: false };
 
-  const text = (evt.text as string) ?? "";
-  const user = evt.user as string;
-  const threadTs = evt.thread_ts as string | undefined;
-  const channel = evt.channel as string;
-  const channelType = evt.channel_type as string | undefined;
+  const subtype = asNonEmptyString(normalizedEvent.subtype) ?? undefined;
+  const text = asNonEmptyString(normalizedEvent.text) ?? "";
+  const user = normalizedEvent.user as string;
+  const threadTs = normalizedEvent.thread_ts as string | undefined;
+  const channel = normalizedEvent.channel as string;
+  const channelType = normalizedEvent.channel_type as string | undefined;
 
   const isKnown = !!threadTs && (isKnownThread?.(threadTs) ?? trackedThreadIds.has(threadTs));
   const isDM = channelType === "im";
@@ -242,10 +485,10 @@ export function classifyMessage(
 
   if (!isKnown && !isDM && !isMention) return { relevant: false };
 
-  const effectiveTs = threadTs ?? (evt.ts as string);
+  const effectiveTs = threadTs ?? (normalizedEvent.ts as string);
   const isChannelMention = isMention && !isDM && !isKnown;
   const cleanText = isChannelMention && botUserId ? stripBotMention(text, botUserId) : text;
-  const slackFiles = extractSlackMessageFileMetadata(evt.files);
+  const slackFiles = extractSlackMessageFileMetadata(normalizedEvent.files);
   const metadata: Record<string, unknown> = {
     ...(subtype ? { slackSubtype: subtype } : {}),
     ...(slackFiles.length > 0 ? { slackFiles } : {}),
@@ -256,10 +499,10 @@ export function classifyMessage(
     threadTs: effectiveTs,
     channel,
     userId: user,
-    text: buildSlackInboundMessageText(cleanText, evt),
+    text: buildSlackInboundMessageText(cleanText, normalizedEvent),
     isDM,
     isChannelMention,
-    messageTs: (evt.ts as string) ?? effectiveTs,
+    messageTs: (normalizedEvent.ts as string) ?? effectiveTs,
     ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
   };
 }


### PR DESCRIPTION
## Summary
Fixes #744.

- normalize Slack `message_replied` payloads so known broker/agent-created thread replies route like normal replies
- hydrate body-less known-thread/DM `message_replied` updates via `conversations.replies`, with safe warning logs on hydration failure
- preserve bot/noise filtering, channel type, legacy threaded-DM suppression, and block/file-only message bodies
- deduplicate normal threaded `message` events vs matching hidden `message_replied` updates before hydration/inbox enqueue

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker/adapters/slack.test.ts single-player-runtime.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`
- local `code-reviewer` subagent final verdict: Approve, no critical/warning findings

## Notes
Slack public docs show `message_replied` as a hidden message subtype carrying thread/root summary fields plus a nested reply object; the fix accepts that current shape and falls back to precise thread hydration when the reply body is omitted.