### PR TITLE
feat: relay tracked GitHub PR events to Slack

### DIFF
--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -440,6 +440,34 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         }
         ensureActivityLogger().log(entry);
       },
+      emitGithubEventRelay: async (payload) => {
+        if (!activeBroker || !activeSelfId) {
+          return;
+        }
+        const adapter = activeBroker.adapters.find(
+          (candidate) => candidate.name === payload.target.source,
+        );
+        if (!adapter) {
+          throw new Error(
+            `No adapter is registered for GitHub relay source ${payload.target.source}.`,
+          );
+        }
+        await adapter.send({
+          threadId: payload.target.threadId,
+          channel: payload.target.channel,
+          text: payload.text,
+          metadata: payload.metadata,
+        });
+        activeBroker.db.insertMessage(
+          payload.target.threadId,
+          payload.target.source,
+          "outbound",
+          activeSelfId,
+          payload.text,
+          [],
+          payload.metadata,
+        );
+      },
       formatTrackedAgent: (agentId) => deps.formatTrackedAgent(agentId),
       summarizeTrackedAssignmentStatus: (status, prNumber, branch) =>
         deps.summarizeTrackedAssignmentStatus(

--- a/slack-bridge/github-event-relay.test.ts
+++ b/slack-bridge/github-event-relay.test.ts
@@ -67,7 +67,7 @@ describe("GitHub event relay helpers", () => {
       url: "https://github.com/gugu91/extensions/pull/123",
     });
     expect(formatGithubEventRelayText(event!)).toBe(
-      "GitHub relay: gugu91/extensions <https://github.com/gugu91/extensions/pull/123|PR #123> opened/ready for review for issue #774.",
+      "GitHub relay: gugu91/extensions <https://github.com/gugu91/extensions/pull/123|PR #123> opened for issue #774.",
     );
     expect(
       buildGithubEventRelayPayload(event!, {

--- a/slack-bridge/github-event-relay.test.ts
+++ b/slack-bridge/github-event-relay.test.ts
@@ -191,4 +191,68 @@ describe("GitHub event relay helpers", () => {
       ),
     ).toBeNull();
   });
+
+  it("prefers active Slack-backed lanes over terminal historical lanes", () => {
+    const event = buildGithubEventRelayEvent(
+      { ...baseAssignment, nextStatus: "pr_open", nextPrNumber: 123 },
+      "2026-06-04T01:02:03.000Z",
+    )!;
+    const activeLane = lane({
+      laneId: "active",
+      threadId: "active-thread",
+      state: "active",
+      metadata: { github: { owner: "gugu91", repo: "extensions" } },
+    });
+    const doneLane = lane({
+      laneId: "done",
+      threadId: "done-thread",
+      state: "done",
+      metadata: { github: { owner: "gugu91", repo: "extensions" } },
+    });
+    const threads = new Map<string, ThreadInfo>([
+      ["active-thread", thread({ threadId: "active-thread", channel: "C123" })],
+      ["done-thread", thread({ threadId: "done-thread", channel: "C999" })],
+    ]);
+
+    expect(
+      resolveSafeGithubEventRelayTarget(
+        (threadId) => threads.get(threadId) ?? null,
+        event,
+        [doneLane, activeLane],
+        "a2a:broker:worker",
+      ),
+    ).toEqual({ threadId: "active-thread", source: "slack", channel: "C123" });
+  });
+
+  it("skips visible delivery when multiple equally ranked safe Slack targets remain", () => {
+    const event = buildGithubEventRelayEvent(
+      { ...baseAssignment, nextStatus: "pr_open", nextPrNumber: 123 },
+      "2026-06-04T01:02:03.000Z",
+    )!;
+    const activeLaneA = lane({
+      laneId: "active-a",
+      threadId: "active-thread-a",
+      state: "active",
+      metadata: { github: { owner: "gugu91", repo: "extensions" } },
+    });
+    const activeLaneB = lane({
+      laneId: "active-b",
+      threadId: "active-thread-b",
+      state: "review",
+      metadata: { github: { owner: "gugu91", repo: "extensions" } },
+    });
+    const threads = new Map<string, ThreadInfo>([
+      ["active-thread-a", thread({ threadId: "active-thread-a", channel: "C123" })],
+      ["active-thread-b", thread({ threadId: "active-thread-b", channel: "C456" })],
+    ]);
+
+    expect(
+      resolveSafeGithubEventRelayTarget(
+        (threadId) => threads.get(threadId) ?? null,
+        event,
+        [activeLaneA, activeLaneB],
+        "a2a:broker:worker",
+      ),
+    ).toBeNull();
+  });
 });

