### PR TITLE
chore: add npm org bootstrap publish script

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,17 +243,34 @@ Safe readiness checks are the default path:
    the full `@pinet/*` package set and does not request npm credentials.
 
 The same dry-run path can be run locally with `pnpm publish:npm`; it defaults to
-readiness only and has no package target selector.
+readiness only and has no package target selector. The one-time npm org package
+creation bootstrap path is `pnpm bootstrap:npm`, which also defaults to dry-run
+and prints the full `@pinet/*` package set it would publish.
 
 Real publishes are intentionally harder to trigger. They require a maintainer to
 dispatch from `main` with `dry_run=false`, enter `publish all` as the exact
 `release_approval` phrase, and approve the protected `npm-publish` environment.
 The publish job uses npm Trusted Publishing / GitHub OIDC with
-`npm publish --provenance`; it does not use `NPM_TOKEN`. Maintainers must also
+`npm publish --provenance`; it does not use a long-lived npm token. Maintainers must also
 configure npm Trusted Publishers for every package in the npm `pinet` org
 settings (`https://www.npmjs.com/settings/pinet/packages`) before real publish.
-The publish script still refuses placeholder `0.0.0` versions and versions that
-already exist on npm.
+If npm requires packages to exist before Trusted Publishing can be configured,
+a `pinet` org owner/admin may use the guarded local bootstrap script only after
+maintainer-approved versions are set:
+
+```bash
+node ./scripts/bootstrap-npm-packages.mjs \
+  --bootstrap-publish \
+  --confirm "bootstrap @pinet packages"
+```
+
+The maintainer must already be logged in with `npm login` as a `pinet` org
+owner/admin. This repo does not add token automation. Immediately after any
+successful bootstrap, configure Trusted Publishing for every `@pinet/*` package
+and use the GitHub Actions workflow for normal future publishes.
+
+The publish and bootstrap scripts still refuse placeholder `0.0.0` versions and
+versions that already exist on npm.
 
 Do not publish, tag, or bump package versions as part of readiness-only changes;
 record release notes in `CHANGELOG.md` only when a maintainer approves a real

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "turbo run test && node --test scripts/*.test.mjs",
     "deploy:slack": "node --experimental-strip-types ./slack-bridge/deploy-manifest.ts",
     "publish:npm": "node ./scripts/publish-npm-packages.mjs",
+    "bootstrap:npm": "node ./scripts/bootstrap-npm-packages.mjs",
     "check": "pnpm lint && pnpm typecheck && pnpm format:check",
     "prepush": "pnpm lint && pnpm typecheck && pnpm test",
     "lint-staged": "lint-staged",

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -32,6 +32,15 @@ node ./scripts/publish-npm-packages.mjs --dry-run
 
 Both forms default to dry-run/readiness. The script has no `--target` flag and always processes the full package set. The `--publish` mode is reserved for the GitHub Actions Trusted Publishing/OIDC workflow context; it is not a local token-publish path.
 
+For one-time npm org package creation before Trusted Publishing can be configured, use the bootstrap script described below:
+
+```bash
+pnpm bootstrap:npm
+node ./scripts/bootstrap-npm-packages.mjs --dry-run
+```
+
+That script also defaults to dry-run/readiness and processes the same full package set. Its real publish mode is a local maintainer bootstrap escape hatch only; it is not the normal release path.
+
 When `dry_run=true`, the workflow stops after the dry-run/readiness job and does not request the `npm-publish` environment. Dry-run dispatches use the `npm-publish-dry-run` concurrency group. Real publish dispatches use the `npm-publish-live` concurrency group so live publishes are globally serialized.
 
 Real publishes require all of these gates before the publish job can run:
@@ -51,10 +60,26 @@ Packages are intended for the npm `pinet` org/package settings area: <https://ww
 
 Keep the GitHub and npm setup separate:
 
-- **GitHub setup:** create/verify the `npm-publish` environment, require maintainer reviewers, restrict deployment branches to `main`, and do not add `NPM_TOKEN` for this workflow.
+- **GitHub setup:** create/verify the `npm-publish` environment, require maintainer reviewers, restrict deployment branches to `main`, and do not add long-lived npm token auth for this workflow.
 - **npm setup:** an npm `pinet` org owner/admin must have package creation/publish authority for the org and must configure Trusted Publishing for every package in the list above.
 
