### PR TITLE
feat(slack): add app-name agents slash command

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -60,9 +60,10 @@ bump versions without explicit maintainer release approval.
 2. Choose **From a manifest**
 3. Select your workspace
 4. Paste the contents of [`manifest.yaml`](./manifest.yaml) from this directory
-5. Click **Create**
+5. If the Slack app is not named Pinet, change `features.slash_commands[0].command` before creating the app (for example, Oathgate uses `/oathgate` instead of the packaged `/pinet` default)
+6. Click **Create**
 
-The manifest configures Socket Mode, the assistant view, all required bot scopes, and event subscriptions automatically.
+The manifest configures Socket Mode, the assistant view, all required bot scopes, event subscriptions, and the packaged Pinet slash-command default automatically.
 
 ### 2. Generate tokens
 
@@ -81,13 +82,13 @@ These are included in the manifest, but for reference:
 app_mentions:read    assistant:write      bookmarks:read
 bookmarks:write      canvases:read        canvases:write
 channels:history     channels:read        chat:write
-files:read           files:write          groups:history
+commands             files:read           files:write          groups:history
 groups:read          im:history           im:read
 im:write             pins:read            pins:write
 reactions:read       reactions:write      users:read
 ```
 
-`files:read` is required because Slack exposes canvas comment pagination through `files.info`, even when the target is first validated via canvas-specific APIs.
+`commands` is required for the Slack slash-command surface (`/<app> agents list [all]`). `files:read` is required because Slack exposes canvas comment pagination through `files.info`, even when the target is first validated via canvas-specific APIs.
 
 Slack thread shimmer/status updates use `assistant.threads.setStatus`; Slack's 2026 scope update allows this method with the existing `chat:write` bot scope, so no new `assistant:write` scope is needed for status-only support.
 
@@ -198,6 +199,8 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 | `ralphSnoozeAfterEmptyCycles`  | no       | Broker RALPH auto-snooze trigger after N empty cycles; defaults to `0` (disabled), valid range `0`-`100`              |
 | `ralphSnoozeDurationMs`        | no       | Broker RALPH auto-snooze duration in milliseconds; defaults to `1800000` (30 minutes), valid range `60000`-`86400000` |
 | `skinTheme`                    | no       | Pinet presentation skin selected at broker startup/reload (`default`, `foundation`, `cosmere`, or free-form)          |
+| `slackCommandName`             | no       | Slack web app slash command name for `agents list`; defaults to `/pinet`, or `/oathgate` for Oathgate/Cosmere skins   |
+| `slackCommandNames`            | no       | Optional list of accepted/deployed Slack slash command aliases when one app needs multiple command names              |
 | `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                     |
 | `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file               |
 | `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                    |
@@ -418,12 +421,13 @@ The `canvas_comments_read` dispatcher action is intentionally narrow:
 
 ### Slash commands
 
-| Command           | Description                                                |
-| ----------------- | ---------------------------------------------------------- |
-| `/pinet <action>` | Unified Pinet command surface; run `/pinet help` for usage |
-| `/pinet status`   | Show connection status, threads, and agent identity        |
-| `/pinet rename`   | Change the agent's display name                            |
-| `/pinet logs`     | Show recent broker activity log entries                    |
+| Command                    | Description                                                |
+| -------------------------- | ---------------------------------------------------------- |
+| `/pinet <action>`          | Unified Pinet command surface; run `/pinet help` for usage |
+| `/pinet status`            | Show connection status, threads, and agent identity        |
+| `/pinet rename`            | Change the agent's display name                            |
+| `/pinet logs`              | Show recent broker activity log entries                    |
+| `/<app> agents list [all]` | Slack-native broker roster, workload, task, and lane view  |
 
 ## Runtime modes
 
@@ -516,7 +520,7 @@ RALPH snooze quiets non-urgent empty maintenance cycles without disabling human-
 
 ### Pinet command surface
 
-Use `/pinet <action> [args]` for mesh lifecycle and broker operations.
+Use `/pinet <action> [args]` for mesh lifecycle and broker operations. In the Slack web app, use `/<app> agents list [all]` for the Slack-native broker roster/current-work view: `/pinet agents list` for the Pinet app, or `/oathgate agents list` for an Oathgate-named app. Set `slackCommandName` (or `slackCommandNames`) in `slack-bridge` settings before deploying the manifest when the Slack command should match a non-default app name.
 
 | Command                               | Description                                                                   |
 | ------------------------------------- | ----------------------------------------------------------------------------- |
