### PR TITLE
Skip stale Slack redelivery after 15 minutes

### DIFF
--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -74,6 +74,7 @@ import { createAgentPromptGuidance } from "./agent-prompt-guidance.js";
 import { createAgentEventRuntime } from "./agent-event-runtime.js";
 import { createSessionUiRuntime } from "./session-ui-runtime.js";
 import { createSlackRequestRuntime } from "./slack-request-runtime.js";
+import { getSlackMessageAgeMs, isStaleSlackMessage } from "./stale-slack-messages.js";
 import {
   formatSlackAgentsDashboard,
   formatSlackAgentsUsage,
@@ -698,6 +699,14 @@ export default function (pi: ExtensionAPI) {
       getMeshRoleFromMetadata(metadata ?? undefined, fallbackRole),
     handleInboundMessage: async ({ message, broker, router, selfId, ctx }) => {
       try {
+        if (isStaleSlackMessage(message)) {
+          const ageMs = getSlackMessageAgeMs(message);
+          console.info(
+            `[slack-bridge] skipped stale Slack inbound message older than 15m: channel=${message.channel} thread=${message.threadId} ts=${message.timestamp} age_ms=${ageMs ?? "unknown"}`,
+          );
+          return;
+        }
+
         const ownerHint =
           message.source === "slack" && message.threadId && message.channel
             ? await resolveBrokerThreadOwnerHint(message.channel, message.threadId)

--- a/slack-bridge/stale-slack-messages.test.ts
+++ b/slack-bridge/stale-slack-messages.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  isStaleSlackMessage,
+  parseSlackTimestampMs,
+  STALE_SLACK_MESSAGE_MAX_AGE_MS,
+} from "./stale-slack-messages.js";
+
+describe("stale Slack message filtering", () => {
+  const baseTimestampMs = Date.parse("2026-06-17T12:00:00.000Z");
+  const baseTimestamp = String(baseTimestampMs / 1000);
+
+  it("parses Slack second timestamps with millisecond precision", () => {
+    expect(parseSlackTimestampMs("1781697298.359899")).toBe(1_781_697_298_359);
+  });
+
+  it("does not mark Slack messages at the 15 minute boundary as stale", () => {
+    expect(
+      isStaleSlackMessage(
+        { source: "slack", timestamp: baseTimestamp },
+        { nowMs: baseTimestampMs + STALE_SLACK_MESSAGE_MAX_AGE_MS },
+      ),
+    ).toBe(false);
+  });
+
+  it("marks Slack messages older than 15 minutes as stale", () => {
+    expect(
+      isStaleSlackMessage(
+        { source: "slack", timestamp: baseTimestamp },
+        { nowMs: baseTimestampMs + STALE_SLACK_MESSAGE_MAX_AGE_MS + 1 },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not drop non-Slack messages", () => {
+    expect(
+      isStaleSlackMessage(
+        { source: "agent", timestamp: baseTimestamp },
+        { nowMs: baseTimestampMs + STALE_SLACK_MESSAGE_MAX_AGE_MS + 60_000 },
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps malformed Slack timestamps deliverable instead of dropping ambiguous mail", () => {
+    expect(
+      isStaleSlackMessage(
+        { source: "slack", timestamp: "not-a-slack-ts" },
+        { nowMs: baseTimestampMs + STALE_SLACK_MESSAGE_MAX_AGE_MS + 60_000 },
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps implausibly small Slack test timestamps deliverable", () => {
+    expect(
+      isStaleSlackMessage(
+        { source: "slack", timestamp: "123.456" },
+        { nowMs: baseTimestampMs + STALE_SLACK_MESSAGE_MAX_AGE_MS + 60_000 },
+      ),
+    ).toBe(false);
+  });
+});

--- a/slack-bridge/stale-slack-messages.ts
+++ b/slack-bridge/stale-slack-messages.ts
@@ -1,0 +1,51 @@
+export const STALE_SLACK_MESSAGE_MAX_AGE_MS = 15 * 60 * 1000;
+// Slack message ts values are epoch seconds. Treat tiny test/sentinel values as
+// ambiguous rather than stale so only plausible Slack-origin event timestamps
+// are skipped.
+const MIN_PLAUSIBLE_SLACK_TIMESTAMP_SECONDS = 1_000_000_000;
+
+export interface SlackMessageStalenessInput {
+  source: string;
+  timestamp: string;
+}
+
+export interface SlackMessageStalenessOptions {
+  nowMs?: number;
+  maxAgeMs?: number;
+}
+
+export function parseSlackTimestampMs(timestamp: string): number | null {
+  const seconds = Number(timestamp);
+  if (!Number.isFinite(seconds) || seconds < MIN_PLAUSIBLE_SLACK_TIMESTAMP_SECONDS) {
+    return null;
+  }
+  return Math.trunc(seconds * 1000);
+}
+
+export function getSlackMessageAgeMs(
+  input: SlackMessageStalenessInput,
+  options: SlackMessageStalenessOptions = {},
+): number | null {
+  if (input.source !== "slack") {
+    return null;
+  }
+
+  const timestampMs = parseSlackTimestampMs(input.timestamp);
+  if (timestampMs === null) {
+    return null;
+  }
+
+  return (options.nowMs ?? Date.now()) - timestampMs;
+}
+
+export function isStaleSlackMessage(
+  input: SlackMessageStalenessInput,
+  options: SlackMessageStalenessOptions = {},
+): boolean {
+  const ageMs = getSlackMessageAgeMs(input, options);
+  if (ageMs === null) {
+    return false;
+  }
+
+  return ageMs > (options.maxAgeMs ?? STALE_SLACK_MESSAGE_MAX_AGE_MS);
+}


### PR DESCRIPTION
## Summary
- Add a 15-minute stale Slack timestamp guard before broker inbound routing enqueues Slack-origin messages into Pinet inbox/backlog flows.
- Log skipped stale Slack deliveries with channel/thread/timestamp/age details, without replaying the message body.
- Add boundary tests for Slack timestamp parsing, >15m stale detection, fresh-at-boundary delivery, non-Slack/A2A preservation, and ambiguous test timestamps.

Closes #831.

## Testing
- `pnpm exec vitest run slack-bridge/stale-slack-messages.test.ts slack-bridge/broker/adapters/slack.test.ts slack-bridge/index.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`
