### PR TITLE
feat(pinet): human-readable expanded agents table + send preview (#763, #762)

### DIFF
--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -369,10 +369,15 @@ describe("registerPinetTools", () => {
     const collapsedText = collapsed?.map((line) => line.trimEnd()).join("\n");
     const expandedText = expanded?.map((line) => line.trimEnd()).join("\n");
 
-    expect(collapsedText).toBe("✓ Pinet message sent to alpha.");
-    expect(expandedText).toContain("details:");
-    expect(expandedText).toContain("messageId: 17");
+    // Collapsed shows the target plus a capped, operator-facing message preview.
+    expect(collapsedText).toBe("✓ Pinet message sent to alpha · “dispatch now”.");
+    // Expanded shows the sent envelope and full body, not a JSON wall.
+    expect(expandedText).toContain("to: alpha");
+    expect(expandedText).toContain("message id: 17");
+    expect(expandedText).toContain("message (1 line, 12 chars):");
+    expect(expandedText).toContain("dispatch now");
     expect(expandedText).not.toContain('"status"');
+    expect(expandedText).not.toContain("details:");
   });
 
   it("uses the broker broadcast path for broadcast dispatcher send targets", async () => {
@@ -405,7 +410,9 @@ describe("registerPinetTools", () => {
     };
 
     expect(sendPinetBroadcastMessage).toHaveBeenCalledWith("#extensions", "hello mesh");
-    expect(result.details.data.text).toBe("Pinet broadcast sent to #extensions (2 recipients).");
+    expect(result.details.data.text).toBe(
+      "Pinet broadcast sent to #extensions (2 recipients) · “hello mesh”.",
+    );
     expect(result.details.data.details).toEqual({
       channel: "#extensions",
       messageCount: 2,
@@ -946,6 +953,8 @@ describe("registerPinetTools", () => {
     expect(result.details.data.action).toBe("send");
     expect(result.details.data.text).toBe("Pinet message sent to alpha.");
     expectJsonStatus(result.content[0]?.text, "succeeded");
+    expect(result.content[0]?.text).not.toContain('"display"');
+    expect(result.content[0]?.text).not.toContain("dispatch now");
   });
 
   it("passes broker thread ownership transfers through pinet send metadata", async () => {
@@ -1448,8 +1457,10 @@ describe("registerPinetTools", () => {
       };
     };
 
-    expect(result.content[0]?.text).toContain("Pinet agents: 1 visible; hints repo=extensions.");
-    expect(result.content[0]?.text).toContain("Golden Chalk Rabbit");
+    expect(result.content[0]?.text).toBe(
+      "Pinet agents: 1 visible (0 working, 1 idle); hints repo=extensions.",
+    );
+    expect(result.content[0]?.text).not.toContain("Golden Chalk Rabbit");
     expect(result.details.data.text).not.toContain("pid:");
     expect(result.details.data.details.agents[0]?.name).toBe("Golden Chalk Rabbit");
     expect(result.details.data.details.agents[0]?.repo).toBe("extensions");
@@ -1489,6 +1500,7 @@ describe("registerPinetTools", () => {
     };
 
     expect(compact.content[0]?.text).not.toContain("very long persona");
+    expect(compact.content[0]?.text).not.toContain('"display"');
     expect(compactEnvelope.data.details.agents[0]?.metadata).toBeUndefined();
     expect(compactEnvelope.data.details.agents[0]?.personality).toBeUndefined();
     expect(compactEnvelope.data.details.agents[0]?.tmuxSession).toBeUndefined();
@@ -1500,35 +1512,205 @@ describe("registerPinetTools", () => {
 
     expect(full.content[0]?.text).toContain("very long persona");
     expect(full.content[0]?.text).toContain("pinet-secret-session");
+    expect(full.content[0]?.text).not.toContain('"display"');
   });
 
-  it("renders expanded Pinet agent details without raw nested JSON", async () => {
+  it("keeps pinet send format=json free of renderer-only display and message body", async () => {
+    const sendPinetAgentMessage = vi.fn(async () => ({ messageId: 99, target: "beta" }));
+    const tools = registerWithDeps(createDeps({ sendPinetAgentMessage }));
+
+    const result = (await tools.get("pinet")?.execute("tool-call-send-json-display-contract", {
+      action: "send",
+      args: { to: "beta", message: "sensitive body for tui only", format: "json" },
+    })) as { content: Array<{ text: string }>; details: { data: { details: unknown } } };
+
+    expect(result.content[0]?.text).not.toContain('"display"');
+    expect(result.content[0]?.text).not.toContain("sensitive body for tui only");
+    expect(JSON.stringify(result.details.data.details)).not.toContain(
+      "sensitive body for tui only",
+    );
+  });
+
+  it("renders pinet agents as a human table when expanded instead of raw JSON", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-14T12:00:00Z"));
 
-    const listBrokerAgents = vi.fn(() =>
-      Array.from({ length: 12 }, (_, index) =>
-        makeAgent({
-          id: `agent-${index}`,
-          name: `Agent ${index}`,
-          metadata: { repo: "extensions", role: "worker" },
-        }),
-      ),
-    );
+    const listBrokerAgents = vi.fn(() => [
+      makeAgent({
+        id: "a0f208e9-3de9-4c06",
+        name: "Aurora Emerald Cobra",
+        emoji: "🐍",
+        status: "working",
+        metadata: { repo: "garage-demo-may-26", branch: "main", role: "worker" },
+      }),
+      makeAgent({
+        id: "50131fcf-909f-4a35",
+        name: "Crystal Coral Bear",
+        emoji: "🐻",
+        status: "idle",
+        metadata: { repo: "projects", role: "worker" },
+      }),
+    ]);
     const tools = registerWithDeps(createDeps({ listBrokerAgents }));
     const pinet = tools.get("pinet");
-    const result = (await pinet?.execute("tool-call-agents-render", {
-      action: "agents",
-      args: { repo: "extensions", format: "json" },
-    })) as { content: Array<{ type: string; text: string }>; details: unknown };
     const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
 
-    const expanded = pinet?.renderResult?.(result, { expanded: true }, theme, {}).render(240);
-    const expandedText = expanded?.map((line) => line.trimEnd()).join("\n") ?? "";
+    const result = (await pinet?.execute("tool-call-agents-table", {
+      action: "agents",
+      args: {},
+    })) as {
+      content?: Array<{ type: string; text?: string }>;
+      details?: unknown;
+      expandedText?: string;
+    };
 
-    expect(expandedText).toContain("agents: 10 items");
-    expect(expandedText).toContain("agents[0]: id=agent-0");
-    expect(expandedText).not.toContain('[{"');
-    expect(expandedText.length).toBeLessThan(8_000);
+    const collapsed = pinet
+      ?.renderResult?.(result, { expanded: false }, theme, {})
+      .render(200)
+      .map((line) => line.trimEnd())
+      .join("\n");
+    const expanded = pinet
+      ?.renderResult?.(result, { expanded: true }, theme, {})
+      .render(200)
+      .map((line) => line.trimEnd())
+      .join("\n");
+
+    expect(collapsed).toBe("✓ Pinet agents: 2 visible (1 working, 1 idle).");
+    // Expanded shows a scannable per-agent table, not a JSON wall.
+    expect(expanded).toContain("Aurora Emerald Cobra");
+    expect(expanded).toContain("a0f208e9");
+    expect(expanded).toContain("garage-demo-may-26/main");
+    expect(expanded).toContain("working");
+    expect(expanded).toContain("Crystal Coral Bear");
+    expect(expanded).not.toContain("capabilityTags");
+    expect(expanded).not.toContain("routingScore");
+    expect(expanded).not.toContain('[{"id"');
+    expect(expanded).not.toContain("status: succeeded");
+  });
+
+  it("caps long pinet send previews and shows the body when expanded", async () => {
+    const longMessage = "L".repeat(200);
+    const sendPinetAgentMessage = vi.fn(async () => ({ messageId: 99, target: "beta" }));
+    const tools = registerWithDeps(createDeps({ sendPinetAgentMessage }));
+    const pinet = tools.get("pinet");
+    const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
+
+    const result = (await pinet?.execute("tool-call-send-long", {
+      action: "send",
+      args: { to: "beta", message: longMessage },
+    })) as {
+      content?: Array<{ type: string; text?: string }>;
+      details?: unknown;
+      expandedText?: string;
+    };
+
+    const collapsed = pinet
+      ?.renderResult?.(result, { expanded: false }, theme, {})
+      .render(200)
+      .join("\n");
+    const expanded = pinet
+      ?.renderResult?.(result, { expanded: true }, theme, {})
+      .render(200)
+      .join("\n");
+
+    // Collapsed preview is capped (ellipsis) and never echoes the full body.
+    expect(collapsed).toContain("…");
+    expect(collapsed).not.toContain("L".repeat(100));
+    // Expanded shows the envelope plus the (capped) body with a char count.
+    expect(expanded).toContain("to: beta");
+    expect(expanded).toContain("message id: 99");
+    expect(expanded).toContain("200 chars");
+  });
+
+  it("reports multi-line pinet send line counts in collapsed and expanded views", async () => {
+    const multiline = "line one\nline two\nline three";
+    const sendPinetAgentMessage = vi.fn(async () => ({ messageId: 7, target: "gamma" }));
+    const tools = registerWithDeps(createDeps({ sendPinetAgentMessage }));
+    const pinet = tools.get("pinet");
+    const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
+
+    const result = (await pinet?.execute("tool-call-send-multiline", {
+      action: "send",
+      args: { to: "gamma", message: multiline },
+    })) as {
+      content?: Array<{ type: string; text?: string }>;
+      details?: unknown;
+      expandedText?: string;
+    };
+
+    const collapsed = pinet
+      ?.renderResult?.(result, { expanded: false }, theme, {})
+      .render(200)
+      .join("\n");
+    const expanded = pinet
+      ?.renderResult?.(result, { expanded: true }, theme, {})
+      .render(200)
+      .join("\n");
+
+    expect(collapsed).toContain("(3 lines)");
+    expect(expanded).toContain("message (3 lines, 28 chars):");
+    expect(expanded).toContain("line one");
+    expect(expanded).toContain("line three");
+  });
+
+  it("summarizes arrays in expanded fallback details instead of dumping JSON", async () => {
+    const readPinetInbox = vi.fn(async () => ({
+      messages: [
+        {
+          inboxId: 31,
+          delivered: true,
+          readAt: null,
+          message: {
+            id: 44,
+            threadId: "a2a:broker:worker",
+            source: "agent",
+            direction: "inbound",
+            sender: "broker",
+            body: "please inspect #594",
+            metadata: { a2a: true },
+            createdAt: "2026-04-25T11:59:00.000Z",
+          },
+        },
+        {
+          inboxId: 32,
+          delivered: true,
+          readAt: null,
+          message: {
+            id: 45,
+            threadId: "a2a:broker:worker",
+            source: "agent",
+            direction: "inbound",
+            sender: "broker",
+            body: "and #595",
+            metadata: { a2a: true },
+            createdAt: "2026-04-25T12:00:00.000Z",
+          },
+        },
+      ],
+      unreadCountBefore: 2,
+      unreadCountAfter: 0,
+      unreadThreads: [],
+      markedReadIds: [31, 32],
+    }));
+    const tools = registerWithDeps(createDeps({ readPinetInbox }));
+    const pinet = tools.get("pinet");
+    const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
+
+    const result = (await pinet?.execute("tool-call-read-fallback", {
+      action: "read",
+      args: { unread_only: true },
+    })) as { content?: Array<{ type: string; text?: string }>; details?: unknown };
+
+    const expanded = pinet
+      ?.renderResult?.(result, { expanded: true }, theme, {})
+      .render(200)
+      .join("\n");
+
+    // Read has no custom expanded view in PR1, so it uses the hardened fallback
+    // which summarizes arrays rather than emitting a JSON wall.
+    expect(expanded).toContain("messages: 2 items");
+    expect(expanded).not.toContain("[{");
+    expect(expanded).not.toContain('"inboxId"');
+    expect(expanded).not.toContain('"preview"');
   });
 });

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -175,6 +175,13 @@ interface PinetToolResult {
   details?: unknown;
   compactDetails?: unknown;
   fullDetails?: unknown;
+  // Renderer-only, human-readable expanded body for the Pi TUI. Never sent to
+  // the model and never part of the machine `data.details` contract. When set,
+  // the expanded tool card shows this instead of JSON-dumping `data.details`.
+  expandedText?: string;
+  // Optional model/machine-safe text when the operator-facing content includes
+  // previews that must stay out of `format=json` serialized envelopes.
+  machineText?: string;
 }
 
 interface PinetActionDefinition {
@@ -210,6 +217,8 @@ interface PinetRenderContentBlock {
 interface PinetRenderResultInput {
   content?: PinetRenderContentBlock[];
   details?: unknown;
+  expandedText?: string;
+  displayText?: string;
 }
 
 const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> = {
@@ -266,8 +275,6 @@ const PINET_OUTPUT_OPTION_PARAMETERS = {
 };
 
 const PINET_COMPACT_LIST_LIMIT = 10;
-const PINET_COMPACT_AGENT_TEXT_LIMIT = 5;
-const PINET_EXPANDED_DETAIL_LIMIT = 10;
 
 function getRecordString(
   record: Record<string, unknown> | null | undefined,
@@ -473,9 +480,13 @@ function shouldRenderStructuredPinetEnvelope(
 function wrapDispatcherEnvelope(
   envelope: PinetDispatcherEnvelope,
   output: PinetOutputOptions = { format: "cli", full: false },
+  expandedText?: string,
+  displayText?: string,
 ): {
   content: Array<{ type: "text"; text: string }>;
   details: PinetDispatcherEnvelope;
+  expandedText?: string;
+  displayText?: string;
 } {
   return {
     content: [
@@ -487,6 +498,8 @@ function wrapDispatcherEnvelope(
       },
     ],
     details: envelope,
+    ...(expandedText ? { expandedText } : {}),
+    ...(displayText ? { displayText } : {}),
   };
 }
 
@@ -513,81 +526,102 @@ function parsePinetDispatcherEnvelopeFromText(text: string): PinetDispatcherEnve
   }
 }
 
-function formatDisplayValue(value: unknown): string {
+function summarizeDetailValue(value: unknown): string {
   if (value === null) return "null";
-  if (["string", "number", "boolean"].includes(typeof value)) return String(value);
-  if (Array.isArray(value)) return `${value.length} item${value.length === 1 ? "" : "s"}`;
-  if (isRecord(value)) {
-    const preferredKeys = [
-      "id",
-      "agentId",
-      "name",
-      "status",
-      "health",
-      "repo",
-      "role",
-      "threadId",
-      "messageId",
-      "sender",
-      "preview",
-      "laneId",
-      "state",
-      "leaseId",
-      "host",
-      "port",
-      "purpose",
-      "expiresAt",
-    ];
-    const parts = preferredKeys
-      .map((key) => {
-        const item = value[key];
-        if (item === null || item === undefined || Array.isArray(item) || isRecord(item)) {
-          return null;
+  if (Array.isArray(value)) {
+    return `${value.length} item${value.length === 1 ? "" : "s"}`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return "{}";
+    const inline = entries
+      .slice(0, 6)
+      .map(([key, nested]) => {
+        if (nested === null || ["string", "number", "boolean"].includes(typeof nested)) {
+          return `${key}=${String(nested)}`;
         }
-        return `${key}=${String(item)}`;
+        return `${key}=…`;
       })
-      .filter((item): item is string => Boolean(item));
-    if (parts.length > 0) return parts.slice(0, 8).join(" · ");
-    return `${Object.keys(value).length} field${Object.keys(value).length === 1 ? "" : "s"}`;
+      .join(", ");
+    return `{ ${inline}${entries.length > 6 ? ", …" : ""} }`;
   }
   return String(value);
 }
 
-function formatStructuredDetails(details: Record<string, unknown>): string[] {
-  const lines: string[] = [];
-  for (const [key, value] of Object.entries(details)) {
-    if (Array.isArray(value)) {
-      lines.push(`${key}: ${value.length} item${value.length === 1 ? "" : "s"}`);
-      for (const [index, item] of value.slice(0, PINET_EXPANDED_DETAIL_LIMIT).entries()) {
-        lines.push(`${key}[${index}]: ${formatDisplayValue(item)}`);
-      }
-      const truncated = value.length - Math.min(value.length, PINET_EXPANDED_DETAIL_LIMIT);
-      if (truncated > 0) {
-        lines.push(`${key}: … ${truncated} more item${truncated === 1 ? "" : "s"}`);
-      }
-      continue;
-    }
-    lines.push(`${key}: ${formatDisplayValue(value)}`);
-  }
-  return lines;
+// Renders `data.details` as compact key lines. Arrays and nested objects are
+// summarized (count / inlined keys) so the expanded view never JSON-dumps a
+// wall of structured data into the operator's TUI.
+function formatPrimitiveDetails(details: Record<string, unknown>): string[] {
+  return Object.entries(details).map(([key, value]) => `${key}: ${summarizeDetailValue(value)}`);
 }
 
-function formatPinetEnvelopeExpandedText(envelope: PinetDispatcherEnvelope): string {
-  const lines = [getPinetEnvelopeCliText(envelope), `status: ${envelope.status}`];
+const PINET_SEND_PREVIEW_MAX = 80;
+const PINET_SEND_BODY_MAX = 600;
+
+// Single-line, whitespace-collapsed, length-capped preview of a sent message.
+// Operator-facing only; kept short so model/CLI text stays compact.
+function formatMessagePreview(message: string, maxLength = PINET_SEND_PREVIEW_MAX): string {
+  const collapsed = message.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= maxLength) return collapsed;
+  return `${collapsed.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function countMessageLines(message: string): number {
+  if (message.length === 0) return 0;
+  return message.split(/\r?\n/).length;
+}
+
+// Capped multi-line body for the expanded TUI card. Preserves line breaks so the
+// operator can see structure, but truncates very long bodies.
+function capMessageBody(message: string, maxLength = PINET_SEND_BODY_MAX): string {
+  if (message.length <= maxLength) return message;
+  return `${message.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function formatSentMessageSuffix(message: string): string {
+  const preview = formatMessagePreview(message);
+  if (!preview) return "";
+  const lines = countMessageLines(message);
+  return ` · “${preview}”${lines > 1 ? ` (${lines} lines)` : ""}`;
+}
+
+function buildSentMessageExpandedText(
+  fields: Array<[string, string | number | undefined]>,
+  message: string,
+): string {
+  const lines = fields
+    .filter((entry): entry is [string, string | number] => entry[1] !== undefined)
+    .map(([label, value]) => `${label}: ${value}`);
+  const chars = message.length;
+  const lineCount = countMessageLines(message);
+  lines.push(`message (${lineCount} line${lineCount === 1 ? "" : "s"}, ${chars} chars):`);
+  lines.push(capMessageBody(message));
+  return lines.join("\n");
+}
+
+function formatPinetEnvelopeExpandedText(
+  envelope: PinetDispatcherEnvelope,
+  expandedText?: string,
+): string {
+  const lines = [getPinetEnvelopeCliText(envelope)];
 
   if (envelope.status === "failed") {
+    lines.push(`status: ${envelope.status}`);
     for (const error of envelope.errors) {
       lines.push(`error[${error.class}]: ${error.message}`);
       if (error.hint) lines.push(`hint: ${error.hint}`);
     }
+  } else if (expandedText && expandedText.trim().length > 0) {
+    lines.push(...expandedText.split("\n"));
   } else if (isRecord(envelope.data)) {
+    lines.push(`status: ${envelope.status}`);
     const action = typeof envelope.data.action === "string" ? envelope.data.action : undefined;
     if (action) lines.push(`action: ${action}`);
 
     const details = envelope.data.details;
     if (isRecord(details)) {
       lines.push("details:");
-      lines.push(...formatStructuredDetails(details).map((line) => `  ${line}`));
+      lines.push(...formatPrimitiveDetails(details).map((line) => `  ${line}`));
     }
   }
 
@@ -613,7 +647,9 @@ export function formatPinetDispatcherResultForDisplay(
 
   return {
     status: envelope.status,
-    text: expanded ? formatPinetEnvelopeExpandedText(envelope) : getPinetEnvelopeCliText(envelope),
+    text: expanded
+      ? formatPinetEnvelopeExpandedText(envelope, result.expandedText)
+      : (result.displayText ?? getPinetEnvelopeCliText(envelope)),
   };
 }
 
@@ -733,10 +769,13 @@ function runPinetSendAction(
       );
     }
 
+    const previewSuffix = formatSentMessageSuffix(message);
+
     if (deps.brokerRole() === "broker" && isBroadcastChannelTarget(to)) {
       const result = deps.sendPinetBroadcastMessage(to, message);
       const preview = result.recipients.slice(0, 5).join(", ");
       const suffix = result.recipients.length > 5 ? ", …" : "";
+      const recipientList = result.recipients.join(", ");
 
       return {
         content: [
@@ -744,7 +783,7 @@ function runPinetSendAction(
             type: "text",
             text: output.full
               ? `Broadcast sent to ${result.channel} (${result.recipients.length} agents: ${preview}${suffix}).`
-              : `Pinet broadcast sent to ${result.channel} (${result.recipients.length} recipients).`,
+              : `Pinet broadcast sent to ${result.channel} (${result.recipients.length} recipients)${previewSuffix}.`,
           },
         ],
         details: {
@@ -764,6 +803,17 @@ function runPinetSendAction(
           messageIds: result.messageIds,
           recipients: result.recipients,
         },
+        machineText: output.full
+          ? `Broadcast sent to ${result.channel} (${result.recipients.length} agents: ${preview}${suffix}).`
+          : `Pinet broadcast sent to ${result.channel} (${result.recipients.length} recipients).`,
+        expandedText: buildSentMessageExpandedText(
+          [
+            ["to", result.channel],
+            ["recipients", `${result.recipients.length} (${recipientList})`],
+            ["message ids", result.messageIds.join(", ")],
+          ],
+          message,
+        ),
       };
     }
 
@@ -772,13 +822,16 @@ function runPinetSendAction(
           threadOwnershipTransfer: { mode: "transfer", threadId: transferThreadId },
         })
       : await deps.sendPinetAgentMessage(to, message);
+    const transferSuffix = result.transferredThreadId
+      ? ` (${result.transferredThreadChannel})`
+      : "";
     return {
       content: [
         {
           type: "text",
           text: output.full
             ? `Message sent to ${result.target} (id: ${result.messageId})${result.transferredThreadId ? ` and transferred Slack thread ${result.transferredThreadId}${result.transferredThreadChannel ? ` (${result.transferredThreadChannel})` : ""}` : ""}.`
-            : `Pinet message sent to ${result.target}${result.transferredThreadId ? `; transferred Slack thread ${result.transferredThreadId}` : ""}.`,
+            : `Pinet message sent to ${result.target}${result.transferredThreadId ? `; transferred Slack thread ${result.transferredThreadId}` : ""}${previewSuffix}.`,
         },
       ],
       details: {
@@ -789,6 +842,19 @@ function runPinetSendAction(
           ? { transferredThreadChannel: result.transferredThreadChannel }
           : {}),
       },
+      machineText: output.full
+        ? `Message sent to ${result.target} (id: ${result.messageId})${result.transferredThreadId ? ` and transferred Slack thread ${result.transferredThreadId}${result.transferredThreadChannel ? ` (${result.transferredThreadChannel})` : ""}` : ""}.`
+        : `Pinet message sent to ${result.target}${result.transferredThreadId ? `; transferred Slack thread ${result.transferredThreadId}` : ""}.`,
+      expandedText: buildSentMessageExpandedText(
+        [
+          ["to", result.target],
+          ["message id", result.messageId],
+          result.transferredThreadId
+            ? ["transferred thread", `${result.transferredThreadId}${transferSuffix}`]
+            : ["transferred thread", undefined],
+        ],
+        message,
+      ),
     };
   })();
 }
@@ -1168,21 +1234,19 @@ function filterAgentsForHierarchyScope(
   return descendants;
 }
 
-function formatCompactAgentRow(agent: AgentDisplayInfo): string {
+function formatAgentStatusBreakdown(agents: AgentDisplayInfo[]): string {
+  if (agents.length === 0) return "";
+  const working = agents.filter((agent) => agent.status === "working").length;
+  const idle = agents.length - working;
+  const ghost = agents.filter((agent) => agent.health === "ghost").length;
+  const stale = agents.filter((agent) => agent.health === "stale").length;
   const parts = [
-    agent.status,
-    agent.health ?? null,
-    getAgentRepo(agent) ? `repo=${getAgentRepo(agent)}` : null,
-    getAgentBranch(agent) ? `branch=${getAgentBranch(agent)}` : null,
-    getAgentRole(agent) ? `role=${getAgentRole(agent)}` : null,
-    agent.metadata?.subtreeRole ? `subtree=${agent.metadata.subtreeRole}` : null,
-    agent.metadata?.laneId ? `lane=${agent.metadata.laneId}` : null,
-    agent.pendingInboxCount != null && agent.pendingInboxCount > 0
-      ? `pending=${agent.pendingInboxCount}`
-      : null,
-    agent.routingScore != null ? `score=${agent.routingScore}` : null,
+    `${working} working`,
+    `${idle} idle`,
+    ghost > 0 ? `${ghost} ghost` : null,
+    stale > 0 ? `${stale} stale` : null,
   ].filter((item): item is string => Boolean(item));
-  return `- ${agent.emoji} ${agent.name} (${agent.id}): ${parts.join("; ")}`;
+  return ` (${parts.join(", ")})`;
 }
 
 function formatCompactAgentList(agents: AgentDisplayInfo[], hint: PinetAgentsRoutingHint): string {
@@ -1196,18 +1260,79 @@ function formatCompactAgentList(agents: AgentDisplayInfo[], hint: PinetAgentsRou
   ].filter((item): item is string => Boolean(item));
   const hintSuffix = hintParts.length > 0 ? `; hints ${hintParts.join(" · ")}` : "";
   const scopeSuffix = hint.scope && hint.scope !== "visible" ? `; scope=${hint.scope}` : "";
-  const header = `Pinet agents: ${agents.length} visible${hintSuffix}${scopeSuffix}.`;
-  const hasRoutingContext = hintParts.length > 0 || Boolean(scopeSuffix);
-  if (!hasRoutingContext || agents.length === 0) return header;
+  const breakdown = formatAgentStatusBreakdown(agents);
+  return `Pinet agents: ${agents.length} visible${breakdown}${hintSuffix}${scopeSuffix}.`;
+}
 
-  const shownAgents = agents.slice(0, PINET_COMPACT_AGENT_TEXT_LIMIT);
-  const lines = [header, ...shownAgents.map(formatCompactAgentRow)];
-  const truncated = agents.length - shownAgents.length;
-  if (truncated > 0) {
-    lines.push(
-      `… ${truncated} more agent${truncated === 1 ? "" : "s"}; narrow filters or use args.full=true.`,
+interface PinetAgentsExpandedRow {
+  name: string;
+  id: string;
+  state: string;
+  where: string;
+  laneOrRole: string;
+  inbox: string;
+}
+
+const PINET_AGENTS_EXPANDED_MAX_ROWS = 30;
+
+// Compact, aligned per-agent rows for the expanded TUI card. Avoids JSON dumps;
+// shows name/id/status-health/repo-branch/lane-or-role/pending-inbox + flags.
+function formatPinetAgentsExpanded(agents: AgentDisplayInfo[]): string {
+  if (agents.length === 0) return "(no agents connected)";
+
+  const shown = agents.slice(0, PINET_AGENTS_EXPANDED_MAX_ROWS);
+  const rows: PinetAgentsExpandedRow[] = shown.map((agent) => {
+    const name = `${agent.emoji} ${agent.name}`;
+    const id = agent.id.length > 8 ? agent.id.slice(0, 8) : agent.id;
+    const healthSuffix = agent.health && agent.health !== "healthy" ? `/${agent.health}` : "";
+    const stuckSuffix = agent.stuck ? " stuck" : "";
+    const state = `${agent.status}${healthSuffix}${stuckSuffix}`;
+    const repo = getAgentRepo(agent);
+    const branch = getAgentBranch(agent);
+    const where = repo ? `${repo}${branch ? `/${branch}` : ""}` : (branch ?? "—");
+    const laneId = typeof agent.metadata?.laneId === "string" ? agent.metadata.laneId : undefined;
+    const role = getAgentRole(agent);
+    const laneOrRole = laneId ? `lane:${laneId}` : (role ?? "");
+    const inbox =
+      agent.pendingInboxCount != null && agent.pendingInboxCount > 0
+        ? `inbox:${agent.pendingInboxCount}`
+        : "";
+    return { name, id, state, where, laneOrRole, inbox };
+  });
+
+  const clip = (value: string, width: number): string =>
+    value.length <= width ? value : `${value.slice(0, Math.max(0, width - 1))}…`;
+  const pad = (value: string, width: number): string =>
+    value.length >= width ? value : `${value}${" ".repeat(width - value.length)}`;
+  const colWidth = (pick: (row: PinetAgentsExpandedRow) => string, cap: number): number =>
+    Math.min(
+      cap,
+      rows.reduce((max, row) => Math.max(max, pick(row).length), 0),
     );
+
+  const nameW = colWidth((row) => row.name, 28);
+  const idW = colWidth((row) => row.id, 8);
+  const stateW = colWidth((row) => row.state, 20);
+  const whereW = colWidth((row) => row.where, 30);
+  const laneW = colWidth((row) => row.laneOrRole, 18);
+
+  const lines = rows.map((row) =>
+    [
+      pad(clip(row.name, nameW), nameW),
+      pad(row.id, idW),
+      pad(clip(row.state, stateW), stateW),
+      pad(clip(row.where, whereW), whereW),
+      pad(clip(row.laneOrRole, laneW), laneW),
+      row.inbox,
+    ]
+      .join("  ")
+      .trimEnd(),
+  );
+
+  if (agents.length > shown.length) {
+    lines.push(`… +${agents.length - shown.length} more`);
   }
+
   return lines.join("\n");
 }
 
@@ -1695,6 +1820,7 @@ function runPinetAgentsAction(
       details: { agents, hint },
       compactDetails: buildCompactAgentDetails(agents, hint),
       fullDetails: { agents, hint },
+      expandedText: formatPinetAgentsExpanded(agents),
     };
   })();
 }
@@ -2123,13 +2249,20 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
 
       try {
         const result = await definition.execute(toolCallId, params.args, output);
+        const expandedText =
+          typeof result.expandedText === "string" && result.expandedText.trim().length > 0
+            ? result.expandedText
+            : undefined;
+        const displayText = result.content[0]?.text ?? "";
         return wrapDispatcherEnvelope(
           buildPinetDispatcherEnvelope("succeeded", {
             action: definition.name,
-            text: result.content[0]?.text ?? "",
+            text: output.format === "json" ? (result.machineText ?? displayText) : displayText,
             details: selectPinetResultDetails(result, output),
           }),
           output,
+          expandedText,
+          displayText,
         );
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {


### PR DESCRIPTION
## Summary

Fixes the two reported Pinet TUI pain points from the design pass:

1. **`pinet agents` expanded view dumped a wall of raw JSON** (the whole `agents[]` array via `JSON.stringify`).
2. **`pinet send` never showed the sent message** anywhere (collapsed or expanded).

This is the display-side fix under the #763 progressive-disclosure contract (compact human summary first, expandable detail second) and the #762 context-efficiency contract. PR2 (stacked) will extend the same pattern to `read`/`ports`/`lanes`/`spawn`/`schedule`.

## What changed

**Renderer-only expanded contract**
- Added an optional `expandedText` on the action result that the dispatcher threads into the success envelope as renderer-only `data.display.expanded`. The expanded TUI card now prefers this human text instead of JSON-dumping `data.details`.
- Hardened the generic fallback (`formatPrimitiveDetails`): arrays render as `N items`, nested objects as inlined primitive keys — never a JSON wall.
- `display` is **renderer-only**: it is not part of `content`/`data.text` and is never sent to the model.

**`pinet agents`**
- Collapsed summary now includes a status breakdown: `Pinet agents: 5 visible (4 working, 1 idle)` (+ `ghost`/`stale` when present).
- Expanded renders a compact, aligned per-agent table: `emoji name · short id · status/health(+stuck) · repo/branch · lane|role · inbox:N`. Capped at 30 rows with `… +k more`.

**`pinet send`**
- Collapsed text adds a capped (≤80 char), whitespace-collapsed preview + line count: `Pinet message sent to alpha · “…” (3 lines)`.
- Expanded shows the envelope (`to` / `message id` / `transferred thread`) and the capped (≤600 char) body with line + char counts.
- Broadcast path gets the same preview + recipient list on expand.

## Contract preservation

- `data.text` stays compact by default (model context unchanged apart from the small capped send preview).
- `format=json` still emits the exact JSON envelope in `content` for automation/debug.
- `full=true` model text unchanged.
- `data.details` shape is additive only (`display` is new and renderer-only).

## Tests

- Updated the 5 contract-locked assertions (send preview, agents breakdown).
- Added: agents expanded table (asserts no `capabilityTags`/`routingScore`/`[{"id"` JSON wall), send long-preview truncation, multi-line line counts, and the hardened array-summary fallback.
- `slack-bridge`: **1418 tests pass**, lint clean, typecheck clean, build clean.

> Note: one pre-existing test (`helpers.test.ts` mesh-secret) only fails when `PINET_MESH_SECRET` is exported into the test env; it is environmental and unrelated to this change. CI env is clean.

Design pass + approval: tracked under #763 / #762.