### PR TITLE
Replace Slack proxy RPC with adapter capabilities

### DIFF
--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -335,6 +335,10 @@ import type {
   InboundMessage as _InboundMessage,
   NormalizedMessageContent as _NormalizedMessageContent,
   OutboundMessage as _OutboundMessage,
+  AdapterCapabilityRequest as _AdapterCapabilityRequest,
+  AdapterCapabilityResult as _AdapterCapabilityResult,
+  AdapterCapabilityEffects as _AdapterCapabilityEffects,
+  AdapterThreadClaimEffect as _AdapterThreadClaimEffect,
   MessageAdapter as _MessageAdapter,
   RuntimeScopeCarrier as _RuntimeScopeCarrier,
   WorkspaceInstallScopeCarrier as _WorkspaceInstallScopeCarrier,
@@ -344,6 +348,10 @@ import type {
 export type InboundMessage = _InboundMessage;
 export type NormalizedMessageContent = _NormalizedMessageContent;
 export type OutboundMessage = _OutboundMessage;
+export type AdapterCapabilityRequest = _AdapterCapabilityRequest;
+export type AdapterCapabilityResult = _AdapterCapabilityResult;
+export type AdapterCapabilityEffects = _AdapterCapabilityEffects;
+export type AdapterThreadClaimEffect = _AdapterThreadClaimEffect;
 export type MessageAdapter = _MessageAdapter;
 export type RuntimeScopeCarrier = _RuntimeScopeCarrier;
 export type WorkspaceInstallScopeCarrier = _WorkspaceInstallScopeCarrier;

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1979,6 +1979,51 @@ describe("SlackAdapter — send", () => {
     });
   }
 
+  it("invokes Slack API calls through the adapter capability boundary", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ messages: [{ text: "hello" }] }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+
+    const response = await adapter.invokeCapability({
+      capability: "api.call",
+      params: {
+        method: "conversations.history",
+        params: { channel: "C123", limit: 1 },
+      },
+    });
+
+    expect(response.result).toEqual({ ok: true, messages: [{ text: "hello" }] });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://slack.com/api/conversations.history");
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("channel")).toBe("C123");
+    expect(body.get("limit")).toBe("1");
+  });
+
+  it("returns thread-claim effects for Slack postMessage capability calls", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ ts: "123.456", channel: "C123" }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+
+    const response = await adapter.invokeCapability({
+      capability: "api.call",
+      params: {
+        method: "chat.postMessage",
+        params: { channel: "C123", text: "hello" },
+      },
+    });
+
+    expect(response.effects).toEqual({
+      claimThread: { threadId: "123.456", channel: "C123" },
+    });
+  });
+
   it("calls chat.postMessage with correct body", async () => {
     fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -38,7 +38,13 @@ import {
   DEFAULT_SLACK_THREAD_STATUS,
   SlackThreadStatusManager,
 } from "../../slack-thread-status.js";
-import type { InboundMessage, OutboundMessage, MessageAdapter } from "./types.js";
+import type {
+  AdapterCapabilityRequest,
+  AdapterCapabilityResult,
+  InboundMessage,
+  OutboundMessage,
+  MessageAdapter,
+} from "./types.js";
 
 export {
   classifyMessage,
@@ -183,6 +189,29 @@ export class SlackAdapter implements MessageAdapter {
     this.inboundHandler = handler;
   }
 
+  async invokeCapability(request: AdapterCapabilityRequest): Promise<AdapterCapabilityResult> {
+    if (request.capability !== "api.call") {
+      throw new Error(`Unsupported Slack adapter capability: ${request.capability}`);
+    }
+
+    const method = typeof request.params.method === "string" ? request.params.method.trim() : "";
+    if (!method) {
+      throw new Error("method is required for Slack api.call capability");
+    }
+
+    const body =
+      request.params.params &&
+      typeof request.params.params === "object" &&
+      !Array.isArray(request.params.params)
+        ? (request.params.params as Record<string, unknown>)
+        : {};
+    const result = await this.callSlack(method, this.config.botToken, body);
+    return {
+      result,
+      ...this.buildSlackApiCapabilityEffects(method, body, result),
+    };
+  }
+
   async send(msg: OutboundMessage): Promise<void> {
     const contentSlackBlocks = msg.content?.slackBlocks;
     const slackBlocks =
@@ -224,6 +253,38 @@ export class SlackAdapter implements MessageAdapter {
     }
 
     void this.clearThreadStatus(msg.channel, msg.threadId);
+  }
+
+  private buildSlackApiCapabilityEffects(
+    method: string,
+    body: Record<string, unknown>,
+    result: Record<string, unknown>,
+  ): Pick<AdapterCapabilityResult, "effects"> {
+    if (method !== "chat.postMessage") {
+      return {};
+    }
+
+    const threadTs = typeof body.thread_ts === "string" ? body.thread_ts : "";
+    const messageTs = typeof result.ts === "string" ? result.ts : "";
+    const channel =
+      typeof body.channel === "string"
+        ? body.channel
+        : typeof result.channel === "string"
+          ? result.channel
+          : undefined;
+    const threadId = threadTs || messageTs;
+    if (!threadId) {
+      return {};
+    }
+
+    return {
+      effects: {
+        claimThread: {
+          threadId,
+          ...(channel ? { channel } : {}),
+        },
+      },
+    };
   }
 
   getBotUserId(): string | null {

--- a/slack-bridge/broker/adapters/types.ts
+++ b/slack-bridge/broker/adapters/types.ts
@@ -1,1 +1,7 @@
-export type { InboundMessage, OutboundMessage, MessageAdapter } from "@gugu910/pi-transport-core";
+export type {
+  AdapterCapabilityRequest,
+  AdapterCapabilityResult,
+  InboundMessage,
+  OutboundMessage,
+  MessageAdapter,
+} from "@gugu910/pi-transport-core";

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -1216,7 +1216,7 @@ describe("BrokerClient — scheduleWakeup", () => {
     client.disconnect();
   });
 });
-describe("BrokerClient — slackProxy", () => {
+describe("BrokerClient — adapter capabilities", () => {
   let mock: MockServer;
 
   beforeEach(async () => {
@@ -1227,7 +1227,38 @@ describe("BrokerClient — slackProxy", () => {
     await mock.close();
   });
 
-  it("sends slack.proxy RPC with method and params", async () => {
+  it("sends adapter.capability RPC with adapter, capability, and params", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const capabilityPromise = client.invokeAdapterCapability("slack", "api.call", {
+      method: "conversations.history",
+      params: {
+        channel: "C123",
+        limit: 10,
+      },
+    });
+
+    await waitFor(() => mock.received.length > 0);
+    const req = JSON.parse(mock.received[0]) as {
+      id: number;
+      method: string;
+      params: { adapter: string; capability: string; params: Record<string, unknown> };
+    };
+    expect(req.method).toBe("adapter.capability");
+    expect(req.params.adapter).toBe("slack");
+    expect(req.params.capability).toBe("api.call");
+    expect(req.params.params.method).toBe("conversations.history");
+
+    mock.respondTo(mock.connections[0], req.id, { messages: [] });
+
+    const result = await capabilityPromise;
+    expect(result).toEqual({ messages: [] });
+
+    client.disconnect();
+  });
+
+  it("maps slackProxy compatibility calls onto adapter.capability", async () => {
     const client = new BrokerClient(mock.connectOpts);
     await client.connect();
 
@@ -1240,13 +1271,52 @@ describe("BrokerClient — slackProxy", () => {
     const req = JSON.parse(mock.received[0]) as {
       id: number;
       method: string;
-      params: { method: string; params: Record<string, unknown> };
+      params: { adapter: string; capability: string; params: Record<string, unknown> };
     };
-    expect(req.method).toBe("slack.proxy");
-    expect(req.params.method).toBe("conversations.history");
-    expect(req.params.params.channel).toBe("C123");
+    expect(req.method).toBe("adapter.capability");
+    expect(req.params.adapter).toBe("slack");
+    expect(req.params.capability).toBe("api.call");
+    expect(req.params.params.method).toBe("conversations.history");
+    expect((req.params.params.params as Record<string, unknown>).channel).toBe("C123");
 
     mock.respondTo(mock.connections[0], req.id, { messages: [] });
+
+    const result = await proxyPromise;
+    expect(result).toEqual({ messages: [] });
+
+    client.disconnect();
+  });
+
+  it("falls back to legacy slack.proxy when an older broker lacks adapter.capability", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+    await client.connect();
+
+    const proxyPromise = client.slackProxy("conversations.history", {
+      channel: "C123",
+      limit: 10,
+    });
+
+    await waitFor(() => mock.received.length > 0);
+    const firstReq = JSON.parse(mock.received[0]) as { id: number; method: string };
+    expect(firstReq.method).toBe("adapter.capability");
+    mock.respondError(
+      mock.connections[0],
+      firstReq.id,
+      RPC_METHOD_NOT_FOUND,
+      "Unknown method: adapter.capability",
+    );
+
+    await waitFor(() => mock.received.length > 1);
+    const fallbackReq = JSON.parse(mock.received[1]) as {
+      id: number;
+      method: string;
+      params: { method: string; params: Record<string, unknown> };
+    };
+    expect(fallbackReq.method).toBe("slack.proxy");
+    expect(fallbackReq.params.method).toBe("conversations.history");
+    expect(fallbackReq.params.params.channel).toBe("C123");
+
+    mock.respondTo(mock.connections[0], fallbackReq.id, { messages: [] });
 
     const result = await proxyPromise;
     expect(result).toEqual({ messages: [] });

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -647,17 +647,39 @@ export class BrokerClient {
     return result;
   }
 
-  // ─── Slack proxy (read-through) ──────────────────────
+  // ─── Adapter capabilities ───────────────────────────
 
+  async invokeAdapterCapability(
+    adapter: string,
+    capability: string,
+    params: Record<string, unknown> = {},
+  ): Promise<Record<string, unknown>> {
+    const result = (await this.request("adapter.capability", {
+      adapter,
+      capability,
+      params,
+    })) as Record<string, unknown>;
+    return result;
+  }
+
+  /**
+   * Compatibility wrapper for callers that still need direct Slack API access.
+   * The broker RPC boundary remains adapter-neutral; Slack-specific payloads are
+   * interpreted inside the Slack adapter's api.call capability.
+   */
   async slackProxy(
     method: string,
     params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
-    const result = (await this.request("slack.proxy", { method, params })) as Record<
-      string,
-      unknown
-    >;
-    return result;
+    try {
+      return await this.invokeAdapterCapability("slack", "api.call", { method, params });
+    } catch (err) {
+      if (!isRpcMethodNotFoundError(err, "adapter.capability")) {
+        throw err;
+      }
+    }
+
+    return (await this.request("slack.proxy", { method, params })) as Record<string, unknown>;
   }
 
   // ─── Events ──────────────────────────────────────────

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -22,6 +22,8 @@ export type {
   InboxEntry,
   InboundMessage,
   OutboundMessage,
+  AdapterCapabilityRequest,
+  AdapterCapabilityResult,
   MessageAdapter,
   JsonRpcRequest,
   JsonRpcResponse,
@@ -98,7 +100,7 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
   const resolvedMeshSecret =
     meshSecret || (meshSecretPath ? loadOrCreateMeshSecret(meshSecretPath) : null);
 
-  const server = new BrokerSocketServer(db, target, undefined, {
+  const server = new BrokerSocketServer(db, target, {
     ...(resolvedMeshSecret ? { meshSecret: resolvedMeshSecret } : {}),
   });
   try {
@@ -119,6 +121,7 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
 
     addAdapter(adapter: MessageAdapter): void {
       adapters.push(adapter);
+      server.setOutboundMessageAdapters(adapters);
     },
 
     async stop(): Promise<void> {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -636,10 +636,14 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     client.disconnect();
     await server.stop();
 
-    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, undefined, {
-      heartbeatTimeoutMs: 50,
-      pruneIntervalMs: 10,
-    });
+    server = new BrokerSocketServer(
+      db,
+      { type: "tcp", host: "127.0.0.1", port: 0 },
+      {
+        heartbeatTimeoutMs: 50,
+        pruneIntervalMs: 10,
+      },
+    );
     await server.start();
 
     const info = server.getConnectInfo();
@@ -916,36 +920,89 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(after).toHaveLength(0);
   });
 
-  it("slack.proxy returns error when not configured", async () => {
-    await client.register("proxy-tester", "🔌");
-    await expect(client.slackProxy("chat.postMessage", { channel: "C1" })).rejects.toThrow(
-      "slack.proxy is not configured",
-    );
+  it("adapter.capability returns error when the adapter does not expose the capability", async () => {
+    await client.register("capability-tester", "🔌");
+    await expect(
+      client.invokeAdapterCapability("slack", "api.call", {
+        method: "chat.postMessage",
+        params: { channel: "C1" },
+      }),
+    ).rejects.toThrow("Adapter slack does not implement capability api.call");
   });
 
-  it("slack.proxy works when configured", async () => {
-    // Stop and recreate server with slack proxy function
-    client.disconnect();
-    await server.stop();
+  it("dispatches adapter.capability through the registered transport adapter", async () => {
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability: async ({ capability, params }) => ({
+          result: { ok: true, capability, echo: params },
+        }),
+      },
+    ]);
 
-    const slackProxy = async (method: string, params: Record<string, unknown>) => {
-      return { ok: true, method, echo: params };
-    };
+    await client.register("capability-agent", "🔌");
 
-    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, slackProxy);
-    await server.start();
+    const result = await client.invokeAdapterCapability("slack", "api.call", {
+      method: "conversations.history",
+      params: { channel: "C123" },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.capability).toBe("api.call");
+    expect(
+      ((result.echo as Record<string, unknown>).params as Record<string, unknown>).channel,
+    ).toBe("C123");
+  });
 
-    const info = server.getConnectInfo();
-    if (info.type !== "tcp") throw new Error("Expected TCP");
-    client = new BrokerClient({ host: info.host, port: info.port });
-    await client.connect();
+  it("keeps slackProxy as a compatibility wrapper over adapter.capability", async () => {
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability: async ({ capability, params }) => ({
+          result: { ok: true, capability, echo: params },
+        }),
+      },
+    ]);
 
     await client.register("proxy-agent", "🔌");
 
     const result = await client.slackProxy("conversations.history", { channel: "C123" });
     expect(result.ok).toBe(true);
-    expect(result.method).toBe("conversations.history");
-    expect((result.echo as Record<string, unknown>).channel).toBe("C123");
+    expect(result.capability).toBe("api.call");
+    expect((result.echo as Record<string, unknown>).method).toBe("conversations.history");
+  });
+
+  it("accepts legacy slack.proxy RPCs as a server-side Slack adapter alias", async () => {
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability: async ({ capability, params }) => ({
+          result: { ok: true, capability, echo: params },
+        }),
+      },
+    ]);
+
+    await client.register("legacy-proxy-agent", "🔌");
+    const rpcClient = client as unknown as {
+      request: (
+        method: string,
+        params: Record<string, unknown>,
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const result = await rpcClient.request("slack.proxy", {
+      method: "conversations.history",
+      params: { channel: "C123" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.capability).toBe("api.call");
+    expect((result.echo as Record<string, unknown>).method).toBe("conversations.history");
+    expect(
+      ((result.echo as Record<string, unknown>).params as Record<string, unknown>).channel,
+    ).toBe("C123");
   });
 
   it("message.send delivers through the registered transport adapter", async () => {
@@ -1133,21 +1190,31 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     await expect(client.resolveThread("missing-thread")).resolves.toBeNull();
   });
 
-  it("slack.proxy chat.postMessage auto-claims thread for calling agent", async () => {
+  it("adapter.capability effects auto-claim thread for calling agent", async () => {
     client.disconnect();
     await server.stop();
 
-    const slackProxy = async (_method: string, params: Record<string, unknown>) => {
-      // Simulate Slack chat.postMessage response
-      return {
-        ok: true,
-        ts: "new-msg-ts",
-        channel: params.channel,
-        message: { ts: "new-msg-ts", text: params.text },
-      };
-    };
-
-    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, slackProxy);
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 });
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability: async ({ params }) => {
+          const body = params.params as Record<string, unknown>;
+          return {
+            result: {
+              ok: true,
+              ts: "new-msg-ts",
+              channel: body.channel,
+              message: { ts: "new-msg-ts", text: body.text },
+            },
+            effects: {
+              claimThread: { threadId: "new-msg-ts", channel: body.channel as string },
+            },
+          };
+        },
+      },
+    ]);
     await server.start();
 
     const info = server.getConnectInfo();
@@ -1169,20 +1236,31 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(thread!.channel).toBe("C-AUTO");
   });
 
-  it("slack.proxy chat.postMessage with thread_ts claims the existing thread", async () => {
+  it("adapter.capability effects claim the existing thread", async () => {
     client.disconnect();
     await server.stop();
 
-    const slackProxy = async (_method: string, params: Record<string, unknown>) => {
-      return {
-        ok: true,
-        ts: "reply-ts",
-        channel: params.channel,
-        message: { ts: "reply-ts", text: params.text },
-      };
-    };
-
-    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, slackProxy);
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 });
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability: async ({ params }) => {
+          const body = params.params as Record<string, unknown>;
+          return {
+            result: {
+              ok: true,
+              ts: "reply-ts",
+              channel: body.channel,
+              message: { ts: "reply-ts", text: body.text },
+            },
+            effects: {
+              claimThread: { threadId: "existing-thread-ts", channel: body.channel as string },
+            },
+          };
+        },
+      },
+    ]);
     await server.start();
 
     const info = server.getConnectInfo();
@@ -1209,15 +1287,20 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(db.getThread("reply-ts")).toBeNull();
   });
 
-  it("slack.proxy non-postMessage methods do not claim threads", async () => {
+  it("adapter.capability calls without claim effects do not claim threads", async () => {
     client.disconnect();
     await server.stop();
 
-    const slackProxy = async (method: string, _params: Record<string, unknown>) => {
-      return { ok: true, method, ts: "some-ts" };
-    };
-
-    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, slackProxy);
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 });
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability: async ({ params }) => ({
+          result: { ok: true, method: params.method, ts: "some-ts" },
+        }),
+      },
+    ]);
     await server.start();
 
     const info = server.getConnectInfo();
@@ -1646,10 +1729,14 @@ describe("broker integration — mesh auth", () => {
     dir = tmpDir();
     db = new BrokerDB(path.join(dir, "auth.db"));
     db.initialize();
-    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 }, undefined, {
-      meshSecret: "shared-secret",
-      authTimeoutMs: 100,
-    });
+    server = new BrokerSocketServer(
+      db,
+      { type: "tcp", host: "127.0.0.1", port: 0 },
+      {
+        meshSecret: "shared-secret",
+        authTimeoutMs: 100,
+      },
+    );
     await server.start();
   });
 

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -16,6 +16,7 @@ import type {
   JsonRpcRequest,
   JsonRpcResponse,
   JsonRpcError,
+  AdapterCapabilityResult,
   MessageAdapter,
   NormalizedMessageContent,
   PortLeaseAcquireInput,
@@ -38,11 +39,6 @@ import {
   RPC_AGENT_NAME_CONFLICT,
   RPC_AGENT_STABLE_ID_CONFLICT,
 } from "./types.js";
-
-export type SlackProxyFn = (
-  method: string,
-  params: Record<string, unknown>,
-) => Promise<Record<string, unknown>>;
 
 export const DEFAULT_HEARTBEAT_TIMEOUT_MS = 15_000;
 export const DEFAULT_PRUNE_INTERVAL_MS = 5_000;
@@ -161,7 +157,6 @@ export class BrokerSocketServer {
   private readonly target: ListenTarget;
   private readonly db: BrokerDB;
   private readonly router: MessageRouter;
-  private readonly slackProxyFn: SlackProxyFn | null;
   private readonly connections = new Map<net.Socket, ConnectionState>();
   private readonly heartbeatTimeoutMs: number;
   private readonly pruneIntervalMs: number;
@@ -171,18 +166,18 @@ export class BrokerSocketServer {
   private assignedPort: number | null = null;
   private agentMessageCallback: AgentMessageCallback | null = null;
   private agentStatusChangeCallback: AgentStatusChangeCallback | null = null;
-  private outboundMessageAdapters: ReadonlyArray<Pick<MessageAdapter, "name" | "send">> = [];
+  private outboundMessageAdapters: ReadonlyArray<
+    Pick<MessageAdapter, "name" | "send" | "invokeCapability">
+  > = [];
   private agentRegistrationResolver: AgentRegistrationResolver | null = null;
 
   constructor(
     db: BrokerDB,
     target?: ListenTarget | string,
-    slackProxyFn?: SlackProxyFn,
     options: BrokerSocketServerOptions = {},
   ) {
     this.db = db;
     this.router = new MessageRouter(db);
-    this.slackProxyFn = slackProxyFn ?? null;
     this.heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS;
     this.pruneIntervalMs = options.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
     this.authTimeoutMs = options.authTimeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
@@ -308,7 +303,9 @@ export class BrokerSocketServer {
     this.agentRegistrationResolver = resolver;
   }
 
-  setOutboundMessageAdapters(adapters: ReadonlyArray<Pick<MessageAdapter, "name" | "send">>): void {
+  setOutboundMessageAdapters(
+    adapters: ReadonlyArray<Pick<MessageAdapter, "name" | "send" | "invokeCapability">>,
+  ): void {
     this.outboundMessageAdapters = adapters;
   }
 
@@ -528,8 +525,10 @@ export class BrokerSocketServer {
           return this.handleScheduleCreate(req, state);
         case "status.update":
           return this.handleStatusUpdate(req, state);
+        case "adapter.capability":
+          return await this.handleAdapterCapability(req, state);
         case "slack.proxy":
-          return await this.handleSlackProxy(req, state);
+          return await this.handleLegacySlackProxy(req, state);
         default:
           return rpcError(req.id, RPC_METHOD_NOT_FOUND, `Unknown method: ${req.method}`);
       }
@@ -1324,48 +1323,116 @@ export class BrokerSocketServer {
     return rpcOk(req.id, { ok: true });
   }
 
-  // ─── Slack proxy handler ──────────────────────────────
+  // ─── Adapter capability handler ───────────────────────
 
-  private async handleSlackProxy(
+  private async handleAdapterCapability(
     req: JsonRpcRequest,
     state: ConnectionState,
   ): Promise<JsonRpcResponse> {
-    if (!this.slackProxyFn) {
-      return rpcError(req.id, RPC_METHOD_NOT_FOUND, "slack.proxy is not configured on this broker");
+    const params = req.params ?? {};
+    const adapterName =
+      typeof params.adapter === "string"
+        ? params.adapter.trim()
+        : typeof params.source === "string"
+          ? params.source.trim()
+          : "";
+    const capability = typeof params.capability === "string" ? params.capability.trim() : "";
+
+    if (!adapterName) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "adapter is required for adapter.capability");
+    }
+    if (!capability) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "capability is required for adapter.capability");
     }
 
+    const capabilityParams =
+      params.params && typeof params.params === "object" && !Array.isArray(params.params)
+        ? (params.params as Record<string, unknown>)
+        : {};
+
+    return await this.dispatchAdapterCapability(
+      req.id,
+      adapterName,
+      capability,
+      capabilityParams,
+      state,
+    );
+  }
+
+  private async handleLegacySlackProxy(
+    req: JsonRpcRequest,
+    state: ConnectionState,
+  ): Promise<JsonRpcResponse> {
     const params = req.params ?? {};
-    const method = typeof params.method === "string" ? params.method : null;
+    const method = typeof params.method === "string" ? params.method.trim() : "";
     if (!method) {
       return rpcError(req.id, RPC_INVALID_PARAMS, "method is required for slack.proxy");
     }
 
     const apiParams =
-      params.params && typeof params.params === "object"
+      params.params && typeof params.params === "object" && !Array.isArray(params.params)
         ? (params.params as Record<string, unknown>)
         : {};
 
+    return await this.dispatchAdapterCapability(
+      req.id,
+      "slack",
+      "api.call",
+      { method, params: apiParams },
+      state,
+      "slack.proxy",
+    );
+  }
+
+  private async dispatchAdapterCapability(
+    id: JsonRpcRequest["id"],
+    adapterName: string,
+    capability: string,
+    capabilityParams: Record<string, unknown>,
+    state: ConnectionState,
+    errorPrefix = `${adapterName}.${capability}`,
+  ): Promise<JsonRpcResponse> {
+    const adapter = this.outboundMessageAdapters.find(
+      (candidate) => candidate.name === adapterName,
+    );
+    if (!adapter?.invokeCapability) {
+      return rpcError(
+        id,
+        RPC_METHOD_NOT_FOUND,
+        `Adapter ${adapterName} does not implement capability ${capability}`,
+      );
+    }
+
     try {
-      const result = await this.slackProxyFn(method, apiParams);
-
-      // Auto-claim thread ownership when a registered agent posts a message
-      if (method === "chat.postMessage" && state.agentId) {
-        const threadTs = typeof apiParams.thread_ts === "string" ? apiParams.thread_ts : null;
-        const messageTs = typeof result.ts === "string" ? (result.ts as string) : null;
-        const postChannel = typeof apiParams.channel === "string" ? apiParams.channel : undefined;
-        const effectiveTs = threadTs ?? messageTs;
-        if (effectiveTs) {
-          const claimed = this.router.claimThread(effectiveTs, state.agentId, postChannel, "slack");
-          if (claimed && postChannel) {
-            this.db.updateThread(effectiveTs, { source: "slack", channel: postChannel });
-          }
-        }
-      }
-
-      return rpcOk(req.id, result);
+      const response = await adapter.invokeCapability({ capability, params: capabilityParams });
+      this.applyAdapterCapabilityEffects(adapterName, response, state);
+      return rpcOk(id, response.result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return rpcError(req.id, RPC_INTERNAL_ERROR, `slack.proxy ${method}: ${message}`);
+      return rpcError(id, RPC_INTERNAL_ERROR, `${errorPrefix}: ${message}`);
+    }
+  }
+
+  private applyAdapterCapabilityEffects(
+    adapterName: string,
+    response: AdapterCapabilityResult,
+    state: ConnectionState,
+  ): void {
+    if (!state.agentId) return;
+
+    const claimThread = response.effects?.claimThread;
+    const claims = Array.isArray(claimThread) ? claimThread : claimThread ? [claimThread] : [];
+    for (const claim of claims) {
+      if (!claim.threadId) continue;
+      const claimed = this.router.claimThread(
+        claim.threadId,
+        state.agentId,
+        claim.channel,
+        adapterName,
+      );
+      if (claimed && claim.channel) {
+        this.db.updateThread(claim.threadId, { source: adapterName, channel: claim.channel });
+      }
     }
   }
 }

--- a/transport-core/index.ts
+++ b/transport-core/index.ts
@@ -118,10 +118,30 @@ export interface OutboundMessage {
   scope?: RuntimeScopeCarrier;
 }
 
+export interface AdapterThreadClaimEffect {
+  threadId: string;
+  channel?: string;
+}
+
+export interface AdapterCapabilityEffects {
+  claimThread?: AdapterThreadClaimEffect | ReadonlyArray<AdapterThreadClaimEffect>;
+}
+
+export interface AdapterCapabilityRequest {
+  capability: string;
+  params: Record<string, unknown>;
+}
+
+export interface AdapterCapabilityResult {
+  result: Record<string, unknown>;
+  effects?: AdapterCapabilityEffects;
+}
+
 export interface MessageAdapter {
   name: string;
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   onInbound(handler: (msg: InboundMessage) => void): void;
   send(msg: OutboundMessage): Promise<void>;
+  invokeCapability?(request: AdapterCapabilityRequest): Promise<AdapterCapabilityResult>;
 }


### PR DESCRIPTION
## Summary
- add a neutral `adapter.capability` broker RPC boundary and transport adapter capability contract
- move direct Slack API passthrough into the Slack adapter's `api.call` capability, with broker-applied thread-claim effects
- keep legacy compatibility in both directions: `BrokerClient.slackProxy` falls back to `slack.proxy` for older brokers, and the broker accepts `slack.proxy` as a Slack adapter alias for older clients

Closes #779

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- push pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`

## Review
- Local `reviewer` subagent: no blockers found
- Repo `code-reviewer` subagent: initial compatibility blocker fixed; re-review approved with no remaining critical/warning findings. PiComms post succeeded; GitHub review/comment posting failed with token write-permission 403.
