### PR TITLE
Repair neutralized Slack channel claims

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -1168,6 +1168,17 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     expect(thread!.source).toBe("slack");
   });
 
+  it("thread.claim without source or channel keeps the neutral broker default", async () => {
+    await client.register("neutral-claimer", "🧱");
+
+    await client.claimThread("t-source-less-neutral");
+
+    const thread = db.getThread("t-source-less-neutral");
+    expect(thread).not.toBeNull();
+    expect(thread!.source).toBe("external");
+    expect(thread!.channel).toBe("");
+  });
+
   it("thread.claim with only a channel remains Slack-sendable via message.send", async () => {
     const sentMessages: OutboundMessage[] = [];
     server.setOutboundMessageAdapters([
@@ -1199,6 +1210,50 @@ describe("broker integration — client ↔ server ↔ DB", () => {
         threadId: "t-channel-only-send",
         channel: "C-LEGACY",
         text: "still Slack-sendable",
+      }),
+    ]);
+  });
+
+  it("thread.claim with only a channel repairs neutralized Slack-channel rows", async () => {
+    const sentMessages: OutboundMessage[] = [];
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async (message) => {
+          sentMessages.push(message);
+        },
+      },
+    ]);
+    await client.register("legacy-repair-claimer", "🧱");
+    db.createThread("t-neutralized-slack-channel", "external", "C-NEUTRALIZED", null);
+
+    await client.claimThread("t-neutralized-slack-channel", "C-NEUTRALIZED");
+    const thread = db.getThread("t-neutralized-slack-channel");
+    expect(thread).toEqual(
+      expect.objectContaining({
+        source: "slack",
+        channel: "C-NEUTRALIZED",
+      }),
+    );
+
+    const result = await client.sendMessage({
+      threadId: "t-neutralized-slack-channel",
+      body: "repaired and sendable",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        adapter: "slack",
+        threadId: "t-neutralized-slack-channel",
+        channel: "C-NEUTRALIZED",
+        source: "slack",
+      }),
+    );
+    expect(sentMessages).toEqual([
+      expect.objectContaining({
+        threadId: "t-neutralized-slack-channel",
+        channel: "C-NEUTRALIZED",
+        text: "repaired and sendable",
       }),
     ]);
   });

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -946,10 +946,14 @@ export class BrokerSocketServer {
     // Backward compatibility: legacy Slack callers used channel-only thread.claim
     // requests. Keep those claims Slack-sendable while allowing truly source-less
     // claims to fall through to broker-core's neutral default.
-    if (!source && channel) {
+    const legacyChannelOnlyClaim = !source && !!channel;
+    if (legacyChannelOnlyClaim) {
       source = "slack";
     }
     const claimed = this.router.claimThread(threadId, state.agentId, channel, source);
+    if (claimed && legacyChannelOnlyClaim) {
+      this.db.updateThread(threadId, { source, channel });
+    }
     return rpcOk(req.id, { claimed });
   }
 


### PR DESCRIPTION
## Summary
- repair existing `external` + Slack-channel rows when a legacy channel-only `thread.claim` succeeds
- keep source-less/no-channel `thread.claim` on broker-core's neutral `external` default
- add regression coverage for seeded neutralized Slack-channel rows followed by `message.send` through the Slack adapter

Follow-up to #788 / #772 after review identified rows already persisted by #786 as a remaining compatibility risk.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @gugu910/pi-slack-bridge test -- broker/integration.test.ts`
- `pnpm --filter @gugu910/pi-slack-bridge typecheck`
- `pnpm --filter @gugu910/pi-slack-bridge lint`
- `pnpm lint && pnpm typecheck && pnpm test`
- push pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`

## Review
- Local `reviewer` subagent checked the diff and found no blockers/warnings.
