### PR TITLE
fix(pinet): preserve channel-only Slack claims

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -7,6 +7,7 @@ import { BrokerSocketServer } from "./socket-server.js";
 import { BrokerClient } from "./client.js";
 import { runBrokerMaintenancePass } from "./maintenance.js";
 import { MessageRouter } from "./router.js";
+import type { OutboundMessage } from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -1164,6 +1165,42 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     const thread = db.getThread("t-with-channel");
     expect(thread).not.toBeNull();
     expect(thread!.channel).toBe("C-TEST-123");
+    expect(thread!.source).toBe("slack");
+  });
+
+  it("thread.claim with only a channel remains Slack-sendable via message.send", async () => {
+    const sentMessages: OutboundMessage[] = [];
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async (message) => {
+          sentMessages.push(message);
+        },
+      },
+    ]);
+    await client.register("legacy-slack-claimer", "📺");
+
+    await client.claimThread("t-channel-only-send", "C-LEGACY");
+    const result = await client.sendMessage({
+      threadId: "t-channel-only-send",
+      body: "still Slack-sendable",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        adapter: "slack",
+        threadId: "t-channel-only-send",
+        channel: "C-LEGACY",
+        source: "slack",
+      }),
+    );
+    expect(sentMessages).toEqual([
+      expect.objectContaining({
+        threadId: "t-channel-only-send",
+        channel: "C-LEGACY",
+        text: "still Slack-sendable",
+      }),
+    ]);
   });
 
   it("thread.claim with source stores source on a new thread", async () => {

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -939,10 +939,16 @@ export class BrokerSocketServer {
     }
 
     const channel = typeof params.channel === "string" ? params.channel : undefined;
-    const source =
+    let source =
       typeof params.source === "string" && params.source.trim().length > 0
         ? params.source.trim()
         : undefined;
+    // Backward compatibility: legacy Slack callers used channel-only thread.claim
+    // requests. Keep those claims Slack-sendable while allowing truly source-less
+    // claims to fall through to broker-core's neutral default.
+    if (!source && channel) {
+      source = "slack";
+    }
     const claimed = this.router.claimThread(threadId, state.agentId, channel, source);
     return rpcOk(req.id, { claimed });
   }


### PR DESCRIPTION
## Summary
- Preserve legacy Slack compatibility for channel-only broker `thread.claim` RPC calls after #786
- Infer `source: "slack"` at the Slack bridge RPC boundary when callers pass a channel but omit source
- Add regression coverage that channel-only claims remain Slack-sendable via the Slack adapter while source-less claims remain neutral

## Testing
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker/integration.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

Follow-up to #786 / #772 after review found the post-merge channel-only Slack sendability compatibility risk.
