### PR TITLE
Fix Pinet-routed Slack guardrail confirmations

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -68,6 +68,7 @@ import { createPinetMaintenanceDelivery } from "./pinet-maintenance-delivery.js"
 import { createPinetRemoteControlAcks } from "./pinet-remote-control-acks.js";
 import { createPinetRemoteControl } from "./pinet-remote-control.js";
 import { createPinetMeshOps } from "./pinet-mesh-ops.js";
+import { consumePinetReadConfirmationReplies } from "./pinet-confirmation-replies.js";
 import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
 import { createAgentEventRuntime } from "./agent-event-runtime.js";
 import { createSessionUiRuntime } from "./session-ui-runtime.js";
@@ -962,22 +963,26 @@ export default function (pi: ExtensionAPI) {
         throw new Error("Broker agent identity is unavailable.");
       }
       const result = db.readInbox(selfId, options);
-      return {
-        messages: result.messages.map((item) => ({
-          inboxId: item.entry.id,
-          delivered: item.entry.delivered,
-          readAt: item.entry.readAt,
-          message: item.message,
-        })),
-        unreadCountBefore: result.unreadCountBefore,
-        unreadCountAfter: result.unreadCountAfter,
-        unreadThreads: result.unreadThreads,
-        markedReadIds: result.markedReadIds,
-      };
+      return consumePinetReadConfirmationReplies(
+        {
+          messages: result.messages.map((item) => ({
+            inboxId: item.entry.id,
+            delivered: item.entry.delivered,
+            readAt: item.entry.readAt,
+            message: item.message,
+          })),
+          unreadCountBefore: result.unreadCountBefore,
+          unreadCountAfter: result.unreadCountAfter,
+          unreadThreads: result.unreadThreads,
+          markedReadIds: result.markedReadIds,
+        },
+        consumeConfirmationReply,
+      );
     }
 
     if (brokerRole === "follower" && brokerClient?.client) {
-      return await brokerClient.client.readInbox(options);
+      const result = await brokerClient.client.readInbox(options);
+      return consumePinetReadConfirmationReplies(result, consumeConfirmationReply);
     }
 
     throw new Error("Pinet is in an unexpected state.");

