### PR TITLE
chore: add tag-gated npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,6 @@
 name: Publish npm packages
 
-run-name: npm ${{ inputs.dry_run && 'dry-run' || 'publish' }} all packages
+run-name: npm ${{ github.event_name == 'push' && github.ref_name || (inputs.dry_run && 'dry-run' || 'publish') }} all packages
 
 on:
   workflow_dispatch:
@@ -11,16 +11,19 @@ on:
         type: boolean
         default: true
       release_approval:
-        description: "For real publishes only: type 'publish all'"
+        description: "For manual real publishes only: type 'publish all'"
         required: false
         type: string
         default: ""
+  push:
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: read
 
 concurrency:
-  group: npm-publish-${{ inputs.dry_run && 'dry-run' || 'live' }}
+  group: npm-publish-${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'dry-run' || 'live' }}
   cancel-in-progress: false
 
 jobs:
@@ -44,6 +47,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Validate tag release version
+        if: ${{ github.event_name == 'push' }}
+        run: node ./scripts/validate-npm-tag-version.mjs "$GITHUB_REF"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -54,29 +61,57 @@ jobs:
 
   publish-preflight:
     name: Check real publish gates
-    if: ${{ !inputs.dry_run }}
+    if: ${{ github.event_name == 'push' || !inputs.dry_run }}
     needs: readiness
     runs-on: ubuntu-latest
     steps:
-      - name: Guard real publish ref
-        if: ${{ github.ref != 'refs/heads/main' }}
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Guard tag points at current main tip
+        if: ${{ github.event_name == 'push' }}
         run: |
-          echo "Real npm publishes must be dispatched from refs/heads/main. Current ref: $GITHUB_REF"
+          git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+          trigger_commit="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+          checkout_commit="$(git rev-parse HEAD)"
+          main_commit="$(git rev-parse refs/remotes/origin/main)"
+          if [ "${trigger_commit}" != "${main_commit}" ] || [ "${checkout_commit}" != "${main_commit}" ]; then
+            echo "Tag-triggered npm publishes require the tag commit to equal the current origin/main tip."
+            echo "Trigger commit: ${trigger_commit}"
+            echo "Checked-out commit: ${checkout_commit}"
+            echo "origin/main: ${main_commit}"
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Guard manual real publish ref
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "Manual real npm publishes must be dispatched from refs/heads/main. Current ref: $GITHUB_REF"
           exit 1
 
-      - name: Guard real publish approval phrase
+      - name: Guard manual real publish approval phrase
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           RELEASE_APPROVAL: ${{ inputs.release_approval }}
         run: |
           expected="publish all"
           if [ "${RELEASE_APPROVAL}" != "${expected}" ]; then
-            echo "Real npm publishes require release_approval exactly: ${expected}"
+            echo "Manual real npm publishes require release_approval exactly: ${expected}"
             exit 1
           fi
 
+      - name: Validate tag release version
+        if: ${{ github.event_name == 'push' }}
+        run: node ./scripts/validate-npm-tag-version.mjs "$GITHUB_REF"
+
   publish:
     name: Publish npm packages
-    if: ${{ !inputs.dry_run }}
+    if: ${{ github.event_name == 'push' || !inputs.dry_run }}
     needs:
       - readiness
       - publish-preflight

--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ expectations and the required smoke checklist.
 The publishable Pinet/Slack package set is tracked in
 [`plans/npm-publish.md`](plans/npm-publish.md) and executed through the manual
 [`Publish npm packages`](.github/workflows/npm-publish.yml) GitHub Actions
-workflow. The workflow intentionally has no package target selector; it always
-validates or publishes the full set in dependency order.
+workflow. The workflow supports manual dry-run/publish dispatches and release-tag
+publishes from `vX.Y.Z` tags. It intentionally has no package target selector; it
+always validates or publishes the full set in dependency order.
 
 Safe readiness checks are the default path:
 
@@ -247,13 +248,23 @@ readiness only and has no package target selector. The one-time npm org package
 creation bootstrap path is `pnpm bootstrap:npm`, which also defaults to dry-run
 and prints the full `@pinet/*` package set it would publish.
 