--- a/slack-bridge/github-event-relay.test.ts
+++ b/slack-bridge/github-event-relay.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import type { PinetLaneInfo, ThreadInfo } from "./broker/types.js";
+import {
+  buildGithubEventRelayEvent,
+  buildGithubEventRelayPayload,
+  formatGithubEventRelayText,
+  mergeGithubEventRelayMetadata,
+  resolveSafeGithubEventRelayTarget,
+  selectPinetLanesForGithubEventRelay,
+} from "./github-event-relay.js";
+
+const baseAssignment = {
+  agentId: "agent-1",
+  issueNumber: 774,
+  repoOwner: "gugu91",
+  repoName: "extensions",
+};
+
+function lane(overrides: Partial<PinetLaneInfo>): PinetLaneInfo {
+  return {
+    laneId: "lane-1",
+    name: null,
+    task: null,
+    issueNumber: 774,
+    prNumber: null,
+    threadId: null,
+    ownerAgentId: null,
+    implementationLeadAgentId: null,
+    pmMode: false,
+    state: "active",
+    summary: null,
+    metadata: null,
+    createdAt: "2026-06-04T00:00:00.000Z",
+    updatedAt: "2026-06-04T00:00:00.000Z",
+    lastActivityAt: "2026-06-04T00:00:00.000Z",
+    participants: [],
+    ...overrides,
+  };
+}
+
+function thread(overrides: Partial<ThreadInfo>): ThreadInfo {
+  return {
+    threadId: "123.456",
+    source: "slack",
+    channel: "C123",
+    ownerAgent: null,
+    ownerBinding: null,
+    metadata: null,
+    createdAt: "2026-06-04T00:00:00.000Z",
+    updatedAt: "2026-06-04T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("GitHub event relay helpers", () => {
+  it("builds structured metadata and copy for PR open events", () => {
+    const event = buildGithubEventRelayEvent(
+      { ...baseAssignment, nextStatus: "pr_open", nextPrNumber: 123 },
+      "2026-06-04T01:02:03.000Z",
+    );
+
+    expect(event).toMatchObject({
+      eventType: "github_pr_lifecycle",
+      eventId: "github:gugu91/extensions:issue:774:pr:123:status:pr_open",
+      repoKey: "gugu91/extensions",
+      status: "pr_open",
+      url: "https://github.com/gugu91/extensions/pull/123",
+    });
+    expect(formatGithubEventRelayText(event!)).toBe(
+      "GitHub relay: gugu91/extensions <https://github.com/gugu91/extensions/pull/123|PR #123> opened/ready for review for issue #774.",
+    );
+    expect(
+      buildGithubEventRelayPayload(event!, {
+        threadId: "123.456",
+        source: "slack",
+        channel: "C123",
+      }).metadata,
+    ).toMatchObject({
+      githubEventRelay: event,
+      github: {
+        repoKey: "gugu91/extensions",
+        prNumber: 123,
+        status: "pr_open",
+      },
+    });
+  });
+
+  it("returns null for non-MVP statuses and missing PR numbers", () => {
+    expect(
+      buildGithubEventRelayEvent(
+        { ...baseAssignment, nextStatus: "pr_closed", nextPrNumber: 123 },
+        "2026-06-04T01:02:03.000Z",
+      ),
+    ).toBeNull();
+    expect(
+      buildGithubEventRelayEvent(
+        { ...baseAssignment, nextStatus: "pr_open", nextPrNumber: null },
+        "2026-06-04T01:02:03.000Z",
+      ),
+    ).toBeNull();
+  });
+
+  it("merges lane metadata without replacing unrelated keys", () => {
+    const event = buildGithubEventRelayEvent(
+      { ...baseAssignment, nextStatus: "pr_merged", nextPrNumber: 124 },
+      "2026-06-04T01:02:03.000Z",
+    )!;
+
+    expect(
+      mergeGithubEventRelayMetadata(
+        {
+          consent: "maintainer",
+          github: { owner: "gugu91", repo: "extensions", previous: true },
+        },
+        event,
+      ),
+    ).toEqual({
+      consent: "maintainer",
+      githubEventRelay: event,
+      github: {
+        owner: "gugu91",
+        repo: "extensions",
+        previous: true,
+        repoKey: "gugu91/extensions",
+        issueNumber: 774,
+        prNumber: 124,
+        status: "pr_merged",
+        url: "https://github.com/gugu91/extensions/pull/124",
+        updatedAt: "2026-06-04T01:02:03.000Z",
+      },
+    });
+  });
+
+  it("selects repo-scoped lanes and avoids ambiguous unscoped issue collisions", () => {
+    const event = buildGithubEventRelayEvent(
+      { ...baseAssignment, nextStatus: "pr_open", nextPrNumber: 123 },
+      "2026-06-04T01:02:03.000Z",
+    )!;
+    const exact = lane({
+      laneId: "exact",
+      metadata: { github: { owner: "gugu91", repo: "extensions" } },
+    });
+    const otherRepo = lane({
+      laneId: "other",
+      metadata: { github: { owner: "other", repo: "extensions" } },
+    });
+    const unscopedA = lane({ laneId: "unscoped-a" });
+    const unscopedB = lane({ laneId: "unscoped-b" });
+
+    expect(selectPinetLanesForGithubEventRelay([otherRepo, exact, unscopedA], event)).toEqual([
+      exact,
+    ]);
+    expect(selectPinetLanesForGithubEventRelay([unscopedA], event)).toEqual([unscopedA]);
+    expect(selectPinetLanesForGithubEventRelay([unscopedA, unscopedB], event)).toEqual([]);
+  });
+
+  it("resolves only safe Slack-backed relay targets", () => {
+    const event = buildGithubEventRelayEvent(
+      { ...baseAssignment, nextStatus: "pr_open", nextPrNumber: 123 },
+      "2026-06-04T01:02:03.000Z",
+    )!;
+    const slackLane = lane({
+      laneId: "slack",
+      threadId: "123.456",
+      metadata: { github: { owner: "gugu91", repo: "extensions" } },
+    });
+    const a2aLane = lane({ laneId: "a2a", threadId: "a2a:broker:worker" });
+    const threads = new Map<string, ThreadInfo>([
+      ["123.456", thread({ threadId: "123.456", source: "slack", channel: "C123" })],
+      [
+        "a2a:broker:worker",
+        thread({ threadId: "a2a:broker:worker", source: "agent", channel: "" }),
+      ],
+    ]);
+
+    expect(
+      resolveSafeGithubEventRelayTarget(
+        (threadId) => threads.get(threadId) ?? null,
+        event,
+        [a2aLane, slackLane],
+        "a2a:broker:worker",
+      ),
+    ).toEqual({ threadId: "123.456", source: "slack", channel: "C123" });
+
+    expect(
+      resolveSafeGithubEventRelayTarget(
+        (threadId) => threads.get(threadId) ?? null,
+        event,
+        [a2aLane],
+        "a2a:broker:worker",
+      ),
+    ).toBeNull();
+  });
+});

