### PR TITLE
broker-core: make routing and inbox persistence transport-neutral

### DIFF
--- a/broker-core/router.ts
+++ b/broker-core/router.ts
@@ -18,6 +18,8 @@ function buildPinetOwnerToken(stableId: string): string {
 }
 
 export interface ThreadOwnerHint {
+  agentId?: string;
+  stableId?: string;
   agentOwner?: string;
   agentName?: string;
 }
@@ -160,32 +162,63 @@ function findBestAgentMention(text: string, candidates: AgentMentionCandidate[])
   return bestMatch;
 }
 
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function normalizeThreadOwnerHint(
+  metadata: Record<string, unknown> | undefined,
+): ThreadOwnerHint | null {
+  const embeddedHint =
+    metadata?.threadOwnerHint &&
+    typeof metadata.threadOwnerHint === "object" &&
+    !Array.isArray(metadata.threadOwnerHint)
+      ? (metadata.threadOwnerHint as Record<string, unknown>)
+      : undefined;
+
+  const agentId = asNonEmptyString(embeddedHint?.agentId ?? metadata?.threadOwnerAgentId);
+  const stableId = asNonEmptyString(embeddedHint?.stableId ?? metadata?.threadOwnerStableId);
+  const agentOwner = asNonEmptyString(embeddedHint?.agentOwner ?? metadata?.threadOwnerAgentOwner);
+  const agentName = asNonEmptyString(embeddedHint?.agentName ?? metadata?.threadOwnerAgentName);
+  const hint: ThreadOwnerHint = {
+    ...(agentId ? { agentId } : {}),
+    ...(stableId ? { stableId } : {}),
+    ...(agentOwner ? { agentOwner } : {}),
+    ...(agentName ? { agentName } : {}),
+  };
+
+  return Object.keys(hint).length > 0 ? hint : null;
+}
+
 function resolveAgentFromThreadOwnerHint(
   metadata: Record<string, unknown> | undefined,
   agents: AgentInfo[],
 ): AgentInfo | null {
-  const hintedOwner =
-    typeof metadata?.threadOwnerAgentOwner === "string" && metadata.threadOwnerAgentOwner
-      ? metadata.threadOwnerAgentOwner
-      : null;
-  if (hintedOwner) {
-    const ownerMatch = agents.find(
-      (agent) => agent.stableId && buildPinetOwnerToken(agent.stableId) === hintedOwner,
-    );
-    if (ownerMatch) {
-      return ownerMatch;
-    }
+  const hint = normalizeThreadOwnerHint(metadata);
+  if (!hint) return null;
+
+  if (hint.agentId) {
+    const idMatch = agents.find((agent) => agent.id === hint.agentId);
+    if (idMatch) return idMatch;
   }
 
-  const hintedName =
-    typeof metadata?.threadOwnerAgentName === "string" && metadata.threadOwnerAgentName
-      ? metadata.threadOwnerAgentName
-      : null;
-  if (!hintedName) {
+  if (hint.stableId) {
+    const stableMatch = agents.find((agent) => agent.stableId === hint.stableId);
+    if (stableMatch) return stableMatch;
+  }
+
+  if (hint.agentOwner) {
+    const ownerMatch = agents.find(
+      (agent) => agent.stableId && buildPinetOwnerToken(agent.stableId) === hint.agentOwner,
+    );
+    if (ownerMatch) return ownerMatch;
+  }
+
+  if (!hint.agentName) {
     return null;
   }
 
-  return findBestAgentMention(hintedName, buildAgentMentionCandidates(agents, false));
+  return findBestAgentMention(hint.agentName, buildAgentMentionCandidates(agents, false));
 }
 
 function resolveRoutableThreadOwner(
@@ -283,7 +316,7 @@ export class MessageRouter {
 
         // Explicit takeovers stay authoritative for the thread. If that owner is
         // unavailable later, require another explicit retarget instead of snapping
-        // back to a stale historical Slack owner hint.
+        // back to a stale historical adapter owner hint.
         return { action: "unrouted" };
       }
 
@@ -297,8 +330,8 @@ export class MessageRouter {
         }
 
         // Owner is gone or no longer routable — clear ownership and stop. Known
-        // Slack-thread replies must not leak to another worker through latest
-        // bot-message owner hints or channel-assignment fallback; a human must
+        // transport-thread replies must not leak to another worker through latest
+        // adapter owner hints or channel-assignment fallback; a human must
         // explicitly retarget the thread if the owner is unavailable.
         this.db.updateThread(msg.threadId, { ownerAgent: null });
         return { action: "unrouted" };
@@ -329,7 +362,7 @@ export class MessageRouter {
 
     // New thread / top-level message: channel assignment can still steer work.
     // Persist that assignment as thread ownership so later generic replies in
-    // the same Slack thread route back to the same agent without another
+    // the same transport thread route back to the same agent without another
     // manual broker/human assignment. Existing known threads stay protected by
     // the `thread` branch above and do not fall back to channel assignment.
     const assignment = this.db.getChannelAssignment(msg.channel);

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -634,6 +634,77 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("deduplicates non-Slack transport messages by neutral transport identity", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("chat:alice", "imessage", "chat:alice", null);
+
+      const first = db.insertMessage(
+        "chat:alice",
+        "imessage",
+        "inbound",
+        "+15551234567",
+        "hello from iMessage",
+        ["agent-1"],
+        { transportChannelId: "chat:alice", transportTimestamp: "msg-1" },
+      );
+      const replay = db.insertMessage(
+        "chat:alice",
+        "imessage",
+        "inbound",
+        "+15551234567",
+        "hello from iMessage replay",
+        ["agent-1", "agent-2"],
+        { transportChannelId: "chat:alice", transportTimestamp: "msg-1" },
+      );
+
+      expect(replay.id).toBe(first.id);
+      expect(first.externalId).toBe("chat:alice:msg-1");
+      expect(first.externalTs).toBe("msg-1");
+      expect(db.getInbox("agent-1")).toHaveLength(1);
+      expect(db.getInbox("agent-2")).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("scopes timestamp-only transport identities by thread", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("chat:alice", "imessage", "chat:alice", null);
+      db.createThread("chat:bob", "imessage", "chat:bob", null);
+
+      const alice = db.insertMessage(
+        "chat:alice",
+        "imessage",
+        "inbound",
+        "+15551234567",
+        "hello from Alice",
+        ["agent-1"],
+        { timestamp: "msg-1" },
+      );
+      const bob = db.insertMessage(
+        "chat:bob",
+        "imessage",
+        "inbound",
+        "+15557654321",
+        "hello from Bob",
+        ["agent-2"],
+        { timestamp: "msg-1" },
+      );
+
+      expect(bob.id).not.toBe(alice.id);
+      expect(alice.externalId).toBe("chat:alice:msg-1");
+      expect(bob.externalId).toBe("chat:bob:msg-1");
+      expect(db.getInbox("agent-1")).toHaveLength(1);
+      expect(db.getInbox("agent-2")).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
   it("stamps queued unrouted Slack backlog mail with an explicit class", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);
@@ -1014,6 +1085,36 @@ describe("BrokerDB message sync identity", () => {
       expect(read.unreadCountBefore).toBe(0);
       expect(read.unreadThreads).toEqual([]);
       expect(db.getInbox("agent-a")).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("applies thread-affinity pruning to non-Slack transport inbox rows", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("chat:alice", "imessage", "chat:alice", "agent-a");
+      db.queueMessage("agent-a", {
+        source: "imessage",
+        threadId: "chat:alice",
+        channel: "chat:alice",
+        userId: "+15551234567",
+        text: "new reply in chat",
+        timestamp: "msg-1",
+      });
+      db.queueMessage("agent-b", {
+        source: "imessage",
+        threadId: "chat:alice",
+        channel: "chat:alice",
+        userId: "+15551234567",
+        text: "new reply in chat fanout",
+        timestamp: "msg-2",
+      });
+
+      expect(db.getInbox("agent-a")).toHaveLength(1);
+      expect(db.getInbox("agent-b")).toHaveLength(0);
+      expect(db.getUnreadInboxCount("agent-b")).toBe(0);
     } finally {
       db.close();
     }

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -255,7 +255,14 @@ function getStringMetadataValue(
   return null;
 }
 
+const INTERNAL_AGENT_SOURCE = "agent";
+
+function isExternalTransportSource(source: string): boolean {
+  return source.trim().length > 0 && source !== INTERNAL_AGENT_SOURCE;
+}
+
 function deriveMessageSyncIdentity(
+  threadId: string,
   source: string,
   metadata?: Record<string, unknown>,
 ): { externalId: string | null; externalTs: string | null } {
@@ -275,15 +282,30 @@ function deriveMessageSyncIdentity(
     return { externalId: explicitExternalId, externalTs: explicitExternalTs };
   }
 
-  if (source === "slack") {
-    const channel = getStringMetadataValue(metadata, ["channel", "channelId", "channel_id"]);
-    const timestamp = getStringMetadataValue(metadata, ["timestamp", "ts"]);
-    if (timestamp && channel) {
-      return { externalId: `${channel}:${timestamp}`, externalTs: timestamp };
-    }
-    if (timestamp) {
-      return { externalId: timestamp, externalTs: timestamp };
-    }
+  if (!isExternalTransportSource(source)) {
+    return { externalId: null, externalTs: explicitExternalTs };
+  }
+
+  const channel = getStringMetadataValue(metadata, [
+    "transportChannelId",
+    "transport_channel_id",
+    "conversationId",
+    "conversation_id",
+    "channel",
+    "channelId",
+    "channel_id",
+  ]);
+  const timestamp = getStringMetadataValue(metadata, [
+    "transportTimestamp",
+    "transport_timestamp",
+    "timestamp",
+    "ts",
+  ]);
+  if (timestamp && channel) {
+    return { externalId: `${channel}:${timestamp}`, externalTs: timestamp };
+  }
+  if (timestamp && threadId.trim().length > 0) {
+    return { externalId: `${threadId}:${timestamp}`, externalTs: timestamp };
   }
 
   return { externalId: null, externalTs: explicitExternalTs };
@@ -855,15 +877,15 @@ function addThreadMetadataColumn(db: DatabaseSync): void {
 
 function backfillMessageSyncIdentities(db: DatabaseSync): void {
   const rows = db
-    .prepare("SELECT id, source, metadata FROM messages WHERE metadata IS NOT NULL")
-    .all() as Array<{ id: number; source: string; metadata: string | null }>;
+    .prepare("SELECT id, thread_id, source, metadata FROM messages WHERE metadata IS NOT NULL")
+    .all() as Array<{ id: number; thread_id: string; source: string; metadata: string | null }>;
   const update = db.prepare("UPDATE messages SET external_id = ?, external_ts = ? WHERE id = ?");
 
   for (const row of rows) {
     if (!row.metadata) continue;
     try {
       const metadata = JSON.parse(row.metadata) as Record<string, unknown>;
-      const identity = deriveMessageSyncIdentity(row.source, metadata);
+      const identity = deriveMessageSyncIdentity(row.thread_id, row.source, metadata);
       if (identity.externalId || identity.externalTs) {
         update.run(identity.externalId, identity.externalTs, row.id);
       }
@@ -2246,7 +2268,7 @@ export class BrokerDB implements BrokerDBInterface {
            FROM inbox i
            JOIN messages m ON m.id = i.message_id
            WHERE m.thread_id = ?
-             AND m.source = 'slack'
+             AND m.source <> 'agent'
              AND m.direction = 'inbound'
              AND i.read_at IS NULL`,
         )
@@ -2444,7 +2466,7 @@ export class BrokerDB implements BrokerDBInterface {
         .get(row.message_id) as
         | { source: string; direction: string; metadata: string | null }
         | undefined;
-      if (message?.source === "slack" && message.direction === "inbound") {
+      if (message && isExternalTransportSource(message.source) && message.direction === "inbound") {
         let metadata: Record<string, unknown> = {};
         if (message.metadata) {
           try {
@@ -2628,7 +2650,7 @@ export class BrokerDB implements BrokerDBInterface {
 
   getPendingInboxCount(agentId: string): number {
     return this.withTransaction(() => {
-      this.dropStaleSlackInboxRows(agentId);
+      this.dropStaleTransportInboxRows(agentId);
       const db = this.getDb();
       const row = db
         .prepare("SELECT COUNT(*) AS count FROM inbox WHERE agent_id = ? AND delivered = 0")
@@ -3276,7 +3298,7 @@ export class BrokerDB implements BrokerDBInterface {
 
   private buildInboundMessageMetadata(message: InboundMessage): Record<string, unknown> {
     const threadOwner =
-      message.source === "slack" && message.threadId
+      isExternalTransportSource(message.source) && message.threadId
         ? this.getThread(message.threadId)?.ownerAgent
         : null;
     return this.withInboundMailClassMetadata(message, {
@@ -3295,7 +3317,7 @@ export class BrokerDB implements BrokerDBInterface {
     message: InboundMessage,
     metadata: Record<string, unknown>,
   ): Record<string, unknown> {
-    if (message.source !== "slack") {
+    if (!isExternalTransportSource(message.source)) {
       return metadata;
     }
 
@@ -3345,7 +3367,7 @@ export class BrokerDB implements BrokerDBInterface {
     ]);
     const externalId =
       referencedExternalId ??
-      (referencedSource === "slack" && referencedChannel && referencedMessageTs
+      (referencedChannel && referencedMessageTs
         ? `${referencedChannel}:${referencedMessageTs}`
         : null);
     if (!externalId) return;
@@ -3477,7 +3499,7 @@ export class BrokerDB implements BrokerDBInterface {
     const db = this.getDb();
     const now = new Date().toISOString();
     const metaJson = metadata ? JSON.stringify(metadata) : null;
-    const identity = deriveMessageSyncIdentity(source, metadata);
+    const identity = deriveMessageSyncIdentity(threadId, source, metadata);
 
     const info = db
       .prepare(
@@ -3591,7 +3613,7 @@ export class BrokerDB implements BrokerDBInterface {
     return row ? rowToBrokerMessage(row) : null;
   }
 
-  private dropStaleSlackInboxRows(agentId: string): number {
+  private dropStaleTransportInboxRows(agentId: string): number {
     const db = this.getDb();
     const rows = db
       .prepare(
@@ -3604,7 +3626,7 @@ export class BrokerDB implements BrokerDBInterface {
          JOIN threads t ON t.thread_id = m.thread_id
          WHERE i.agent_id = ?
            AND (i.delivered = 0 OR i.read_at IS NULL)
-           AND m.source = 'slack'
+           AND m.source <> 'agent'
            AND m.direction = 'inbound'
            AND t.owner_agent IS NOT NULL`,
       )
@@ -3644,7 +3666,7 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   getInbox(agentId: string, limit = 50): { entry: InboxEntry; message: BrokerMessage }[] {
-    this.dropStaleSlackInboxRows(agentId);
+    this.dropStaleTransportInboxRows(agentId);
     const db = this.getDb();
 
     const rows = db
@@ -3706,7 +3728,7 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   readInbox(agentId: string, options: InboxReadOptions = {}): InboxReadResult {
-    this.dropStaleSlackInboxRows(agentId);
+    this.dropStaleTransportInboxRows(agentId);
     const db = this.getDb();
     const unreadOnly = options.unreadOnly ?? true;
     const markRead = options.markRead ?? true;
@@ -3833,7 +3855,7 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   getUnreadInboxCount(agentId: string): number {
-    this.dropStaleSlackInboxRows(agentId);
+    this.dropStaleTransportInboxRows(agentId);
     const db = this.getDb();
     const row = db
       .prepare("SELECT COUNT(*) AS count FROM inbox WHERE agent_id = ? AND read_at IS NULL")
@@ -3842,7 +3864,7 @@ export class BrokerDB implements BrokerDBInterface {
   }
 
   getUnreadThreadSummary(agentId: string, limit = 20): InboxThreadUnreadSummary[] {
-    this.dropStaleSlackInboxRows(agentId);
+    this.dropStaleTransportInboxRows(agentId);
     const db = this.getDb();
     const clampedLimit = Math.min(Math.max(Math.trunc(limit), 1), 100);
     const rows = db

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -316,6 +316,38 @@ describe("MessageRouter — route", () => {
     expect(db.threads.get("t-100")?.ownerAgent).toBe("hippo");
   });
 
+  it("uses a neutral transport owner hint for an existing unowned non-Slack thread", () => {
+    const hippo = makeAgent({ id: "hippo", name: "Pixel Lime Hippo", stableId: "stable-hippo" });
+    const cobra = makeAgent({ id: "cobra", name: "Aurora Pearl Cobra", stableId: "stable-cobra" });
+    db.agents = [hippo, cobra];
+    db.threads.set(
+      "chat:alice",
+      makeThread({
+        threadId: "chat:alice",
+        source: "imessage",
+        channel: "chat:alice",
+        ownerAgent: null,
+      }),
+    );
+
+    const decision = router.route(
+      makeMessage({
+        source: "imessage",
+        threadId: "chat:alice",
+        channel: "chat:alice",
+        userId: "+15551234567",
+        text: "please keep this with the current owner",
+        timestamp: "msg-2",
+        metadata: {
+          threadOwnerHint: { stableId: "stable-hippo", agentName: "Pixel Lime Hippo" },
+        },
+      }),
+    );
+
+    expect(decision).toEqual({ action: "deliver", agentId: "hippo" });
+    expect(db.threads.get("chat:alice")?.ownerAgent).toBe("hippo");
+  });
+
   it("does not leak a known-thread reply to a channel assignment when ownership is missing", () => {
     const hippo = makeAgent({ id: "hippo", name: "Pixel Lime Hippo" });
     const cobra = makeAgent({ id: "cobra", name: "Aurora Pearl Cobra" });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -653,6 +653,7 @@ export default function (pi: ExtensionAPI) {
                 ...message,
                 metadata: {
                   ...(message.metadata ?? {}),
+                  threadOwnerHint: ownerHint,
                   ...(ownerHint.agentOwner ? { threadOwnerAgentOwner: ownerHint.agentOwner } : {}),
                   ...(ownerHint.agentName ? { threadOwnerAgentName: ownerHint.agentName } : {}),
                 },


### PR DESCRIPTION
## Summary
- Generalize broker-core message sync identity derivation to external transport metadata instead of Slack-only source checks, with thread-scoped timestamp fallback.
- Apply thread-affinity owner metadata, transfer, and stale inbox pruning to all external transports while preserving internal `agent` A2A rows.
- Add neutral `threadOwnerHint` routing support while keeping Slack adapter legacy owner-hint compatibility.

Closes #778

## Testing
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge test`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`

## Review
- Local `reviewer` subagent second pass: no blockers found for #778 acceptance.
