### PR TITLE
Prepare npm package declaration artifacts

### DIFF
--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -44,5 +44,6 @@
   },
   "dependencies": {
     "@gugu910/pi-transport-core": "file:../transport-core"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -33,5 +33,6 @@
   },
   "dependencies": {
     "@gugu910/pi-transport-core": "file:../transport-core"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -36,5 +36,6 @@
   "dependencies": {
     "@gugu910/pi-broker-core": "file:../broker-core",
     "@gugu910/pi-transport-core": "file:../transport-core"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -33,7 +33,15 @@ The Slack lane includes the Pinet package closure because `slack-bridge` depends
 - `target`: `pinet` or `slack-bridge`
 - `dry_run`: defaults to `true`
 
-The workflow installs with `pnpm install --frozen-lockfile`, builds packages, rewrites local `file:../...` workspace dependencies to exact package versions in the CI checkout, verifies declared `dist/` exports exist, and then runs `npm publish` in dependency order. Dry runs use `npm publish --dry-run`; real publishes must be dispatched from `refs/heads/main`, use `npm publish --provenance`, and fail closed if any target package version already exists on npm.
+The workflow installs with `pnpm install --frozen-lockfile`, builds packages in dependency order with `pnpm run build:packages`, rewrites local `file:../...` workspace dependencies to exact package versions in the CI checkout, verifies declared `dist/` JavaScript exports and declaration outputs exist, and then runs `npm publish` in dependency order. Dry runs use `npm publish --dry-run`; real publishes must be dispatched from `refs/heads/main`, use `npm publish --provenance`, and fail closed if any target package version already exists on npm.
+
+## Type/declaration artifacts
+
+Publishable packages must expose `types: "./dist/index.d.ts"` and build matching `.d.ts` files alongside their `dist/*.js` outputs. The publish script validates both the root `types` entry and declarations for JavaScript export targets before any dry-run or real publish.
+
+## `transport-core.slackBlocks` decision
+
+`NormalizedMessageContent.slackBlocks` remains a compatibility/native-rendering field for the current release-readiness track. It is intentionally documented as a Slack-specific rendering escape hatch on the otherwise transport-neutral content contract so existing Slack Block Kit callers can keep working while future transport-neutral rich-content design is considered separately. This is **not** a blocker for dry-run/release-readiness, but it remains a follow-up API design decision before claiming the content model is fully transport-native.
 
 ## Required GitHub/npm configuration
 

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -6,10 +6,12 @@ import ts from "typescript";
 
 const packageDir = process.cwd();
 const packageName = path.basename(packageDir);
+const repoRoot = path.resolve(packageDir, "..");
 const distDir = path.join(packageDir, "dist");
 
 const packageConfigs = {
   "transport-core": {
+    declaration: true,
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
     excludeFiles: new Set(),
     excludePrefixes: [],
@@ -17,6 +19,7 @@ const packageConfigs = {
     importRewrites: [],
   },
   "broker-core": {
+    declaration: true,
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
     excludeFiles: new Set(),
     excludePrefixes: [],
@@ -24,6 +27,7 @@ const packageConfigs = {
     importRewrites: [],
   },
   "pinet-core": {
+    declaration: true,
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
     excludeFiles: new Set(),
     excludePrefixes: [],
@@ -31,6 +35,7 @@ const packageConfigs = {
     importRewrites: [],
   },
   "imessage-bridge": {
+    declaration: true,
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
     excludeFiles: new Set(),
     excludePrefixes: [],
@@ -38,6 +43,7 @@ const packageConfigs = {
     importRewrites: [],
   },
   "slack-bridge": {
+    declaration: true,
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
     excludeFiles: new Set(["vitest.config.ts"]),
     excludePrefixes: [],
@@ -82,6 +88,7 @@ if (!config) {
 
 function shouldInclude(relativePath, localConfig = config) {
   if (!relativePath.endsWith(".ts")) return false;
+  if (relativePath.endsWith(".d.ts")) return false;
   if (relativePath.endsWith(".test.ts")) return false;
   if (localConfig.excludeFiles.has(relativePath)) return false;
   if (localConfig.excludePrefixes.some((prefix) => relativePath.startsWith(prefix))) return false;
@@ -141,6 +148,64 @@ async function copyDirectory(sourceDir, outputDir) {
     if (entry.isFile()) {
       await fs.copyFile(sourcePath, outputPath);
     }
+  }
+}
+
+async function collectAmbientDeclarations() {
+  const typesDir = path.join(repoRoot, "types");
+  try {
+    const entries = await fs.readdir(typesDir, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".d.ts"))
+      .map((entry) => path.join(typesDir, entry.name))
+      .sort();
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function emitDeclarations(sourceFiles) {
+  if (!config.declaration) return;
+
+  const rootNames = [
+    ...sourceFiles.map((relativePath) => path.join(packageDir, relativePath)),
+    ...(await collectAmbientDeclarations()),
+  ];
+  const compilerOptions = {
+    allowImportingTsExtensions: true,
+    declaration: true,
+    declarationDir: distDir,
+    emitDeclarationOnly: true,
+    forceConsistentCasingInFileNames: true,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    noEmit: false,
+    outDir: distDir,
+    rootDir: packageDir,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+    types: ["node"],
+    verbatimModuleSyntax: true,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const program = ts.createProgram(rootNames, compilerOptions, host);
+  const emitResult = program.emit(undefined, undefined, undefined, true);
+  const diagnostics = [...ts.getPreEmitDiagnostics(program), ...emitResult.diagnostics].filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+
+  if (diagnostics.length > 0) {
+    throw new Error(
+      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCanonicalFileName: (fileName) => fileName,
+        getCurrentDirectory: () => packageDir,
+        getNewLine: () => "\n",
+      }),
+    );
   }
 }
 
@@ -207,6 +272,8 @@ async function build() {
     await fs.mkdir(path.dirname(item.outputPath), { recursive: true });
     await fs.writeFile(item.outputPath, transpiled.outputText, "utf8");
   }
+
+  await emitDeclarations(sourceFiles);
 
   for (const assetDir of config.assetDirs ?? []) {
     await copyDirectory(path.join(packageDir, assetDir), path.join(distDir, assetDir));

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -151,6 +151,7 @@ export function validatePublishMetadata(entries, { dryRun }) {
       errors.push(`${manifest.name}: publishConfig.access must be public`);
     }
     if (!manifest.main) errors.push(`${manifest.name}: package.json must include main`);
+    if (!manifest.types) errors.push(`${manifest.name}: package.json must include types`);
     if (!manifest.files?.includes("dist/")) {
       errors.push(`${manifest.name}: package files must include dist/`);
     }
@@ -207,18 +208,33 @@ export function assertVersionsNotAlreadyPublished(entries, versionExists) {
   }
 }
 
+function declarationPathForJavaScript(exportedPath) {
+  return exportedPath.endsWith(".js") ? exportedPath.replace(/\.js$/, ".d.ts") : undefined;
+}
+
 export async function validateBuildOutputs(repoRoot, entries) {
   const missing = [];
 
   for (const { directory, manifest } of entries) {
     const packageRoot = path.join(repoRoot, directory);
-    const exportedPaths = new Set([manifest.main]);
+    const exportedPaths = new Set([manifest.main, manifest.types]);
 
     for (const value of Object.values(manifest.exports ?? {})) {
       if (typeof value === "string" && value !== "./package.json") {
         exportedPaths.add(value);
+        const declarationPath = declarationPathForJavaScript(value);
+        if (declarationPath) exportedPaths.add(declarationPath);
+      } else if (value && typeof value === "object") {
+        for (const conditionalValue of Object.values(value)) {
+          if (typeof conditionalValue === "string" && conditionalValue !== "./package.json") {
+            exportedPaths.add(conditionalValue);
+          }
+        }
       }
     }
+
+    const mainDeclarationPath = declarationPathForJavaScript(manifest.main ?? "");
+    if (mainDeclarationPath) exportedPaths.add(mainDeclarationPath);
 
     for (const exportedPath of exportedPaths) {
       if (typeof exportedPath !== "string") continue;

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   assertVersionsNotAlreadyPublished,
@@ -7,6 +10,7 @@ import {
   parseArgs,
   parseNpmViewVersionExists,
   rewriteLocalDependencySpecs,
+  validateBuildOutputs,
   validatePublishMetadata,
 } from "./npm-publish-helpers.mjs";
 
@@ -100,6 +104,7 @@ test("validatePublishMetadata blocks placeholder versions for real publish only"
       version: "0.0.0",
       publishConfig: { access: "public" },
       main: "./dist/index.js",
+      types: "./dist/index.d.ts",
       files: ["dist/"],
     }),
   ];
@@ -108,6 +113,60 @@ test("validatePublishMetadata blocks placeholder versions for real publish only"
   assert.throws(
     () => validatePublishMetadata(entries, { dryRun: false }),
     /placeholder version 0.0.0/,
+  );
+});
+
+test("validatePublishMetadata requires declaration metadata", () => {
+  const entries = [
+    entry("pinet-core", {
+      name: "@gugu910/pi-pinet-core",
+      version: "0.0.0",
+      publishConfig: { access: "public" },
+      main: "./dist/index.js",
+      files: ["dist/"],
+    }),
+  ];
+
+  assert.throws(() => validatePublishMetadata(entries, { dryRun: true }), /must include types/);
+});
+
+test("validateBuildOutputs checks JavaScript exports and declaration outputs", async () => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "npm-publish-outputs-"));
+  await mkdir(path.join(repoRoot, "pinet-core", "dist"), { recursive: true });
+  await writeFile(path.join(repoRoot, "pinet-core", "dist", "index.js"), "export {};\n");
+  await writeFile(path.join(repoRoot, "pinet-core", "dist", "index.d.ts"), "export {};\n");
+  await writeFile(path.join(repoRoot, "pinet-core", "dist", "helpers.js"), "export {};\n");
+
+  await assert.rejects(
+    () =>
+      validateBuildOutputs(repoRoot, [
+        entry("pinet-core", {
+          name: "@gugu910/pi-pinet-core",
+          main: "./dist/index.js",
+          types: "./dist/index.d.ts",
+          exports: {
+            ".": "./dist/index.js",
+            "./helpers": "./dist/helpers.js",
+          },
+        }),
+      ]),
+    /\.\/dist\/helpers\.d\.ts/,
+  );
+
+  await writeFile(path.join(repoRoot, "pinet-core", "dist", "helpers.d.ts"), "export {};\n");
+
+  await assert.doesNotReject(() =>
+    validateBuildOutputs(repoRoot, [
+      entry("pinet-core", {
+        name: "@gugu910/pi-pinet-core",
+        main: "./dist/index.js",
+        types: "./dist/index.d.ts",
+        exports: {
+          ".": "./dist/index.js",
+          "./helpers": "./dist/helpers.js",
+        },
+      }),
+    ]),
   );
 });
 

--- a/scripts/publish-npm-packages.mjs
+++ b/scripts/publish-npm-packages.mjs
@@ -26,7 +26,7 @@ function run(command, args, options = {}) {
   });
 
   if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+    throw new Error(`${command} ${args.join(" ")} failed with status ${result.status ?? 1}`);
   }
 }
 
@@ -52,35 +52,50 @@ async function main() {
 
   validatePublishMetadata(entries, { dryRun: args.dryRun });
 
-  run("pnpm", ["run", "build"]);
+  run("pnpm", ["run", "build:packages"]);
   await validateBuildOutputs(repoRoot, entries);
 
-  for (const entry of entries) {
-    await writeJson(entry.packageJsonPath, entry.manifest);
-    for (const rewrite of entry.rewrites) {
-      console.log(`${entry.manifest.name}: ${rewrite}`);
-    }
-  }
+  const originalManifests = entries.map(({ directory, packageJsonPath }) => ({
+    packageJsonPath,
+    manifest: manifests.get(directory).manifest,
+  }));
+  let wrotePatchedManifests = false;
 
-  if (!args.dryRun) {
-    if (!process.env.NPM_TOKEN) {
-      throw new Error("NPM_TOKEN is required for real npm publishing");
-    }
-    assertVersionsNotAlreadyPublished(entries, versionExists);
-  }
-
-  for (const { directory, manifest } of entries) {
-    const publishArgs = ["publish", "--access", "public"];
-    if (args.dryRun) {
-      publishArgs.push("--dry-run");
-    } else {
-      publishArgs.push("--provenance");
+  try {
+    for (const entry of entries) {
+      await writeJson(entry.packageJsonPath, entry.manifest);
+      wrotePatchedManifests = true;
+      for (const rewrite of entry.rewrites) {
+        console.log(`${entry.manifest.name}: ${rewrite}`);
+      }
     }
 
-    console.log(
-      `${args.dryRun ? "Dry-run publishing" : "Publishing"} ${manifest.name}@${manifest.version}`,
-    );
-    run("npm", publishArgs, { cwd: path.join(repoRoot, directory) });
+    if (!args.dryRun) {
+      if (!process.env.NPM_TOKEN) {
+        throw new Error("NPM_TOKEN is required for real npm publishing");
+      }
+      assertVersionsNotAlreadyPublished(entries, versionExists);
+    }
+
+    for (const { directory, manifest } of entries) {
+      const publishArgs = ["publish", "--access", "public"];
+      if (args.dryRun) {
+        publishArgs.push("--dry-run");
+      } else {
+        publishArgs.push("--provenance");
+      }
+
+      console.log(
+        `${args.dryRun ? "Dry-run publishing" : "Publishing"} ${manifest.name}@${manifest.version}`,
+      );
+      run("npm", publishArgs, { cwd: path.join(repoRoot, directory) });
+    }
+  } finally {
+    if (wrotePatchedManifests) {
+      for (const original of originalManifests) {
+        await writeJson(original.packageJsonPath, original.manifest);
+      }
+    }
   }
 }
 

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -49,5 +49,6 @@
     "@gugu910/pi-pinet-core": "file:../pinet-core",
     "@gugu910/pi-transport-core": "file:../transport-core",
     "@sinclair/typebox": "^0.34.49"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/transport-core/index.ts
+++ b/transport-core/index.ts
@@ -102,6 +102,11 @@ export interface InboundMessage {
 export interface NormalizedMessageContent {
   text: string;
   markdown?: string;
+  /**
+   * Compatibility/native-rendering escape hatch for Slack Block Kit payloads.
+   * This remains intentionally Slack-shaped for the current publish-readiness
+   * track while a future transport-neutral rich-content model is considered.
+   */
   slackBlocks?: ReadonlyArray<Record<string, unknown>>;
 }
 

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -30,5 +30,6 @@
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
     "test": "node --experimental-strip-types --test *.test.ts"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
+      "dependsOn": ["^build"],
       "inputs": [
         "**/*.ts",
         "!**/*.test.ts",


### PR DESCRIPTION
## Summary
- emit `.d.ts` declaration artifacts for the publishable transport/Pinet/Slack package lane and add root `types` metadata
- tighten publish validation so dry-run/release-readiness checks require declaration outputs for root and exported JS paths
- run package builds in dependency order for publishing and restore rewritten manifests after dry-run/publish attempts
- document `transport-core.slackBlocks` as a compatibility/native-rendering escape hatch, not a dry-run blocker

Refs #773.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build:packages`
- `node --test scripts/*.test.mjs`
- `node ./scripts/publish-npm-packages.mjs --target pinet --dry-run`
- `node ./scripts/publish-npm-packages.mjs --target slack-bridge --dry-run`
- `node ./scripts/publish-npm-packages.mjs --target pinet --publish` (expected guard failure at placeholder `0.0.0` versions; no publish)
- `pnpm lint && pnpm typecheck && pnpm test`
- push pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`

## Notes
- No version bump, tag, real publish, or merge in this PR.
- Real publish remains gated on explicit maintainer-approved versions and npm environment/token setup.
- Local `reviewer` subagent reviewed the diff; no blockers after the manifest-restore fix.
