### PR TITLE
feat(pinet): expanded rows for read/ports/lanes + schedule id (#763, #762)

### DIFF
--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -345,7 +345,7 @@ describe("registerPinetTools", () => {
 
     expect(collapsed).toEqual({
       status: "succeeded",
-      text: "Pinet wake-up scheduled for 2026-07-01T00:05:00.000Z.",
+      text: "Pinet wake-up scheduled for 2026-07-01T00:05:00.000Z (id 7).",
     });
     expect(expanded.text).toContain("status: succeeded");
     expect(expanded.text).toContain("action: schedule");
@@ -1085,7 +1085,9 @@ describe("registerPinetTools", () => {
     };
 
     expect(scheduleBrokerWakeup).toHaveBeenCalledWith("2026-04-14T12:05:00.000Z", "check queue");
-    expect(result.details.data.text).toBe("Pinet wake-up scheduled for 2026-04-14T12:05:00.000Z.");
+    expect(result.details.data.text).toBe(
+      "Pinet wake-up scheduled for 2026-04-14T12:05:00.000Z (id 7).",
+    );
     expect(result.details.data.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
   });
 
@@ -1653,8 +1655,8 @@ describe("registerPinetTools", () => {
     expect(expanded).toContain("line three");
   });
 
-  it("summarizes arrays in expanded fallback details instead of dumping JSON", async () => {
-    const readPinetInbox = vi.fn(async () => ({
+  function makeReadResult() {
+    return {
       messages: [
         {
           inboxId: 31,
@@ -1691,14 +1693,64 @@ describe("registerPinetTools", () => {
       unreadCountAfter: 0,
       unreadThreads: [],
       markedReadIds: [31, 32],
-    }));
+    };
+  }
+
+  it("renders pinet read messages as rows when expanded but stays compact collapsed", async () => {
+    const readPinetInbox = vi.fn(async () => makeReadResult());
     const tools = registerWithDeps(createDeps({ readPinetInbox }));
     const pinet = tools.get("pinet");
     const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
 
-    const result = (await pinet?.execute("tool-call-read-fallback", {
+    const result = (await pinet?.execute("tool-call-read-rows", {
       action: "read",
       args: { unread_only: true },
+    })) as { content?: Array<{ type: string; text?: string }>; details?: unknown };
+
+    const collapsed = pinet
+      ?.renderResult?.(result, { expanded: false }, theme, {})
+      .render(200)
+      .join("\n");
+    const expanded = pinet
+      ?.renderResult?.(result, { expanded: true }, theme, {})
+      .render(200)
+      .join("\n");
+
+    // Collapsed keeps the one-line summary (no per-message bodies).
+    expect(collapsed).toContain("Pinet read: 2 unread messages");
+    expect(collapsed).not.toContain("please inspect #594");
+    // Expanded shows the per-message rows, not a JSON wall.
+    expect(expanded).toContain("please inspect #594");
+    expect(expanded).toContain("and #595");
+    expect(expanded).not.toContain("[{");
+    expect(expanded).not.toContain('"inboxId"');
+  });
+
+  it("summarizes arrays in expanded fallback details instead of dumping JSON", async () => {
+    const lease = (id: string) => ({
+      id,
+      purpose: "preview",
+      port: 49152,
+      host: "127.0.0.1",
+      ownerAgentId: "agent-1",
+      pid: null,
+      status: "expired" as const,
+      metadata: null,
+      acquiredAt: "2026-05-01T00:00:00.000Z",
+      renewedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-05-01T00:10:00.000Z",
+      releasedAt: null,
+    });
+    const expirePortLeases = vi.fn(async () => [lease("lease-1"), lease("lease-2")]);
+    const tools = registerWithDeps(createDeps({ expirePortLeases }));
+    const pinet = tools.get("pinet");
+    const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
+
+    // ports op=expire has no custom expanded view, so it exercises the hardened
+    // fallback which summarizes arrays rather than emitting a JSON wall.
+    const result = (await pinet?.execute("tool-call-ports-expire", {
+      action: "ports",
+      args: { op: "expire" },
     })) as { content?: Array<{ type: string; text?: string }>; details?: unknown };
 
     const expanded = pinet
@@ -1706,11 +1758,96 @@ describe("registerPinetTools", () => {
       .render(200)
       .join("\n");
 
-    // Read has no custom expanded view in PR1, so it uses the hardened fallback
-    // which summarizes arrays rather than emitting a JSON wall.
-    expect(expanded).toContain("messages: 2 items");
+    expect(expanded).toContain("leases: 2 items");
     expect(expanded).not.toContain("[{");
-    expect(expanded).not.toContain('"inboxId"');
-    expect(expanded).not.toContain('"preview"');
+    expect(expanded).not.toContain('"expiresAt"');
+  });
+
+  it("renders pinet ports list rows on expand but a count when collapsed", async () => {
+    const listPortLeases = vi.fn(async () => [
+      {
+        id: "lease-1",
+        purpose: "preview",
+        port: 49152,
+        host: "127.0.0.1",
+        ownerAgentId: "agent-1",
+        pid: null,
+        status: "active" as const,
+        metadata: null,
+        acquiredAt: "2026-05-01T00:00:00.000Z",
+        renewedAt: "2026-05-01T00:00:00.000Z",
+        expiresAt: "2026-05-01T00:10:00.000Z",
+        releasedAt: null,
+      },
+    ]);
+    const tools = registerWithDeps(createDeps({ listPortLeases }));
+    const pinet = tools.get("pinet");
+    const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
+
+    const result = (await pinet?.execute("tool-call-ports-list-rows", {
+      action: "ports",
+      args: { op: "list" },
+    })) as { content?: Array<{ type: string; text?: string }>; details?: unknown };
+
+    const collapsed = pinet
+      ?.renderResult?.(result, { expanded: false }, theme, {})
+      .render(200)
+      .map((line) => line.trimEnd())
+      .join("\n");
+    const expanded = pinet
+      ?.renderResult?.(result, { expanded: true }, theme, {})
+      .render(200)
+      .join("\n");
+
+    expect(collapsed).toBe("✓ Pinet port leases: 1.");
+    expect(expanded).toContain("127.0.0.1:49152");
+    expect(expanded).toContain("lease=lease-1");
+    expect(expanded).not.toContain("leases: 1 item");
+  });
+
+  it("renders pinet lanes rows on expand but a count when collapsed", async () => {
+    const listPinetLanes = vi.fn(async () => [
+      {
+        laneId: "issue-688",
+        name: "Dispatcher UX",
+        task: null,
+        issueNumber: 688,
+        prNumber: null,
+        threadId: null,
+        ownerAgentId: "agent-1",
+        implementationLeadAgentId: null,
+        pmMode: true,
+        state: "active" as const,
+        summary: null,
+        metadata: null,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+        lastActivityAt: "2026-05-01T00:00:00.000Z",
+        participants: [],
+      },
+    ]);
+    const tools = registerWithDeps(createDeps({ listPinetLanes }));
+    const pinet = tools.get("pinet");
+    const theme: MinimalRenderTheme = { fg: (_color, text) => text, bold: (text) => text };
+
+    const result = (await pinet?.execute("tool-call-lanes-list-rows", {
+      action: "lanes",
+      args: { op: "list" },
+    })) as { content?: Array<{ type: string; text?: string }>; details?: unknown };
+
+    const collapsed = pinet
+      ?.renderResult?.(result, { expanded: false }, theme, {})
+      .render(200)
+      .map((line) => line.trimEnd())
+      .join("\n");
+    const expanded = pinet
+      ?.renderResult?.(result, { expanded: true }, theme, {})
+      .render(200)
+      .join("\n");
+
+    expect(collapsed).toBe("✓ Pinet lanes: 1 tracked.");
+    expect(expanded).toContain("issue-688");
+    expect(expanded).toContain("[active]");
+    expect(expanded).toContain("#688");
   });
 });

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -901,6 +901,10 @@ function runPinetReadAction(
       details: result,
       compactDetails: buildCompactPinetReadDetails(result),
       fullDetails: result,
+      // When the model/CLI text is the compact one-liner, give the operator the
+      // full per-message rows on expand. In full/thread mode `text` already
+      // carries the rich view, so no separate expanded body is needed.
+      ...(shouldRenderFull ? {} : { expandedText: formatPinetReadResultFull(result, options) }),
     };
   })();
 }
@@ -1125,7 +1129,7 @@ function runPinetScheduleAction(
             type: "text",
             text: output.full
               ? `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`
-              : `Pinet wake-up scheduled for ${wakeup.fireAt}.`,
+              : `Pinet wake-up scheduled for ${wakeup.fireAt} (id ${wakeup.id}).`,
           },
         ],
         details: wakeup,
@@ -1140,7 +1144,7 @@ function runPinetScheduleAction(
             type: "text",
             text: output.full
               ? `Wake-up scheduled for ${wakeup.fireAt} (id: ${wakeup.id}).`
-              : `Pinet wake-up scheduled for ${wakeup.fireAt}.`,
+              : `Pinet wake-up scheduled for ${wakeup.fireAt} (id ${wakeup.id}).`,
           },
         ],
         details: wakeup,
@@ -1603,6 +1607,10 @@ function runPinetPortsAction(
         details: { leases },
         compactDetails: buildCompactPortLeaseDetails(leases),
         fullDetails: { leases },
+        // Compact text is a count; show the per-lease rows on expand.
+        ...(output.full || leases.length === 0
+          ? {}
+          : { expandedText: formatPortLeases(leases, true) }),
       };
     }
 
@@ -1641,6 +1649,10 @@ function runPinetLanesAction(
         details: { lanes },
         compactDetails: buildCompactLaneDetails(lanes),
         fullDetails: { lanes },
+        // Compact text is a count; show the per-lane rows on expand.
+        ...(output.full || lanes.length === 0
+          ? {}
+          : { expandedText: formatPinetLanes(lanes, true) }),
       };
     }
 


### PR DESCRIPTION
## Summary

PR2 of the Pinet TUI UX work — **stacked on #823** (base = `feat/pinet-tui-expanded-render`). Extends the renderer-only `data.display.expanded` contract from PR1 to the remaining list-shaped actions and polishes confirmations.

> Review/merge #823 first. This PR's diff is only the PR2 commit on top.

## What changed

**`pinet read`**
- When the model/CLI text is the compact one-liner, the expanded TUI card now shows the full per-message rows (class-labelled `- [steering] [src/thread #id] sender: body`), plus unread-thread pointers and marked-read ids.
- In full/thread mode `text` already carries the rich view, so no separate expanded body is added (avoids duplication).
- Collapsed model text and `data.details` preview truncation are unchanged — full bodies appear only in the operator's expanded card (renderer-only, never sent to the model).

**`pinet ports` (list)** / **`pinet lanes` (list)**
- Collapsed stays a count (`Pinet port leases: 2.` / `Pinet lanes: 1 tracked.`).
- Expanded shows per-lease / per-lane rows (reusing the existing `full` formatters).
- Gated to the compact path so full/json callers keep their existing rich text with no duplication.

**`pinet schedule`**
- Surfaces the wake-up id in the compact confirmation (`… (id 7)`), not just in `full=true`.

## Contract preservation

- `data.text` compact paths unchanged except the additive schedule id.
- `format=json` exact envelope and `full=true` text unchanged.
- `data.details` shape unchanged; `display` remains renderer-only.

## Tests

- read rows-on-expand (collapsed stays the summary, no bodies leaked to collapsed);
- ports/lanes rows-on-expand (collapsed stays a count);
- hardened array-summary fallback re-pointed at `ports expire` (still proves no JSON wall);
- schedule id assertions updated.
- `slack-bridge`: **1421 tests pass**, lint clean, typecheck clean, build clean.

Tracked under #763 / #762.
