### PR TITLE
fix(pinet): refresh observed git branch + dirty flag on heartbeat

### DIFF
--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -1865,6 +1865,18 @@ export class BrokerDB implements BrokerDBInterface {
     }
   }
 
+  updateAgentMetadata(id: string, metadata: Record<string, unknown> | null): AgentInfo | null {
+    const db = this.getDb();
+    if (!this.getAgentRowById(id)) return null;
+    db.prepare("UPDATE agents SET metadata = ?, last_seen = ? WHERE id = ?").run(
+      metadata ? JSON.stringify(metadata) : null,
+      new Date().toISOString(),
+      id,
+    );
+    const updated = this.getAgentRowById(id);
+    return updated ? rowToAgent(updated) : null;
+  }
+
   updateAgentIdentity(
     id: string,
     identity: { name: string; emoji: string; metadata?: Record<string, unknown> | null },

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -10,6 +10,7 @@ import {
   INITIAL_RECONNECT_DELAY_MS,
   MAX_RECONNECT_DELAY_MS,
   HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_METADATA_PROVIDER_TIMEOUT_MS,
   computeReconnectDelay,
 } from "./client.js";
 import type { BrokerConnectOpts } from "./client.js";
@@ -364,6 +365,91 @@ describe("BrokerClient — heartbeat / unregister", () => {
     const heartbeatReq = JSON.parse(mock.received[1]) as { id: number; method: string };
     expect(heartbeatReq.method).toBe("heartbeat");
     mock.respondTo(mock.connections[0], heartbeatReq.id, { ok: true });
+
+    setIntervalSpy.mockRestore();
+    client.disconnect();
+  });
+
+  it("sends heartbeat metadata when the provider resolves", async () => {
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+    client.setHeartbeatMetadataProvider(async () => ({
+      branch: "feature/live",
+      workdirDirty: true,
+    }));
+
+    const registerPromise = client.register("HeartbeatBot", "💓");
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as { id: number };
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "hb-meta",
+      name: "HeartbeatBot",
+      emoji: "💓",
+    });
+    await registerPromise;
+
+    const heartbeatTick = setIntervalSpy.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    heartbeatTick?.();
+
+    await waitFor(() => mock.received.length > 1);
+    const heartbeatReq = JSON.parse(mock.received[1]) as {
+      id: number;
+      method: string;
+      params?: { metadata?: Record<string, unknown> };
+    };
+    expect(heartbeatReq.method).toBe("heartbeat");
+    expect(heartbeatReq.params?.metadata).toEqual({ branch: "feature/live", workdirDirty: true });
+    mock.respondTo(mock.connections[0], heartbeatReq.id, { ok: true });
+
+    setIntervalSpy.mockRestore();
+    client.disconnect();
+  });
+
+  it("falls back to a plain heartbeat while a metadata provider is hung", async () => {
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+    const metadataProvider = vi.fn(
+      () =>
+        new Promise<Record<string, unknown>>(() => {
+          // never resolves
+        }),
+    );
+    client.setHeartbeatMetadataProvider(metadataProvider);
+
+    const registerPromise = client.register("HeartbeatBot", "💓");
+    await waitFor(() => mock.received.length > 0);
+    const registerReq = JSON.parse(mock.received[0]) as { id: number };
+    mock.respondTo(mock.connections[0], registerReq.id, {
+      agentId: "hb-timeout",
+      name: "HeartbeatBot",
+      emoji: "💓",
+    });
+    await registerPromise;
+
+    const heartbeatTick = setIntervalSpy.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    vi.useFakeTimers();
+    try {
+      heartbeatTick?.();
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_METADATA_PROVIDER_TIMEOUT_MS + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await waitFor(() => mock.received.length > 1);
+    const heartbeatReq = JSON.parse(mock.received[1]) as {
+      id: number;
+      method: string;
+      params?: { metadata?: unknown };
+    };
+    expect(heartbeatReq.method).toBe("heartbeat");
+    expect(heartbeatReq.params?.metadata).toBeUndefined();
+    mock.respondTo(mock.connections[0], heartbeatReq.id, { ok: true });
+
+    heartbeatTick?.();
+    await waitFor(() => mock.received.length > 2);
+    expect(metadataProvider).toHaveBeenCalledTimes(1);
 
     setIntervalSpy.mockRestore();
     client.disconnect();

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -102,6 +102,24 @@ export const RECONNECT_DELAY_MS = 3000;
 export const INITIAL_RECONNECT_DELAY_MS = 1000;
 export const MAX_RECONNECT_DELAY_MS = 30000;
 export const HEARTBEAT_INTERVAL_MS = 5000;
+export const HEARTBEAT_METADATA_PROVIDER_TIMEOUT_MS = 2500;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
 
 /** Compute reconnect delay with exponential backoff and jitter. */
 export function computeReconnectDelay(attempt: number, random = Math.random()): number {
@@ -230,6 +248,11 @@ export class BrokerClient {
   private reconnectAttempt = 0;
   private registrationSnapshot: RegistrationSnapshot | null = null;
   private registeredIdentity: RegistrationResult | null = null;
+  private heartbeatMetadataProvider:
+    | (() => Promise<Record<string, unknown> | null | undefined>)
+    | null = null;
+  private heartbeatMetadataInFlight: Promise<Record<string, unknown> | null | undefined> | null =
+    null;
 
   private nextId = 1;
   private readonly pending = new Map<number, PendingRequest>();
@@ -380,8 +403,18 @@ export class BrokerClient {
     }
   }
 
-  async heartbeat(): Promise<void> {
-    await this.request("heartbeat");
+  async heartbeat(metadata?: Record<string, unknown> | null): Promise<void> {
+    if (metadata === undefined) {
+      await this.request("heartbeat");
+      return;
+    }
+    await this.request("heartbeat", { metadata });
+  }
+
+  setHeartbeatMetadataProvider(
+    provider: (() => Promise<Record<string, unknown> | null | undefined>) | null,
+  ): void {
+    this.heartbeatMetadataProvider = provider;
   }
 
   // ─── Messaging ───────────────────────────────────────
@@ -844,11 +877,37 @@ export class BrokerClient {
     this.stopHeartbeat();
     this.heartbeatTimer = setInterval(() => {
       if (!this.connected) return;
-      void this.heartbeat().catch(() => {
+      void this.runHeartbeatTick().catch(() => {
         /* best effort */
       });
     }, HEARTBEAT_INTERVAL_MS);
     this.heartbeatTimer.unref?.();
+  }
+
+  private async readHeartbeatMetadata(): Promise<Record<string, unknown> | null | undefined> {
+    const provider = this.heartbeatMetadataProvider;
+    if (!provider || this.heartbeatMetadataInFlight) {
+      return undefined;
+    }
+
+    const work = Promise.resolve()
+      .then(() => provider())
+      .finally(() => {
+        if (this.heartbeatMetadataInFlight === work) {
+          this.heartbeatMetadataInFlight = null;
+        }
+      });
+    this.heartbeatMetadataInFlight = work;
+
+    try {
+      return await withTimeout(work, HEARTBEAT_METADATA_PROVIDER_TIMEOUT_MS);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async runHeartbeatTick(): Promise<void> {
+    await this.heartbeat(await this.readHeartbeatMetadata());
   }
 
   private stopHeartbeat(): void {

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -713,6 +713,31 @@ describe("BrokerDB", () => {
     });
   });
 
+  it("updates agent metadata without changing identity fields", () => {
+    db.registerAgent(
+      "a1",
+      "Hyper Owl",
+      "🦉",
+      100,
+      { branch: "main", role: "worker" },
+      "host:session:/tmp/a",
+    );
+
+    const updated = db.updateAgentMetadata("a1", {
+      branch: "feature/live",
+      workdirDirty: true,
+    });
+
+    expect(updated).toMatchObject({
+      id: "a1",
+      stableId: "host:session:/tmp/a",
+      name: "Hyper Owl",
+      emoji: "🦉",
+      metadata: { branch: "feature/live", workdirDirty: true },
+    });
+    expect(db.updateAgentMetadata("missing", { branch: "main" })).toBeNull();
+  });
+
   it("records and updates task assignment progress", () => {
     db.registerAgent("worker-1", "Hyper Horse", "🐎", 100);
 

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -606,6 +606,17 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(db.getInbox(reg.agentId)).toHaveLength(0);
   });
 
+  it("heartbeat metadata refreshes the broker's agent row", async () => {
+    const reg = await client.register("metadata-agent", "🌿", { branch: "main" });
+
+    await client.heartbeat({ branch: "feature/live", workdirDirty: true });
+
+    expect(db.getAgentById(reg.agentId)?.metadata).toEqual({
+      branch: "feature/live",
+      workdirDirty: true,
+    });
+  });
+
   it("maintenance pruning disconnects stale agents and releases claims", async () => {
     const reg = await client.register("stale-agent", "💤");
     await client.claimThread("t-stale");

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -672,7 +672,16 @@ export class BrokerSocketServer {
       return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
     }
 
+    const params = req.params ?? {};
+    const metadata = params.metadata;
+    if (metadata !== undefined && (typeof metadata !== "object" || Array.isArray(metadata))) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "metadata must be an object or null");
+    }
+
     this.db.heartbeatAgent(state.agentId);
+    if (metadata !== undefined) {
+      this.db.updateAgentMetadata(state.agentId, metadata as Record<string, unknown> | null);
+    }
     return rpcOk(req.id, { ok: true });
   }
 

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -224,6 +224,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
         deps.getAgentStableId(),
       );
       deps.applyRegistrationIdentity(registration);
+      client.setHeartbeatMetadataProvider(() => deps.getAgentMetadata("worker"));
     }
 
     async function resumeThreadClaims(): Promise<void> {

--- a/slack-bridge/git-metadata.test.ts
+++ b/slack-bridge/git-metadata.test.ts
@@ -3,6 +3,7 @@ import {
   createGitContextCache,
   probeGitBranch,
   probeGitContext,
+  probeGitDynamic,
   type ExecFileAsyncLike,
 } from "./git-metadata.js";
 
@@ -23,13 +24,16 @@ describe("probeGitBranch", () => {
 });
 
 describe("probeGitContext", () => {
-  it("returns repo, repoRoot, and branch when git commands succeed", async () => {
+  it("returns repo, repoRoot, branch, and dirty signal when git commands succeed", async () => {
     const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
       if (args[0] === "rev-parse") {
         return { stdout: "/Users/alice/src/extensions\n" };
       }
       if (args[0] === "branch") {
         return { stdout: "main\n" };
+      }
+      if (args[0] === "status") {
+        return { stdout: "" };
       }
       throw new Error("unexpected command");
     });
@@ -41,6 +45,8 @@ describe("probeGitContext", () => {
       repo: "extensions",
       repoRoot: "/Users/alice/src/extensions",
       branch: "main",
+      dirty: false,
+      dirtyFileCount: 0,
     });
   });
 
@@ -53,7 +59,6 @@ describe("probeGitContext", () => {
       cwd: "/tmp/scratch",
       repo: "scratch",
       repoRoot: undefined,
-      branch: undefined,
     });
   });
 
@@ -62,14 +67,93 @@ describe("probeGitContext", () => {
       if (args[0] === "rev-parse") {
         return { stdout: "\n" };
       }
-      return { stdout: "   \n" };
+      if (args[0] === "branch") {
+        return { stdout: "   \n" };
+      }
+      if (args[0] === "status") {
+        return { stdout: "" };
+      }
+      throw new Error("unexpected command");
     });
 
     await expect(probeGitContext("/tmp/scratch", runner)).resolves.toEqual({
       cwd: "/tmp/scratch",
       repo: "scratch",
       repoRoot: undefined,
-      branch: undefined,
+      dirty: false,
+      dirtyFileCount: 0,
+    });
+  });
+});
+
+describe("probeGitDynamic", () => {
+  it("returns live branch and clean dirty state when git succeeds", async () => {
+    const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
+      if (args[0] === "branch") {
+        return { stdout: "feat/runtime-metadata\n" };
+      }
+      if (args[0] === "status") {
+        return { stdout: "" };
+      }
+      throw new Error("unexpected command");
+    });
+
+    await expect(probeGitDynamic("/Users/alice/repo", runner)).resolves.toEqual({
+      branch: "feat/runtime-metadata",
+      dirty: false,
+      dirtyFileCount: 0,
+      probeFailed: false,
+    });
+  });
+
+  it("flags dirty trees and counts entries", async () => {
+    const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
+      if (args[0] === "branch") {
+        return { stdout: "main\n" };
+      }
+      if (args[0] === "status") {
+        return { stdout: " M a.ts\n?? b.ts\n" };
+      }
+      throw new Error("unexpected command");
+    });
+
+    await expect(probeGitDynamic("/Users/alice/repo", runner)).resolves.toEqual({
+      branch: "main",
+      dirty: true,
+      dirtyFileCount: 2,
+      probeFailed: false,
+    });
+  });
+
+  it("does not report clean when status fails", async () => {
+    const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
+      if (args[0] === "branch") {
+        return { stdout: "main\n" };
+      }
+      throw new Error("status unavailable");
+    });
+
+    await expect(probeGitDynamic("/Users/alice/repo", runner)).resolves.toEqual({
+      branch: "main",
+      probeFailed: true,
+    });
+  });
+
+  it("omits branch on detached HEAD instead of inventing one", async () => {
+    const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
+      if (args[0] === "branch") {
+        return { stdout: "\n" };
+      }
+      if (args[0] === "status") {
+        return { stdout: " M a.ts\n" };
+      }
+      throw new Error("unexpected command");
+    });
+
+    await expect(probeGitDynamic("/Users/alice/repo", runner)).resolves.toEqual({
+      dirty: true,
+      dirtyFileCount: 1,
+      probeFailed: false,
     });
   });
 });

