### PR TITLE
docs: polish slack bridge pi package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ This repo now uses pnpm workspaces + Turborepo for **repo-internal monorepo
 tooling**. It is **not** yet a supported root-level `pi install git:...`
 package target.
 
+For the published Pinet Slack bridge pi package, install from npm:
+
+```bash
+pi install npm:@pinet/slack-bridge
+pi install npm:@pinet/slack-bridge@0.1.0 # pinned version
+```
+
 For local development, load individual extensions directly:
 
 ```bash

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -4,17 +4,42 @@ Slack assistant integration for [pi](https://github.com/badlogic/pi-mono) — mu
 
 ## Install
 
+Install the latest Pinet Slack bridge pi package:
+
 ```bash
 pi install npm:@pinet/slack-bridge
 ```
 
-Or with npm:
+Or pin an exact published version for reproducible installs:
+
+```bash
+pi install npm:@pinet/slack-bridge@0.1.0
+```
+
+For package managers or local inspection, the npm package is also installable directly:
 
 ```bash
 npm install @pinet/slack-bridge
 ```
 
-## Publishing
+## Package metadata and publishing
+
+This package declares pi package/gallery metadata in [`package.json`](./package.json):
+
+- `keywords` includes `pi-package` for gallery discovery.
+- `pi.extensions` points at the built extension entrypoint, `./dist/index.js`.
+- `pi.skills` points at the bundled skill directory, `./skills`.
+- No `pi.image` or `pi.video` preview is declared yet because this package does
+  not currently include a reviewed gallery image/video asset.
+
+The published tarball is expected to include the package metadata, README,
+Slack app manifest, built `dist/` files, bundled `skills/`, and LICENSE. Verify
+that locally with:
+
+```bash
+cd slack-bridge
+npm pack --dry-run
+```
 
 This package is included in the full npm publish set tracked in
 [`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -2,7 +2,7 @@
   "name": "@pinet/slack-bridge",
   "version": "0.1.0",
   "type": "module",
-  "description": "Slack assistant integration for pi (Pinet) — multi-agent broker, thread routing, and inbox tools",
+  "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
   "license": "MIT",
   "repository": {
@@ -26,7 +26,12 @@
     "dist/"
   ],
   "keywords": [
-    "pi-package"
+    "pi-package",
+    "pi",
+    "pinet",
+    "slack",
+    "assistant",
+    "agent"
   ],
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary

Small #773 follow-up for pi package/listing/install readiness for the published `@pinet/slack-bridge` package.

Changed files:
- `slack-bridge/package.json`
  - sharpens the package description for Pi/Pinet Slack bridge usage;
  - expands keywords while keeping `pi-package` for gallery discovery;
  - leaves the existing pi manifest intact (`./dist/index.js` extension and `./skills` skills);
  - does not add `pi.image` or `pi.video` because there is no reviewed gallery asset in-repo.
- `slack-bridge/README.md`
  - adds latest and pinned pi install commands;
  - documents pi package/gallery metadata;
  - documents local tarball verification and expected packaged contents.
- `README.md`
  - adds root-level npm install commands for `pi install npm:@pinet/slack-bridge` and pinned installs.

## Safety / scope

- Listing/install readiness only.
- No workflow changes.
- No publish script changes.
- No publish, tag creation, version bump, or merge.

## Tarball verification

`npm pack --dry-run --json` from `slack-bridge/` runs prepack/build and verifies the package tarball includes:

- `package.json`
- `README.md`
- `LICENSE`
- `manifest.yaml`
- `dist/index.js`
- `dist/index.d.ts`
- `skills/slack-bridge/SKILL.md`
- `skills/pinet-skin-creator/SKILL.md`

Observed: `@pinet/slack-bridge@0.1.0`, 179 files, 1,178,286 unpacked bytes.

## Validation

- Read pi packages docs: `/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/docs/packages.md`
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --write README.md slack-bridge/README.md slack-bridge/package.json`
- `cd slack-bridge && npm pack --dry-run --json` + required-file assertion
- `pnpm format:check`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge test` → 78 files / 1369 tests passed
- `pnpm lint && pnpm typecheck && pnpm test`
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`
- Local reviewer pass found no blockers/warnings.