-Trusted Publishing is package-scoped in npm's settings UI. If npm does not allow a Trusted Publisher to be configured for a package before that package exists, do not add a token fallback in this repo. The safe bootstrap is to have an npm `pinet` org owner/admin create or first-publish/claim the packages using npm-approved org procedures, then configure Trusted Publishing for each package, then use this GitHub Actions workflow for subsequent provenance publishes. If npm's team/access UI loops or blocks package creation, resolve org/team/admin access in npm first rather than adding CI token automation.
+Trusted Publishing is package-scoped in npm's settings UI. If npm does not allow a Trusted Publisher to be configured for a package before that package exists, do not add a token fallback in this repo.
+
+The repo includes a guarded first-publish bootstrap script for that narrow package-creation gap:
+
+```bash
+# safe default: builds, validates, and runs npm publish --dry-run for the full set
+pnpm bootstrap:npm
+
+# real one-time bootstrap only, after maintainer-approved versions are set
+node ./scripts/bootstrap-npm-packages.mjs \
+  --bootstrap-publish \
+  --confirm "bootstrap @pinet packages"
+```
+
+The real bootstrap mode still runs the same package-name, metadata/artifact, build-output, public-type, placeholder-version, and already-published-version gates. It then runs `npm publish --access public` for the full package set from the local npm CLI login. The maintainer running it must already be logged in with `npm login` as a `pinet` org owner/admin with package creation rights. This repo does not configure token auth and does not make bootstrap publishing the normal release path.
+
+Immediately after any successful first-publish bootstrap, configure npm Trusted Publishing for every package in <https://www.npmjs.com/settings/pinet/packages> with owner/repo `gugu91/extensions`, workflow `npm-publish.yml`, and environment `npm-publish` if npm asks for one. Normal future publishes should then use the GitHub Actions Trusted Publishing/OIDC workflow with provenance. If npm's team/access UI loops or blocks package creation, resolve org/team/admin access in npm first rather than adding CI token automation.
 
 ## Package artifacts and type/declaration artifacts
 
@@ -74,9 +99,9 @@ Publishable packages must also expose `types: "./dist/index.d.ts"` and build mat
 
 ## Required GitHub/npm configuration
 
-Secret names:
+Secrets:
 
-- No `NPM_TOKEN` is required or expected for the Trusted Publishing workflow.
+- No long-lived npm token secret is required or expected for the Trusted Publishing workflow.
 
 GitHub environment:
 
@@ -100,7 +125,7 @@ GitHub permissions:
 ## Release gates before setting `dry_run=false`
 
 - #772 has confirmed the Pinet/Slack boundary and the full publish set is still correct.
-- Package versions are intentionally bumped. The publish script refuses real publishes for placeholder `0.0.0` packages or versions already present on npm.
+- Package versions are intentionally bumped. The publish and bootstrap scripts refuse real publishes for placeholder `0.0.0` packages or versions already present on npm.
 - `CHANGELOG.md` has a maintainer-approved entry covering the full package set and package versions.
 - The dry-run/readiness job is green on the same `main` commit intended for release.
 - The workflow dispatch includes the exact `publish all` release approval phrase.

