### PR TITLE
Extract Pinet runtime adapter composition

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -426,6 +426,10 @@ Startup selection:
 
 Pinet supports a broker/follower architecture for coordinating multiple pi agents over Slack.
 
+### Runtime composition boundary
+
+Broker startup is composed as Pinet core plus injected transport adapter factories. `broker-runtime.ts` starts the broker DB/socket/router and skin/agent state, then calls `createAdapterBindings` to attach transports. The packaged Slack bridge passes `createSlackPinetRuntimeAdapterFactory(...)`, while tests use an in-memory non-Slack adapter to demonstrate the same boundary without Slack tokens or Slack-specific metadata. Adapter factories return `MessageAdapter` bindings; the core wires inbound delivery, registers adapters on the broker, and connects them.
+
 ### Quick start
 
 **Broker** (one per mesh — coordinates routing and health):

--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -3,7 +3,6 @@ import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane
 import {
   createBrokerRuntime,
   resolveConfiguredBrokerSkinTheme,
-  shouldRouteKnownSlackThread,
   type BrokerRuntimeDeps,
 } from "./broker-runtime.js";
 import type { SlackActivityLogger } from "./activity-log.js";
@@ -11,10 +10,7 @@ import type { SlackActivityLogger } from "./activity-log.js";
 function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDeps {
   return {
     getSettings: () => ({}),
-    getBotToken: () => "xoxb-test",
-    getAppToken: () => "xapp-test",
     getAllowedUsers: () => null,
-    shouldAllowAllWorkspaceUsers: () => false,
     getBrokerStableId: () => "broker-stable-id",
     setBrokerStableId: vi.fn(),
     getActiveSkinTheme: () => null,
@@ -27,7 +23,6 @@ function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDe
       () => "broker" as ReturnType<BrokerRuntimeDeps["getMeshRoleFromMetadata"]>,
     ) as BrokerRuntimeDeps["getMeshRoleFromMetadata"],
     handleInboundMessage: vi.fn(),
-    onAppHomeOpened: vi.fn(),
     pushInboxMessages: vi.fn(),
     updateBadge: vi.fn(),
     maybeDrainInboxIfIdle: vi.fn(() => false),
@@ -70,54 +65,10 @@ function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDe
       (input) => input as unknown as BrokerControlPlaneDashboardSnapshot,
     ),
     buildCurrentDashboardSnapshot: vi.fn(async () => null),
+    createAdapterBindings: [],
     ...overrides,
   };
 }
