### PR TITLE
chore: harden npm publish workflow readiness

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: npm-publish-${{ inputs.target }}
+  group: npm-publish-${{ inputs.dry_run && format('dry-run-{0}', inputs.target) || 'live' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,12 @@
 name: Publish npm packages
 
+run-name: npm ${{ inputs.dry_run && 'dry-run' || 'publish' }} ${{ inputs.target }} packages
+
 on:
   workflow_dispatch:
     inputs:
       target:
-        description: "Package lane to publish"
+        description: "Package lane to validate or publish"
         required: true
         type: choice
         options:
@@ -15,20 +17,23 @@ on:
         required: true
         type: boolean
         default: true
+      release_approval:
+        description: "For real publishes only: type 'publish <target>'"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
-  group: npm-publish
+  group: npm-publish-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish ${{ inputs.target }} packages
+  readiness:
+    name: Validate ${{ inputs.target }} publish readiness
     runs-on: ubuntu-latest
-    environment: npm-publish
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -50,26 +55,76 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Dry-run publish target packages
-        if: ${{ inputs.dry_run }}
         run: >-
           node ./scripts/publish-npm-packages.mjs
           --target "${{ inputs.target }}"
           --dry-run
 
+  publish-preflight:
+    name: Check real publish gates
+    if: ${{ !inputs.dry_run }}
+    needs: readiness
+    runs-on: ubuntu-latest
+    steps:
       - name: Guard real publish ref
-        if: ${{ !inputs.dry_run && github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           echo "Real npm publishes must be dispatched from refs/heads/main. Current ref: $GITHUB_REF"
           exit 1
 
+      - name: Guard real publish approval phrase
+        env:
+          RELEASE_APPROVAL: ${{ inputs.release_approval }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          expected="publish ${TARGET}"
+          if [ "${RELEASE_APPROVAL}" != "${expected}" ]; then
+            echo "Real npm publishes require release_approval exactly: ${expected}"
+            exit 1
+          fi
+
+  publish:
+    name: Publish ${{ inputs.target }} packages
+    if: ${{ !inputs.dry_run }}
+    needs:
+      - readiness
+      - publish-preflight
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Configure npm authentication
-        if: ${{ !inputs.dry_run }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "NPM_TOKEN is required for real npm publishing"
+            exit 1
+          fi
+          npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
 
       - name: Publish target packages
-        if: ${{ !inputs.dry_run }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this repository are documented in this file.
 
+## Release note policy
+
+Readiness-only npm publishing workflow or documentation changes do not by
+themselves create a new release entry, tag, or package version. Add a versioned
+entry only when a maintainer approves a real release with intentional package
+version bumps and publish scope.
+
 ## [0.1.4] - 2026-04-23
 
 Pinet v0.1.4 is a focused patch release for `@gugu910/pi-slack-bridge` that fixes Slack external file-upload requests to use the form encoding Slack expects. The runtime behavior change is intentionally narrow: `slack_upload` should stop failing with `invalid_arguments` when it calls `files.getUploadURLExternal` and `files.completeUploadExternal`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ The reviewer posts findings to PiComms and GitHub. Fix any critical/warning issu
 - Auth: `GH_TOKEN=$(gh auth token --user gugu91)` prefix for `gh` commands
 - Create PRs with `gh pr create`
 - Merge with `gh pr merge`
+- npm publish readiness lives in `.github/workflows/npm-publish.yml` and `plans/npm-publish.md`. Do not run real publishes, tag, or bump versions without explicit maintainer release approval.
 
 ## Extension patterns
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,10 @@ Safe readiness checks are the default path:
 Real publishes are intentionally harder to trigger. They require a maintainer to
 dispatch from `main` with `dry_run=false`, enter the exact `release_approval`
 phrase shown in the workflow, approve the protected `npm-publish` environment,
-and provide the environment-scoped `NPM_TOKEN`. The publish script still refuses
-placeholder `0.0.0` versions and versions that already exist on npm.
+and provide the environment-scoped `NPM_TOKEN`. That environment is an external
+repository prerequisite that must be configured and verified before any real
+publish attempt. The publish script still refuses placeholder `0.0.0` versions
+and versions that already exist on npm.
 
 Do not publish, tag, or bump package versions as part of readiness-only changes;
 record release notes in `CHANGELOG.md` only when a maintainer approves a real

--- a/README.md
+++ b/README.md
@@ -227,6 +227,31 @@ where broad Slack/Pinet action families can otherwise bloat every agent turn
 See [`plans/test-policy.md`](plans/test-policy.md) for merge-ready test
 expectations and the required smoke checklist.
 
+## npm publish readiness
+
+The publishable Pinet/Slack package lanes are tracked in
+[`plans/npm-publish.md`](plans/npm-publish.md) and executed through the manual
+[`Publish npm packages`](.github/workflows/npm-publish.yml) GitHub Actions
+workflow.
+
+Safe readiness checks are the default path:
+
+1. Open **Actions → Publish npm packages → Run workflow**.
+2. Choose `target` as `pinet` or `slack-bridge`.
+3. Leave `dry_run=true`.
+4. Confirm the workflow runs `scripts/publish-npm-packages.mjs --dry-run` and
+   does not request npm credentials.
+
+Real publishes are intentionally harder to trigger. They require a maintainer to
+dispatch from `main` with `dry_run=false`, enter the exact `release_approval`
+phrase shown in the workflow, approve the protected `npm-publish` environment,
+and provide the environment-scoped `NPM_TOKEN`. The publish script still refuses
+placeholder `0.0.0` versions and versions that already exist on npm.
+
+Do not publish, tag, or bump package versions as part of readiness-only changes;
+record release notes in `CHANGELOG.md` only when a maintainer approves a real
+versioned release.
+
 ## Git workflow
 
 1. Branch from `main` — use `feat/`, `fix/`, `chore/` prefixes

--- a/broker-core/LICENSE
+++ b/broker-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/broker-core/README.md
+++ b/broker-core/README.md
@@ -17,3 +17,10 @@ Transport-neutral broker kernel primitives for the `extensions` repo.
 - Pi extension command/tool wiring
 - broker runtime orchestration and RALPH UI flows
 - follower runtime and single-player runtime glue
+
+## Publishing
+
+This package is part of both manual npm publish lanes tracked in
+[`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
+workflow's default dry-run/readiness path for validation; do not publish, tag, or
+bump versions without explicit maintainer release approval.

--- a/imessage-bridge/LICENSE
+++ b/imessage-bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/imessage-bridge/README.md
+++ b/imessage-bridge/README.md
@@ -42,6 +42,13 @@ In the current repo bring-up path, enable the adapter with `slack-bridge.imessag
 - AppleScript send helper + adapter-local transport code
 - stable default thread-id helper for send-first bring-up
 
+## Publishing
+
+This package is included in the manual `slack-bridge` npm publish lane tracked in
+[`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
+workflow's default dry-run/readiness path for validation; do not publish, tag, or
+bump versions without explicit maintainer release approval.
+
 ## What stays out of scope
 
 - inbound iMessage sync

--- a/pinet-core/LICENSE
+++ b/pinet-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pinet-core/README.md
+++ b/pinet-core/README.md
@@ -11,3 +11,10 @@ Current seam:
 `@gugu910/pi-slack-bridge` still composes the extension and preserves compatibility wrappers, but these helpers now live behind package exports so future extraction can move one boundary at a time.
 
 Design proposal: `plans/slack-split-proposal.md`
+
+## Publishing
+
+This package is included in the manual `pinet` and `slack-bridge` npm publish
+lanes tracked in [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the
+GitHub Actions workflow's default dry-run/readiness path for validation; do not
+publish, tag, or bump versions without explicit maintainer release approval.

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "README.md",
+    "LICENSE",
     "dist/"
   ],
   "pi": {},

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -28,16 +28,35 @@ The Slack lane includes the Pinet package closure because `slack-bridge` depends
 
 ## Workflow
 
-`.github/workflows/npm-publish.yml` is a manual `workflow_dispatch` workflow with two inputs:
+`.github/workflows/npm-publish.yml` is a manual `workflow_dispatch` workflow with three inputs:
 
 - `target`: `pinet` or `slack-bridge`
 - `dry_run`: defaults to `true`
+- `release_approval`: real publishes only; must exactly match `publish <target>`
 
-The workflow installs with `pnpm install --frozen-lockfile`, builds packages in dependency order with `pnpm run build:packages`, rewrites local `file:../...` workspace dependencies to exact package versions in the CI checkout, verifies declared `dist/` JavaScript exports and declaration outputs exist, and then runs `npm publish` in dependency order. Dry runs use `npm publish --dry-run`; real publishes must be dispatched from `refs/heads/main`, use `npm publish --provenance`, and fail closed if any target package version already exists on npm.
+Every dispatch first runs the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order.
 
-## Type/declaration artifacts
+When `dry_run=true`, the workflow stops after that dry-run/readiness job and does not request the `npm-publish` environment or npm token. Real publishes require all of these gates before the publish job can run:
 
-Publishable packages must expose `types: "./dist/index.d.ts"` and build matching `.d.ts` files alongside their `dist/*.js` outputs. The publish script validates both the root `types` entry and declarations for JavaScript export targets before any dry-run or real publish.
+- `dry_run=false` was selected manually.
+- A non-environment preflight job confirms the dispatch ref is `refs/heads/main`.
+- The same preflight job confirms `release_approval` exactly matches `publish <target>`.
+- The `npm-publish` GitHub environment is approved by a maintainer after preflight passes.
+- `NPM_TOKEN` is present in that environment.
+
+The real publish job then reruns the same publish script with `--publish`, which uses `npm publish --provenance` and fails closed if any target package version already exists on npm.
+
+## Package artifacts and type/declaration artifacts
+
+Publishable packages must include npm-visible package basics:
+
+- `README.md`
+- `LICENSE`
+- `dist/`
+- `license` metadata
+- `publishConfig.access: "public"`
+
+Publishable packages must also expose `types: "./dist/index.d.ts"` and build matching `.d.ts` files alongside their `dist/*.js` outputs. The publish script validates root metadata, package file allowlists, JavaScript export targets, declaration outputs, and public `.d.ts` import resolution before any dry-run or real publish. Public declaration imports are checked in an isolated TypeScript smoke test, and sibling publish-target imports must be declared in package dependencies, optional dependencies, or peer dependencies.
 
 ## `transport-core.slackBlocks` decision
 
@@ -49,14 +68,23 @@ Secret names only:
 
 - `NPM_TOKEN` in the `npm-publish` GitHub environment
 
+GitHub environment:
+
+- `npm-publish` should require maintainer approval before the publish job can access `NPM_TOKEN`.
+- Dry-run/readiness dispatches do not use the environment and do not need the token.
+
 GitHub permissions:
 
-- `contents: read`
-- `id-token: write` for npm provenance
+- Readiness job: `contents: read`
+- Publish job: `contents: read` plus `id-token: write` for npm provenance
 
 ## Release gates before setting `dry_run=false`
 
 - #772 has confirmed the Pinet/Slack boundary and the target lane is still correct.
 - Package versions are intentionally bumped. The publish script refuses real publishes for placeholder `0.0.0` packages or versions already present on npm.
+- `CHANGELOG.md` has a maintainer-approved entry covering the selected release lane and package versions.
+- The dry-run/readiness job is green on the same `main` commit intended for release.
+- The workflow dispatch includes the explicit `release_approval` phrase for the selected target.
+- The `npm-publish` environment approval is granted by a maintainer for that release.
 - Built outputs are produced from the current commit and match `main`/`exports` entries.
 - No npm token values are requested, printed, or committed.

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -36,7 +36,9 @@ The Slack lane includes the Pinet package closure because `slack-bridge` depends
 
 Every dispatch first runs the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order.
 
-When `dry_run=true`, the workflow stops after that dry-run/readiness job and does not request the `npm-publish` environment or npm token. Real publishes require all of these gates before the publish job can run:
+When `dry_run=true`, the workflow stops after that dry-run/readiness job and does not request the `npm-publish` environment or npm token. Dry-run dispatches are serialized per target. Real publish dispatches share a single global `npm-publish-live` concurrency group because the `pinet` and `slack-bridge` lanes publish overlapping packages.
+
+Real publishes require all of these gates before the publish job can run:
 
 - `dry_run=false` was selected manually.
 - A non-environment preflight job confirms the dispatch ref is `refs/heads/main`.
@@ -70,6 +72,8 @@ Secret names only:
 
 GitHub environment:
 
+- `npm-publish` is an external repository prerequisite, not something this repo can create in source control.
+- Configure or verify the environment before any real publish attempt.
 - `npm-publish` should require maintainer approval before the publish job can access `NPM_TOKEN`.
 - Dry-run/readiness dispatches do not use the environment and do not need the token.
 

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -153,10 +153,13 @@ export function validatePublishMetadata(entries, { dryRun }) {
     if (manifest.publishConfig?.access !== "public") {
       errors.push(`${manifest.name}: publishConfig.access must be public`);
     }
+    if (!manifest.license) errors.push(`${manifest.name}: package.json must include license`);
     if (!manifest.main) errors.push(`${manifest.name}: package.json must include main`);
     if (!manifest.types) errors.push(`${manifest.name}: package.json must include types`);
-    if (!manifest.files?.includes("dist/")) {
-      errors.push(`${manifest.name}: package files must include dist/`);
+    for (const requiredFile of ["README.md", "LICENSE", "dist/"]) {
+      if (!manifest.files?.includes(requiredFile)) {
+        errors.push(`${manifest.name}: package files must include ${requiredFile}`);
+      }
     }
     if (!dryRun && manifest.version === "0.0.0") {
       errors.push(`${manifest.name}: refusing a real npm publish at placeholder version 0.0.0`);

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -16,6 +16,7 @@ export const publishTargets = Object.freeze({
 
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 const publicDependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
+const requiredPackageFiles = ["README.md", "LICENSE", "dist/"];
 
 export function parseArgs(argv) {
   const args = {
@@ -156,7 +157,7 @@ export function validatePublishMetadata(entries, { dryRun }) {
     if (!manifest.license) errors.push(`${manifest.name}: package.json must include license`);
     if (!manifest.main) errors.push(`${manifest.name}: package.json must include main`);
     if (!manifest.types) errors.push(`${manifest.name}: package.json must include types`);
-    for (const requiredFile of ["README.md", "LICENSE", "dist/"]) {
+    for (const requiredFile of requiredPackageFiles) {
       if (!manifest.files?.includes(requiredFile)) {
         errors.push(`${manifest.name}: package files must include ${requiredFile}`);
       }
@@ -220,9 +221,18 @@ function declarationPathForJavaScript(exportedPath) {
 
 export async function validateBuildOutputs(repoRoot, entries) {
   const missing = [];
+  const missingPackageFiles = [];
 
   for (const { directory, manifest } of entries) {
     const packageRoot = path.join(repoRoot, directory);
+
+    for (const requiredFile of requiredPackageFiles) {
+      const requiredPath = path.join(packageRoot, requiredFile.replace(/\/$/, ""));
+      if (!(await pathExists(requiredPath))) {
+        missingPackageFiles.push(`${manifest.name}: ${requiredFile}`);
+      }
+    }
+
     const exportedPaths = new Set([manifest.main, manifest.types]);
 
     for (const value of Object.values(manifest.exports ?? {})) {
@@ -251,6 +261,12 @@ export async function validateBuildOutputs(repoRoot, entries) {
         missing.push(`${manifest.name}: ${exportedPath}`);
       }
     }
+  }
+
+  if (missingPackageFiles.length > 0) {
+    throw new Error(
+      `Missing package files for npm publish:\n- ${missingPackageFiles.join("\n- ")}`,
+    );
   }
 
   if (missing.length > 0) {

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -133,9 +133,31 @@ test("validatePublishMetadata requires declaration metadata", () => {
   assert.throws(() => validatePublishMetadata(entries, { dryRun: true }), /must include types/);
 });
 
+test("validateBuildOutputs checks package files", async () => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), "npm-publish-package-files-"));
+  await mkdir(path.join(repoRoot, "pinet-core", "dist"), { recursive: true });
+  await writeFile(path.join(repoRoot, "pinet-core", "README.md"), "# pinet-core\n");
+  await writeFile(path.join(repoRoot, "pinet-core", "dist", "index.js"), "export {};\n");
+  await writeFile(path.join(repoRoot, "pinet-core", "dist", "index.d.ts"), "export {};\n");
+
+  await assert.rejects(
+    () =>
+      validateBuildOutputs(repoRoot, [
+        entry("pinet-core", {
+          name: "@gugu910/pi-pinet-core",
+          main: "./dist/index.js",
+          types: "./dist/index.d.ts",
+        }),
+      ]),
+    /LICENSE/,
+  );
+});
+
 test("validateBuildOutputs checks JavaScript exports and declaration outputs", async () => {
   const repoRoot = await mkdtemp(path.join(tmpdir(), "npm-publish-outputs-"));
   await mkdir(path.join(repoRoot, "pinet-core", "dist"), { recursive: true });
+  await writeFile(path.join(repoRoot, "pinet-core", "README.md"), "# pinet-core\n");
+  await writeFile(path.join(repoRoot, "pinet-core", "LICENSE"), "MIT\n");
   await writeFile(path.join(repoRoot, "pinet-core", "dist", "index.js"), "export {};\n");
   await writeFile(path.join(repoRoot, "pinet-core", "dist", "index.d.ts"), "export {};\n");
   await writeFile(path.join(repoRoot, "pinet-core", "dist", "helpers.js"), "export {};\n");

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -103,10 +103,11 @@ test("validatePublishMetadata blocks placeholder versions for real publish only"
     entry("pinet-core", {
       name: "@gugu910/pi-pinet-core",
       version: "0.0.0",
+      license: "MIT",
       publishConfig: { access: "public" },
       main: "./dist/index.js",
       types: "./dist/index.d.ts",
-      files: ["dist/"],
+      files: ["README.md", "LICENSE", "dist/"],
     }),
   ];
 
@@ -122,9 +123,10 @@ test("validatePublishMetadata requires declaration metadata", () => {
     entry("pinet-core", {
       name: "@gugu910/pi-pinet-core",
       version: "0.0.0",
+      license: "MIT",
       publishConfig: { access: "public" },
       main: "./dist/index.js",
-      files: ["dist/"],
+      files: ["README.md", "LICENSE", "dist/"],
     }),
   ];
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -14,6 +14,13 @@ Or with npm:
 npm install @gugu910/pi-slack-bridge
 ```
 
+## Publishing
+
+This package is released through the manual `slack-bridge` npm publish lane
+tracked in [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub
+Actions workflow's default dry-run/readiness path for validation; do not publish,
+tag, or bump versions without explicit maintainer release approval.
+
 ## Prerequisites
 
 - A Slack workspace where you have permission to install apps

--- a/transport-core/LICENSE
+++ b/transport-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/transport-core/README.md
+++ b/transport-core/README.md
@@ -20,6 +20,13 @@ Tiny transport-neutral contracts package for the `extensions` repo.
 
 This package exists to keep transport contracts transport-neutral while other packages decide how to route, persist, or render those messages.
 
+## Publishing
+
+This package is part of both manual npm publish lanes tracked in
+[`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
+workflow's default dry-run/readiness path for validation; do not publish, tag, or
+bump versions without explicit maintainer release approval.
+
 ## Outbound content rules
 
 `OutboundMessage.text` remains the backward-compatible plain-text fallback and persistence body.


### PR DESCRIPTION
## Summary

Advances #773 with a safer manual npm publish workflow and release-readiness docs sweep.

Changed files and why they belong to #773:
- `.github/workflows/npm-publish.yml` — keeps `workflow_dispatch` dry-run/readiness as the default path, splits real publish into readiness → non-secret preflight → protected `npm-publish` environment publish, adds an explicit `release_approval` phrase, and scopes `id-token: write` only to real publishes for provenance.
- `scripts/npm-publish-helpers.mjs` / `scripts/npm-publish-helpers.test.mjs` — strengthens release gates so publishable packages must carry `license` metadata plus `README.md`, `LICENSE`, and `dist/` in npm package files.
- `transport-core/LICENSE`, `broker-core/LICENSE`, `pinet-core/LICENSE`, `imessage-bridge/LICENSE`, `pinet-core/package.json` — ensures the publishable Pinet-lane packages actually include MIT license artifacts in dry-run tarballs; `pinet-core` now lists `LICENSE` like its sibling packages.
- `plans/npm-publish.md` — documents readiness vs real publish flow, preflight gates, protected environment requirements, declaration smoke tests, package artifact requirements, and changelog/version gates.
- `README.md` — adds operator-facing npm publish readiness instructions and real-publish safety notes.
- `transport-core/README.md`, `broker-core/README.md`, `pinet-core/README.md`, `imessage-bridge/README.md`, `slack-bridge/README.md` — adds package-level breadcrumbs to the publish plan and dry-run-first workflow.
- `CHANGELOG.md` — clarifies readiness-only changes do not create a release entry/tag/version by themselves.
- `CLAUDE.md` / `AGENTS.md` symlink target — adds agent-facing reminder not to publish/tag/bump without maintainer release approval.

## Publish safety

No real publish performed. No tags, merges, or version bumps. Real publish remains gated on maintainer-approved package versions, `NPM_TOKEN` in the protected `npm-publish` environment, explicit release approval, and the script's placeholder/already-published version refusals.

## Validation

- `pnpm install --frozen-lockfile`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-publish.yml"); puts "workflow yaml ok"'`
- `pnpm exec prettier --check .github/workflows/npm-publish.yml README.md plans/npm-publish.md CHANGELOG.md CLAUDE.md transport-core/README.md broker-core/README.md pinet-core/README.md imessage-bridge/README.md slack-bridge/README.md scripts/npm-publish-helpers.mjs scripts/npm-publish-helpers.test.mjs pinet-core/package.json`
- `node --test scripts/*.test.mjs`
- `node ./scripts/publish-npm-packages.mjs --target pinet --dry-run`
- `node ./scripts/publish-npm-packages.mjs --target slack-bridge --dry-run`
- `pnpm lint && pnpm typecheck && pnpm test`
- `pnpm format:check`
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

Note: `actionlint` was not installed locally, so workflow validation was YAML parse + dry-run script coverage rather than actionlint.