--- a/scripts/bootstrap-npm-packages.mjs
+++ b/scripts/bootstrap-npm-packages.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertVersionsNotAlreadyPublished,
+  getPublishPackages,
+  loadWorkspaceManifests,
+  parseBootstrapArgs,
+  parseNpmViewVersionExists,
+  publishPackages,
+  rewriteLocalDependencySpecs,
+  validateBuildOutputs,
+  validatePublicTypeResolution,
+  validatePublishMetadata,
+  writeJson,
+} from "./npm-publish-helpers.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with status ${result.status ?? 1}`);
+  }
+}
+
+function versionExists(packageName, version) {
+  const result = spawnSync("npm", ["view", `${packageName}@${version}`, "version"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  return parseNpmViewVersionExists(result, packageName, version);
+}
+
+function assertNpmOrgBootstrapLogin() {
+  const result = spawnSync("npm", ["whoami", "--registry", "https://registry.npmjs.org"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+    throw new Error(
+      `One-time @pinet package bootstrap requires an existing npm CLI login as a pinet org owner/admin. Run npm login with the appropriate npm account first; this repo does not configure token auth. npm whoami failed${output ? `:\n${output}` : "."}`,
+    );
+  }
+
+  console.log(`npm CLI account for bootstrap: ${result.stdout.trim()}`);
+}
+
+function printBootstrapPlan({ dryRun }) {
+  console.log("npm org pinet first-publish bootstrap plan");
+  console.log(`Mode: ${dryRun ? "dry-run/readiness only" : "REAL one-time bootstrap publish"}`);
+  console.log("Package set, in dependency order:");
+  for (const { packageName, directory } of publishPackages) {
+    console.log(`- ${packageName} from ${directory}/`);
+  }
+  console.log(
+    dryRun
+      ? "No packages will be published. The script will build, validate, patch local file: dependencies to exact versions in a temporary checkout state, and run npm publish --dry-run for every package."
+      : "Packages WILL be published with npm publish --access public from the local npm CLI login. Use this only for first package creation in the npm pinet org; configure npm Trusted Publishing immediately afterward for normal future CI publishes.",
+  );
+}
+
+async function main() {
+  const args = parseBootstrapArgs(process.argv.slice(2));
+  const packageDirectories = getPublishPackages();
+  const manifests = await loadWorkspaceManifests(repoRoot);
+  const entries = rewriteLocalDependencySpecs(packageDirectories, manifests);
+
+  printBootstrapPlan(args);
+  validatePublishMetadata(entries, { dryRun: args.dryRun });
+
+  run("pnpm", ["run", "build:packages"]);
+  await validateBuildOutputs(repoRoot, entries);
+  await validatePublicTypeResolution(repoRoot, entries);
+
+  const originalManifests = entries.map(({ directory, packageJsonPath }) => ({
+    packageJsonPath,
+    manifest: manifests.get(directory).manifest,
+  }));
+  let wrotePatchedManifests = false;
+
+  try {
+    for (const entry of entries) {
+      await writeJson(entry.packageJsonPath, entry.manifest);
+      wrotePatchedManifests = true;
+      for (const rewrite of entry.rewrites) {
+        console.log(`${entry.manifest.name}: ${rewrite}`);
+      }
+    }
+
+    if (!args.dryRun) {
+      assertVersionsNotAlreadyPublished(entries, versionExists);
+      assertNpmOrgBootstrapLogin();
+    }
+
+    for (const { directory, manifest } of entries) {
+      const publishArgs = ["publish", "--access", "public"];
+      if (args.dryRun) {
+        publishArgs.push("--dry-run");
+      }
+
+      console.log(
+        `${args.dryRun ? "Dry-run bootstrap publishing" : "Bootstrap publishing"} ${manifest.name}@${manifest.version}`,
+      );
+      run("npm", publishArgs, { cwd: path.join(repoRoot, directory) });
+    }
+
+    if (!args.dryRun) {
+      console.log(
+        "Bootstrap publish complete. Configure npm Trusted Publishing for every @pinet/* package before using the GitHub Actions publish workflow.",
+      );
+    }
+  } finally {
+    if (wrotePatchedManifests) {
+      for (const original of originalManifests) {
+        await writeJson(original.packageJsonPath, original.manifest);
+      }
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -44,6 +44,49 @@ export function parseArgs(argv) {
   return args;
 }
 
+const bootstrapConfirmationPhrase = "bootstrap @pinet packages";
+
+export function parseBootstrapArgs(argv) {
+  const args = {
+    dryRun: true,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--dry-run") {
+      args.dryRun = true;
+      continue;
+    }
+    if (arg === "--bootstrap-publish") {
+      args.dryRun = false;
+      continue;
+    }
+    if (arg === "--confirm") {
+      index += 1;
+      const confirmation = argv[index];
+      if (!confirmation) {
+        throw new Error("--confirm requires a confirmation phrase");
+      }
+      if (confirmation !== bootstrapConfirmationPhrase) {
+        throw new Error(
+          `Real npm org pinet bootstrap requires --confirm ${JSON.stringify(bootstrapConfirmationPhrase)}`,
+        );
+      }
+      args.confirmed = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!args.dryRun && !args.confirmed) {
+    throw new Error(
+      `Real npm org pinet bootstrap requires --bootstrap-publish --confirm ${JSON.stringify(bootstrapConfirmationPhrase)}`,
+    );
+  }
+
+  return { dryRun: args.dryRun };
+}
+
 export function getPublishPackages() {
   return [...publishPackageDirectories];
 }

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -8,6 +8,7 @@ import {
   assertVersionsNotAlreadyPublished,
   getPublishPackages,
   parseArgs,
+  parseBootstrapArgs,
   parseNpmViewVersionExists,
   rewriteLocalDependencySpecs,
   validateBuildOutputs,
@@ -37,6 +38,24 @@ test("parseArgs defaults to dry-run and accepts publish mode", () => {
   assert.deepEqual(parseArgs([]), { dryRun: true });
   assert.deepEqual(parseArgs(["--publish"]), { dryRun: false });
   assert.throws(() => parseArgs(["--target", "pinet"]), /Unknown argument: --target/);
+});
+
+test("parseBootstrapArgs defaults to dry-run and requires scary real-publish confirmation", () => {
+  assert.deepEqual(parseBootstrapArgs([]), { dryRun: true });
+  assert.deepEqual(parseBootstrapArgs(["--dry-run"]), { dryRun: true });
+  assert.deepEqual(
+    parseBootstrapArgs(["--bootstrap-publish", "--confirm", "bootstrap @pinet packages"]),
+    { dryRun: false },
+  );
+  assert.throws(
+    () => parseBootstrapArgs(["--bootstrap-publish"]),
+    /requires --bootstrap-publish --confirm/,
+  );
+  assert.throws(
+    () => parseBootstrapArgs(["--bootstrap-publish", "--confirm", "publish all"]),
+    /requires --confirm "bootstrap @pinet packages"/,
+  );
+  assert.throws(() => parseBootstrapArgs(["--target", "pinet"]), /Unknown argument: --target/);
 });
 
 test("rewriteLocalDependencySpecs replaces in-set file dependencies with exact versions", () => {


### PR DESCRIPTION
## Summary

Follow-up to #797 / #773 for Will's request: “can we make a script in the repo for it” — a safe one-time first-publish/bootstrap script for creating the npm org `pinet` scoped packages before npm Trusted Publishing can be configured.

Changed files:
- `scripts/bootstrap-npm-packages.mjs` — new guarded bootstrap path for the full `@pinet/*` package set. Defaults to dry-run/readiness, prints the package plan, reuses the existing publish helpers/validation flow, and only performs real local bootstrap publish with `--bootstrap-publish --confirm "bootstrap @pinet packages"`.
- `scripts/npm-publish-helpers.mjs` — adds `parseBootstrapArgs` with the scary confirmation requirement; existing no-target publish args remain unchanged.
- `scripts/npm-publish-helpers.test.mjs` — covers dry-run default, confirmation-required real bootstrap mode, wrong phrase rejection, and `--target` rejection.
- `package.json` — adds `pnpm bootstrap:npm` as the safe dry-run/readiness alias.
- `README.md` and `plans/npm-publish.md` — document first-publish bootstrap separately from normal Trusted Publishing/OIDC flow, the exact package set, maintainer npm org owner/admin login requirement, no token automation, and immediate Trusted Publisher setup after bootstrap.

## Bootstrap behavior

Safe default:

```bash
pnpm bootstrap:npm
node ./scripts/bootstrap-npm-packages.mjs --dry-run
```

Real one-time package creation only:

```bash
node ./scripts/bootstrap-npm-packages.mjs \
  --bootstrap-publish \
  --confirm "bootstrap @pinet packages"
```

The real path still runs package-name, metadata/artifact, build-output, public-type, placeholder-version, and already-published-version gates. It requires the maintainer to already be logged in with `npm login` as a `pinet` org owner/admin; the repo does not configure token auth. Normal future publishes remain the GitHub Actions Trusted Publishing/OIDC workflow with provenance.

## Full package set

Always in dependency order:

1. `@pinet/transport-core`
2. `@pinet/broker-core`
3. `@pinet/pinet-core`
4. `@pinet/imessage-bridge`
5. `@pinet/slack-bridge`

## Validation

- workflow YAML parse via Ruby → `workflow yaml ok`
- `node --check scripts/bootstrap-npm-packages.mjs`
- `node --check scripts/npm-publish-helpers.mjs`
- `node --check scripts/publish-npm-packages.mjs`
- `node --test scripts/*.test.mjs` → 15 passed
- `pnpm publish:npm` → dry-ran all five `@pinet/*` packages
- `pnpm bootstrap:npm` → printed bootstrap plan and dry-ran all five `@pinet/*` packages
- `node ./scripts/bootstrap-npm-packages.mjs --bootstrap-publish --confirm 'publish all'` → failed on confirmation phrase as expected
- `node ./scripts/bootstrap-npm-packages.mjs --bootstrap-publish --confirm 'bootstrap @pinet packages'` → failed before publish on placeholder `0.0.0` versions as expected
- `pnpm lint && pnpm typecheck && pnpm test`
- `pnpm format:check`
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

No actual publish, tag, version bump, or merge performed.
