### PR TITLE
fix: guard npm package GitHub metadata

### DIFF
--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -22,6 +22,9 @@ const publishPackageNamesByDirectory = new Map(
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 const publicDependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 const requiredPackageFiles = ["README.md", "LICENSE", "dist/"];
+const expectedRepositoryUrl = "git+https://github.com/gugu91/extensions.git";
+const expectedHomepageUrl = "https://github.com/gugu91/extensions#readme";
+const expectedBugsUrl = "https://github.com/gugu91/extensions/issues";
 
 export function parseArgs(argv) {
   const args = {
@@ -220,6 +223,18 @@ export function validatePublishMetadata(entries, { dryRun }) {
     }
     if (!manifest.version) errors.push(`${directory}: package.json must include version`);
     if (manifest.private === true) errors.push(`${manifest.name}: package must not be private`);
+    if (manifest.repository?.type !== "git" || manifest.repository?.url !== expectedRepositoryUrl) {
+      errors.push(`${manifest.name}: repository.url must be ${expectedRepositoryUrl}`);
+    }
+    if (manifest.repository?.directory !== directory) {
+      errors.push(`${manifest.name}: repository.directory must be ${directory}`);
+    }
+    if (manifest.homepage && manifest.homepage !== expectedHomepageUrl) {
+      errors.push(`${manifest.name}: homepage must be ${expectedHomepageUrl}`);
+    }
+    if (manifest.bugs?.url && manifest.bugs.url !== expectedBugsUrl) {
+      errors.push(`${manifest.name}: bugs.url must be ${expectedBugsUrl}`);
+    }
     if (manifest.publishConfig?.access !== "public") {
       errors.push(`${manifest.name}: publishConfig.access must be public`);
     }

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -26,6 +26,24 @@ function entry(directory, manifest) {
   };
 }
 
+function publishManifest(directory, overrides = {}) {
+  return {
+    name: `@pinet/${directory}`,
+    version: "0.1.0",
+    license: "MIT",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/gugu91/extensions.git",
+      directory,
+    },
+    publishConfig: { access: "public" },
+    main: "./dist/index.js",
+    types: "./dist/index.d.ts",
+    files: ["README.md", "LICENSE", "dist/"],
+    ...overrides,
+  };
+}
+
 test("getPublishPackages returns the full publish set in dependency order", () => {
   assert.deepEqual(getPublishPackages(), [
     "transport-core",
@@ -150,17 +168,7 @@ test("rewriteLocalDependencySpecs rejects local dependencies outside the publish
 });
 
 test("validatePublishMetadata blocks placeholder versions for real publish only", () => {
-  const entries = [
-    entry("pinet-core", {
-      name: "@pinet/pinet-core",
-      version: "0.0.0",
-      license: "MIT",
-      publishConfig: { access: "public" },
-      main: "./dist/index.js",
-      types: "./dist/index.d.ts",
-      files: ["README.md", "LICENSE", "dist/"],
-    }),
-  ];
+  const entries = [entry("pinet-core", publishManifest("pinet-core", { version: "0.0.0" }))];
 
   assert.doesNotThrow(() => validatePublishMetadata(entries, { dryRun: true }));
   assert.throws(
@@ -171,14 +179,7 @@ test("validatePublishMetadata blocks placeholder versions for real publish only"
 
 test("validatePublishMetadata requires declaration metadata", () => {
   const entries = [
-    entry("pinet-core", {
-      name: "@pinet/pinet-core",
-      version: "0.0.0",
-      license: "MIT",
-      publishConfig: { access: "public" },
-      main: "./dist/index.js",
-      files: ["README.md", "LICENSE", "dist/"],
-    }),
+    entry("pinet-core", publishManifest("pinet-core", { version: "0.0.0", types: undefined })),
   ];
 
   assert.throws(() => validatePublishMetadata(entries, { dryRun: true }), /must include types/);
@@ -186,20 +187,37 @@ test("validatePublishMetadata requires declaration metadata", () => {
 
 test("validatePublishMetadata requires npm org pinet package names", () => {
   const entries = [
-    entry("pinet-core", {
-      name: "@gugu910/pi-pinet-core",
-      version: "0.0.0",
-      license: "MIT",
-      publishConfig: { access: "public" },
-      main: "./dist/index.js",
-      types: "./dist/index.d.ts",
-      files: ["README.md", "LICENSE", "dist/"],
-    }),
+    entry(
+      "pinet-core",
+      publishManifest("pinet-core", { name: "@gugu910/pi-pinet-core", version: "0.0.0" }),
+    ),
   ];
 
   assert.throws(
     () => validatePublishMetadata(entries, { dryRun: true }),
     /package name must be @pinet\/pinet-core/,
+  );
+});
+
+test("validatePublishMetadata blocks incorrect GitHub package links", () => {
+  const entries = [
+    entry(
+      "slack-bridge",
+      publishManifest("slack-bridge", {
+        repository: {
+          type: "git",
+          url: "git+https://github.com/gugu910/extensions.git",
+          directory: "wrong-directory",
+        },
+        homepage: "https://github.com/gugu910/extensions#readme",
+        bugs: { url: "https://github.com/gugu910/extensions/issues" },
+      }),
+    ),
+  ];
+
+  assert.throws(
+    () => validatePublishMetadata(entries, { dryRun: true }),
+    /repository\.url must be git\+https:\/\/github\.com\/gugu91\/extensions\.git[\s\S]*repository\.directory must be slack-bridge[\s\S]*homepage must be https:\/\/github\.com\/gugu91\/extensions#readme[\s\S]*bugs\.url must be https:\/\/github\.com\/gugu91\/extensions\/issues/,
   );
 });
 

--- a/slack-bridge/broker-prompt-loader.test.ts
+++ b/slack-bridge/broker-prompt-loader.test.ts
@@ -299,8 +299,9 @@ describe("packaged default broker prompt", () => {
     expect(defaultPrompt).toContain("Never echo tokens");
   });
 
-  // This exercises the real package build, including declaration emit; CI can exceed Vitest's
-  // default 5s test timeout even though the build path is expected for publish readiness.
+  // This exercises the real package build, including declaration emit; loaded worktrees and
+  // pre-push runs can exceed Vitest's default 5s timeout even though the build path is expected
+  // for publish readiness.
   it("copies prompt assets into dist/prompts so the packaged tmux.md is loadable", async () => {
     await execFileAsync("node", ["../scripts/build-package.mjs"], { cwd: process.cwd() });
 
@@ -314,5 +315,5 @@ describe("packaged default broker prompt", () => {
 
     expect(result.source).toBe("packaged");
     expect(result.content).toContain("PRIORITIZED ISSUE GATE");
-  }, 20_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary
- reject publish metadata that points package repository/homepage/bugs links away from github.com/gugu91/extensions
- validate repository.directory matches each publish package directory
- add regression coverage for the historical gugu910 GitHub-link typo
- relax the broker prompt package-build test timeout so pre-push can complete under load

## Tests
- node --test scripts/npm-publish-helpers.test.mjs
- pnpm --filter @pinet/slack-bridge exec vitest run broker-prompt-loader.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test

Note: this PR prevents future bad source/publish metadata. Correcting the already-published legacy @gugu910/pi-slack-bridge Pi page still requires an explicit npm deprecate or legacy patch publish.
