### PR TITLE
Add Slack shimmer statuses for Pinet

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -57,6 +57,8 @@ reactions:read       reactions:write      users:read
 
 `files:read` is required because Slack exposes canvas comment pagination through `files.info`, even when the target is first validated via canvas-specific APIs.
 
+Slack thread shimmer/status updates use `assistant.threads.setStatus`; Slack's 2026 scope update allows this method with the existing `chat:write` bot scope, so no new `assistant:write` scope is needed for status-only support.
+
 ## Configuration
 
 Add your tokens to `~/.pi/agent/settings.json`:

--- a/slack-bridge/agent-event-runtime.ts
+++ b/slack-bridge/agent-event-runtime.ts
@@ -27,6 +27,9 @@ export function createAgentEventRuntime(deps: AgentEventRuntimeDeps): AgentEvent
     formatAction: deps.formatAction,
     formatError: deps.formatError,
     deliverFollowUpMessage: deps.deliverFollowUpMessage,
+    beginThreadStatus: deps.beginThreadStatus,
+    updateThreadStatus: deps.updateThreadStatus,
+    clearThreadStatus: deps.clearThreadStatus,
   });
 
   deps.setDeliverTrackedSlackFollowUpMessage(

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -2,7 +2,6 @@ import {
   addSlackReaction,
   buildSlackThreadRuntimeScope,
   classifyMessage,
-  clearSlackThreadStatus,
   extractAppHomeOpened,
   extractThreadContextChanged,
   extractThreadStarted,
@@ -35,6 +34,10 @@ import {
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
 } from "../../slack-access.js";
+import {
+  DEFAULT_SLACK_THREAD_STATUS,
+  SlackThreadStatusManager,
+} from "../../slack-thread-status.js";
 import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
 
 export {
@@ -105,6 +108,7 @@ export class SlackAdapter implements MessageAdapter {
     ttlMs: SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,
   });
   private readonly pendingEyes: TtlCache<string, { channel: string; messageTs: string }[]>;
+  private readonly threadStatuses: SlackThreadStatusManager;
 
   constructor(config: SlackAdapterConfig) {
     this.config = config;
@@ -115,6 +119,12 @@ export class SlackAdapter implements MessageAdapter {
     this.pendingEyes = new TtlCache<string, { channel: string; messageTs: string }[]>({
       maxSize: SLACK_PENDING_ATTENTION_MAX_THREADS,
       ttlMs: SLACK_PENDING_ATTENTION_TTL_MS,
+    });
+    this.threadStatuses = new SlackThreadStatusManager({
+      slack: this.callSlack.bind(this),
+      getBotToken: () => this.config.botToken,
+      formatError: errorMsg,
+      logger: console,
     });
     this.allowlist = buildAllowlist(
       {
@@ -159,6 +169,7 @@ export class SlackAdapter implements MessageAdapter {
 
   async disconnect(): Promise<void> {
     this.shuttingDown = true;
+    await this.threadStatuses.clearAll();
     const socketMode = this.socketMode;
     this.socketMode = null;
     if (socketMode) {
@@ -475,6 +486,7 @@ export class SlackAdapter implements MessageAdapter {
 
     if (!isSlackUserAllowed(this.allowlist, userId)) return;
 
+    void this.threadStatuses.begin(channel, threadTs, DEFAULT_SLACK_THREAD_STATUS);
     void this.addReaction(channel, messageTs, "eyes");
     const pending = this.pendingEyes.get(threadTs) ?? [];
     pending.push({ channel, messageTs });
@@ -621,12 +633,7 @@ export class SlackAdapter implements MessageAdapter {
   }
 
   private async clearThreadStatus(channelId: string, threadTs: string): Promise<void> {
-    await clearSlackThreadStatus({
-      slack: this.callSlack.bind(this),
-      token: this.config.botToken,
-      channelId,
-      threadTs,
-    });
+    await this.threadStatuses.clear(channelId, threadTs);
   }
 
   private async setSuggestedPrompts(channelId: string, threadTs: string): Promise<void> {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -78,6 +78,7 @@ import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
 import { createInboxDrainRuntime } from "./inbox-drain-runtime.js";
 import { createAgentCompletionRuntime } from "./agent-completion-runtime.js";
 import { sendBrokerMessage } from "./broker/message-send.js";
+import { SlackThreadStatusManager } from "./slack-thread-status.js";
 import {
   type SlackBridgeRuntimeMode,
   isBrokerManagedFollowerLaunch,
@@ -378,6 +379,12 @@ export default function (pi: ExtensionAPI) {
 
   let isSinglePlayerShuttingDown = () => false;
   let isSinglePlayerConnected = () => false;
+  const slackThreadStatuses = new SlackThreadStatusManager({
+    slack,
+    getBotToken: () => botToken!,
+    formatError: msg,
+    logger: console,
+  });
   const slackRuntimeAccess = createSlackRuntimeAccess({
     slack,
     getBotToken: () => botToken!,
@@ -470,6 +477,11 @@ export default function (pi: ExtensionAPI) {
     formatAction: formatConfirmationAction,
     formatError: msg,
     deliverFollowUpMessage,
+    beginThreadStatus: (channel, threadTs, status) =>
+      slackThreadStatuses.begin(channel, threadTs, status),
+    updateThreadStatus: (channel, threadTs, status) =>
+      slackThreadStatuses.update(channel, threadTs, status),
+    clearThreadStatus: (channel, threadTs) => slackThreadStatuses.clear(channel, threadTs),
     beforeAgentStart: agentPromptGuidance.beforeAgentStart,
     onCompletionAgentEnd: agentCompletionRuntime.onAgentEnd,
     setDeliverTrackedSlackFollowUpMessage: (deliver) => {
@@ -565,6 +577,8 @@ export default function (pi: ExtensionAPI) {
     isUserAllowed,
     getReactionCommand: (reactionName) => reactionCommands.get(reactionName),
     consumeConfirmationReply,
+    beginThreadStatus: (channelId, threadTs, status) =>
+      slackThreadStatuses.begin(channelId, threadTs, status),
     claimOwnedThread: (threadTs, channelId, source = "slack") => {
       if (brokerRole === "broker") {
         brokerRuntime.claimThread(threadTs, channelId, source);

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -78,6 +78,7 @@ export interface SinglePlayerRuntimeDeps {
   getReactionCommand: (reactionName: string) => ReactionCommandTemplate | undefined;
   consumeConfirmationReply: (threadTs: string, text: string) => { approved: boolean } | null;
   claimOwnedThread: (threadTs: string, channelId: string, source?: string) => void;
+  beginThreadStatus?: (channelId: string, threadTs: string, status: string) => Promise<void>;
 }
 
 type SinglePlayerControlContext = ExtensionContext & {
@@ -419,6 +420,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
     if (shuttingDown) return;
     ctx.ui.notify(`${name}: ${text.slice(0, 100)}`, "info");
 
+    void deps.beginThreadStatus?.(channel, threadTs, "is thinking…");
     void deps.addReaction(channel, messageTs, "eyes");
     const pending = deps.getPendingEyes().get(threadTs) ?? [];
     pending.push({ channel, messageTs });
@@ -482,6 +484,8 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       deps.setLastDmChannel(normalized.channel);
     }
     deps.persistState();
+
+    void deps.beginThreadStatus?.(normalized.channel, normalized.threadTs, "is thinking…");
 
     const name = await deps.resolveUser(normalized.userId);
     if (shuttingDown) return;

--- a/slack-bridge/slack-thread-status.test.ts
+++ b/slack-bridge/slack-thread-status.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SLACK_THREAD_STATUS,
+  setSlackThreadStatus,
+  SlackThreadStatusManager,
+  SLACK_THREAD_LOADING_MESSAGES,
+} from "./slack-thread-status.js";
+import type { SlackCall } from "./slack-access.js";
+
+describe("setSlackThreadStatus", () => {
+  it("sets status with controlled whimsical loading copy", async () => {
+    const slack = vi.fn(async () => ({}));
+
+    await setSlackThreadStatus({
+      slack,
+      token: "xoxb-test",
+      channelId: "C123",
+      threadTs: "123.456",
+      status: DEFAULT_SLACK_THREAD_STATUS,
+    });
+
+    expect(slack).toHaveBeenCalledWith("assistant.threads.setStatus", "xoxb-test", {
+      channel_id: "C123",
+      thread_ts: "123.456",
+      status: DEFAULT_SLACK_THREAD_STATUS,
+      loading_messages: [...SLACK_THREAD_LOADING_MESSAGES],
+    });
+  });
+
+  it("clears status without loading messages", async () => {
+    const slack = vi.fn(async () => ({}));
+
+    await setSlackThreadStatus({
+      slack,
+      token: "xoxb-test",
+      channelId: "C123",
+      threadTs: "123.456",
+      status: "",
+    });
+
+    expect(slack).toHaveBeenCalledWith("assistant.threads.setStatus", "xoxb-test", {
+      channel_id: "C123",
+      thread_ts: "123.456",
+      status: "",
+    });
+  });
+});
+
+describe("SlackThreadStatusManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("heartbeats latest status without overlapping refreshes", async () => {
+    let resolveSecondCall: (() => void) | undefined;
+    const slack: SlackCall = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockImplementationOnce(
+        () =>
+          new Promise<Record<string, unknown>>((resolve) => {
+            resolveSecondCall = () => resolve({});
+          }),
+      )
+      .mockResolvedValue({});
+    const manager = new SlackThreadStatusManager({
+      slack,
+      getBotToken: () => "xoxb-test",
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+      heartbeatMs: 90_000,
+    });
+
+    await manager.begin("C123", "123.456", "Reading context…");
+    await vi.advanceTimersByTimeAsync(90_000);
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(slack).toHaveBeenCalledTimes(2);
+    expect(slack).toHaveBeenLastCalledWith("assistant.threads.setStatus", "xoxb-test", {
+      channel_id: "C123",
+      thread_ts: "123.456",
+      status: "Reading context…",
+      loading_messages: [...SLACK_THREAD_LOADING_MESSAGES],
+    });
+
+    resolveSecondCall?.();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(slack).toHaveBeenCalledTimes(3);
+  });
+
+  it("logs status failures instead of throwing", async () => {
+    const logger = { error: vi.fn() };
+    const manager = new SlackThreadStatusManager({
+      slack: vi.fn(async () => {
+        throw new Error("rate_limited");
+      }),
+      getBotToken: () => "xoxb-test",
+      formatError: (error) => (error instanceof Error ? error.message : String(error)),
+      logger,
+    });
+
+    await expect(manager.begin("C123", "123.456")).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[slack-bridge] Slack thread status update failed: rate_limited",
+    );
+  });
+});

--- a/slack-bridge/slack-thread-status.ts
+++ b/slack-bridge/slack-thread-status.ts
@@ -1,0 +1,218 @@
+import type { SlackCall } from "./slack-access.js";
+
+export const SLACK_THREAD_STATUS_HEARTBEAT_MS = 90_000;
+
+export const SLACK_THREAD_LOADING_MESSAGES = [
+  "Schlepping...",
+  "Combobulating...",
+  "Vibing...",
+  "Noodling...",
+  "Percolating...",
+  "Ruminating...",
+  "Consulting the void...",
+  "Asking the electrons...",
+  "Reticulating splines...",
+  "Consulting the rubber duck...",
+] as const;
+
+export const DEFAULT_SLACK_THREAD_STATUS = "is thinking…";
+export const SLACK_THREAD_SAFE_STATUSES = [
+  DEFAULT_SLACK_THREAD_STATUS,
+  "Reading context…",
+  "Calling tool…",
+  "Drafting reply…",
+  "Checking Slack…",
+] as const;
+
+export interface SlackThreadStatusInput {
+  slack: SlackCall;
+  token: string;
+  channelId: string;
+  threadTs: string;
+  status: string;
+  loadingMessages?: readonly string[];
+}
+
+export async function setSlackThreadStatus(input: SlackThreadStatusInput): Promise<void> {
+  await input.slack("assistant.threads.setStatus", input.token, {
+    channel_id: input.channelId,
+    thread_ts: input.threadTs,
+    status: input.status,
+    ...(input.status.length > 0
+      ? { loading_messages: [...(input.loadingMessages ?? SLACK_THREAD_LOADING_MESSAGES)] }
+      : {}),
+  });
+}
+
+export interface SlackThreadStatusManagerDeps {
+  slack: SlackCall;
+  getBotToken: () => string;
+  formatError: (error: unknown) => string;
+  setInterval?: typeof setInterval;
+  clearInterval?: typeof clearInterval;
+  heartbeatMs?: number;
+  logger?: Pick<Console, "error">;
+  maxActiveThreads?: number;
+  maxConsecutiveFailures?: number;
+}
+
+interface ActiveSlackThreadStatus {
+  channelId: string;
+  threadTs: string;
+  status: string;
+  timer: ReturnType<typeof setInterval> | null;
+  heartbeatInFlight: boolean;
+  consecutiveFailures: number;
+}
+
+function statusKey(channelId: string, threadTs: string): string {
+  return `${channelId}:${threadTs}`;
+}
+
+export function normalizeSlackThreadStatus(status: string | undefined): string {
+  const normalized = (status ?? "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!normalized) return DEFAULT_SLACK_THREAD_STATUS;
+  return (
+    SLACK_THREAD_SAFE_STATUSES.find((candidate) => candidate === normalized) ??
+    DEFAULT_SLACK_THREAD_STATUS
+  );
+}
+
+export class SlackThreadStatusManager {
+  private readonly deps: Required<Pick<SlackThreadStatusManagerDeps, "formatError">> &
+    SlackThreadStatusManagerDeps;
+  private readonly active = new Map<string, ActiveSlackThreadStatus>();
+
+  constructor(deps: SlackThreadStatusManagerDeps) {
+    this.deps = deps;
+  }
+
+  async begin(
+    channelId: string,
+    threadTs: string,
+    status = DEFAULT_SLACK_THREAD_STATUS,
+  ): Promise<void> {
+    await this.update(channelId, threadTs, status, { startHeartbeat: true });
+  }
+
+  async update(
+    channelId: string,
+    threadTs: string,
+    status: string,
+    options: { startHeartbeat?: boolean } = {},
+  ): Promise<void> {
+    const normalized = normalizeSlackThreadStatus(status);
+    const key = statusKey(channelId, threadTs);
+    let entry = this.active.get(key);
+    if (!entry) {
+      this.evictOldestIfNeeded();
+      entry = {
+        channelId,
+        threadTs,
+        status: normalized,
+        timer: null,
+        heartbeatInFlight: false,
+        consecutiveFailures: 0,
+      };
+      this.active.set(key, entry);
+    } else {
+      entry.status = normalized;
+    }
+
+    if (options.startHeartbeat && !entry.timer) {
+      const setIntervalFn = this.deps.setInterval ?? setInterval;
+      entry.timer = setIntervalFn(() => {
+        void this.heartbeat(entry!);
+      }, this.deps.heartbeatMs ?? SLACK_THREAD_STATUS_HEARTBEAT_MS);
+    }
+
+    await this.trySet(entry, normalized);
+  }
+
+  async clear(channelId: string, threadTs: string): Promise<void> {
+    const key = statusKey(channelId, threadTs);
+    const entry = this.active.get(key);
+    if (entry?.timer) {
+      const clearIntervalFn = this.deps.clearInterval ?? clearInterval;
+      clearIntervalFn(entry.timer);
+    }
+    this.active.delete(key);
+
+    await this.trySet(
+      {
+        channelId,
+        threadTs,
+        status: "",
+        timer: null,
+        heartbeatInFlight: false,
+        consecutiveFailures: 0,
+      },
+      "",
+    );
+  }
+
+  async clearAll(): Promise<void> {
+    const entries = [...this.active.values()];
+    for (const entry of entries) {
+      await this.clear(entry.channelId, entry.threadTs);
+    }
+  }
+
+  private async heartbeat(entry: ActiveSlackThreadStatus): Promise<void> {
+    if (entry.heartbeatInFlight) return;
+    entry.heartbeatInFlight = true;
+    try {
+      await this.trySet(entry, entry.status);
+    } finally {
+      entry.heartbeatInFlight = false;
+    }
+  }
+
+  private evictOldestIfNeeded(): void {
+    const maxActiveThreads = this.deps.maxActiveThreads ?? 100;
+    if (this.active.size < maxActiveThreads) return;
+    const oldest = this.active.entries().next().value as
+      | [string, ActiveSlackThreadStatus]
+      | undefined;
+    if (!oldest) return;
+    const [key, entry] = oldest;
+    if (entry.timer) {
+      const clearIntervalFn = this.deps.clearInterval ?? clearInterval;
+      clearIntervalFn(entry.timer);
+    }
+    this.active.delete(key);
+  }
+
+  private stopHeartbeat(entry: ActiveSlackThreadStatus): void {
+    if (entry.timer) {
+      const clearIntervalFn = this.deps.clearInterval ?? clearInterval;
+      clearIntervalFn(entry.timer);
+      entry.timer = null;
+    }
+    this.active.delete(statusKey(entry.channelId, entry.threadTs));
+  }
+
+  private async trySet(entry: ActiveSlackThreadStatus, status: string): Promise<void> {
+    try {
+      await setSlackThreadStatus({
+        slack: this.deps.slack,
+        token: this.deps.getBotToken(),
+        channelId: entry.channelId,
+        threadTs: entry.threadTs,
+        status,
+      });
+      entry.consecutiveFailures = 0;
+    } catch (error) {
+      entry.consecutiveFailures += 1;
+      (this.deps.logger ?? console).error(
+        `[slack-bridge] Slack thread status update failed: ${this.deps.formatError(error)}`,
+      );
+      if (status && entry.consecutiveFailures >= (this.deps.maxConsecutiveFailures ?? 3)) {
+        this.stopHeartbeat(entry);
+      }
+    }
+  }
+}

--- a/slack-bridge/slack-tool-policy-runtime.test.ts
+++ b/slack-bridge/slack-tool-policy-runtime.test.ts
@@ -169,6 +169,32 @@ describe("createSlackToolPolicyRuntime", () => {
     expect(requireToolPolicy).not.toHaveBeenCalled();
   });
 
+  it("brackets a single Slack thread with visible status updates", async () => {
+    const beginThreadStatus = vi.fn(async () => undefined);
+    const updateThreadStatus = vi.fn(async () => undefined);
+    const clearThreadStatus = vi.fn(async () => undefined);
+    const { deps } = createDeps({
+      beginThreadStatus,
+      updateThreadStatus,
+      clearThreadStatus,
+    });
+    const runtime = createSlackToolPolicyRuntime(deps);
+
+    runtime.deliverTrackedSlackFollowUpMessage({
+      prompt: "status prompt",
+      messages: [{ channel: "C100", threadTs: "100.1" }],
+    });
+    await runtime.onInput({ source: "extension", text: "status prompt" });
+    await runtime.onTurnStart();
+    expect(beginThreadStatus).toHaveBeenCalledWith("C100", "100.1", "is thinking…");
+
+    await runtime.onToolCall({ toolName: "read", input: { path: "README.md" } });
+    expect(updateThreadStatus).toHaveBeenCalledWith("C100", "100.1", "Calling tool…");
+
+    await runtime.onTurnEnd();
+    expect(clearThreadStatus).toHaveBeenCalledWith("C100", "100.1");
+  });
+
   it("clears the active Slack tool-policy turn on agent_end", async () => {
     const { deps, requireToolPolicy } = createDeps({
       getGuardrails: () => ({ requireConfirmation: ["read"] }),

--- a/slack-bridge/slack-tool-policy-runtime.ts
+++ b/slack-bridge/slack-tool-policy-runtime.ts
@@ -1,4 +1,7 @@
 import type { InboxMessage } from "./helpers.js";
+
+type SlackToolPolicyMessageRef = Pick<InboxMessage, "threadTs"> &
+  Partial<Pick<InboxMessage, "channel">>;
 import { evaluateSlackOriginCoreToolPolicy } from "./core-tool-guardrails.js";
 import { evaluateSlackOriginRepoToolPolicy } from "./repo-tool-guardrails.js";
 import { isBrokerForbiddenTool, type SecurityGuardrails } from "./guardrails.js";
@@ -15,12 +18,15 @@ export interface SlackToolPolicyRuntimeDeps {
   formatAction: (action: string) => string;
   formatError: (error: unknown) => string;
   deliverFollowUpMessage: (prompt: string) => boolean;
+  beginThreadStatus?: (channel: string, threadTs: string, status: string) => Promise<void>;
+  updateThreadStatus?: (channel: string, threadTs: string, status: string) => Promise<void>;
+  clearThreadStatus?: (channel: string, threadTs: string) => Promise<void>;
 }
 
 export interface SlackToolPolicyRuntime {
   deliverTrackedSlackFollowUpMessage: (options: {
     prompt: string;
-    messages: Pick<InboxMessage, "threadTs">[];
+    messages: SlackToolPolicyMessageRef[];
   }) => boolean;
   onInput: (event: { source?: string; text: string }) => Promise<void>;
   onTurnStart: () => Promise<void>;
@@ -41,7 +47,7 @@ export function createSlackToolPolicyRuntime(
 
   function deliverTrackedSlackFollowUpMessage(options: {
     prompt: string;
-    messages: Pick<InboxMessage, "threadTs">[];
+    messages: SlackToolPolicyMessageRef[];
   }): boolean {
     return trackAndDeliverSlackFollowUpMessage({
       queue: pendingSlackToolPolicyTurns,
@@ -65,20 +71,55 @@ export function createSlackToolPolicyRuntime(
   async function onTurnStart(): Promise<void> {
     activeSlackToolPolicyTurn = nextSlackToolPolicyTurn;
     nextSlackToolPolicyTurn = null;
+    if (activeSlackToolPolicyTurn?.channel && activeSlackToolPolicyTurn.threadTs) {
+      await deps
+        .beginThreadStatus?.(
+          activeSlackToolPolicyTurn.channel,
+          activeSlackToolPolicyTurn.threadTs,
+          "is thinking…",
+        )
+        .catch(() => {
+          /* best effort */
+        });
+    }
   }
 
   async function onTurnEnd(): Promise<void> {
+    const turn = activeSlackToolPolicyTurn;
     activeSlackToolPolicyTurn = null;
+    if (turn?.channel && turn.threadTs) {
+      await deps.clearThreadStatus?.(turn.channel, turn.threadTs).catch(() => {
+        /* best effort */
+      });
+    }
   }
 
   async function onAgentEnd(): Promise<void> {
+    const turn = activeSlackToolPolicyTurn;
     activeSlackToolPolicyTurn = null;
+    if (turn?.channel && turn.threadTs) {
+      await deps.clearThreadStatus?.(turn.channel, turn.threadTs).catch(() => {
+        /* best effort */
+      });
+    }
   }
 
   async function onToolCall(event: {
     toolName: string;
     input: Record<string, unknown>;
   }): Promise<{ block: true; reason: string } | undefined> {
+    if (activeSlackToolPolicyTurn?.channel && activeSlackToolPolicyTurn.threadTs) {
+      await deps
+        .updateThreadStatus?.(
+          activeSlackToolPolicyTurn.channel,
+          activeSlackToolPolicyTurn.threadTs,
+          "Calling tool…",
+        )
+        .catch(() => {
+          /* best effort */
+        });
+    }
+
     if (deps.getBrokerRole() === "broker" && isBrokerForbiddenTool(event.toolName)) {
       return {
         block: true,

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -41,6 +41,12 @@ import { normalizeReactionName } from "./reaction-triggers.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
 import { performSlackUpload, prepareSlackUpload } from "./slack-upload.js";
 import { TtlCache } from "./ttl-cache.js";
+import {
+  DEFAULT_SLACK_THREAD_STATUS,
+  normalizeSlackThreadStatus,
+  setSlackThreadStatus,
+  SLACK_THREAD_LOADING_MESSAGES,
+} from "./slack-thread-status.js";
 
 export interface SlackToolsThreadContextPort {
   resolveThreadChannel: (threadTs: string | undefined) => Promise<string | null>;
@@ -168,6 +174,10 @@ const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
   ],
   presence: [{ action: "presence", args: { users: ["@alice", "U123456"] } }],
   export: [{ action: "export", args: { thread_ts: "1712345678.000100", format: "markdown" } }],
+  status: [
+    { action: "status", args: { thread_ts: "1712345678.000100", status: "Reading context…" } },
+    { action: "status", args: { thread_ts: "1712345678.000100", clear: true } },
+  ],
   post_channel: [
     {
       action: "post_channel",
@@ -2024,6 +2034,71 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             text: message.text,
           })),
         },
+      };
+    },
+  });
+
+  registerSlackAction({
+    name: "slack_status",
+    label: "Slack Thread Status",
+    description:
+      "Set or clear Slack's in-thread shimmer/thinking status for the current thread. Best-effort; failures do not affect final replies.",
+    promptSnippet:
+      "Update visible Slack thread status with short safe progress hints such as Reading context… or Drafting reply…. Do not expose chain-of-thought.",
+    parameters: Type.Object({
+      thread_ts: Type.String({ description: "Slack thread timestamp to update." }),
+      channel: Type.Optional(
+        Type.String({
+          description:
+            "Optional channel name or ID. Omit when the thread is tracked by the Slack bridge.",
+        }),
+      ),
+      status: Type.Optional(
+        Type.Union(
+          [
+            Type.Literal("is thinking…"),
+            Type.Literal("Reading context…"),
+            Type.Literal("Calling tool…"),
+            Type.Literal("Drafting reply…"),
+            Type.Literal("Checking Slack…"),
+          ],
+          {
+            description:
+              "Controlled visible status text. Ignored when clear=true. Only safe operational progress labels are accepted.",
+          },
+        ),
+      ),
+      clear: Type.Optional(Type.Boolean({ description: "Clear the visible thread status." })),
+    }),
+    async execute(_id, params) {
+      requireToolPolicy(
+        "slack_status",
+        params.thread_ts,
+        `thread_ts=${params.thread_ts} | channel=${params.channel ?? ""} | clear=${params.clear === true}`,
+      );
+      const channelId = await resolveSlackTargetChannel(params.thread_ts, params.channel);
+      const status =
+        params.clear === true
+          ? ""
+          : normalizeSlackThreadStatus(params.status ?? DEFAULT_SLACK_THREAD_STATUS);
+      await setSlackThreadStatus({
+        slack,
+        token: getBotToken(),
+        channelId,
+        threadTs: params.thread_ts,
+        status,
+        loadingMessages: SLACK_THREAD_LOADING_MESSAGES,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: status
+              ? `Updated Slack thread status to “${status}”.`
+              : "Cleared Slack thread status.",
+          },
+        ],
+        details: { channel: channelId, thread_ts: params.thread_ts, status },
       };
     },
   });

--- a/slack-bridge/slack-turn-guardrails.ts
+++ b/slack-bridge/slack-turn-guardrails.ts
@@ -1,19 +1,24 @@
 import type { InboxMessage } from "./helpers.js";
 
+type SlackTurnMessageRef = Pick<InboxMessage, "threadTs"> & Partial<Pick<InboxMessage, "channel">>;
+
 export interface PendingSlackToolPolicyTurn {
   prompt: string;
   threadTs: string | undefined;
+  channel: string | undefined;
   threadCount: number;
 }
 
 export function buildPendingSlackToolPolicyTurn(
   prompt: string,
-  messages: Pick<InboxMessage, "threadTs">[],
+  messages: SlackTurnMessageRef[],
 ): PendingSlackToolPolicyTurn {
   const threadIds = [...new Set(messages.map((message) => message.threadTs).filter(Boolean))];
+  const channels = [...new Set(messages.map((message) => message.channel).filter(Boolean))];
   return {
     prompt,
     threadTs: threadIds.length === 1 ? threadIds[0] : undefined,
+    channel: channels.length === 1 ? channels[0] : undefined,
     threadCount: threadIds.length,
   };
 }
@@ -21,7 +26,7 @@ export function buildPendingSlackToolPolicyTurn(
 export function enqueuePendingSlackToolPolicyTurn(
   queue: PendingSlackToolPolicyTurn[],
   prompt: string,
-  messages: Pick<InboxMessage, "threadTs">[],
+  messages: SlackTurnMessageRef[],
 ): PendingSlackToolPolicyTurn {
   const entry = buildPendingSlackToolPolicyTurn(prompt, messages);
   queue.push(entry);
@@ -51,7 +56,7 @@ export function removePendingSlackToolPolicyTurn(
 export function deliverTrackedSlackFollowUpMessage(options: {
   queue: PendingSlackToolPolicyTurn[];
   prompt: string;
-  messages: Pick<InboxMessage, "threadTs">[];
+  messages: SlackTurnMessageRef[];
   deliver: (prompt: string) => boolean;
 }): boolean {
   const entry = enqueuePendingSlackToolPolicyTurn(options.queue, options.prompt, options.messages);


### PR DESCRIPTION
Closes #754.\n\n## Summary\n- Add best-effort Slack thread status manager using assistant.threads.setStatus with controlled whimsical loading messages.\n- Start shimmer promptly for single-player and broker Slack channel/thread requests, heartbeat active statuses, and clear on final replies/turn completion.\n- Add a controlled slack status dispatcher action for safe mid-turn status labels; document that chat:write is sufficient for status support.\n\n## Safety\n- Status labels are restricted to a safe vocabulary; no raw chain-of-thought/tool details are posted.\n- Heartbeats are non-overlapping, capped, and stopped after repeated Slack API failures.\n- Slack API status errors are logged best-effort and do not block final replies.\n\n## Tests\n- pnpm prepush\n\n## Warden/security review\n- Local reviewer with vercel-deepsec, wrdn-data-exfil, wrdn-pii, and wrdn-authz lenses reviewed the diff.\n- Initial findings (unbounded heartbeat/rate-limit vector, arbitrary status text) were fixed. Re-review found no remaining Warden/security findings requiring code changes.\n- GitHub Actions/workflows were not touched, so GHA lens was not applicable.