### PR TITLE
Require explicit Pinet invocation in guarded Slack contexts

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -160,6 +160,15 @@ Behavior and precedence:
     "appToken": "xapp-...",
     "runtimeMode": "single",
     "allowedUsers": ["U_EXAMPLE_MEMBER_ID"],
+    "ingressGuard": {
+      "requireMention": {
+        "channels": ["C_EXTERNAL_CHANNEL_ID"],
+        "mixedParticipantThreads": {
+          "enabled": true,
+          "trustedUsers": ["U_EXAMPLE_MEMBER_ID"]
+        }
+      }
+    },
     "defaultChannel": "C_EXAMPLE_CHANNEL_ID",
     "logChannel": "#pinet-logs",
     "logLevel": "actions",
@@ -183,30 +192,33 @@ Slack access is now **default-deny** unless you configure one of these explicitl
 - `allowedUsers` / `SLACK_ALLOWED_USERS` — allow only specific Slack user IDs
 - `allowAllWorkspaceUsers: true` / `SLACK_ALLOW_ALL_WORKSPACE_USERS=true` — explicit workspace-wide opt-in
 
-| Key                            | Required | Description                                                                                                           |
-| ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                                     |
-| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                          |
-| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true                |
-| `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                                 |
-| `defaultChannel`               | no       | Default channel for the `slack` dispatcher `post_channel` action                                                      |
-| `logChannel`                   | no       | Channel for broker activity logs                                                                                      |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                     |
-| `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                               |
-| `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                                |
-| `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                           |
-| `ralphLoopIntervalMs`          | no       | Broker RALPH maintenance cadence in milliseconds; defaults to `300000` (5 minutes), valid range `1000`-`2147483647`   |
-| `ralphSnoozeAfterEmptyCycles`  | no       | Broker RALPH auto-snooze trigger after N empty cycles; defaults to `0` (disabled), valid range `0`-`100`              |
-| `ralphSnoozeDurationMs`        | no       | Broker RALPH auto-snooze duration in milliseconds; defaults to `1800000` (30 minutes), valid range `60000`-`86400000` |
-| `skinTheme`                    | no       | Pinet presentation skin selected at broker startup/reload (`default`, `foundation`, `cosmere`, or free-form)          |
-| `slackCommandName`             | no       | Slack web app slash command name for `agents list`; defaults to `/pinet`, or `/oathgate` for Oathgate/Cosmere skins   |
-| `slackCommandNames`            | no       | Optional list of accepted/deployed Slack slash command aliases when one app needs multiple command names              |
-| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                     |
-| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file               |
-| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                    |
-| `security.readOnly`            | no       | Runtime-block write-capable tools for Slack-triggered turns, including core tools like `bash`, `edit`, and `write`    |
-| `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context         |
-| `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                          |
+Optional explicit invocation guard: `ingressGuard.requireMention` is off by default. Set `channels` to Slack channel IDs where otherwise-actionable messages must mention the bot (`@pinet` / `<@bot>`), and set `mixedParticipantThreads.enabled: true` with `trustedUsers` to require a mention in Pinet-owned Slack threads once anyone outside `trustedUsers` plus the bot has participated. This guard is orthogonal to `allowedUsers`: sender authorization still decides who may invoke Pinet; the guard only decides when an explicit mention is required.
+
+| Key                            | Required | Description                                                                                                            |
+| ------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                                      |
+| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                           |
+| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true                 |
+| `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                                  |
+| `ingressGuard.requireMention`  | no       | Optional Slack ingress guard requiring `@pinet` in configured channel IDs and/or mixed-participant Pinet-owned threads |
+| `defaultChannel`               | no       | Default channel for the `slack` dispatcher `post_channel` action                                                       |
+| `logChannel`                   | no       | Channel for broker activity logs                                                                                       |
+| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                      |
+| `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                                |
+| `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                                 |
+| `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                            |
+| `ralphLoopIntervalMs`          | no       | Broker RALPH maintenance cadence in milliseconds; defaults to `300000` (5 minutes), valid range `1000`-`2147483647`    |
+| `ralphSnoozeAfterEmptyCycles`  | no       | Broker RALPH auto-snooze trigger after N empty cycles; defaults to `0` (disabled), valid range `0`-`100`               |
+| `ralphSnoozeDurationMs`        | no       | Broker RALPH auto-snooze duration in milliseconds; defaults to `1800000` (30 minutes), valid range `60000`-`86400000`  |
+| `skinTheme`                    | no       | Pinet presentation skin selected at broker startup/reload (`default`, `foundation`, `cosmere`, or free-form)           |
+| `slackCommandName`             | no       | Slack web app slash command name for `agents list`; defaults to `/pinet`, or `/oathgate` for Oathgate/Cosmere skins    |
+| `slackCommandNames`            | no       | Optional list of accepted/deployed Slack slash command aliases when one app needs multiple command names               |
+| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                      |
+| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file                |
+| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                     |
+| `security.readOnly`            | no       | Runtime-block write-capable tools for Slack-triggered turns, including core tools like `bash`, `edit`, and `write`     |
+| `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context          |
+| `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                           |
 
 ## Scope carrier model (compatibility-first)
 

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1827,6 +1827,287 @@ describe("SlackAdapter — allowlist filtering", () => {
   });
 });
 
