### PR TITLE
Add npm publish workflow scaffold

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,78 @@
+name: Publish npm packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Package lane to publish"
+        required: true
+        type: choice
+        options:
+          - pinet
+          - slack-bridge
+      dry_run:
+        description: "Run npm publish --dry-run only"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.target }} packages
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Dry-run publish target packages
+        if: ${{ inputs.dry_run }}
+        run: >-
+          node ./scripts/publish-npm-packages.mjs
+          --target "${{ inputs.target }}"
+          --dry-run
+
+      - name: Guard real publish ref
+        if: ${{ !inputs.dry_run && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "Real npm publishes must be dispatched from refs/heads/main. Current ref: $GITHUB_REF"
+          exit 1
+
+      - name: Configure npm authentication
+        if: ${{ !inputs.dry_run }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+
+      - name: Publish target packages
+        if: ${{ !inputs.dry_run }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >-
+          node ./scripts/publish-npm-packages.mjs
+          --target "${{ inputs.target }}"
+          --publish

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typecheck": "turbo run typecheck",
     "build": "turbo run build",
     "build:packages": "node ./scripts/build-all.mjs",
-    "test": "turbo run test",
+    "test": "turbo run test && node --test scripts/*.test.mjs",
     "deploy:slack": "node --experimental-strip-types ./slack-bridge/deploy-manifest.ts",
     "check": "pnpm lint && pnpm typecheck && pnpm format:check",
     "prepush": "pnpm lint && pnpm typecheck && pnpm test",

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -1,0 +1,54 @@
+# npm publish plan for Pinet and Slack bridge
+
+Issue: #773. Dependency: #772 should confirm the Pinet/Slack package boundary before real releases.
+
+## Package lanes
+
+### Pinet lane
+
+Publish in dependency order:
+
+1. `@gugu910/pi-transport-core` from `transport-core/`
+2. `@gugu910/pi-broker-core` from `broker-core/`
+3. `@gugu910/pi-pinet-core` from `pinet-core/`
+
+This lane is transport-neutral and must not publish Slack-specific packages.
+
+### Slack bridge lane
+
+Publish in dependency order:
+
+1. `@gugu910/pi-transport-core` from `transport-core/`
+2. `@gugu910/pi-broker-core` from `broker-core/`
+3. `@gugu910/pi-pinet-core` from `pinet-core/`
+4. `@gugu910/pi-imessage-bridge` from `imessage-bridge/`
+5. `@gugu910/pi-slack-bridge` from `slack-bridge/`
+
+The Slack lane includes the Pinet package closure because `slack-bridge` depends on Pinet and broker primitives, but the workflow keeps it as a separate manual target.
+
+## Workflow
+
+`.github/workflows/npm-publish.yml` is a manual `workflow_dispatch` workflow with two inputs:
+
+- `target`: `pinet` or `slack-bridge`
+- `dry_run`: defaults to `true`
+
+The workflow installs with `pnpm install --frozen-lockfile`, builds packages, rewrites local `file:../...` workspace dependencies to exact package versions in the CI checkout, verifies declared `dist/` exports exist, and then runs `npm publish` in dependency order. Dry runs use `npm publish --dry-run`; real publishes must be dispatched from `refs/heads/main`, use `npm publish --provenance`, and fail closed if any target package version already exists on npm.
+
+## Required GitHub/npm configuration
+
+Secret names only:
+
+- `NPM_TOKEN` in the `npm-publish` GitHub environment
+
+GitHub permissions:
+
+- `contents: read`
+- `id-token: write` for npm provenance
+
+## Release gates before setting `dry_run=false`
+
+- #772 has confirmed the Pinet/Slack boundary and the target lane is still correct.
+- Package versions are intentionally bumped. The publish script refuses real publishes for placeholder `0.0.0` packages or versions already present on npm.
+- Built outputs are produced from the current commit and match `main`/`exports` entries.
+- No npm token values are requested, printed, or committed.

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -1,0 +1,237 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export const publishTargets = Object.freeze({
+  pinet: ["transport-core", "broker-core", "pinet-core"],
+  "slack-bridge": [
+    "transport-core",
+    "broker-core",
+    "pinet-core",
+    "imessage-bridge",
+    "slack-bridge",
+  ],
+});
+
+const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
+
+export function parseArgs(argv) {
+  const args = {
+    dryRun: true,
+    target: undefined,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--dry-run") {
+      args.dryRun = true;
+      continue;
+    }
+    if (arg === "--publish") {
+      args.dryRun = false;
+      continue;
+    }
+    if (arg === "--target") {
+      args.target = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--target=")) {
+      args.target = arg.slice("--target=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+export function getTargetPackages(target) {
+  const packages = publishTargets[target];
+  if (!packages) {
+    throw new Error(
+      `Unknown npm publish target "${target}". Expected one of: ${Object.keys(publishTargets).join(", ")}`,
+    );
+  }
+  return packages;
+}
+
+export async function readJson(filePath) {
+  const text = await fs.readFile(filePath, "utf8");
+  return JSON.parse(text);
+}
+
+export async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export async function loadWorkspaceManifests(repoRoot) {
+  const rootPackageJson = await readJson(path.join(repoRoot, "package.json"));
+  const workspaceDirs = rootPackageJson.workspaces ?? [];
+  const manifests = new Map();
+
+  for (const directory of workspaceDirs) {
+    const packageJsonPath = path.join(repoRoot, directory, "package.json");
+    const manifest = await readJson(packageJsonPath);
+    manifests.set(directory, {
+      directory,
+      manifest,
+      packageJsonPath,
+    });
+  }
+
+  return manifests;
+}
+
+export function rewriteLocalDependencySpecs(targetDirectories, manifests) {
+  const targetSet = new Set(targetDirectories);
+  const patched = [];
+  const byDirectory = new Map(manifests);
+
+  for (const directory of targetDirectories) {
+    const entry = byDirectory.get(directory);
+    if (!entry) {
+      throw new Error(`Target package directory is not a workspace: ${directory}`);
+    }
+
+    const manifest = structuredClone(entry.manifest);
+    const rewrites = [];
+
+    for (const field of dependencyFields) {
+      const dependencies = manifest[field];
+      if (!dependencies) continue;
+
+      for (const [dependencyName, specifier] of Object.entries(dependencies)) {
+        if (typeof specifier !== "string" || !specifier.startsWith("file:")) {
+          continue;
+        }
+
+        const dependencyDirectory = path.normalize(
+          path.join(directory, specifier.slice("file:".length)),
+        );
+        const dependencyEntry = byDirectory.get(dependencyDirectory);
+        if (!dependencyEntry) {
+          throw new Error(
+            `${manifest.name} has unsupported local dependency ${dependencyName}@${specifier}`,
+          );
+        }
+        if (!targetSet.has(dependencyDirectory)) {
+          throw new Error(
+            `${manifest.name} depends on ${dependencyEntry.manifest.name}, but ${dependencyDirectory} is not in the ${targetDirectories.join(", ")} publish target`,
+          );
+        }
+        if (dependencyName !== dependencyEntry.manifest.name) {
+          throw new Error(
+            `${manifest.name} declares ${dependencyName}@${specifier}, but ${dependencyDirectory} is named ${dependencyEntry.manifest.name}`,
+          );
+        }
+
+        dependencies[dependencyName] = dependencyEntry.manifest.version;
+        rewrites.push(`${dependencyName}: ${specifier} -> ${dependencyEntry.manifest.version}`);
+      }
+    }
+
+    patched.push({
+      ...entry,
+      manifest,
+      rewrites,
+    });
+  }
+
+  return patched;
+}
+
+export function validatePublishMetadata(entries, { dryRun }) {
+  const errors = [];
+
+  for (const { directory, manifest } of entries) {
+    if (!manifest.name) errors.push(`${directory}: package.json must include name`);
+    if (!manifest.version) errors.push(`${directory}: package.json must include version`);
+    if (manifest.private === true) errors.push(`${manifest.name}: package must not be private`);
+    if (manifest.publishConfig?.access !== "public") {
+      errors.push(`${manifest.name}: publishConfig.access must be public`);
+    }
+    if (!manifest.main) errors.push(`${manifest.name}: package.json must include main`);
+    if (!manifest.files?.includes("dist/")) {
+      errors.push(`${manifest.name}: package files must include dist/`);
+    }
+    if (!dryRun && manifest.version === "0.0.0") {
+      errors.push(`${manifest.name}: refusing a real npm publish at placeholder version 0.0.0`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`npm publish metadata validation failed:\n- ${errors.join("\n- ")}`);
+  }
+}
+
+export function parseNpmViewVersionExists(result, packageName, version) {
+  if (result.error) {
+    throw new Error(`Unable to verify ${packageName}@${version} on npm: ${result.error.message}`);
+  }
+
+  const stdout = result.stdout?.toString() ?? "";
+  const stderr = result.stderr?.toString() ?? "";
+  const output = `${stdout}\n${stderr}`;
+
+  if (result.status === 0) {
+    if (stdout.trim() === version) {
+      return true;
+    }
+    throw new Error(
+      `Unable to verify ${packageName}@${version} on npm: unexpected npm view output ${JSON.stringify(stdout.trim())}`,
+    );
+  }
+
+  if (/\bE404\b|404 Not Found|No match found/i.test(output)) {
+    return false;
+  }
+
+  throw new Error(
+    `Unable to verify ${packageName}@${version} on npm before publishing. npm view exited with status ${result.status}.`,
+  );
+}
+
+export function assertVersionsNotAlreadyPublished(entries, versionExists) {
+  const existing = [];
+
+  for (const { manifest } of entries) {
+    if (versionExists(manifest.name, manifest.version)) {
+      existing.push(`${manifest.name}@${manifest.version}`);
+    }
+  }
+
+  if (existing.length > 0) {
+    throw new Error(
+      `Refusing real npm publish because these versions already exist. Bump versions or start a new release.\n- ${existing.join("\n- ")}`,
+    );
+  }
+}
+
+export async function validateBuildOutputs(repoRoot, entries) {
+  const missing = [];
+
+  for (const { directory, manifest } of entries) {
+    const packageRoot = path.join(repoRoot, directory);
+    const exportedPaths = new Set([manifest.main]);
+
+    for (const value of Object.values(manifest.exports ?? {})) {
+      if (typeof value === "string" && value !== "./package.json") {
+        exportedPaths.add(value);
+      }
+    }
+
+    for (const exportedPath of exportedPaths) {
+      if (typeof exportedPath !== "string") continue;
+      const absolutePath = path.join(packageRoot, exportedPath);
+      try {
+        await fs.access(absolutePath);
+      } catch {
+        missing.push(`${manifest.name}: ${exportedPath}`);
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Missing build outputs for npm publish:\n- ${missing.join("\n- ")}`);
+  }
+}

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -1,0 +1,171 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assertVersionsNotAlreadyPublished,
+  getTargetPackages,
+  parseArgs,
+  parseNpmViewVersionExists,
+  rewriteLocalDependencySpecs,
+  validatePublishMetadata,
+} from "./npm-publish-helpers.mjs";
+
+function entry(directory, manifest) {
+  return {
+    directory,
+    manifest,
+    packageJsonPath: `${directory}/package.json`,
+  };
+}
+
+test("getTargetPackages keeps Pinet and Slack bridge targets separated", () => {
+  assert.deepEqual(getTargetPackages("pinet"), ["transport-core", "broker-core", "pinet-core"]);
+  assert.deepEqual(getTargetPackages("slack-bridge"), [
+    "transport-core",
+    "broker-core",
+    "pinet-core",
+    "imessage-bridge",
+    "slack-bridge",
+  ]);
+});
+
+test("parseArgs defaults to dry-run and accepts publish mode", () => {
+  assert.deepEqual(parseArgs(["--target", "pinet"]), { target: "pinet", dryRun: true });
+  assert.deepEqual(parseArgs(["--target=slack-bridge", "--publish"]), {
+    target: "slack-bridge",
+    dryRun: false,
+  });
+});
+
+test("rewriteLocalDependencySpecs replaces in-target file dependencies with exact versions", () => {
+  const manifests = new Map([
+    [
+      "transport-core",
+      entry("transport-core", {
+        name: "@gugu910/pi-transport-core",
+        version: "0.1.0",
+      }),
+    ],
+    [
+      "broker-core",
+      entry("broker-core", {
+        name: "@gugu910/pi-broker-core",
+        version: "0.1.0",
+        dependencies: {
+          "@gugu910/pi-transport-core": "file:../transport-core",
+        },
+      }),
+    ],
+  ]);
+
+  const rewritten = rewriteLocalDependencySpecs(["transport-core", "broker-core"], manifests);
+
+  assert.equal(rewritten[1].manifest.dependencies["@gugu910/pi-transport-core"], "0.1.0");
+  assert.deepEqual(rewritten[1].rewrites, [
+    "@gugu910/pi-transport-core: file:../transport-core -> 0.1.0",
+  ]);
+});
+
+test("rewriteLocalDependencySpecs rejects local dependencies outside the target", () => {
+  const manifests = new Map([
+    [
+      "transport-core",
+      entry("transport-core", {
+        name: "@gugu910/pi-transport-core",
+        version: "0.1.0",
+      }),
+    ],
+    [
+      "broker-core",
+      entry("broker-core", {
+        name: "@gugu910/pi-broker-core",
+        version: "0.1.0",
+        dependencies: {
+          "@gugu910/pi-transport-core": "file:../transport-core",
+        },
+      }),
+    ],
+  ]);
+
+  assert.throws(
+    () => rewriteLocalDependencySpecs(["broker-core"], manifests),
+    /transport-core is not in the broker-core publish target/,
+  );
+});
+
+test("validatePublishMetadata blocks placeholder versions for real publish only", () => {
+  const entries = [
+    entry("pinet-core", {
+      name: "@gugu910/pi-pinet-core",
+      version: "0.0.0",
+      publishConfig: { access: "public" },
+      main: "./dist/index.js",
+      files: ["dist/"],
+    }),
+  ];
+
+  assert.doesNotThrow(() => validatePublishMetadata(entries, { dryRun: true }));
+  assert.throws(
+    () => validatePublishMetadata(entries, { dryRun: false }),
+    /placeholder version 0.0.0/,
+  );
+});
+
+test("parseNpmViewVersionExists distinguishes found, not-found, and lookup errors", () => {
+  assert.equal(
+    parseNpmViewVersionExists(
+      { status: 0, stdout: "0.1.0\n", stderr: "" },
+      "@gugu910/pi-broker-core",
+      "0.1.0",
+    ),
+    true,
+  );
+  assert.equal(
+    parseNpmViewVersionExists(
+      { status: 1, stdout: "", stderr: "npm ERR! code E404\nnpm ERR! 404 Not Found" },
+      "@gugu910/pi-broker-core",
+      "0.1.0",
+    ),
+    false,
+  );
+  assert.throws(
+    () =>
+      parseNpmViewVersionExists(
+        { status: 1, stdout: "", stderr: "npm ERR! network timeout" },
+        "@gugu910/pi-broker-core",
+        "0.1.0",
+      ),
+    /Unable to verify @gugu910\/pi-broker-core@0.1.0/,
+  );
+  assert.throws(
+    () =>
+      parseNpmViewVersionExists(
+        { status: 1, stdout: "", stderr: "" },
+        "@gugu910/pi-broker-core",
+        "0.1.0",
+      ),
+    /Unable to verify @gugu910\/pi-broker-core@0.1.0/,
+  );
+});
+
+test("assertVersionsNotAlreadyPublished fails closed for existing versions", () => {
+  const entries = [
+    entry("transport-core", {
+      name: "@gugu910/pi-transport-core",
+      version: "0.1.0",
+    }),
+    entry("broker-core", {
+      name: "@gugu910/pi-broker-core",
+      version: "0.1.0",
+    }),
+  ];
+
+  assert.throws(
+    () =>
+      assertVersionsNotAlreadyPublished(
+        entries,
+        (packageName, version) => packageName === "@gugu910/pi-broker-core" && version === "0.1.0",
+      ),
+    /@gugu910\/pi-broker-core@0.1.0/,
+  );
+});

--- a/scripts/publish-npm-packages.mjs
+++ b/scripts/publish-npm-packages.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertVersionsNotAlreadyPublished,
+  getTargetPackages,
+  loadWorkspaceManifests,
+  parseArgs,
+  parseNpmViewVersionExists,
+  rewriteLocalDependencySpecs,
+  validateBuildOutputs,
+  validatePublishMetadata,
+  writeJson,
+} from "./npm-publish-helpers.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function versionExists(packageName, version) {
+  const result = spawnSync("npm", ["view", `${packageName}@${version}`, "version"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  return parseNpmViewVersionExists(result, packageName, version);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.target) {
+    throw new Error("Missing required --target argument");
+  }
+
+  const targetDirectories = getTargetPackages(args.target);
+  const manifests = await loadWorkspaceManifests(repoRoot);
+  const entries = rewriteLocalDependencySpecs(targetDirectories, manifests);
+
+  validatePublishMetadata(entries, { dryRun: args.dryRun });
+
+  run("pnpm", ["run", "build"]);
+  await validateBuildOutputs(repoRoot, entries);
+
+  for (const entry of entries) {
+    await writeJson(entry.packageJsonPath, entry.manifest);
+    for (const rewrite of entry.rewrites) {
+      console.log(`${entry.manifest.name}: ${rewrite}`);
+    }
+  }
+
+  if (!args.dryRun) {
+    if (!process.env.NPM_TOKEN) {
+      throw new Error("NPM_TOKEN is required for real npm publishing");
+    }
+    assertVersionsNotAlreadyPublished(entries, versionExists);
+  }
+
+  for (const { directory, manifest } of entries) {
+    const publishArgs = ["publish", "--access", "public"];
+    if (args.dryRun) {
+      publishArgs.push("--dry-run");
+    } else {
+      publishArgs.push("--provenance");
+    }
+
+    console.log(
+      `${args.dryRun ? "Dry-run publishing" : "Publishing"} ${manifest.name}@${manifest.version}`,
+    );
+    run("npm", publishArgs, { cwd: path.join(repoRoot, directory) });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a manual `workflow_dispatch` npm publish workflow with separate `pinet` and `slack-bridge` lanes.
- Add a publish helper that builds, validates package metadata/exports, rewrites local `file:../...` deps to exact versions in CI, dry-runs by default, and blocks real publishes at placeholder `0.0.0` versions.
- Document the release plan, package order, release gates, and required secret name (`NPM_TOKEN`) without exposing token values.

## Dependency / release gates
- Refs #773.
- Real `dry_run=false` publishing remains gated on #772 confirming the Pinet/Slack package boundary and intentional non-placeholder package versions.

## Testing
- `pnpm install --frozen-lockfile`
- `node --test scripts/*.test.mjs`
- `node ./scripts/publish-npm-packages.mjs --target pinet --dry-run`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `git push` pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`
