### PR TITLE
fix(slack): support files on channel posts

### DIFF
--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -50,7 +50,7 @@ should use the colon form.
 
 - Thread/channel messaging: `post_channel`, `read`, `read_channel`, `export`
 - Lightweight acknowledgement: `react`
-- Files/snippets: `upload`, `file`; `slack_send.files` for text plus attachments in one reply
+- Files/snippets: `upload`, `file`; `slack_send.files` and `post_channel.files` for text plus attachments in one message
 - Time-based follow-up: `schedule`
 - People/timing: `presence`
 - Durable channel affordances: `pin`, `bookmark`
@@ -146,8 +146,11 @@ snippets:
 
 ## File workflows
 
-For outbound local files, use `slack_send` when the message should include both
-text and one or more files in a single Slack reply:
+For outbound local files, attach them to the message-posting surface you are
+already using. Use `slack_send.files` for owned assistant-thread replies, and
+`slack` action `post_channel` with `args.files` for explicit channel/thread
+posts. Both use the same file object shape and send text plus files in one Slack
+message:
 
 ```json
 {
@@ -157,6 +160,17 @@ text and one or more files in a single Slack reply:
     { "path": "./out/report.pdf", "title": "Report" },
     { "path": "/tmp/capture.bin", "filename": "capture.bin" }
   ]
+}
+```
+
+```json
+{
+  "action": "post_channel",
+  "args": {
+    "channel": "#deployments",
+    "text": "Here is the deploy evidence.",
+    "files": [{ "path": "/tmp/evidence.png", "filename": "evidence.png" }]
+  }
 }
 ```
 

--- a/slack-bridge/skills/slack-bridge/SKILL.md
+++ b/slack-bridge/skills/slack-bridge/SKILL.md
@@ -177,8 +177,13 @@ message:
 Local path guardrails still apply: paths must resolve inside the current working
 directory or the system temp directory. Binary files are supported.
 
-For inbound Slack-hosted files, use the `slackFiles` metadata from incoming
-messages to get the file ID, then download explicitly:
+For inbound Slack-hosted files, `slack` action `read` downloads attached files to
+the local temp cache by default and returns safe descriptors alongside the
+message metadata. Use `args.download_files=false` when you only need message text
+and file metadata.
+
+Use the explicit `file` action when you have a specific file ID to retry,
+validate, or fetch outside a normal read flow:
 
 ```json
 {
@@ -192,9 +197,11 @@ messages to get the file ID, then download explicitly:
 }
 ```
 
-The result is a safe local descriptor with path, filename, type, size, SHA-256,
-cache expiry, and residual risks. Private Slack download URLs are fetched with
-bot auth but are not returned in normal output.
+Both read-time downloads and the explicit file action download Slack-hosted user
+content into the local temp cache and return safe descriptors: file ID,
+filename/type, local temp path, size, SHA-256, cache directory, expiry, and
+residual risk notes. They must not print private Slack download URLs or raw file
+contents.
 
 ## Modal patterns
 

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -511,6 +511,7 @@ describe("registerSlackTools", () => {
         ts: "123.001",
         user: "Ada",
         preview: expect.stringContaining("status"),
+        files: [],
       }),
     ]);
 
@@ -520,8 +521,92 @@ describe("registerSlackTools", () => {
     });
     expect(full.content?.[0]?.text).toContain(longText);
     expect(full.details?.messages).toEqual([
-      expect.objectContaining({ ts: "123.001", user: "Ada", text: longText }),
+      expect.objectContaining({ ts: "123.001", user: "Ada", text: longText, files: [] }),
     ]);