@@ -580,7 +584,7 @@ pnpm test
 pnpm deploy:slack
 ```
 
-Requires `appId` and `appConfigToken` in settings (or `SLACK_APP_ID` / `SLACK_APP_CONFIG_TOKEN` env vars).
+Requires `appId` and `appConfigToken` in settings (or `SLACK_APP_ID` / `SLACK_APP_CONFIG_TOKEN` env vars). The deploy path rewrites `features.slash_commands` from `slackCommandName` / `slackCommandNames` (or the configured `skinTheme`) before validating and uploading, so set `slackCommandName: "/oathgate"` for an Oathgate app and leave it unset for the packaged Pinet `/pinet` default.
 
 ### Architecture
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -107,6 +107,32 @@ describe("parseSocketFrame", () => {
       actions: [{ action_id: "review.approve" }],
     });
   });
+
+  it("extracts Slack slash command payloads", () => {
+    const frame = JSON.stringify({
+      envelope_id: "env-1",
+      type: "slash_commands",
+      payload: {
+        command: "/pinet",
+        text: "agents list all",
+        channel_id: "C123",
+        user_id: "U123",
+        response_url: "https://hooks.slack.com/commands/T/1/x",
+        trigger_id: "trigger-1",
+        team_id: "T123",
+      },
+    });
+
+    expect(parseSocketFrame(frame)?.slashCommand).toEqual({
+      command: "/pinet",
+      text: "agents list all",
+      channelId: "C123",
+      userId: "U123",
+      responseUrl: "https://hooks.slack.com/commands/T/1/x",
+      triggerId: "trigger-1",
+      teamId: "T123",
+    });
+  });
 });
 
 // ─── extractThreadStarted ────────────────────────────────
@@ -708,6 +734,212 @@ describe("SlackAdapter", () => {
       isKnownThread: () => false,
     });
     expect(adapter.name).toBe("slack");
+  });
+
+  it("handles authorized slash commands with an ephemeral Slack response", async () => {
+    const onSlashCommand = vi.fn(() => "Pinet agents: 1 shown");
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onSlashCommand,
+    });
+    const callSlack = vi
+      .spyOn(
+        adapter as unknown as {
+          callSlack: (
+            method: string,
+            token: string,
+            body?: Record<string, unknown>,
+          ) => Promise<Record<string, unknown>>;
+        },
+        "callSlack",
+      )
+      .mockResolvedValue({ ok: true });
+
+    await (
+      adapter as unknown as {
+        onSlashCommand: (event: {
+          command: string;
+          text: string;
+          channelId: string;
+          userId: string;
+        }) => Promise<void>;
+      }
+    ).onSlashCommand({
+      command: "/pinet",
+      text: "agents list",
+      channelId: "C123",
+      userId: "U123",
+    });
+
+    expect(onSlashCommand).toHaveBeenCalledWith({
+      command: "/pinet",
+      text: "agents list",
+      channelId: "C123",
+      userId: "U123",
+    });
+    expect(callSlack).toHaveBeenCalledWith("chat.postEphemeral", "xoxb-test-token", {
+      channel: "C123",
+      user: "U123",
+      text: "Pinet agents: 1 shown",
+    });
+  });
+
+  it("prefers Slack slash command response_url when present", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("ok", {
+        status: 200,
+      }),
+    );
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onSlashCommand: () => "Pinet agents: 1 shown",
+    });
+    const callSlack = vi.spyOn(
+      adapter as unknown as {
+        callSlack: (
+          method: string,
+          token: string,
+          body?: Record<string, unknown>,
+        ) => Promise<Record<string, unknown>>;
+      },
+      "callSlack",
+    );
+
+    await (
+      adapter as unknown as {
+        onSlashCommand: (event: {
+          command: string;
+          text: string;
+          channelId: string;
+          userId: string;
+          responseUrl: string;
+        }) => Promise<void>;
+      }
+    ).onSlashCommand({
+      command: "/pinet",
+      text: "agents list",
+      channelId: "C123",
+      userId: "U123",
+      responseUrl: "https://hooks.slack.com/commands/T/1/x",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith("https://hooks.slack.com/commands/T/1/x", {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ response_type: "ephemeral", text: "Pinet agents: 1 shown" }),
+      signal: expect.any(AbortSignal) as AbortSignal,
+    });
+    expect(callSlack).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("falls back to chat.postEphemeral when Slack slash command response_url fails", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("no", {
+        status: 500,
+      }),
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onSlashCommand: () => "Pinet agents: 1 shown",
+    });
+    const callSlack = vi
+      .spyOn(
+        adapter as unknown as {
+          callSlack: (
+            method: string,
+            token: string,
+            body?: Record<string, unknown>,
+          ) => Promise<Record<string, unknown>>;
+        },
+        "callSlack",
+      )
+      .mockResolvedValue({ ok: true });
+
+    await (
+      adapter as unknown as {
+        onSlashCommand: (event: {
+          command: string;
+          text: string;
+          channelId: string;
+          userId: string;
+          responseUrl: string;
+        }) => Promise<void>;
+      }
+    ).onSlashCommand({
+      command: "/pinet",
+      text: "agents list",
+      channelId: "C123",
+      userId: "U123",
+      responseUrl: "https://hooks.slack.com/commands/T/1/x",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(callSlack).toHaveBeenCalledWith("chat.postEphemeral", "xoxb-test-token", {
+      channel: "C123",
+      user: "U123",
+      text: "Pinet agents: 1 shown",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[slack-adapter] Slash command response_url failed: HTTP 500",
+    );
+    fetchSpy.mockRestore();
+    consoleError.mockRestore();
+  });
+
+  it("uses chat.postEphemeral directly for slash command error responses", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("ok", {
+        status: 200,
+      }),
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const adapter = new SlackAdapter({
+      ...baseConfig,
+      onSlashCommand: () => {
+        throw new Error("boom");
+      },
+    });
+    const callSlack = vi
+      .spyOn(
+        adapter as unknown as {
+          callSlack: (
+            method: string,
+            token: string,
+            body?: Record<string, unknown>,
+          ) => Promise<Record<string, unknown>>;
+        },
+        "callSlack",
+      )
+      .mockResolvedValue({ ok: true });
+
+    await (
+      adapter as unknown as {
+        onSlashCommand: (event: {
+          command: string;
+          text: string;
+          channelId: string;
+          userId: string;
+          responseUrl: string;
+        }) => Promise<void>;
+      }
+    ).onSlashCommand({
+      command: "/pinet",
+      text: "agents list",
+      channelId: "C123",
+      userId: "U123",
+      responseUrl: "https://hooks.slack.com/commands/T/1/x",
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(callSlack).toHaveBeenCalledWith("chat.postEphemeral", "xoxb-test-token", {
+      channel: "C123",
+      user: "U123",
+      text: "Slack command failed: boom",
+    });
+    fetchSpy.mockRestore();
+    consoleError.mockRestore();
   });
 
   it("records known threads on assistant_thread_started without claiming ownership", async () => {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -12,6 +12,7 @@ import {
   setSlackSuggestedPrompts,
   SlackSocketModeClient,
   type ParsedAppHomeOpened,
+  type ParsedSlashCommand,
   type ParsedThreadContextChanged,
   type ParsedThreadStarted,
 } from "../../slack-access.js";
@@ -77,6 +78,8 @@ export interface SlackAdapterConfig {
   ) => void;
   /** Best-effort callback for Home tab opens. */
   onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
+  /** Best-effort callback for Slack slash commands handled by the broker process. */
+  onSlashCommand?: (event: ParsedSlashCommand) => Promise<string | null> | string | null;
 }
 
 interface SlackThreadInfo {
@@ -163,6 +166,7 @@ export class SlackAdapter implements MessageAdapter {
       onMemberJoinedChannel: (event) => this.onMemberJoined(event),
       onAppHomeOpened: (event) => this.onAppHomeOpened(event),
       onInteractive: (event) => this.emitInteractiveInbound(event),
+      onSlashCommand: (event) => this.onSlashCommand(event),
       onError: (error) => {
         if (!isAbortError(error)) {
           console.error(`[slack-adapter] Socket Mode: ${errorMsg(error)}`);
@@ -349,6 +353,61 @@ export class SlackAdapter implements MessageAdapter {
       this.config.rememberKnownThread?.(parsed.threadTs, existing.channelId, existing.context);
     } catch {
       /* best effort — DB cache sync must not break Slack event handling */
+    }
+  }
+
+  private async sendSlashCommandResponse(
+    event: ParsedSlashCommand,
+    text: string,
+    options: { useResponseUrl?: boolean } = {},
+  ): Promise<void> {
+    if (options.useResponseUrl !== false && event.responseUrl) {
+      try {
+        const response = await this.slackRequests.run((signal) =>
+          fetch(event.responseUrl!, {
+            method: "POST",
+            headers: { "Content-Type": "application/json; charset=utf-8" },
+            body: JSON.stringify({ response_type: "ephemeral", text }),
+            signal,
+          }),
+        );
+        if (response.ok) {
+          return;
+        }
+        console.error(`[slack-adapter] Slash command response_url failed: HTTP ${response.status}`);
+      } catch (error) {
+        console.error(`[slack-adapter] Slash command response_url failed: ${errorMsg(error)}`);
+      }
+    }
+
+    await this.callSlack("chat.postEphemeral", this.config.botToken, {
+      channel: event.channelId,
+      user: event.userId,
+      text,
+    });
+  }
+
+  private async onSlashCommand(event: ParsedSlashCommand): Promise<void> {
+    if (this.shuttingDown || !this.config.onSlashCommand) return;
+
+    if (!isSlackUserAllowed(this.allowlist, event.userId)) {
+      await this.sendSlashCommandResponse(
+        event,
+        "Sorry, I can only respond to authorized users. Please contact an admin if you need access.",
+      );
+      return;
+    }
+
+    try {
+      const responseText = await this.config.onSlashCommand(event);
+      if (responseText && !this.shuttingDown) {
+        await this.sendSlashCommandResponse(event, responseText);
+      }
+    } catch (error) {
+      console.error(`[slack-adapter] Slash command failed: ${errorMsg(error)}`);
+      await this.sendSlashCommandResponse(event, `Slack command failed: ${errorMsg(error)}`, {
+        useResponseUrl: false,
+      });
     }
   }
 

--- a/slack-bridge/deploy-manifest.test.ts
+++ b/slack-bridge/deploy-manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyConfiguredSlashCommands,
   diffManifestScopes,
   formatScopeChangeSummary,
   getDeployConfigError,
@@ -27,6 +28,11 @@ describe("resolveDeployConfig", () => {
       appId: "ASETTINGS",
       appConfigToken: "xoxe-settings",
       appToken: "xapp-settings",
+      settings: {
+        appId: "ASETTINGS",
+        appConfigToken: "xoxe-settings",
+        appToken: "xapp-settings",
+      },
     });
   });
 
@@ -38,6 +44,7 @@ describe("resolveDeployConfig", () => {
       appId: "AENV",
       appConfigToken: "xoxe-env",
       appToken: undefined,
+      settings: {},
     });
   });
 });
@@ -48,10 +55,38 @@ describe("getDeployConfigError", () => {
       manifestPath: "manifest.yaml",
       appId: "A123",
       appToken: "xapp-123",
+      settings: {},
     });
 
     expect(error).toContain("Missing Slack app configuration token");
     expect(error).toContain("xapp token");
+  });
+});
+
+describe("applyConfiguredSlashCommands", () => {
+  it("rewrites slash command names from settings and keeps commands scope", () => {
+    const manifest = applyConfiguredSlashCommands(
+      {
+        features: { slash_commands: [{ command: "/pinet" }] },
+        oauth_config: { scopes: { bot: ["chat:write"] } },
+      },
+      { slackCommandName: "Oathgate" },
+    );
+
+    expect(manifest.features).toEqual({
+      slash_commands: [
+        {
+          command: "/oathgate",
+          description: "Show the Pinet broker roster and current work",
+          usage_hint: "agents list [all]",
+          should_escape: false,
+        },
+      ],
+    });
+    expect((manifest.oauth_config as { scopes: { bot: string[] } }).scopes.bot).toEqual([
+      "chat:write",
+      "commands",
+    ]);
   });
 });
 

--- a/slack-bridge/deploy-manifest.ts
+++ b/slack-bridge/deploy-manifest.ts
@@ -3,11 +3,15 @@ import * as path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { pathToFileURL } from "node:url";
+import { resolveSlackAgentCommandNames } from "./slack-agents-command.js";
 
 export interface SlackBridgeSettings {
   appId?: string;
   appToken?: string;
   appConfigToken?: string;
+  skinTheme?: string;
+  slackCommandName?: string;
+  slackCommandNames?: string[];
 }
 
 const execFile = promisify(execFileCallback);
@@ -24,6 +28,7 @@ export interface ResolvedDeployConfig {
   appId?: string;
   appConfigToken?: string;
   appToken?: string;
+  settings: SlackBridgeSettings;
 }
 
 export interface DeployResult {
@@ -176,6 +181,7 @@ export function resolveDeployConfig(
     appId: settings.appId ?? env.SLACK_APP_ID,
     appConfigToken: settings.appConfigToken ?? env.SLACK_APP_CONFIG_TOKEN ?? env.SLACK_CONFIG_TOKEN,
     appToken: settings.appToken ?? env.SLACK_APP_TOKEN,
+    settings,
   };
 }
 
@@ -201,6 +207,38 @@ export function getDeployConfigError(config: ResolvedDeployConfig): string | nul
   }
 
   return messages.length > 0 ? messages.join(" ") : null;
+}
+
+export function applyConfiguredSlashCommands(
+  manifest: Record<string, unknown>,
+  settings: SlackBridgeSettings,
+): Record<string, unknown> {
+  const commandNames = resolveSlackAgentCommandNames(settings);
+  const features = asRecord(manifest.features) ?? {};
+  const oauthConfig = asRecord(manifest.oauth_config) ?? {};
+  const scopes = asRecord(oauthConfig.scopes) ?? {};
+  const botScopes = readScopeList(manifest, "bot");
+  const nextBotScopes = botScopes.includes("commands") ? botScopes : [...botScopes, "commands"];
+
+  return {
+    ...manifest,
+    features: {
+      ...features,
+      slash_commands: commandNames.map((command) => ({
+        command,
+        description: "Show the Pinet broker roster and current work",
+        usage_hint: "agents list [all]",
+        should_escape: false,
+      })),
+    },
+    oauth_config: {
+      ...oauthConfig,
+      scopes: {
+        ...scopes,
+        bot: nextBotScopes,
+      },
+    },
+  };
 }
 
 async function parseManifestYaml(manifestPath: string): Promise<Record<string, unknown>> {
@@ -273,7 +311,10 @@ export async function deploySlackManifest(config: ResolvedDeployConfig): Promise
 
   const appId = config.appId as string;
   const appConfigToken = config.appConfigToken as string;
-  const manifest = await parseManifestYaml(config.manifestPath);
+  const manifest = applyConfiguredSlashCommands(
+    await parseManifestYaml(config.manifestPath),
+    config.settings,
+  );
   const previousManifest = await exportRemoteManifest(appId, appConfigToken);
 
   await validateManifest(manifest, appConfigToken);

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -37,6 +37,8 @@ export interface SlackBridgeSettings {
   ralphSnoozeAfterEmptyCycles?: number;
   ralphSnoozeDurationMs?: number;
   skinTheme?: string;
+  slackCommandName?: string;
+  slackCommandNames?: string[];
   agentName?: string;
   agentEmoji?: string;
   meshSecret?: string;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -74,6 +74,14 @@ import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
 import { createAgentEventRuntime } from "./agent-event-runtime.js";
 import { createSessionUiRuntime } from "./session-ui-runtime.js";
 import { createSlackRequestRuntime } from "./slack-request-runtime.js";
+import {
+  formatSlackAgentsDashboard,
+  formatSlackAgentsUsage,
+  isSlackAgentCommand,
+  isSlackAgentsListCommand,
+  resolveSlackAgentCommandNames,
+  shouldIncludeSlackAgentsGhosts,
+} from "./slack-agents-command.js";
 import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
 import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
 import { createInboxDrainRuntime } from "./inbox-drain-runtime.js";
@@ -621,6 +629,23 @@ export default function (pi: ExtensionAPI) {
   const handleBrokerAppHomeOpened = async (userId: string, ctx: ExtensionContext) => {
     await pinetHomeTabs.publishCurrentPinetHomeTabSafely(userId, ctx, new Date().toISOString());
   };
+  const handleBrokerSlackSlashCommand = async (event: {
+    command: string;
+    text: string;
+  }): Promise<string | null> => {
+    const commandNames = resolveSlackAgentCommandNames(settings, activeSkinTheme);
+    if (!isSlackAgentCommand(event.command, commandNames)) {
+      return null;
+    }
+    if (!isSlackAgentsListCommand(event.command, event.text, commandNames)) {
+      return formatSlackAgentsUsage(commandNames);
+    }
+    const snapshot = await buildCurrentBrokerControlPlaneDashboardSnapshot();
+    if (!snapshot) {
+      return "Pinet broker dashboard data is not available yet. Try again after the broker completes a maintenance cycle.";
+    }
+    return formatSlackAgentsDashboard(snapshot, shouldIncludeSlackAgentsGhosts(event.text));
+  };
   const slackPinetAdapterFactory = createSlackPinetRuntimeAdapterFactory({
     getSettings: () => settings,
     getBotToken: () => botToken!,
@@ -629,6 +654,7 @@ export default function (pi: ExtensionAPI) {
     shouldAllowAllWorkspaceUsers: () =>
       resolveAllowAllWorkspaceUsers(settings, process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS),
     onAppHomeOpened: handleBrokerAppHomeOpened,
+    onSlashCommand: handleBrokerSlackSlashCommand,
   });
 
   const brokerRuntime = createBrokerRuntime({

--- a/slack-bridge/manifest.yaml
+++ b/slack-bridge/manifest.yaml
@@ -11,6 +11,14 @@ features:
   bot_user:
     display_name: Pinet
     always_online: true
+  # Default packaged command for the Pinet app. For Oathgate or another app name,
+  # either edit this command before manual Slack import or run `pnpm deploy:slack`
+  # with slackCommandName/slackCommandNames configured so deployment rewrites it.
+  slash_commands:
+    - command: /pinet
+      description: Show the Pinet broker roster and current work
+      usage_hint: "agents list [all]"
+      should_escape: false
   assistant_view:
     assistant_description: Pi coding agent
     suggested_prompts: []
@@ -23,6 +31,7 @@ oauth_config:
       - channels:history
       - channels:read
       - chat:write
+      - commands
       - files:read
       - files:write
       - bookmarks:read

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -74,12 +74,23 @@ export function buildSlackThreadRuntimeScope(input: {
   );
 }
 
+export interface ParsedSlashCommand {
+  command: string;
+  text: string;
+  channelId: string;
+  userId: string;
+  responseUrl?: string;
+  triggerId?: string;
+  teamId?: string;
+}
+
 export interface ParsedEnvelope {
   envelopeId?: string;
   type: string;
   dedupKey?: string;
   event?: Record<string, unknown>;
   interactivePayload?: Record<string, unknown>;
+  slashCommand?: ParsedSlashCommand;
 }
 
 export function isSlackUserAllowed(allowlist: Set<string> | null, userId: string): boolean {
@@ -112,10 +123,35 @@ export function parseSocketFrame(raw: string): ParsedEnvelope | null {
     if (interactivePayload) {
       result.interactivePayload = interactivePayload;
     }
+    if (data.type === "slash_commands") {
+      const slashCommand = extractSlackSlashCommandPayload(data.payload);
+      if (slashCommand) {
+        result.slashCommand = slashCommand;
+      }
+    }
     return result;
   } catch {
     return null;
   }
+}
+
+function extractSlackSlashCommandPayload(payload: unknown): ParsedSlashCommand | null {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return null;
+  const record = payload as Record<string, unknown>;
+  const command = typeof record.command === "string" ? record.command.trim() : "";
+  const text = typeof record.text === "string" ? record.text : "";
+  const channelId = typeof record.channel_id === "string" ? record.channel_id : "";
+  const userId = typeof record.user_id === "string" ? record.user_id : "";
+  if (!command || !channelId || !userId) return null;
+  return {
+    command,
+    text,
+    channelId,
+    userId,
+    ...(typeof record.response_url === "string" ? { responseUrl: record.response_url } : {}),
+    ...(typeof record.trigger_id === "string" ? { triggerId: record.trigger_id } : {}),
+    ...(typeof record.team_id === "string" ? { teamId: record.team_id } : {}),
+  };
 }
 
 export interface ParsedThreadStarted {
@@ -510,6 +546,7 @@ export interface SlackSocketModeClientConfig {
   onMemberJoinedChannel?: (event: { channel: string; isSelf: boolean }) => Promise<void> | void;
   onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
   onInteractive?: (event: SlackInteractiveInboxEvent) => Promise<void> | void;
+  onSlashCommand?: (event: ParsedSlashCommand) => Promise<void> | void;
 }
 
 export class SlackSocketModeClient {
@@ -624,6 +661,11 @@ export class SlackSocketModeClient {
         if (normalized) {
           await this.config.onInteractive?.(normalized);
         }
+        return;
+      }
+
+      if (envelope.slashCommand) {
+        await this.config.onSlashCommand?.(envelope.slashCommand);
         return;
       }
 

--- a/slack-bridge/slack-agents-command.test.ts
+++ b/slack-bridge/slack-agents-command.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatSlackAgentsDashboard,
+  formatSlackAgentsUsage,
+  isSlackAgentCommand,
+  isSlackAgentsListCommand,
+  resolveSlackAgentCommandNames,
+  shouldIncludeSlackAgentsGhosts,
+} from "./slack-agents-command.js";
+import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
+
+function createSnapshot(): BrokerControlPlaneDashboardSnapshot {
+  return {
+    cycleStartedAt: "2026-06-05T09:00:00.000Z",
+    cycleDurationMs: 0,
+    currentBranch: "main",
+    ralphSnooze: null,
+    totalAgents: 2,
+    liveAgents: 1,
+    brokerCount: 1,
+    workerCount: 1,
+    idleWorkers: 0,
+    workingWorkers: 1,
+    ghostAgents: 1,
+    stuckAgents: 0,
+    pendingBacklogCount: 2,
+    nudgesThisCycle: 0,
+    idleDrainCandidates: 0,
+    assignedBacklogCount: 0,
+    reapedAgents: 0,
+    repairedThreadClaims: 0,
+    maintenanceAnomalies: [],
+    anomalies: [],
+    taskCounts: { assigned: 1, branchPushed: 0, openPrs: 0, mergedPrs: 0, closedPrs: 0 },
+    activeTasks: ["#805 assigned"],
+    recentOutcomes: [],
+    activeLanes: ["agents-command [active] lead agent-1 — Slack /pinet agents list command"],
+    detachedLanes: [],
+    roster: [
+      {
+        id: "agent-1",
+        role: "worker",
+        label: "🛡️ Cobalt Guard",
+        status: "working",
+        health: "healthy",
+        workload: "1 inbox / 1 thread",
+        taskSummary: "#805 assigned",
+        heartbeat: "1s ago",
+        branch: "feat/slack-agents-command",
+        worktree: "~/extensions/.worktrees/agents-status-command",
+      },
+      {
+        id: "agent-ghost",
+        role: "worker",
+        label: "👻 Ghost Worker",
+        status: "offline",
+        health: "ghost",
+        workload: "none",
+        taskSummary: "none",
+        heartbeat: "10m ago",
+        branch: "main",
+        worktree: "~/extensions",
+      },
+    ],
+    recentCycles: [],
+  };
+}
+
+describe("Slack app-name agents list command helpers", () => {
+  it("resolves command names from explicit settings or skin defaults", () => {
+    expect(resolveSlackAgentCommandNames({})).toEqual(["/pinet"]);
+    expect(resolveSlackAgentCommandNames({ skinTheme: "oathgate" })).toEqual(["/oathgate"]);
+    expect(resolveSlackAgentCommandNames({ slackCommandName: "Oathgate" })).toEqual(["/oathgate"]);
+    expect(
+      resolveSlackAgentCommandNames({ slackCommandNames: ["/pinet", "oathgate", "bad name"] }),
+    ).toEqual(["/pinet", "/oathgate"]);
+  });
+
+  it("recognizes configured Slack command names", () => {
+    const commandNames = ["/pinet", "/oathgate"];
+    expect(isSlackAgentCommand("/pinet", commandNames)).toBe(true);
+    expect(isSlackAgentCommand(" /OATHGATE ", commandNames)).toBe(true);
+    expect(isSlackAgentCommand("/agents", commandNames)).toBe(false);
+  });
+
+  it("recognizes app-name agents list text", () => {
+    const commandNames = ["/pinet", "/oathgate"];
+    expect(isSlackAgentsListCommand("/pinet", "agents list", commandNames)).toBe(true);
+    expect(isSlackAgentsListCommand("/oathgate", "agents list all", commandNames)).toBe(true);
+    expect(isSlackAgentsListCommand("/pinet", "agents", commandNames)).toBe(false);
+    expect(isSlackAgentsListCommand("/agents", "all", commandNames)).toBe(false);
+    expect(formatSlackAgentsUsage(["/oathgate"])).toBe("Usage: /oathgate agents list [all]");
+  });
+
+  it("parses all/ghost flags", () => {
+    expect(shouldIncludeSlackAgentsGhosts("agents list all")).toBe(true);
+    expect(shouldIncludeSlackAgentsGhosts("all")).toBe(true);
+    expect(shouldIncludeSlackAgentsGhosts("--ghosts")).toBe(true);
+    expect(shouldIncludeSlackAgentsGhosts("")).toBe(false);
+  });
+
+  it("formats broker roster and current lane data while hiding ghosts by default", () => {
+    const output = formatSlackAgentsDashboard(createSnapshot(), false);
+
+    expect(output).toContain("Pinet agents: 1 shown · 1 live · 1 workers · 1 working");
+    expect(output).toContain("🛡️ Cobalt Guard · worker · working · healthy");
+    expect(output).toContain("Task: #805 assigned");
+    expect(output).toContain("Active lanes:");
+    expect(output).not.toContain("Ghost Worker");
+  });
+
+  it("includes ghosts when requested", () => {
+    expect(formatSlackAgentsDashboard(createSnapshot(), true)).toContain("Ghost Worker");
+  });
+});

--- a/slack-bridge/slack-agents-command.ts
+++ b/slack-bridge/slack-agents-command.ts
@@ -1,0 +1,130 @@
+import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
+
+export interface SlackAgentCommandSettings {
+  skinTheme?: string | null;
+  slackCommandName?: string | null;
+  slackCommandNames?: string[] | null;
+}
+
+export interface SlackAgentsCommandInput {
+  command: string;
+  text: string;
+  channelId: string;
+  userId: string;
+}
+
+const DEFAULT_SLACK_COMMAND_NAME = "/pinet";
+const OATHGATE_SLACK_COMMAND_NAME = "/oathgate";
+
+export function normalizeSlackCommandName(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().toLowerCase();
+  if (!trimmed) return null;
+  const command = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return /^\/[a-z0-9_-]+$/.test(command) ? command : null;
+}
+
+function defaultSlackCommandNameForSkin(skinTheme: string | null | undefined): string {
+  const normalized = skinTheme?.trim().toLowerCase();
+  if (normalized === "oathgate" || normalized === "cosmere" || normalized === "cosmere-inspired") {
+    return OATHGATE_SLACK_COMMAND_NAME;
+  }
+  return DEFAULT_SLACK_COMMAND_NAME;
+}
+
+export function resolveSlackAgentCommandNames(
+  settings: SlackAgentCommandSettings,
+  activeSkinTheme?: string | null,
+): string[] {
+  const configured = [
+    ...(settings.slackCommandName ? [settings.slackCommandName] : []),
+    ...(Array.isArray(settings.slackCommandNames) ? settings.slackCommandNames : []),
+  ]
+    .map(normalizeSlackCommandName)
+    .filter((command): command is string => command !== null);
+
+  const names =
+    configured.length > 0
+      ? configured
+      : [defaultSlackCommandNameForSkin(activeSkinTheme ?? settings.skinTheme)];
+  return [...new Set(names)];
+}
+
+export function formatSlackAgentsUsage(commandNames: string[]): string {
+  return `Usage: ${commandNames[0] ?? DEFAULT_SLACK_COMMAND_NAME} agents list [all]`;
+}
+
+function parseSlackCommandTokens(text: string): string[] {
+  return text.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+export function isSlackAgentCommand(command: string, commandNames: string[]): boolean {
+  const normalized = normalizeSlackCommandName(command);
+  return normalized !== null && commandNames.includes(normalized);
+}
+
+export function isSlackAgentsListCommand(
+  command: string,
+  text: string,
+  commandNames: string[],
+): boolean {
+  if (!isSlackAgentCommand(command, commandNames)) return false;
+  const [subject, action] = parseSlackCommandTokens(text);
+  return subject === "agents" && action === "list";
+}
+
+export function shouldIncludeSlackAgentsGhosts(text: string): boolean {
+  return parseSlackCommandTokens(text).some(
+    (token) => token === "all" || token === "ghosts" || token === "--all" || token === "--ghosts",
+  );
+}
+
+export function formatSlackAgentsDashboard(
+  snapshot: BrokerControlPlaneDashboardSnapshot,
+  includeGhosts: boolean,
+): string {
+  const rows = includeGhosts
+    ? snapshot.roster
+    : snapshot.roster.filter(
+        (row) => !row.health.includes("ghost") && !row.health.includes("resumable"),
+      );
+  const visibleRows = rows.slice(0, 20);
+  const headerParts = [
+    `Pinet agents: ${visibleRows.length}${rows.length !== visibleRows.length ? ` of ${rows.length}` : ""} shown`,
+    `${snapshot.liveAgents} live`,
+    `${snapshot.workerCount} workers`,
+    `${snapshot.workingWorkers} working`,
+    `${snapshot.idleWorkers} idle`,
+    `backlog ${snapshot.pendingBacklogCount}`,
+  ];
+  if (snapshot.ghostAgents > 0) {
+    headerParts.push(`${snapshot.ghostAgents} ghost${snapshot.ghostAgents === 1 ? "" : "s"}`);
+  }
+  if (snapshot.stuckAgents > 0) {
+    headerParts.push(`${snapshot.stuckAgents} stuck`);
+  }
+
+  const rosterLines = visibleRows.length
+    ? visibleRows.flatMap((row) => [
+        `${row.label} · ${row.role} · ${row.status} · ${row.health}`,
+        `  Workload: ${row.workload}`,
+        `  Task: ${row.taskSummary}`,
+        `  Heartbeat: ${row.heartbeat}`,
+        `  Branch: ${row.branch} · Worktree: ${row.worktree}`,
+      ])
+    : ["No agents are currently registered."];
+
+  const activeLanes = snapshot.activeLanes.slice(0, 8);
+  const detachedLanes = snapshot.detachedLanes.slice(0, 4);
+  return [
+    headerParts.join(" · "),
+    rosterLines.join("\n"),
+    activeLanes.length > 0
+      ? ["Active lanes:", ...activeLanes.map((lane) => `• ${lane}`)].join("\n")
+      : null,
+    detachedLanes.length > 0
+      ? ["Detached lanes:", ...detachedLanes.map((lane) => `• ${lane}`)].join("\n")
+      : null,
+  ]
+    .filter((section): section is string => Boolean(section))
+    .join("\n\n");
+}

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -3,7 +3,11 @@ import { SlackAdapter } from "./broker/adapters/slack.js";
 import type { Broker, ThreadInfo } from "./broker/index.js";
 import type { PinetRuntimeAdapterFactory } from "./pinet-runtime-composition.js";
 import type { ReactionCommandSettings } from "./reaction-triggers.js";
-import type { ParsedThreadStarted, SlackThreadContext } from "./slack-access.js";
+import type {
+  ParsedSlashCommand,
+  ParsedThreadStarted,
+  SlackThreadContext,
+} from "./slack-access.js";
 import type { SlackBridgeSettings } from "./helpers.js";
 
 export function readStoredSlackThreadContext(
@@ -42,6 +46,10 @@ export interface SlackPinetRuntimeAdapterDeps {
   getAllowedUsers: () => Set<string> | null;
   shouldAllowAllWorkspaceUsers: () => boolean;
   onAppHomeOpened: (userId: string, ctx: ExtensionContext) => Promise<void> | void;
+  onSlashCommand?: (
+    event: ParsedSlashCommand,
+    ctx: ExtensionContext,
+  ) => Promise<string | null> | string | null;
 }
 
 function getKnownSlackThread(
@@ -95,6 +103,9 @@ export function createSlackPinetRuntimeAdapterFactory(
       onAppHomeOpened: async ({ userId }) => {
         await deps.onAppHomeOpened(userId, ctx);
       },
+      onSlashCommand: deps.onSlashCommand
+        ? (event) => deps.onSlashCommand?.(event, ctx) ?? null
+        : undefined,
     });
 
     return {


### PR DESCRIPTION
## Summary
- add Slack Socket Mode slash-command parsing for app-name command surfaces such as `/pinet` or `/oathgate`
- route `/<app> agents list [all]` through the broker Slack adapter and respond ephemerally, preferring Slack `response_url` when present
- fall back to `chat.postEphemeral` when `response_url` delivery fails, and send error responses directly through `chat.postEphemeral` to avoid retrying a broken response URL
- add `slackCommandName` / `slackCommandNames` settings and deploy-manifest rewriting so Oathgate can deploy `/oathgate` while Pinet deploys `/pinet`
- keep the checked-in `manifest.yaml` as the packaged Pinet default, with comments/docs making clear that non-Pinet apps must edit the command for manual import or use `pnpm deploy:slack` with `slackCommandName`
- document the Slack web app command shape and required `commands` scope; no Pi-local `/pinet agents` command and no model-facing Pinet action schema expansion

## Testing
- `pnpm --filter @pinet/slack-bridge test -- broker/adapters/slack.test.ts slack-agents-command.test.ts deploy-manifest.test.ts`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`