--- a/slack-bridge/github-event-relay.ts
+++ b/slack-bridge/github-event-relay.ts
@@ -180,29 +180,57 @@ function hasSlackThreadContext(metadata: Record<string, unknown> | null | undefi
   return typeof context?.channelId === "string" && context.channelId.length > 0;
 }
 
+function isTerminalLaneForVisibleRelay(lane: Pick<PinetLaneInfo, "state">): boolean {
+  return lane.state === "done" || lane.state === "cancelled" || lane.state === "detached";
+}
+
+function getVisibleRelayLaneRank(lane: Pick<PinetLaneInfo, "state">): number {
+  return isTerminalLaneForVisibleRelay(lane) ? 2 : 0;
+}
+
+function getSafeGithubEventRelayTarget(
+  threadsById: (threadId: string) => ThreadInfo | null,
+  threadId: string | null | undefined,
+): GithubEventRelayTarget | null {
+  if (!threadId) return null;
+  const thread = threadsById(threadId);
+  if (!thread || thread.source !== "slack" || !thread.channel) {
+    return null;
+  }
+  if (thread.channel.startsWith("D") && !hasSlackThreadContext(thread.metadata)) {
+    return null;
+  }
+  return { threadId, source: "slack", channel: thread.channel };
+}
+
 export function resolveSafeGithubEventRelayTarget(
   threadsById: (threadId: string) => ThreadInfo | null,
   event: GithubEventRelayEvent,
   lanes: ReadonlyArray<PinetLaneInfo>,
   assignmentThreadId: string,
 ): GithubEventRelayTarget | null {
-  const laneThreadIds = selectPinetLanesForGithubEventRelay(lanes, event)
-    .map((lane) => lane.threadId)
-    .filter((threadId): threadId is string => typeof threadId === "string" && threadId.length > 0);
-  const candidateThreadIds = [...new Set([...laneThreadIds, assignmentThreadId])];
+  const candidatesByThreadId = new Map<string, { target: GithubEventRelayTarget; rank: number }>();
+  const addCandidate = (threadId: string | null | undefined, rank: number): void => {
+    const target = getSafeGithubEventRelayTarget(threadsById, threadId);
+    if (!target) return;
 
-  for (const threadId of candidateThreadIds) {
-    const thread = threadsById(threadId);
-    if (!thread || thread.source !== "slack" || !thread.channel) {
-      continue;
+    const existing = candidatesByThreadId.get(target.threadId);
+    if (!existing || rank < existing.rank) {
+      candidatesByThreadId.set(target.threadId, { target, rank });
     }
-    if (thread.channel.startsWith("D") && !hasSlackThreadContext(thread.metadata)) {
-      continue;
-    }
-    return { threadId, source: "slack", channel: thread.channel };
+  };
+
+  for (const lane of selectPinetLanesForGithubEventRelay(lanes, event)) {
+    addCandidate(lane.threadId, getVisibleRelayLaneRank(lane));
   }
+  addCandidate(assignmentThreadId, 1);
 
-  return null;
+  const candidates = [...candidatesByThreadId.values()];
+  if (candidates.length === 0) return null;
+
+  const bestRank = Math.min(...candidates.map((candidate) => candidate.rank));
+  const bestCandidates = candidates.filter((candidate) => candidate.rank === bestRank);
+  return bestCandidates.length === 1 ? bestCandidates[0]!.target : null;
 }
 
 export function buildGithubEventRelayPayload(

--- a/slack-bridge/github-event-relay.ts
+++ b/slack-bridge/github-event-relay.ts
@@ -101,7 +101,7 @@ export function formatGithubEventRelayText(event: GithubEventRelayEvent): string
   if (event.status === "pr_merged") {
     return `GitHub relay: ${repoPrefix}${linkedPr} merged for issue #${event.issueNumber}.`;
   }
-  return `GitHub relay: ${repoPrefix}${linkedPr} opened/ready for review for issue #${event.issueNumber}.`;
+  return `GitHub relay: ${repoPrefix}${linkedPr} opened for issue #${event.issueNumber}.`;
 }
 
 export function buildGithubEventRelayMetadata(

--- a/slack-bridge/github-event-relay.ts
+++ b/slack-bridge/github-event-relay.ts
@@ -1,0 +1,218 @@
+import type {
+  PinetLaneInfo,
+  TaskAssignmentInfo,
+  TaskAssignmentStatus,
+  ThreadInfo,
+} from "./broker/types.js";
+
+export type GithubEventRelayStatus = Extract<TaskAssignmentStatus, "pr_open" | "pr_merged">;
+
+export interface GithubEventRelayEvent {
+  eventType: "github_pr_lifecycle";
+  eventId: string;
+  source: "task_assignment_poll";
+  owner: string | null;
+  repo: string | null;
+  repoKey: string;
+  issueNumber: number;
+  prNumber: number;
+  status: GithubEventRelayStatus;
+  url: string | null;
+  actorAgentId: string;
+  occurredAt: string;
+}
+
+export interface GithubEventRelayTarget {
+  threadId: string;
+  source: "slack";
+  channel: string;
+}
+
+export interface GithubEventRelayPayload {
+  event: GithubEventRelayEvent;
+  text: string;
+  metadata: Record<string, unknown>;
+  target: GithubEventRelayTarget;
+}
+
+function normalizeRepoPart(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function buildGithubRepoKey(input: { owner?: string | null; repo?: string | null }): string {
+  const owner = normalizeRepoPart(input.owner);
+  const repo = normalizeRepoPart(input.repo);
+  return owner && repo ? `${owner}/${repo}`.toLowerCase() : "repo_unknown";
+}
+
+function buildPullRequestUrl(input: {
+  owner: string | null;
+  repo: string | null;
+  prNumber: number;
+}): string | null {
+  return input.owner && input.repo
+    ? `https://github.com/${input.owner}/${input.repo}/pull/${input.prNumber}`
+    : null;
+}
+
+export function isGithubEventRelayStatus(
+  status: TaskAssignmentStatus,
+): status is GithubEventRelayStatus {
+  return status === "pr_open" || status === "pr_merged";
+}
+
+export function buildGithubEventRelayEvent(
+  assignment: Pick<TaskAssignmentInfo, "agentId" | "issueNumber" | "repoOwner" | "repoName"> & {
+    nextStatus: TaskAssignmentStatus;
+    nextPrNumber: number | null;
+  },
+  occurredAt: string,
+): GithubEventRelayEvent | null {
+  if (!isGithubEventRelayStatus(assignment.nextStatus) || assignment.nextPrNumber == null) {
+    return null;
+  }
+
+  const owner = normalizeRepoPart(assignment.repoOwner);
+  const repo = normalizeRepoPart(assignment.repoName);
+  const repoKey = buildGithubRepoKey({ owner, repo });
+  const prNumber = assignment.nextPrNumber;
+  const status = assignment.nextStatus;
+
+  return {
+    eventType: "github_pr_lifecycle",
+    eventId: `github:${repoKey}:issue:${assignment.issueNumber}:pr:${prNumber}:status:${status}`,
+    source: "task_assignment_poll",
+    owner,
+    repo,
+    repoKey,
+    issueNumber: assignment.issueNumber,
+    prNumber,
+    status,
+    url: buildPullRequestUrl({ owner, repo, prNumber }),
+    actorAgentId: assignment.agentId,
+    occurredAt,
+  };
+}
+
+export function formatGithubEventRelayText(event: GithubEventRelayEvent): string {
+  const repoPrefix = event.repoKey === "repo_unknown" ? "" : `${event.repoKey} `;
+  const linkedPr = event.url ? `<${event.url}|PR #${event.prNumber}>` : `PR #${event.prNumber}`;
+  if (event.status === "pr_merged") {
+    return `GitHub relay: ${repoPrefix}${linkedPr} merged for issue #${event.issueNumber}.`;
+  }
+  return `GitHub relay: ${repoPrefix}${linkedPr} opened/ready for review for issue #${event.issueNumber}.`;
+}
+
+export function buildGithubEventRelayMetadata(
+  event: GithubEventRelayEvent,
+): Record<string, unknown> {
+  return {
+    githubEventRelay: event,
+    github: {
+      owner: event.owner,
+      repo: event.repo,
+      repoKey: event.repoKey,
+      issueNumber: event.issueNumber,
+      prNumber: event.prNumber,
+      status: event.status,
+      url: event.url,
+    },
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getLaneGithubRepoKey(lane: Pick<PinetLaneInfo, "metadata">): string | null {
+  const metadata = asRecord(lane.metadata);
+  const github = asRecord(metadata?.github);
+  const owner =
+    normalizeRepoPart(github?.owner as string | null | undefined) ??
+    normalizeRepoPart(metadata?.githubOwner as string | null | undefined);
+  const repo =
+    normalizeRepoPart(github?.repo as string | null | undefined) ??
+    normalizeRepoPart(metadata?.githubRepo as string | null | undefined);
+  return owner && repo ? buildGithubRepoKey({ owner, repo }) : null;
+}
+
+export function selectPinetLanesForGithubEventRelay(
+  lanes: ReadonlyArray<PinetLaneInfo>,
+  event: Pick<GithubEventRelayEvent, "issueNumber" | "repoKey">,
+): PinetLaneInfo[] {
+  const issueMatches = lanes.filter((lane) => lane.issueNumber === event.issueNumber);
+  const exactMatches = issueMatches.filter((lane) => getLaneGithubRepoKey(lane) === event.repoKey);
+  if (exactMatches.length > 0) {
+    return exactMatches;
+  }
+
+  const unscopedMatches = issueMatches.filter((lane) => getLaneGithubRepoKey(lane) === null);
+  return unscopedMatches.length === 1 ? unscopedMatches : [];
+}
+
+export function mergeGithubEventRelayMetadata(
+  existing: Record<string, unknown> | null | undefined,
+  event: GithubEventRelayEvent,
+): Record<string, unknown> {
+  const base = existing ? { ...existing } : {};
+  return {
+    ...base,
+    githubEventRelay: event,
+    github: {
+      ...asRecord(base.github),
+      owner: event.owner,
+      repo: event.repo,
+      repoKey: event.repoKey,
+      issueNumber: event.issueNumber,
+      prNumber: event.prNumber,
+      status: event.status,
+      url: event.url,
+      updatedAt: event.occurredAt,
+    },
+  };
+}
+
+function hasSlackThreadContext(metadata: Record<string, unknown> | null | undefined): boolean {
+  const context = asRecord(metadata?.slackThreadContext);
+  return typeof context?.channelId === "string" && context.channelId.length > 0;
+}
+
+export function resolveSafeGithubEventRelayTarget(
+  threadsById: (threadId: string) => ThreadInfo | null,
+  event: GithubEventRelayEvent,
+  lanes: ReadonlyArray<PinetLaneInfo>,
+  assignmentThreadId: string,
+): GithubEventRelayTarget | null {
+  const laneThreadIds = selectPinetLanesForGithubEventRelay(lanes, event)
+    .map((lane) => lane.threadId)
+    .filter((threadId): threadId is string => typeof threadId === "string" && threadId.length > 0);
+  const candidateThreadIds = [...new Set([...laneThreadIds, assignmentThreadId])];
+
+  for (const threadId of candidateThreadIds) {
+    const thread = threadsById(threadId);
+    if (!thread || thread.source !== "slack" || !thread.channel) {
+      continue;
+    }
+    if (thread.channel.startsWith("D") && !hasSlackThreadContext(thread.metadata)) {
+      continue;
+    }
+    return { threadId, source: "slack", channel: thread.channel };
+  }
+
+  return null;
+}
+
+export function buildGithubEventRelayPayload(
+  event: GithubEventRelayEvent,
+  target: GithubEventRelayTarget,
+): GithubEventRelayPayload {
+  return {
+    event,
+    target,
+    text: formatGithubEventRelayText(event),
+    metadata: buildGithubEventRelayMetadata(event),
+  };
+}

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -472,7 +472,7 @@ describe("runRalphLoopCycle GitHub event relay", () => {
     expect(emitGithubEventRelay).toHaveBeenCalledWith(
       expect.objectContaining({
         target: { threadId: "123.456", source: "slack", channel: "C123" },
-        text: expect.stringContaining("opened/ready for review"),
+        text: expect.stringContaining("opened"),
         metadata: expect.objectContaining({
           githubEventRelay: expect.objectContaining({ status: "pr_open", prNumber: 123 }),
         }),

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { PinetLaneInfo, ThreadInfo } from "./broker/types.js";
 import {
   applyTrackedAssignmentIdleReplyStalls,
   buildTrackedAssignmentReplyNudgeMessage,
@@ -334,6 +335,8 @@ describe("runRalphLoopCycle GitHub event relay", () => {
       nextStatus?: "assigned" | "pr_open" | "pr_merged" | "pr_closed";
       nextPrNumber?: number | null;
       safeThread?: boolean;
+      lanes?: PinetLaneInfo[];
+      threads?: Map<string, ThreadInfo>;
     } = {},
   ) {
     const state = createRalphLoopState();
@@ -358,7 +361,7 @@ describe("runRalphLoopCycle GitHub event relay", () => {
       createdAt: now,
       updatedAt: now,
     } as const;
-    const lane = {
+    const lane: PinetLaneInfo = {
       laneId: "issue-774",
       name: null,
       task: null,
@@ -376,6 +379,23 @@ describe("runRalphLoopCycle GitHub event relay", () => {
       lastActivityAt: now,
       participants: [],
     };
+    const threads =
+      overrides.threads ??
+      new Map<string, ThreadInfo>([
+        [
+          "123.456",
+          {
+            threadId: "123.456",
+            source: "slack",
+            channel: "C123",
+            ownerAgent: "worker-1",
+            ownerBinding: null,
+            metadata: null,
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      ]);
     const db = {
       getRecentRalphCycles: () => [],
       getAllAgents: () => [],
@@ -385,22 +405,11 @@ describe("runRalphLoopCycle GitHub event relay", () => {
       listTaskAssignmentsAwaitingFirstReply: () => [],
       listTaskAssignments: () => [rawAssignment],
       getMessagesByIds: () => [],
-      listPinetLanes: () => [lane],
+      listPinetLanes: () => overrides.lanes ?? [lane],
       upsertPinetLane,
       updateTaskAssignmentProgress,
       getThread: (threadId: string) =>
-        overrides.safeThread === false || threadId !== "123.456"
-          ? null
-          : {
-              threadId: "123.456",
-              source: "slack",
-              channel: "C123",
-              ownerAgent: "worker-1",
-              ownerBinding: null,
-              metadata: null,
-              createdAt: now,
-              updatedAt: now,
-            },
+        overrides.safeThread === false ? null : (threads.get(threadId) ?? null),
       recordRalphCycle: vi.fn(),
     };
     const deps = createLoopDeps({
@@ -476,6 +485,77 @@ describe("runRalphLoopCycle GitHub event relay", () => {
         metadata: expect.objectContaining({
           githubEventRelay: expect.objectContaining({ status: "pr_open", prNumber: 123 }),
         }),
+      }),
+    );
+  });
+
+  it("uses active lanes for visible delivery when exact repo matches include done lanes", async () => {
+    const now = "2026-06-04T00:00:00.000Z";
+    const baseLane = {
+      name: null,
+      task: null,
+      issueNumber: 774,
+      prNumber: null,
+      ownerAgentId: null,
+      implementationLeadAgentId: null,
+      pmMode: false,
+      summary: null,
+      metadata: { github: { owner: "gugu91", repo: "extensions" } },
+      createdAt: now,
+      updatedAt: now,
+      lastActivityAt: now,
+      participants: [],
+    } satisfies Partial<PinetLaneInfo>;
+    const activeLane: PinetLaneInfo = {
+      ...baseLane,
+      laneId: "active-lane",
+      threadId: "active-thread",
+      state: "active",
+    } as PinetLaneInfo;
+    const doneLane: PinetLaneInfo = {
+      ...baseLane,
+      laneId: "done-lane",
+      threadId: "done-thread",
+      state: "done",
+    } as PinetLaneInfo;
+    const threads = new Map<string, ThreadInfo>([
+      [
+        "active-thread",
+        {
+          threadId: "active-thread",
+          source: "slack",
+          channel: "C123",
+          ownerAgent: "worker-1",
+          ownerBinding: null,
+          metadata: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      [
+        "done-thread",
+        {
+          threadId: "done-thread",
+          source: "slack",
+          channel: "C999",
+          ownerAgent: "worker-1",
+          ownerBinding: null,
+          metadata: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+    ]);
+
+    const { emitGithubEventRelay, upsertPinetLane } = await runGithubRelayCycle({
+      lanes: [doneLane, activeLane],
+      threads,
+    });
+
+    expect(upsertPinetLane).toHaveBeenCalledTimes(2);
+    expect(emitGithubEventRelay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { threadId: "active-thread", source: "slack", channel: "C123" },
       }),
     );
   });

--- a/slack-bridge/ralph-loop.test.ts
+++ b/slack-bridge/ralph-loop.test.ts
@@ -327,6 +327,179 @@ describe("runRalphLoopCycle snooze", () => {
   });
 });
 
+describe("runRalphLoopCycle GitHub event relay", () => {
+  async function runGithubRelayCycle(
+    overrides: {
+      resolvedStatus?: "assigned" | "pr_open" | "pr_merged";
+      nextStatus?: "assigned" | "pr_open" | "pr_merged" | "pr_closed";
+      nextPrNumber?: number | null;
+      safeThread?: boolean;
+    } = {},
+  ) {
+    const state = createRalphLoopState();
+    const logActivity = vi.fn();
+    const emitGithubEventRelay = vi.fn(async () => undefined);
+    const upsertPinetLane = vi.fn();
+    const updateTaskAssignmentProgress = vi.fn();
+    const now = new Date().toISOString();
+    const rawAssignment = {
+      id: 1,
+      agentId: "worker-1",
+      issueNumber: 774,
+      branch: "feat/github-event-relay-774",
+      prNumber: null,
+      status: "assigned",
+      threadId: "a2a:broker:worker",
+      sourceMessageId: null,
+      repoOwner: "gugu91",
+      repoName: "extensions",
+      repoRoot: null,
+      taskKind: "implementation",
+      createdAt: now,
+      updatedAt: now,
+    } as const;
+    const lane = {
+      laneId: "issue-774",
+      name: null,
+      task: null,
+      issueNumber: 774,
+      prNumber: null,
+      threadId: "123.456",
+      ownerAgentId: null,
+      implementationLeadAgentId: null,
+      pmMode: false,
+      state: "active",
+      summary: null,
+      metadata: { consent: "maintainer", github: { owner: "gugu91", repo: "extensions" } },
+      createdAt: now,
+      updatedAt: now,
+      lastActivityAt: now,
+      participants: [],
+    };
+    const db = {
+      getRecentRalphCycles: () => [],
+      getAllAgents: () => [],
+      getPendingInboxCount: () => 0,
+      getOwnedThreadCount: () => 0,
+      getBacklogCount: () => 0,
+      listTaskAssignmentsAwaitingFirstReply: () => [],
+      listTaskAssignments: () => [rawAssignment],
+      getMessagesByIds: () => [],
+      listPinetLanes: () => [lane],
+      upsertPinetLane,
+      updateTaskAssignmentProgress,
+      getThread: (threadId: string) =>
+        overrides.safeThread === false || threadId !== "123.456"
+          ? null
+          : {
+              threadId: "123.456",
+              source: "slack",
+              channel: "C123",
+              ownerAgent: "worker-1",
+              ownerBinding: null,
+              metadata: null,
+              createdAt: now,
+              updatedAt: now,
+            },
+      recordRalphCycle: vi.fn(),
+    };
+    const deps = createLoopDeps({
+      getBrokerDb: () => db as never,
+      getBrokerAgentId: () => "broker-1",
+      getLastMaintenance: () => ({
+        pendingBacklogCount: 0,
+        assignedBacklogCount: 0,
+        reapedAgentIds: [],
+        nudgedAgentIds: [],
+        repairedThreadClaims: 0,
+        anomalies: [],
+      }),
+      logActivity,
+      emitGithubEventRelay,
+      resolveTrackedTaskAssignments: vi.fn(async () => [
+        {
+          ...rawAssignment,
+          status: overrides.resolvedStatus ?? "assigned",
+          prNumber:
+            (overrides.resolvedStatus ?? "assigned") === (overrides.nextStatus ?? "pr_open")
+              ? overrides.nextPrNumber === undefined
+                ? 123
+                : overrides.nextPrNumber
+              : rawAssignment.prNumber,
+          nextStatus: overrides.nextStatus ?? "pr_open",
+          nextPrNumber: overrides.nextPrNumber === undefined ? 123 : overrides.nextPrNumber,
+          branchAheadCount: 0,
+          issueState: "OPEN" as const,
+        },
+      ]),
+    });
+    const ctx = { isIdle: () => true, ui: { notify: vi.fn() } } as unknown as ExtensionContext;
+
+    const originalCwd = process.cwd();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ralph-github-relay-test-"));
+    try {
+      process.chdir(tempDir);
+      await runRalphLoopCycle(ctx, state, deps);
+    } finally {
+      process.chdir(originalCwd);
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    return { emitGithubEventRelay, logActivity, upsertPinetLane, updateTaskAssignmentProgress };
+  }
+
+  it("emits PR-open relays, merges lane metadata, and updates assignment progress", async () => {
+    const { emitGithubEventRelay, upsertPinetLane, updateTaskAssignmentProgress } =
+      await runGithubRelayCycle();
+
+    expect(updateTaskAssignmentProgress).toHaveBeenCalledWith(1, "pr_open", 123);
+    expect(upsertPinetLane).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneId: "issue-774",
+        prNumber: 123,
+        metadata: expect.objectContaining({
+          consent: "maintainer",
+          github: expect.objectContaining({
+            owner: "gugu91",
+            repo: "extensions",
+            repoKey: "gugu91/extensions",
+            prNumber: 123,
+            status: "pr_open",
+          }),
+        }),
+      }),
+    );
+    expect(emitGithubEventRelay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { threadId: "123.456", source: "slack", channel: "C123" },
+        text: expect.stringContaining("opened/ready for review"),
+        metadata: expect.objectContaining({
+          githubEventRelay: expect.objectContaining({ status: "pr_open", prNumber: 123 }),
+        }),
+      }),
+    );
+  });
+
+  it("skips unchanged assignments to preserve status-transition dedupe", async () => {
+    const { emitGithubEventRelay, upsertPinetLane, updateTaskAssignmentProgress } =
+      await runGithubRelayCycle({ resolvedStatus: "pr_open", nextStatus: "pr_open" });
+
+    expect(updateTaskAssignmentProgress).not.toHaveBeenCalled();
+    expect(upsertPinetLane).not.toHaveBeenCalled();
+    expect(emitGithubEventRelay).not.toHaveBeenCalled();
+  });
+
+  it("skips visible delivery when no safe Slack-backed target is resolvable", async () => {
+    const { emitGithubEventRelay, logActivity, upsertPinetLane } = await runGithubRelayCycle({
+      safeThread: false,
+    });
+
+    expect(upsertPinetLane).toHaveBeenCalled();
+    expect(emitGithubEventRelay).not.toHaveBeenCalled();
+    expect(logActivity.mock.calls.map(([entry]) => entry.title)).toContain("GitHub relay skipped");
+  });
+});
+
 describe("hydrateRalphLoopReportedGhosts", () => {
   it("hydrates the latest persisted ghost ids into a fresh state", () => {
     const state = createRalphLoopState();

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -315,8 +315,8 @@ async function processGithubEventRelayForAssignment(
   if (!event) return;
 
   const lanes = db.listPinetLanes({ includeDone: true });
-  const matchingLanes = selectPinetLanesForGithubEventRelay(lanes, event);
-  for (const lane of matchingLanes) {
+  const metadataLanes = selectPinetLanesForGithubEventRelay(lanes, event);
+  for (const lane of metadataLanes) {
     db.upsertPinetLane({
       laneId: lane.laneId,
       prNumber: event.prNumber,
@@ -327,7 +327,7 @@ async function processGithubEventRelayForAssignment(
   const target = resolveSafeGithubEventRelayTarget(
     (threadId) => db.getThread(threadId),
     event,
-    matchingLanes,
+    lanes,
     assignment.threadId,
   );
 

--- a/slack-bridge/ralph-loop.ts
+++ b/slack-bridge/ralph-loop.ts
@@ -31,6 +31,14 @@ import {
   type ResolvedTaskAssignment,
 } from "./task-assignments.js";
 import type { ActivityLogEntry, ActivityLogTone } from "./activity-log.js";
+import {
+  buildGithubEventRelayEvent,
+  buildGithubEventRelayPayload,
+  mergeGithubEventRelayMetadata,
+  resolveSafeGithubEventRelayTarget,
+  selectPinetLanesForGithubEventRelay,
+  type GithubEventRelayPayload,
+} from "./github-event-relay.js";
 import { probeGitBranch } from "./git-metadata.js";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
 import type { BrokerMaintenanceResult } from "./broker/maintenance.js";
@@ -267,6 +275,11 @@ export interface RalphLoopDeps {
   sendMaintenanceMessage: (targetAgentId: string, body: string) => void;
   trySendFollowUp: (body: string, onDelivered: () => void) => void;
   logActivity: (entry: ActivityLogEntry) => void;
+  emitGithubEventRelay?: (payload: GithubEventRelayPayload) => Promise<void> | void;
+  resolveTrackedTaskAssignments?: (
+    assignments: TaskAssignmentInfo[],
+    cwd: string,
+  ) => Promise<ResolvedTaskAssignment[]>;
   formatTrackedAgent: (agentId: string) => string;
   summarizeTrackedAssignmentStatus: (
     status: string,
@@ -290,6 +303,80 @@ export interface RalphLoopDeps {
   setLastHomeTabSnapshot: (snapshot: BrokerControlPlaneDashboardSnapshot) => void;
   getLastHomeTabError: () => string | null;
   setLastHomeTabError: (err: string | null) => void;
+}
+
+async function processGithubEventRelayForAssignment(
+  db: BrokerDB,
+  deps: RalphLoopDeps,
+  assignment: ResolvedTaskAssignment,
+  occurredAt: string,
+): Promise<void> {
+  const event = buildGithubEventRelayEvent(assignment, occurredAt);
+  if (!event) return;
+
+  const lanes = db.listPinetLanes({ includeDone: true });
+  const matchingLanes = selectPinetLanesForGithubEventRelay(lanes, event);
+  for (const lane of matchingLanes) {
+    db.upsertPinetLane({
+      laneId: lane.laneId,
+      prNumber: event.prNumber,
+      metadata: mergeGithubEventRelayMetadata(lane.metadata, event),
+    });
+  }
+
+  const target = resolveSafeGithubEventRelayTarget(
+    (threadId) => db.getThread(threadId),
+    event,
+    matchingLanes,
+    assignment.threadId,
+  );
+
+  if (!target) {
+    deps.logActivity({
+      kind: "task_progress",
+      level: "verbose",
+      title: "GitHub relay skipped",
+      summary: `No safe Slack coordination thread for issue #${event.issueNumber} / PR #${event.prNumber}.`,
+      fields: [
+        { label: "Repo", value: event.repoKey },
+        { label: "Status", value: event.status },
+      ],
+      tone: "info",
+    });
+    return;
+  }
+
+  const payload = buildGithubEventRelayPayload(event, target);
+  if (!deps.emitGithubEventRelay) {
+    deps.logActivity({
+      kind: "task_progress",
+      level: "verbose",
+      title: "GitHub relay skipped",
+      summary: "No GitHub relay delivery seam is configured.",
+      fields: [
+        { label: "Thread", value: target.threadId },
+        { label: "Status", value: event.status },
+      ],
+      tone: "info",
+    });
+    return;
+  }
+
+  try {
+    await deps.emitGithubEventRelay(payload);
+  } catch (error) {
+    deps.logActivity({
+      kind: "task_progress",
+      level: "verbose",
+      title: "GitHub relay failed",
+      summary: error instanceof Error ? error.message : String(error),
+      fields: [
+        { label: "Thread", value: target.threadId },
+        { label: "Status", value: event.status },
+      ],
+      tone: "warning",
+    });
+  }
 }
 
 // ─── Core loop ───────────────────────────────────────────
@@ -416,10 +503,9 @@ export async function runRalphLoopCycle(
       state.pendingTaskAssignmentReport = null;
       state.taskAssignmentReportSignature = "";
     } else {
-      const resolvedAssignments = await resolveTaskAssignments(
-        trackedAssignments as TaskAssignmentInfo[],
-        process.cwd(),
-      );
+      const resolvedAssignments = await (
+        deps.resolveTrackedTaskAssignments ?? resolveTaskAssignments
+      )(trackedAssignments as TaskAssignmentInfo[], process.cwd());
       const changedAssignments = resolvedAssignments.filter(hasTaskAssignmentStatusChange);
       taskProgressChanged = changedAssignments.length > 0;
       projectedAssignments = resolvedAssignments.map((assignment) => {
@@ -432,6 +518,10 @@ export async function runRalphLoopCycle(
         }
         return { ...assignment, status: assignment.nextStatus, prNumber: assignment.nextPrNumber };
       });
+
+      for (const assignment of changedAssignments) {
+        await processGithubEventRelayForAssignment(db, deps, assignment, cycleStartedAt);
+      }
 
       if (changedAssignments.length > 0) {
         const openedCount = changedAssignments.filter((a) => a.nextStatus === "pr_open").length;


### PR DESCRIPTION
## Summary
- Add structured GitHub PR lifecycle relay metadata/helpers for tracked assignment polling.
- Relay only `pr_open` and `pr_merged` transitions to safely resolved Slack-backed coordination threads.
- Merge namespaced `githubEventRelay`/`github` lane metadata without replacing existing lane metadata; skip/log when no safe Slack target exists.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge test -- github-event-relay ralph-loop`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm lint && pnpm typecheck && pnpm test`

## Notes
- Best-effort/no-retry MVP per maintainer guidance.
- Native GitHub App/API/webhook integration and `pr_closed` warnings remain deferred.
