### PR TITLE
Fix legacy Pinet assignment progress visibility

### DIFF
--- a/slack-bridge/task-assignments.test.ts
+++ b/slack-bridge/task-assignments.test.ts
@@ -627,6 +627,40 @@ describe("resolveTaskAssignments", () => {
     expect(hasTaskAssignmentStatusChange(assignment)).toBe(false);
   });
 
+  it("resolves repo-less legacy issues from the provided cwd so closed stale rows can be hidden", async () => {
+    const runner: CommandRunner = vi.fn(async (file, args, options) => {
+      if (file === "gh" && args[0] === "issue" && args[1] === "view") {
+        expect(args).not.toContain("--repo");
+        expect(options).toMatchObject({ cwd: "/repo" });
+        return { stdout: JSON.stringify({ number: 271, state: "CLOSED" }) };
+      }
+      throw new Error(`unexpected command: ${file} ${args.join(" ")}`);
+    });
+
+    const [assignment] = await resolveTaskAssignments(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-1",
+          issueNumber: 271,
+          status: "assigned",
+          repoOwner: null,
+          repoName: null,
+          repoRoot: null,
+        }),
+      ],
+      "/repo",
+      runner,
+    );
+
+    expect(assignment.issueState).toBe("CLOSED");
+    expect(runner).toHaveBeenCalledWith(
+      "gh",
+      ["issue", "view", "271", "--json", "number,state"],
+      expect.objectContaining({ cwd: "/repo" }),
+    );
+  });
+
   it("resolves same-number issues against their captured repositories", async () => {
     const runner: CommandRunner = vi.fn(async (file, args) => {
       if (
@@ -785,6 +819,54 @@ describe("buildTaskAssignmentReport", () => {
         "RALPH LOOP — WORKER STATUS:",
         "- 🐦‍⬛ Frozen Raven: #287 → review task, no implementation PR expected",
       ].join("\n"),
+    );
+  });
+
+  it("keeps legacy unknown assignments visible instead of suppressing implementation pressure", () => {
+    const report = buildTaskAssignmentReport(
+      [
+        makeAssignment({
+          id: 1,
+          agentId: "worker-2",
+          issueNumber: 114,
+          taskKind: "unknown",
+          repoOwner: null,
+          repoName: null,
+          repoRoot: null,
+          status: "assigned",
+        }),
+      ],
+      new Map([["worker-2", makeAgent("worker-2", "Frozen Raven", "🐦‍⬛")]]),
+    );
+
+    expect(report).toBe(
+      [
+        "RALPH LOOP — WORKER STATUS:",
+        "- 🐦‍⬛ Frozen Raven: #114 → repo unknown; progress not checked ⚠️",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps closed-unmerged PR warnings visible while the implementation issue is open", () => {
+    const report = buildTaskAssignmentReport(
+      [
+        {
+          ...makeAssignment({
+            id: 1,
+            agentId: "worker-2",
+            issueNumber: 114,
+            status: "pr_closed",
+            prNumber: 115,
+            taskKind: "implementation",
+          }),
+          issueState: "OPEN" as const,
+        },
+      ],
+      new Map([["worker-2", makeAgent("worker-2", "Frozen Raven", "🐦‍⬛")]]),
+    );
+
+    expect(report).toBe(
+      ["RALPH LOOP — WORKER STATUS:", "- 🐦‍⬛ Frozen Raven: #114 → PR #115 CLOSED ⚠️"].join("\n"),
     );
   });
 

--- a/slack-bridge/task-assignments.ts
+++ b/slack-bridge/task-assignments.ts
@@ -452,10 +452,6 @@ async function getIssueByNumber(
   cwd: string,
   runner: CommandRunner,
 ): Promise<IssueSnapshot | null | undefined> {
-  if (!assignment.repoOwner || !assignment.repoName) {
-    return null;
-  }
-
   const issue = await runJsonCommand<IssueSnapshot>(
     "gh",
     [
@@ -656,6 +652,10 @@ export function hasTaskAssignmentStatusChange(assignment: ResolvedTaskAssignment
   );
 }
 
+function isImplementationProgressTask(taskKind: TaskAssignmentInfo["taskKind"]): boolean {
+  return taskKind === "implementation" || taskKind === "unknown";
+}
+
 function formatTaskProgressFragment(
   assignment: Pick<
     TaskAssignmentInfo,
@@ -669,7 +669,7 @@ function formatTaskProgressFragment(
     | "repoRoot"
   >,
 ): string {
-  if (assignment.taskKind !== "implementation") {
+  if (!isImplementationProgressTask(assignment.taskKind)) {
     return `#${assignment.issueNumber} → ${assignment.taskKind} task, no implementation PR expected`;
   }
 
@@ -719,7 +719,7 @@ function getVisibleTaskAssignmentReportEntries<
     (assignment) =>
       assignment.issueState !== "CLOSED" &&
       assignment.status !== "pr_merged" &&
-      assignment.status !== "pr_closed",
+      (assignment.status !== "pr_closed" || isImplementationProgressTask(assignment.taskKind)),
   );
 }
 


### PR DESCRIPTION
## Summary
- treat legacy `unknown` task assignments as implementation-like for progress reporting instead of suppressing them as read-only work
- resolve repo-less legacy issue rows against the current cwd repo so closed stale issues can be hidden
- keep closed/unmerged PR warnings visible while the implementation issue remains open

Follow-up to #751 / fixes remaining review concerns for #747.

## Tests
- `pnpm exec vitest run slack-bridge/task-assignments.test.ts slack-bridge/pinet-mesh-ops.test.ts slack-bridge/broker/helpers.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