-Real publishes are intentionally harder to trigger. They require a maintainer to
-dispatch from `main` with `dry_run=false`, enter `publish all` as the exact
-`release_approval` phrase, and approve the protected `npm-publish` environment.
-The publish job uses npm Trusted Publishing / GitHub OIDC with
-`npm publish --provenance`; it does not use a long-lived npm token. Maintainers must also
-configure npm Trusted Publishers for every package in the npm `pinet` org
-settings (`https://www.npmjs.com/settings/pinet/packages`) before real publish.
+Real publishes are intentionally harder to trigger. Maintainers can either
+manually dispatch from `main` with `dry_run=false` and `release_approval` exactly
+`publish all`, or push a release tag named `vX.Y.Z` after the version bump has
+merged to the current `main` tip. Tag-triggered publishes validate that the tag
+commit equals the current `origin/main` tip and that all five `@pinet/*` package
+versions equal the tag version before the protected publish job can request the
+`npm-publish` environment. Both real publish paths require maintainer approval of
+the protected `npm-publish` environment. The publish job uses npm Trusted
+Publishing / GitHub OIDC with `npm publish --provenance`; it does not use a
+long-lived npm token. Maintainers must also configure npm Trusted Publishers for
+every package in the npm `pinet` org settings
+(`https://www.npmjs.com/settings/pinet/packages`) before real publish. The live
+GitHub `npm-publish` environment must also be verified out-of-band by a
+maintainer before tag releases are considered ready: it should require approval
+and allow deployments from `main` plus release tags matching `v*.*.*`. That tag
+environment allowance does not replace the workflow guard that requires the tag
+commit to equal the current `origin/main` tip.
 If npm requires packages to exist before Trusted Publishing can be configured,
 a `pinet` org owner/admin may use the guarded local bootstrap script only after
 maintainer-approved versions are set:
@@ -271,6 +282,18 @@ and use the GitHub Actions workflow for normal future publishes.
 
 The publish and bootstrap scripts still refuse placeholder `0.0.0` versions and
 versions that already exist on npm.
+
+Normal tag-release procedure:
+
+1. Bump all five `@pinet/*` package versions to the same version, update
+   `pnpm-lock.yaml`, and add a maintainer-approved `CHANGELOG.md` entry.
+2. Open and merge that version-bump PR to `main` after dry-run/readiness is
+   green.
+3. Create and push a `vX.Y.Z` tag on the current `main` tip after the merge. The
+   tag-triggered workflow validates the tag commit equals the current
+   `origin/main` tip and every publishable package version equals `X.Y.Z` before
+   any dry-run/publish step, dry-runs the full set, then waits for `npm-publish`
+   environment approval before publishing.
 
 Do not publish, tag, or bump package versions as part of readiness-only changes;
 record release notes in `CHANGELOG.md` only when a maintainer approves a real

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -16,12 +16,16 @@ There is intentionally no workflow target selector or script target flag. Real r
 
 ## Workflow and script
 
-`.github/workflows/npm-publish.yml` is a manual `workflow_dispatch` workflow with two inputs:
+`.github/workflows/npm-publish.yml` supports both manual `workflow_dispatch` runs and release-tag publishes.
+
+Manual dispatch inputs:
 
 - `dry_run`: defaults to `true`
-- `release_approval`: real publishes only; must exactly match `publish all`
+- `release_approval`: manual real publishes only; must exactly match `publish all`
 
-Every dispatch first runs the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order.
+Tag-triggered publishes run only for `vX.Y.Z` tags. The readiness job validates every package in the full `@pinet/*` set has `package.json.version` equal to the tag version before any `npm publish --dry-run`; the preflight job also fetches `origin/main`, fails unless the tag commit equals the current `origin/main` tip, and repeats the package-version check before the protected publish job can request the `npm-publish` environment.
+
+Every run first executes the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order.
 
 For local/readiness use, run the same script directly or through the safe npm script:
 
@@ -41,9 +45,9 @@ node ./scripts/bootstrap-npm-packages.mjs --dry-run
 
 That script also defaults to dry-run/readiness and processes the same full package set. Its real publish mode is a local maintainer bootstrap escape hatch only; it is not the normal release path.
 
-When `dry_run=true`, the workflow stops after the dry-run/readiness job and does not request the `npm-publish` environment. Dry-run dispatches use the `npm-publish-dry-run` concurrency group. Real publish dispatches use the `npm-publish-live` concurrency group so live publishes are globally serialized.
+When manual `dry_run=true`, the workflow stops after the dry-run/readiness job and does not request the `npm-publish` environment. Dry-run dispatches use the `npm-publish-dry-run` concurrency group. Manual real publishes and tag-triggered publishes use the `npm-publish-live` concurrency group so live publishes are globally serialized.
 
