### PR TITLE
chore: publish full npm package set

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -105,19 +105,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Configure npm authentication
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Verify Trusted Publishing context
         run: |
-          if [ -z "${NPM_TOKEN}" ]; then
-            echo "NPM_TOKEN is required for real npm publishing"
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "GitHub OIDC is required for npm Trusted Publishing. Check id-token: write and the npm-publish environment."
             exit 1
           fi
-          npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
 
       - name: Publish packages
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: >-
           node ./scripts/publish-npm-packages.mjs
           --publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,24 +1,17 @@
 name: Publish npm packages
 
-run-name: npm ${{ inputs.dry_run && 'dry-run' || 'publish' }} ${{ inputs.target }} packages
+run-name: npm ${{ inputs.dry_run && 'dry-run' || 'publish' }} all packages
 
 on:
   workflow_dispatch:
     inputs:
-      target:
-        description: "Package lane to validate or publish"
-        required: true
-        type: choice
-        options:
-          - pinet
-          - slack-bridge
       dry_run:
         description: "Run npm publish --dry-run only"
         required: true
         type: boolean
         default: true
       release_approval:
-        description: "For real publishes only: type 'publish <target>'"
+        description: "For real publishes only: type 'publish all'"
         required: false
         type: string
         default: ""
@@ -27,12 +20,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: npm-publish-${{ inputs.dry_run && format('dry-run-{0}', inputs.target) || 'live' }}
+  group: npm-publish-${{ inputs.dry_run && 'dry-run' || 'live' }}
   cancel-in-progress: false
 
 jobs:
   readiness:
-    name: Validate ${{ inputs.target }} publish readiness
+    name: Validate npm publish readiness
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -54,10 +47,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Dry-run publish target packages
+      - name: Dry-run publish packages
         run: >-
           node ./scripts/publish-npm-packages.mjs
-          --target "${{ inputs.target }}"
           --dry-run
 
   publish-preflight:
@@ -75,16 +67,15 @@ jobs:
       - name: Guard real publish approval phrase
         env:
           RELEASE_APPROVAL: ${{ inputs.release_approval }}
-          TARGET: ${{ inputs.target }}
         run: |
-          expected="publish ${TARGET}"
+          expected="publish all"
           if [ "${RELEASE_APPROVAL}" != "${expected}" ]; then
             echo "Real npm publishes require release_approval exactly: ${expected}"
             exit 1
           fi
 
   publish:
-    name: Publish ${{ inputs.target }} packages
+    name: Publish npm packages
     if: ${{ !inputs.dry_run }}
     needs:
       - readiness
@@ -124,10 +115,9 @@ jobs:
           fi
           npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
 
-      - name: Publish target packages
+      - name: Publish packages
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: >-
           node ./scripts/publish-npm-packages.mjs
-          --target "${{ inputs.target }}"
           --publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ export default function (pi: ExtensionAPI) {
 ```json
 // package.json
 {
-  "name": "@gugu910/pi-slack-bridge",
+  "name": "@pinet/slack-bridge",
   "keywords": ["pi-package"],
   "pi": { "extensions": ["./index.ts"] }
 }

--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ caching.
 
 ```
 extensions/
-├── transport-core/     # @gugu910/pi-transport-core
+├── transport-core/     # @pinet/transport-core
 │   ├── index.ts        #   canonical transport message contracts
 │   └── package.json    #   workspace package
 ├── browser-playwright/ # @gugu910/pi-browser-playwright
 │   ├── index.ts        #   Playwright-first single `browser` tool entry point
 │   ├── helpers.ts      #   security defaults + install guidance
 │   └── package.json    #   workspace package + pi manifest
-├── slack-bridge/       # @gugu910/pi-slack-bridge
+├── slack-bridge/       # @pinet/slack-bridge
 │   ├── broker/         #   message routing, socket server, adapters
 │   ├── index.ts        #   extension entry point
 │   └── package.json    #   workspace package + pi manifest
@@ -168,7 +168,7 @@ extensions/
 │   ├── generated/      #   generated typed Slack Web API client
 │   ├── cli.ts          #   CLI wrapper around generated methods
 │   └── package.json    #   workspace package + pi manifest
-├── imessage-bridge/    # @gugu910/pi-imessage-bridge
+├── imessage-bridge/    # @pinet/imessage-bridge
 │   ├── mvp.ts          #   local macOS/iMessage readiness helpers
 │   ├── send.ts         #   AppleScript send-first transport helper
 │   └── package.json    #   standalone workspace package
@@ -240,15 +240,20 @@ Safe readiness checks are the default path:
 1. Open **Actions → Publish npm packages → Run workflow**.
 2. Leave `dry_run=true`.
 3. Confirm the workflow runs `scripts/publish-npm-packages.mjs --dry-run` for
-   the full package set and does not request npm credentials.
+   the full `@pinet/*` package set and does not request npm credentials.
+
+The same dry-run path can be run locally with `pnpm publish:npm`; it defaults to
+readiness only and has no package target selector.
 
 Real publishes are intentionally harder to trigger. They require a maintainer to
 dispatch from `main` with `dry_run=false`, enter `publish all` as the exact
-`release_approval` phrase, approve the protected `npm-publish` environment,
-and provide the environment-scoped `NPM_TOKEN`. That environment is an external
-repository prerequisite that must be configured and verified before any real
-publish attempt. The publish script still refuses placeholder `0.0.0` versions
-and versions that already exist on npm.
+`release_approval` phrase, and approve the protected `npm-publish` environment.
+The publish job uses npm Trusted Publishing / GitHub OIDC with
+`npm publish --provenance`; it does not use `NPM_TOKEN`. Maintainers must also
+configure npm Trusted Publishers for every package in the npm `pinet` org
+settings (`https://www.npmjs.com/settings/pinet/packages`) before real publish.
+The publish script still refuses placeholder `0.0.0` versions and versions that
+already exist on npm.
 
 Do not publish, tag, or bump package versions as part of readiness-only changes;
 record release notes in `CHANGELOG.md` only when a maintainer approves a real

--- a/README.md
+++ b/README.md
@@ -229,22 +229,22 @@ expectations and the required smoke checklist.
 
 ## npm publish readiness
 
-The publishable Pinet/Slack package lanes are tracked in
+The publishable Pinet/Slack package set is tracked in
 [`plans/npm-publish.md`](plans/npm-publish.md) and executed through the manual
 [`Publish npm packages`](.github/workflows/npm-publish.yml) GitHub Actions
-workflow.
+workflow. The workflow intentionally has no package target selector; it always
+validates or publishes the full set in dependency order.
 
 Safe readiness checks are the default path:
 
 1. Open **Actions → Publish npm packages → Run workflow**.
-2. Choose `target` as `pinet` or `slack-bridge`.
-3. Leave `dry_run=true`.
-4. Confirm the workflow runs `scripts/publish-npm-packages.mjs --dry-run` and
-   does not request npm credentials.
+2. Leave `dry_run=true`.
+3. Confirm the workflow runs `scripts/publish-npm-packages.mjs --dry-run` for
+   the full package set and does not request npm credentials.
 
 Real publishes are intentionally harder to trigger. They require a maintainer to
-dispatch from `main` with `dry_run=false`, enter the exact `release_approval`
-phrase shown in the workflow, approve the protected `npm-publish` environment,
+dispatch from `main` with `dry_run=false`, enter `publish all` as the exact
+`release_approval` phrase, approve the protected `npm-publish` environment,
 and provide the environment-scoped `NPM_TOKEN`. That environment is an external
 repository prerequisite that must be configured and verified before any real
 publish attempt. The publish script still refuses placeholder `0.0.0` versions

--- a/broker-core/README.md
+++ b/broker-core/README.md
@@ -1,4 +1,4 @@
-# @gugu910/pi-broker-core
+# @pinet/broker-core
 
 Transport-neutral broker kernel primitives for the `extensions` repo.
 

--- a/broker-core/README.md
+++ b/broker-core/README.md
@@ -20,7 +20,7 @@ Transport-neutral broker kernel primitives for the `extensions` repo.
 
 ## Publishing
 
-This package is part of both manual npm publish lanes tracked in
+This package is part of the full npm publish set tracked in
 [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
 workflow's default dry-run/readiness path for validation; do not publish, tag, or
 bump versions without explicit maintainer release approval.

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu910/pi-broker-core",
+  "name": "@pinet/broker-core",
   "version": "0.0.0",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
@@ -43,7 +43,7 @@
     "test": "vitest run *.test.ts"
   },
   "dependencies": {
-    "@gugu910/pi-transport-core": "file:../transport-core"
+    "@pinet/transport-core": "file:../transport-core"
   },
   "types": "./dist/index.d.ts"
 }

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -332,7 +332,7 @@ import {
   buildCompatibilityInstanceScope as _buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope as _buildCompatibilityWorkspaceScope,
   buildRuntimeScopeCarrier as _buildRuntimeScopeCarrier,
-} from "@gugu910/pi-transport-core";
+} from "@pinet/transport-core";
 import type {
   InboundMessage as _InboundMessage,
   NormalizedMessageContent as _NormalizedMessageContent,
@@ -345,7 +345,7 @@ import type {
   RuntimeScopeCarrier as _RuntimeScopeCarrier,
   WorkspaceInstallScopeCarrier as _WorkspaceInstallScopeCarrier,
   InstanceScopeCarrier as _InstanceScopeCarrier,
-} from "@gugu910/pi-transport-core";
+} from "@pinet/transport-core";
 
 export type InboundMessage = _InboundMessage;
 export type NormalizedMessageContent = _NormalizedMessageContent;

