### PR TITLE
chore: bump pinet packages to 0.1.1

### DIFF
--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- bump the full `@pinet/*` publish set from `0.1.0` to `0.1.1`
- keep workspace-local `file:` dependencies unchanged; publish tooling rewrites them to exact versions during pack/publish
- no tag creation or publish in this PR

## Validation
- `pnpm install --frozen-lockfile`
- `node scripts/validate-npm-tag-version.mjs refs/tags/v0.1.1`
- `! node scripts/validate-npm-tag-version.mjs refs/tags/v0.1.0`
- `pnpm format:check`
- `pnpm lint && pnpm typecheck && pnpm test`
- `node scripts/publish-npm-packages.mjs --dry-run`
- `npm view <pkg>@0.1.1` checked all five packages: not published
- push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

## Release note
After merge, the publish path is: tag the current `main` tip as `v0.1.1`, run/approve the protected `npm-publish` environment, and let Trusted Publishing/OIDC handle npm auth/provenance.