-Real publishes require all of these gates before the publish job can run:
+Manual real publishes require all of these gates before the publish job can run:
 
 - `dry_run=false` was selected manually.
 - A non-environment preflight job confirms the dispatch ref is `refs/heads/main`.
@@ -51,6 +55,15 @@ Real publishes require all of these gates before the publish job can run:
 - The `npm-publish` GitHub environment is approved by a maintainer after preflight passes.
 - The publish job has `id-token: write` so npm Trusted Publishing can exchange GitHub OIDC for npm publish authority.
 - npm Trusted Publishers are configured for every package in the full set with repository `gugu91/extensions`, workflow `npm-publish.yml`, and environment `npm-publish` when npm asks for an environment.
+
+Tag-triggered real publishes require all of these gates before the publish job can run:
+
+- A maintainer-approved version-bump PR has landed on `main`, with all five `@pinet/*` package versions and `pnpm-lock.yaml` aligned.
+- A `vX.Y.Z` tag points at the current `main` tip after the version-bump PR merges.
+- The non-environment preflight job fetches `origin/main` and confirms the tag commit equals the current `origin/main` tip.
+- The same preflight job confirms every full-set package version equals `X.Y.Z`.
+- The `npm-publish` GitHub environment is approved by a maintainer after preflight passes.
+- The publish job has `id-token: write` and npm Trusted Publishers are configured for every package as above.
 
 The real publish job then reruns the same publish script with `--publish`, which uses `npm publish --provenance` and fails closed if any target package version already exists on npm.
 
@@ -60,7 +73,7 @@ Packages are intended for the npm `pinet` org/package settings area: <https://ww
 
 Keep the GitHub and npm setup separate:
 
-- **GitHub setup:** create/verify the `npm-publish` environment, require maintainer reviewers, restrict deployment branches to `main`, and do not add long-lived npm token auth for this workflow.
+- **GitHub setup:** create/verify the `npm-publish` environment, require maintainer reviewers, allow deployments from `main` and release tags matching `v*.*.*`, and do not add long-lived npm token auth for this workflow. The tag allowance is only an environment policy prerequisite; the workflow still independently fails unless the tag commit equals the current `origin/main` tip.
 - **npm setup:** an npm `pinet` org owner/admin must have package creation/publish authority for the org and must configure Trusted Publishing for every package in the list above.
 
 Trusted Publishing is package-scoped in npm's settings UI. If npm does not allow a Trusted Publisher to be configured for a package before that package exists, do not add a token fallback in this repo.
@@ -108,7 +121,8 @@ GitHub environment:
 - `npm-publish` is an external repository prerequisite, not something this repo can create in source control.
 - Configure or verify the environment before any real publish attempt.
 - `npm-publish` should require maintainer approval before the publish job can run.
-- Restrict environment deployment branches to `main`.
+- Restrict environment deployments to `main` for manual real publishes and allow the `v*.*.*` release tag pattern for tag-triggered publishes.
+- Treat this environment branch/tag policy as out-of-band maintainer setup: verify the live repo environment allows both `main` and `v*.*.*` before considering tag releases ready. Do not rely on environment tag allowance alone; the workflow guard still requires the tag commit to equal the current `origin/main` tip.
 - Dry-run/readiness dispatches do not use the environment.
 
 npm org/package configuration:
@@ -122,13 +136,15 @@ GitHub permissions:
 - Readiness job: `contents: read`
 - Publish job: `contents: read` plus `id-token: write` for npm Trusted Publishing/provenance
 
-## Release gates before setting `dry_run=false`
+## Release gates before real publish
 
 - #772 has confirmed the Pinet/Slack boundary and the full publish set is still correct.
-- Package versions are intentionally bumped. The publish and bootstrap scripts refuse real publishes for placeholder `0.0.0` packages or versions already present on npm.
+- Package versions are intentionally bumped together. The publish and bootstrap scripts refuse real publishes for placeholder `0.0.0` packages or versions already present on npm.
+- `pnpm-lock.yaml` is updated for the package-version bump.
 - `CHANGELOG.md` has a maintainer-approved entry covering the full package set and package versions.
 - The dry-run/readiness job is green on the same `main` commit intended for release.
-- The workflow dispatch includes the exact `publish all` release approval phrase.
+- For manual real publishes, the workflow dispatch includes the exact `publish all` release approval phrase and runs from `main`.
+- For tag-triggered real publishes, the maintainer creates a `vX.Y.Z` tag on the current `main` tip after the version-bump PR merges; the workflow validates the tag commit equals the current `origin/main` tip and every full-set package version equals `X.Y.Z` before publish approval.
 - The `npm-publish` environment approval is granted by a maintainer for that release.
 - npm Trusted Publishing is configured for every package in the full set.
 - Built outputs are produced from the current commit and match `main`/`exports` entries.

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -91,6 +91,39 @@ export function getPublishPackages() {
   return [...publishPackageDirectories];
 }
 