+  });
+
+  it("downloads Slack read message attachments to temp cache by default", async () => {
+    const { tools, setConversationsReplies, setResolveThreadChannel, setFilesInfoResponse } =
+      setup();
+    setResolveThreadChannel(async () => "C-DB");
+    const messageWithFile = {
+      ts: "123.001",
+      user: "U123",
+      text: "See attached",
+      files: [
+        {
+          id: "F_READ",
+          name: "brief.pdf",
+          mimetype: "application/pdf",
+          filetype: "pdf",
+          pretty_type: "PDF",
+          size: 8,
+          url_private_download: "https://files.slack.com/private/read-brief",
+        },
+      ],
+    };
+    setConversationsReplies([
+      {
+        ok: true,
+        messages: [messageWithFile],
+      } as SlackResult,
+      {
+        ok: true,
+        messages: [messageWithFile],
+      } as SlackResult,
+    ]);
+    setFilesInfoResponse({
+      ok: true,
+      file: {
+        id: "F_READ",
+        name: "brief.pdf",
+        mimetype: "application/pdf",
+        filetype: "pdf",
+        pretty_type: "PDF",
+        size: 8,
+        url_private_download: "https://files.slack.com/private/read-brief",
+      },
+    } as SlackResult);
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(init.headers).toEqual({ Authorization: "Bearer xoxb-initial" });
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: async () => Buffer.from("pdf body").buffer,
+        text: async () => "",
+      };
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    try {
+      const response = await tools.get("slack_read")!.execute("tool-read-file", {
+        thread_ts: "123.456",
+      });
+      const text = response.content?.[0]?.text ?? "";
+      expect(text).toContain("[file downloaded] F_READ brief.pdf (PDF) ->");
+      expect(text).toContain("File attachments: 1 downloaded to the local temp cache.");
+      expect(text).not.toContain("files.slack.com/private");
+      expect(response.details).toMatchObject({
+        downloadedFilesCount: 1,
+        failedFilesCount: 0,
+        messages: [
+          expect.objectContaining({
+            files: [
+              expect.objectContaining({
+                fileId: "F_READ",
+                filename: "brief.pdf",
+                downloadStatus: "downloaded",
+                path: expect.stringContaining("pi-slack-files"),
+                sha256: expect.any(String),
+              }),
+            ],
+          }),
+        ],
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("uses compact dispatcher text by default and JSON when requested", async () => {

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -233,10 +233,18 @@ describe("registerSlackTools", () => {
       }
 
       if (method === "files.completeUploadExternal") {
+        const channelId = typeof body?.channel_id === "string" ? body.channel_id : "C_UPLOAD";
+        const uploadTs = typeof body?.thread_ts === "string" ? body.thread_ts : "1712345678.999999";
         return {
           ok: true,
           body,
-          files: [{ id: "F_UPLOAD", permalink: "https://slack.test/files/F_UPLOAD" }],
+          files: [
+            {
+              id: "F_UPLOAD",
+              permalink: "https://slack.test/files/F_UPLOAD",
+              shares: { public: { [channelId]: [{ ts: uploadTs }] } },
+            },
+          ],
         } as SlackResult;
       }
 
@@ -1311,6 +1319,46 @@ describe("registerSlackTools", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
+  it("sends slack_post_channel text and local files in one external upload", async () => {
+    const { slack, tools } = setup();
+    const dir = await mkdtemp(path.join(os.tmpdir(), "slack-post-channel-file-test-"));
+    const filePath = path.join(dir, "evidence.bin");
+    await writeFile(filePath, Buffer.from([4, 5, 6]));
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchImpl);
+    try {
+      const response = await tools.get("slack_post_channel")!.execute("tool-post-files", {
+        channel: "deployments",
+        text: "Deploy evidence",
+        files: [{ path: filePath, filename: "evidence.bin", title: "Evidence" }],
+      });
+      expect(response.details).toMatchObject({
+        channel: "resolved:deployments",
+        delivery: "slack",
+        filesCount: 1,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    expect(slack).toHaveBeenCalledWith(
+      "files.completeUploadExternal",
+      "xoxb-initial",
+      expect.objectContaining({
+        channel_id: "resolved:deployments",
+        initial_comment: "Deploy evidence",
+        files: [{ id: "F_UPLOAD", title: "Evidence" }],
+      }),
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it("downloads Slack-hosted files through slack file action with safe descriptor output", async () => {
     const { tools, setFilesInfoResponse } = setup();
     const cacheDir = await mkdtemp(path.join(os.tmpdir(), "slack-file-action-test-"));
@@ -1400,12 +1448,14 @@ describe("registerSlackTools", () => {
       channel: "deployments",
       thread_ts: "222.333",
       text: "Threaded status",
+      files: [{ path: "/tmp/status.txt", filename: "status.txt" }],
     });
 
     expect(sendPinetSlackMessage).toHaveBeenCalledWith({
       threadId: "222.333",
       channel: "resolved:deployments",
       text: "Threaded status",
+      files: [{ path: "/tmp/status.txt", filename: "status.txt" }],
     });
     expect(slack).not.toHaveBeenCalledWith(
       "chat.postMessage",
@@ -1416,6 +1466,7 @@ describe("registerSlackTools", () => {
       thread_ts: "222.333",
       channel: "resolved:deployments",
       delivery: "pinet",
+      filesCount: 1,
     });
     expect(response.details).not.toHaveProperty("ts");
   });
@@ -1552,11 +1603,17 @@ describe("registerSlackTools", () => {
     expect(schemaEnvelope.data).toMatchObject({
       action: "post_channel",
       guardrail_tool: "slack:post_channel",
-      examples: [expect.objectContaining({ action: "post_channel" })],
     });
+    expect(schemaEnvelope.data).toEqual(
+      expect.objectContaining({
+        examples: expect.arrayContaining([expect.objectContaining({ action: "post_channel" })]),
+      }),
+    );
     expect(schemaResponse.content?.[0]?.text).toContain("args_schema");
     expect(JSON.stringify(schemaEnvelope.data)).toContain("output_controls");
     expect(JSON.stringify(schemaEnvelope.data)).toContain("response_format");
+    expect(JSON.stringify(schemaEnvelope.data)).toContain("files");
+    expect(JSON.stringify(schemaEnvelope.data)).toContain("Local file path to attach");
 
     const confirmationHelp = await dispatcher.execute("tool-help-confirm", {
       action: "help",

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -39,7 +39,8 @@ import {
 } from "./slack-export.js";
 import { normalizeReactionName } from "./reaction-triggers.js";
 import { resolveScheduledWakeupFireAt } from "./scheduled-wakeups.js";
-import { fetchSlackFileToCache } from "./slack-file-access.js";
+import { fetchSlackFileToCache, type SlackFileDescriptor } from "./slack-file-access.js";
+import { extractSlackMessageFileMetadata } from "./slack-message-context.js";
 import { performSlackUpload, performSlackUploads, prepareSlackUpload } from "./slack-upload.js";
 import { TtlCache } from "./ttl-cache.js";
 import {
@@ -721,6 +722,22 @@ function asTrimmedSlackString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+interface SlackReadFileAttachment {
+  fileId?: string;
+  messageTs: string;
+  filename?: string;
+  mimetype?: string;
+  filetype?: string;
+  prettyType?: string;
+  size?: number;
+  path?: string;
+  sha256?: string;
+  cacheDir?: string;
+  expiresAt?: string;
+  downloadStatus: "downloaded" | "failed" | "metadata-only";
+  error?: string;
 }
 
 function extractSlackUploadMessageTs(
@@ -2238,13 +2255,19 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     parameters: Type.Object({
       thread_ts: Type.String({ description: "Thread to read." }),
       limit: Type.Optional(Type.Number({ description: "Max messages (default 20)" })),
+      download_files: Type.Optional(
+        Type.Boolean({
+          description:
+            "Download attached Slack-hosted files to the local temp cache and return safe descriptors. Defaults to true.",
+        }),
+      ),
       ...SLACK_OUTPUT_OPTION_PARAMETERS,
     }),
     async execute(_id, params) {
       requireToolPolicy(
         "slack_read",
         params.thread_ts,
-        `thread_ts=${params.thread_ts} | limit=${params.limit ?? 20}`,
+        `thread_ts=${params.thread_ts} | limit=${params.limit ?? 20} | download_files=${params.download_files !== false}`,
       );
 
       const channel = (await resolveTrackedThreadChannel(params.thread_ts)) ?? getLastDmChannel();
@@ -2260,42 +2283,149 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
       const messages = response.messages as Record<string, unknown>[];
       const full = params.full === true;
+      const shouldDownloadFiles = params.download_files !== false;
+      const downloadFile = async (
+        fileId: string,
+        messageTs: string,
+      ): Promise<SlackFileDescriptor> =>
+        fetchSlackFileToCache(
+          fileId,
+          { channelId: channel, threadTs: params.thread_ts, messageTs },
+          { slack, token: getBotToken() },
+        );
       const formattedMessages = await Promise.all(
         messages.map(async (message) => {
           const userId = message.user as string | undefined;
           const name = userId ? await resolveUser(userId) : "bot";
           const text = (message.text as string) ?? "";
           const ts = message.ts as string;
-          return { ts, name, text, preview: truncateSlackText(text) };
+          const files = await Promise.all(
+            extractSlackMessageFileMetadata(message.files).map(async (file) => {
+              const fileId = file.id;
+              if (!fileId) {
+                return {
+                  messageTs: ts,
+                  ...(file.name ? { filename: file.name } : {}),
+                  ...(file.mimetype ? { mimetype: file.mimetype } : {}),
+                  ...(file.filetype ? { filetype: file.filetype } : {}),
+                  ...(file.prettyType ? { prettyType: file.prettyType } : {}),
+                  ...(file.size != null ? { size: file.size } : {}),
+                  downloadStatus: "metadata-only",
+                } satisfies Omit<SlackReadFileAttachment, "fileId">;
+              }
+              const base = {
+                fileId,
+                messageTs: ts,
+                ...(file.name ? { filename: file.name } : {}),
+                ...(file.mimetype ? { mimetype: file.mimetype } : {}),
+                ...(file.filetype ? { filetype: file.filetype } : {}),
+                ...(file.prettyType ? { prettyType: file.prettyType } : {}),
+                ...(file.size != null ? { size: file.size } : {}),
+              };
+              if (!shouldDownloadFiles) {
+                return {
+                  ...base,
+                  downloadStatus: "metadata-only",
+                } satisfies SlackReadFileAttachment;
+              }
+              try {
+                const descriptor = await downloadFile(fileId, ts);
+                return {
+                  ...base,
+                  filename: descriptor.filename,
+                  ...(descriptor.mimetype ? { mimetype: descriptor.mimetype } : {}),
+                  ...(descriptor.filetype ? { filetype: descriptor.filetype } : {}),
+                  ...(descriptor.prettyType ? { prettyType: descriptor.prettyType } : {}),
+                  size: descriptor.size,
+                  path: descriptor.path,
+                  sha256: descriptor.sha256,
+                  cacheDir: descriptor.cacheDir,
+                  expiresAt: descriptor.expiresAt,
+                  downloadStatus: "downloaded",
+                } satisfies SlackReadFileAttachment;
+              } catch (error) {
+                return {
+                  ...base,
+                  downloadStatus: "failed",
+                  error: getErrorMessage(error),
+                } satisfies SlackReadFileAttachment;
+              }
+            }),
+          );
+          return { ts, name, text, preview: truncateSlackText(text), files };
         }),
       );
-      const lines = formattedMessages.map((message) =>
-        full
+      const lines = formattedMessages.flatMap((message) => {
+        const messageLine = full
           ? `[${message.ts}] ${message.name}: ${message.text}`
-          : `[${message.ts}] ${message.name}: ${message.preview}`,
+          : `[${message.ts}] ${message.name}: ${message.preview}`;
+        const fileLines = message.files.map((file) => {
+          const filename = file.filename ? ` ${file.filename}` : "";
+          const type = file.prettyType ?? file.filetype ?? file.mimetype ?? "file";
+          if (file.downloadStatus === "downloaded") {
+            return `  [file downloaded] ${file.fileId}${filename} (${type}) -> ${file.path}`;
+          }
+          if (file.downloadStatus === "failed") {
+            return `  [file metadata] ${file.fileId}${filename} (${type}) download failed: ${file.error}`;
+          }
+          return `  [file metadata] ${"fileId" in file ? file.fileId : "unknown-file"}${filename} (${type})`;
+        });
+        return [messageLine, ...fileLines];
+      });
+      const downloadedFilesCount = formattedMessages.reduce(
+        (count, message) =>
+          count + message.files.filter((file) => file.downloadStatus === "downloaded").length,
+        0,
+      );
+      const failedFilesCount = formattedMessages.reduce(
+        (count, message) =>
+          count + message.files.filter((file) => file.downloadStatus === "failed").length,
+        0,
       );
       if (!full && messages.length > 0) {
         lines.push("", "Use args.full=true for exact message text.");
+      }
+      if (downloadedFilesCount > 0 || failedFilesCount > 0) {
+        lines.push(
+          "",
+          `File attachments: ${downloadedFilesCount} downloaded to the local temp cache${failedFilesCount > 0 ? `; ${failedFilesCount} failed and returned metadata only` : ""}.`,
+        );
       }
 
       return {
         content: [{ type: "text", text: lines.join("\n") || "(no messages)" }],
         details: full
-          ? { count: messages.length }
+          ? {
+              count: messages.length,
+              downloadedFilesCount,
+              failedFilesCount,
+              messages: formattedMessages.map((message) => ({
+                ts: message.ts,
+                user: message.name,
+                text: message.text,
+                files: message.files,
+              })),
+            }
           : {
               count: messages.length,
+              downloadedFilesCount,
+              failedFilesCount,
               messages: formattedMessages.map((message) => ({
                 ts: message.ts,
                 user: message.name,
                 preview: message.preview,
+                files: message.files,
               })),
             },
         fullDetails: {
           count: messages.length,
+          downloadedFilesCount,
+          failedFilesCount,
           messages: formattedMessages.map((message) => ({
             ts: message.ts,
             user: message.name,
             text: message.text,
+            files: message.files,
           })),
         },
       };

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -147,6 +147,19 @@ const SLACK_OUTPUT_OPTION_PARAMETERS = {
 
 const SLACK_ACTIONS_WITH_FORMAT_ARG = new Set(["export"]);
 
+const SLACK_LOCAL_FILE_ATTACHMENT_PARAMETERS = Type.Array(
+  Type.Object({
+    path: Type.String({
+      description:
+        "Local file path to attach. For safety, only files inside the current working directory or system temp directory are allowed.",
+    }),
+    filename: Type.Optional(Type.String({ description: "Optional Slack filename override" })),
+    title: Type.Optional(Type.String({ description: "Optional Slack title" })),
+    filetype: Type.Optional(Type.String({ description: "Optional Slack filetype override" })),
+  }),
+  { description: "Optional local files to attach to the same Slack message as text." },
+);
+
 interface SlackActionToolDefinition extends ToolDefinition {
   name: string;
   description?: string;
@@ -194,6 +207,14 @@ const SLACK_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
     {
       action: "post_channel",
       args: { channel: "#deployments", text: "Deploy complete" },
+    },
+    {
+      action: "post_channel",
+      args: {
+        channel: "#deployments",
+        text: "Deploy evidence attached",
+        files: [{ path: "/tmp/evidence.png", filename: "evidence.png" }],
+      },
     },
   ],
   read_channel: [{ action: "read_channel", args: { channel: "#deployments", limit: 20 } }],
@@ -702,6 +723,29 @@ function asTrimmedSlackString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function extractSlackUploadMessageTs(
+  response: Record<string, unknown>,
+  channelId: string,
+): string | undefined {
+  const files = Array.isArray(response.files) ? response.files : [];
+  for (const fileValue of files) {
+    const file = asSlackObject(fileValue);
+    const shares = asSlackObject(file?.shares);
+    for (const shareKind of ["public", "private"] as const) {
+      const shareByChannel = asSlackObject(shares?.[shareKind]);
+      const channelShares = shareByChannel?.[channelId];
+      if (!Array.isArray(channelShares)) continue;
+      for (const shareValue of channelShares) {
+        const share = asSlackObject(shareValue);
+        const ts = asTrimmedSlackString(share?.ts);
+        if (ts) return ts;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 function extractSlackCanvasPermalink(response: Record<string, unknown>): string | undefined {
   const direct =
     asTrimmedSlackString(response.permalink) ??
@@ -875,7 +919,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           ),
         ),
       );
-      await performSlackUploads({
+      const uploadResult = await performSlackUploads({
         uploads,
         channelId: input.channel,
         ...(input.threadTs ? { threadTs: input.threadTs } : {}),
@@ -883,8 +927,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         slack,
         token: getBotToken(),
       });
+      const uploadTs = extractSlackUploadMessageTs(uploadResult.response, input.channel);
       return {
-        threadTs: input.threadTs,
+        ...(uploadTs ? { ts: uploadTs } : {}),
+        threadTs: input.threadTs ?? uploadTs,
         channel: input.channel,
         blocksCount: blocks?.length ?? 0,
         delivery: "slack",
@@ -1891,24 +1937,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           description: "Optional Slack Block Kit blocks JSON array",
         }),
       ),
-      files: Type.Optional(
-        Type.Array(
-          Type.Object({
-            path: Type.String({
-              description:
-                "Local file path to attach. For safety, only files inside the current working directory or system temp directory are allowed.",
-            }),
-            filename: Type.Optional(
-              Type.String({ description: "Optional Slack filename override" }),
-            ),
-            title: Type.Optional(Type.String({ description: "Optional Slack title" })),
-            filetype: Type.Optional(
-              Type.String({ description: "Optional Slack filetype override" }),
-            ),
-          }),
-          { description: "Optional local files to attach to the same Slack reply as text." },
-        ),
-      ),
+      files: Type.Optional(SLACK_LOCAL_FILE_ATTACHMENT_PARAMETERS),
     }),
     async execute(_id, params) {
       requireToolPolicy(
@@ -2726,12 +2755,13 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           description: "Optional Slack Block Kit blocks JSON array",
         }),
       ),
+      files: Type.Optional(SLACK_LOCAL_FILE_ATTACHMENT_PARAMETERS),
     }),
     async execute(_id, params) {
       requireToolPolicy(
         "slack_post_channel",
         params.thread_ts,
-        `channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | text=${params.text} | blocks=${summarizeSlackBlocksForPolicy(params.blocks)}`,
+        `channel=${params.channel ?? getDefaultChannel() ?? ""} | thread_ts=${params.thread_ts ?? ""} | text=${params.text} | blocks=${summarizeSlackBlocksForPolicy(params.blocks)} | files=${Array.isArray(params.files) ? params.files.length : 0}`,
       );
 
       const resolvedThreadChannel = await resolveTrackedThreadChannel(params.thread_ts);
@@ -2750,6 +2780,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         text: params.text,
         ...(params.thread_ts ? { threadTs: params.thread_ts } : {}),
         ...(params.blocks ? { blocks: params.blocks } : {}),
+        ...(params.files ? { files: params.files } : {}),
       });
       const ts = delivery.ts;
       const threadTs = params.thread_ts ?? delivery.threadTs;
@@ -2776,6 +2807,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           channel: channelId,
           blocksCount: delivery.blocksCount,
           delivery: delivery.delivery,
+          filesCount: Array.isArray(params.files) ? params.files.length : 0,
           ...(delivery.adapter ? { adapter: delivery.adapter } : {}),
           ...(delivery.messageId ? { messageId: delivery.messageId } : {}),
           ...(delivery.fallbackReason ? { fallbackReason: delivery.fallbackReason } : {}),


### PR DESCRIPTION
## Summary

- add the same optional `files` attachment shape to the Slack dispatcher `post_channel` action that `slack_send` already supports
- route `post_channel.files` through the shared message delivery path, including Pinet threaded delivery and direct Slack external upload fallback
- make `slack read` download attached Slack-hosted files to the local temp cache by default and return safe descriptors/metadata, with `download_files=false` as an opt-out
- document the consistent outbound and inbound file workflows and add regression coverage for schema discovery, Pinet delivery, direct external upload, and read-time attachment downloads

## Tests

- `pnpm --filter @pinet/slack-bridge test -- slack-tools.test.ts`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- pre-push: `pnpm lint && pnpm typecheck && pnpm test`
