### PR TITLE
Fix npm publish readiness push gate

### DIFF
--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.1.4",
+  "version": "0.1.0",
   "type": "module",
   "description": "Slack assistant integration for pi (Pinet) — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "./broker/types.js";
 import {
   createPinetMeshOps,
+  parseGitHubRemoteRepo,
   type PinetMeshOpsBrokerDbPort,
   type PinetMeshOpsDeps,
   type PinetMeshOpsFollowerClientPort,
@@ -227,6 +228,23 @@ function createFollowerDeps(overrides: Partial<PinetMeshOpsDeps> = {}) {
     listAgents,
   };
 }
+
+describe("parseGitHubRemoteRepo", () => {
+  it("parses github.com remotes and local SSH host aliases", () => {
+    expect(parseGitHubRemoteRepo("git@github.com:gugu91/extensions.git")).toEqual({
+      repoOwner: "gugu91",
+      repoName: "extensions",
+    });
+    expect(parseGitHubRemoteRepo("github-gugu91:gugu91/extensions.git")).toEqual({
+      repoOwner: "gugu91",
+      repoName: "extensions",
+    });
+    expect(parseGitHubRemoteRepo("https://github.com/gugu91/extensions")).toEqual({
+      repoOwner: "gugu91",
+      repoName: "extensions",
+    });
+  });
+});
 
 describe("createPinetMeshOps", () => {
   it("normalizes broker direct control messages before dispatch", async () => {

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -160,8 +160,14 @@ function appendSlackThreadTransferNotice(body: string, threadId: string, channel
   ].join("\n");
 }
 
-function parseGitHubRemoteRepo(remoteUrl: string): { repoOwner: string; repoName: string } | null {
-  const match = remoteUrl.match(/github\.com[:/]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/i);
+export function parseGitHubRemoteRepo(
+  remoteUrl: string,
+): { repoOwner: string; repoName: string } | null {
+  const match = remoteUrl
+    .trim()
+    .match(
+      /^(?:(?:https?:\/\/|ssh:\/\/)(?:[^@/\s]+@)?|(?:[^@/\s]+@)?)github(?:\.com|[-.][^/:]+)?[:/]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/i,
+    );
   if (!match?.[1] || !match[2]) {
     return null;
   }

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- preserve version bump branch work in the willp/versionm worktree
- fix GitHub remote parsing for local SSH host aliases like github-gugu91:gugu91/extensions.git
- add coverage for github.com and host-alias remote URL parsing

## Validation
- pnpm install --frozen-lockfile
- pnpm format:check
- pnpm publish:npm (dry-run/readiness)
- pnpm bootstrap:npm (dry-run/readiness)
- pnpm prepush
- pnpm --dir slack-bridge test -- pinet-mesh-ops.test.ts