+const releaseTagPattern = /^refs\/tags\/v(\d+\.\d+\.\d+)$/;
+
+export function parseReleaseTagVersion(ref) {
+  const match = releaseTagPattern.exec(ref);
+  if (!match?.[1]) {
+    throw new Error(
+      `Tag-triggered npm publishes require a ref like refs/tags/vX.Y.Z. Current ref: ${ref}`,
+    );
+  }
+  return match[1];
+}
+
+export function assertReleaseTagVersionMatchesManifests(ref, entries) {
+  const version = parseReleaseTagVersion(ref);
+  const mismatches = [];
+
+  for (const { manifest } of entries) {
+    if (manifest.version !== version) {
+      mismatches.push(
+        `${manifest.name}: package.json version ${manifest.version} != tag version ${version}`,
+      );
+    }
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `Tag-triggered npm publish version validation failed:\n- ${mismatches.join("\n- ")}`,
+    );
+  }
+
+  return version;
+}
+
 export async function readJson(filePath) {
   const text = await fs.readFile(filePath, "utf8");
   return JSON.parse(text);

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -8,8 +8,10 @@ import {
   assertVersionsNotAlreadyPublished,
   getPublishPackages,
   parseArgs,
+  assertReleaseTagVersionMatchesManifests,
   parseBootstrapArgs,
   parseNpmViewVersionExists,
+  parseReleaseTagVersion,
   rewriteLocalDependencySpecs,
   validateBuildOutputs,
   validatePublicTypeResolution,
@@ -56,6 +58,39 @@ test("parseBootstrapArgs defaults to dry-run and requires scary real-publish con
     /requires --confirm "bootstrap @pinet packages"/,
   );
   assert.throws(() => parseBootstrapArgs(["--target", "pinet"]), /Unknown argument: --target/);
+});
+
+test("parseReleaseTagVersion accepts stable vX.Y.Z release tags", () => {
+  assert.equal(parseReleaseTagVersion("refs/tags/v1.2.3"), "1.2.3");
+  assert.throws(
+    () => parseReleaseTagVersion("refs/tags/v1.2.3-alpha.1"),
+    /require a ref like refs\/tags\/vX\.Y\.Z/,
+  );
+  assert.throws(
+    () => parseReleaseTagVersion("refs/tags/npm-v1.2.3"),
+    /require a ref like refs\/tags\/vX\.Y\.Z/,
+  );
+  assert.throws(
+    () => parseReleaseTagVersion("refs/heads/main"),
+    /require a ref like refs\/tags\/vX\.Y\.Z/,
+  );
+});
+
+test("assertReleaseTagVersionMatchesManifests requires the full set to match the tag", () => {
+  const entries = [
+    entry("transport-core", { name: "@pinet/transport-core", version: "1.2.3" }),
+    entry("broker-core", { name: "@pinet/broker-core", version: "1.2.3" }),
+  ];
+
+  assert.equal(assertReleaseTagVersionMatchesManifests("refs/tags/v1.2.3", entries), "1.2.3");
+  assert.throws(
+    () =>
+      assertReleaseTagVersionMatchesManifests("refs/tags/v1.2.4", [
+        entries[0],
+        entry("broker-core", { name: "@pinet/broker-core", version: "1.2.3" }),
+      ]),
+    /@pinet\/transport-core: package\.json version 1\.2\.3 != tag version 1\.2\.4/,
+  );
 });
 
 test("rewriteLocalDependencySpecs replaces in-set file dependencies with exact versions", () => {

--- a/scripts/validate-npm-tag-version.mjs
+++ b/scripts/validate-npm-tag-version.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertReleaseTagVersionMatchesManifests,
+  getPublishPackages,
+  loadWorkspaceManifests,
+  rewriteLocalDependencySpecs,
+} from "./npm-publish-helpers.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function main() {
+  const ref = process.argv[2] ?? process.env.GITHUB_REF;
+  if (!ref) {
+    throw new Error("Tag version validation requires a Git ref argument or GITHUB_REF");
+  }
+
+  const packageDirectories = getPublishPackages();
+  const manifests = await loadWorkspaceManifests(repoRoot);
+  const entries = rewriteLocalDependencySpecs(packageDirectories, manifests);
+  const version = assertReleaseTagVersionMatchesManifests(ref, entries);
+  console.log(`Validated ${entries.length} @pinet/* package versions match ${ref} (${version})`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

#773 follow-up for Will’s direction that Trusted Publishing is configured and the npm publish action should support version-bump/tag releases.

This branch is unstacked from #799 and based directly on current `origin/main`; it contains only the tag-gated publish workflow follow-up.

Changed files:
- `.github/workflows/npm-publish.yml` — preserves manual `workflow_dispatch` dry-run/publish, adds `push` tag trigger for stable `v*.*.*` release tags, keeps live publishes globally serialized, keeps protected `npm-publish` environment and `id-token: write` only on the publish job, validates tag versions before dry-run/publish work, and blocks tag-triggered publish unless the tag commit equals the current `origin/main` tip.
- `scripts/validate-npm-tag-version.mjs` — new thin workflow script that checks the full publish set against the Git ref tag version.
- `scripts/npm-publish-helpers.mjs` — adds `parseReleaseTagVersion()` and `assertReleaseTagVersionMatchesManifests()` for stable `refs/tags/vX.Y.Z` validation.
- `scripts/npm-publish-helpers.test.mjs` — tests accepted/rejected tag refs and full-set package-version mismatch reporting.
- `README.md` and `plans/npm-publish.md` — document the tag release procedure: bump all five versions + lockfile/changelog, merge, verify the protected environment allows `main` and `v*.*.*` tags, tag the current `main` tip as `vX.Y.Z`, then approve the `npm-publish` environment.

## Publish safety

- No arbitrary push-to-main publish trigger; tag-triggered publish only for stable `vX.Y.Z` tags.
- Chosen documented tag format: `vX.Y.Z`.
- Strict merged-main rule: on tag-triggered publish preflight, the workflow fetches `origin/main` and fails unless both `GITHUB_SHA^{commit}` and the checked-out tag commit equal the current `origin/main` tip.
- The live GitHub `npm-publish` environment is an out-of-band maintainer setup prerequisite: it must require approval and allow deployments from `main` plus release tags matching `v*.*.*`. Environment tag allowance does not replace the workflow's strict tag-main-tip guard.
- On tag-triggered runs, the readiness job validates all five `@pinet/*` package versions match the tag before any `npm publish --dry-run`; publish preflight repeats that validation before environment approval/publish.
- Manual dry-run remains available via workflow dispatch and local `pnpm publish:npm` for not-yet-published versions.
- Manual real publish remains available only from `main` with exact `publish all` approval phrase.
- Real publish still uses protected `npm-publish` environment, Trusted Publishing/OIDC, `npm publish --provenance`, global live concurrency, artifact/public-type gates, and already-published refusal.
- No `NPM_TOKEN` path added.
- No actual publish, tag creation, version bump, or merge performed.

## Validation

- `pnpm install --frozen-lockfile`
- workflow YAML parse via Ruby → `workflow yaml ok`
- `node --check scripts/npm-publish-helpers.mjs`
- `node --check scripts/publish-npm-packages.mjs`
- `node --check scripts/validate-npm-tag-version.mjs`
- `node --test scripts/*.test.mjs` → 17 passed
- `node ./scripts/validate-npm-tag-version.mjs refs/tags/v0.1.0` → validated all five `@pinet/*` packages match `0.1.0`
- `node ./scripts/validate-npm-tag-version.mjs refs/tags/v0.1.1` → failed with all five package-version mismatches, as expected
- `node ./scripts/validate-npm-tag-version.mjs refs/tags/v0.1.0-alpha.1` → rejected non-`vX.Y.Z` tag, as expected
- Main-tip guard smoke: rejects a tag-trigger simulation on this feature-branch head because it is not current `origin/main`; accepts a detached worktree at current `origin/main`.
- Docs/workflow check for environment policy wording and workflow YAML parse.
- Live GitHub environment verification via API: `npm-publish` deployment policies include branch `main` and tag `v*.*.*`.
- `pnpm format:check`
- `pnpm lint && pnpm typecheck && pnpm test`
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`
- Local reviewer pass found no blockers/warnings.

Validation caveat: `pnpm publish:npm` on the current checkout now fails during `npm publish --dry-run` because Will already published all five `@pinet/*@0.1.0` packages to npm. That is expected for the already-published current version; the tag workflow is intended for the next maintainer-approved version bump, and real publish still fails closed for already-published versions.