--- a/imessage-bridge/README.md
+++ b/imessage-bridge/README.md
@@ -44,7 +44,7 @@ In the current repo bring-up path, enable the adapter with `slack-bridge.imessag
 
 ## Publishing
 
-This package is included in the manual `slack-bridge` npm publish lane tracked in
+This package is included in the full npm publish set tracked in
 [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
 workflow's default dry-run/readiness path for validation; do not publish, tag, or
 bump versions without explicit maintainer release approval.

--- a/imessage-bridge/README.md
+++ b/imessage-bridge/README.md
@@ -1,4 +1,4 @@
-# @gugu910/pi-imessage-bridge
+# @pinet/imessage-bridge
 
 Thin macOS/iMessage **send-first** package for the `extensions` repo.
 
@@ -24,7 +24,7 @@ That means outbound sends can work even when the local Messages database is unav
 
 ## Trust boundary notes
 
-`@gugu910/pi-imessage-bridge` is an intentional **same-host local-power surface**.
+`@pinet/imessage-bridge` is an intentional **same-host local-power surface**.
 
 - When enabled, outbound sends run through the local Messages app via `/usr/bin/osascript` as the current macOS user.
 - There is no extra approval or policy layer inside this package today; the trust boundary is local operator intent on the same host.
@@ -64,7 +64,7 @@ import {
   createIMessageAdapter,
   detectIMessageMvpEnvironment,
   getDefaultIMessageThreadId,
-} from "@gugu910/pi-imessage-bridge";
+} from "@pinet/imessage-bridge";
 
 const readiness = detectIMessageMvpEnvironment();
 if (readiness.canAttemptSend) {

--- a/imessage-bridge/adapter.ts
+++ b/imessage-bridge/adapter.ts
@@ -2,7 +2,7 @@ import type {
   InboundMessage as IMessageAdapterInboundMessage,
   MessageAdapter,
   OutboundMessage as IMessageAdapterOutboundMessage,
-} from "@gugu910/pi-transport-core";
+} from "@pinet/transport-core";
 import { assertIMessageSendCapability, sendIMessage, type RunAppleScript } from "./send.js";
 import {
   formatIMessageMvpReadiness,

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu910/pi-imessage-bridge",
+  "name": "@pinet/imessage-bridge",
   "version": "0.0.0",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
@@ -32,7 +32,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gugu910/pi-transport-core": "file:../transport-core"
+    "@pinet/transport-core": "file:../transport-core"
   },
   "types": "./dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build:packages": "node ./scripts/build-all.mjs",
     "test": "turbo run test && node --test scripts/*.test.mjs",
     "deploy:slack": "node --experimental-strip-types ./slack-bridge/deploy-manifest.ts",
+    "publish:npm": "node ./scripts/publish-npm-packages.mjs",
     "check": "pnpm lint && pnpm typecheck && pnpm format:check",
     "prepush": "pnpm lint && pnpm typecheck && pnpm test",
     "lint-staged": "lint-staged",

--- a/pinet-core/README.md
+++ b/pinet-core/README.md
@@ -1,4 +1,4 @@
-# @gugu910/pi-pinet-core
+# @pinet/pinet-core
 
 Runtime-core helpers for Pinet that are independent of any Slack adapter.
 
@@ -8,7 +8,7 @@ Current seam:
 - durable Pinet read result text/detail formatting
 - scheduled wake-up time parsing and thread ID helpers
 
-`@gugu910/pi-slack-bridge` still composes the extension and preserves compatibility wrappers, but these helpers now live behind package exports so future extraction can move one boundary at a time.
+`@pinet/slack-bridge` still composes the extension and preserves compatibility wrappers, but these helpers now live behind package exports so future extraction can move one boundary at a time.
 
 Design proposal: `plans/slack-split-proposal.md`
 

--- a/pinet-core/README.md
+++ b/pinet-core/README.md
@@ -14,7 +14,7 @@ Design proposal: `plans/slack-split-proposal.md`
 
 ## Publishing
 
-This package is included in the manual `pinet` and `slack-bridge` npm publish
-lanes tracked in [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the
-GitHub Actions workflow's default dry-run/readiness path for validation; do not
-publish, tag, or bump versions without explicit maintainer release approval.
+This package is included in the full npm publish set tracked in
+[`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
+workflow's default dry-run/readiness path for validation; do not publish, tag, or
+bump versions without explicit maintainer release approval.

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu910/pi-pinet-core",
+  "name": "@pinet/pinet-core",
   "version": "0.0.0",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
@@ -35,8 +35,8 @@
     "test": "vitest run *.test.ts"
   },
   "dependencies": {
-    "@gugu910/pi-broker-core": "file:../broker-core",
-    "@gugu910/pi-transport-core": "file:../transport-core"
+    "@pinet/broker-core": "file:../broker-core",
+    "@pinet/transport-core": "file:../transport-core"
   },
   "types": "./dist/index.d.ts"
 }