+// ─── SlackAdapter — ingress guard ───────────────────────
+
+describe("SlackAdapter — ingress guard", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn<typeof fetch>();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockSlackResponse(data: Record<string, unknown> = {}) {
+    return new Response(JSON.stringify({ ok: true, ...data }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  function parseSlackBody(init?: RequestInit): Record<string, string> {
+    const rawBody = typeof init?.body === "string" ? init.body : "";
+    if (rawBody.startsWith("{")) {
+      return JSON.parse(rawBody) as Record<string, string>;
+    }
+    return Object.fromEntries(new URLSearchParams(rawBody));
+  }
+
+  function adapterMessagePort(adapter: SlackAdapter) {
+    return adapter as unknown as {
+      botUserId: string | null;
+      onMessage: (evt: Record<string, unknown>) => Promise<void>;
+    };
+  }
+
+  function installSuccessfulRoutingFetchMock(participants: Record<string, unknown>[] = []) {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const body = parseSlackBody(init);
+      if (url.endsWith("/conversations.replies")) {
+        expect(body.channel).toBe("C_MIXED");
+        expect(body.ts).toBe("200.100");
+        return mockSlackResponse({ messages: participants });
+      }
+      if (url.endsWith("/users.info")) {
+        return mockSlackResponse({
+          user: { real_name: body.user === "U_ALICE" ? "Alice" : "Thomas" },
+        });
+      }
+      if (url.endsWith("/reactions.add") || url.endsWith("/assistant.threads.setStatus")) {
+        return mockSlackResponse();
+      }
+      throw new Error(`unexpected Slack API call: ${url}`);
+    });
+  }
+
+  it("requires an explicit bot mention in configured external-party channels", async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error("ignored messages must not call Slack APIs");
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowedUsers: ["U_THOMAS"],
+      ingressGuard: { requireMention: { channels: ["C_EXT"] } },
+      isKnownThread: (threadTs) => threadTs === "100.100",
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    const port = adapterMessagePort(adapter);
+    port.botUserId = "U_BOT";
+
+    await port.onMessage({
+      type: "message",
+      user: "U_THOMAS",
+      text: "plain follow-up for the external party",
+      channel: "C_EXT",
+      channel_type: "channel",
+      thread_ts: "100.100",
+      ts: "100.200",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adapter.getTrackedThreadIds()).toEqual(new Set());
+  });
+
+  it("keeps sender authorization orthogonal to configured channel mention requirements", async () => {
+    installSuccessfulRoutingFetchMock();
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowedUsers: ["U_THOMAS", "U_ALICE"],
+      ingressGuard: { requireMention: { channels: ["C_EXT"] } },
+      isKnownThread: (threadTs) => threadTs === "100.100",
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    const port = adapterMessagePort(adapter);
+    port.botUserId = "U_BOT";
+
+    await port.onMessage({
+      type: "message",
+      user: "U_ALICE",
+      text: "allowed but not invoked",
+      channel: "C_EXT",
+      channel_type: "channel",
+      thread_ts: "100.100",
+      ts: "100.200",
+    });
+    expect(handler).not.toHaveBeenCalled();
+
+    await port.onMessage({
+      type: "message",
+      user: "U_ALICE",
+      text: "<@U_BOT> allowed and invoked",
+      channel: "C_EXT",
+      channel_type: "channel",
+      thread_ts: "100.100",
+      ts: "100.300",
+    });
+
+    await waitForAssertion(() => {
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+    expect(handler.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        userId: "U_ALICE",
+        threadId: "100.100",
+        channel: "C_EXT",
+        text: "<@U_BOT> allowed and invoked",
+      }),
+    );
+  });
+
+  it("requires a bot mention in Pinet-owned threads with untrusted participants", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const body = parseSlackBody(init);
+      if (url.endsWith("/conversations.replies")) {
+        expect(body.channel).toBe("C_MIXED");
+        expect(body.ts).toBe("200.100");
+        return mockSlackResponse({
+          messages: [{ user: "U_THOMAS" }, { user: "U_EXTERNAL" }, { user: "U_BOT" }],
+        });
+      }
+      throw new Error(
+        "mixed-thread messages without invocation must not call write/user Slack APIs",
+      );
+    });
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowedUsers: ["U_THOMAS"],
+      ingressGuard: {
+        requireMention: {
+          mixedParticipantThreads: { enabled: true, trustedUsers: ["U_THOMAS"] },
+        },
+      },
+      isKnownThread: (threadTs) => threadTs === "200.100",
+      isPinetOwnedThread: (threadTs, channelId) =>
+        threadTs === "200.100" && channelId === "C_MIXED",
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    const port = adapterMessagePort(adapter);
+    port.botUserId = "U_BOT";
+
+    await port.onMessage({
+      type: "message",
+      user: "U_THOMAS",
+      text: "continuing the customer thread, not invoking Pinet",
+      channel: "C_MIXED",
+      channel_type: "channel",
+      thread_ts: "200.100",
+      ts: "200.200",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    await waitForAssertion(() => {
+      const endpoints = fetchMock.mock.calls.map(([url]) => String(url));
+      expect(endpoints).toEqual(["https://slack.com/api/conversations.replies"]);
+    });
+  });
+
+  it("keeps trusted-only Pinet-owned threads usable without a bot mention", async () => {
+    installSuccessfulRoutingFetchMock([{ user: "U_THOMAS" }, { user: "U_BOT" }]);
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowedUsers: ["U_THOMAS"],
+      ingressGuard: {
+        requireMention: {
+          mixedParticipantThreads: { enabled: true, trustedUsers: ["U_THOMAS"] },
+        },
+      },
+      isKnownThread: (threadTs) => threadTs === "200.100",
+      isPinetOwnedThread: (threadTs, channelId) =>
+        threadTs === "200.100" && channelId === "C_MIXED",
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    const port = adapterMessagePort(adapter);
+    port.botUserId = "U_BOT";
+
+    await port.onMessage({
+      type: "message",
+      user: "U_THOMAS",
+      text: "normal trusted follow-up",
+      channel: "C_MIXED",
+      channel_type: "channel",
+      thread_ts: "200.100",
+      ts: "200.200",
+    });
+
+    await waitForAssertion(() => {
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+    expect(handler.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        userId: "U_THOMAS",
+        threadId: "200.100",
+        channel: "C_MIXED",
+        text: "normal trusted follow-up",
+      }),
+    );
+  });
+
+  it("accepts an explicit bot mention in mixed-participant Pinet-owned threads", async () => {
+    installSuccessfulRoutingFetchMock([{ user: "U_THOMAS" }, { user: "U_EXTERNAL" }]);
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      allowedUsers: ["U_THOMAS"],
+      ingressGuard: {
+        requireMention: {
+          mixedParticipantThreads: { enabled: true, trustedUsers: ["U_THOMAS"] },
+        },
+      },
+      isKnownThread: (threadTs) => threadTs === "200.100",
+      isPinetOwnedThread: (threadTs, channelId) =>
+        threadTs === "200.100" && channelId === "C_MIXED",
+    });
+    const handler = vi.fn();
+    adapter.onInbound(handler);
+    const port = adapterMessagePort(adapter);
+    port.botUserId = "U_BOT";
+
+    await port.onMessage({
+      type: "message",
+      user: "U_THOMAS",
+      text: "<@U_BOT> please help here",
+      channel: "C_MIXED",
+      channel_type: "channel",
+      thread_ts: "200.100",
+      ts: "200.200",
+    });
+
+    await waitForAssertion(() => {
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+    expect(handler.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        userId: "U_THOMAS",
+        threadId: "200.100",
+        channel: "C_MIXED",
+        text: "<@U_BOT> please help here",
+      }),
+    );
+  });
+});
+
 // ─── SlackAdapter — send (mocked fetch) ─────────────────
 
 describe("SlackAdapter — reaction triggers", () => {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -25,6 +25,7 @@ import {
   buildAllowlist,
   buildPinetControlMessage,
   buildPinetControlMetadata,
+  type SlackIngressGuardSettings,
 } from "../../helpers.js";
 import {
   buildReactionTriggerMessage,
@@ -64,6 +65,7 @@ export interface SlackAdapterConfig {
   appToken: string;
   allowedUsers?: string[];
   allowAllWorkspaceUsers?: boolean;
+  ingressGuard?: SlackIngressGuardSettings;
   suggestedPrompts?: { title: string; message: string }[];
   reactionCommands?: ReactionCommandSettings;
   /** Check whether a thread_ts belongs to a known thread in the broker DB. */
@@ -91,6 +93,8 @@ export interface SlackAdapterConfig {
    * Slack messages (#812).
    */
   isReactionThreadAuthorized?: (threadTs: string, channelId: string) => boolean;
+  /** Check whether a known Slack thread is Pinet-owned for mixed-participant mention gating. */
+  isPinetOwnedThread?: (threadTs: string, channelId: string) => boolean;
   /** Best-effort callback for Home tab opens. */
   onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
   /** Best-effort callback for Slack slash commands handled by the broker process. */
@@ -109,6 +113,7 @@ export const SLACK_THREAD_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 export const SLACK_PENDING_ATTENTION_MAX_THREADS = 1000;
 export const SLACK_PENDING_ATTENTION_TTL_MS = 2 * 60 * 60 * 1000;
 export const SLACK_PENDING_ATTENTION_MAX_MESSAGES_PER_THREAD = 50;
+export const SLACK_INGRESS_GUARD_THREAD_PARTICIPANT_LIMIT = 200;
 
 export class SlackAdapter implements MessageAdapter {
   readonly name = "slack";
@@ -640,6 +645,113 @@ export class SlackAdapter implements MessageAdapter {
     }
   }
 
+  private messageMentionsBot(evt: Record<string, unknown>): boolean {
+    if (!this.botUserId) return false;
+    const text = typeof evt.text === "string" ? evt.text : "";
+    return text.includes(`<@${this.botUserId}>`) || text.includes(`<@${this.botUserId}|`);
+  }
+
+  private requiresMentionInChannel(channelId: string): boolean {
+    const channels = this.config.ingressGuard?.requireMention?.channels ?? [];
+    return channels.some((channel) => channel.trim() === channelId);
+  }
+
+  private async shouldRequireMentionForMixedParticipantThread(input: {
+    evt: Record<string, unknown>;
+    channel: string;
+    threadTs: string;
+    userId: string;
+    isDM: boolean;
+  }): Promise<boolean> {
+    const config = this.config.ingressGuard?.requireMention?.mixedParticipantThreads;
+    if (!config?.enabled || input.isDM || typeof input.evt.thread_ts !== "string") {
+      return false;
+    }
+
+    if (!this.isPinetOwnedThreadForIngressGuard(input.threadTs, input.channel)) {
+      return false;
+    }
+
+    const participants = await this.fetchThreadParticipantUserIds(
+      input.channel,
+      input.threadTs,
+      input.userId,
+    );
+    if (!participants) {
+      // Fail closed for this guard: if we cannot inspect the thread makeup,
+      // require an explicit mention before Pinet acts in a configured mixed-thread posture.
+      return true;
+    }
+
+    const trustedUsers = new Set(
+      (config.trustedUsers ?? []).map((user) => user.trim()).filter(Boolean),
+    );
+    for (const participant of participants) {
+      if (this.botUserId && participant === this.botUserId) continue;
+      if (trustedUsers.has(participant)) continue;
+      return true;
+    }
+    return false;
+  }
+
+  private isPinetOwnedThreadForIngressGuard(threadTs: string, channelId: string): boolean {
+    const isOwned = this.config.isPinetOwnedThread;
+    if (isOwned) {
+      try {
+        return isOwned(threadTs, channelId);
+      } catch (error) {
+        console.error(`[slack-adapter] Pinet-owned thread check failed: ${errorMsg(error)}`);
+        return false;
+      }
+    }
+
+    const thread = this.getThread(threadTs);
+    return !!thread && thread.channelId === channelId;
+  }
+
+  private async fetchThreadParticipantUserIds(
+    channelId: string,
+    threadTs: string,
+    currentUserId: string,
+  ): Promise<Set<string> | null> {
+    const participants = new Set<string>();
+    if (currentUserId) participants.add(currentUserId);
+
+    try {
+      const response = await this.callSlack("conversations.replies", this.config.botToken, {
+        channel: channelId,
+        ts: threadTs,
+        limit: SLACK_INGRESS_GUARD_THREAD_PARTICIPANT_LIMIT,
+      });
+      const messages = Array.isArray(response.messages) ? response.messages : [];
+      for (const message of messages) {
+        if (!message || typeof message !== "object" || Array.isArray(message)) continue;
+        const userId = (message as Record<string, unknown>).user;
+        if (typeof userId === "string" && userId.length > 0) {
+          participants.add(userId);
+        }
+      }
+      return participants;
+    } catch (error) {
+      console.error(
+        `[slack-adapter] failed to inspect Slack thread participants: ${errorMsg(error)}`,
+      );
+      return null;
+    }
+  }
+
+  private async shouldRequireExplicitMention(input: {
+    evt: Record<string, unknown>;
+    channel: string;
+    threadTs: string;
+    userId: string;
+    isDM: boolean;
+  }): Promise<boolean> {
+    if (!this.config.ingressGuard?.requireMention) return false;
+    if (this.requiresMentionInChannel(input.channel)) return true;
+    return this.shouldRequireMentionForMixedParticipantThread(input);
+  }
+
   private async onMessage(evt: Record<string, unknown>): Promise<void> {
     if (this.shuttingDown) return;
 
@@ -665,6 +777,13 @@ export class SlackAdapter implements MessageAdapter {
     // Check the allowlist before recording any thread state so unauthorized
     // traffic can never mint known-thread/affinity side effects (#812).
     if (!isSlackUserAllowed(this.allowlist, userId)) return;
+
+    if (
+      !this.messageMentionsBot(evt) &&
+      (await this.shouldRequireExplicitMention({ evt, channel, threadTs, userId, isDM }))
+    ) {
+      return;
+    }
 
     if (!this.getThread(threadTs)) {
       this.threads.set(threadTs, {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -17,6 +17,18 @@ import { matchesToolPattern } from "./guardrails.js";
 
 // ─── Settings ────────────────────────────────────────────
 
+export interface SlackIngressGuardSettings {
+  requireMention?: {
+    /** Slack channel IDs where every actionable message must explicitly mention the bot. */
+    channels?: string[];
+    /** Require mention in Pinet-owned threads once anyone outside trustedUsers + the bot participates. */
+    mixedParticipantThreads?: {
+      enabled?: boolean;
+      trustedUsers?: string[];
+    };
+  };
+}
+
 export interface SlackBridgeSettings {
   botToken?: string;
   appToken?: string;
@@ -24,6 +36,7 @@ export interface SlackBridgeSettings {
   appConfigToken?: string;
   allowedUsers?: string[];
   allowAllWorkspaceUsers?: boolean;
+  ingressGuard?: SlackIngressGuardSettings;
   defaultChannel?: string;
   logChannel?: string;
   logLevel?: "errors" | "actions" | "verbose";

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -103,6 +103,7 @@ export function createSlackPinetRuntimeAdapterFactory(
       appToken: deps.getAppToken(),
       allowedUsers: allowedUsers ? [...allowedUsers] : undefined,
       allowAllWorkspaceUsers: deps.shouldAllowAllWorkspaceUsers(),
+      ingressGuard: settings.ingressGuard,
       suggestedPrompts: settings.suggestedPrompts,
       reactionCommands: settings.reactionCommands as ReactionCommandSettings | undefined,
       isKnownThread: (threadTs: string) =>
@@ -113,6 +114,11 @@ export function createSlackPinetRuntimeAdapterFactory(
       },
       isReactionThreadAuthorized: (threadTs: string, channelId: string) =>
         isAuthorizedReactionThread(broker, threadTs, channelId),
+      isPinetOwnedThread: (threadTs: string, channelId: string) => {
+        const thread = broker.db.getThread(threadTs);
+        if (!thread || thread.source !== "slack" || thread.channel !== channelId) return false;
+        return !!thread.ownerAgent || readStoredSlackThreadContext(thread.metadata) !== null;
+      },
       onAppHomeOpened: async ({ userId }) => {
         await deps.onAppHomeOpened(userId, ctx);
       },


### PR DESCRIPTION
## Summary
- Add optional `slack-bridge.ingressGuard.requireMention` settings for explicit `@pinet` invocation gating.
- Require mentions in configured Slack channel IDs and in Pinet-owned Slack threads when participants include anyone outside configured trusted users plus the bot.
- Keep sender authorization (`allowedUsers` / allow-all) independent from explicit-mention requirements.
- Document rollout/config examples in the Slack bridge README.

Closes #836

## Tests
- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm prepush`
- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm exec vitest run broker/adapters/slack.test.ts` (from `slack-bridge/`)
