### PR TITLE
Add Pinet a2a comment compatibility shims

### DIFF
--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -1584,6 +1584,46 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("filters inbox reads by legacy a2a compatibility thread before applying read limits", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    try {
+      db.createThread("a2a:worker:broker", "agent", "", null);
+      db.createThread("a2a:other:broker", "agent", "", null);
+      const legacy = db.insertMessage(
+        "a2a:worker:broker",
+        "agent",
+        "inbound",
+        "worker",
+        "legacy comment",
+        ["broker"],
+        { legacyThreadId: "pr-820-review", a2aCompat: true },
+      );
+      db.insertMessage(
+        "a2a:other:broker",
+        "agent",
+        "inbound",
+        "other",
+        "newer unrelated mail",
+        ["broker"],
+        { legacyThreadId: "other-thread", a2aCompat: true },
+      );
+
+      const read = db.readInbox("broker", {
+        legacyThreadId: "pr-820-review",
+        limit: 1,
+        unreadOnly: false,
+        markRead: false,
+      });
+
+      expect(read.totalMatching).toBe(1);
+      expect(read.messages).toHaveLength(1);
+      expect(read.messages[0].message.id).toBe(legacy.id);
+    } finally {
+      db.close();
+    }
+  });
+
   it("acquires requested and allocated port leases with active uniqueness", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -4051,6 +4051,7 @@ export class BrokerDB implements BrokerDBInterface {
     const markRead = options.markRead ?? true;
     const limit = Math.min(Math.max(Math.trunc(options.limit ?? 20), 1), 100);
     const threadId = options.threadId?.trim();
+    const legacyThreadId = options.legacyThreadId?.trim();
     const unreadCountBefore = this.getUnreadInboxCount(agentId);
 
     const clauses = ["i.agent_id = ?"];
@@ -4062,6 +4063,20 @@ export class BrokerDB implements BrokerDBInterface {
       clauses.push("m.thread_id = ?");
       values.push(threadId);
     }
+    if (legacyThreadId) {
+      clauses.push("json_extract(m.metadata, '$.legacyThreadId') = ?");
+      values.push(legacyThreadId);
+    }
+
+    const totalMatchingRow = db
+      .prepare(
+        `SELECT COUNT(*) AS count
+         FROM inbox i
+         JOIN messages m ON m.id = i.message_id
+         WHERE ${clauses.join(" AND ")}`,
+      )
+      .get(...values) as { count?: number } | undefined;
+    const totalMatching = Number(totalMatchingRow?.count ?? 0);
 
     const order = unreadOnly ? "m.created_at ASC, i.id ASC" : "m.created_at DESC, i.id DESC";
     const limitClause = unreadOnly ? "" : "\n         LIMIT ?";
@@ -4164,6 +4179,7 @@ export class BrokerDB implements BrokerDBInterface {
     const unreadThreads = this.getUnreadThreadSummary(agentId);
     return {
       messages: prioritizedMessages,
+      totalMatching,
       unreadCountBefore,
       unreadCountAfter,
       unreadThreads,

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -70,6 +70,7 @@ export interface InboxEntry {
 
 export interface InboxReadOptions {
   threadId?: string;
+  legacyThreadId?: string;
   limit?: number;
   unreadOnly?: boolean;
   markRead?: boolean;
@@ -88,6 +89,7 @@ export interface InboxThreadUnreadSummary {
 
 export interface InboxReadResult {
   messages: Array<{ entry: InboxEntry; message: BrokerMessage }>;
+  totalMatching: number;
   unreadCountBefore: number;
   unreadCountAfter: number;
   unreadThreads: InboxThreadUnreadSummary[];

--- a/pinet-core/pinet-read-formatting.ts
+++ b/pinet-core/pinet-read-formatting.ts
@@ -40,6 +40,7 @@ export interface PinetUnreadThreadSummary {
 
 export interface PinetReadResult {
   messages: PinetReadMessage[];
+  totalMatching?: number;
   unreadCountBefore: number;
   unreadCountAfter: number;
   unreadThreads: PinetUnreadThreadSummary[];
@@ -48,6 +49,7 @@ export interface PinetReadResult {
 
 export interface PinetReadOptions {
   threadId?: string;
+  legacyThreadId?: string;
   limit?: number;
   unreadOnly?: boolean;
   markRead?: boolean;

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -516,9 +516,11 @@ Only broker prompt content is replaceable. Broker runtime/tool restrictions rema
 
 ### Multi-agent tools
 
-| Tool    | Description                                                                                                                                                                |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pinet` | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `snooze`, `schedule`, `agents`, `lanes`, `ports`, `spawn`, `reload`, `exit`) |
+| Tool           | Description                                                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pinet`        | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `snooze`, `schedule`, `agents`, `lanes`, `ports`, `spawn`, `reload`, `exit`) |
+| `comment_add`  | Legacy PiComms/a2a compatibility shim that sends comment-shaped coordination through Pinet to the visible broker or subtree broker                                         |
+| `comment_list` | Legacy PiComms/a2a compatibility shim that returns this agent's Pinet inbox rows as comment-shaped records without restoring the removed local PiComms store               |
 
 Use the dispatcher for Pinet tool actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=snooze`, `pinet action=schedule`, `pinet action=agents`, `pinet action=lanes`, `pinet action=ports`, `pinet action=spawn`, `pinet action=reload`, and `pinet action=exit`. Use slash commands for UI lifecycle transitions: `/pinet start`, `/pinet follow`, `/pinet unfollow`, and `/pinet subtree start`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
 
@@ -529,6 +531,8 @@ Use `pinet action=spawn args.repo=<repo> args.task=<task> [args.role=<role>] [ar
 Dispatcher content defaults to terse CLI-style confirmations/summaries for noisy reads, sends, and agent lists. Bulky read/agent payloads are compacted in `data.details` by default, including when `args.format="json"` (or `args.f` / `args["-f"]`) renders the dispatcher envelope in content. Use `args.full=true` / `args["--full"]=true` only when you need verbose text and full structured debug details such as exact message bodies or agent metadata.
 
 Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet action=read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
+
+The `comment_add` / `comment_list` tools are compatibility shims for older a2a/PiComms-aware agents and reviewers. They do not re-enable the local `.pi/a2a/comments` store; `comment_add` packages the legacy comment fields into Pinet metadata/body and sends them to the visible broker (or a worker-owned subtree broker), while `comment_list` reads this agent's own Pinet inbox and maps rows into the old comment-shaped response contract. They are registered unconditionally as a temporary migration bridge so older reviewer agents fail less often while the legacy comment callers are phased out.
 
 Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are persisted/stamped as Pinet follow-up mail and surfaced through compact `pinet action=read` pointers rather than direct reminder-body prompts. Wake-up bodies and metadata are treated as mail content only; they do not trigger Pinet remote-control commands such as `/exit`, `/reload`, or structured `pinet:control` JSON.
 

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -428,6 +428,7 @@ export class BrokerClient {
   async readInbox(options: PinetReadOptions = {}): Promise<PinetReadResult> {
     const result = (await this.request("inbox.read", {
       ...(options.threadId ? { threadId: options.threadId } : {}),
+      ...(options.legacyThreadId ? { legacyThreadId: options.legacyThreadId } : {}),
       ...(typeof options.limit === "number" ? { limit: options.limit } : {}),
       ...(typeof options.unreadOnly === "boolean" ? { unreadOnly: options.unreadOnly } : {}),
       ...(typeof options.markRead === "boolean" ? { markRead: options.markRead } : {}),
@@ -436,6 +437,7 @@ export class BrokerClient {
         entry: { id: number; delivered: boolean; readAt: string | null };
         message: InboxItem["message"];
       }>;
+      totalMatching?: number;
       unreadCountBefore: number;
       unreadCountAfter: number;
       unreadThreads: PinetUnreadThreadSummary[];
@@ -449,6 +451,7 @@ export class BrokerClient {
         readAt: item.entry.readAt,
         message: item.message,
       })),
+      ...(typeof result.totalMatching === "number" ? { totalMatching: result.totalMatching } : {}),
       unreadCountBefore: result.unreadCountBefore,
       unreadCountAfter: result.unreadCountAfter,
       unreadThreads: result.unreadThreads,

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -718,6 +718,12 @@ export class BrokerSocketServer {
       return rpcError(req.id, RPC_INVALID_PARAMS, "threadId must be a non-empty string");
     }
 
+    const legacyThreadId =
+      typeof params.legacyThreadId === "string" ? params.legacyThreadId.trim() : undefined;
+    if (params.legacyThreadId !== undefined && !legacyThreadId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "legacyThreadId must be a non-empty string");
+    }
+
     const limit = params.limit === undefined ? undefined : params.limit;
     if (limit !== undefined && (typeof limit !== "number" || !Number.isFinite(limit))) {
       return rpcError(req.id, RPC_INVALID_PARAMS, "limit must be a finite number");
@@ -737,6 +743,7 @@ export class BrokerSocketServer {
       req.id,
       this.db.readInbox(state.agentId, {
         ...(threadId ? { threadId } : {}),
+        ...(legacyThreadId ? { legacyThreadId } : {}),
         ...(typeof limit === "number" ? { limit } : {}),
         ...(typeof unreadOnly === "boolean" ? { unreadOnly } : {}),
         ...(typeof markRead === "boolean" ? { markRead } : {}),

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1295,6 +1295,15 @@ export default function (pi: ExtensionAPI) {
       snoozeRalphLoop: (input) => brokerRuntime.snoozeRalphLoop(input),
       clearRalphSnooze: () => brokerRuntime.clearRalphSnooze(),
     },
+    pinetA2ACompatTools: {
+      pinetEnabled: () => pinetEnabled,
+      brokerRole: () => brokerRole,
+      requireToolPolicy,
+      sendPinetAgentMessage,
+      readPinetInbox,
+      listBrokerAgents,
+      listFollowerAgents,
+    },
     iMessageTools: {
       pinetEnabled: () => pinetEnabled,
       brokerRole: () => brokerRole,

--- a/slack-bridge/pinet-a2a-compat.test.ts
+++ b/slack-bridge/pinet-a2a-compat.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  buildCompatCommentMessage,
+  mapPinetReadResultToCompatComments,
+  registerPinetA2ACompatTools,
+} from "./pinet-a2a-compat.js";
+import type { PinetReadResult } from "@pinet/pinet-core/pinet-read-formatting";
+
+function makeReadResult(): PinetReadResult {
+  return {
+    messages: [
+      {
+        inboxId: 7,
+        delivered: true,
+        readAt: null,
+        message: {
+          id: 42,
+          threadId: "a2a:worker:broker",
+          source: "agent",
+          direction: "inbound",
+          sender: "worker",
+          body: "A2A compatibility comment\nThread: review\nActor: agent:reviewer\n\nLooks good",
+          metadata: {
+            a2a: true,
+            a2aCompat: true,
+            legacyThreadId: "review",
+            legacyActorType: "agent",
+            legacyActorId: "reviewer",
+            legacyContext: { file: "src/app.ts", startLine: 4, endLine: 2 },
+          },
+          createdAt: "2026-01-02T03:04:05.000Z",
+        },
+      },
+    ],
+    unreadCountBefore: 1,
+    unreadCountAfter: 1,
+    unreadThreads: [],
+    markedReadIds: [],
+  };
+}
+
+describe("Pinet A2A compatibility helpers", () => {
+  it("builds a Pinet message that preserves legacy comment fields in metadata", () => {
+    const result = buildCompatCommentMessage({
+      comment: "Please check this",
+      thread_id: "ctx:src/app.ts:10-12",
+      actor_type: "human",
+      actor_id: "will",
+      file: "src/app.ts",
+      start_line: 12,
+      end_line: 10,
+    });
+
+    expect(result.body).toContain("A2A compatibility comment");
+    expect(result.body).toContain("Thread: ctx:src/app.ts:10-12");
+    expect(result.body).toContain("Context: src/app.ts:10-12");
+    expect(result.body).toContain("Please check this");
+    expect(result.metadata).toMatchObject({
+      a2aCompat: true,
+      legacyTool: "comment_add",
+      legacyThreadId: "ctx:src/app.ts:10-12",
+      legacyActorType: "human",
+      legacyActorId: "will",
+      legacyContext: { file: "src/app.ts", startLine: 10, endLine: 12 },
+    });
+  });
+
+  it("derives legacy context thread ids when no explicit thread id is supplied", () => {
+    const result = buildCompatCommentMessage({
+      comment: "Inline note",
+      file: "src/app.ts",
+      start_line: 12,
+      end_line: 10,
+    });
+
+    expect(result.threadId).toBe("ctx:src/app.ts:10-12");
+    expect(result.metadata).toMatchObject({
+      legacyThreadId: "ctx:src/app.ts:10-12",
+      legacyContext: { file: "src/app.ts", startLine: 10, endLine: 12 },
+    });
+  });
+
+  it("maps Pinet inbox rows back into comment-shaped records", () => {
+    const readResult = makeReadResult();
+    readResult.totalMatching = 4;
+    const result = mapPinetReadResultToCompatComments(readResult, "review");
+
+    expect(result).toMatchObject({
+      threadId: "review",
+      total: 4,
+      comments: [
+        {
+          id: "pinet-42",
+          threadId: "review",
+          actorType: "agent",
+          actorId: "reviewer",
+          bodyPath: "pinet:42",
+          body: "Looks good",
+          context: { file: "src/app.ts", startLine: 2, endLine: 4 },
+          pinetThreadId: "a2a:worker:broker",
+          pinetMessageId: 42,
+        },
+      ],
+    });
+  });
+});
+
+describe("registerPinetA2ACompatTools", () => {
+  it("sends legacy comment_add through the visible broker agent", async () => {
+    const tools = new Map<
+      string,
+      { execute: (id: string, params: Record<string, unknown>) => Promise<unknown> }
+    >();
+    const sendPinetAgentMessage = vi.fn(async () => ({ messageId: 123, target: "broker-1" }));
+    const pi = {
+      registerTool: vi.fn(
+        (definition: {
+          name: string;
+          execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
+        }) => {
+          tools.set(definition.name, definition);
+        },
+      ),
+    } as unknown as ExtensionAPI;
+
+    registerPinetA2ACompatTools(pi, {
+      pinetEnabled: () => true,
+      brokerRole: () => "follower",
+      requireToolPolicy: vi.fn(),
+      sendPinetAgentMessage,
+      readPinetInbox: vi.fn(async () => makeReadResult()),
+      listBrokerAgents: () => [],
+      listFollowerAgents: vi.fn(async () => [
+        {
+          emoji: "📔",
+          name: "The Broker",
+          id: "broker-1",
+          status: "idle" as const,
+          metadata: { role: "broker" },
+          lastHeartbeat: "2026-01-02T03:04:05.000Z",
+        },
+      ]),
+    });
+
+    const result = await tools.get("comment_add")?.execute("tool-1", {
+      comment: "Review posted",
+      thread_id: "pr-819-review",
+    });
+
+    expect(sendPinetAgentMessage).toHaveBeenCalledWith(
+      "broker-1",
+      expect.stringContaining("Review posted"),
+      expect.objectContaining({
+        a2aCompat: true,
+        legacyThreadId: "pr-819-review",
+      }),
+    );
+    expect(result).toMatchObject({
+      details: { id: "pinet-123", threadId: "pr-819-review", target: "broker-1" },
+    });
+  });
+
+  it("does not silently send legacy comment_add to a disconnected broker", async () => {
+    const tools = new Map<
+      string,
+      { execute: (id: string, params: Record<string, unknown>) => Promise<unknown> }
+    >();
+    const sendPinetAgentMessage = vi.fn(async () => ({ messageId: 123, target: "broker-1" }));
+    const pi = {
+      registerTool: vi.fn(
+        (definition: {
+          name: string;
+          execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
+        }) => {
+          tools.set(definition.name, definition);
+        },
+      ),
+    } as unknown as ExtensionAPI;
+
+    registerPinetA2ACompatTools(pi, {
+      pinetEnabled: () => true,
+      brokerRole: () => "follower",
+      requireToolPolicy: vi.fn(),
+      sendPinetAgentMessage,
+      readPinetInbox: vi.fn(async () => makeReadResult()),
+      listBrokerAgents: () => [],
+      listFollowerAgents: vi.fn(async () => [
+        {
+          emoji: "📔",
+          name: "The Broker",
+          id: "broker-1",
+          status: "idle" as const,
+          metadata: { role: "broker" },
+          lastHeartbeat: "2026-01-02T03:04:05.000Z",
+          disconnectedAt: "2026-01-02T03:05:00.000Z",
+        },
+      ]),
+    });
+
+    await expect(
+      tools.get("comment_add")?.execute("tool-1", {
+        comment: "Review posted",
+        thread_id: "pr-819-review",
+      }),
+    ).rejects.toThrow("No live Pinet broker/subtree broker agent");
+    expect(sendPinetAgentMessage).not.toHaveBeenCalled();
+  });
+
+  it("defaults comment_list to the legacy global thread", async () => {
+    const tools = new Map<
+      string,
+      { execute: (id: string, params: Record<string, unknown>) => Promise<unknown> }
+    >();
+    const readPinetInbox = vi.fn(async () => makeReadResult());
+    const pi = {
+      registerTool: vi.fn(
+        (definition: {
+          name: string;
+          execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
+        }) => {
+          tools.set(definition.name, definition);
+        },
+      ),
+    } as unknown as ExtensionAPI;
+
+    registerPinetA2ACompatTools(pi, {
+      pinetEnabled: () => true,
+      brokerRole: () => "follower",
+      requireToolPolicy: vi.fn(),
+      sendPinetAgentMessage: vi.fn(async () => ({ messageId: 123, target: "broker-1" })),
+      readPinetInbox,
+      listBrokerAgents: () => [],
+      listFollowerAgents: vi.fn(async () => []),
+    });
+
+    await tools.get("comment_list")?.execute("tool-2", {});
+
+    expect(readPinetInbox).toHaveBeenCalledWith({
+      legacyThreadId: "global",
+      unreadOnly: false,
+      markRead: false,
+    });
+  });
+
+  it("reads legacy thread ids through the broker-side metadata filter before limiting", async () => {
+    const tools = new Map<
+      string,
+      { execute: (id: string, params: Record<string, unknown>) => Promise<unknown> }
+    >();
+    const readPinetInbox = vi.fn(async () => makeReadResult());
+    const pi = {
+      registerTool: vi.fn(
+        (definition: {
+          name: string;
+          execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
+        }) => {
+          tools.set(definition.name, definition);
+        },
+      ),
+    } as unknown as ExtensionAPI;
+
+    registerPinetA2ACompatTools(pi, {
+      pinetEnabled: () => true,
+      brokerRole: () => "follower",
+      requireToolPolicy: vi.fn(),
+      sendPinetAgentMessage: vi.fn(async () => ({ messageId: 123, target: "broker-1" })),
+      readPinetInbox,
+      listBrokerAgents: () => [],
+      listFollowerAgents: vi.fn(async () => []),
+    });
+
+    await tools.get("comment_list")?.execute("tool-2", {
+      thread_id: "review",
+      limit: 5,
+    });
+
+    expect(readPinetInbox).toHaveBeenCalledWith({
+      legacyThreadId: "review",
+      limit: 5,
+      unreadOnly: false,
+      markRead: false,
+    });
+  });
+});

--- a/slack-bridge/pinet-a2a-compat.ts
+++ b/slack-bridge/pinet-a2a-compat.ts
@@ -1,0 +1,384 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import type { PinetReadOptions, PinetReadResult } from "@pinet/pinet-core/pinet-read-formatting";
+import type { PinetToolsAgentRecord } from "./pinet-tools.js";
+
+export interface RegisterPinetA2ACompatToolsDeps {
+  pinetEnabled: () => boolean;
+  brokerRole: () => "broker" | "follower" | null;
+  requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
+  sendPinetAgentMessage: (
+    target: string,
+    body: string,
+    metadata?: Record<string, unknown>,
+  ) => Promise<{ messageId: number; target: string }>;
+  readPinetInbox: (options: PinetReadOptions) => Promise<PinetReadResult>;
+  listBrokerAgents: () => PinetToolsAgentRecord[];
+  listFollowerAgents: (includeGhosts: boolean) => Promise<PinetToolsAgentRecord[]>;
+}
+
+type CommentActorType = "human" | "agent";
+
+const DEFAULT_THREAD_ID = "global";
+const CONTEXT_THREAD_PREFIX = "ctx:";
+
+interface CommentContext {
+  file: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+interface CompatCommentAddParams {
+  body?: string;
+  comment?: string;
+  threadId?: string;
+  thread_id?: string;
+  actorType?: string;
+  actor_type?: string;
+  actorId?: string;
+  actor_id?: string;
+  file?: string;
+  start_line?: number;
+  end_line?: number;
+  context?: {
+    file?: string;
+    startLine?: number;
+    endLine?: number;
+  } | null;
+}
+
+interface CompatCommentRecord {
+  id: string;
+  threadId: string;
+  actorType: CommentActorType;
+  actorId: string;
+  createdAt: string;
+  bodyPath: string;
+  body: string;
+  context?: CommentContext;
+  pinetThreadId: string;
+  pinetMessageId: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeThreadId(value: unknown): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : DEFAULT_THREAD_ID;
+}
+
+function normalizeActorType(value: unknown): CommentActorType {
+  return value === "human" ? "human" : "agent";
+}
+
+function normalizeActorId(value: unknown, actorType: CommentActorType): string {
+  if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  if (actorType === "human") return process.env.USER?.trim() || "human";
+  return process.env.PI_NICKNAME?.trim() || "pi";
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function normalizeContext(value: unknown): CommentContext | undefined {
+  if (!isRecord(value) || typeof value.file !== "string") return undefined;
+  const file = value.file.trim();
+  if (!file) return undefined;
+
+  let startLine = normalizePositiveInteger(value.startLine);
+  let endLine = normalizePositiveInteger(value.endLine);
+  if (startLine != null && endLine == null) endLine = startLine;
+  if (startLine == null && endLine != null) startLine = endLine;
+  if (startLine != null && endLine != null && startLine > endLine) {
+    [startLine, endLine] = [endLine, startLine];
+  }
+
+  return {
+    file,
+    ...(startLine != null ? { startLine } : {}),
+    ...(endLine != null ? { endLine } : {}),
+  };
+}
+
+function getStringMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function getRecordMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  key: string,
+): Record<string, unknown> | null {
+  const value = metadata?.[key];
+  return isRecord(value) ? value : null;
+}
+
+function isBrokerAgent(agent: PinetToolsAgentRecord): boolean {
+  const metadata = agent.metadata;
+  const capabilities = getRecordMetadata(metadata, "capabilities");
+  return (
+    metadata?.role === "broker" ||
+    capabilities?.role === "broker" ||
+    metadata?.subtreeBroker === true
+  );
+}
+
+async function listVisibleAgents(
+  deps: RegisterPinetA2ACompatToolsDeps,
+): Promise<PinetToolsAgentRecord[]> {
+  if (deps.brokerRole() === "broker") return deps.listBrokerAgents();
+  if (deps.brokerRole() === "follower") return await deps.listFollowerAgents(true);
+  return [];
+}
+
+async function resolveCompatTarget(deps: RegisterPinetA2ACompatToolsDeps): Promise<string> {
+  const agents = await listVisibleAgents(deps);
+  const liveBroker = agents.find((agent) => isBrokerAgent(agent) && !agent.disconnectedAt);
+  if (liveBroker) return liveBroker.id;
+
+  const brokerWasVisible = agents.some(isBrokerAgent);
+  throw new Error(
+    brokerWasVisible
+      ? "No live Pinet broker/subtree broker agent is visible for legacy a2a comment compatibility."
+      : "No Pinet broker/subtree broker agent is visible for legacy a2a comment compatibility.",
+  );
+}
+
+function buildContextThreadId(context: CommentContext | undefined): string | null {
+  if (!context?.file || context.startLine == null || context.endLine == null) return null;
+  return `${CONTEXT_THREAD_PREFIX}${context.file}:${context.startLine}-${context.endLine}`;
+}
+
+function resolveThreadId(threadId: unknown, context: CommentContext | undefined): string {
+  const normalized = normalizeThreadId(threadId);
+  if (normalized !== DEFAULT_THREAD_ID) return normalized;
+  return buildContextThreadId(context) ?? DEFAULT_THREAD_ID;
+}
+
+function formatContextLine(context: CommentContext | undefined): string | null {
+  if (!context) return null;
+  if (context.startLine != null && context.endLine != null) {
+    return `Context: ${context.file}:${context.startLine}-${context.endLine}`;
+  }
+  return `Context: ${context.file}`;
+}
+
+export function buildCompatCommentMessage(input: CompatCommentAddParams): {
+  body: string;
+  threadId: string;
+  actorType: CommentActorType;
+  actorId: string;
+  context?: CommentContext;
+  metadata: Record<string, unknown>;
+} {
+  const rawBody = typeof input.comment === "string" ? input.comment : input.body;
+  const body = rawBody?.trim() ?? "";
+  if (!body) throw new Error("Comment body cannot be empty");
+
+  const actorType = normalizeActorType(input.actor_type ?? input.actorType);
+  const actorId = normalizeActorId(input.actor_id ?? input.actorId, actorType);
+  const context = normalizeContext(
+    input.context ??
+      (typeof input.file === "string"
+        ? { file: input.file, startLine: input.start_line, endLine: input.end_line }
+        : undefined),
+  );
+  const threadId = resolveThreadId(input.thread_id ?? input.threadId, context);
+  const header = [
+    "A2A compatibility comment",
+    `Thread: ${threadId}`,
+    `Actor: ${actorType}:${actorId}`,
+    formatContextLine(context),
+  ].filter((line): line is string => Boolean(line));
+
+  return {
+    body: `${header.join("\n")}\n\n${body}`,
+    threadId,
+    actorType,
+    actorId,
+    ...(context ? { context } : {}),
+    metadata: {
+      a2aCompat: true,
+      legacyTool: "comment_add",
+      legacyThreadId: threadId,
+      legacyActorType: actorType,
+      legacyActorId: actorId,
+      ...(context ? { legacyContext: context } : {}),
+    },
+  };
+}
+
+function getCompatMessageBody(body: string): string {
+  const marker = "\n\n";
+  const index = body.indexOf(marker);
+  return index >= 0 && body.startsWith("A2A compatibility comment\n")
+    ? body.slice(index + marker.length)
+    : body;
+}
+
+export function mapPinetReadResultToCompatComments(
+  result: PinetReadResult,
+  requestedThreadId?: string,
+): { threadId: string; total: number; comments: CompatCommentRecord[] } {
+  const filterThreadId = requestedThreadId?.trim();
+  const comments = result.messages
+    .map((item): CompatCommentRecord | null => {
+      const metadata = item.message.metadata ?? {};
+      const legacyThreadId = getStringMetadata(metadata, "legacyThreadId") ?? item.message.threadId;
+      if (
+        filterThreadId &&
+        legacyThreadId !== filterThreadId &&
+        item.message.threadId !== filterThreadId
+      ) {
+        return null;
+      }
+      const legacyContext = getRecordMetadata(metadata, "legacyContext");
+      const context = normalizeContext(legacyContext);
+      const actorType = normalizeActorType(metadata.legacyActorType);
+      const actorId =
+        getStringMetadata(metadata, "legacyActorId") ??
+        getStringMetadata(metadata, "senderAgent") ??
+        item.message.sender;
+      return {
+        id: `pinet-${item.message.id}`,
+        threadId: legacyThreadId,
+        actorType,
+        actorId,
+        createdAt: item.message.createdAt,
+        bodyPath: `pinet:${item.message.id}`,
+        body: getCompatMessageBody(item.message.body),
+        ...(context ? { context } : {}),
+        pinetThreadId: item.message.threadId,
+        pinetMessageId: item.message.id,
+      };
+    })
+    .filter((comment): comment is CompatCommentRecord => comment !== null);
+
+  return {
+    threadId: filterThreadId || DEFAULT_THREAD_ID,
+    total: result.totalMatching ?? comments.length,
+    comments,
+  };
+}
+
+export function registerPinetA2ACompatTools(
+  pi: ExtensionAPI,
+  deps: RegisterPinetA2ACompatToolsDeps,
+): void {
+  pi.registerTool({
+    name: "comment_add",
+    label: "A2A Comment Add (Pinet compatibility)",
+    description:
+      "Compatibility shim for legacy PiComms/a2a comment writers. Sends the comment through Pinet to the visible broker or subtree broker instead of writing the removed local PiComms store.",
+    parameters: Type.Object({
+      comment: Type.Optional(Type.String({ description: "Legacy markdown comment body" })),
+      body: Type.Optional(Type.String({ description: "Comment body (camelCase alias)" })),
+      thread_id: Type.Optional(Type.String({ description: "Legacy PiComms/a2a thread id" })),
+      threadId: Type.Optional(Type.String({ description: "Thread id (camelCase alias)" })),
+      actor_type: Type.Optional(
+        Type.String({ description: 'Legacy actor type: "agent" or "human"' }),
+      ),
+      actorType: Type.Optional(Type.String({ description: "Actor type (camelCase alias)" })),
+      actor_id: Type.Optional(Type.String({ description: "Legacy actor id/name" })),
+      actorId: Type.Optional(Type.String({ description: "Actor id/name (camelCase alias)" })),
+      file: Type.Optional(Type.String({ description: "Optional legacy file path for context" })),
+      start_line: Type.Optional(Type.Number({ description: "Optional legacy start line" })),
+      end_line: Type.Optional(Type.Number({ description: "Optional legacy end line" })),
+      context: Type.Optional(
+        Type.Union([
+          Type.Object({
+            file: Type.Optional(Type.String()),
+            startLine: Type.Optional(Type.Number()),
+            endLine: Type.Optional(Type.Number()),
+          }),
+          Type.Null(),
+        ]),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      deps.requireToolPolicy(
+        "comment_add",
+        undefined,
+        `thread_id=${params.thread_id ?? params.threadId ?? ""}`,
+      );
+      if (!deps.pinetEnabled()) {
+        throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
+      }
+
+      const compat = buildCompatCommentMessage(params);
+      const target = await resolveCompatTarget(deps);
+      const sent = await deps.sendPinetAgentMessage(target, compat.body, compat.metadata);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `A2A compatibility comment sent through Pinet to ${sent.target} (message ${sent.messageId}).`,
+          },
+        ],
+        details: {
+          id: `pinet-${sent.messageId}`,
+          threadId: compat.threadId,
+          target: sent.target,
+          messageId: sent.messageId,
+          actorType: compat.actorType,
+          actorId: compat.actorId,
+          ...(compat.context ? { context: compat.context } : {}),
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "comment_list",
+    label: "A2A Comment List (Pinet compatibility)",
+    description:
+      "Compatibility shim for legacy PiComms/a2a comment readers. Returns this agent's Pinet inbox rows as comment-shaped records; it does not read the removed local PiComms store.",
+    parameters: Type.Object({
+      thread_id: Type.Optional(
+        Type.String({
+          description:
+            "Legacy thread id to filter; use an a2a: prefix to filter by native Pinet thread id",
+        }),
+      ),
+      threadId: Type.Optional(Type.String({ description: "Thread id (camelCase alias)" })),
+      limit: Type.Optional(Type.Number({ description: "Maximum messages to return" })),
+    }),
+    async execute(_toolCallId, params) {
+      deps.requireToolPolicy(
+        "comment_list",
+        undefined,
+        `thread_id=${params.thread_id ?? params.threadId ?? ""}`,
+      );
+      if (!deps.pinetEnabled()) {
+        throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
+      }
+
+      const rawThreadId = params.thread_id ?? params.threadId;
+      const threadId = normalizeThreadId(rawThreadId);
+      const result = await deps.readPinetInbox({
+        ...(threadId.startsWith("a2a:") ? { threadId } : {}),
+        ...(!threadId.startsWith("a2a:") ? { legacyThreadId: threadId } : {}),
+        ...(typeof params.limit === "number" ? { limit: params.limit } : {}),
+        unreadOnly: false,
+        markRead: false,
+      });
+      const comments = mapPinetReadResultToCompatComments(result, threadId || undefined);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(comments, null, 2),
+          },
+        ],
+        details: comments,
+      };
+    },
+  });
+}

--- a/slack-bridge/tool-registration-runtime.test.ts
+++ b/slack-bridge/tool-registration-runtime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { RegisterIMessageToolsDeps } from "./imessage-tools.js";
+import type { RegisterPinetA2ACompatToolsDeps } from "./pinet-a2a-compat.js";
 import type { RegisterPinetToolsDeps } from "./pinet-tools.js";
 import type { RegisterSlackToolsDeps } from "./slack-tools.js";
 import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
@@ -8,6 +9,7 @@ import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
 const registrationState = vi.hoisted(() => ({
   registerSlackTools: vi.fn(),
   registerPinetTools: vi.fn(),
+  registerPinetA2ACompatTools: vi.fn(),
   registerIMessageTools: vi.fn(),
 }));
 
@@ -19,6 +21,10 @@ vi.mock("./pinet-tools.js", () => ({
   registerPinetTools: registrationState.registerPinetTools,
 }));
 
+vi.mock("./pinet-a2a-compat.js", () => ({
+  registerPinetA2ACompatTools: registrationState.registerPinetA2ACompatTools,
+}));
+
 vi.mock("./imessage-tools.js", () => ({
   registerIMessageTools: registrationState.registerIMessageTools,
 }));
@@ -27,6 +33,7 @@ describe("createToolRegistrationRuntime", () => {
   beforeEach(() => {
     registrationState.registerSlackTools.mockReset();
     registrationState.registerPinetTools.mockReset();
+    registrationState.registerPinetA2ACompatTools.mockReset();
     registrationState.registerIMessageTools.mockReset();
   });
 
@@ -34,10 +41,12 @@ describe("createToolRegistrationRuntime", () => {
     const pi = { registerTool: vi.fn() } as unknown as ExtensionAPI;
     const slackTools = {} as RegisterSlackToolsDeps;
     const pinetTools = {} as RegisterPinetToolsDeps;
+    const pinetA2ACompatTools = {} as RegisterPinetA2ACompatToolsDeps;
     const iMessageTools = {} as RegisterIMessageToolsDeps;
     const runtime = createToolRegistrationRuntime({
       slackTools,
       pinetTools,
+      pinetA2ACompatTools,
       iMessageTools,
     });
 
@@ -47,6 +56,11 @@ describe("createToolRegistrationRuntime", () => {
     expect(registrationState.registerSlackTools).toHaveBeenCalledWith(pi, slackTools);
     expect(registrationState.registerPinetTools).toHaveBeenCalledTimes(1);
     expect(registrationState.registerPinetTools).toHaveBeenCalledWith(pi, pinetTools);
+    expect(registrationState.registerPinetA2ACompatTools).toHaveBeenCalledTimes(1);
+    expect(registrationState.registerPinetA2ACompatTools).toHaveBeenCalledWith(
+      pi,
+      pinetA2ACompatTools,
+    );
     expect(registrationState.registerIMessageTools).toHaveBeenCalledTimes(1);
     expect(registrationState.registerIMessageTools).toHaveBeenCalledWith(pi, iMessageTools);
 
@@ -54,6 +68,9 @@ describe("createToolRegistrationRuntime", () => {
       registrationState.registerPinetTools.mock.invocationCallOrder[0] ?? Infinity,
     );
     expect(registrationState.registerPinetTools.mock.invocationCallOrder[0]).toBeLessThan(
+      registrationState.registerPinetA2ACompatTools.mock.invocationCallOrder[0] ?? Infinity,
+    );
+    expect(registrationState.registerPinetA2ACompatTools.mock.invocationCallOrder[0]).toBeLessThan(
       registrationState.registerIMessageTools.mock.invocationCallOrder[0] ?? Infinity,
     );
   });

--- a/slack-bridge/tool-registration-runtime.ts
+++ b/slack-bridge/tool-registration-runtime.ts
@@ -1,11 +1,16 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerIMessageTools, type RegisterIMessageToolsDeps } from "./imessage-tools.js";
+import {
+  registerPinetA2ACompatTools,
+  type RegisterPinetA2ACompatToolsDeps,
+} from "./pinet-a2a-compat.js";
 import { registerPinetTools, type RegisterPinetToolsDeps } from "./pinet-tools.js";
 import { registerSlackTools, type RegisterSlackToolsDeps } from "./slack-tools.js";
 
 export interface ToolRegistrationRuntimeDeps {
   slackTools: RegisterSlackToolsDeps;
   pinetTools: RegisterPinetToolsDeps;
+  pinetA2ACompatTools: RegisterPinetA2ACompatToolsDeps;
   iMessageTools: RegisterIMessageToolsDeps;
 }
 
@@ -19,6 +24,7 @@ export function createToolRegistrationRuntime(
   function register(pi: ExtensionAPI): void {
     registerSlackTools(pi, deps.slackTools);
     registerPinetTools(pi, deps.pinetTools);
+    registerPinetA2ACompatTools(pi, deps.pinetA2ACompatTools);
     registerIMessageTools(pi, deps.iMessageTools);
   }
 


### PR DESCRIPTION
## Summary
- Add `comment_add` / `comment_list` compatibility tools in slack-bridge that translate legacy PiComms/a2a comment calls into Pinet broker/subtree-broker message flow.
- Preserve legacy comment-shaped metadata and read responses without re-enabling the removed local `.pi/a2a/comments` store.
- Wire the compatibility tools into the shared tool-registration runtime and document the behavior.

Closes #819

## Testing
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge test -- pinet-a2a-compat.test.ts tool-registration-runtime.test.ts`
- `pnpm prepush`

## Safety
- No publish/release/version bump/tag/merge/deploy.
- No secret or credential changes.
