### PR TITLE
fix(publish): harden prompt asset packaging test

### DIFF
--- a/slack-bridge/broker-prompt-loader.test.ts
+++ b/slack-bridge/broker-prompt-loader.test.ts
@@ -299,6 +299,8 @@ describe("packaged default broker prompt", () => {
     expect(defaultPrompt).toContain("Never echo tokens");
   });
 
+  // This exercises the real package build, including declaration emit; CI can exceed Vitest's
+  // default 5s test timeout even though the build path is expected for publish readiness.
   it("copies prompt assets into dist/prompts so the packaged tmux.md is loadable", async () => {
     await execFileAsync("node", ["../scripts/build-package.mjs"], { cwd: process.cwd() });
 
@@ -312,5 +314,5 @@ describe("packaged default broker prompt", () => {
 
     expect(result.source).toBe("packaged");
     expect(result.content).toContain("PRIORITIZED ISSUE GATE");
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary
- follow up after #792 merged with GitHub quality still red
- give the real prompt-assets package-build test a 20s timeout with rationale, preserving coverage while allowing declaration-emitting builds under CI variance

## Validation
Reported by implementer on branch:
- pnpm --dir slack-bridge exec vitest run broker-prompt-loader.test.ts --reporter verbose
- node --test scripts/*.test.mjs
- node ./scripts/publish-npm-packages.mjs --target pinet --dry-run
- node ./scripts/publish-npm-packages.mjs --target slack-bridge --dry-run
- pnpm lint && pnpm typecheck && pnpm test
- push pre-push hook reran pnpm lint && pnpm typecheck && pnpm test

No publish, tag, version bump, or merge requested.