### PR TITLE
Neutralize broker-core fallback thread sources

### DIFF
--- a/broker-core/router.ts
+++ b/broker-core/router.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_EXTERNAL_THREAD_SOURCE } from "./types.js";
 import type { AgentInfo, BrokerDBInterface, InboundMessage, RoutingDecision } from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -402,13 +403,20 @@ export class MessageRouter {
   /**
    * Claim a thread for an agent (first-responder-wins).
    * Optionally provide the transport source and channel to store when creating
-   * a new thread. Defaults to Slack for backward compatibility.
+   * a new thread. Defaults to a neutral external source when callers do not
+   * provide one; Slack call sites should continue passing `source: "slack"`
+   * explicitly through inbound messages or compatibility wrappers.
    * Returns true if the claim succeeded, false if another agent already owns it.
    *
    * Delegates to the DB layer which performs the claim atomically
    * (single SQL statement) to avoid TOCTOU races. (#125)
    */
-  claimThread(threadId: string, agentId: string, channel?: string, source = "slack"): boolean {
+  claimThread(
+    threadId: string,
+    agentId: string,
+    channel?: string,
+    source = DEFAULT_EXTERNAL_THREAD_SOURCE,
+  ): boolean {
     return this.db.claimThread(threadId, agentId, source, channel ?? "");
   }
 

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -431,6 +431,36 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("uses a neutral fallback source when upserting or claiming missing-source threads", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.updateThread("metadata-only", { metadata: { migrated: true } });
+      expect(db.getThread("metadata-only")).toMatchObject({
+        source: "external",
+        channel: "",
+        ownerAgent: null,
+        metadata: { migrated: true },
+      });
+
+      expect(db.claimThread("missing-claim", "agent-neutral")).toBe(true);
+      expect(db.getThread("missing-claim")).toMatchObject({
+        source: "external",
+        channel: "",
+        ownerAgent: "agent-neutral",
+      });
+
+      expect(db.claimThread("slack-claim", "agent-slack", "slack", "C123")).toBe(true);
+      expect(db.getThread("slack-claim")).toMatchObject({
+        source: "slack",
+        channel: "C123",
+        ownerAgent: "agent-slack",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("persists PM lane metadata and participants across reopen", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);
@@ -1149,7 +1179,7 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
-  it("reclassifies the original Slack message as steering for linked arrow-up reaction mail", () => {
+  it("reclassifies the original Slack message with a neutral reaction steering reason", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);
     try {
@@ -1191,12 +1221,12 @@ describe("BrokerDB message sync identity", () => {
       const reclassified = read.messages.find((item) => item.message.id === original.id)?.message;
       expect(reclassified?.metadata).toMatchObject({
         pinet_mail_class: "steering",
-        pinet_mail_class_reason: "slack_reaction_arrow_up",
+        pinet_mail_class_reason: "reaction_steer",
       });
       expect(reclassified?.metadata?.pinet_mail_class_audit).toEqual([
         expect.objectContaining({
           class: "steering",
-          reason: "slack_reaction_arrow_up",
+          reason: "reaction_steer",
           reactionName: "arrow_up",
           reactorUserId: "U_REACTOR",
           reactorName: "Alice",

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { classifyPinetMail } from "./mail-classification.js";
 import { getDefaultDbPath } from "./paths.js";
+import { DEFAULT_EXTERNAL_THREAD_SOURCE } from "./types.js";
 import type { PinetMailClass } from "./mail-classification.js";
 import type {
   AgentInfo,
@@ -2196,7 +2197,7 @@ export class BrokerDB implements BrokerDBInterface {
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       ).run(
         threadId,
-        updates.source ?? "slack",
+        updates.source ?? DEFAULT_EXTERNAL_THREAD_SOURCE,
         updates.channel ?? "",
         updates.ownerAgent !== undefined ? updates.ownerAgent : null,
         updates.ownerBinding !== undefined ? updates.ownerBinding : null,
@@ -2324,7 +2325,12 @@ export class BrokerDB implements BrokerDBInterface {
     }
   }
 
-  claimThread(threadId: string, agentId: string, source = "slack", channel = ""): boolean {
+  claimThread(
+    threadId: string,
+    agentId: string,
+    source = DEFAULT_EXTERNAL_THREAD_SOURCE,
+    channel = "",
+  ): boolean {
     const db = this.getDb();
     const now = new Date().toISOString();
 
@@ -3383,7 +3389,7 @@ export class BrokerDB implements BrokerDBInterface {
       externalId,
       "steering",
       {
-        reason: "slack_reaction_arrow_up",
+        reason: "reaction_steer",
         reactionName,
         reactorUserId: getStringMetadataValue(metadata, ["reactorUserId", "reactor_user_id"]),
         reactorName: getStringMetadataValue(metadata, ["reactorName", "reactor_name"]),

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -1,5 +1,7 @@
 import type { PinetMailClass } from "./mail-classification.js";
 
+export const DEFAULT_EXTERNAL_THREAD_SOURCE = "external";
+
 // ─── Domain types ─────────────────────────────────────────
 
 export interface AgentInfo {

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -1514,25 +1514,39 @@ describe("broker integration — router with real DB", () => {
     expect(db.getChannelAssignment("C123")).toBeNull();
   });
 
-  it("updateThread upserts when thread does not exist", () => {
-    // Thread does not exist yet — updateThread should create it
+  it("updateThread upserts missing-source threads with a neutral source", () => {
+    // Thread does not exist yet — updateThread should create it without assuming Slack.
     db.updateThread("t-upsert", { ownerAgent: "agent-1", channel: "C-UPSERT" });
 
     const thread = db.getThread("t-upsert");
     expect(thread).not.toBeNull();
     expect(thread!.ownerAgent).toBe("agent-1");
     expect(thread!.channel).toBe("C-UPSERT");
-    expect(thread!.source).toBe("slack");
+    expect(thread!.source).toBe("external");
   });
 
-  it("updateThread upsert defaults source to slack and channel to empty", () => {
+  it("updateThread upsert defaults source to external and channel to empty", () => {
     db.updateThread("t-upsert-defaults", { ownerAgent: "agent-2" });
 
     const thread = db.getThread("t-upsert-defaults");
     expect(thread).not.toBeNull();
-    expect(thread!.source).toBe("slack");
+    expect(thread!.source).toBe("external");
     expect(thread!.channel).toBe("");
     expect(thread!.ownerAgent).toBe("agent-2");
+  });
+
+  it("updateThread preserves explicit Slack compatibility upserts", () => {
+    db.updateThread("t-upsert-slack", {
+      ownerAgent: "agent-slack",
+      source: "slack",
+      channel: "C-SLACK",
+    });
+
+    const thread = db.getThread("t-upsert-slack");
+    expect(thread).not.toBeNull();
+    expect(thread!.source).toBe("slack");
+    expect(thread!.channel).toBe("C-SLACK");
+    expect(thread!.ownerAgent).toBe("agent-slack");
   });
 
   it("updateThread still works normally for existing threads", () => {


### PR DESCRIPTION
## Summary
- default missing-source broker thread upserts/claims to a neutral `external` source instead of Slack
- keep explicit Slack compatibility paths working when callers pass `source: "slack"`
- rename reaction-trigger reclassification audit reason from `slack_reaction_arrow_up` to transport-neutral `reaction_steer`

Refs #772.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-broker-core test`
- `pnpm --filter @gugu910/pi-broker-core typecheck`
- `pnpm --filter @gugu910/pi-broker-core lint`
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker/router.test.ts broker/message-send.test.ts broker/integration.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm lint && pnpm typecheck && pnpm test`
- push pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`
