### PR TITLE
fix: guard npm bootstrap against automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,13 @@ node ./scripts/bootstrap-npm-packages.mjs \
 ```
 
 The maintainer must already be logged in with `npm login` as a `pinet` org
-owner/admin. This repo does not add token automation. Immediately after any
-successful bootstrap, configure Trusted Publishing for every `@pinet/*` package
-and use the GitHub Actions workflow for normal future publishes.
+owner/admin. The script enforces this local-maintainer-only path by refusing real
+bootstrap mode when CI markers (`CI`, `GITHUB_ACTIONS`) or common npm token auth
+environment variables, including case/punctuation variants of npm auth config
+names, are present. This repo does not add token automation.
+Immediately after any successful bootstrap, configure Trusted Publishing for
+every `@pinet/*` package and use the GitHub Actions workflow for normal future
+publishes.
 
 The publish and bootstrap scripts still refuse placeholder `0.0.0` versions and
 versions that already exist on npm.

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -39,7 +39,7 @@ pnpm bootstrap:npm
 node ./scripts/bootstrap-npm-packages.mjs --dry-run
 ```
 
-That script also defaults to dry-run/readiness and processes the same full package set. Its real publish mode is a local maintainer bootstrap escape hatch only; it is not the normal release path.
+That script also defaults to dry-run/readiness and processes the same full package set. Its real publish mode is a local maintainer bootstrap escape hatch only; the code refuses CI/automation and common npm token-authenticated environments. It is not the normal release path.
 
 When `dry_run=true`, the workflow stops after the dry-run/readiness job and does not request the `npm-publish` environment. Dry-run dispatches use the `npm-publish-dry-run` concurrency group. Real publish dispatches use the `npm-publish-live` concurrency group so live publishes are globally serialized.
 
@@ -77,7 +77,7 @@ node ./scripts/bootstrap-npm-packages.mjs \
   --confirm "bootstrap @pinet packages"
 ```
 
-The real bootstrap mode still runs the same package-name, metadata/artifact, build-output, public-type, placeholder-version, and already-published-version gates. It then runs `npm publish --access public` for the full package set from the local npm CLI login. The maintainer running it must already be logged in with `npm login` as a `pinet` org owner/admin with package creation rights. This repo does not configure token auth and does not make bootstrap publishing the normal release path.
+The real bootstrap mode still runs the same package-name, metadata/artifact, build-output, public-type, placeholder-version, and already-published-version gates. Before any publish attempt, it also refuses automated or token-authenticated environments by failing when `CI`, `GITHUB_ACTIONS`, `NODE_AUTH_TOKEN`, `NPM_TOKEN`, or common npm auth config variables are present, including case/punctuation/camelCase variants such as `npm_config__authToken`. It then runs `npm publish --access public` for the full package set from the local npm CLI login. The maintainer running it must already be logged in with `npm login` as a `pinet` org owner/admin with package creation rights. This repo does not configure token auth and does not make bootstrap publishing the normal release path.
 
 Immediately after any successful first-publish bootstrap, configure npm Trusted Publishing for every package in <https://www.npmjs.com/settings/pinet/packages> with owner/repo `gugu91/extensions`, workflow `npm-publish.yml`, and environment `npm-publish` if npm asks for one. Normal future publishes should then use the GitHub Actions Trusted Publishing/OIDC workflow with provenance. If npm's team/access UI loops or blocks package creation, resolve org/team/admin access in npm first rather than adding CI token automation.
 

--- a/scripts/bootstrap-npm-packages.mjs
+++ b/scripts/bootstrap-npm-packages.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  assertLocalNpmOrgBootstrapEnvironment,
   assertVersionsNotAlreadyPublished,
   getPublishPackages,
   loadWorkspaceManifests,
@@ -68,13 +69,17 @@ function printBootstrapPlan({ dryRun }) {
   }
   console.log(
     dryRun
-      ? "No packages will be published. The script will build, validate, patch local file: dependencies to exact versions in a temporary checkout state, and run npm publish --dry-run for every package."
+      ? "No packages will be published. The script will build, validate, patch local file: dependencies to exact versions in place, restore those manifests before exit, and run npm publish --dry-run for every package."
       : "Packages WILL be published with npm publish --access public from the local npm CLI login. Use this only for first package creation in the npm pinet org; configure npm Trusted Publishing immediately afterward for normal future CI publishes.",
   );
 }
 
 async function main() {
   const args = parseBootstrapArgs(process.argv.slice(2));
+  if (!args.dryRun) {
+    assertLocalNpmOrgBootstrapEnvironment();
+  }
+
   const packageDirectories = getPublishPackages();
   const manifests = await loadWorkspaceManifests(repoRoot);
   const entries = rewriteLocalDependencySpecs(packageDirectories, manifests);

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -46,6 +46,53 @@ export function parseArgs(argv) {
 
 const bootstrapConfirmationPhrase = "bootstrap @pinet packages";
 
+const bootstrapBlockedEnvNames = Object.freeze([
+  "CI",
+  "GITHUB_ACTIONS",
+  "NODE_AUTH_TOKEN",
+  "NPM_TOKEN",
+]);
+
+const normalizedBootstrapBlockedEnvNames = new Set(
+  bootstrapBlockedEnvNames.map(normalizeEnvNameForAuthDetection),
+);
+
+function hasValue(value) {
+  return value !== undefined && value !== "";
+}
+
+function normalizeEnvNameForAuthDetection(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function isNpmAuthEnvVar(name) {
+  const normalized = normalizeEnvNameForAuthDetection(name);
+  if (!normalized.startsWith("npmconfig")) {
+    return false;
+  }
+
+  const configName = normalized.slice("npmconfig".length);
+  return configName === "auth" || configName.endsWith("auth") || configName.endsWith("authtoken");
+}
+
+export function assertLocalNpmOrgBootstrapEnvironment(env = process.env) {
+  const blocked = [];
+
+  for (const [name, value] of Object.entries(env)) {
+    if (!hasValue(value)) continue;
+    const normalized = normalizeEnvNameForAuthDetection(name);
+    if (normalizedBootstrapBlockedEnvNames.has(normalized) || isNpmAuthEnvVar(name)) {
+      blocked.push(name);
+    }
+  }
+
+  if (blocked.length > 0) {
+    throw new Error(
+      `Real npm org pinet bootstrap is local-maintainer-only and refuses automated or token-authenticated environments. Unset before retrying: ${blocked.sort().join(", ")}`,
+    );
+  }
+}
+
 export function parseBootstrapArgs(argv) {
   const args = {
     dryRun: true,

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  assertLocalNpmOrgBootstrapEnvironment,
   assertVersionsNotAlreadyPublished,
   getPublishPackages,
   parseArgs,
@@ -56,6 +57,45 @@ test("parseBootstrapArgs defaults to dry-run and requires scary real-publish con
     /requires --confirm "bootstrap @pinet packages"/,
   );
   assert.throws(() => parseBootstrapArgs(["--target", "pinet"]), /Unknown argument: --target/);
+});
+
+test("assertLocalNpmOrgBootstrapEnvironment blocks CI and token-authenticated live bootstrap contexts", () => {
+  assert.doesNotThrow(() => assertLocalNpmOrgBootstrapEnvironment({ PATH: "/usr/bin" }));
+  assert.throws(
+    () => assertLocalNpmOrgBootstrapEnvironment({ CI: "true" }),
+    /local-maintainer-only.*CI/,
+  );
+  assert.throws(
+    () => assertLocalNpmOrgBootstrapEnvironment({ GITHUB_ACTIONS: "true" }),
+    /local-maintainer-only.*GITHUB_ACTIONS/,
+  );
+  assert.throws(
+    () => assertLocalNpmOrgBootstrapEnvironment({ NODE_AUTH_TOKEN: "token" }),
+    /local-maintainer-only.*NODE_AUTH_TOKEN/,
+  );
+  assert.throws(
+    () => assertLocalNpmOrgBootstrapEnvironment({ npm_config__authToken: "token" }),
+    /local-maintainer-only.*npm_config__authToken/,
+  );
+  assert.throws(
+    () => assertLocalNpmOrgBootstrapEnvironment({ npm_config__authtoken: "token" }),
+    /local-maintainer-only.*npm_config__authtoken/,
+  );
+  assert.throws(
+    () => assertLocalNpmOrgBootstrapEnvironment({ NPM_CONFIG__AUTHTOKEN: "token" }),
+    /local-maintainer-only.*NPM_CONFIG__AUTHTOKEN/,
+  );
+  assert.throws(
+    () => assertLocalNpmOrgBootstrapEnvironment({ npm_config_authToken: "token" }),
+    /local-maintainer-only.*npm_config_authToken/,
+  );
+  assert.throws(
+    () =>
+      assertLocalNpmOrgBootstrapEnvironment({
+        "npm_config_//registry.npmjs.org/:_authToken": "token",
+      }),
+    /local-maintainer-only.*npm_config_\/\/registry\.npmjs\.org\/:_authToken/,
+  );
 });
 
 test("rewriteLocalDependencySpecs replaces in-set file dependencies with exact versions", () => {


### PR DESCRIPTION
## Summary

Follow-up to #798 / #773. #798 merged while the blocking code-reviewer safety finding was being fixed, so this PR carries the remaining guard on current `main`.

Fixes the gap where real local bootstrap mode was documented as local-maintainer-only but code did not enforce that. The bootstrap script now refuses automated/token-authenticated contexts before any publish attempt.

Changed files:
- `scripts/npm-publish-helpers.mjs` — adds `assertLocalNpmOrgBootstrapEnvironment()` to block real bootstrap when CI/automation or common npm token-auth env vars are present.
- `scripts/bootstrap-npm-packages.mjs` — calls the guard immediately after parsing real bootstrap args, before loading/building/validating/publishing; also tightens dry-run plan wording to say manifests are patched in place and restored before exit.
- `scripts/npm-publish-helpers.test.mjs` — regression coverage for blocking `CI`, `GITHUB_ACTIONS`, `NODE_AUTH_TOKEN`, and npm registry auth token env contexts.
- `README.md` and `plans/npm-publish.md` — document that the local-maintainer-only guard is enforced by code.

## Safety behavior

Real bootstrap still requires:

```bash
node ./scripts/bootstrap-npm-packages.mjs \
  --bootstrap-publish \
  --confirm "bootstrap @pinet packages"
```

In addition, before any publish attempt, real bootstrap now fails when any of these are present:
- `CI`
- `GITHUB_ACTIONS`
- `NODE_AUTH_TOKEN`
- `NPM_TOKEN`
- `NPM_CONFIG__AUTH`
- `NPM_CONFIG__AUTH_TOKEN`
- npm registry auth config variants such as `npm_config_//registry.npmjs.org/:_authToken`

This keeps the bootstrap path local-maintainer-only and prevents it from becoming an unprotected CI/token publish path. No token automation was added.

## Validation

- `pnpm exec prettier --write README.md plans/npm-publish.md scripts/bootstrap-npm-packages.mjs scripts/npm-publish-helpers.mjs scripts/npm-publish-helpers.test.mjs`
- workflow YAML parse via Ruby → `workflow yaml ok`
- `node --check scripts/bootstrap-npm-packages.mjs`
- `node --check scripts/npm-publish-helpers.mjs`
- `node --check scripts/publish-npm-packages.mjs`
- `node --test scripts/*.test.mjs` → 16 passed
- `GITHUB_ACTIONS=true node ./scripts/bootstrap-npm-packages.mjs --bootstrap-publish --confirm "bootstrap @pinet packages"` → failed before any publish attempt with the new local-maintainer-only guard, as expected
- `pnpm bootstrap:npm` → dry-ran full `@pinet/*` package set
- `pnpm publish:npm` → dry-ran full `@pinet/*` package set
- `pnpm format:check`
- `pnpm lint && pnpm typecheck && pnpm test`
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

No actual publish, tag, version bump, or merge performed.
