### PR TITLE
fix(slack-bridge): canonicalize guarded delete actions from resolved targets

### DIFF
--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -436,10 +436,13 @@ describe("registerSlackTools", () => {
       confirm: true,
     });
 
+    // The guarded action must carry the RESOLVED channel id so the string in
+    // guardrail errors, confirm_action registrations, and the post-approval
+    // retry always match (#814).
     expect(requireToolPolicy).toHaveBeenCalledWith(
       "slack:delete",
       undefined,
-      "channel=ops-alerts | thread_ts= | ts=123.789 | thread=false",
+      "channel=resolved:ops-alerts | thread_ts= | ts=123.789 | thread=false",
     );
     expect(slack).toHaveBeenCalledWith("chat.delete", "xoxb-reloaded", {
       channel: "resolved:ops-alerts",
@@ -642,7 +645,7 @@ describe("registerSlackTools", () => {
   });
 
   it("uses thread channel resolution for slack_delete", async () => {
-    const { slack, tools, setResolveThreadChannel } = setup();
+    const { slack, tools, setResolveThreadChannel, requireToolPolicy } = setup();
     setResolveThreadChannel(async (threadTs: string | undefined) => {
       expect(threadTs).toBe("123.456");
       return "C-DB";
@@ -658,6 +661,77 @@ describe("registerSlackTools", () => {
       channel: "C-DB",
       ts: "123.789",
     });
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "slack:delete",
+      "123.456",
+      "channel=C-DB | thread_ts=123.456 | ts=123.789 | thread=false",
+    );
+  });
+
+  it("builds the same canonical delete action for omitted and explicit channel phrasings", async () => {
+    const { tools, setResolveThreadChannel, requireToolPolicy } = setup();
+    setResolveThreadChannel(async () => "C-DB");
+
+    await tools.get("slack_delete")!.execute("tool-3c", {
+      ts: "123.789",
+      thread_ts: "123.456",
+      confirm: true,
+    });
+    await tools.get("slack_delete")!.execute("tool-3d", {
+      ts: "123.789",
+      thread_ts: "123.456",
+      channel: "deployments",
+      confirm: true,
+    });
+
+    const actions = requireToolPolicy.mock.calls.map(([, , action]) => action);
+    expect(actions).toHaveLength(2);
+    expect(actions[0]).toBe(actions[1]);
+    expect(actions[0]).toBe("channel=C-DB | thread_ts=123.456 | ts=123.789 | thread=false");
+  });
+
+  it("batch-deletes multiple bot messages under one canonical action", async () => {
+    const { slack, tools, setDefaultChannel, requireToolPolicy } = setup();
+    setDefaultChannel("ops-alerts");
+
+    const response = await tools.get("slack_delete")!.execute("tool-3e", {
+      ts: "123.790, 123.788,123.790",
+      confirm: true,
+    });
+
+    // One normalized (deduped, sorted) canonical action covers the batch, so a
+    // single explicit approval is enough to clean up several bot messages.
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "slack:delete",
+      undefined,
+      "channel=resolved:ops-alerts | thread_ts= | ts=123.788,123.790 | thread=false",
+    );
+    const deletes = slack.mock.calls.filter(([method]) => method === "chat.delete");
+    expect(deletes).toEqual([
+      ["chat.delete", "xoxb-initial", { channel: "resolved:ops-alerts", ts: "123.788" }],
+      ["chat.delete", "xoxb-initial", { channel: "resolved:ops-alerts", ts: "123.790" }],
+    ]);
+    expect(response.content?.[0]?.text).toContain("Deleted 2 messages (123.788, 123.790)");
+    expect(response.details).toMatchObject({
+      channel: "resolved:ops-alerts",
+      thread: false,
+      deleted_count: 2,
+      deleted_ts: ["123.788", "123.790"],
+    });
+  });
+
+  it("rejects multiple ts values when thread=true", async () => {
+    const { slack, tools, setDefaultChannel } = setup();
+    setDefaultChannel("ops-alerts");
+
+    await expect(
+      tools.get("slack_delete")!.execute("tool-3f", {
+        ts: "123.788,123.790",
+        thread: true,
+        confirm: true,
+      }),
+    ).rejects.toThrow("When thread=true, ts must be a single thread root timestamp.");
+    expect(slack.mock.calls.filter(([method]) => method === "chat.delete")).toHaveLength(0);
   });
 
   it("reports presence and dnd status for a single user", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -808,14 +808,48 @@ function isPiAgentSlackMessage(
   return (eventPayload as { agent_owner?: unknown }).agent_owner === agentOwnerToken;
 }
 
+/**
+ * Build the canonical guarded action string for a Slack delete.
+ *
+ * This must be derived from RESOLVED values (resolved channel ID, normalized
+ * ts list) — never raw caller params — so that the string quoted in guardrail
+ * errors, registered via confirm_action, and re-checked on the post-approval
+ * retry always agree regardless of how the caller phrased the request (#814).
+ */
 function summarizeSlackDeleteAction(input: {
-  channel?: string;
-  defaultChannel?: string;
+  channel: string;
   threadTs?: string;
-  ts: string;
+  tsList: string[];
   thread?: boolean;
 }): string {
-  return `channel=${input.channel ?? input.defaultChannel ?? ""} | thread_ts=${input.threadTs ?? ""} | ts=${input.ts} | thread=${input.thread ?? false}`;
+  return `channel=${input.channel} | thread_ts=${input.threadTs ?? ""} | ts=${input.tsList.join(",")} | thread=${input.thread ?? false}`;
+}
+
+/**
+ * Normalize the delete `ts` input into a deterministic target list.
+ *
+ * Multiple comma/whitespace-separated timestamps are allowed for single-message
+ * deletes so one explicit approval can cover one batch of bot-authored cleanup
+ * messages in the same thread (#814). The list is trimmed, deduplicated, and
+ * sorted so the canonical action string is stable across caller phrasings.
+ */
+function parseSlackDeleteTsInput(ts: string, deleteThread: boolean): string[] {
+  const tsList = [
+    ...new Set(
+      ts
+        .split(/[\s,]+/)
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    ),
+  ].sort();
+
+  if (tsList.length === 0) {
+    throw new Error("ts is required.");
+  }
+  if (deleteThread && tsList.length > 1) {
+    throw new Error("When thread=true, ts must be a single thread root timestamp.");
+  }
+  return tsList;
 }
 
 export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDeps): void {
@@ -1348,19 +1382,18 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
   }
 
   async function resolveSlackDeleteTargets(input: {
-    channel?: string;
-    threadTs?: string;
-    ts: string;
+    channelId: string;
+    tsList: string[];
     thread?: boolean;
   }): Promise<{ channelId: string; messageTsList: string[] }> {
-    const channelId = await resolveSlackTargetChannel(input.threadTs, input.channel);
-    const targetTs = input.ts.trim();
+    const { channelId } = input;
+    const targetTs = input.tsList[0];
     if (!targetTs) {
       throw new Error("ts is required.");
     }
 
     if (!input.thread) {
-      return { channelId, messageTsList: [targetTs] };
+      return { channelId, messageTsList: input.tsList };
     }
 
     const messages = await fetchSlackThreadMessages(
@@ -1376,7 +1409,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         : undefined;
     if (!threadRootTs) {
       throw new Error(
-        `Slack did not return a thread rooted at ${targetTs} in channel ${input.channel ?? channelId}.`,
+        `Slack did not return a thread rooted at ${targetTs} in channel ${channelId}.`,
       );
     }
     if (threadRootTs !== targetTs) {
@@ -2956,7 +2989,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     parameters: Type.Object({
       ts: Type.String({
         description:
-          "Timestamp (ts) of the message to delete. When thread=true, this must be the thread root timestamp.",
+          "Timestamp (ts) of the message to delete, or a comma-separated list of bot-posted message timestamps to delete in one confirmed batch. When thread=true, this must be a single thread root timestamp.",
       }),
       channel: Type.Optional(
         Type.String({
@@ -2988,23 +3021,29 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         );
       }
 
+      const deleteThread = params.thread === true;
+      const requestedTsList = parseSlackDeleteTsInput(params.ts, deleteThread);
+
+      // Resolve the actual deletion channel BEFORE the guardrail check so the
+      // canonical action quoted in errors, registered via confirm_action, and
+      // enforced on the post-approval retry is identical regardless of how the
+      // caller phrased channel/ts (#814).
+      const channelId = await resolveSlackTargetChannel(params.thread_ts, params.channel);
+
       requireToolPolicy(
         "slack_delete",
         params.thread_ts,
         summarizeSlackDeleteAction({
-          channel: params.channel,
-          defaultChannel: getDefaultChannel(),
+          channel: channelId,
           threadTs: params.thread_ts,
-          ts: params.ts,
-          thread: params.thread,
+          tsList: requestedTsList,
+          thread: deleteThread,
         }),
       );
 
-      const deleteThread = params.thread === true;
-      const { channelId, messageTsList } = await resolveSlackDeleteTargets({
-        channel: params.channel,
-        threadTs: params.thread_ts,
-        ts: params.ts,
+      const { messageTsList } = await resolveSlackDeleteTargets({
+        channelId,
+        tsList: requestedTsList,
         thread: deleteThread,
       });
 
@@ -3015,7 +3054,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         });
       }
 
-      const targetTs = params.ts.trim();
+      const targetTs = requestedTsList[0];
       const deletedCount = messageTsList.length;
       const channelLabel = params.channel ?? channelId;
 
@@ -3025,7 +3064,9 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
             type: "text",
             text: deleteThread
               ? `Deleted thread rooted at ${targetTs} in channel ${channelLabel} (${deletedCount} message${deletedCount === 1 ? "" : "s"}).`
-              : `Deleted message ${targetTs} from channel ${channelLabel}.`,
+              : deletedCount === 1
+                ? `Deleted message ${targetTs} from channel ${channelLabel}.`
+                : `Deleted ${deletedCount} messages (${messageTsList.join(", ")}) from channel ${channelLabel}.`,
           },
         ],
         details: {


### PR DESCRIPTION
Closes #814. Companion to #813 (same incident family, separate concern).

## Problem
`slack_delete` enforcement built its canonical action string from **raw caller params** (`channel=${params.channel ?? defaultChannel ?? ""}`), while the actual deletion channel resolves via tracked-thread → explicit → DM → default. `confirm_action` registers whatever string the agent passes, and approval matching is byte-exact. So any phrasing drift (omitted channel, #name vs ID, default-channel fallback) meant:
1. approval registered ≠ action enforced → post-approval delete failed,
2. the failure quoted a *new* canonical string → second confirmation prompt,
3. prompts are bot messages whose cleanup recurses through the same guardrail,
4. a stale pending blocked the thread for the 5-minute TTL.

This cost Thomas literal hours when trying to delete a single mistaken bot reply.

## Changes
- **Canonical action from resolved values**: the delete handler resolves the target channel *before* the guardrail check and builds the action string from the resolved channel ID plus a normalized (trimmed/deduped/sorted) ts list. Guardrail errors, confirm_action registrations, and post-approval retries now always agree, so a copied confirmation approves first try regardless of phrasing.
- **Single approval for batch cleanup**: `ts` accepts a comma/whitespace-separated list of bot-posted message timestamps for non-thread deletes. The approved canonical action enumerates the exact timestamps — one explicit approval covers one batch of cleanup messages, no blanket grants. `thread=true` still requires a single root ts.
- **Protections preserved**: `confirm=true` still required; whole-thread deletes still verify pi-agent authorship of every message; Slack's API still rejects deleting other authors' messages with a bot token.

## Tests
- Canonical action equality across omitted/explicit channel phrasings
- Resolved-channel canonical strings (default-channel and tracked-thread paths)
- Batch delete: normalized canonical action, per-ts `chat.delete` calls, result details
- Multi-ts rejection when `thread=true`
- Full repo: `pnpm lint` ✅ `pnpm typecheck` ✅ `pnpm test` ✅ (10/10 turbo tasks)

## Possible follow-up (not in scope)
Auto-deleting the bot's own confirmation prompt after a decision would remove the residual prompt-cleanup step entirely; left out to keep this change focused.