--- a/slack-bridge/pinet-confirmation-replies.test.ts
+++ b/slack-bridge/pinet-confirmation-replies.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { PinetReadResult } from "@gugu910/pi-pinet-core/pinet-read-formatting";
+import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
+import { consumePinetReadConfirmationReplies } from "./pinet-confirmation-replies.js";
+
+function makeReadResult(overrides: Partial<PinetReadResult> = {}): PinetReadResult {
+  return {
+    messages: [
+      {
+        inboxId: 2571,
+        delivered: true,
+        readAt: "2026-05-18T12:00:00.000Z",
+        message: {
+          id: 99,
+          threadId: "1779126107.662159",
+          source: "slack",
+          direction: "inbound",
+          sender: "U0AF5S3LQ5C",
+          body: "yes",
+          metadata: null,
+          createdAt: "2026-05-18T12:00:00.000Z",
+        },
+      },
+    ],
+    unreadCountBefore: 1,
+    unreadCountAfter: 0,
+    unreadThreads: [],
+    markedReadIds: [2571],
+    ...overrides,
+  };
+}
+
+describe("consumePinetReadConfirmationReplies", () => {
+  it("lets a guarded Slack action proceed after its Slack approval is read via Pinet", () => {
+    const action =
+      "channel=C0AF7L69E5C | thread_ts=1779126107.662159 | ts=1779126146.246369 | thread=false";
+    const policy = createThreadConfirmationPolicy({
+      getGuardrails: () => ({ requireConfirmation: ["slack:delete"] }),
+    });
+
+    expect(policy.registerRequest("1779126107.662159", "slack:delete", action).status).toBe(
+      "created",
+    );
+
+    const result = consumePinetReadConfirmationReplies(makeReadResult(), policy.consumeReply);
+
+    expect(result.messages[0]?.message.body).toContain(
+      "User approved security confirmation request",
+    );
+    expect(() =>
+      policy.requireToolPolicy("slack:delete", "1779126107.662159", action),
+    ).not.toThrow();
+  });
+
+  it("does not relax exact tool/action matching after a Pinet-routed approval", () => {
+    const action = "channel=C0 | thread_ts=100.1 | ts=100.2 | thread=false";
+    const policy = createThreadConfirmationPolicy({
+      getGuardrails: () => ({ requireConfirmation: ["slack:delete", "slack:pin"] }),
+    });
+
+    policy.registerRequest("100.1", "slack:delete", action);
+    consumePinetReadConfirmationReplies(
+      makeReadResult({
+        messages: [
+          {
+            inboxId: 1,
+            delivered: true,
+            readAt: "2026-05-18T12:00:00.000Z",
+            message: {
+              id: 1,
+              threadId: "100.1",
+              source: "slack",
+              direction: "inbound",
+              sender: "U0AF5S3LQ5C",
+              body: "yes",
+              metadata: null,
+              createdAt: "2026-05-18T12:00:00.000Z",
+            },
+          },
+        ],
+        markedReadIds: [1],
+      }),
+      policy.consumeReply,
+    );
+
+    expect(() =>
+      policy.requireToolPolicy(
+        "slack:delete",
+        "100.1",
+        "channel=C0 | thread_ts=100.1 | ts=DIFFERENT | thread=false",
+      ),
+    ).toThrow('Tool "slack:delete" requires confirmation');
+    expect(() => policy.requireToolPolicy("slack:pin", "100.1", action)).toThrow(
+      'Tool "slack:pin" requires confirmation',
+    );
+  });
+
+  it("ignores already-read or non-Slack messages", () => {
+    const consumed: Array<[string, string]> = [];
+    const result = consumePinetReadConfirmationReplies(
+      makeReadResult({
+        markedReadIds: [],
+      }),
+      (threadTs, text) => {
+        consumed.push([threadTs, text]);
+        return { approved: true };
+      },
+    );
+
+    expect(consumed).toEqual([]);
+    expect(result.messages[0]?.message.body).toBe("yes");
+  });
+});