--- a/pinet-core/pinet-read-formatting.ts
+++ b/pinet-core/pinet-read-formatting.ts
@@ -2,7 +2,7 @@ import {
   classifyPinetMail,
   formatPinetMailClassLabel,
   type PinetMailClass,
-} from "@gugu910/pi-broker-core/mail-classification";
+} from "@pinet/broker-core/mail-classification";
 
 export interface PinetInboxItem {
   inboxId: number;

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -2,21 +2,9 @@
 
 Issue: #773. Dependency: #772 should confirm the Pinet/Slack package boundary before real releases.
 
-## Package lanes
+## Package set
 
-### Pinet lane
-
-Publish in dependency order:
-
-1. `@gugu910/pi-transport-core` from `transport-core/`
-2. `@gugu910/pi-broker-core` from `broker-core/`
-3. `@gugu910/pi-pinet-core` from `pinet-core/`
-
-This lane is transport-neutral and must not publish Slack-specific packages.
-
-### Slack bridge lane
-
-Publish in dependency order:
+The publish workflow always validates or publishes the full package set in dependency order:
 
 1. `@gugu910/pi-transport-core` from `transport-core/`
 2. `@gugu910/pi-broker-core` from `broker-core/`
@@ -24,25 +12,24 @@ Publish in dependency order:
 4. `@gugu910/pi-imessage-bridge` from `imessage-bridge/`
 5. `@gugu910/pi-slack-bridge` from `slack-bridge/`
 
-The Slack lane includes the Pinet package closure because `slack-bridge` depends on Pinet and broker primitives, but the workflow keeps it as a separate manual target.
+There is intentionally no workflow target selector or script target flag. Real releases publish the shared core packages and Slack bridge package together so dependency versions stay aligned and operators cannot accidentally publish only a subset.
 
 ## Workflow
 
-`.github/workflows/npm-publish.yml` is a manual `workflow_dispatch` workflow with three inputs:
+`.github/workflows/npm-publish.yml` is a manual `workflow_dispatch` workflow with two inputs:
 
-- `target`: `pinet` or `slack-bridge`
 - `dry_run`: defaults to `true`
-- `release_approval`: real publishes only; must exactly match `publish <target>`
+- `release_approval`: real publishes only; must exactly match `publish all`
 
 Every dispatch first runs the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order.
 
-When `dry_run=true`, the workflow stops after that dry-run/readiness job and does not request the `npm-publish` environment or npm token. Dry-run dispatches are serialized per target. Real publish dispatches share a single global `npm-publish-live` concurrency group because the `pinet` and `slack-bridge` lanes publish overlapping packages.
+When `dry_run=true`, the workflow stops after that dry-run/readiness job and does not request the `npm-publish` environment or npm token. Dry-run dispatches use the `npm-publish-dry-run` concurrency group. Real publish dispatches use the `npm-publish-live` concurrency group so live publishes are globally serialized.
 
 Real publishes require all of these gates before the publish job can run:
 
 - `dry_run=false` was selected manually.
 - A non-environment preflight job confirms the dispatch ref is `refs/heads/main`.
-- The same preflight job confirms `release_approval` exactly matches `publish <target>`.
+- The same preflight job confirms `release_approval` exactly matches `publish all`.
 - The `npm-publish` GitHub environment is approved by a maintainer after preflight passes.
 - `NPM_TOKEN` is present in that environment.
 
@@ -58,7 +45,7 @@ Publishable packages must include npm-visible package basics:
 - `license` metadata
 - `publishConfig.access: "public"`
 
-Publishable packages must also expose `types: "./dist/index.d.ts"` and build matching `.d.ts` files alongside their `dist/*.js` outputs. The publish script validates root metadata, package file allowlists, JavaScript export targets, declaration outputs, and public `.d.ts` import resolution before any dry-run or real publish. Public declaration imports are checked in an isolated TypeScript smoke test, and sibling publish-target imports must be declared in package dependencies, optional dependencies, or peer dependencies.
+Publishable packages must also expose `types: "./dist/index.d.ts"` and build matching `.d.ts` files alongside their `dist/*.js` outputs. The publish script validates root metadata, package file allowlists, JavaScript export targets, declaration outputs, and public `.d.ts` import resolution before any dry-run or real publish. Public declaration imports are checked in an isolated TypeScript smoke test, and sibling publish-set imports must be declared in package dependencies, optional dependencies, or peer dependencies.
 
 ## `transport-core.slackBlocks` decision
 
@@ -84,11 +71,11 @@ GitHub permissions:
 
 ## Release gates before setting `dry_run=false`
 
-- #772 has confirmed the Pinet/Slack boundary and the target lane is still correct.
+- #772 has confirmed the Pinet/Slack boundary and the full publish set is still correct.
 - Package versions are intentionally bumped. The publish script refuses real publishes for placeholder `0.0.0` packages or versions already present on npm.
-- `CHANGELOG.md` has a maintainer-approved entry covering the selected release lane and package versions.
+- `CHANGELOG.md` has a maintainer-approved entry covering the full package set and package versions.
 - The dry-run/readiness job is green on the same `main` commit intended for release.
-- The workflow dispatch includes the explicit `release_approval` phrase for the selected target.
+- The workflow dispatch includes the exact `publish all` release approval phrase.
 - The `npm-publish` environment approval is granted by a maintainer for that release.
 - Built outputs are produced from the current commit and match `main`/`exports` entries.
 - No npm token values are requested, printed, or committed.

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -4,17 +4,17 @@ Issue: #773. Dependency: #772 should confirm the Pinet/Slack package boundary be
 
 ## Package set
 
-The publish workflow always validates or publishes the full package set in dependency order:
+The publish workflow always validates or publishes the full npm org `pinet` package set in dependency order:
 
-1. `@gugu910/pi-transport-core` from `transport-core/`
-2. `@gugu910/pi-broker-core` from `broker-core/`
-3. `@gugu910/pi-pinet-core` from `pinet-core/`
-4. `@gugu910/pi-imessage-bridge` from `imessage-bridge/`
-5. `@gugu910/pi-slack-bridge` from `slack-bridge/`
+1. `@pinet/transport-core` from `transport-core/`
+2. `@pinet/broker-core` from `broker-core/`
+3. `@pinet/pinet-core` from `pinet-core/`
+4. `@pinet/imessage-bridge` from `imessage-bridge/`
+5. `@pinet/slack-bridge` from `slack-bridge/`
 
 There is intentionally no workflow target selector or script target flag. Real releases publish the shared core packages and Slack bridge package together so dependency versions stay aligned and operators cannot accidentally publish only a subset.
 
-## Workflow
+## Workflow and script
 
 `.github/workflows/npm-publish.yml` is a manual `workflow_dispatch` workflow with two inputs:
 
@@ -23,7 +23,16 @@ There is intentionally no workflow target selector or script target flag. Real r
 
 Every dispatch first runs the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order.
 
-When `dry_run=true`, the workflow stops after that dry-run/readiness job and does not request the `npm-publish` environment or npm token. Dry-run dispatches use the `npm-publish-dry-run` concurrency group. Real publish dispatches use the `npm-publish-live` concurrency group so live publishes are globally serialized.
+For local/readiness use, run the same script directly or through the safe npm script:
+
+```bash
+pnpm publish:npm
+node ./scripts/publish-npm-packages.mjs --dry-run
+```
+
+Both forms default to dry-run/readiness. The script has no `--target` flag and always processes the full package set. The `--publish` mode is reserved for the GitHub Actions Trusted Publishing/OIDC workflow context; it is not a local token-publish path.
+
+When `dry_run=true`, the workflow stops after the dry-run/readiness job and does not request the `npm-publish` environment. Dry-run dispatches use the `npm-publish-dry-run` concurrency group. Real publish dispatches use the `npm-publish-live` concurrency group so live publishes are globally serialized.
 
 Real publishes require all of these gates before the publish job can run:
 
@@ -31,9 +40,21 @@ Real publishes require all of these gates before the publish job can run:
 - A non-environment preflight job confirms the dispatch ref is `refs/heads/main`.
 - The same preflight job confirms `release_approval` exactly matches `publish all`.
 - The `npm-publish` GitHub environment is approved by a maintainer after preflight passes.
-- `NPM_TOKEN` is present in that environment.
+- The publish job has `id-token: write` so npm Trusted Publishing can exchange GitHub OIDC for npm publish authority.
+- npm Trusted Publishers are configured for every package in the full set with repository `gugu91/extensions`, workflow `npm-publish.yml`, and environment `npm-publish` when npm asks for an environment.
 
 The real publish job then reruns the same publish script with `--publish`, which uses `npm publish --provenance` and fails closed if any target package version already exists on npm.
+
+## npm org and first-publish bootstrap
+
+Packages are intended for the npm `pinet` org/package settings area: <https://www.npmjs.com/settings/pinet/packages>.
+
+Keep the GitHub and npm setup separate:
+
+- **GitHub setup:** create/verify the `npm-publish` environment, require maintainer reviewers, restrict deployment branches to `main`, and do not add `NPM_TOKEN` for this workflow.
+- **npm setup:** an npm `pinet` org owner/admin must have package creation/publish authority for the org and must configure Trusted Publishing for every package in the list above.
+
+Trusted Publishing is package-scoped in npm's settings UI. If npm does not allow a Trusted Publisher to be configured for a package before that package exists, do not add a token fallback in this repo. The safe bootstrap is to have an npm `pinet` org owner/admin create or first-publish/claim the packages using npm-approved org procedures, then configure Trusted Publishing for each package, then use this GitHub Actions workflow for subsequent provenance publishes. If npm's team/access UI loops or blocks package creation, resolve org/team/admin access in npm first rather than adding CI token automation.
 
 ## Package artifacts and type/declaration artifacts
 
@@ -53,21 +74,28 @@ Publishable packages must also expose `types: "./dist/index.d.ts"` and build mat
 
 ## Required GitHub/npm configuration
 
-Secret names only:
+Secret names:
 
-- `NPM_TOKEN` in the `npm-publish` GitHub environment
+- No `NPM_TOKEN` is required or expected for the Trusted Publishing workflow.
 
 GitHub environment:
 
 - `npm-publish` is an external repository prerequisite, not something this repo can create in source control.
 - Configure or verify the environment before any real publish attempt.
-- `npm-publish` should require maintainer approval before the publish job can access `NPM_TOKEN`.
-- Dry-run/readiness dispatches do not use the environment and do not need the token.
+- `npm-publish` should require maintainer approval before the publish job can run.
+- Restrict environment deployment branches to `main`.
+- Dry-run/readiness dispatches do not use the environment.
+
+npm org/package configuration:
+
+- Configure/verify the npm `pinet` org package settings for every package in the full set.
+- Each package's Trusted Publisher should point at owner/repo `gugu91/extensions`, workflow `npm-publish.yml`, and environment `npm-publish` if npm asks for one.
+- The maintainer performing npm setup must have enough org/package admin rights to create packages and configure publishing trust.
 
 GitHub permissions:
 
 - Readiness job: `contents: read`
-- Publish job: `contents: read` plus `id-token: write` for npm provenance
+- Publish job: `contents: read` plus `id-token: write` for npm Trusted Publishing/provenance
 
 ## Release gates before setting `dry_run=false`
 
@@ -77,5 +105,6 @@ GitHub permissions:
 - The dry-run/readiness job is green on the same `main` commit intended for release.
 - The workflow dispatch includes the exact `publish all` release approval phrase.
 - The `npm-publish` environment approval is granted by a maintainer for that release.
+- npm Trusted Publishing is configured for every package in the full set.
 - Built outputs are produced from the current commit and match `main`/`exports` entries.
 - No npm token values are requested, printed, or committed.

--- a/plans/slack-split-proposal.md
+++ b/plans/slack-split-proposal.md
@@ -18,25 +18,25 @@ It currently bundles four layers:
 
 The lowest-regret target is **not** to create two peer extensions that both try to own runtime state. The better split is:
 
-- keep **`@gugu910/pi-slack-bridge`** as the published **Slack adapter extension package** and compatibility entrypoint
-- add **`@gugu910/pi-pinet-core`** as a **library package** for broker/runtime/Pinet orchestration
-- continue using **`@gugu910/pi-broker-core`** for transport-neutral broker kernel code, and move more broker primitives there instead of leaving them under `slack-bridge/broker/*`
+- keep **`@pinet/slack-bridge`** as the published **Slack adapter extension package** and compatibility entrypoint
+- add **`@pinet/pinet-core`** as a **library package** for broker/runtime/Pinet orchestration
+- continue using **`@pinet/broker-core`** for transport-neutral broker kernel code, and move more broker primitives there instead of leaving them under `slack-bridge/broker/*`
 
 That keeps the runtime composition model simple:
 
 ```text
 pi session
-  └─ @gugu910/pi-slack-bridge (extension entrypoint / Slack adapter)
-       ├─ @gugu910/pi-pinet-core (runtime orchestration)
-       ├─ @gugu910/pi-broker-core (broker kernel)
-       └─ @gugu910/pi-transport-core (transport contracts)
+  └─ @pinet/slack-bridge (extension entrypoint / Slack adapter)
+       ├─ @pinet/pinet-core (runtime orchestration)
+       ├─ @pinet/broker-core (broker kernel)
+       └─ @pinet/transport-core (transport contracts)
 ```
 
 ## Current topology
 
 ### Workspace/package topology today
 
-- `slack-bridge/` is one package: `@gugu910/pi-slack-bridge`
+- `slack-bridge/` is one package: `@pinet/slack-bridge`
 - package export surface is only:
   - `.` → `./dist/index.js`
   - `./package.json`
@@ -44,10 +44,10 @@ pi session
 - root workspace `pi.extensions` points to `./slack-bridge/index.ts`
 - there is **no `imports` map** in `slack-bridge/package.json`; composition is all internal relative imports
 - `slack-bridge` already depends on:
-  - `@gugu910/pi-broker-core`
-  - `@gugu910/pi-transport-core`
-  - `@gugu910/pi-imessage-bridge`
-- `broker-core/` already exists and `slack-bridge/broker/agent-messaging.ts` is already a shim that re-exports `@gugu910/pi-broker-core/agent-messaging`
+  - `@pinet/broker-core`
+  - `@pinet/transport-core`
+  - `@pinet/imessage-bridge`
+- `broker-core/` already exists and `slack-bridge/broker/agent-messaging.ts` is already a shim that re-exports `@pinet/broker-core/agent-messaging`
 
 ### Runtime wiring today
 
@@ -88,7 +88,7 @@ It directly wires:
 
 ## Recommended package split
 
-### 1) Keep and slim `@gugu910/pi-slack-bridge`
+### 1) Keep and slim `@pinet/slack-bridge`
 
 Purpose: **Slack adapter only**.
 
@@ -104,7 +104,7 @@ Responsibilities:
 - single-player direct Slack runtime
 - top-level extension entrypoint that composes Slack adapter + Pinet core
 
-### 2) Add `@gugu910/pi-pinet-core`
+### 2) Add `@pinet/pinet-core`
 
 Purpose: **runtime orchestration library**.
 
@@ -121,9 +121,9 @@ Responsibilities:
 - shared non-Slack runtime helpers and ports
 
 This package should **not** own a `pi.extensions` entrypoint in phase 1.
-It should be a library used by `@gugu910/pi-slack-bridge`.
+It should be a library used by `@pinet/slack-bridge`.
 
-### 3) Continue expanding `@gugu910/pi-broker-core`
+### 3) Continue expanding `@pinet/broker-core`
 
 Purpose: **transport-neutral broker kernel**.
 
@@ -154,7 +154,7 @@ Making `pinet-core` a library first avoids inventing a second extension-to-exten
 
 Below is the current source inventory bucketed by intent.
 
-### A. Slack-specific / should stay in `@gugu910/pi-slack-bridge`
+### A. Slack-specific / should stay in `@pinet/slack-bridge`
 
 - `activity-log.ts`
 - `broker-thread-owner-hints.ts`
@@ -322,7 +322,7 @@ This is the recommended destination map for the actual extraction.
 
 ### Delete compatibility wrappers after imports are rewritten
 
-These should stop being owned by `slack-bridge` once callers use `@gugu910/pi-broker-core/*` directly.
+These should stop being owned by `slack-bridge` once callers use `@pinet/broker-core/*` directly.
 
 - `slack-bridge/broker/agent-messaging.ts`
 - `slack-bridge/broker/auth.ts`
@@ -347,11 +347,11 @@ These should stop being owned by `slack-bridge` once callers use `@gugu910/pi-br
 - `slack-bridge/broker/schema.ts`
   - retain broker-core base schema where it is, move Pinet-specific Ralph-cycle extension to `pinet-core`
 - `slack-bridge/broker/adapters/types.ts`
-  - replace with direct imports from `@gugu910/pi-transport-core`
+  - replace with direct imports from `@pinet/transport-core`
 
 ## Proposed public API surface
 
-## `@gugu910/pi-pinet-core`
+## `@pinet/pinet-core`
 
 Recommended exported surface:
 
@@ -389,7 +389,7 @@ Recommended exported surface:
 
 This package should **not** export a default extension entrypoint in phase 1.
 
-## `@gugu910/pi-slack-bridge`
+## `@pinet/slack-bridge`
 
 Recommended exported surface:
 
@@ -406,7 +406,7 @@ Recommended exported surface:
   - control-plane canvas publishing helpers
 - Slack manifest / deployment helpers
 
-## `@gugu910/pi-broker-core`
+## `@pinet/broker-core`
 
 Recommended export additions:
 
@@ -422,9 +422,9 @@ It already owns most of the rest of the transport-neutral broker kernel.
 
 Recommended approach: **avoid a package rename for existing Slack users**.
 
-- keep `@gugu910/pi-slack-bridge` as the package users install for Slack
-- do not require users to install `@gugu910/pi-pinet-core` directly in phase 1
-- keep the `pi.extensions` entrypoint in `@gugu910/pi-slack-bridge`
+- keep `@pinet/slack-bridge` as the package users install for Slack
+- do not require users to install `@pinet/pinet-core` directly in phase 1
+- keep the `pi.extensions` entrypoint in `@pinet/slack-bridge`
 
 That makes the split mostly internal at first.
 
@@ -433,7 +433,7 @@ That makes the split mostly internal at first.
 These imports should eventually change:
 
 - from `./broker/*` wrappers
-- to `@gugu910/pi-broker-core/*` or `@gugu910/pi-pinet-core/*`
+- to `@pinet/broker-core/*` or `@pinet/pinet-core/*`
 
 ### For settings/config
 
@@ -607,7 +607,7 @@ The root can continue to load `./slack-bridge/index.ts` while that file becomes 
 
 ### Phase 2 — move broker/runtime core
 
-- create `@gugu910/pi-pinet-core` real exports
+- create `@pinet/pinet-core` real exports
 - move runtime/Pinet modules into `pinet-core/`
 - update imports in `slack-bridge/index.ts`
 
@@ -634,8 +634,8 @@ The root can continue to load `./slack-bridge/index.ts` while that file becomes 
 
 Proceed with the split using this package boundary:
 
-- **`@gugu910/pi-broker-core`** = transport-neutral broker kernel
-- **`@gugu910/pi-pinet-core`** = broker/follower/runtime/Pinet orchestration library
-- **`@gugu910/pi-slack-bridge`** = Slack adapter extension and compatibility package
+- **`@pinet/broker-core`** = transport-neutral broker kernel
+- **`@pinet/pinet-core`** = broker/follower/runtime/Pinet orchestration library
+- **`@pinet/slack-bridge`** = Slack adapter extension and compatibility package
 
 That boundary best matches the current code shape, the prior Pinet planning docs, and the existing partial extraction work already landed under #531 and related refactors.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
 
   broker-core:
     dependencies:
-      "@gugu910/pi-transport-core":
+      "@pinet/transport-core":
         specifier: file:../transport-core
         version: link:../transport-core
 
@@ -69,7 +69,7 @@ importers:
 
   imessage-bridge:
     dependencies:
-      "@gugu910/pi-transport-core":
+      "@pinet/transport-core":
         specifier: file:../transport-core
         version: link:../transport-core
 
@@ -98,10 +98,10 @@ importers:
 
   pinet-core:
     dependencies:
-      "@gugu910/pi-broker-core":
+      "@pinet/broker-core":
         specifier: file:../broker-core
         version: link:../broker-core
-      "@gugu910/pi-transport-core":
+      "@pinet/transport-core":
         specifier: file:../transport-core
         version: link:../transport-core
 
@@ -113,16 +113,16 @@ importers:
 
   slack-bridge:
     dependencies:
-      "@gugu910/pi-broker-core":
+      "@pinet/broker-core":
         specifier: file:../broker-core
         version: link:../broker-core
-      "@gugu910/pi-imessage-bridge":
+      "@pinet/imessage-bridge":
         specifier: file:../imessage-bridge
         version: link:../imessage-bridge
-      "@gugu910/pi-pinet-core":
+      "@pinet/pinet-core":
         specifier: file:../pinet-core
         version: link:../pinet-core
-      "@gugu910/pi-transport-core":
+      "@pinet/transport-core":
         specifier: file:../transport-core
         version: link:../transport-core
       "@sinclair/typebox":

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -3,13 +3,21 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-export const publishPackageDirectories = Object.freeze([
-  "transport-core",
-  "broker-core",
-  "pinet-core",
-  "imessage-bridge",
-  "slack-bridge",
+export const publishPackages = Object.freeze([
+  { directory: "transport-core", packageName: "@pinet/transport-core" },
+  { directory: "broker-core", packageName: "@pinet/broker-core" },
+  { directory: "pinet-core", packageName: "@pinet/pinet-core" },
+  { directory: "imessage-bridge", packageName: "@pinet/imessage-bridge" },
+  { directory: "slack-bridge", packageName: "@pinet/slack-bridge" },
 ]);
+
+export const publishPackageDirectories = Object.freeze(
+  publishPackages.map(({ directory }) => directory),
+);
+
+const publishPackageNamesByDirectory = new Map(
+  publishPackages.map(({ directory, packageName }) => [directory, packageName]),
+);
 
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 const publicDependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
@@ -129,7 +137,11 @@ export function validatePublishMetadata(entries, { dryRun }) {
   const errors = [];
 
   for (const { directory, manifest } of entries) {
+    const expectedName = publishPackageNamesByDirectory.get(directory);
     if (!manifest.name) errors.push(`${directory}: package.json must include name`);
+    if (expectedName && manifest.name !== expectedName) {
+      errors.push(`${directory}: package name must be ${expectedName} for npm org pinet publish`);
+    }
     if (!manifest.version) errors.push(`${directory}: package.json must include version`);
     if (manifest.private === true) errors.push(`${manifest.name}: package must not be private`);
     if (manifest.publishConfig?.access !== "public") {

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -3,16 +3,13 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-export const publishTargets = Object.freeze({
-  pinet: ["transport-core", "broker-core", "pinet-core"],
-  "slack-bridge": [
-    "transport-core",
-    "broker-core",
-    "pinet-core",
-    "imessage-bridge",
-    "slack-bridge",
-  ],
-});
+export const publishPackageDirectories = Object.freeze([
+  "transport-core",
+  "broker-core",
+  "pinet-core",
+  "imessage-bridge",
+  "slack-bridge",
+]);
 
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 const publicDependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
@@ -21,7 +18,6 @@ const requiredPackageFiles = ["README.md", "LICENSE", "dist/"];
 export function parseArgs(argv) {
   const args = {
     dryRun: true,
-    target: undefined,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -34,29 +30,14 @@ export function parseArgs(argv) {
       args.dryRun = false;
       continue;
     }
-    if (arg === "--target") {
-      args.target = argv[index + 1];
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith("--target=")) {
-      args.target = arg.slice("--target=".length);
-      continue;
-    }
     throw new Error(`Unknown argument: ${arg}`);
   }
 
   return args;
 }
 
-export function getTargetPackages(target) {
-  const packages = publishTargets[target];
-  if (!packages) {
-    throw new Error(
-      `Unknown npm publish target "${target}". Expected one of: ${Object.keys(publishTargets).join(", ")}`,
-    );
-  }
-  return packages;
+export function getPublishPackages() {
+  return [...publishPackageDirectories];
 }
 
 export async function readJson(filePath) {
@@ -86,12 +67,12 @@ export async function loadWorkspaceManifests(repoRoot) {
   return manifests;
 }
 
-export function rewriteLocalDependencySpecs(targetDirectories, manifests) {
-  const targetSet = new Set(targetDirectories);
+export function rewriteLocalDependencySpecs(packageDirectories, manifests) {
+  const packageSet = new Set(packageDirectories);
   const patched = [];
   const byDirectory = new Map(manifests);
 
-  for (const directory of targetDirectories) {
+  for (const directory of packageDirectories) {
     const entry = byDirectory.get(directory);
     if (!entry) {
       throw new Error(`Target package directory is not a workspace: ${directory}`);
@@ -118,9 +99,9 @@ export function rewriteLocalDependencySpecs(targetDirectories, manifests) {
             `${manifest.name} has unsupported local dependency ${dependencyName}@${specifier}`,
           );
         }
-        if (!targetSet.has(dependencyDirectory)) {
+        if (!packageSet.has(dependencyDirectory)) {
           throw new Error(
-            `${manifest.name} depends on ${dependencyEntry.manifest.name}, but ${dependencyDirectory} is not in the ${targetDirectories.join(", ")} publish target`,
+            `${manifest.name} depends on ${dependencyEntry.manifest.name}, but ${dependencyDirectory} is not in the ${packageDirectories.join(", ")} publish package set`,
           );
         }
         if (dependencyName !== dependencyEntry.manifest.name) {

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -44,17 +44,17 @@ test("rewriteLocalDependencySpecs replaces in-set file dependencies with exact v
     [
       "transport-core",
       entry("transport-core", {
-        name: "@gugu910/pi-transport-core",
+        name: "@pinet/transport-core",
         version: "0.1.0",
       }),
     ],
     [
       "broker-core",
       entry("broker-core", {
-        name: "@gugu910/pi-broker-core",
+        name: "@pinet/broker-core",
         version: "0.1.0",
         dependencies: {
-          "@gugu910/pi-transport-core": "file:../transport-core",
+          "@pinet/transport-core": "file:../transport-core",
         },
       }),
     ],
@@ -62,9 +62,9 @@ test("rewriteLocalDependencySpecs replaces in-set file dependencies with exact v
 
   const rewritten = rewriteLocalDependencySpecs(["transport-core", "broker-core"], manifests);
 
-  assert.equal(rewritten[1].manifest.dependencies["@gugu910/pi-transport-core"], "0.1.0");
+  assert.equal(rewritten[1].manifest.dependencies["@pinet/transport-core"], "0.1.0");
   assert.deepEqual(rewritten[1].rewrites, [
-    "@gugu910/pi-transport-core: file:../transport-core -> 0.1.0",
+    "@pinet/transport-core: file:../transport-core -> 0.1.0",
   ]);
 });
 
@@ -73,17 +73,17 @@ test("rewriteLocalDependencySpecs rejects local dependencies outside the publish
     [
       "transport-core",
       entry("transport-core", {
-        name: "@gugu910/pi-transport-core",
+        name: "@pinet/transport-core",
         version: "0.1.0",
       }),
     ],
     [
       "broker-core",
       entry("broker-core", {
-        name: "@gugu910/pi-broker-core",
+        name: "@pinet/broker-core",
         version: "0.1.0",
         dependencies: {
-          "@gugu910/pi-transport-core": "file:../transport-core",
+          "@pinet/transport-core": "file:../transport-core",
         },
       }),
     ],
@@ -98,7 +98,7 @@ test("rewriteLocalDependencySpecs rejects local dependencies outside the publish
 test("validatePublishMetadata blocks placeholder versions for real publish only", () => {
   const entries = [
     entry("pinet-core", {
-      name: "@gugu910/pi-pinet-core",
+      name: "@pinet/pinet-core",
       version: "0.0.0",
       license: "MIT",
       publishConfig: { access: "public" },
@@ -118,7 +118,7 @@ test("validatePublishMetadata blocks placeholder versions for real publish only"
 test("validatePublishMetadata requires declaration metadata", () => {
   const entries = [
     entry("pinet-core", {
-      name: "@gugu910/pi-pinet-core",
+      name: "@pinet/pinet-core",
       version: "0.0.0",
       license: "MIT",
       publishConfig: { access: "public" },
@@ -128,6 +128,25 @@ test("validatePublishMetadata requires declaration metadata", () => {
   ];
 
   assert.throws(() => validatePublishMetadata(entries, { dryRun: true }), /must include types/);
+});
+
+test("validatePublishMetadata requires npm org pinet package names", () => {
+  const entries = [
+    entry("pinet-core", {
+      name: "@gugu910/pi-pinet-core",
+      version: "0.0.0",
+      license: "MIT",
+      publishConfig: { access: "public" },
+      main: "./dist/index.js",
+      types: "./dist/index.d.ts",
+      files: ["README.md", "LICENSE", "dist/"],
+    }),
+  ];
+
+  assert.throws(
+    () => validatePublishMetadata(entries, { dryRun: true }),
+    /package name must be @pinet\/pinet-core/,
+  );
 });
 
 test("validateBuildOutputs checks package files", async () => {
@@ -141,7 +160,7 @@ test("validateBuildOutputs checks package files", async () => {
     () =>
       validateBuildOutputs(repoRoot, [
         entry("pinet-core", {
-          name: "@gugu910/pi-pinet-core",
+          name: "@pinet/pinet-core",
           main: "./dist/index.js",
           types: "./dist/index.d.ts",
         }),
@@ -163,7 +182,7 @@ test("validateBuildOutputs checks JavaScript exports and declaration outputs", a
     () =>
       validateBuildOutputs(repoRoot, [
         entry("pinet-core", {
-          name: "@gugu910/pi-pinet-core",
+          name: "@pinet/pinet-core",
           main: "./dist/index.js",
           types: "./dist/index.d.ts",
           exports: {
@@ -180,7 +199,7 @@ test("validateBuildOutputs checks JavaScript exports and declaration outputs", a
   await assert.doesNotReject(() =>
     validateBuildOutputs(repoRoot, [
       entry("pinet-core", {
-        name: "@gugu910/pi-pinet-core",
+        name: "@pinet/pinet-core",
         main: "./dist/index.js",
         types: "./dist/index.d.ts",
         exports: {
@@ -405,7 +424,7 @@ test("parseNpmViewVersionExists distinguishes found, not-found, and lookup error
   assert.equal(
     parseNpmViewVersionExists(
       { status: 0, stdout: "0.1.0\n", stderr: "" },
-      "@gugu910/pi-broker-core",
+      "@pinet/broker-core",
       "0.1.0",
     ),
     true,
@@ -413,7 +432,7 @@ test("parseNpmViewVersionExists distinguishes found, not-found, and lookup error
   assert.equal(
     parseNpmViewVersionExists(
       { status: 1, stdout: "", stderr: "npm ERR! code E404\nnpm ERR! 404 Not Found" },
-      "@gugu910/pi-broker-core",
+      "@pinet/broker-core",
       "0.1.0",
     ),
     false,
@@ -422,30 +441,30 @@ test("parseNpmViewVersionExists distinguishes found, not-found, and lookup error
     () =>
       parseNpmViewVersionExists(
         { status: 1, stdout: "", stderr: "npm ERR! network timeout" },
-        "@gugu910/pi-broker-core",
+        "@pinet/broker-core",
         "0.1.0",
       ),
-    /Unable to verify @gugu910\/pi-broker-core@0.1.0/,
+    /Unable to verify @pinet\/broker-core@0.1.0/,
   );
   assert.throws(
     () =>
       parseNpmViewVersionExists(
         { status: 1, stdout: "", stderr: "" },
-        "@gugu910/pi-broker-core",
+        "@pinet/broker-core",
         "0.1.0",
       ),
-    /Unable to verify @gugu910\/pi-broker-core@0.1.0/,
+    /Unable to verify @pinet\/broker-core@0.1.0/,
   );
 });
 
 test("assertVersionsNotAlreadyPublished fails closed for existing versions", () => {
   const entries = [
     entry("transport-core", {
-      name: "@gugu910/pi-transport-core",
+      name: "@pinet/transport-core",
       version: "0.1.0",
     }),
     entry("broker-core", {
-      name: "@gugu910/pi-broker-core",
+      name: "@pinet/broker-core",
       version: "0.1.0",
     }),
   ];
@@ -454,8 +473,8 @@ test("assertVersionsNotAlreadyPublished fails closed for existing versions", () 
     () =>
       assertVersionsNotAlreadyPublished(
         entries,
-        (packageName, version) => packageName === "@gugu910/pi-broker-core" && version === "0.1.0",
+        (packageName, version) => packageName === "@pinet/broker-core" && version === "0.1.0",
       ),
-    /@gugu910\/pi-broker-core@0.1.0/,
+    /@pinet\/broker-core@0.1.0/,
   );
 });

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import {
   assertVersionsNotAlreadyPublished,
-  getTargetPackages,
+  getPublishPackages,
   parseArgs,
   parseNpmViewVersionExists,
   rewriteLocalDependencySpecs,
@@ -23,9 +23,8 @@ function entry(directory, manifest) {
   };
 }
 
-test("getTargetPackages keeps Pinet and Slack bridge targets separated", () => {
-  assert.deepEqual(getTargetPackages("pinet"), ["transport-core", "broker-core", "pinet-core"]);
-  assert.deepEqual(getTargetPackages("slack-bridge"), [
+test("getPublishPackages returns the full publish set in dependency order", () => {
+  assert.deepEqual(getPublishPackages(), [
     "transport-core",
     "broker-core",
     "pinet-core",
@@ -35,14 +34,12 @@ test("getTargetPackages keeps Pinet and Slack bridge targets separated", () => {
 });
 
 test("parseArgs defaults to dry-run and accepts publish mode", () => {
-  assert.deepEqual(parseArgs(["--target", "pinet"]), { target: "pinet", dryRun: true });
-  assert.deepEqual(parseArgs(["--target=slack-bridge", "--publish"]), {
-    target: "slack-bridge",
-    dryRun: false,
-  });
+  assert.deepEqual(parseArgs([]), { dryRun: true });
+  assert.deepEqual(parseArgs(["--publish"]), { dryRun: false });
+  assert.throws(() => parseArgs(["--target", "pinet"]), /Unknown argument: --target/);
 });
 
-test("rewriteLocalDependencySpecs replaces in-target file dependencies with exact versions", () => {
+test("rewriteLocalDependencySpecs replaces in-set file dependencies with exact versions", () => {
   const manifests = new Map([
     [
       "transport-core",
@@ -71,7 +68,7 @@ test("rewriteLocalDependencySpecs replaces in-target file dependencies with exac
   ]);
 });
 
-test("rewriteLocalDependencySpecs rejects local dependencies outside the target", () => {
+test("rewriteLocalDependencySpecs rejects local dependencies outside the publish set", () => {
   const manifests = new Map([
     [
       "transport-core",
@@ -94,7 +91,7 @@ test("rewriteLocalDependencySpecs rejects local dependencies outside the target"
 
   assert.throws(
     () => rewriteLocalDependencySpecs(["broker-core"], manifests),
-    /transport-core is not in the broker-core publish target/,
+    /transport-core is not in the broker-core publish package set/,
   );
 });
 
@@ -314,7 +311,7 @@ test("validatePublicTypeResolution catches declared but unresolvable declaration
   );
 });
 
-test("validatePublicTypeResolution catches undeclared sibling target declaration imports", async () => {
+test("validatePublicTypeResolution catches undeclared sibling publish-set declaration imports", async () => {
   const repoRoot = await mkdtemp(path.join(tmpdir(), "npm-publish-sibling-types-"));
   const packageARoot = path.join(repoRoot, "package-a");
   const packageBRoot = path.join(repoRoot, "package-b");

--- a/scripts/publish-npm-packages.mjs
+++ b/scripts/publish-npm-packages.mjs
@@ -41,6 +41,19 @@ function versionExists(packageName, version) {
   return parseNpmViewVersionExists(result, packageName, version);
 }
 
+function assertTrustedPublishingRuntime() {
+  if (process.env.GITHUB_ACTIONS !== "true") {
+    throw new Error(
+      "Real npm publishing requires the GitHub Actions Trusted Publishing/OIDC workflow context; run the Publish npm packages workflow from main instead of local token publishing.",
+    );
+  }
+  if (!process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN || !process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+    throw new Error(
+      "Real npm publishing requires GitHub OIDC id-token access for npm Trusted Publishing; check id-token: write and the npm-publish environment.",
+    );
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const packageDirectories = getPublishPackages();
@@ -69,9 +82,7 @@ async function main() {
     }
 
     if (!args.dryRun) {
-      if (!process.env.NPM_TOKEN) {
-        throw new Error("NPM_TOKEN is required for real npm publishing");
-      }
+      assertTrustedPublishingRuntime();
       assertVersionsNotAlreadyPublished(entries, versionExists);
     }
 

--- a/scripts/publish-npm-packages.mjs
+++ b/scripts/publish-npm-packages.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   assertVersionsNotAlreadyPublished,
-  getTargetPackages,
+  getPublishPackages,
   loadWorkspaceManifests,
   parseArgs,
   parseNpmViewVersionExists,
@@ -43,13 +43,9 @@ function versionExists(packageName, version) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  if (!args.target) {
-    throw new Error("Missing required --target argument");
-  }
-
-  const targetDirectories = getTargetPackages(args.target);
+  const packageDirectories = getPublishPackages();
   const manifests = await loadWorkspaceManifests(repoRoot);
-  const entries = rewriteLocalDependencySpecs(targetDirectories, manifests);
+  const entries = rewriteLocalDependencySpecs(packageDirectories, manifests);
 
   validatePublishMetadata(entries, { dryRun: args.dryRun });
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -5,13 +5,13 @@ Slack assistant integration for [pi](https://github.com/badlogic/pi-mono) — mu
 ## Install
 
 ```bash
-pi install npm:@gugu910/pi-slack-bridge
+pi install npm:@pinet/slack-bridge
 ```
 
 Or with npm:
 
 ```bash
-npm install @gugu910/pi-slack-bridge
+npm install @pinet/slack-bridge
 ```
 
 ## Publishing

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -16,10 +16,10 @@ npm install @gugu910/pi-slack-bridge
 
 ## Publishing
 
-This package is released through the manual `slack-bridge` npm publish lane
-tracked in [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub
-Actions workflow's default dry-run/readiness path for validation; do not publish,
-tag, or bump versions without explicit maintainer release approval.
+This package is included in the full npm publish set tracked in
+[`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
+workflow's default dry-run/readiness path for validation; do not publish, tag, or
+bump versions without explicit maintainer release approval.
 
 ## Prerequisites
 

--- a/slack-bridge/broker-inbound-persistence.test.ts
+++ b/slack-bridge/broker-inbound-persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { DeliveredInboundMessageResult, InboundMessage } from "@gugu910/pi-broker-core/types";
+import type { DeliveredInboundMessageResult, InboundMessage } from "@pinet/broker-core/types";
 import {
   buildPersistedInboundNotificationText,
   buildPinetReadPointer,

--- a/slack-bridge/broker-inbound-persistence.ts
+++ b/slack-bridge/broker-inbound-persistence.ts
@@ -2,7 +2,7 @@ import type {
   BrokerMessage,
   DeliveredInboundMessageResult,
   InboundMessage,
-} from "@gugu910/pi-broker-core/types";
+} from "@pinet/broker-core/types";
 
 export interface DeliveredInboundPersistenceStore {
   queueDeliveredMessage(agentId: string, message: InboundMessage): DeliveredInboundMessageResult;

--- a/slack-bridge/broker/adapters/types.ts
+++ b/slack-bridge/broker/adapters/types.ts
@@ -4,4 +4,4 @@ export type {
   InboundMessage,
   OutboundMessage,
   MessageAdapter,
-} from "@gugu910/pi-transport-core";
+} from "@pinet/transport-core";

--- a/slack-bridge/broker/agent-messaging.ts
+++ b/slack-bridge/broker/agent-messaging.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/agent-messaging";
+export * from "@pinet/broker-core/agent-messaging";

--- a/slack-bridge/broker/auth.ts
+++ b/slack-bridge/broker/auth.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/auth";
+export * from "@pinet/broker-core/auth";

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -7,7 +7,7 @@ import type {
   PinetReadOptions,
   PinetReadResult,
   PinetUnreadThreadSummary,
-} from "@gugu910/pi-pinet-core/pinet-read-formatting";
+} from "@pinet/pinet-core/pinet-read-formatting";
 import type {
   ClientAgentInfo,
   NormalizedMessageContent,
@@ -44,7 +44,7 @@ export type {
   PinetReadOptions,
   PinetReadResult,
   PinetUnreadThreadSummary,
-} from "@gugu910/pi-pinet-core/pinet-read-formatting";
+} from "@pinet/pinet-core/pinet-read-formatting";
 
 export interface ThreadInfo {
   threadId: string;

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import * as net from "node:net";
-import { BrokerDB as CoreBrokerDB } from "@gugu910/pi-broker-core/schema";
+import { BrokerDB as CoreBrokerDB } from "@pinet/broker-core/schema";
 import { BrokerDB, CURRENT_BROKER_SCHEMA_VERSION } from "./schema.js";
 import { LeaderLock } from "./leader.js";
 import { startBroker, type Broker } from "./index.js";

--- a/slack-bridge/broker/leader.ts
+++ b/slack-bridge/broker/leader.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/leader";
+export * from "@pinet/broker-core/leader";

--- a/slack-bridge/broker/maintenance.ts
+++ b/slack-bridge/broker/maintenance.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/maintenance";
+export * from "@pinet/broker-core/maintenance";

--- a/slack-bridge/broker/message-send.ts
+++ b/slack-bridge/broker/message-send.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/message-send";
+export * from "@pinet/broker-core/message-send";

--- a/slack-bridge/broker/paths.ts
+++ b/slack-bridge/broker/paths.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/paths";
+export * from "@pinet/broker-core/paths";

--- a/slack-bridge/broker/raw-tcp-loopback.ts
+++ b/slack-bridge/broker/raw-tcp-loopback.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/raw-tcp-loopback";
+export * from "@pinet/broker-core/raw-tcp-loopback";

--- a/slack-bridge/broker/router.ts
+++ b/slack-bridge/broker/router.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/router";
+export * from "@pinet/broker-core/router";

--- a/slack-bridge/broker/schema.ts
+++ b/slack-bridge/broker/schema.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_RESUMABLE_WINDOW_MS,
   defaultDbPath,
   type TaskAssignmentAwaitingReplyInfo,
-} from "@gugu910/pi-broker-core/schema";
+} from "@pinet/broker-core/schema";
 import type { RalphCycleRecord } from "../helpers.js";
 
 interface RalphCycleRow {

--- a/slack-bridge/broker/types.ts
+++ b/slack-bridge/broker/types.ts
@@ -1,1 +1,1 @@
-export * from "@gugu910/pi-broker-core/types";
+export * from "@pinet/broker-core/types";

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -4,13 +4,13 @@ import * as path from "node:path";
 import {
   classifyPinetMail,
   formatPinetMailClassLabel,
-} from "@gugu910/pi-broker-core/mail-classification";
+} from "@pinet/broker-core/mail-classification";
 import {
   buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope,
   buildRuntimeScopeCarrier,
   type RuntimeScopeCarrier,
-} from "@gugu910/pi-transport-core";
+} from "@pinet/transport-core";
 import type { ReactionCommandSettings } from "./reaction-triggers.js";
 import { buildPinetReadPointer } from "./broker-inbound-persistence.js";
 import { matchesToolPattern } from "./guardrails.js";

--- a/slack-bridge/imessage-tools.ts
+++ b/slack-bridge/imessage-tools.ts
@@ -1,10 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { NormalizedMessageContent } from "@gugu910/pi-transport-core";
+import type { NormalizedMessageContent } from "@pinet/transport-core";
 import { Type } from "@sinclair/typebox";
-import {
-  getDefaultIMessageThreadId,
-  normalizeIMessageRecipient,
-} from "@gugu910/pi-imessage-bridge";
+import { getDefaultIMessageThreadId, normalizeIMessageRecipient } from "@pinet/imessage-bridge";
 import type { Broker } from "./broker/index.js";
 import { sendBrokerMessage } from "./broker/message-send.js";
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -9,7 +9,7 @@ import * as brokerModule from "./broker/index.js";
 import * as maintenanceModule from "./broker/maintenance.js";
 import { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
-import * as imessageModule from "@gugu910/pi-imessage-bridge";
+import * as imessageModule from "@pinet/imessage-bridge";
 import slackBridge from "./index.js";
 
 type ToolDefinition = {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -37,7 +37,7 @@ import {
   createIMessageAdapter,
   detectIMessageMvpEnvironment,
   formatIMessageMvpReadiness,
-} from "@gugu910/pi-imessage-bridge";
+} from "@pinet/imessage-bridge";
 import {
   SLACK_SOCKET_DELIVERY_DEDUP_MAX_SIZE,
   SLACK_SOCKET_DELIVERY_DEDUP_TTL_MS,

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu910/pi-slack-bridge",
+  "name": "@pinet/slack-bridge",
   "version": "0.1.4",
   "type": "module",
   "description": "Slack assistant integration for pi (Pinet) — multi-agent broker, thread routing, and inbox tools",
@@ -44,10 +44,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@gugu910/pi-broker-core": "file:../broker-core",
-    "@gugu910/pi-imessage-bridge": "file:../imessage-bridge",
-    "@gugu910/pi-pinet-core": "file:../pinet-core",
-    "@gugu910/pi-transport-core": "file:../transport-core",
+    "@pinet/broker-core": "file:../broker-core",
+    "@pinet/imessage-bridge": "file:../imessage-bridge",
+    "@pinet/pinet-core": "file:../pinet-core",
+    "@pinet/transport-core": "file:../transport-core",
     "@sinclair/typebox": "^0.34.49"
   },
   "types": "./dist/index.d.ts",

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { parseScheduledWakeupDelay } from "@gugu910/pi-pinet-core/scheduled-wakeups";
+import { parseScheduledWakeupDelay } from "@pinet/pinet-core/scheduled-wakeups";
 import {
   generateAgentName,
   agentOwnsThread,

--- a/slack-bridge/pinet-confirmation-replies.test.ts
+++ b/slack-bridge/pinet-confirmation-replies.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PinetReadResult } from "@gugu910/pi-pinet-core/pinet-read-formatting";
+import type { PinetReadResult } from "@pinet/pinet-core/pinet-read-formatting";
 import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
 import { consumePinetReadConfirmationReplies } from "./pinet-confirmation-replies.js";
 

--- a/slack-bridge/pinet-confirmation-replies.ts
+++ b/slack-bridge/pinet-confirmation-replies.ts
@@ -1,4 +1,4 @@
-import type { PinetReadResult } from "@gugu910/pi-pinet-core/pinet-read-formatting";
+import type { PinetReadResult } from "@pinet/pinet-core/pinet-read-formatting";
 
 export type ConsumePinetConfirmationReply = (
   threadTs: string,

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -5,15 +5,15 @@ import {
   formatPinetReadResultFull,
   type PinetReadOptions,
   type PinetReadResult,
-} from "@gugu910/pi-pinet-core/pinet-read-formatting";
+} from "@pinet/pinet-core/pinet-read-formatting";
 import {
   normalizePinetOutputOptions,
   type PinetOutputOptions,
-} from "@gugu910/pi-pinet-core/output-options";
+} from "@pinet/pinet-core/output-options";
 import {
   parseScheduledWakeupDelay,
   resolveScheduledWakeupFireAt,
-} from "@gugu910/pi-pinet-core/scheduled-wakeups";
+} from "@pinet/pinet-core/scheduled-wakeups";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import {

--- a/slack-bridge/scheduled-wakeups.ts
+++ b/slack-bridge/scheduled-wakeups.ts
@@ -3,4 +3,4 @@ export {
   parseScheduledWakeupDelay,
   resolveScheduledWakeupFireAt,
   type ScheduledWakeupInput,
-} from "@gugu910/pi-pinet-core/scheduled-wakeups";
+} from "@pinet/pinet-core/scheduled-wakeups";

--- a/slack-bridge/skills/pinet-skin-creator/SKILL.md
+++ b/slack-bridge/skills/pinet-skin-creator/SKILL.md
@@ -83,8 +83,8 @@ do not add model calls to broker startup or follower join paths.
 7. **Validate**
    - Run focused tests for descriptor loading/selection and status-vocabulary
      propagation if code changed.
-   - Run package `pnpm --filter @gugu910/pi-slack-bridge lint` and
-     `pnpm --filter @gugu910/pi-slack-bridge typecheck` when touching
+   - Run package `pnpm --filter @pinet/slack-bridge lint` and
+     `pnpm --filter @pinet/slack-bridge typecheck` when touching
      TypeScript.
    - For JSON descriptor work, run a targeted test that reads/validates the
      descriptor and verifies the authored identity pool is large enough without

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-bridge
-description: Warm reference for the @gugu910/pi-slack-bridge Slack dispatcher. Use when building Slack Block Kit messages, modals, canvases, uploads, schedules, pins/bookmarks, or when you need per-action usage patterns beyond slack action=help schemas.
+description: Warm reference for the @pinet/slack-bridge Slack dispatcher. Use when building Slack Block Kit messages, modals, canvases, uploads, schedules, pins/bookmarks, or when you need per-action usage patterns beyond slack action=help schemas.
 ---
 
 # Slack Bridge Warm Reference

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -1,4 +1,4 @@
-import type { RuntimeScopeCarrier } from "@gugu910/pi-transport-core";
+import type { RuntimeScopeCarrier } from "@pinet/transport-core";
 import {
   buildSlackCompatibilityScope,
   isUserAllowed,

--- a/transport-core/README.md
+++ b/transport-core/README.md
@@ -1,4 +1,4 @@
-# @gugu910/pi-transport-core
+# @pinet/transport-core
 
 Tiny transport-neutral contracts package for the `extensions` repo.
 

--- a/transport-core/README.md
+++ b/transport-core/README.md
@@ -22,7 +22,7 @@ This package exists to keep transport contracts transport-neutral while other pa
 
 ## Publishing
 
-This package is part of both manual npm publish lanes tracked in
+This package is part of the full npm publish set tracked in
 [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
 workflow's default dry-run/readiness path for validation; do not publish, tag, or
 bump versions without explicit maintainer release approval.

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gugu910/pi-transport-core",
+  "name": "@pinet/transport-core",
   "version": "0.0.0",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,12 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@gugu910/pi-broker-core": ["./broker-core/index.ts"],
-      "@gugu910/pi-broker-core/*": ["./broker-core/*.ts"],
-      "@gugu910/pi-imessage-bridge": ["./imessage-bridge/index.ts"],
-      "@gugu910/pi-pinet-core": ["./pinet-core/index.ts"],
-      "@gugu910/pi-pinet-core/*": ["./pinet-core/*.ts"],
-      "@gugu910/pi-transport-core": ["./transport-core/index.ts"]
+      "@pinet/broker-core": ["./broker-core/index.ts"],
+      "@pinet/broker-core/*": ["./broker-core/*.ts"],
+      "@pinet/imessage-bridge": ["./imessage-bridge/index.ts"],
+      "@pinet/pinet-core": ["./pinet-core/index.ts"],
+      "@pinet/pinet-core/*": ["./pinet-core/*.ts"],
+      "@pinet/transport-core": ["./transport-core/index.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

Follow-up to #796 for maintainer direction on #773: “we should always publish everything, no config in publishing.”

#796 was already merged at `251aaec` from head `2365b28`, so this PR carries the no-target publish update on top of current `main`.

Changed files and why:
- `.github/workflows/npm-publish.yml` — removes the `target` workflow input; readiness and publish jobs always run the full package set; real publish approval phrase is now exactly `publish all`; dry-run default, main-only preflight, protected `npm-publish` environment, `NPM_TOKEN`, provenance, and global live-publish concurrency remain.
- `scripts/publish-npm-packages.mjs` — removes required `--target` path and always resolves the full publish set.
- `scripts/npm-publish-helpers.mjs` / `scripts/npm-publish-helpers.test.mjs` — replaces target-lane helper with a fixed full package set in dependency order and verifies `--target` is rejected.
- `plans/npm-publish.md` — replaces lane/target docs with the single full package set, `publish all` approval phrase, and no-selector policy.
- `README.md` and package READMEs — updates operator/package breadcrumbs to say the workflow validates/publishes the full set with no target selector.

## Full publish set

Always in dependency order:

1. `@gugu910/pi-transport-core`
2. `@gugu910/pi-broker-core`
3. `@gugu910/pi-pinet-core`
4. `@gugu910/pi-imessage-bridge`
5. `@gugu910/pi-slack-bridge`

## Publish safety

No real publish performed. No tags, merges, or version bumps. Real publish remains gated on maintainer-approved versions, `dry_run=false`, `main`, exact `publish all` approval phrase, protected `npm-publish` environment with `NPM_TOKEN`, provenance publish, global live-publish concurrency, and the script's placeholder/already-published version refusals.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-publish.yml"); puts "workflow yaml ok"'`
- `node --test scripts/*.test.mjs` → 13 passed
- `node ./scripts/publish-npm-packages.mjs --dry-run` → dry-ran all five packages
- `node ./scripts/publish-npm-packages.mjs --target pinet` → fails with `Unknown argument: --target` as expected
- `pnpm lint && pnpm typecheck && pnpm test`
- `pnpm format:check`
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`
- local reviewer pass found no blockers/warnings

Actions-aware validation caveat remains: local `actionlint` is unavailable; `pnpm dlx actionlint` has no binary and `pnpm dlx @rhysd/actionlint` returned npm 404, so workflow validation is YAML parse + manual expression review + script dry-run coverage.