-
-describe("broker-runtime known Slack thread routing", () => {
-  it("does not route legacy DM assistant threads without persisted context after cache loss", () => {
-    expect(
-      shouldRouteKnownSlackThread({
-        source: "slack",
-        channel: "D123",
-        metadata: null,
-      }),
-    ).toBe(false);
-  });
-
-  it("routes DM assistant threads once Slack context is persisted", () => {
-    expect(
-      shouldRouteKnownSlackThread({
-        source: "slack",
-        channel: "D123",
-        metadata: {
-          slackThreadContext: {
-            channelId: "C_TEAM",
-            scope: {
-              workspace: {
-                provider: "slack",
-                source: "compatibility",
-                compatibilityKey: "default",
-                channelId: "C_TEAM",
-              },
-              instance: { source: "compatibility", compatibilityKey: "default" },
-            },
-          },
-        },
-      }),
-    ).toBe(true);
-  });
-
-  it("continues routing non-DM Slack threads without extra context", () => {
-    expect(
-      shouldRouteKnownSlackThread({
-        source: "slack",
-        channel: "C123",
-        metadata: null,
-      }),
-    ).toBe(true);
-  });
-});
 
 describe("broker-runtime", () => {
   it("resolves broker skin strictly from config with default fallback", () => {

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -12,10 +12,8 @@ import {
   resolvePinetMeshAuth,
   syncBrokerInboxEntries,
 } from "./helpers.js";
-import { startBroker, type Broker, type ThreadInfo } from "./broker/index.js";
+import { startBroker, type Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
-import { SlackAdapter } from "./broker/adapters/slack.js";
-import type { SlackThreadContext } from "./slack-access.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { MessageRouter } from "./broker/router.js";
 import {
@@ -52,6 +50,11 @@ import {
 } from "./ralph-loop.js";
 import { TtlCache } from "./ttl-cache.js";
 import { createBrokerGhostReaper } from "./broker/ghost-reaper.js";
+import {
+  buildPinetRuntimeAdapterBindings,
+  connectPinetRuntimeAdapters,
+  type PinetRuntimeAdapterFactory,
+} from "./pinet-runtime-composition.js";
 
 export interface BrokerRuntimeConnectResult {
   botUserId: string | null;
@@ -62,10 +65,7 @@ export interface BrokerRuntimeConnectResult {
 
 export interface BrokerRuntimeDeps {
   getSettings: () => SlackBridgeSettings;
-  getBotToken: () => string;
-  getAppToken: () => string;
   getAllowedUsers: () => Set<string> | null;
-  shouldAllowAllWorkspaceUsers: () => boolean;
   getBrokerStableId: () => string;
   setBrokerStableId: (stableId: string) => void;
   getActiveSkinTheme: () => string | null;
@@ -89,7 +89,6 @@ export interface BrokerRuntimeDeps {
     selfId: string;
     ctx: ExtensionContext;
   }) => Promise<void> | void;
-  onAppHomeOpened: (userId: string, ctx: ExtensionContext) => Promise<void> | void;
   pushInboxMessages: (messages: InboxMessage[]) => void;
   updateBadge: () => void;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
@@ -137,6 +136,7 @@ export interface BrokerRuntimeDeps {
   buildCurrentDashboardSnapshot: (
     openedAt?: string,
   ) => Promise<BrokerControlPlaneDashboardSnapshot | null>;
+  createAdapterBindings: readonly PinetRuntimeAdapterFactory[];
 }
 
 function normalizeOptionalSetting(value: string | null | undefined): string | null {
@@ -179,35 +179,6 @@ export interface BrokerRuntime {
     ctx: ExtensionContext,
     openedAt?: string,
   ) => Promise<boolean>;
-}
-
-export function readStoredSlackThreadContext(
-  metadata: Record<string, unknown> | null | undefined,
-): SlackThreadContext | null {
-  const value = metadata?.slackThreadContext;
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
-
-  const record = value as Record<string, unknown>;
-  if (typeof record.channelId !== "string" || record.channelId.length === 0) return null;
-  if (typeof record.scope !== "object" || record.scope === null || Array.isArray(record.scope)) {
-    return null;
-  }
-
-  return {
-    channelId: record.channelId,
-    ...(typeof record.teamId === "string" && record.teamId.length > 0
-      ? { teamId: record.teamId }
-      : {}),
-    scope: record.scope as SlackThreadContext["scope"],
-  };
-}
-
-export function shouldRouteKnownSlackThread(
-  thread: Pick<ThreadInfo, "source" | "channel" | "metadata"> | null,
-): boolean {
-  if (!thread || thread.source !== "slack") return false;
-  if (!thread.channel.startsWith("D")) return true;
-  return readStoredSlackThreadContext(thread.metadata) !== null;
 }
 
 export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
@@ -548,38 +519,6 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
         ...(meshAuth.meshSecretPath ? { meshSecretPath: meshAuth.meshSecretPath } : {}),
       });
-      const adapter = new SlackAdapter({
-        botToken: deps.getBotToken(),
-        appToken: deps.getAppToken(),
-        allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
-        allowAllWorkspaceUsers: deps.shouldAllowAllWorkspaceUsers(),
-        suggestedPrompts: settings.suggestedPrompts,
-        reactionCommands: settings.reactionCommands,
-        isKnownThread: (threadTs: string) =>
-          shouldRouteKnownSlackThread(broker.db.getThread(threadTs)),
-        getKnownThread: (threadTs: string) => {
-          const thread = broker.db.getThread(threadTs);
-          if (!thread || thread.source !== "slack") return null;
-          return {
-            channelId: thread.channel,
-            context: readStoredSlackThreadContext(thread.metadata),
-          };
-        },
-        rememberKnownThread: (threadTs: string, channelId: string, context) => {
-          const existingMetadata = broker.db.getThread(threadTs)?.metadata ?? {};
-          broker.db.updateThread(threadTs, {
-            source: "slack",
-            channel: channelId,
-            metadata: {
-              ...existingMetadata,
-              ...(context ? { slackThreadContext: context } : {}),
-            },
-          });
-        },
-        onAppHomeOpened: async ({ userId }) => {
-          await deps.onAppHomeOpened(userId, ctx);
-        },
-      });
       let selfId: string | null = null;
       activityLogContext = ctx;
 
@@ -658,12 +597,19 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         deps.applyLocalAgentIdentity(selfAgent.name, selfAgent.emoji, selfAssignment.personality);
 
         const brokerSelfId = selfId;
-        adapter.onInbound((message) => {
-          void deps.handleInboundMessage({ message, broker, router, selfId: brokerSelfId, ctx });
+        const adapterBindings = await buildPinetRuntimeAdapterBindings(deps.createAdapterBindings, {
+          broker,
+          router,
+          selfId: brokerSelfId,
+          ctx,
         });
-
-        broker.addAdapter(adapter);
-        await adapter.connect();
+        const adapterConnectResult = await connectPinetRuntimeAdapters({
+          broker,
+          bindings: adapterBindings,
+          onInbound: (message) => {
+            void deps.handleInboundMessage({ message, broker, router, selfId: brokerSelfId, ctx });
+          },
+        });
 
         activeBroker = broker;
         activeRouter = router;
@@ -691,17 +637,12 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         startBrokerScheduledWakeups(ctx);
 
         return {
-          botUserId: adapter.getBotUserId(),
+          botUserId: adapterConnectResult.botUserId,
           recoveredBrokerMessages,
           recoveredTargetedBacklogCount,
           releasedBrokerClaims,
         };
       } catch (error) {
-        try {
-          await adapter.disconnect();
-        } catch {
-          /* best effort */
-        }
         try {
           if (selfId) {
             broker.db.unregisterAgent(selfId);

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -54,6 +54,7 @@ import {
   type SinglePlayerThreadInfo,
 } from "./single-player-runtime.js";
 import { createBrokerRuntime } from "./broker-runtime.js";
+import { createSlackPinetRuntimeAdapterFactory } from "./slack-pinet-runtime-adapter.js";
 import { SlackActivityLogger } from "./activity-log.js";
 import { createBrokerDeliveryState, queueBrokerInboxIds } from "./broker-delivery.js";
 import { buildBrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
@@ -617,13 +618,22 @@ export default function (pi: ExtensionAPI) {
   });
   const { resolveBrokerThreadOwnerHint } = brokerThreadOwnerHints;
 
-  const brokerRuntime = createBrokerRuntime({
+  const handleBrokerAppHomeOpened = async (userId: string, ctx: ExtensionContext) => {
+    await pinetHomeTabs.publishCurrentPinetHomeTabSafely(userId, ctx, new Date().toISOString());
+  };
+  const slackPinetAdapterFactory = createSlackPinetRuntimeAdapterFactory({
     getSettings: () => settings,
     getBotToken: () => botToken!,
     getAppToken: () => appToken!,
     getAllowedUsers: () => allowedUsers,
     shouldAllowAllWorkspaceUsers: () =>
       resolveAllowAllWorkspaceUsers(settings, process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS),
+    onAppHomeOpened: handleBrokerAppHomeOpened,
+  });
+
+  const brokerRuntime = createBrokerRuntime({
+    getSettings: () => settings,
+    getAllowedUsers: () => allowedUsers,
     getBrokerStableId: () => brokerStableId,
     setBrokerStableId: (stableId) => {
       brokerStableId = stableId;
@@ -702,9 +712,6 @@ export default function (pi: ExtensionAPI) {
         console.error(`[slack-bridge] broker inbound routing failed: ${msg(err)}`);
       }
     },
-    onAppHomeOpened: async (userId, ctx) => {
-      await pinetHomeTabs.publishCurrentPinetHomeTabSafely(userId, ctx, new Date().toISOString());
-    },
     pushInboxMessages: (messages) => {
       inbox.push(...messages);
     },
@@ -743,6 +750,7 @@ export default function (pi: ExtensionAPI) {
       ),
     buildCurrentDashboardSnapshot: async (openedAt) =>
       buildCurrentBrokerControlPlaneDashboardSnapshot(openedAt),
+    createAdapterBindings: [slackPinetAdapterFactory],
     onMaintenanceResult: (ctx, { result, previousSignature, signature }) => {
       if (signature && signature !== previousSignature) {
         ctx.ui.notify(`Pinet broker: ${result.anomalies.join("; ")}`, "warning");

--- a/slack-bridge/pinet-runtime-composition.test.ts
+++ b/slack-bridge/pinet-runtime-composition.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Broker } from "./broker/index.js";
+import type { MessageRouter } from "./broker/router.js";
+import type { InboundMessage, MessageAdapter, OutboundMessage } from "./broker/types.js";
+import {
+  buildPinetRuntimeAdapterBindings,
+  connectPinetRuntimeAdapters,
+} from "./pinet-runtime-composition.js";
+
+class MemoryAdapter implements MessageAdapter {
+  private inboundHandler: ((message: InboundMessage) => void) | null = null;
+  connected = false;
+
+  constructor(readonly name: string) {}
+
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+
+  onInbound(handler: (message: InboundMessage) => void): void {
+    this.inboundHandler = handler;
+  }
+
+  async send(_message: OutboundMessage): Promise<void> {
+    return undefined;
+  }
+
+  emit(message: InboundMessage): void {
+    this.inboundHandler?.(message);
+  }
+}
+
+describe("Pinet runtime composition", () => {
+  it("builds adapter bindings from injected factories without Slack adapter assumptions", async () => {
+    const matrixAdapter = new MemoryAdapter("matrix");
+    const broker = {} as Broker;
+    const router = {} as MessageRouter;
+    const ctx = {} as ExtensionContext;
+
+    const bindings = await buildPinetRuntimeAdapterBindings(
+      [
+        ({ broker: seenBroker, router: seenRouter, ctx: seenCtx, selfId }) => {
+          expect(seenBroker).toBe(broker);
+          expect(seenRouter).toBe(router);
+          expect(seenCtx).toBe(ctx);
+          expect(selfId).toBe("broker-self");
+          return { adapter: matrixAdapter };
+        },
+      ],
+      { broker, router, selfId: "broker-self", ctx },
+    );
+
+    expect(bindings).toEqual([{ adapter: matrixAdapter }]);
+  });
+
+  it("connects a non-Slack adapter at the Pinet core composition boundary", async () => {
+    const matrixAdapter = new MemoryAdapter("matrix");
+    const addAdapter = vi.fn();
+    const inbound: InboundMessage[] = [];
+
+    const result = await connectPinetRuntimeAdapters({
+      broker: { addAdapter },
+      bindings: [
+        {
+          adapter: matrixAdapter,
+          getBotUserId: () => "matrix-bot",
+        },
+      ],
+      onInbound: (message) => inbound.push(message),
+    });
+
+    const message: InboundMessage = {
+      source: "matrix",
+      threadId: "room-1/thread-1",
+      channel: "room-1",
+      userId: "user-1",
+      text: "hello from another transport",
+      timestamp: "2026-06-03T09:00:00.000Z",
+    };
+    matrixAdapter.emit(message);
+
+    expect(addAdapter).toHaveBeenCalledWith(matrixAdapter);
+    expect(matrixAdapter.connected).toBe(true);
+    expect(inbound).toEqual([message]);
+    expect(result.botUserId).toBe("matrix-bot");
+  });
+});

--- a/slack-bridge/pinet-runtime-composition.ts
+++ b/slack-bridge/pinet-runtime-composition.ts
@@ -1,0 +1,71 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Broker } from "./broker/index.js";
+import type { MessageRouter } from "./broker/router.js";
+import type { InboundMessage, MessageAdapter } from "./broker/types.js";
+
+export interface PinetRuntimeAdapterBinding {
+  /** Transport adapter to attach to the broker runtime. */
+  adapter: MessageAdapter;
+  /** Optional compatibility status used by Slack bridge startup/status surfaces. */
+  getBotUserId?: () => string | null;
+}
+
+export interface PinetRuntimeAdapterFactoryContext {
+  broker: Broker;
+  router: MessageRouter;
+  selfId: string;
+  ctx: ExtensionContext;
+}
+
+export type PinetRuntimeAdapterFactory = (
+  context: PinetRuntimeAdapterFactoryContext,
+) =>
+  | PinetRuntimeAdapterBinding
+  | PinetRuntimeAdapterBinding[]
+  | Promise<PinetRuntimeAdapterBinding | PinetRuntimeAdapterBinding[]>;
+
+export interface ConnectPinetRuntimeAdaptersOptions {
+  broker: Pick<Broker, "addAdapter">;
+  bindings: PinetRuntimeAdapterBinding[];
+  onInbound: (message: InboundMessage) => void;
+}
+
+export interface ConnectPinetRuntimeAdaptersResult {
+  botUserId: string | null;
+}
+
+function normalizeAdapterBindings(
+  value: PinetRuntimeAdapterBinding | PinetRuntimeAdapterBinding[],
+): PinetRuntimeAdapterBinding[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+export async function buildPinetRuntimeAdapterBindings(
+  factories: readonly PinetRuntimeAdapterFactory[],
+  context: PinetRuntimeAdapterFactoryContext,
+): Promise<PinetRuntimeAdapterBinding[]> {
+  const bindings: PinetRuntimeAdapterBinding[] = [];
+
+  for (const factory of factories) {
+    bindings.push(...normalizeAdapterBindings(await factory(context)));
+  }
+
+  return bindings;
+}
+
+export async function connectPinetRuntimeAdapters({
+  broker,
+  bindings,
+  onInbound,
+}: ConnectPinetRuntimeAdaptersOptions): Promise<ConnectPinetRuntimeAdaptersResult> {
+  let botUserId: string | null = null;
+
+  for (const binding of bindings) {
+    binding.adapter.onInbound(onInbound);
+    broker.addAdapter(binding.adapter);
+    await binding.adapter.connect();
+    botUserId ??= binding.getBotUserId?.() ?? null;
+  }
+
+  return { botUserId };
+}

--- a/slack-bridge/slack-pinet-runtime-adapter.test.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { shouldRouteKnownSlackThread } from "./slack-pinet-runtime-adapter.js";
+
+describe("Slack Pinet runtime adapter known thread routing", () => {
+  it("does not route legacy DM assistant threads without persisted context after cache loss", () => {
+    expect(
+      shouldRouteKnownSlackThread({
+        source: "slack",
+        channel: "D123",
+        metadata: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("routes DM assistant threads once Slack context is persisted", () => {
+    expect(
+      shouldRouteKnownSlackThread({
+        source: "slack",
+        channel: "D123",
+        metadata: {
+          slackThreadContext: {
+            channelId: "C_TEAM",
+            scope: {
+              workspace: {
+                provider: "slack",
+                source: "compatibility",
+                compatibilityKey: "default",
+                channelId: "C_TEAM",
+              },
+              instance: { source: "compatibility", compatibilityKey: "default" },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("continues routing non-DM Slack threads without extra context", () => {
+    expect(
+      shouldRouteKnownSlackThread({
+        source: "slack",
+        channel: "C123",
+        metadata: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -1,0 +1,105 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { SlackAdapter } from "./broker/adapters/slack.js";
+import type { Broker, ThreadInfo } from "./broker/index.js";
+import type { PinetRuntimeAdapterFactory } from "./pinet-runtime-composition.js";
+import type { ReactionCommandSettings } from "./reaction-triggers.js";
+import type { ParsedThreadStarted, SlackThreadContext } from "./slack-access.js";
+import type { SlackBridgeSettings } from "./helpers.js";
+
+export function readStoredSlackThreadContext(
+  metadata: Record<string, unknown> | null | undefined,
+): SlackThreadContext | null {
+  const value = metadata?.slackThreadContext;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.channelId !== "string" || record.channelId.length === 0) return null;
+  if (typeof record.scope !== "object" || record.scope === null || Array.isArray(record.scope)) {
+    return null;
+  }
+
+  return {
+    channelId: record.channelId,
+    ...(typeof record.teamId === "string" && record.teamId.length > 0
+      ? { teamId: record.teamId }
+      : {}),
+    scope: record.scope as SlackThreadContext["scope"],
+  };
+}
+
+export function shouldRouteKnownSlackThread(
+  thread: Pick<ThreadInfo, "source" | "channel" | "metadata"> | null,
+): boolean {
+  if (!thread || thread.source !== "slack") return false;
+  if (!thread.channel.startsWith("D")) return true;
+  return readStoredSlackThreadContext(thread.metadata) !== null;
+}
+
+export interface SlackPinetRuntimeAdapterDeps {
+  getSettings: () => SlackBridgeSettings;
+  getBotToken: () => string;
+  getAppToken: () => string;
+  getAllowedUsers: () => Set<string> | null;
+  shouldAllowAllWorkspaceUsers: () => boolean;
+  onAppHomeOpened: (userId: string, ctx: ExtensionContext) => Promise<void> | void;
+}
+
+function getKnownSlackThread(
+  broker: Broker,
+  threadTs: string,
+): { channelId: string; context?: ParsedThreadStarted["context"] | null } | null {
+  const thread = broker.db.getThread(threadTs);
+  if (!thread || thread.source !== "slack") return null;
+  return {
+    channelId: thread.channel,
+    context: readStoredSlackThreadContext(thread.metadata),
+  };
+}
+
+function rememberKnownSlackThread(
+  broker: Broker,
+  threadTs: string,
+  channelId: string,
+  context?: ParsedThreadStarted["context"] | null,
+): void {
+  const existingMetadata = broker.db.getThread(threadTs)?.metadata ?? {};
+  broker.db.updateThread(threadTs, {
+    source: "slack",
+    channel: channelId,
+    metadata: {
+      ...existingMetadata,
+      ...(context ? { slackThreadContext: context } : {}),
+    },
+  });
+}
+
+export function createSlackPinetRuntimeAdapterFactory(
+  deps: SlackPinetRuntimeAdapterDeps,
+): PinetRuntimeAdapterFactory {
+  return ({ broker, ctx }) => {
+    const settings = deps.getSettings();
+    const allowedUsers = deps.getAllowedUsers();
+    const adapter = new SlackAdapter({
+      botToken: deps.getBotToken(),
+      appToken: deps.getAppToken(),
+      allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
+      allowAllWorkspaceUsers: deps.shouldAllowAllWorkspaceUsers(),
+      suggestedPrompts: settings.suggestedPrompts,
+      reactionCommands: settings.reactionCommands as ReactionCommandSettings | undefined,
+      isKnownThread: (threadTs: string) =>
+        shouldRouteKnownSlackThread(broker.db.getThread(threadTs)),
+      getKnownThread: (threadTs: string) => getKnownSlackThread(broker, threadTs),
+      rememberKnownThread: (threadTs: string, channelId: string, context) => {
+        rememberKnownSlackThread(broker, threadTs, channelId, context);
+      },
+      onAppHomeOpened: async ({ userId }) => {
+        await deps.onAppHomeOpened(userId, ctx);
+      },
+    });
+
+    return {
+      adapter,
+      getBotUserId: () => adapter.getBotUserId(),
+    };
+  };
+}


### PR DESCRIPTION
Closes #780.

## Summary
- Extracted broker adapter composition into injectable Pinet runtime adapter bindings.
- Moved Slack-specific adapter wiring and known-thread helpers into a Slack adapter factory module.
- Added non-Slack in-memory adapter tests and README docs for the composition boundary.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pre-push hook reran pnpm lint && pnpm typecheck && pnpm test

## Review
- Local reviewer subagent: no blockers; prior Slack wiring/helper placement warnings resolved.