--- a/slack-bridge/pinet-confirmation-replies.test.ts
+++ b/slack-bridge/pinet-confirmation-replies.test.ts
@@ -36,6 +36,7 @@ describe("consumePinetReadConfirmationReplies", () => {
       "channel=C0AF7L69E5C | thread_ts=1779126107.662159 | ts=1779126146.246369 | thread=false";
     const policy = createThreadConfirmationPolicy({
       getGuardrails: () => ({ requireConfirmation: ["slack:delete"] }),
+      now: () => Date.parse("2026-05-18T11:59:59.000Z"),
     });
 
     expect(policy.registerRequest("1779126107.662159", "slack:delete", action).status).toBe(
@@ -56,6 +57,7 @@ describe("consumePinetReadConfirmationReplies", () => {
     const action = "channel=C0 | thread_ts=100.1 | ts=100.2 | thread=false";
     const policy = createThreadConfirmationPolicy({
       getGuardrails: () => ({ requireConfirmation: ["slack:delete", "slack:pin"] }),
+      now: () => Date.parse("2026-05-18T11:59:59.000Z"),
     });
 
     policy.registerRequest("100.1", "slack:delete", action);
@@ -92,6 +94,44 @@ describe("consumePinetReadConfirmationReplies", () => {
     ).toThrow('Tool "slack:delete" requires confirmation');
     expect(() => policy.requireToolPolicy("slack:pin", "100.1", action)).toThrow(
       'Tool "slack:pin" requires confirmation',
+    );
+  });
+
+  it("rejects stale unread Slack approvals that predate the confirmation request", () => {
+    const action = "channel=C0 | thread_ts=100.1 | ts=100.2 | thread=false";
+    const policy = createThreadConfirmationPolicy({
+      getGuardrails: () => ({ requireConfirmation: ["slack:delete"] }),
+      now: () => Date.parse("2026-05-18T12:00:00.000Z"),
+    });
+
+    policy.registerRequest("100.1", "slack:delete", action);
+    const result = consumePinetReadConfirmationReplies(
+      makeReadResult({
+        messages: [
+          {
+            inboxId: 1,
+            delivered: true,
+            readAt: "2026-05-18T12:00:00.000Z",
+            message: {
+              id: 1,
+              threadId: "100.1",
+              source: "slack",
+              direction: "inbound",
+              sender: "U0AF5S3LQ5C",
+              body: "yes",
+              metadata: null,
+              createdAt: "2026-05-18T11:59:59.000Z",
+            },
+          },
+        ],
+        markedReadIds: [1],
+      }),
+      policy.consumeReply,
+    );
+
+    expect(result.messages[0]?.message.body).toBe("yes");
+    expect(() => policy.requireToolPolicy("slack:delete", "100.1", action)).toThrow(
+      'Tool "slack:delete" requires confirmation for action "channel=C0 | thread_ts=100.1 | ts=100.2 | thread=false". A matching confirmation request is already pending in thread 100.1; wait for the user\'s approval first.',
     );
   });
 

--- a/slack-bridge/pinet-confirmation-replies.ts
+++ b/slack-bridge/pinet-confirmation-replies.ts
@@ -1,0 +1,43 @@
+import type { PinetReadResult } from "@gugu910/pi-pinet-core/pinet-read-formatting";
+
+export type ConsumePinetConfirmationReply = (
+  threadTs: string,
+  text: string,
+) => { approved: boolean } | null;
+
+export function consumePinetReadConfirmationReplies(
+  result: PinetReadResult,
+  consumeReply: ConsumePinetConfirmationReply,
+): PinetReadResult {
+  if (result.markedReadIds.length === 0) return result;
+
+  const markedReadIds = new Set(result.markedReadIds);
+
+  return {
+    ...result,
+    messages: result.messages.map((item) => {
+      if (
+        !markedReadIds.has(item.inboxId) ||
+        item.message.source !== "slack" ||
+        item.message.direction !== "inbound"
+      ) {
+        return item;
+      }
+
+      const confirmationResult = consumeReply(item.message.threadId, item.message.body);
+      if (confirmationResult === null) return item;
+
+      const suffix = confirmationResult.approved
+        ? "✅ User approved security confirmation request in this thread."
+        : "❌ User denied security confirmation request in this thread.";
+
+      return {
+        ...item,
+        message: {
+          ...item.message,
+          body: `${item.message.body}\n\n${suffix}`,
+        },
+      };
+    }),
+  };
+}

--- a/slack-bridge/pinet-confirmation-replies.ts
+++ b/slack-bridge/pinet-confirmation-replies.ts
@@ -3,6 +3,7 @@ import type { PinetReadResult } from "@gugu910/pi-pinet-core/pinet-read-formatti
 export type ConsumePinetConfirmationReply = (
   threadTs: string,
   text: string,
+  options?: { receivedAt?: string | number | Date },
 ) => { approved: boolean } | null;
 
 export function consumePinetReadConfirmationReplies(
@@ -24,7 +25,9 @@ export function consumePinetReadConfirmationReplies(
         return item;
       }
 
-      const confirmationResult = consumeReply(item.message.threadId, item.message.body);
+      const confirmationResult = consumeReply(item.message.threadId, item.message.body, {
+        receivedAt: item.message.createdAt,
+      });
       if (confirmationResult === null) return item;
 
       const suffix = confirmationResult.approved

--- a/slack-bridge/thread-confirmations.test.ts
+++ b/slack-bridge/thread-confirmations.test.ts
@@ -257,6 +257,26 @@ describe("createThreadConfirmationPolicy", () => {
     );
   });
 
+  it("does not consume timestamped replies that predate the pending request", () => {
+    const { policy, advance } = createPolicyHarness({
+      requireConfirmation: ["bash"],
+    });
+
+    const staleReplyAt = "2026-04-14T11:59:59.000Z";
+    expect(policy.registerRequest("100.1", "bash", "run: ls").status).toBe("created");
+
+    expect(policy.consumeReply("100.1", "yes", { receivedAt: staleReplyAt })).toBeNull();
+    expect(() => policy.requireToolPolicy("bash", "100.1", "run: ls")).toThrow(
+      'Tool "bash" requires confirmation for action "run: ls". A matching confirmation request is already pending in thread 100.1; wait for the user\'s approval first.',
+    );
+
+    advance(1_000);
+    expect(policy.consumeReply("100.1", "yes", { receivedAt: "2026-04-14T12:00:01.000Z" })).toEqual(
+      { approved: true },
+    );
+    expect(() => policy.requireToolPolicy("bash", "100.1", "run: ls")).not.toThrow();
+  });
+
   it("ignores non-confirmation replies and expires stale pending requests", () => {
     const { policy, advance, setGuardrails } = createPolicyHarness({
       requireConfirmation: ["bash"],

--- a/slack-bridge/thread-confirmations.ts
+++ b/slack-bridge/thread-confirmations.ts
@@ -27,7 +27,11 @@ export interface ThreadConfirmationPolicy {
     tool: string,
     action: string,
   ) => RegisterConfirmationRequestResult;
-  consumeReply: (threadTs: string, text: string) => { approved: boolean } | null;
+  consumeReply: (
+    threadTs: string,
+    text: string,
+    options?: { receivedAt?: string | number | Date },
+  ) => { approved: boolean } | null;
   requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
 }
 
@@ -109,7 +113,11 @@ export function createThreadConfirmationPolicy(
     };
   }
 
-  function consumeReply(threadTs: string, text: string): { approved: boolean } | null {
+  function consumeReply(
+    threadTs: string,
+    text: string,
+    options: { receivedAt?: string | number | Date } = {},
+  ): { approved: boolean } | null {
     sweepThreadConfirmationStates();
     const state = threadConfirmationStates.get(threadTs);
     if (!state || state.pending.length === 0) return null;
@@ -119,8 +127,22 @@ export function createThreadConfirmationPolicy(
     const isRejection = isConfirmationRejection(trimmed);
     if (!isApproval && !isRejection) return null;
 
-    const request = state.pending.shift();
+    const request = state.pending[0];
     if (!request) return null;
+
+    if (options.receivedAt !== undefined) {
+      const receivedAtMs =
+        options.receivedAt instanceof Date
+          ? options.receivedAt.getTime()
+          : typeof options.receivedAt === "number"
+            ? options.receivedAt
+            : Date.parse(options.receivedAt);
+      if (!Number.isFinite(receivedAtMs) || receivedAtMs < request.requestedAt) {
+        return null;
+      }
+    }
+
+    state.pending.shift();
 
     if (isApproval) {
       state.approved.push(request);


### PR DESCRIPTION
## Summary\n- consume Slack confirmation replies when unread Slack inbox rows are read through Pinet\n- annotate Pinet-read confirmation messages the same way Slack inbox messages are annotated\n- add regression coverage for confirm_action -> Pinet-read yes -> guarded retry, while preserving exact tool/action matching\n\nFixes #750.\n\n## Tests\n- pnpm vitest run slack-bridge/pinet-confirmation-replies.test.ts slack-bridge/thread-confirmations.test.ts slack-bridge/pinet-tools.test.ts\n- pnpm lint && pnpm typecheck && pnpm test\n- git push prepush hook: pnpm lint && pnpm typecheck && pnpm test