### PR TITLE
Fix Pinet task assignment scope and intent tracking

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { classifyPinetMail } from "./mail-classification.js";
-import { BrokerDB } from "./schema.js";
+import { BrokerDB, CURRENT_BROKER_SCHEMA_VERSION } from "./schema.js";
 
 function createDb(): { db: BrokerDB; dir: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-core-schema-"));
@@ -229,7 +229,7 @@ describe("BrokerDB message sync identity", () => {
         ),
       );
 
-      expect(version.user_version).toBe(16);
+      expect(version.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
       expect(messageColumns.has("external_id")).toBe(true);
       expect(messageColumns.has("external_ts")).toBe(true);
       expect(inboxColumns.has("read_at")).toBe(true);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -19,6 +19,7 @@ import type {
   InboundMessage,
   ChannelAssignment,
   TaskAssignmentInfo,
+  TaskAssignmentKind,
   TaskAssignmentStatus,
   ScheduledWakeupInfo,
   ScheduledWakeupDelivery,
@@ -110,6 +111,11 @@ interface TaskAssignmentRow {
   status: string;
   thread_id: string;
   source_message_id: number | null;
+  repo_key: string | null;
+  repo_owner: string | null;
+  repo_name: string | null;
+  repo_root: string | null;
+  task_kind: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -367,6 +373,34 @@ function rowToBacklog(row: BacklogRow): BacklogEntry {
   };
 }
 
+function normalizeTaskAssignmentKind(value: string | null | undefined): TaskAssignmentKind {
+  switch (value) {
+    case "implementation":
+    case "review":
+    case "qa":
+    case "merge":
+    case "interactive":
+    case "unknown":
+      return value;
+    default:
+      return "unknown";
+  }
+}
+
+function buildTaskAssignmentRepoKey(input: {
+  repoOwner?: string | null;
+  repoName?: string | null;
+  repoRoot?: string | null;
+}): string {
+  const owner = input.repoOwner?.trim().toLowerCase();
+  const name = input.repoName?.trim().toLowerCase();
+  if (owner && name) {
+    return `${owner}/${name}`;
+  }
+  const repoRoot = input.repoRoot?.trim();
+  return repoRoot ? `root:${repoRoot}` : "repo_unknown";
+}
+
 function rowToTaskAssignment(row: TaskAssignmentRow): TaskAssignmentInfo {
   return {
     id: row.id,
@@ -377,6 +411,10 @@ function rowToTaskAssignment(row: TaskAssignmentRow): TaskAssignmentInfo {
     status: row.status as TaskAssignmentStatus,
     threadId: row.thread_id,
     sourceMessageId: row.source_message_id,
+    repoOwner: row.repo_owner,
+    repoName: row.repo_name,
+    repoRoot: row.repo_root,
+    taskKind: normalizeTaskAssignmentKind(row.task_kind),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -596,7 +634,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 16;
+export const CURRENT_BROKER_SCHEMA_VERSION = 17;
 
 const REQUIRED_AGENT_LIFECYCLE_COLUMNS = [
   "stable_id",
@@ -1013,9 +1051,15 @@ function createTaskAssignmentTable(db: DatabaseSync): void {
         CHECK(status IN ('assigned', 'branch_pushed', 'pr_open', 'pr_merged', 'pr_closed')),
       thread_id TEXT NOT NULL,
       source_message_id INTEGER,
+      repo_key TEXT NOT NULL DEFAULT 'repo_unknown',
+      repo_owner TEXT,
+      repo_name TEXT,
+      repo_root TEXT,
+      task_kind TEXT NOT NULL DEFAULT 'unknown'
+        CHECK(task_kind IN ('implementation', 'review', 'qa', 'merge', 'interactive', 'unknown')),
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
-      UNIQUE(issue_number)
+      UNIQUE(repo_key, issue_number)
     );
 
     CREATE INDEX IF NOT EXISTS idx_task_assignments_agent_status
@@ -1051,6 +1095,11 @@ function migrateTaskAssignmentsToIssueOwnership(db: DatabaseSync): void {
       status,
       thread_id,
       source_message_id,
+      repo_key,
+      repo_owner,
+      repo_name,
+      repo_root,
+      task_kind,
       created_at,
       updated_at
     )
@@ -1062,6 +1111,88 @@ function migrateTaskAssignmentsToIssueOwnership(db: DatabaseSync): void {
       legacy.status,
       legacy.thread_id,
       legacy.source_message_id,
+      'repo_unknown',
+      NULL,
+      NULL,
+      NULL,
+      'unknown',
+      legacy.created_at,
+      legacy.updated_at
+    FROM task_assignments_legacy AS legacy
+    WHERE legacy.id = (
+      SELECT latest.id
+      FROM task_assignments_legacy AS latest
+      WHERE latest.issue_number = legacy.issue_number
+      ORDER BY latest.updated_at DESC, latest.created_at DESC, latest.id DESC
+      LIMIT 1
+    );
+
+    DROP TABLE task_assignments_legacy;
+  `);
+}
+
+function migrateTaskAssignmentsToRepoScopedTracking(db: DatabaseSync): void {
+  if (!tableExists(db, "task_assignments")) {
+    createTaskAssignmentTable(db);
+    return;
+  }
+
+  const existingColumns = getTableColumns(db, "task_assignments");
+  if (!existingColumns.has("agent_id") || !existingColumns.has("issue_number")) {
+    db.exec("DROP TABLE task_assignments");
+    createTaskAssignmentTable(db);
+    return;
+  }
+
+  db.exec(`
+    ALTER TABLE task_assignments RENAME TO task_assignments_legacy;
+    DROP INDEX IF EXISTS idx_task_assignments_agent_status;
+    DROP INDEX IF EXISTS idx_task_assignments_branch;
+  `);
+
+  createTaskAssignmentTable(db);
+
+  const legacyColumns = getTableColumns(db, "task_assignments_legacy");
+  const repoKeyExpr = legacyColumns.has("repo_key")
+    ? "COALESCE(repo_key, 'repo_unknown')"
+    : "'repo_unknown'";
+  const repoOwnerExpr = legacyColumns.has("repo_owner") ? "repo_owner" : "NULL";
+  const repoNameExpr = legacyColumns.has("repo_name") ? "repo_name" : "NULL";
+  const repoRootExpr = legacyColumns.has("repo_root") ? "repo_root" : "NULL";
+  const taskKindExpr = legacyColumns.has("task_kind")
+    ? "COALESCE(task_kind, 'unknown')"
+    : "'unknown'";
+
+  db.exec(`
+    INSERT INTO task_assignments (
+      agent_id,
+      issue_number,
+      branch,
+      pr_number,
+      status,
+      thread_id,
+      source_message_id,
+      repo_key,
+      repo_owner,
+      repo_name,
+      repo_root,
+      task_kind,
+      created_at,
+      updated_at
+    )
+    SELECT
+      legacy.agent_id,
+      legacy.issue_number,
+      legacy.branch,
+      legacy.pr_number,
+      legacy.status,
+      legacy.thread_id,
+      legacy.source_message_id,
+      ${repoKeyExpr},
+      ${repoOwnerExpr},
+      ${repoNameExpr},
+      ${repoRootExpr},
+      ${taskKindExpr},
       legacy.created_at,
       legacy.updated_at
     FROM task_assignments_legacy AS legacy
@@ -1253,6 +1384,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 16:
           createPortLeaseTable(db);
+          break;
+        case 17:
+          migrateTaskAssignmentsToRepoScopedTracking(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -2527,22 +2661,47 @@ export class BrokerDB implements BrokerDBInterface {
     branch: string | null,
     threadId: string,
     sourceMessageId: number | null,
+    options: {
+      repoOwner?: string | null;
+      repoName?: string | null;
+      repoRoot?: string | null;
+      taskKind?: TaskAssignmentKind;
+    } = {},
   ): TaskAssignmentInfo {
     const db = this.getDb();
     const now = new Date().toISOString();
+    const repoOwner = options.repoOwner ?? null;
+    const repoName = options.repoName ?? null;
+    const repoRoot = options.repoRoot ?? null;
+    const repoKey = buildTaskAssignmentRepoKey({ repoOwner, repoName, repoRoot });
+    const taskKind = normalizeTaskAssignmentKind(options.taskKind ?? "implementation");
     const existing = db
-      .prepare("SELECT * FROM task_assignments WHERE issue_number = ?")
-      .get(issueNumber) as TaskAssignmentRow | undefined;
+      .prepare("SELECT * FROM task_assignments WHERE repo_key = ? AND issue_number = ?")
+      .get(repoKey, issueNumber) as TaskAssignmentRow | undefined;
 
     if (!existing) {
       const info = db
         .prepare(
           `INSERT INTO task_assignments (
              agent_id, issue_number, branch, pr_number, status,
-             thread_id, source_message_id, created_at, updated_at
-           ) VALUES (?, ?, ?, NULL, 'assigned', ?, ?, ?, ?)`,
+             thread_id, source_message_id, repo_key, repo_owner, repo_name, repo_root, task_kind,
+             created_at, updated_at
+           ) VALUES (?, ?, ?, NULL, 'assigned', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
-        .run(agentId, issueNumber, branch, threadId, sourceMessageId, now, now);
+        .run(
+          agentId,
+          issueNumber,
+          branch,
+          threadId,
+          sourceMessageId,
+          repoKey,
+          repoOwner,
+          repoName,
+          repoRoot,
+          taskKind,
+          now,
+          now,
+        );
 
       const row = db
         .prepare("SELECT * FROM task_assignments WHERE id = ?")
@@ -2555,6 +2714,8 @@ export class BrokerDB implements BrokerDBInterface {
 
     const isReassignment = existing.agent_id !== agentId;
     const nextBranch = isReassignment ? branch : (branch ?? existing.branch);
+    const nextTaskKind =
+      taskKind === "unknown" ? normalizeTaskAssignmentKind(existing.task_kind) : taskKind;
     const shouldResetProgress = isReassignment || nextBranch !== existing.branch;
     db.prepare(
       `UPDATE task_assignments
@@ -2564,6 +2725,10 @@ export class BrokerDB implements BrokerDBInterface {
            status = CASE WHEN ? THEN 'assigned' ELSE status END,
            thread_id = ?,
            source_message_id = ?,
+           repo_owner = ?,
+           repo_name = ?,
+           repo_root = ?,
+           task_kind = ?,
            updated_at = ?
        WHERE id = ?`,
     ).run(
@@ -2573,6 +2738,10 @@ export class BrokerDB implements BrokerDBInterface {
       shouldResetProgress ? 1 : 0,
       threadId,
       sourceMessageId,
+      repoOwner,
+      repoName,
+      repoRoot,
+      nextTaskKind,
       now,
       existing.id,
     );

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -115,6 +115,14 @@ export type TaskAssignmentStatus =
   | "pr_merged"
   | "pr_closed";
 
+export type TaskAssignmentKind =
+  | "implementation"
+  | "review"
+  | "qa"
+  | "merge"
+  | "interactive"
+  | "unknown";
+
 export interface TaskAssignmentInfo {
   id: number;
   agentId: string;
@@ -124,6 +132,10 @@ export interface TaskAssignmentInfo {
   status: TaskAssignmentStatus;
   threadId: string;
   sourceMessageId: number | null;
+  repoOwner: string | null;
+  repoName: string | null;
+  repoRoot: string | null;
+  taskKind: TaskAssignmentKind;
   createdAt: string;
   updatedAt: string;
 }

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -855,7 +855,10 @@ describe("BrokerDB", () => {
       ]),
     );
     expect(report).toBe(
-      ["RALPH LOOP — WORKER STATUS:", "- 🐦‍⬛ Frozen Raven: #114 → no commits, no PR ⚠️"].join("\n"),
+      [
+        "RALPH LOOP — WORKER STATUS:",
+        "- 🐦‍⬛ Frozen Raven: #114 → repo unknown; progress not checked ⚠️",
+      ].join("\n"),
     );
   });
 

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ActivityLogEntry } from "./activity-log.js";
-import type { AgentInfo, BrokerMessage, TaskAssignmentInfo } from "./broker/types.js";
+import type {
+  AgentInfo,
+  BrokerMessage,
+  TaskAssignmentInfo,
+  TaskAssignmentKind,
+} from "./broker/types.js";
 import {
   createPinetMeshOps,
   type PinetMeshOpsBrokerDbPort,
@@ -104,6 +109,12 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
       branch: string | null,
       threadId: string,
       sourceMessageId: number,
+      options: {
+        repoOwner?: string | null;
+        repoName?: string | null;
+        repoRoot?: string | null;
+        taskKind?: TaskAssignmentKind;
+      } = {},
     ): TaskAssignmentInfo => ({
       id: sourceMessageId,
       agentId,
@@ -113,6 +124,10 @@ function createBrokerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
       status: "assigned",
       threadId,
       sourceMessageId,
+      repoOwner: options.repoOwner ?? null,
+      repoName: options.repoName ?? null,
+      repoRoot: options.repoRoot ?? null,
+      taskKind: options.taskKind ?? "implementation",
       createdAt: "2026-04-15T13:06:00.000Z",
       updatedAt: "2026-04-15T13:06:00.000Z",
     }),
@@ -253,6 +268,7 @@ describe("createPinetMeshOps", () => {
       "refactor/418-pinet-mesh-ops",
       "a2a:broker-1:worker-1",
       1,
+      { repoOwner: null, repoName: null, taskKind: "implementation" },
     );
     expect(logActivity).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -268,7 +268,12 @@ describe("createPinetMeshOps", () => {
       "refactor/418-pinet-mesh-ops",
       "a2a:broker-1:worker-1",
       1,
-      { repoOwner: null, repoName: null, taskKind: "implementation" },
+      expect.objectContaining({
+        repoOwner: "gugu91",
+        repoName: "extensions",
+        repoRoot: expect.stringContaining("gugu91-extensions-747"),
+        taskKind: "implementation",
+      }),
     );
     expect(logActivity).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -291,6 +291,34 @@ describe("createPinetMeshOps", () => {
     );
   });
 
+  it("does not attach the current repo root to an explicit different repo assignment", async () => {
+    const { deps, recordTaskAssignment } = createBrokerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    await pinetMeshOps.sendPinetAgentMessage(
+      "worker-1",
+      [
+        "Implementation lane:",
+        "Issue: https://github.com/Nexcade/garage/issues/418",
+        "Branch: `fix/garage-418`",
+      ].join("\n"),
+    );
+
+    expect(recordTaskAssignment).toHaveBeenCalledWith(
+      "worker-1",
+      418,
+      "fix/garage-418",
+      "a2a:broker-1:worker-1",
+      1,
+      expect.objectContaining({
+        repoOwner: "Nexcade",
+        repoName: "garage",
+        repoRoot: null,
+        taskKind: "implementation",
+      }),
+    );
+  });
+
   it("transfers broker thread ownership to the direct recipient when requested", async () => {
     const { deps, insertedMessages, logActivity, transferThreadOwnership } = createBrokerDeps();
     const db = deps.getActiveBrokerDb();

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -271,7 +271,7 @@ describe("createPinetMeshOps", () => {
       expect.objectContaining({
         repoOwner: "gugu91",
         repoName: "extensions",
-        repoRoot: expect.stringContaining("gugu91-extensions-747"),
+        repoRoot: expect.any(String),
         taskKind: "implementation",
       }),
     );

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -1,3 +1,5 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { normalizeOutgoingPinetControlMessage } from "./helpers.js";
 import {
   dispatchBroadcastAgentMessage,
@@ -8,6 +10,8 @@ import {
 import type { AgentInfo, TaskAssignmentInfo, TaskAssignmentKind } from "./broker/types.js";
 import type { ActivityLogEntry } from "./activity-log.js";
 import { extractTaskAssignmentsFromMessage } from "./task-assignments.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface PinetMeshOpsAgentRecord {
   emoji: string;
@@ -135,6 +139,35 @@ function getThreadOwnershipTransferId(metadata?: Record<string, unknown>): strin
   return typeof threadId === "string" && threadId.trim().length > 0 ? threadId.trim() : null;
 }
 
+function parseGitHubRemoteRepo(remoteUrl: string): { repoOwner: string; repoName: string } | null {
+  const match = remoteUrl.match(/github\.com[:/]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/i);
+  if (!match?.[1] || !match[2]) {
+    return null;
+  }
+  return { repoOwner: match[1], repoName: match[2] };
+}
+
+async function resolveCurrentGitHubRepo(): Promise<{
+  repoOwner: string | null;
+  repoName: string | null;
+  repoRoot: string | null;
+}> {
+  try {
+    const [rootResult, remoteResult] = await Promise.all([
+      execFileAsync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf-8" }),
+      execFileAsync("git", ["remote", "get-url", "origin"], { encoding: "utf-8" }),
+    ]);
+    const remoteRepo = parseGitHubRemoteRepo(String(remoteResult.stdout).trim());
+    return {
+      repoOwner: remoteRepo?.repoOwner ?? null,
+      repoName: remoteRepo?.repoName ?? null,
+      repoRoot: String(rootResult.stdout).trim() || null,
+    };
+  } catch {
+    return { repoOwner: null, repoName: null, repoRoot: null };
+  }
+}
+
 export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
   async function sendPinetAgentMessage(
     targetRef: string,
@@ -196,8 +229,14 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
         });
       }
 
+      const parsedAssignments = extractTaskAssignmentsFromMessage(body);
+      const fallbackRepo = parsedAssignments.some(
+        (assignment) => !assignment.repoOwner || !assignment.repoName,
+      )
+        ? await resolveCurrentGitHubRepo()
+        : { repoOwner: null, repoName: null, repoRoot: null };
       const recordedAssignments: PinetMeshOpsRecordedAssignment[] = [];
-      for (const assignment of extractTaskAssignmentsFromMessage(body)) {
+      for (const assignment of parsedAssignments) {
         const tracked = db.recordTaskAssignment(
           result.target.id,
           assignment.issueNumber,
@@ -205,8 +244,9 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
           result.threadId,
           result.messageId,
           {
-            repoOwner: assignment.repoOwner,
-            repoName: assignment.repoName,
+            repoOwner: assignment.repoOwner ?? fallbackRepo.repoOwner,
+            repoName: assignment.repoName ?? fallbackRepo.repoName,
+            repoRoot: fallbackRepo.repoRoot,
             taskKind: assignment.taskKind,
           },
         );

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -5,7 +5,7 @@ import {
   isBroadcastChannelTarget,
   type AgentMessageStorage,
 } from "./broker/agent-messaging.js";
-import type { AgentInfo, TaskAssignmentInfo } from "./broker/types.js";
+import type { AgentInfo, TaskAssignmentInfo, TaskAssignmentKind } from "./broker/types.js";
 import type { ActivityLogEntry } from "./activity-log.js";
 import { extractTaskAssignmentsFromMessage } from "./task-assignments.js";
 
@@ -49,6 +49,12 @@ export interface PinetMeshOpsBrokerDbPort extends AgentMessageStorage {
     branch: string | null,
     threadId: string,
     sourceMessageId: number,
+    options?: {
+      repoOwner?: string | null;
+      repoName?: string | null;
+      repoRoot?: string | null;
+      taskKind?: TaskAssignmentKind;
+    },
   ) => TaskAssignmentInfo;
   scheduleWakeup: (
     agentId: string,
@@ -198,6 +204,11 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
           assignment.branch,
           result.threadId,
           result.messageId,
+          {
+            repoOwner: assignment.repoOwner,
+            repoName: assignment.repoName,
+            taskKind: assignment.taskKind,
+          },
         );
         recordedAssignments.push({ issueNumber: tracked.issueNumber, branch: tracked.branch });
       }

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -237,6 +237,14 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
         : { repoOwner: null, repoName: null, repoRoot: null };
       const recordedAssignments: PinetMeshOpsRecordedAssignment[] = [];
       for (const assignment of parsedAssignments) {
+        const repoOwner = assignment.repoOwner ?? fallbackRepo.repoOwner;
+        const repoName = assignment.repoName ?? fallbackRepo.repoName;
+        const usesFallbackRepoIdentity = !assignment.repoOwner || !assignment.repoName;
+        const fallbackMatchesAssignmentRepo =
+          assignment.repoOwner?.toLowerCase() === fallbackRepo.repoOwner?.toLowerCase() &&
+          assignment.repoName?.toLowerCase() === fallbackRepo.repoName?.toLowerCase();
+        const repoRoot =
+          usesFallbackRepoIdentity || fallbackMatchesAssignmentRepo ? fallbackRepo.repoRoot : null;
         const tracked = db.recordTaskAssignment(
           result.target.id,
           assignment.issueNumber,
@@ -244,9 +252,9 @@ export function createPinetMeshOps(deps: PinetMeshOpsDeps): PinetMeshOps {
           result.threadId,
           result.messageId,
           {
-            repoOwner: assignment.repoOwner ?? fallbackRepo.repoOwner,
-            repoName: assignment.repoName ?? fallbackRepo.repoName,
-            repoRoot: fallbackRepo.repoRoot,
+            repoOwner,
+            repoName,
+            repoRoot,
             taskKind: assignment.taskKind,
           },
         );

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -348,6 +348,39 @@ describe("resolveTaskAssignments", () => {
     expect(hasTaskAssignmentStatusChange(assignment)).toBe(true);
   });
 
+  it("does not check branch progress from broker cwd when repo root is unavailable", async () => {
+    const runner: CommandRunner = vi.fn(async (file, args) => {
+      if (file === "gh") {
+        return { stdout: "[]\n" };
+      }
+      throw new Error(`unexpected command: ${file} ${args.join(" ")}`);
+    });
+
+    const [assignment] = await resolveTaskAssignments(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 114,
+          branch: "feat/ralph",
+          repoOwner: "gugu91",
+          repoName: "extensions",
+          repoRoot: null,
+        }),
+      ],
+      "/broker/repo",
+      runner,
+    );
+
+    expect(assignment.branchAheadCount).toBe(0);
+    expect(assignment.nextStatus).toBe("assigned");
+    expect(runner).not.toHaveBeenCalledWith(
+      "git",
+      expect.any(Array),
+      expect.objectContaining({ cwd: "/broker/repo" }),
+    );
+  });
+
   it("checks branch progress from the captured repo root", async () => {
     const runner: CommandRunner = vi.fn(async (file, args, options) => {
       if (
@@ -733,6 +766,31 @@ describe("buildTaskAssignmentReport", () => {
       [
         "RALPH LOOP — WORKER STATUS:",
         "- 🐦‍⬛ Frozen Raven: #287 → review task, no implementation PR expected",
+      ].join("\n"),
+    );
+  });
+
+  it("does not claim no commits when branch progress is unsafe to check", () => {
+    const report = buildTaskAssignmentReport(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-2",
+          issueNumber: 114,
+          branch: "feat/ralph",
+          repoOwner: "gugu91",
+          repoName: "extensions",
+          repoRoot: null,
+          status: "assigned",
+        }),
+      ],
+      new Map([["worker-2", makeAgent("worker-2", "Frozen Raven", "🐦‍⬛")]]),
+    );
+
+    expect(report).toBe(
+      [
+        "RALPH LOOP — WORKER STATUS:",
+        "- 🐦‍⬛ Frozen Raven: #114 → no PR found for feat/ralph; commits not checked (repo root unavailable) ⚠️",
       ].join("\n"),
     );
   });

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -140,6 +140,41 @@ describe("extractTaskAssignmentsFromMessage", () => {
 });
 
 describe("normalizeTrackedTaskAssignments", () => {
+  it("preserves captured repo identity when reparsing issue-only source messages", () => {
+    const normalized = normalizeTrackedTaskAssignments(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 418,
+          branch: "fix/task-tracker-418",
+          repoOwner: "gugu91",
+          repoName: "extensions",
+          sourceMessageId: 100,
+        }),
+      ],
+      new Map([
+        [
+          100,
+          [
+            "Please implement the fix and open a PR.",
+            "Issue: #418",
+            "Branch: `fix/task-tracker-418`",
+          ].join("\n"),
+        ],
+      ]),
+    );
+
+    expect(normalized).toEqual([
+      expect.objectContaining({
+        issueNumber: 418,
+        repoOwner: "gugu91",
+        repoName: "extensions",
+        taskKind: "implementation",
+      }),
+    ]);
+  });
+
   it("drops stale update rows and repairs the canonical issue and branch from the source message", () => {
     const assignments = [
       makeAssignment({

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -140,6 +140,29 @@ describe("extractTaskAssignmentsFromMessage", () => {
 });
 
 describe("normalizeTrackedTaskAssignments", () => {
+  it("keeps same-number assignments separate when only repo roots are known", () => {
+    const normalized = normalizeTrackedTaskAssignments([
+      makeAssignment({
+        id: 2,
+        agentId: "worker-2",
+        issueNumber: 418,
+        repoRoot: "/repos/two",
+        updatedAt: "2026-04-02T10:01:00.000Z",
+      }),
+      makeAssignment({
+        id: 1,
+        agentId: "worker-1",
+        issueNumber: 418,
+        repoRoot: "/repos/one",
+      }),
+    ]);
+
+    expect(normalized.map((assignment) => assignment.repoRoot)).toEqual([
+      "/repos/two",
+      "/repos/one",
+    ]);
+  });
+
   it("preserves captured repo identity when reparsing issue-only source messages", () => {
     const normalized = normalizeTrackedTaskAssignments(
       [
@@ -323,6 +346,44 @@ describe("resolveTaskAssignments", () => {
     expect(assignment.nextStatus).toBe("branch_pushed");
     expect(assignment.nextPrNumber).toBeNull();
     expect(hasTaskAssignmentStatusChange(assignment)).toBe(true);
+  });
+
+  it("checks branch progress from the captured repo root", async () => {
+    const runner: CommandRunner = vi.fn(async (file, args, options) => {
+      if (
+        file === "git" &&
+        args.slice(0, 4).join(" ") === "rev-parse --verify --quiet origin/main"
+      ) {
+        return { stdout: options.cwd === "/assigned/repo" ? "origin/main\n" : "" };
+      }
+      if (file === "git" && args[0] === "rev-parse" && args.at(-1) === "feat/ralph") {
+        return { stdout: options.cwd === "/assigned/repo" ? "feat/ralph\n" : "" };
+      }
+      if (file === "git" && args[0] === "rev-list") {
+        return { stdout: options.cwd === "/assigned/repo" ? "2\n" : "0\n" };
+      }
+      if (file === "gh") {
+        return { stdout: "[]\n" };
+      }
+      throw new Error(`unexpected command: ${file} ${args.join(" ")}`);
+    });
+
+    const [assignment] = await resolveTaskAssignments(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 114,
+          branch: "feat/ralph",
+          repoRoot: "/assigned/repo",
+        }),
+      ],
+      "/broker/repo",
+      runner,
+    );
+
+    expect(assignment.branchAheadCount).toBe(2);
+    expect(assignment.nextStatus).toBe("branch_pushed");
   });
 
   it("detects open and merged PRs from GitHub", async () => {

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -25,7 +25,7 @@ function makeAssignment(
     sourceMessageId: overrides.sourceMessageId ?? null,
     repoOwner: overrides.repoOwner ?? null,
     repoName: overrides.repoName ?? null,
-    repoRoot: overrides.repoRoot ?? null,
+    repoRoot: overrides.repoRoot === undefined ? "/repo" : overrides.repoRoot,
     taskKind: overrides.taskKind ?? "implementation",
     createdAt: overrides.createdAt ?? "2026-04-02T10:00:00.000Z",
     updatedAt: overrides.updatedAt ?? "2026-04-02T10:00:00.000Z",

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -120,6 +120,24 @@ describe("extractTaskAssignmentsFromMessage", () => {
     ]);
   });
 
+  it("uses pull request URLs for repo context without tracking the PR number as an issue", () => {
+    const message = [
+      "Please do a read-only review of https://github.com/gugu91/extensions/pull/292.",
+      "Issue: #287",
+      "Do not mutate files; just report findings.",
+    ].join("\n");
+
+    expect(extractTaskAssignmentsFromMessage(message)).toEqual([
+      {
+        issueNumber: 287,
+        branch: null,
+        repoOwner: "gugu91",
+        repoName: "extensions",
+        taskKind: "review",
+      },
+    ]);
+  });
+
   it("lets explicit implementation branch signals win over generic review wording", () => {
     const message = [
       "Please review the code, implement the fix, and open a PR.",

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -23,6 +23,10 @@ function makeAssignment(
     status: overrides.status ?? "assigned",
     threadId: overrides.threadId ?? `a2a:broker:${overrides.agentId}`,
     sourceMessageId: overrides.sourceMessageId ?? null,
+    repoOwner: overrides.repoOwner ?? null,
+    repoName: overrides.repoName ?? null,
+    repoRoot: overrides.repoRoot ?? null,
+    taskKind: overrides.taskKind ?? "implementation",
     createdAt: overrides.createdAt ?? "2026-04-02T10:00:00.000Z",
     updatedAt: overrides.updatedAt ?? "2026-04-02T10:00:00.000Z",
   };
@@ -45,7 +49,13 @@ describe("extractTaskAssignmentsFromMessage", () => {
     ].join("\n");
 
     expect(extractTaskAssignmentsFromMessage(message)).toEqual([
-      { issueNumber: 114, branch: "feat/ralph-completion-v2" },
+      {
+        issueNumber: 114,
+        branch: "feat/ralph-completion-v2",
+        repoOwner: null,
+        repoName: null,
+        taskKind: "implementation",
+      },
     ]);
   });
 
@@ -61,7 +71,13 @@ describe("extractTaskAssignmentsFromMessage", () => {
     ].join("\n");
 
     expect(extractTaskAssignmentsFromMessage(message)).toEqual([
-      { issueNumber: 287, branch: "fix/pinet-follow-auth-method" },
+      {
+        issueNumber: 287,
+        branch: "fix/pinet-follow-auth-method",
+        repoOwner: null,
+        repoName: null,
+        taskKind: "implementation",
+      },
     ]);
   });
 
@@ -85,6 +101,23 @@ describe("extractTaskAssignmentsFromMessage", () => {
     ].join("\n");
 
     expect(extractTaskAssignmentsFromMessage(message)).toEqual([]);
+  });
+
+  it("captures repo identity from GitHub issue URLs and classifies review-only work", () => {
+    const message = [
+      "Please do a read-only review of PR #292 against https://github.com/gugu91/extensions/issues/287.",
+      "Do not mutate files; just report findings.",
+    ].join("\n");
+
+    expect(extractTaskAssignmentsFromMessage(message)).toEqual([
+      {
+        issueNumber: 287,
+        branch: null,
+        repoOwner: "gugu91",
+        repoName: "extensions",
+        taskKind: "review",
+      },
+    ]);
   });
 });
 
@@ -409,7 +442,16 @@ describe("resolveTaskAssignments", () => {
     });
 
     const [assignment] = await resolveTaskAssignments(
-      [makeAssignment({ id: 1, agentId: "worker-1", issueNumber: 271, status: "assigned" })],
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 271,
+          status: "assigned",
+          repoOwner: "gugu91",
+          repoName: "extensions",
+        }),
+      ],
       "/repo",
       runner,
     );
@@ -418,6 +460,63 @@ describe("resolveTaskAssignments", () => {
     expect(assignment.nextPrNumber).toBeNull();
     expect(assignment.issueState).toBe("CLOSED");
     expect(hasTaskAssignmentStatusChange(assignment)).toBe(false);
+  });
+
+  it("resolves same-number issues against their captured repositories", async () => {
+    const runner: CommandRunner = vi.fn(async (file, args) => {
+      if (
+        file === "git" &&
+        args.slice(0, 4).join(" ") === "rev-parse --verify --quiet origin/main"
+      ) {
+        return { stdout: "origin/main\n" };
+      }
+      if (file === "gh" && args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]\n" };
+      }
+      if (file === "gh" && args[0] === "issue" && args[1] === "view") {
+        const repo = args[args.indexOf("--repo") + 1];
+        return {
+          stdout: JSON.stringify({
+            number: 747,
+            state: repo === "gugu91/extensions" ? "CLOSED" : "OPEN",
+          }),
+        };
+      }
+      throw new Error(`unexpected command: ${file} ${args.join(" ")}`);
+    });
+
+    const assignments = await resolveTaskAssignments(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 747,
+          repoOwner: "gugu91",
+          repoName: "extensions",
+        }),
+        makeAssignment({
+          id: 2,
+          agentId: "worker-2",
+          issueNumber: 747,
+          repoOwner: "Nexcade",
+          repoName: "garage",
+        }),
+      ],
+      "/repo",
+      runner,
+    );
+
+    expect(assignments.map((assignment) => assignment.issueState)).toEqual(["CLOSED", "OPEN"]);
+    expect(runner).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["issue", "view", "747", "--repo", "gugu91/extensions"]),
+      expect.any(Object),
+    );
+    expect(runner).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["issue", "view", "747", "--repo", "Nexcade/garage"]),
+      expect.any(Object),
+    );
   });
 });
 
@@ -456,7 +555,6 @@ describe("buildTaskAssignmentReport", () => {
       [
         "RALPH LOOP — WORKER STATUS:",
         "- 🐦‍⬛ Frozen Raven: #103 → no commits, no PR ⚠️; #104 → commits on feat/worker-2, no PR 👀",
-        "- 🐎 Hyper Horse: #106 → PR #109 MERGED ✅",
       ].join("\n"),
     );
   });
@@ -502,6 +600,28 @@ describe("buildTaskAssignmentReport", () => {
 
     expect(report).toBeNull();
   });
+
+  it("does not describe review-only work as missing commits or PRs", () => {
+    const report = buildTaskAssignmentReport(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-2",
+          issueNumber: 287,
+          status: "assigned",
+          taskKind: "review",
+        }),
+      ],
+      new Map([["worker-2", makeAgent("worker-2", "Frozen Raven", "🐦‍⬛")]]),
+    );
+
+    expect(report).toBe(
+      [
+        "RALPH LOOP — WORKER STATUS:",
+        "- 🐦‍⬛ Frozen Raven: #287 → review task, no implementation PR expected",
+      ].join("\n"),
+    );
+  });
 });
 
 describe("getPendingTaskAssignmentReport", () => {
@@ -538,12 +658,7 @@ describe("getPendingTaskAssignmentReport", () => {
     });
   });
 
-  it("does not queue a report when it matches the last delivered summary signature", () => {
-    const lastDeliveredReport = [
-      "RALPH LOOP — WORKER STATUS:",
-      "- 🐎 Hyper Horse: #106 → PR #109 MERGED ✅",
-    ].join("\n");
-
+  it("does not queue a recurring report for terminal merged assignments", () => {
     const report = getPendingTaskAssignmentReport(
       [
         makeAssignment({
@@ -555,7 +670,7 @@ describe("getPendingTaskAssignmentReport", () => {
         }),
       ],
       agentsById,
-      lastDeliveredReport,
+      "",
       "2026-04-02T14:10:00.000Z",
     );
 

--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -119,6 +119,24 @@ describe("extractTaskAssignmentsFromMessage", () => {
       },
     ]);
   });
+
+  it("lets explicit implementation branch signals win over generic review wording", () => {
+    const message = [
+      "Please review the code, implement the fix, and open a PR.",
+      "Issue: #418",
+      "Branch: `fix/task-tracker-418`",
+    ].join("\n");
+
+    expect(extractTaskAssignmentsFromMessage(message)).toEqual([
+      {
+        issueNumber: 418,
+        branch: "fix/task-tracker-418",
+        repoOwner: null,
+        repoName: null,
+        taskKind: "implementation",
+      },
+    ]);
+  });
 });
 
 describe("normalizeTrackedTaskAssignments", () => {

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -261,7 +261,9 @@ export function normalizeTrackedTaskAssignments(
     const repoKey =
       assignment.repoOwner && assignment.repoName
         ? `${assignment.repoOwner.toLowerCase()}/${assignment.repoName.toLowerCase()}`
-        : "repo_unknown";
+        : assignment.repoRoot
+          ? `root:${assignment.repoRoot}`
+          : "repo_unknown";
     const issueKey = `${repoKey}#${assignment.issueNumber}`;
     if (seenIssueKeys.has(issueKey)) {
       continue;
@@ -523,7 +525,14 @@ export async function resolveTaskAssignments(
     return [];
   }
 
-  const baseRef = await resolveBaseRef(cwd, runner);
+  const baseRefCache = new Map<string, Promise<string | null>>();
+  const resolveBaseRefForCwd = (repoCwd: string): Promise<string | null> => {
+    const cached = baseRefCache.get(repoCwd);
+    if (cached) return cached;
+    const promise = resolveBaseRef(repoCwd, runner);
+    baseRefCache.set(repoCwd, promise);
+    return promise;
+  };
   const branchProgressCache = new Map<
     string,
     Promise<{ branchAheadCount: number; pr: PullRequestSnapshot | null | undefined }>
@@ -537,15 +546,18 @@ export async function resolveTaskAssignments(
   const resolveBranchProgress = (
     assignment: TaskAssignmentInfo,
   ): Promise<{ branchAheadCount: number; pr: PullRequestSnapshot | null | undefined }> => {
-    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}:${assignment.branch ?? ""}`;
+    const repoCwd = assignment.repoRoot ?? cwd;
+    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}:${repoCwd}:${assignment.branch ?? ""}`;
     const cached = branchProgressCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
     const promise = Promise.all([
-      getBranchAheadCount(assignment.branch, baseRef, cwd, runner),
-      getPullRequestForBranch(assignment, cwd, runner),
+      resolveBaseRefForCwd(repoCwd).then((baseRef) =>
+        getBranchAheadCount(assignment.branch, baseRef, repoCwd, runner),
+      ),
+      getPullRequestForBranch(assignment, repoCwd, runner),
     ]).then(([branchAheadCount, pr]) => ({ branchAheadCount, pr }));
     branchProgressCache.set(cacheKey, promise);
     return promise;

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -60,7 +60,10 @@ const GITHUB_REPO_ISSUE_URL_REGEX =
 const REPO_LABEL_REGEX =
   /(?:^|\n)\s*(?:[-*]\s*)?(?:repo|repository)\s*:\s*(?:https?:\/\/github\.com\/)?([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\b/i;
 const READ_ONLY_REVIEW_REGEX =
-  /\b(?:read-only|do not mutate|do not edit|review|second-pass|second pass|code review)\b/i;
+  /\b(?:read-only|do not mutate|do not edit|review-only|review only|second-pass|second pass|code review)\b/i;
+const REVIEW_TASK_REGEX = /\b(?:review|code review)\b/i;
+const QA_ONLY_TASK_REGEX =
+  /\b(?:qa-only|qa only|test-only|test only|verify-only|verify only|validation-only|validation only)\b/i;
 const QA_TASK_REGEX = /\b(?:qa|test|verify|validation|visual verify|visual verification)\b/i;
 const MERGE_TASK_REGEX = /\bmerge\s+pr\s*#?\d+|\bmerge-only\b|\bmerge only\b/i;
 const INTERACTIVE_TASK_REGEX = /\b(?:interactive-session|human-gated|manual|browser session)\b/i;
@@ -165,8 +168,10 @@ function parseTaskKind(message: string, branch: string | null): TaskAssignmentKi
   if (MERGE_TASK_REGEX.test(normalized)) return "merge";
   if (INTERACTIVE_TASK_REGEX.test(normalized)) return "interactive";
   if (READ_ONLY_REVIEW_REGEX.test(normalized)) return "review";
-  if (QA_TASK_REGEX.test(normalized)) return "qa";
+  if (QA_ONLY_TASK_REGEX.test(normalized)) return "qa";
   if (branch || IMPLEMENTATION_TASK_REGEX.test(normalized)) return "implementation";
+  if (REVIEW_TASK_REGEX.test(normalized)) return "review";
+  if (QA_TASK_REGEX.test(normalized)) return "qa";
   return "unknown";
 }
 

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -223,8 +223,8 @@ function canonicalizeTaskAssignmentFromSourceMessage(
     return {
       ...assignment,
       branch: matchingAssignment.branch,
-      repoOwner: matchingAssignment.repoOwner,
-      repoName: matchingAssignment.repoName,
+      repoOwner: matchingAssignment.repoOwner ?? assignment.repoOwner,
+      repoName: matchingAssignment.repoName ?? assignment.repoName,
       taskKind: matchingAssignment.taskKind,
     };
   }
@@ -235,8 +235,8 @@ function canonicalizeTaskAssignmentFromSourceMessage(
       ...assignment,
       issueNumber: canonicalAssignment.issueNumber,
       branch: canonicalAssignment.branch,
-      repoOwner: canonicalAssignment.repoOwner,
-      repoName: canonicalAssignment.repoName,
+      repoOwner: canonicalAssignment.repoOwner ?? assignment.repoOwner,
+      repoName: canonicalAssignment.repoName ?? assignment.repoName,
       taskKind: canonicalAssignment.taskKind,
     };
   }

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -546,18 +546,23 @@ export async function resolveTaskAssignments(
   const resolveBranchProgress = (
     assignment: TaskAssignmentInfo,
   ): Promise<{ branchAheadCount: number; pr: PullRequestSnapshot | null | undefined }> => {
-    const repoCwd = assignment.repoRoot ?? cwd;
-    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}:${repoCwd}:${assignment.branch ?? ""}`;
+    const repoCwd =
+      assignment.repoRoot ?? (assignment.repoOwner && assignment.repoName ? null : cwd);
+    const commandCwd = repoCwd ?? cwd;
+    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}:${repoCwd ?? "repo_root_unavailable"}:${assignment.branch ?? ""}`;
     const cached = branchProgressCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
+    const branchAheadCountPromise = repoCwd
+      ? resolveBaseRefForCwd(repoCwd).then((baseRef) =>
+          getBranchAheadCount(assignment.branch, baseRef, repoCwd, runner),
+        )
+      : Promise.resolve(0);
     const promise = Promise.all([
-      resolveBaseRefForCwd(repoCwd).then((baseRef) =>
-        getBranchAheadCount(assignment.branch, baseRef, repoCwd, runner),
-      ),
-      getPullRequestForBranch(assignment, repoCwd, runner),
+      branchAheadCountPromise,
+      getPullRequestForBranch(assignment, commandCwd, runner),
     ]).then(([branchAheadCount, pr]) => ({ branchAheadCount, pr }));
     branchProgressCache.set(cacheKey, promise);
     return promise;
@@ -625,7 +630,14 @@ export function hasTaskAssignmentStatusChange(assignment: ResolvedTaskAssignment
 function formatTaskProgressFragment(
   assignment: Pick<
     TaskAssignmentInfo,
-    "issueNumber" | "branch" | "status" | "prNumber" | "taskKind"
+    | "issueNumber"
+    | "branch"
+    | "status"
+    | "prNumber"
+    | "taskKind"
+    | "repoOwner"
+    | "repoName"
+    | "repoRoot"
   >,
 ): string {
   if (assignment.taskKind !== "implementation") {
@@ -643,6 +655,14 @@ function formatTaskProgressFragment(
       return `#${assignment.issueNumber} → commits on ${assignment.branch ?? "tracked branch"}, no PR 👀`;
     case "assigned":
     default:
+      if (
+        assignment.branch &&
+        assignment.repoOwner &&
+        assignment.repoName &&
+        !assignment.repoRoot
+      ) {
+        return `#${assignment.issueNumber} → no PR found for ${assignment.branch}; commits not checked (repo root unavailable) ⚠️`;
+      }
       return `#${assignment.issueNumber} → no commits, no PR ⚠️`;
   }
 }
@@ -650,7 +670,15 @@ function formatTaskProgressFragment(
 function getVisibleTaskAssignmentReportEntries<
   T extends Pick<
     TaskAssignmentInfo,
-    "agentId" | "issueNumber" | "branch" | "status" | "prNumber" | "taskKind"
+    | "agentId"
+    | "issueNumber"
+    | "branch"
+    | "status"
+    | "prNumber"
+    | "taskKind"
+    | "repoOwner"
+    | "repoName"
+    | "repoRoot"
   > & {
     issueState?: ResolvedTaskAssignment["issueState"];
   },
@@ -684,7 +712,15 @@ function getAgentSortKey(
 
 type ReportableTaskAssignment = Pick<
   TaskAssignmentInfo,
-  "agentId" | "issueNumber" | "branch" | "status" | "prNumber" | "taskKind"
+  | "agentId"
+  | "issueNumber"
+  | "branch"
+  | "status"
+  | "prNumber"
+  | "taskKind"
+  | "repoOwner"
+  | "repoName"
+  | "repoRoot"
 > & {
   issueState?: ResolvedTaskAssignment["issueState"];
 };

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -1,6 +1,11 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import type { AgentInfo, TaskAssignmentInfo, TaskAssignmentStatus } from "./broker/types.js";
+import type {
+  AgentInfo,
+  TaskAssignmentInfo,
+  TaskAssignmentKind,
+  TaskAssignmentStatus,
+} from "./broker/types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -14,6 +19,9 @@ export type CommandRunner = (
 export interface ParsedTaskAssignment {
   issueNumber: number;
   branch: string | null;
+  repoOwner: string | null;
+  repoName: string | null;
+  taskKind: TaskAssignmentKind;
 }
 
 export interface PullRequestSnapshot {
@@ -47,6 +55,17 @@ const NEW_TASK_ISSUE_REGEX =
   /(?:^|\n)\s*(?:[-*]\s*)?new(?:\s+[a-z-]+){0,3}\s+task\b[^\n#]*\bissue\s*#(\d+)\b/gi;
 const FOLLOW_UP_TASK_ISSUE_REGEX =
   /(?:^|\n)\s*(?:[-*]\s*)?follow-up\s+task(?:\s+from)?\s+issue\s*#(\d+)\b/gi;
+const GITHUB_REPO_ISSUE_URL_REGEX =
+  /github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/(?:issues|pull)\/(\d+)\b/gi;
+const REPO_LABEL_REGEX =
+  /(?:^|\n)\s*(?:[-*]\s*)?(?:repo|repository)\s*:\s*(?:https?:\/\/github\.com\/)?([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\b/i;
+const READ_ONLY_REVIEW_REGEX =
+  /\b(?:read-only|do not mutate|do not edit|review|second-pass|second pass|code review)\b/i;
+const QA_TASK_REGEX = /\b(?:qa|test|verify|validation|visual verify|visual verification)\b/i;
+const MERGE_TASK_REGEX = /\bmerge\s+pr\s*#?\d+|\bmerge-only\b|\bmerge only\b/i;
+const INTERACTIVE_TASK_REGEX = /\b(?:interactive-session|human-gated|manual|browser session)\b/i;
+const IMPLEMENTATION_TASK_REGEX =
+  /\b(?:implementation lane|implement|fix|build|change|patch|create a pr|open a pr|branch|worktree)\b/i;
 
 async function runCommand(
   file: string,
@@ -116,12 +135,50 @@ function parseIssueNumbers(message: string): number[] {
     }
   }
 
+  for (const match of normalized.matchAll(GITHUB_REPO_ISSUE_URL_REGEX)) {
+    const issueNumber = Number(match[3]);
+    if (Number.isFinite(issueNumber)) {
+      issueNumbers.add(issueNumber);
+    }
+  }
+
   return [...issueNumbers].sort((left, right) => left - right);
+}
+
+function parseRepo(
+  message: string,
+  issueNumber: number,
+): Pick<ParsedTaskAssignment, "repoOwner" | "repoName"> {
+  const normalized = normalizeMessageForTaskParsing(message);
+  for (const match of normalized.matchAll(GITHUB_REPO_ISSUE_URL_REGEX)) {
+    if (Number(match[3]) === issueNumber) {
+      return { repoOwner: match[1] ?? null, repoName: match[2] ?? null };
+    }
+  }
+
+  const repoMatch = normalized.match(REPO_LABEL_REGEX);
+  return { repoOwner: repoMatch?.[1] ?? null, repoName: repoMatch?.[2] ?? null };
+}
+
+function parseTaskKind(message: string, branch: string | null): TaskAssignmentKind {
+  const normalized = normalizeMessageForTaskParsing(message);
+  if (MERGE_TASK_REGEX.test(normalized)) return "merge";
+  if (INTERACTIVE_TASK_REGEX.test(normalized)) return "interactive";
+  if (READ_ONLY_REVIEW_REGEX.test(normalized)) return "review";
+  if (QA_TASK_REGEX.test(normalized)) return "qa";
+  if (branch || IMPLEMENTATION_TASK_REGEX.test(normalized)) return "implementation";
+  return "unknown";
 }
 
 export function extractTaskAssignmentsFromMessage(message: string): ParsedTaskAssignment[] {
   const branch = parseBranch(message);
-  return parseIssueNumbers(message).map((issueNumber) => ({ issueNumber, branch }));
+  const taskKind = parseTaskKind(message, branch);
+  return parseIssueNumbers(message).map((issueNumber) => ({
+    issueNumber,
+    branch,
+    ...parseRepo(message, issueNumber),
+    taskKind,
+  }));
 }
 
 function compareTaskAssignmentRecency(left: TaskAssignmentInfo, right: TaskAssignmentInfo): number {
@@ -158,10 +215,13 @@ function canonicalizeTaskAssignmentFromSourceMessage(
     (candidate) => candidate.issueNumber === assignment.issueNumber,
   );
   if (matchingAssignment) {
-    if (matchingAssignment.branch === assignment.branch) {
-      return assignment;
-    }
-    return { ...assignment, branch: matchingAssignment.branch };
+    return {
+      ...assignment,
+      branch: matchingAssignment.branch,
+      repoOwner: matchingAssignment.repoOwner,
+      repoName: matchingAssignment.repoName,
+      taskKind: matchingAssignment.taskKind,
+    };
   }
 
   if (parsedAssignments.length === 1) {
@@ -170,6 +230,9 @@ function canonicalizeTaskAssignmentFromSourceMessage(
       ...assignment,
       issueNumber: canonicalAssignment.issueNumber,
       branch: canonicalAssignment.branch,
+      repoOwner: canonicalAssignment.repoOwner,
+      repoName: canonicalAssignment.repoName,
+      taskKind: canonicalAssignment.taskKind,
     };
   }
 
@@ -188,12 +251,17 @@ export function normalizeTrackedTaskAssignments(
     .sort(compareTaskAssignmentRecency);
 
   const visibleAssignments: TaskAssignmentInfo[] = [];
-  const seenIssueNumbers = new Set<number>();
+  const seenIssueKeys = new Set<string>();
   for (const assignment of canonicalAssignments) {
-    if (seenIssueNumbers.has(assignment.issueNumber)) {
+    const repoKey =
+      assignment.repoOwner && assignment.repoName
+        ? `${assignment.repoOwner.toLowerCase()}/${assignment.repoName.toLowerCase()}`
+        : "repo_unknown";
+    const issueKey = `${repoKey}#${assignment.issueNumber}`;
+    if (seenIssueKeys.has(issueKey)) {
       continue;
     }
-    seenIssueNumbers.add(assignment.issueNumber);
+    seenIssueKeys.add(issueKey);
     visibleAssignments.push(assignment);
   }
 
@@ -289,12 +357,18 @@ async function getBranchAheadCount(
   return maxAheadCount;
 }
 
+function getRepoArg(assignment: Pick<TaskAssignmentInfo, "repoOwner" | "repoName">): string[] {
+  return assignment.repoOwner && assignment.repoName
+    ? ["--repo", `${assignment.repoOwner}/${assignment.repoName}`]
+    : [];
+}
+
 async function getPullRequestForBranch(
-  branch: string | null,
+  assignment: Pick<TaskAssignmentInfo, "branch" | "repoOwner" | "repoName">,
   cwd: string,
   runner: CommandRunner,
 ): Promise<PullRequestSnapshot | null | undefined> {
-  if (!branch) {
+  if (!assignment.branch) {
     return null;
   }
 
@@ -303,8 +377,9 @@ async function getPullRequestForBranch(
     [
       "pr",
       "list",
+      ...getRepoArg(assignment),
       "--head",
-      branch,
+      assignment.branch,
       "--state",
       "all",
       "--json",
@@ -323,12 +398,20 @@ async function getPullRequestForBranch(
 
 async function getPullRequestByNumber(
   prNumber: number,
+  assignment: Pick<TaskAssignmentInfo, "repoOwner" | "repoName">,
   cwd: string,
   runner: CommandRunner,
 ): Promise<PullRequestSnapshot | null | undefined> {
   const pr = await runJsonCommand<PullRequestSnapshot>(
     "gh",
-    ["pr", "view", String(prNumber), "--json", "number,state,mergedAt,headRefName"],
+    [
+      "pr",
+      "view",
+      String(prNumber),
+      ...getRepoArg(assignment),
+      "--json",
+      "number,state,mergedAt,headRefName",
+    ],
     cwd,
     runner,
   );
@@ -339,13 +422,24 @@ async function getPullRequestByNumber(
 }
 
 async function getIssueByNumber(
-  issueNumber: number,
+  assignment: Pick<TaskAssignmentInfo, "issueNumber" | "repoOwner" | "repoName">,
   cwd: string,
   runner: CommandRunner,
 ): Promise<IssueSnapshot | null | undefined> {
+  if (!assignment.repoOwner || !assignment.repoName) {
+    return null;
+  }
+
   const issue = await runJsonCommand<IssueSnapshot>(
     "gh",
-    ["issue", "view", String(issueNumber), "--json", "number,state"],
+    [
+      "issue",
+      "view",
+      String(assignment.issueNumber),
+      ...getRepoArg(assignment),
+      "--json",
+      "number,state",
+    ],
     cwd,
     runner,
   );
@@ -430,23 +524,23 @@ export async function resolveTaskAssignments(
     Promise<{ branchAheadCount: number; pr: PullRequestSnapshot | null | undefined }>
   >();
   const pullRequestByNumberCache = new Map<
-    number,
+    string,
     Promise<PullRequestSnapshot | null | undefined>
   >();
-  const issueByNumberCache = new Map<number, Promise<IssueSnapshot | null | undefined>>();
+  const issueByNumberCache = new Map<string, Promise<IssueSnapshot | null | undefined>>();
 
   const resolveBranchProgress = (
-    branch: string | null,
+    assignment: TaskAssignmentInfo,
   ): Promise<{ branchAheadCount: number; pr: PullRequestSnapshot | null | undefined }> => {
-    const cacheKey = branch ?? "";
+    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}:${assignment.branch ?? ""}`;
     const cached = branchProgressCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
     const promise = Promise.all([
-      getBranchAheadCount(branch, baseRef, cwd, runner),
-      getPullRequestForBranch(branch, cwd, runner),
+      getBranchAheadCount(assignment.branch, baseRef, cwd, runner),
+      getPullRequestForBranch(assignment, cwd, runner),
     ]).then(([branchAheadCount, pr]) => ({ branchAheadCount, pr }));
     branchProgressCache.set(cacheKey, promise);
     return promise;
@@ -454,36 +548,41 @@ export async function resolveTaskAssignments(
 
   const resolvePullRequestByNumber = (
     prNumber: number,
+    assignment: TaskAssignmentInfo,
   ): Promise<PullRequestSnapshot | null | undefined> => {
-    const cached = pullRequestByNumberCache.get(prNumber);
+    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}#${prNumber}`;
+    const cached = pullRequestByNumberCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
-    const promise = getPullRequestByNumber(prNumber, cwd, runner);
-    pullRequestByNumberCache.set(prNumber, promise);
+    const promise = getPullRequestByNumber(prNumber, assignment, cwd, runner);
+    pullRequestByNumberCache.set(cacheKey, promise);
     return promise;
   };
 
-  const resolveIssueByNumber = (issueNumber: number): Promise<IssueSnapshot | null | undefined> => {
-    const cached = issueByNumberCache.get(issueNumber);
+  const resolveIssueByNumber = (
+    assignment: TaskAssignmentInfo,
+  ): Promise<IssueSnapshot | null | undefined> => {
+    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}#${assignment.issueNumber}`;
+    const cached = issueByNumberCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
-    const promise = getIssueByNumber(issueNumber, cwd, runner);
-    issueByNumberCache.set(issueNumber, promise);
+    const promise = getIssueByNumber(assignment, cwd, runner);
+    issueByNumberCache.set(cacheKey, promise);
     return promise;
   };
 
   return Promise.all(
     assignments.map(async (assignment) => {
-      const { branchAheadCount, pr } = await resolveBranchProgress(assignment.branch);
+      const { branchAheadCount, pr } = await resolveBranchProgress(assignment);
       const resolvedPr =
         pr == null && assignment.prNumber != null
-          ? await resolvePullRequestByNumber(assignment.prNumber)
+          ? await resolvePullRequestByNumber(assignment.prNumber, assignment)
           : pr;
-      const issueState = normalizeIssueState(await resolveIssueByNumber(assignment.issueNumber));
+      const issueState = normalizeIssueState(await resolveIssueByNumber(assignment));
       const { nextStatus, nextPrNumber } = resolveTaskStatus(
         assignment,
         branchAheadCount,
@@ -507,8 +606,15 @@ export function hasTaskAssignmentStatusChange(assignment: ResolvedTaskAssignment
 }
 
 function formatTaskProgressFragment(
-  assignment: Pick<TaskAssignmentInfo, "issueNumber" | "branch" | "status" | "prNumber">,
+  assignment: Pick<
+    TaskAssignmentInfo,
+    "issueNumber" | "branch" | "status" | "prNumber" | "taskKind"
+  >,
 ): string {
+  if (assignment.taskKind !== "implementation") {
+    return `#${assignment.issueNumber} → ${assignment.taskKind} task, no implementation PR expected`;
+  }
+
   switch (assignment.status) {
     case "pr_merged":
       return `#${assignment.issueNumber} → PR #${assignment.prNumber ?? "?"} MERGED ✅`;
@@ -527,12 +633,17 @@ function formatTaskProgressFragment(
 function getVisibleTaskAssignmentReportEntries<
   T extends Pick<
     TaskAssignmentInfo,
-    "agentId" | "issueNumber" | "branch" | "status" | "prNumber"
+    "agentId" | "issueNumber" | "branch" | "status" | "prNumber" | "taskKind"
   > & {
     issueState?: ResolvedTaskAssignment["issueState"];
   },
 >(assignments: T[]): T[] {
-  return assignments.filter((assignment) => assignment.issueState !== "CLOSED");
+  return assignments.filter(
+    (assignment) =>
+      assignment.issueState !== "CLOSED" &&
+      assignment.status !== "pr_merged" &&
+      assignment.status !== "pr_closed",
+  );
 }
 
 function formatAgentLabel(
@@ -554,10 +665,15 @@ function getAgentSortKey(
   return agent?.name ?? agentId;
 }
 
+type ReportableTaskAssignment = Pick<
+  TaskAssignmentInfo,
+  "agentId" | "issueNumber" | "branch" | "status" | "prNumber" | "taskKind"
+> & {
+  issueState?: ResolvedTaskAssignment["issueState"];
+};
+
 export function buildTaskAssignmentReport(
-  assignments: Array<
-    Pick<TaskAssignmentInfo, "agentId" | "issueNumber" | "branch" | "status" | "prNumber">
-  >,
+  assignments: ReportableTaskAssignment[],
   agentsById: ReadonlyMap<string, Pick<AgentInfo, "emoji" | "name">>,
   cycleStartedAt?: string,
 ): string | null {
@@ -566,10 +682,7 @@ export function buildTaskAssignmentReport(
     return null;
   }
 
-  const grouped = new Map<
-    string,
-    Array<Pick<TaskAssignmentInfo, "agentId" | "issueNumber" | "branch" | "status" | "prNumber">>
-  >();
+  const grouped = new Map<string, ReportableTaskAssignment[]>();
   for (const assignment of visibleAssignments) {
     const bucket = grouped.get(assignment.agentId);
     if (bucket) {
@@ -605,9 +718,7 @@ export interface PendingTaskAssignmentReport {
 }
 
 export function getPendingTaskAssignmentReport(
-  assignments: Array<
-    Pick<TaskAssignmentInfo, "agentId" | "issueNumber" | "branch" | "status" | "prNumber">
-  >,
+  assignments: ReportableTaskAssignment[],
   agentsById: ReadonlyMap<string, Pick<AgentInfo, "emoji" | "name">>,
   lastDeliveredSignature: string,
   cycleStartedAt?: string,

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -566,7 +566,7 @@ export async function resolveTaskAssignments(
     assignment: TaskAssignmentInfo,
   ): Promise<{ branchAheadCount: number; pr: PullRequestSnapshot | null | undefined }> => {
     const repoCwd =
-      assignment.repoRoot ?? (assignment.repoOwner && assignment.repoName ? null : cwd);
+      assignment.repoRoot ?? (assignment.repoOwner && assignment.repoName ? null : null);
     const commandCwd = repoCwd ?? cwd;
     const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}:${repoCwd ?? "repo_root_unavailable"}:${assignment.branch ?? ""}`;
     const cached = branchProgressCache.get(cacheKey);
@@ -574,6 +574,8 @@ export async function resolveTaskAssignments(
       return cached;
     }
 
+    const canResolveRemotePr =
+      repoCwd != null || (assignment.repoOwner != null && assignment.repoName != null);
     const branchAheadCountPromise = repoCwd
       ? resolveBaseRefForCwd(repoCwd).then((baseRef) =>
           getBranchAheadCount(assignment.branch, baseRef, repoCwd, runner),
@@ -581,7 +583,7 @@ export async function resolveTaskAssignments(
       : Promise.resolve(0);
     const promise = Promise.all([
       branchAheadCountPromise,
-      getPullRequestForBranch(assignment, commandCwd, runner),
+      canResolveRemotePr ? getPullRequestForBranch(assignment, commandCwd, runner) : null,
     ]).then(([branchAheadCount, pr]) => ({ branchAheadCount, pr }));
     branchProgressCache.set(cacheKey, promise);
     return promise;
@@ -590,14 +592,15 @@ export async function resolveTaskAssignments(
   const resolvePullRequestByNumber = (
     prNumber: number,
     assignment: TaskAssignmentInfo,
+    repoCwd: string,
   ): Promise<PullRequestSnapshot | null | undefined> => {
-    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}#${prNumber}`;
+    const cacheKey = `${assignment.repoOwner ?? ""}/${assignment.repoName ?? ""}:${repoCwd}#${prNumber}`;
     const cached = pullRequestByNumberCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
-    const promise = getPullRequestByNumber(prNumber, assignment, cwd, runner);
+    const promise = getPullRequestByNumber(prNumber, assignment, repoCwd, runner);
     pullRequestByNumberCache.set(cacheKey, promise);
     return promise;
   };
@@ -619,9 +622,16 @@ export async function resolveTaskAssignments(
   return Promise.all(
     assignments.map(async (assignment) => {
       const { branchAheadCount, pr } = await resolveBranchProgress(assignment);
+      const canResolveStoredPr =
+        assignment.repoRoot != null ||
+        (assignment.repoOwner != null && assignment.repoName != null);
       const resolvedPr =
-        pr == null && assignment.prNumber != null
-          ? await resolvePullRequestByNumber(assignment.prNumber, assignment)
+        pr == null && assignment.prNumber != null && canResolveStoredPr
+          ? await resolvePullRequestByNumber(
+              assignment.prNumber,
+              assignment,
+              assignment.repoRoot ?? cwd,
+            )
           : pr;
       const issueState = normalizeIssueState(await resolveIssueByNumber(assignment));
       const { nextStatus, nextPrNumber } = resolveTaskStatus(
@@ -674,6 +684,9 @@ function formatTaskProgressFragment(
       return `#${assignment.issueNumber} → commits on ${assignment.branch ?? "tracked branch"}, no PR 👀`;
     case "assigned":
     default:
+      if (!assignment.repoOwner && !assignment.repoName && !assignment.repoRoot) {
+        return `#${assignment.issueNumber} → repo unknown; progress not checked ⚠️`;
+      }
       if (
         assignment.branch &&
         assignment.repoOwner &&

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -55,8 +55,10 @@ const NEW_TASK_ISSUE_REGEX =
   /(?:^|\n)\s*(?:[-*]\s*)?new(?:\s+[a-z-]+){0,3}\s+task\b[^\n#]*\bissue\s*#(\d+)\b/gi;
 const FOLLOW_UP_TASK_ISSUE_REGEX =
   /(?:^|\n)\s*(?:[-*]\s*)?follow-up\s+task(?:\s+from)?\s+issue\s*#(\d+)\b/gi;
-const GITHUB_REPO_ISSUE_URL_REGEX =
+const GITHUB_REPO_URL_REGEX =
   /github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/(?:issues|pull)\/(\d+)\b/gi;
+const GITHUB_REPO_ISSUE_URL_REGEX =
+  /github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/issues\/(\d+)\b/gi;
 const REPO_LABEL_REGEX =
   /(?:^|\n)\s*(?:[-*]\s*)?(?:repo|repository)\s*:\s*(?:https?:\/\/github\.com\/)?([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\b/i;
 const READ_ONLY_REVIEW_REGEX =
@@ -160,7 +162,24 @@ function parseRepo(
   }
 
   const repoMatch = normalized.match(REPO_LABEL_REGEX);
-  return { repoOwner: repoMatch?.[1] ?? null, repoName: repoMatch?.[2] ?? null };
+  if (repoMatch) {
+    return { repoOwner: repoMatch[1] ?? null, repoName: repoMatch[2] ?? null };
+  }
+
+  const urlRepos = new Map<string, { repoOwner: string; repoName: string }>();
+  for (const match of normalized.matchAll(GITHUB_REPO_URL_REGEX)) {
+    if (match[1] && match[2]) {
+      urlRepos.set(`${match[1].toLowerCase()}/${match[2].toLowerCase()}`, {
+        repoOwner: match[1],
+        repoName: match[2],
+      });
+    }
+  }
+  if (urlRepos.size === 1) {
+    return [...urlRepos.values()][0] ?? { repoOwner: null, repoName: null };
+  }
+
+  return { repoOwner: null, repoName: null };
 }
 
 function parseTaskKind(message: string, branch: string | null): TaskAssignmentKind {


### PR DESCRIPTION
## Summary\n- record repo identity and task intent on Pinet task assignments, with a v17 broker DB migration for existing rows\n- resolve GitHub issue/PR state with captured --repo context instead of the broker cwd\n- classify review/QA/merge/interactive work so RALPH no longer reports it as missing implementation commits/PRs\n- suppress terminal merged/closed rows from recurring worker-status reports\n\nFixes #747.\n\n## Tests\n- pnpm exec vitest run slack-bridge/task-assignments.test.ts slack-bridge/pinet-mesh-ops.test.ts slack-bridge/broker/helpers.test.ts\n- pnpm typecheck\n- pnpm lint\n- pnpm test\n- git push pre-push hook: pnpm lint && pnpm typecheck && pnpm test\n