### PR TITLE
Add broker tmux presence probe

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -913,6 +913,19 @@ export interface AgentCapabilities {
 
 export type AgentHealth = "healthy" | "stale" | "ghost" | "resumable";
 
+export interface AgentTmuxPresenceInfo {
+  session: string;
+  status: "attached" | "detached" | "unknown";
+  attachedClientCount: number;
+  interactiveClientCount: number;
+  controlClientCount: number;
+  recentInteractiveClientCount: number;
+  latestClientActivityAt?: string;
+  latestInteractiveClientActivityAt?: string;
+  probedAt: string;
+  error?: string;
+}
+
 export interface AgentDisplayInfo {
   emoji: string;
   name: string;
@@ -957,6 +970,7 @@ export interface AgentDisplayInfo {
   outboundCount?: number | null;
   pendingInboxCount?: number | null;
   capabilityTags?: string[];
+  tmuxPresence?: AgentTmuxPresenceInfo;
   routingScore?: number;
   routingReasons?: string[];
 }
@@ -2558,6 +2572,31 @@ export function formatAgentList(agents: AgentDisplayInfo[], homedir: string): st
           meta.brokerManagedBy ? `by=${meta.brokerManagedBy}` : null,
         ].filter((item): item is string => Boolean(item));
         line += `\n   managed: ${managed.join(" · ")}`;
+      }
+
+      if (a.tmuxPresence) {
+        const presence = a.tmuxPresence;
+        const presenceSummary =
+          presence.status === "unknown"
+            ? `unknown${presence.error ? ` (${presence.error})` : ""}`
+            : presence.attachedClientCount === 0
+              ? "no tmux clients attached"
+              : [
+                  `${presence.interactiveClientCount} interactive client${presence.interactiveClientCount === 1 ? "" : "s"}`,
+                  presence.controlClientCount > 0
+                    ? `${presence.controlClientCount} control client${presence.controlClientCount === 1 ? "" : "s"}`
+                    : null,
+                  presence.attachedClientCount >
+                  presence.interactiveClientCount + presence.controlClientCount
+                    ? `${presence.attachedClientCount} attached reported`
+                    : null,
+                  presence.recentInteractiveClientCount > 0
+                    ? `${presence.recentInteractiveClientCount} recently active`
+                    : null,
+                ]
+                  .filter((item): item is string => Boolean(item))
+                  .join(" · ");
+        line += `\n   tmux presence: ${presenceSummary}`;
       }
 
       if (meta?.skinTheme) {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -27,6 +27,7 @@ import { isBroadcastChannelTarget } from "./broker/agent-messaging.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
 import type { RalphSnoozeStatus } from "./ralph-loop.js";
+import { inspectBrokerManagedTmuxSessionPresence } from "./tmux-presence.js";
 import type {
   PortLeaseAcquireInput,
   PortLeaseInfo,
@@ -823,6 +824,30 @@ function getAgentRole(agent: AgentDisplayInfo): string | undefined {
   return getRecordString(agent.metadata, "role");
 }
 
+function getBrokerManagedTmuxSession(agent: AgentDisplayInfo): string | undefined {
+  const metadata = agent.metadata;
+  if (!metadata?.brokerManaged) return undefined;
+  if (metadata.launchSource !== "broker-tmux") return undefined;
+  if (!metadata.brokerManagedBy) return undefined;
+  return metadata.tmuxSession;
+}
+
+function addBrokerManagedTmuxPresence(agents: AgentDisplayInfo[]): AgentDisplayInfo[] {
+  const targets = agents.flatMap((agent) => {
+    const session = getBrokerManagedTmuxSession(agent);
+    if (!session || agent.pid == null) return [];
+    return [{ session, pid: agent.pid }];
+  });
+  if (targets.length === 0) return agents;
+
+  const presenceBySession = inspectBrokerManagedTmuxSessionPresence(targets);
+  return agents.map((agent) => {
+    const session = getBrokerManagedTmuxSession(agent);
+    const tmuxPresence = session ? presenceBySession.get(session) : undefined;
+    return tmuxPresence ? { ...agent, tmuxPresence } : agent;
+  });
+}
+
 function buildCompactAgentDetails(
   agents: AgentDisplayInfo[],
   hint: PinetAgentsRoutingHint,
@@ -844,6 +869,7 @@ function buildCompactAgentDetails(
         brokerManaged: agent.metadata?.brokerManaged === true,
         launchSource: agent.metadata?.launchSource ?? null,
         tmuxSession: agent.metadata?.tmuxSession ?? null,
+        ...(agent.tmuxPresence ? { tmuxPresence: agent.tmuxPresence } : {}),
         routingScore: agent.routingScore ?? null,
         ...(agent.pendingInboxCount != null && agent.pendingInboxCount > 0
           ? { pendingInboxCount: agent.pendingInboxCount }
@@ -1277,7 +1303,11 @@ function runPinetAgentsAction(
       includeGhosts,
       recentDisconnectWindowMs: recentGhostWindowMs,
     }).map(toDisplay);
-    const agents = rankAgentsForRouting(visibleAgents, hint);
+    const agentsWithTmuxPresence =
+      deps.brokerRole() === "broker" && output.full
+        ? addBrokerManagedTmuxPresence(visibleAgents)
+        : visibleAgents;
+    const agents = rankAgentsForRouting(agentsWithTmuxPresence, hint);
     const header = hasHint && output.full ? `${buildPinetAgentsHintText(hint)}\n\n` : "";
     const text = `${header}${
       output.full ? formatAgentList(agents, os.homedir()) : formatCompactAgentList(agents, hint)

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -836,14 +836,13 @@ function addBrokerManagedTmuxPresence(agents: AgentDisplayInfo[]): AgentDisplayI
   const targets = agents.flatMap((agent) => {
     const session = getBrokerManagedTmuxSession(agent);
     if (!session || agent.pid == null) return [];
-    return [{ session, pid: agent.pid }];
+    return [{ id: agent.id, session, pid: agent.pid }];
   });
   if (targets.length === 0) return agents;
 
-  const presenceBySession = inspectBrokerManagedTmuxSessionPresence(targets);
+  const presenceByAgentId = inspectBrokerManagedTmuxSessionPresence(targets);
   return agents.map((agent) => {
-    const session = getBrokerManagedTmuxSession(agent);
-    const tmuxPresence = session ? presenceBySession.get(session) : undefined;
+    const tmuxPresence = presenceByAgentId.get(agent.id);
     return tmuxPresence ? { ...agent, tmuxPresence } : agent;
   });
 }

--- a/slack-bridge/tmux-presence.test.ts
+++ b/slack-bridge/tmux-presence.test.ts
@@ -145,4 +145,64 @@ describe("tmux presence helpers", () => {
     });
     expect(execFileSync).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps broker-managed presence keyed to each agent id for reused sessions", () => {
+    const execFileSync = vi
+      .fn()
+      .mockReturnValueOnce("101\n")
+      .mockReturnValueOnce("worker-one\t1\n")
+      .mockReturnValueOnce("worker-one\t10\t0\n");
+
+    const result = inspectBrokerManagedTmuxSessionPresence(
+      [
+        { id: "active-agent", session: "worker-one", pid: 101 },
+        { id: "stale-agent", session: "worker-one", pid: 202 },
+      ],
+      {
+        execFileSync,
+        now: () => 10_000,
+      },
+    );
+
+    expect(result.get("active-agent")).toMatchObject({
+      session: "worker-one",
+      status: "attached",
+      interactiveClientCount: 1,
+      latestInteractiveClientActivityAt: "1970-01-01T00:00:10.000Z",
+    });
+    expect(result.get("stale-agent")).toEqual({
+      session: "worker-one",
+      status: "unknown",
+      attachedClientCount: 0,
+      interactiveClientCount: 0,
+      controlClientCount: 0,
+      recentInteractiveClientCount: 0,
+      probedAt: "1970-01-01T00:00:10.000Z",
+      error: "tmux_session_not_verified_for_agent_pid",
+    });
+    expect(execFileSync).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports tmux probe failures separately from broker-managed pid mismatches", () => {
+    const execFileSync = vi.fn(() => {
+      throw new Error("tmux unavailable");
+    });
+
+    const result = inspectBrokerManagedTmuxSessionPresence([{ session: "worker-one", pid: 101 }], {
+      execFileSync,
+      now: () => 10_000,
+    });
+
+    expect(result.get("worker-one")).toEqual({
+      session: "worker-one",
+      status: "unknown",
+      attachedClientCount: 0,
+      interactiveClientCount: 0,
+      controlClientCount: 0,
+      recentInteractiveClientCount: 0,
+      probedAt: "1970-01-01T00:00:10.000Z",
+      error: "tmux_probe_failed",
+    });
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+  });
 });

--- a/slack-bridge/tmux-presence.test.ts
+++ b/slack-bridge/tmux-presence.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  inspectBrokerManagedTmuxSessionPresence,
+  inspectTmuxSessionPresence,
+  parseTmuxListClients,
+  parseTmuxListSessions,
+  parseTmuxPanePids,
+  summarizeTmuxSessionPresence,
+} from "./tmux-presence.js";
+
+describe("tmux presence helpers", () => {
+  it("parses tmux session attachment counts", () => {
+    expect(parseTmuxListSessions("worker-one\t0\nworker-two\t2\nmalformed\n")).toEqual([
+      { session: "worker-one", attachedClientCount: 0 },
+      { session: "worker-two", attachedClientCount: 2 },
+    ]);
+  });
+
+  it("parses tmux clients without exposing terminal details", () => {
+    expect(parseTmuxListClients("worker-one\t100\t0\nworker-one\t101\t1\n")).toEqual([
+      { session: "worker-one", activityAtMs: 100_000, controlMode: false },
+      { session: "worker-one", activityAtMs: 101_000, controlMode: true },
+    ]);
+  });
+
+  it("parses pane pids for broker-managed ownership checks", () => {
+    expect(parseTmuxPanePids("101\nnot-a-pid\n1\n202\n")).toEqual([101, 202]);
+  });
+
+  it("summarizes only explicitly allowed sessions", () => {
+    const result = summarizeTmuxSessionPresence(
+      ["worker-one"],
+      [
+        { session: "worker-one", attachedClientCount: 2 },
+        { session: "private-shell", attachedClientCount: 1 },
+      ],
+      [
+        { session: "worker-one", activityAtMs: 1_000, controlMode: false },
+        { session: "worker-one", activityAtMs: 2_000, controlMode: true },
+        { session: "private-shell", activityAtMs: 3_000, controlMode: false },
+      ],
+      2_000,
+    );
+
+    expect(result.get("worker-one")).toEqual({
+      session: "worker-one",
+      status: "attached",
+      attachedClientCount: 2,
+      interactiveClientCount: 1,
+      controlClientCount: 1,
+      recentInteractiveClientCount: 1,
+      latestClientActivityAt: "1970-01-01T00:00:02.000Z",
+      latestInteractiveClientActivityAt: "1970-01-01T00:00:01.000Z",
+      probedAt: "1970-01-01T00:00:02.000Z",
+    });
+    expect(result.has("private-shell")).toBe(false);
+  });
+
+  it("marks mapped sessions missing from tmux as unknown", () => {
+    const result = summarizeTmuxSessionPresence(["missing-worker"], [], [], 1_000);
+
+    expect(result.get("missing-worker")).toMatchObject({
+      session: "missing-worker",
+      status: "unknown",
+      error: "tmux_session_not_found",
+    });
+  });
+
+  it("fails closed when tmux cannot be inspected", () => {
+    const execFileSync = vi.fn(() => {
+      throw new Error("tmux unavailable");
+    });
+
+    const result = inspectTmuxSessionPresence(["worker-one"], {
+      execFileSync,
+      now: () => 10_000,
+    });
+
+    expect(result.get("worker-one")).toEqual({
+      session: "worker-one",
+      status: "unknown",
+      attachedClientCount: 0,
+      interactiveClientCount: 0,
+      controlClientCount: 0,
+      recentInteractiveClientCount: 0,
+      probedAt: "1970-01-01T00:00:10.000Z",
+      error: "tmux_probe_failed",
+    });
+  });
+
+  it("uses session attachment counts when list-clients has no rows", () => {
+    const execFileSync = vi.fn().mockReturnValueOnce("worker-one\t1\n").mockReturnValueOnce("");
+
+    const result = inspectTmuxSessionPresence(["worker-one"], {
+      execFileSync,
+      now: () => 10_000,
+    });
+
+    expect(result.get("worker-one")).toMatchObject({
+      session: "worker-one",
+      status: "attached",
+      attachedClientCount: 1,
+      interactiveClientCount: 0,
+      controlClientCount: 0,
+    });
+  });
+
+  it("requires a broker-managed target pid to own a pane before reporting clients", () => {
+    const execFileSync = vi
+      .fn()
+      .mockReturnValueOnce("101\n")
+      .mockReturnValueOnce("worker-one\t1\n")
+      .mockReturnValueOnce("worker-one\t10\t0\n");
+
+    const result = inspectBrokerManagedTmuxSessionPresence([{ session: "worker-one", pid: 101 }], {
+      execFileSync,
+      now: () => 10_000,
+    });
+
+    expect(result.get("worker-one")).toMatchObject({
+      session: "worker-one",
+      status: "attached",
+      interactiveClientCount: 1,
+      latestInteractiveClientActivityAt: "1970-01-01T00:00:10.000Z",
+    });
+  });
+
+  it("fails closed when the claimed broker-managed pid is not a pane owner", () => {
+    const execFileSync = vi.fn().mockReturnValueOnce("202\n");
+
+    const result = inspectBrokerManagedTmuxSessionPresence([{ session: "worker-one", pid: 101 }], {
+      execFileSync,
+      now: () => 10_000,
+    });
+
+    expect(result.get("worker-one")).toEqual({
+      session: "worker-one",
+      status: "unknown",
+      attachedClientCount: 0,
+      interactiveClientCount: 0,
+      controlClientCount: 0,
+      recentInteractiveClientCount: 0,
+      probedAt: "1970-01-01T00:00:10.000Z",
+      error: "tmux_session_not_verified_for_agent_pid",
+    });
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/slack-bridge/tmux-presence.ts
+++ b/slack-bridge/tmux-presence.ts
@@ -32,6 +32,7 @@ export interface InspectTmuxPresenceDeps {
 }
 
 export interface BrokerManagedTmuxPresenceTarget {
+  id?: string;
   session: string;
   pid: number;
 }
@@ -176,29 +177,33 @@ export function summarizeTmuxSessionPresence(
   return result;
 }
 
+function buildUnknownPresenceInfo(
+  session: string,
+  nowMs: number,
+  error: string,
+): TmuxSessionPresenceInfo {
+  return {
+    session,
+    status: "unknown",
+    attachedClientCount: 0,
+    interactiveClientCount: 0,
+    controlClientCount: 0,
+    recentInteractiveClientCount: 0,
+    probedAt: new Date(nowMs).toISOString(),
+    error,
+  };
+}
+
 function buildUnknownPresence(
   sessionNames: Iterable<string>,
   nowMs: number,
   error: string,
 ): Map<string, TmuxSessionPresenceInfo> {
-  const probedAt = new Date(nowMs).toISOString();
   return new Map(
     Array.from(sessionNames)
       .map((session) => session.trim())
       .filter((session) => session.length > 0)
-      .map((session) => [
-        session,
-        {
-          session,
-          status: "unknown" as const,
-          attachedClientCount: 0,
-          interactiveClientCount: 0,
-          controlClientCount: 0,
-          recentInteractiveClientCount: 0,
-          probedAt,
-          error,
-        },
-      ]),
+      .map((session) => [session, buildUnknownPresenceInfo(session, nowMs, error)]),
   );
 }
 
@@ -303,13 +308,61 @@ export function inspectBrokerManagedTmuxSessionPresence(
   targets: Iterable<BrokerManagedTmuxPresenceTarget>,
   deps: InspectTmuxPresenceDeps = {},
 ): Map<string, TmuxSessionPresenceInfo> {
-  const pidsBySession = new Map<string, Set<number>>();
+  const nowMs = deps.now?.() ?? Date.now();
+  const exec = deps.execFileSync ?? execFileSync;
+  const result = new Map<string, TmuxSessionPresenceInfo>();
+  const verifiedKeysBySession = new Map<string, string[]>();
+  const panePidsBySession = new Map<string, number[] | null>();
+
   for (const target of targets) {
     const session = target.session.trim();
-    if (!session || !Number.isInteger(target.pid) || target.pid <= 1) continue;
-    const pids = pidsBySession.get(session) ?? new Set<number>();
-    pids.add(target.pid);
-    pidsBySession.set(session, pids);
+    const key = target.id?.trim() || session;
+    if (!session || !key || !Number.isInteger(target.pid) || target.pid <= 1) continue;
+
+    let panePids = panePidsBySession.get(session);
+    if (panePids === undefined) {
+      try {
+        const panesOutput = exec("tmux", ["list-panes", "-t", session, "-F", LIST_PANES_FORMAT], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }) as string;
+        panePids = parseTmuxPanePids(panesOutput);
+      } catch {
+        panePids = null;
+      }
+      panePidsBySession.set(session, panePids);
+    }
+
+    if (panePids === null) {
+      result.set(key, buildUnknownPresenceInfo(session, nowMs, "tmux_probe_failed"));
+      continue;
+    }
+
+    if (!panePids.includes(target.pid)) {
+      result.set(
+        key,
+        buildUnknownPresenceInfo(session, nowMs, "tmux_session_not_verified_for_agent_pid"),
+      );
+      continue;
+    }
+
+    const verifiedKeys = verifiedKeysBySession.get(session) ?? [];
+    verifiedKeys.push(key);
+    verifiedKeysBySession.set(session, verifiedKeys);
   }
-  return inspectAllowedTmuxSessions([...pidsBySession.keys()], deps, pidsBySession);
+
+  const verifiedPresenceBySession = inspectAllowedTmuxSessions([...verifiedKeysBySession.keys()], {
+    ...deps,
+    now: () => nowMs,
+  });
+  for (const [session, keys] of verifiedKeysBySession) {
+    const presence =
+      verifiedPresenceBySession.get(session) ??
+      buildUnknownPresenceInfo(session, nowMs, "tmux_session_not_found");
+    for (const key of keys) {
+      result.set(key, presence);
+    }
+  }
+
+  return result;
 }

--- a/slack-bridge/tmux-presence.ts
+++ b/slack-bridge/tmux-presence.ts
@@ -1,0 +1,315 @@
+import { execFileSync } from "node:child_process";
+
+export type TmuxSessionPresenceStatus = "attached" | "detached" | "unknown";
+
+export interface TmuxClientSnapshot {
+  session: string;
+  activityAtMs: number | null;
+  controlMode: boolean;
+}
+
+export interface TmuxSessionSnapshot {
+  session: string;
+  attachedClientCount: number;
+}
+
+export interface TmuxSessionPresenceInfo {
+  session: string;
+  status: TmuxSessionPresenceStatus;
+  attachedClientCount: number;
+  interactiveClientCount: number;
+  controlClientCount: number;
+  recentInteractiveClientCount: number;
+  latestClientActivityAt?: string;
+  latestInteractiveClientActivityAt?: string;
+  probedAt: string;
+  error?: string;
+}
+
+export interface InspectTmuxPresenceDeps {
+  execFileSync?: typeof execFileSync;
+  now?: () => number;
+}
+
+export interface BrokerManagedTmuxPresenceTarget {
+  session: string;
+  pid: number;
+}
+
+export const DEFAULT_RECENT_TMUX_CLIENT_ACTIVITY_MS = 5 * 60 * 1000;
+
+const LIST_SESSIONS_FORMAT = "#{session_name}\t#{session_attached}";
+const LIST_CLIENTS_FORMAT = "#{client_session}\t#{client_activity}\t#{client_control_mode}";
+const LIST_PANES_FORMAT = "#{pane_pid}";
+
+function parseNonNegativeInteger(value: string | undefined): number | null {
+  if (value == null || value.trim().length === 0) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+function parseEpochSecondsMs(value: string | undefined): number | null {
+  const parsed = parseNonNegativeInteger(value);
+  return parsed == null ? null : parsed * 1000;
+}
+
+function parseTmuxBoolean(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+export function parseTmuxListSessions(output: string): TmuxSessionSnapshot[] {
+  return output
+    .split(/\r?\n/u)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+    .flatMap((line) => {
+      const [session, attached] = line.split("\t");
+      if (!session || session.trim().length === 0) return [];
+      const attachedClientCount = parseNonNegativeInteger(attached);
+      if (attachedClientCount == null) return [];
+      return [{ session, attachedClientCount }];
+    });
+}
+
+export function parseTmuxListClients(output: string): TmuxClientSnapshot[] {
+  return output
+    .split(/\r?\n/u)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+    .flatMap((line) => {
+      const [session, activity, controlMode] = line.split("\t");
+      if (!session || session.trim().length === 0) return [];
+      return [
+        {
+          session,
+          activityAtMs: parseEpochSecondsMs(activity),
+          controlMode: parseTmuxBoolean(controlMode),
+        },
+      ];
+    });
+}
+
+export function parseTmuxPanePids(output: string): number[] {
+  return output
+    .split(/\r?\n/u)
+    .map((line) => parseNonNegativeInteger(line.trim()))
+    .filter((pid): pid is number => pid != null && pid > 1);
+}
+
+export function summarizeTmuxSessionPresence(
+  sessionNames: Iterable<string>,
+  sessions: TmuxSessionSnapshot[],
+  clients: TmuxClientSnapshot[],
+  nowMs: number,
+  recentActivityMs = DEFAULT_RECENT_TMUX_CLIENT_ACTIVITY_MS,
+): Map<string, TmuxSessionPresenceInfo> {
+  const probedAt = new Date(nowMs).toISOString();
+  const allowedSessions = new Set(
+    Array.from(sessionNames)
+      .map((session) => session.trim())
+      .filter((session) => session.length > 0),
+  );
+  const sessionsByName = new Map(sessions.map((session) => [session.session, session]));
+  const clientsBySession = new Map<string, TmuxClientSnapshot[]>();
+
+  for (const client of clients) {
+    if (!allowedSessions.has(client.session)) continue;
+    const existing = clientsBySession.get(client.session) ?? [];
+    existing.push(client);
+    clientsBySession.set(client.session, existing);
+  }
+
+  const result = new Map<string, TmuxSessionPresenceInfo>();
+  for (const session of allowedSessions) {
+    const snapshot = sessionsByName.get(session);
+    if (!snapshot) {
+      result.set(session, {
+        session,
+        status: "unknown",
+        attachedClientCount: 0,
+        interactiveClientCount: 0,
+        controlClientCount: 0,
+        recentInteractiveClientCount: 0,
+        probedAt,
+        error: "tmux_session_not_found",
+      });
+      continue;
+    }
+
+    const sessionClients = clientsBySession.get(session) ?? [];
+    const interactiveClients = sessionClients.filter((client) => !client.controlMode);
+    const controlClientCount = sessionClients.length - interactiveClients.length;
+    const recentInteractiveClientCount = interactiveClients.filter(
+      (client) => client.activityAtMs != null && nowMs - client.activityAtMs <= recentActivityMs,
+    ).length;
+    const latestClientActivityMs = Math.max(
+      ...sessionClients.map((client) => client.activityAtMs ?? Number.NEGATIVE_INFINITY),
+    );
+    const latestInteractiveClientActivityMs = Math.max(
+      ...interactiveClients.map((client) => client.activityAtMs ?? Number.NEGATIVE_INFINITY),
+    );
+    const attachedClientCount = Math.max(snapshot.attachedClientCount, sessionClients.length);
+
+    result.set(session, {
+      session,
+      status: attachedClientCount > 0 ? "attached" : "detached",
+      attachedClientCount,
+      interactiveClientCount: interactiveClients.length,
+      controlClientCount,
+      recentInteractiveClientCount,
+      ...(Number.isFinite(latestClientActivityMs)
+        ? { latestClientActivityAt: new Date(latestClientActivityMs).toISOString() }
+        : {}),
+      ...(Number.isFinite(latestInteractiveClientActivityMs)
+        ? {
+            latestInteractiveClientActivityAt: new Date(
+              latestInteractiveClientActivityMs,
+            ).toISOString(),
+          }
+        : {}),
+      probedAt,
+    });
+  }
+
+  return result;
+}
+
+function buildUnknownPresence(
+  sessionNames: Iterable<string>,
+  nowMs: number,
+  error: string,
+): Map<string, TmuxSessionPresenceInfo> {
+  const probedAt = new Date(nowMs).toISOString();
+  return new Map(
+    Array.from(sessionNames)
+      .map((session) => session.trim())
+      .filter((session) => session.length > 0)
+      .map((session) => [
+        session,
+        {
+          session,
+          status: "unknown" as const,
+          attachedClientCount: 0,
+          interactiveClientCount: 0,
+          controlClientCount: 0,
+          recentInteractiveClientCount: 0,
+          probedAt,
+          error,
+        },
+      ]),
+  );
+}
+
+function normalizeSessionNames(sessionNames: Iterable<string>): string[] {
+  return Array.from(
+    new Set(
+      Array.from(sessionNames)
+        .map((session) => session.trim())
+        .filter((session) => session.length > 0),
+    ),
+  );
+}
+
+function inspectAllowedTmuxSessions(
+  allowedSessions: string[],
+  deps: InspectTmuxPresenceDeps,
+  verifiedPidsBySession?: Map<string, Set<number>>,
+): Map<string, TmuxSessionPresenceInfo> {
+  const nowMs = deps.now?.() ?? Date.now();
+  if (allowedSessions.length === 0) return new Map();
+
+  const exec = deps.execFileSync ?? execFileSync;
+  const sessions: TmuxSessionSnapshot[] = [];
+  const clients: TmuxClientSnapshot[] = [];
+  const unverifiedSessions = new Set<string>();
+  let failedSessionProbeCount = 0;
+
+  for (const session of allowedSessions) {
+    const verifiedPids = verifiedPidsBySession?.get(session);
+    if (verifiedPids) {
+      let panePids: number[];
+      try {
+        const panesOutput = exec("tmux", ["list-panes", "-t", session, "-F", LIST_PANES_FORMAT], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }) as string;
+        panePids = parseTmuxPanePids(panesOutput);
+      } catch {
+        unverifiedSessions.add(session);
+        continue;
+      }
+      if (!panePids.some((pid) => verifiedPids.has(pid))) {
+        unverifiedSessions.add(session);
+        continue;
+      }
+    }
+
+    try {
+      const sessionOutput = exec(
+        "tmux",
+        ["display-message", "-p", "-t", session, LIST_SESSIONS_FORMAT],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ) as string;
+      sessions.push(...parseTmuxListSessions(sessionOutput));
+    } catch {
+      failedSessionProbeCount += 1;
+      continue;
+    }
+
+    try {
+      const clientsOutput = exec(
+        "tmux",
+        ["list-clients", "-t", session, "-F", LIST_CLIENTS_FORMAT],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ) as string;
+      clients.push(...parseTmuxListClients(clientsOutput));
+    } catch {
+      // A session can exist with no attached clients; that is a detached session, not a failure.
+    }
+  }
+
+  if (failedSessionProbeCount === allowedSessions.length && unverifiedSessions.size === 0) {
+    return buildUnknownPresence(allowedSessions, nowMs, "tmux_probe_failed");
+  }
+
+  const result = summarizeTmuxSessionPresence(allowedSessions, sessions, clients, nowMs);
+  const unverified = buildUnknownPresence(
+    unverifiedSessions,
+    nowMs,
+    "tmux_session_not_verified_for_agent_pid",
+  );
+  for (const [session, presence] of unverified) {
+    result.set(session, presence);
+  }
+  return result;
+}
+
+export function inspectTmuxSessionPresence(
+  sessionNames: Iterable<string>,
+  deps: InspectTmuxPresenceDeps = {},
+): Map<string, TmuxSessionPresenceInfo> {
+  return inspectAllowedTmuxSessions(normalizeSessionNames(sessionNames), deps);
+}
+
+export function inspectBrokerManagedTmuxSessionPresence(
+  targets: Iterable<BrokerManagedTmuxPresenceTarget>,
+  deps: InspectTmuxPresenceDeps = {},
+): Map<string, TmuxSessionPresenceInfo> {
+  const pidsBySession = new Map<string, Set<number>>();
+  for (const target of targets) {
+    const session = target.session.trim();
+    if (!session || !Number.isInteger(target.pid) || target.pid <= 1) continue;
+    const pids = pidsBySession.get(session) ?? new Set<number>();
+    pids.add(target.pid);
+    pidsBySession.set(session, pids);
+  }
+  return inspectAllowedTmuxSessions([...pidsBySession.keys()], deps, pidsBySession);
+}


### PR DESCRIPTION
## Summary
- Add a read-only tmux presence probe for broker-managed Pinet follower sessions in `/pinet agents --full` output.
- Restrict probing to broker-mode, explicit `broker-tmux` metadata, recorded agent PIDs, and a matching tmux pane PID before reporting any client presence.
- Report conservative counts/status only (interactive/control client counts, recent activity count, unknown/fail-closed errors), without TTY/client identity details.

Closes #770.
Slack thread: `1780474385.588819`.

## Safety / limitations
- This detects attached tmux clients and recent tmux client activity; it does not prove a specific human is present or attentive.
- If tmux is unavailable, the session is missing, or the registered agent PID does not own a pane, presence reports `unknown` rather than inspecting/reporting client details.
- Default compact `pinet agents` output does not run the tmux probe; full output is required.

## Validation
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- `pnpm --filter @gugu910/pi-slack-bridge build`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`
- local subagent review: final pass found no blockers
