### PR TITLE
Make Pinet dispatcher results human-readable in Pi

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       "@earendil-works/pi-coding-agent":
         specifier: ^0.74.0
         version: 0.74.0(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-tui":
+        specifier: ^0.74.0
+        version: 0.74.0
 
   transport-core: {}
 

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -57,9 +57,11 @@
   },
   "types": "./dist/index.d.ts",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.74.0"
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0"
   }
 }

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -1,16 +1,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
+  formatPinetDispatcherResultForDisplay,
   registerPinetTools,
   type PinetToolsAgentRecord,
   type RegisterPinetToolsDeps,
 } from "./pinet-tools.js";
+
+interface MinimalRenderTheme {
+  fg: (_color: string, text: string) => string;
+  bold: (text: string) => string;
+}
+
+interface MinimalComponent {
+  render(width: number): string[];
+}
 
 type ToolDefinition = {
   name: string;
   promptSnippet?: string;
   parameters?: unknown;
   execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
+  renderResult?: (
+    result: { content?: Array<{ type: string; text?: string }>; details?: unknown },
+    options: { expanded: boolean; isPartial?: boolean },
+    theme: MinimalRenderTheme,
+    context: unknown,
+  ) => MinimalComponent;
 };
 
 function makeAgent(overrides: Partial<PinetToolsAgentRecord> = {}): PinetToolsAgentRecord {
@@ -309,6 +325,50 @@ describe("registerPinetTools", () => {
     expect(result.content[0]?.text).not.toContain('"errors"');
     expect(result.details.status).toBe("failed");
     expect(result.details.errors[0]?.message).toBe("Unknown Pinet action: skin");
+  });
+
+  it("formats Pinet dispatcher results for human-readable TUI display", async () => {
+    const tools = registerWithDeps(createDeps());
+    const result = (await tools.get("pinet")?.execute("tool-call-schedule-json", {
+      action: "schedule",
+      args: { at: "2026-07-01T00:05:00.000Z", message: "check queue", format: "json" },
+    })) as { content: Array<{ type: string; text: string }>; details: unknown };
+
+    expect(result.content[0]?.text).toContain('"status": "succeeded"');
+
+    const collapsed = formatPinetDispatcherResultForDisplay(result, false);
+    const expanded = formatPinetDispatcherResultForDisplay(result, true);
+
+    expect(collapsed).toEqual({
+      status: "succeeded",
+      text: "Pinet wake-up scheduled for 2026-07-01T00:05:00.000Z.",
+    });
+    expect(expanded.text).toContain("status: succeeded");
+    expect(expanded.text).toContain("action: schedule");
+    expect(expanded.text).toContain("id: 7");
+    expect(expanded.text).not.toContain('"errors"');
+  });
+
+  it("renders Pinet dispatcher results as readable text instead of raw JSON", async () => {
+    const tools = registerWithDeps(createDeps());
+    const pinet = tools.get("pinet");
+    const result = (await pinet?.execute("tool-call-send-json", {
+      action: "send",
+      args: { to: "alpha", message: "dispatch now", format: "json" },
+    })) as { content: Array<{ type: string; text: string }>; details: unknown };
+    const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
+
+    const collapsed = pinet?.renderResult?.(result, { expanded: false }, theme, {}).render(200);
+    const expanded = pinet?.renderResult?.(result, { expanded: true }, theme, {}).render(200);
+
+    expect(result.content[0]?.text).toContain('"status": "succeeded"');
+    const collapsedText = collapsed?.map((line) => line.trimEnd()).join("\n");
+    const expandedText = expanded?.map((line) => line.trimEnd()).join("\n");
+
+    expect(collapsedText).toBe("✓ Pinet message sent to alpha.");
+    expect(expandedText).toContain("details:");
+    expect(expandedText).toContain("messageId: 17");
+    expect(expandedText).not.toContain('"status"');
   });
 
   it("uses the broker broadcast path for broadcast dispatcher send targets", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -15,6 +15,7 @@ import {
   resolveScheduledWakeupFireAt,
 } from "@pinet/pinet-core/scheduled-wakeups";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import {
   buildAgentDisplayInfo,
@@ -199,6 +200,16 @@ interface PinetDispatcherEnvelope {
   data: unknown;
   errors: PinetDispatcherError[];
   warnings: string[];
+}
+
+interface PinetRenderContentBlock {
+  type: string;
+  text?: string;
+}
+
+interface PinetRenderResultInput {
+  content?: PinetRenderContentBlock[];
+  details?: unknown;
 }
 
 const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> = {
@@ -472,6 +483,82 @@ function wrapDispatcherEnvelope(
       },
     ],
     details: envelope,
+  };
+}
+
+function isPinetDispatcherEnvelope(value: unknown): value is PinetDispatcherEnvelope {
+  if (!isRecord(value)) return false;
+  if (value.status !== "succeeded" && value.status !== "failed") return false;
+  return Array.isArray(value.errors) && Array.isArray(value.warnings);
+}
+
+function getFirstTextContent(result: PinetRenderResultInput): string {
+  return (
+    result.content?.find((block) => block.type === "text" && typeof block.text === "string")
+      ?.text ?? ""
+  );
+}
+
+function parsePinetDispatcherEnvelopeFromText(text: string): PinetDispatcherEnvelope | null {
+  if (!text.trim().startsWith("{")) return null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isPinetDispatcherEnvelope(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatPrimitiveDetails(details: Record<string, unknown>): string[] {
+  return Object.entries(details).map(([key, value]) => {
+    if (value === null) return `${key}: null`;
+    if (["string", "number", "boolean"].includes(typeof value)) return `${key}: ${String(value)}`;
+    return `${key}: ${JSON.stringify(value)}`;
+  });
+}
+
+function formatPinetEnvelopeExpandedText(envelope: PinetDispatcherEnvelope): string {
+  const lines = [getPinetEnvelopeCliText(envelope), `status: ${envelope.status}`];
+
+  if (envelope.status === "failed") {
+    for (const error of envelope.errors) {
+      lines.push(`error[${error.class}]: ${error.message}`);
+      if (error.hint) lines.push(`hint: ${error.hint}`);
+    }
+  } else if (isRecord(envelope.data)) {
+    const action = typeof envelope.data.action === "string" ? envelope.data.action : undefined;
+    if (action) lines.push(`action: ${action}`);
+
+    const details = envelope.data.details;
+    if (isRecord(details)) {
+      lines.push("details:");
+      lines.push(...formatPrimitiveDetails(details).map((line) => `  ${line}`));
+    }
+  }
+
+  for (const warning of envelope.warnings) {
+    lines.push(`warning: ${warning}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatPinetDispatcherResultForDisplay(
+  result: PinetRenderResultInput,
+  expanded: boolean,
+): { status: PinetDispatcherStatus | "unknown"; text: string } {
+  const firstText = getFirstTextContent(result);
+  const envelope = isPinetDispatcherEnvelope(result.details)
+    ? result.details
+    : parsePinetDispatcherEnvelopeFromText(firstText);
+
+  if (!envelope) {
+    return { status: "unknown", text: firstText || "Pinet result." };
+  }
+
+  return {
+    status: envelope.status,
+    text: expanded ? formatPinetEnvelopeExpandedText(envelope) : getPinetEnvelopeCliText(envelope),
   };
 }
 
@@ -1750,6 +1837,44 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
         }),
       ),
     }),
+    renderCall(args, theme) {
+      const action =
+        typeof args.action === "string" && args.action.trim() ? args.action.trim() : "?";
+      let suffix = "";
+      if (isRecord(args.args)) {
+        const topic = typeof args.args.topic === "string" ? args.args.topic.trim() : "";
+        const op = typeof args.args.op === "string" ? args.args.op.trim() : "";
+        if (topic) suffix = ` ${theme.fg("dim", `topic=${topic}`)}`;
+        else if (op) suffix = ` ${theme.fg("dim", `op=${op}`)}`;
+      }
+      return new Text(
+        `${theme.fg("toolTitle", theme.bold("pinet"))} ${theme.fg("muted", action)}${suffix}`,
+        0,
+        0,
+      );
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      if (isPartial) {
+        return new Text(theme.fg("warning", "Pinet running…"), 0, 0);
+      }
+
+      const display = formatPinetDispatcherResultForDisplay(result, expanded);
+      const color =
+        display.status === "failed"
+          ? "error"
+          : display.status === "succeeded"
+            ? "success"
+            : "muted";
+      const icon = display.status === "failed" ? "✗" : display.status === "succeeded" ? "✓" : "•";
+      const lines = display.text.split("\n");
+      const first = lines[0] ?? "Pinet result.";
+      const rest = lines.slice(1).map((line) => theme.fg("dim", line));
+      return new Text(
+        [`${theme.fg(color, icon)} ${theme.fg(color, first)}`, ...rest].join("\n"),
+        0,
+        0,
+      );
+    },
     async execute(toolCallId, params) {
       let normalizedAction: PinetDispatcherAction;
       try {


### PR DESCRIPTION
## Summary\n- add custom renderCall/renderResult for the compact Pinet dispatcher\n- render JSON/full dispatcher envelopes as readable success/error summaries in Pi, with compact expanded details\n- add renderer tests for explicit JSON output so the model contract stays structured while the TUI stays readable\n- add @earendil-works/pi-tui as a peer/dev dependency for slack-bridge renderer usage\n\n## Validation\n- pnpm --filter @pinet/slack-bridge typecheck\n- pnpm --filter @pinet/slack-bridge lint\n- env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test\n- pnpm --filter @pinet/slack-bridge build