### PR TITLE
fix(publish): validate public declaration dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,10 @@ importers:
       "@sinclair/typebox":
         specifier: ^0.34.49
         version: 0.34.49
+    devDependencies:
+      "@earendil-works/pi-coding-agent":
+        specifier: ^0.74.0
+        version: 0.74.0(ws@8.20.0)(zod@4.3.6)
 
   transport-core: {}
 

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -1,4 +1,6 @@
+import { spawnSync } from "node:child_process";
 import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 export const publishTargets = Object.freeze({
@@ -13,6 +15,7 @@ export const publishTargets = Object.freeze({
 });
 
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
+const publicDependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 
 export function parseArgs(argv) {
   const args = {
@@ -249,5 +252,207 @@ export async function validateBuildOutputs(repoRoot, entries) {
 
   if (missing.length > 0) {
     throw new Error(`Missing build outputs for npm publish:\n- ${missing.join("\n- ")}`);
+  }
+}
+
+function packagePath(parentDirectory, packageName) {
+  return path.join(parentDirectory, ...packageName.split("/"));
+}
+
+function packageBaseName(specifier) {
+  if (specifier.startsWith("@")) {
+    const [scope, name] = specifier.split("/");
+    return scope && name ? `${scope}/${name}` : specifier;
+  }
+  return specifier.split("/")[0];
+}
+
+function isBareTypeSpecifier(specifier) {
+  return !specifier.startsWith(".") && !specifier.startsWith("/") && !specifier.startsWith("node:");
+}
+
+function declaredPublicDependencies(manifest) {
+  const dependencies = new Set();
+  for (const field of publicDependencyFields) {
+    for (const name of Object.keys(manifest[field] ?? {})) {
+      dependencies.add(name);
+    }
+  }
+  return dependencies;
+}
+
+function declarationImports(source) {
+  const specifiers = new Set();
+  const importExportPattern =
+    /(?:import|export)\s+(?:type\s+)?(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g;
+  const dynamicImportPattern = /import\(["']([^"']+)["']\)/g;
+
+  for (const pattern of [importExportPattern, dynamicImportPattern]) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.add(match[1]);
+    }
+  }
+
+  return specifiers;
+}
+
+async function collectDeclarationFiles(directory) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectDeclarationFiles(absolutePath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".d.ts")) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findInstalledPackageRoot(repoRoot, packageRoot, packageName) {
+  const candidates = [
+    packagePath(path.join(packageRoot, "node_modules"), packageName),
+    packagePath(path.join(repoRoot, "node_modules"), packageName),
+    packagePath(path.join(repoRoot, "node_modules", ".pnpm", "node_modules"), packageName),
+  ];
+
+  for (const candidate of candidates) {
+    if (await pathExists(path.join(candidate, "package.json"))) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+async function linkPackage(nodeModulesDir, packageName, targetPath) {
+  const linkPath = packagePath(nodeModulesDir, packageName);
+  await fs.mkdir(path.dirname(linkPath), { recursive: true });
+  await fs.rm(linkPath, { recursive: true, force: true });
+  await fs.symlink(targetPath, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
+function typeScriptCliPath(repoRoot) {
+  return path.join(repoRoot, "node_modules", "typescript", "bin", "tsc");
+}
+
+export async function validatePublicTypeResolution(repoRoot, entries) {
+  const targetNames = new Set(entries.map(({ manifest }) => manifest.name));
+  const importedExternalDependencies = new Map();
+  const declarationErrors = [];
+
+  for (const { directory, manifest } of entries) {
+    const packageRoot = path.join(repoRoot, directory);
+    const declaredDependencies = declaredPublicDependencies(manifest);
+    const declarationFiles = await collectDeclarationFiles(path.join(packageRoot, "dist"));
+
+    for (const declarationFile of declarationFiles) {
+      const source = await fs.readFile(declarationFile, "utf8");
+      for (const specifier of declarationImports(source)) {
+        if (!isBareTypeSpecifier(specifier)) continue;
+
+        const packageName = packageBaseName(specifier);
+        if (targetNames.has(packageName)) continue;
+
+        if (!declaredDependencies.has(packageName)) {
+          declarationErrors.push(
+            `${manifest.name}: ${path.relative(packageRoot, declarationFile)} imports ${packageName}, but package.json does not declare it in dependencies, optionalDependencies, or peerDependencies`,
+          );
+          continue;
+        }
+
+        const installedRoot = await findInstalledPackageRoot(repoRoot, packageRoot, packageName);
+        if (!installedRoot) {
+          declarationErrors.push(
+            `${manifest.name}: ${packageName} is declared for public types but is not installed for the isolated type-resolution smoke test`,
+          );
+          continue;
+        }
+        importedExternalDependencies.set(packageName, installedRoot);
+      }
+    }
+  }
+
+  if (declarationErrors.length > 0) {
+    throw new Error(
+      `Public declaration dependency validation failed:\n- ${declarationErrors.join("\n- ")}`,
+    );
+  }
+
+  const tempRoot = await fs.mkdtemp(path.join(tmpdir(), "npm-publish-types-"));
+  try {
+    const nodeModulesDir = path.join(tempRoot, "node_modules");
+    await fs.mkdir(nodeModulesDir, { recursive: true });
+
+    for (const { directory, manifest } of entries) {
+      await linkPackage(nodeModulesDir, manifest.name, path.join(repoRoot, directory));
+    }
+    for (const [packageName, installedRoot] of importedExternalDependencies) {
+      await linkPackage(nodeModulesDir, packageName, installedRoot);
+    }
+
+    await fs.writeFile(
+      path.join(tempRoot, "package.json"),
+      `${JSON.stringify({ type: "module", private: true }, null, 2)}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(tempRoot, "index.ts"),
+      entries.map(({ manifest }) => `import ${JSON.stringify(manifest.name)};`).join("\n") + "\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(tempRoot, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            strict: true,
+            noEmit: true,
+            preserveSymlinks: true,
+            skipLibCheck: true,
+            types: [],
+          },
+          include: ["index.ts"],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const repoTypeScriptCliPath = typeScriptCliPath(repoRoot);
+    const tscPath = (await pathExists(repoTypeScriptCliPath))
+      ? repoTypeScriptCliPath
+      : typeScriptCliPath(process.cwd());
+    const result = spawnSync(process.execPath, [tscPath, "-p", "tsconfig.json"], {
+      cwd: tempRoot,
+      encoding: "utf8",
+    });
+
+    if (result.status !== 0) {
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+      throw new Error(
+        `Public type-resolution smoke test failed with status ${result.status ?? 1}:\n${output}`,
+      );
+    }
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
   }
 }

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -353,6 +353,7 @@ function typeScriptCliPath(repoRoot) {
 export async function validatePublicTypeResolution(repoRoot, entries) {
   const targetNames = new Set(entries.map(({ manifest }) => manifest.name));
   const importedExternalDependencies = new Map();
+  const publicTypeSpecifiers = new Set();
   const declarationErrors = [];
 
   for (const { directory, manifest } of entries) {
@@ -364,6 +365,8 @@ export async function validatePublicTypeResolution(repoRoot, entries) {
       const source = await fs.readFile(declarationFile, "utf8");
       for (const specifier of declarationImports(source)) {
         if (!isBareTypeSpecifier(specifier)) continue;
+
+        publicTypeSpecifiers.add(specifier);
 
         const packageName = packageBaseName(specifier);
         if (targetNames.has(packageName)) continue;
@@ -410,11 +413,16 @@ export async function validatePublicTypeResolution(repoRoot, entries) {
       `${JSON.stringify({ type: "module", private: true }, null, 2)}\n`,
       "utf8",
     );
-    await fs.writeFile(
-      path.join(tempRoot, "index.ts"),
-      entries.map(({ manifest }) => `import ${JSON.stringify(manifest.name)};`).join("\n") + "\n",
-      "utf8",
-    );
+    const smokeImports = [
+      ...entries.map(({ manifest }) => `import ${JSON.stringify(manifest.name)};`),
+      ...[...publicTypeSpecifiers]
+        .sort()
+        .map(
+          (specifier, index) =>
+            `import type * as PublicType${index} from ${JSON.stringify(specifier)};`,
+        ),
+    ];
+    await fs.writeFile(path.join(tempRoot, "index.ts"), `${smokeImports.join("\n")}\n`, "utf8");
     await fs.writeFile(
       path.join(tempRoot, "tsconfig.json"),
       `${JSON.stringify(

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -240,6 +240,56 @@ test("validatePublicTypeResolution catches undeclared declaration imports", asyn
   );
 });
 
+test("validatePublicTypeResolution catches declared but unresolvable declaration subpaths", async () => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "npm-publish-subpath-types-"));
+  const packageRoot = path.join(repoRoot, "example-package");
+  const dependencyRoot = path.join(repoRoot, "node_modules", "resolved-pkg");
+  await mkdir(path.join(packageRoot, "dist"), { recursive: true });
+  await mkdir(dependencyRoot, { recursive: true });
+
+  await writeFile(path.join(packageRoot, "dist", "index.js"), "export {};\n");
+  await writeFile(
+    path.join(packageRoot, "dist", "index.d.ts"),
+    'import type { MissingSubpathType } from "resolved-pkg/missing-subpath";\nexport type Example = MissingSubpathType;\n',
+  );
+  await writeFile(
+    path.join(dependencyRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "resolved-pkg",
+        type: "module",
+        main: "./index.js",
+        types: "./index.d.ts",
+        exports: {
+          ".": {
+            types: "./index.d.ts",
+            default: "./index.js",
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(path.join(dependencyRoot, "index.js"), "\n");
+  await writeFile(path.join(dependencyRoot, "index.d.ts"), "export interface RootType {}\n");
+
+  await assert.rejects(
+    () =>
+      validatePublicTypeResolution(repoRoot, [
+        entry("example-package", {
+          name: "example-package",
+          main: "./dist/index.js",
+          types: "./dist/index.d.ts",
+          peerDependencies: {
+            "resolved-pkg": "*",
+          },
+        }),
+      ]),
+    /resolved-pkg\/missing-subpath/s,
+  );
+});
+
 test("parseNpmViewVersionExists distinguishes found, not-found, and lookup errors", () => {
   assert.equal(
     parseNpmViewVersionExists(

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -11,6 +11,7 @@ import {
   parseNpmViewVersionExists,
   rewriteLocalDependencySpecs,
   validateBuildOutputs,
+  validatePublicTypeResolution,
   validatePublishMetadata,
 } from "./npm-publish-helpers.mjs";
 
@@ -164,6 +165,75 @@ test("validateBuildOutputs checks JavaScript exports and declaration outputs", a
         exports: {
           ".": "./dist/index.js",
           "./helpers": "./dist/helpers.js",
+        },
+      }),
+    ]),
+  );
+});
+
+test("validatePublicTypeResolution catches undeclared declaration imports", async () => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "npm-publish-types-"));
+  const packageRoot = path.join(repoRoot, "example-package");
+  await mkdir(path.join(packageRoot, "dist"), { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "example-package",
+        type: "module",
+        main: "./dist/index.js",
+        types: "./dist/index.d.ts",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(path.join(packageRoot, "dist", "index.js"), "export {};\n");
+  await writeFile(
+    path.join(packageRoot, "dist", "index.d.ts"),
+    'import type { MissingType } from "missing-public-types";\nexport type Example = MissingType;\n',
+  );
+
+  await assert.rejects(
+    () =>
+      validatePublicTypeResolution(repoRoot, [
+        entry("example-package", {
+          name: "example-package",
+          main: "./dist/index.js",
+          types: "./dist/index.d.ts",
+        }),
+      ]),
+    /missing-public-types.*does not declare/s,
+  );
+
+  await mkdir(path.join(repoRoot, "node_modules", "missing-public-types"), { recursive: true });
+  await writeFile(
+    path.join(repoRoot, "node_modules", "missing-public-types", "package.json"),
+    `${JSON.stringify(
+      {
+        name: "missing-public-types",
+        type: "module",
+        main: "./index.js",
+        types: "./index.d.ts",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(path.join(repoRoot, "node_modules", "missing-public-types", "index.js"), "\n");
+  await writeFile(
+    path.join(repoRoot, "node_modules", "missing-public-types", "index.d.ts"),
+    "export interface MissingType { value: string; }\n",
+  );
+
+  await assert.doesNotReject(() =>
+    validatePublicTypeResolution(repoRoot, [
+      entry("example-package", {
+        name: "example-package",
+        main: "./dist/index.js",
+        types: "./dist/index.d.ts",
+        peerDependencies: {
+          "missing-public-types": "*",
         },
       }),
     ]),

--- a/scripts/publish-npm-packages.mjs
+++ b/scripts/publish-npm-packages.mjs
@@ -11,6 +11,7 @@ import {
   parseNpmViewVersionExists,
   rewriteLocalDependencySpecs,
   validateBuildOutputs,
+  validatePublicTypeResolution,
   validatePublishMetadata,
   writeJson,
 } from "./npm-publish-helpers.mjs";
@@ -54,6 +55,7 @@ async function main() {
 
   run("pnpm", ["run", "build:packages"]);
   await validateBuildOutputs(repoRoot, entries);
+  await validatePublicTypeResolution(repoRoot, entries);
 
   const originalManifests = entries.map(({ directory, packageJsonPath }) => ({
     packageJsonPath,

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -50,5 +50,11 @@
     "@gugu910/pi-transport-core": "file:../transport-core",
     "@sinclair/typebox": "^0.34.49"
   },
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.74.0"
+  }
 }


### PR DESCRIPTION
## Summary
- Fix the post-#791 public type-surface readiness gap for `@gugu910/pi-slack-bridge`
- Declare `@earendil-works/pi-coding-agent` for published consumers and local validation
- Extend npm publish readiness checks to validate bare imports in emitted public `.d.ts` files with an isolated consumer smoke test

## Testing
- `pnpm build:packages`
- `node --test scripts/*.test.mjs`
- `node ./scripts/publish-npm-packages.mjs --target pinet --dry-run`
- `node ./scripts/publish-npm-packages.mjs --target slack-bridge --dry-run`
- `node ./scripts/publish-npm-packages.mjs --target slack-bridge --publish` (expected placeholder-version guard failure; no publish)
- `pnpm lint && pnpm typecheck && pnpm test`
- pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

Follow-up to #791 / #773 after review found `slack-bridge` advertised declarations importing an undeclared external type dependency.
