### PR TITLE
Fix Slack Markdown bold rendering

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -2776,6 +2776,27 @@ describe("SlackAdapter — send", () => {
     expect(body.metadata).toBeUndefined();
   });
 
+  it("renders Markdown bold in Slack-bound text while preserving literals", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+
+    await adapter.send({
+      threadId: "1.1",
+      channel: "C1",
+      text: "Please review **bold text**; math 4*3; glob src/**/*.ts; code `**literal**`.",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.text).toBe(
+      "Please review *bold text*; math 4*3; glob src/**/*.ts; code `**literal**`.",
+    );
+  });
+
   it("prefers transport-aware Slack blocks when present", async () => {
     fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
 
@@ -2810,7 +2831,7 @@ describe("SlackAdapter — send", () => {
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
-    expect(body.text).toBe("plain fallback");
+    expect(body.text).toBe("*plain fallback*");
     expect(body.blocks).toEqual(slackBlocks);
   });
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -41,6 +41,7 @@ import {
   DEFAULT_SLACK_THREAD_STATUS,
   SlackThreadStatusManager,
 } from "../../slack-thread-status.js";
+import { renderMarkdownForSlackMrkdwn } from "../../slack-markdown.js";
 import { performSlackUploads, prepareSlackUpload } from "../../slack-upload.js";
 import type {
   AdapterCapabilityRequest,
@@ -239,9 +240,12 @@ export class SlackAdapter implements MessageAdapter {
         : msg.blocks && msg.blocks.length > 0
           ? msg.blocks
           : undefined;
+    const renderedText = renderMarkdownForSlackMrkdwn(
+      msg.content?.markdown ?? msg.content?.text ?? msg.text,
+    );
     const body: Record<string, unknown> = {
       channel: msg.channel,
-      text: msg.content?.text ?? msg.text,
+      text: renderedText,
       thread_ts: msg.threadId,
       ...(slackBlocks ? { blocks: slackBlocks } : {}),
     };
@@ -284,7 +288,7 @@ export class SlackAdapter implements MessageAdapter {
         uploads,
         channelId: msg.channel,
         threadTs: msg.threadId,
-        initialComment: msg.content?.text ?? msg.text,
+        initialComment: renderedText,
         slack: this.callSlack.bind(this),
         token: this.config.botToken,
       });

--- a/slack-bridge/slack-markdown.test.ts
+++ b/slack-bridge/slack-markdown.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { renderMarkdownForSlackMrkdwn } from "./slack-markdown.js";
+
+describe("renderMarkdownForSlackMrkdwn", () => {
+  it("converts Markdown strong emphasis into Slack bold", () => {
+    expect(renderMarkdownForSlackMrkdwn("Please review **bold text** now.")).toBe(
+      "Please review *bold text* now.",
+    );
+    expect(renderMarkdownForSlackMrkdwn("**Leading** and **trailing**")).toBe(
+      "*Leading* and *trailing*",
+    );
+  });
+
+  it("preserves existing Slack mrkdwn and literal single-star expressions", () => {
+    expect(renderMarkdownForSlackMrkdwn("Already *Slack bold* and 4*3=12.")).toBe(
+      "Already *Slack bold* and 4*3=12.",
+    );
+  });
+
+  it("does not treat globstars as Markdown bold", () => {
+    expect(renderMarkdownForSlackMrkdwn("Check src/**/*.ts and packages/**/README.md.")).toBe(
+      "Check src/**/*.ts and packages/**/README.md.",
+    );
+    expect(renderMarkdownForSlackMrkdwn("Copy src/**/foo/**/bar before **announcing**.")).toBe(
+      "Copy src/**/foo/**/bar before *announcing*.",
+    );
+  });
+
+  it("does not convert strong markers inside code spans", () => {
+    expect(renderMarkdownForSlackMrkdwn("Use `**literal**` then **announce**.")).toBe(
+      "Use `**literal**` then *announce*.",
+    );
+  });
+
+  it("does not convert strong markers inside fenced code blocks", () => {
+    const input = [
+      "Before **bold**",
+      "```",
+      'const pattern = "**literal**";',
+      "```",
+      "After **bold**",
+    ].join("\n");
+
+    const output = [
+      "Before *bold*",
+      "```",
+      'const pattern = "**literal**";',
+      "```",
+      "After *bold*",
+    ].join("\n");
+
+    expect(renderMarkdownForSlackMrkdwn(input)).toBe(output);
+  });
+});

--- a/slack-bridge/slack-markdown.ts
+++ b/slack-bridge/slack-markdown.ts
@@ -1,0 +1,155 @@
+export function renderMarkdownForSlackMrkdwn(text: string): string {
+  if (!text.includes("**")) {
+    return text;
+  }
+
+  return transformOutsideBacktickCode(text, convertMarkdownStrongToSlackBold);
+}
+
+function transformOutsideBacktickCode(
+  text: string,
+  transform: (segment: string) => string,
+): string {
+  let output = "";
+  let segmentStart = 0;
+  let index = 0;
+
+  while (index < text.length) {
+    if (text[index] !== "`") {
+      index += 1;
+      continue;
+    }
+
+    const runLength = countRepeated(text, index, "`");
+    const closingIndex = findClosingBacktickRun(text, index + runLength, runLength);
+    if (closingIndex === -1) {
+      index += runLength;
+      continue;
+    }
+
+    output += transform(text.slice(segmentStart, index));
+    output += text.slice(index, closingIndex + runLength);
+    index = closingIndex + runLength;
+    segmentStart = index;
+  }
+
+  output += transform(text.slice(segmentStart));
+  return output;
+}
+
+function convertMarkdownStrongToSlackBold(segment: string): string {
+  let output = "";
+  let index = 0;
+
+  while (index < segment.length) {
+    if (segment.startsWith("**", index) && isStrongOpeningDelimiter(segment, index)) {
+      const closingIndex = findStrongClosingDelimiter(segment, index + 2);
+      if (closingIndex !== -1) {
+        output += `*${segment.slice(index + 2, closingIndex)}*`;
+        index = closingIndex + 2;
+        continue;
+      }
+    }
+
+    output += segment[index];
+    index += 1;
+  }
+
+  return output;
+}
+
+function findStrongClosingDelimiter(segment: string, fromIndex: number): number {
+  let index = fromIndex;
+  while (index < segment.length) {
+    const next = segment.indexOf("**", index);
+    if (next === -1) {
+      return -1;
+    }
+    if (isStrongClosingDelimiter(segment, next)) {
+      return next;
+    }
+    index = next + 2;
+  }
+
+  return -1;
+}
+
+function isStrongOpeningDelimiter(text: string, index: number): boolean {
+  if (isEscaped(text, index)) {
+    return false;
+  }
+
+  const previous = text[index - 1];
+  const next = text[index + 2];
+  return isSafeOpeningBoundary(previous, next);
+}
+
+function isStrongClosingDelimiter(text: string, index: number): boolean {
+  if (isEscaped(text, index)) {
+    return false;
+  }
+
+  const previous = text[index - 1];
+  const next = text[index + 2];
+  return isSafeClosingBoundary(previous, next);
+}
+
+function isSafeOpeningBoundary(previous: string | undefined, next: string | undefined): boolean {
+  if (!next || isWhitespace(next) || next === "*" || next === "/") {
+    return false;
+  }
+  if (previous === "*" || previous === "/") {
+    return false;
+  }
+  return true;
+}
+
+function isSafeClosingBoundary(previous: string | undefined, next: string | undefined): boolean {
+  if (!previous || isWhitespace(previous) || previous === "*" || previous === "/") {
+    return false;
+  }
+  if (next === "*" || next === "/") {
+    return false;
+  }
+  return true;
+}
+
+function isWhitespace(value: string): boolean {
+  return /\s/u.test(value);
+}
+
+function countRepeated(text: string, index: number, char: string): number {
+  let count = 0;
+  while (text[index + count] === char) {
+    count += 1;
+  }
+  return count;
+}
+
+function findClosingBacktickRun(text: string, fromIndex: number, runLength: number): number {
+  let index = fromIndex;
+  while (index < text.length) {
+    const next = text.indexOf("`", index);
+    if (next === -1) {
+      return -1;
+    }
+
+    const nextRunLength = countRepeated(text, next, "`");
+    if (nextRunLength === runLength) {
+      return next;
+    }
+    index = next + nextRunLength;
+  }
+
+  return -1;
+}
+
+function isEscaped(text: string, index: number): boolean {
+  let slashCount = 0;
+  let cursor = index - 1;
+  while (cursor >= 0 && text[cursor] === "\\") {
+    slashCount += 1;
+    cursor -= 1;
+  }
+  return slashCount % 2 === 1;
+}


### PR DESCRIPTION
## Summary
- Add Slack mrkdwn rendering for safe Markdown strong emphasis (`**bold**` -> `*bold*`) before Slack-bound adapter posts/uploads.
- Preserve code spans/fenced blocks, existing Slack `*bold*`, multiplication/literal-star text, and globstar paths.
- Cover helper and Slack adapter rendering with focused tests.

Closes #839

## Tests
- `pnpm format:check:ts`
- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm prepush`
- push hook also ran `pnpm prepush` from the worktree (cache-hit pass)