--- a/slack-bridge/git-metadata.ts
+++ b/slack-bridge/git-metadata.ts
@@ -16,43 +16,106 @@ export interface GitContext {
   repo: string;
   repoRoot?: string;
   branch?: string;
+  dirty?: boolean;
+  dirtyFileCount?: number;
+}
+
+export interface GitDynamicState {
+  /** Current branch, omitted when detached/unknown/not in a repo. */
+  branch?: string;
+  /** Dirty flag, omitted when `git status` could not be read. */
+  dirty?: boolean;
+  /** Number of changed/untracked entries when dirty state is known. */
+  dirtyFileCount?: number;
+  /** True when any git probe failed; callers should treat omitted values as unknown. */
+  probeFailed: boolean;
 }
 
 async function runGitCommand(
   args: string[],
   cwd: string,
   runner: ExecFileAsyncLike,
-): Promise<string | undefined> {
+): Promise<{ stdout: string | undefined; ok: boolean }> {
   try {
     const result = await runner("git", args, { cwd, encoding: "utf-8" });
     const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout?.toString();
-    const trimmed = stdout?.trim();
-    return trimmed ? trimmed : undefined;
+    return { stdout, ok: true };
   } catch {
-    return undefined;
+    return { stdout: undefined, ok: false };
   }
+}
+
+async function readGitTrimmed(
+  args: string[],
+  cwd: string,
+  runner: ExecFileAsyncLike,
+): Promise<{ value: string | undefined; ok: boolean }> {
+  const { stdout, ok } = await runGitCommand(args, cwd, runner);
+  const trimmed = stdout?.trim();
+  return { value: trimmed ? trimmed : undefined, ok };
 }
 
 export async function probeGitBranch(
   cwd = process.cwd(),
   runner: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike,
 ): Promise<string | undefined> {
-  return runGitCommand(["branch", "--show-current"], cwd, runner);
+  return (await readGitTrimmed(["branch", "--show-current"], cwd, runner)).value;
+}
+
+async function probeGitDirty(
+  cwd: string,
+  runner: ExecFileAsyncLike,
+): Promise<{ dirty?: boolean; dirtyFileCount?: number; ok: boolean }> {
+  const { stdout, ok } = await runGitCommand(
+    ["status", "--porcelain", "--untracked-files=normal"],
+    cwd,
+    runner,
+  );
+  if (!ok) {
+    return { ok: false };
+  }
+
+  const dirtyFileCount = (stdout ?? "")
+    .split("\n")
+    .map((line) => line.replace(/\r$/, ""))
+    .filter((line) => line.length > 0).length;
+  return { dirty: dirtyFileCount > 0, dirtyFileCount, ok: true };
+}
+
+export async function probeGitDynamic(
+  cwd = process.cwd(),
+  runner: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike,
+): Promise<GitDynamicState> {
+  const branchProbe = await readGitTrimmed(["branch", "--show-current"], cwd, runner);
+  const dirtyProbe = await probeGitDirty(cwd, runner);
+
+  return {
+    ...(branchProbe.value ? { branch: branchProbe.value } : {}),
+    ...(typeof dirtyProbe.dirty === "boolean" ? { dirty: dirtyProbe.dirty } : {}),
+    ...(typeof dirtyProbe.dirtyFileCount === "number"
+      ? { dirtyFileCount: dirtyProbe.dirtyFileCount }
+      : {}),
+    probeFailed: !branchProbe.ok || !dirtyProbe.ok,
+  };
 }
 
 export async function probeGitContext(
   cwd = process.cwd(),
   runner: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike,
 ): Promise<GitContext> {
-  const repoRoot = await runGitCommand(["rev-parse", "--show-toplevel"], cwd, runner);
-  const branch = await probeGitBranch(cwd, runner);
+  const repoRoot = (await readGitTrimmed(["rev-parse", "--show-toplevel"], cwd, runner)).value;
+  const dynamic = await probeGitDynamic(cwd, runner);
   const resolvedRepoRoot = repoRoot ?? cwd;
 
   return {
     cwd,
     repo: path.basename(resolvedRepoRoot),
     repoRoot,
-    branch,
+    ...(dynamic.branch ? { branch: dynamic.branch } : {}),
+    ...(typeof dynamic.dirty === "boolean" ? { dirty: dynamic.dirty } : {}),
+    ...(typeof dynamic.dirtyFileCount === "number"
+      ? { dirtyFileCount: dynamic.dirtyFileCount }
+      : {}),
   };
 }
 

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -904,6 +904,7 @@ export interface AgentCapabilities {
   repo?: string;
   repoRoot?: string;
   branch?: string;
+  workdirDirty?: boolean;
   role?: string;
   tools?: string[];
   tags?: string[];
@@ -921,6 +922,10 @@ export interface AgentDisplayInfo {
   metadata?: {
     cwd?: string;
     branch?: string;
+    workdirDirty?: boolean;
+    workdirDirtyFileCount?: number;
+    gitProbeFailed?: boolean;
+    gitProbedAt?: string;
     host?: string;
     repo?: string;
     role?: string;
@@ -1126,6 +1131,9 @@ export function extractAgentCapabilities(
     repo: asString(capabilitiesRecord?.repo) ?? asString(record?.repo),
     repoRoot: asString(capabilitiesRecord?.repoRoot) ?? asString(record?.repoRoot),
     branch: asString(capabilitiesRecord?.branch) ?? asString(record?.branch),
+    ...(capabilitiesRecord?.workdirDirty === true || record?.workdirDirty === true
+      ? { workdirDirty: true }
+      : {}),
     role: asString(capabilitiesRecord?.role) ?? asString(record?.role),
     tools: asStringArray(capabilitiesRecord?.tools),
     tags: asStringArray(capabilitiesRecord?.tags),
@@ -1139,6 +1147,7 @@ export function buildAgentCapabilityTags(capabilities: AgentCapabilities): strin
   if (capabilities.role) tags.add(`role:${capabilities.role}`);
   if (capabilities.repo) tags.add(`repo:${capabilities.repo}`);
   if (capabilities.branch) tags.add(`branch:${capabilities.branch}`);
+  if (capabilities.workdirDirty) tags.add("workdir:dirty");
   if (capabilities.scope?.workspace?.provider) {
     tags.add(`scope-provider:${capabilities.scope.workspace.provider}`);
   }
@@ -1250,6 +1259,14 @@ export function buildAgentDisplayInfo(
       ? {
           cwd: asString(metadata.cwd),
           branch: asString(metadata.branch),
+          ...(metadata.workdirDirty === true ? { workdirDirty: true } : {}),
+          ...(typeof metadata.workdirDirtyFileCount === "number"
+            ? { workdirDirtyFileCount: metadata.workdirDirtyFileCount }
+            : {}),
+          ...(metadata.gitProbeFailed === true ? { gitProbeFailed: true } : {}),
+          ...(asString(metadata.gitProbedAt)
+            ? { gitProbedAt: asString(metadata.gitProbedAt) }
+            : {}),
           host: asString(metadata.host),
           repo: asString(metadata.repo) ?? capabilities.repo,
           role: asString(metadata.role) ?? capabilities.role,
@@ -2526,11 +2543,12 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
       let line = `${a.emoji} ${a.name} (${a.id}) \u2014 ${a.status}${statusFlavor}${health}${stuckTag}${pid}`;
 
       const meta = a.metadata;
-      if (meta && (meta.cwd || meta.branch || meta.host)) {
+      if (meta && (meta.cwd || meta.branch || meta.host || meta.gitProbeFailed)) {
         const cwd = meta.cwd ? shortenPath(meta.cwd, homedir) : "";
-        const branch = meta.branch ? ` (${meta.branch})` : "";
+        const branch = meta.branch ? ` (${meta.branch}${meta.workdirDirty ? "*" : ""})` : "";
         const host = meta.host ? ` @ ${meta.host}` : "";
-        line += `\n   ${cwd}${branch}${host}`;
+        const probe = meta.gitProbeFailed ? " [git probe failed]" : "";
+        line += `\n   ${cwd}${branch}${host}${probe}`;
       }
 
       if (meta?.brokerManaged) {

--- a/slack-bridge/runtime-agent-context.test.ts
+++ b/slack-bridge/runtime-agent-context.test.ts
@@ -14,7 +14,7 @@ import {
   type RuntimeAgentContextDeps,
 } from "./runtime-agent-context.js";
 import type { SecurityGuardrails } from "./guardrails.js";
-import type { GitContext } from "./git-metadata.js";
+import type { GitContext, GitDynamicState } from "./git-metadata.js";
 import type { SinglePlayerThreadInfo } from "./single-player-runtime.js";
 
 interface MutableRuntimeAgentState {
@@ -67,6 +67,7 @@ function createDeps(
     agentAliases?: Set<string>;
     extensionContext?: ExtensionContext | null;
     gitContext?: GitContext;
+    dynamicGitState?: GitDynamicState;
   } = {},
 ) {
   const cwd = overrides.cwd ?? process.cwd();
@@ -108,6 +109,14 @@ function createDeps(
     repo: path.basename(cwd),
     repoRoot: cwd,
     branch: "main",
+  };
+  const dynamicGitState: GitDynamicState = overrides.dynamicGitState ?? {
+    ...(gitContext.branch ? { branch: gitContext.branch } : {}),
+    ...(typeof gitContext.dirty === "boolean" ? { dirty: gitContext.dirty } : {}),
+    ...(typeof gitContext.dirtyFileCount === "number"
+      ? { dirtyFileCount: gitContext.dirtyFileCount }
+      : {}),
+    probeFailed: false,
   };
   const persistState = vi.fn();
   const updateBadge = vi.fn();
@@ -171,6 +180,7 @@ function createDeps(
     persistState,
     updateBadge,
     getGitContext: async () => gitContext,
+    getDynamicGitState: async () => dynamicGitState,
   };
 
   return {
@@ -548,6 +558,101 @@ describe("createRuntimeAgentContext", () => {
     });
 
     fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("uses live git state instead of the cached launch branch", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-agent-context-live-"));
+    try {
+      const { deps } = createDeps({
+        cwd: repoRoot,
+        gitContext: {
+          cwd: repoRoot,
+          repo: "extensions",
+          repoRoot,
+          branch: "main",
+          dirty: false,
+          dirtyFileCount: 0,
+        },
+        dynamicGitState: {
+          branch: "agent/portable-commercial-pi-runtime",
+          dirty: true,
+          dirtyFileCount: 2,
+          probeFailed: false,
+        },
+      });
+      const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+      const metadata = await runtimeAgentContext.getAgentMetadata("worker");
+      expect(metadata).toMatchObject({
+        branch: "agent/portable-commercial-pi-runtime",
+        workdirDirty: true,
+        workdirDirtyFileCount: 2,
+      });
+      expect(metadata.capabilities).toMatchObject({
+        branch: "agent/portable-commercial-pi-runtime",
+        workdirDirty: true,
+      });
+      expect((metadata.capabilities as { tags: string[] }).tags).toEqual(
+        expect.arrayContaining(["branch:agent/portable-commercial-pi-runtime", "workdir:dirty"]),
+      );
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not fall back to a cached branch when the live probe observes no branch", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-agent-context-detached-"));
+    try {
+      const { deps } = createDeps({
+        cwd: repoRoot,
+        gitContext: {
+          cwd: repoRoot,
+          repo: "extensions",
+          repoRoot,
+          branch: "main",
+        },
+        dynamicGitState: {
+          dirty: false,
+          dirtyFileCount: 0,
+          probeFailed: false,
+        },
+      });
+      const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+      const metadata = await runtimeAgentContext.getAgentMetadata("worker");
+      expect(metadata).not.toHaveProperty("branch");
+      expect(metadata).toMatchObject({ workdirDirty: false });
+      expect((metadata.capabilities as { tags: string[] }).tags).not.toContain("branch:main");
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("marks probe failures without reporting an unknown dirty state as clean", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-agent-context-probe-fail-"));
+    try {
+      const { deps } = createDeps({
+        cwd: repoRoot,
+        gitContext: {
+          cwd: repoRoot,
+          repo: "extensions",
+          repoRoot,
+          branch: "main",
+        },
+        dynamicGitState: {
+          branch: "main",
+          probeFailed: true,
+        },
+      });
+      const runtimeAgentContext = createRuntimeAgentContext(deps);
+
+      const metadata = await runtimeAgentContext.getAgentMetadata("worker");
+      expect(metadata).toMatchObject({ branch: "main", gitProbeFailed: true });
+      expect(metadata).not.toHaveProperty("workdirDirty");
+      expect((metadata.capabilities as { tags: string[] }).tags).toContain("git-probe-failed");
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 
   it("includes broker-managed launch metadata for marked follower workers", async () => {

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { GitContext } from "./git-metadata.js";
+import { type GitContext, type GitDynamicState, probeGitDynamic } from "./git-metadata.js";
 import {
   buildAllowlist,
   buildIdentityReplyGuidelines,
@@ -80,6 +80,8 @@ export interface RuntimeAgentContextDeps {
   persistState: () => void;
   updateBadge: () => void;
   getGitContext: () => Promise<GitContext>;
+  /** Optional test hook for live branch/dirty probing. */
+  getDynamicGitState?: (cwd: string) => Promise<GitDynamicState>;
 }
 
 export interface RuntimeAgentContext {
@@ -369,18 +371,31 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     return [...tools].sort();
   }
 
+  const dynamicGitProbe = deps.getDynamicGitState ?? ((cwd: string) => probeGitDynamic(cwd));
+
   async function getAgentMetadata(
     role: RuntimeAgentRole = "worker",
   ): Promise<Record<string, unknown>> {
     const gitContext = await deps.getGitContext();
-    const { cwd, repo, repoRoot, branch } = gitContext;
+    const { cwd, repo, repoRoot } = gitContext;
     const resolvedRepoRoot = repoRoot ?? cwd;
     const tools = detectProjectTools(resolvedRepoRoot, cwd);
     const scope = buildSlackCompatibilityScope();
+    let dynamic: GitDynamicState;
+    try {
+      dynamic = await dynamicGitProbe(cwd);
+    } catch {
+      dynamic = { probeFailed: true };
+    }
+    const branch = dynamic.branch;
+    const workdirDirty = dynamic.dirty;
+    const gitProbeFailed = dynamic.probeFailed;
     const tags = [
       `role:${role}`,
       `repo:${repo}`,
       ...(branch ? [`branch:${branch}`] : []),
+      ...(workdirDirty === true ? ["workdir:dirty"] : []),
+      ...(gitProbeFailed ? ["git-probe-failed"] : []),
       ...(scope.workspace?.provider ? [`scope-provider:${scope.workspace.provider}`] : []),
       ...(scope.workspace?.compatibilityKey ? [`scope:${scope.workspace.compatibilityKey}`] : []),
       ...tools.map((tool) => `tool:${tool}`),
@@ -400,7 +415,13 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
 
     return {
       cwd,
-      branch,
+      ...(branch ? { branch } : {}),
+      ...(typeof workdirDirty === "boolean" ? { workdirDirty } : {}),
+      ...(typeof dynamic.dirtyFileCount === "number"
+        ? { workdirDirtyFileCount: dynamic.dirtyFileCount }
+        : {}),
+      ...(gitProbeFailed ? { gitProbeFailed: true } : {}),
+      gitProbedAt: new Date().toISOString(),
       host: os.hostname(),
       role,
       repo,
@@ -415,7 +436,8 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
       capabilities: {
         repo,
         repoRoot,
-        branch,
+        ...(branch ? { branch } : {}),
+        ...(typeof workdirDirty === "boolean" ? { workdirDirty } : {}),
         role,
         tools,
         tags,


### PR DESCRIPTION
## Problem

`pinet agents` could keep advertising the launch-time git branch even after a follower's working tree changed. That made agent visibility/routing rely on stale metadata.

## Minimal fix

Refresh only the existing git-related metadata on follower heartbeats:

- Re-probe the worker cwd for the live branch with `git branch --show-current`.
- Re-probe dirty state with `git status --porcelain --untracked-files=normal`.
- Publish the existing `branch` field as the live observed branch, plus:
  - `workdirDirty`
  - `workdirDirtyFileCount`
  - `gitProbeFailed`
  - `gitProbedAt`
- If the branch is detached/unknown, omit `branch` rather than falling back to the cached launch branch.
- If dirty probing fails, do not report the tree as clean; mark `gitProbeFailed` instead.
- Let broker heartbeat accept optional metadata and replace the stored agent metadata in-place without touching identity fields.
- Keep heartbeat liveness protected: the metadata provider has a short timeout and an in-flight guard, so a hung git probe falls back to a plain heartbeat and cannot pile up repeated probes.

Deliberately not included in this smaller version:

- no `observedBranch` / `desiredBranch` split
- no `branchMismatch` model
- no routing score changes
- no broker self-heartbeat refresh
- no large `pinet agents` output redesign

## Tests

- `pnpm prepush`
- Added/updated coverage for:
  - live branch + dirty probing
  - detached/no-branch behavior
  - dirty-probe failure not reported as clean
  - heartbeat metadata timeout/in-flight fallback
  - heartbeat metadata round-trip to broker DB
  - metadata replacement preserving agent identity fields
