### PR TITLE
fix(pinet): reduce full=true pressure on routine pinet read (#841)

### DIFF
--- a/pinet-core/pinet-read-formatting.test.ts
+++ b/pinet-core/pinet-read-formatting.test.ts
@@ -50,12 +50,24 @@ describe("Pinet read formatting", () => {
     );
   });
 
-  it("points truncated compact thread previews to the exact-body retry", () => {
+  it("includes the same per-message preview on inbox-wide compact reads (no thread_id)", () => {
+    // Regression: previously compact mode only emitted previews when a
+    // `thread_id` was supplied, which left inbox-wide `pinet action=read`
+    // callers with only the counts header and pushed agents toward `full=true`.
+    const compact = formatPinetReadResultCompact(makeReadResult(), {});
+    expect(compact).toContain(
+      "- [steering] [agent/a2a:broker:worker #44] broker: please inspect issue context",
+    );
+  });
+
+  it("mentions full=true as a verbatim affordance, not as a directive, when previews truncate", () => {
     const compact = formatPinetReadResultCompact(makeReadResult("dense detail ".repeat(40)), {
       threadId: "a2a:broker:worker",
     });
 
-    expect(compact).toContain("args.full=true args.unread_only=false");
+    expect(compact).toContain("args.full=true args.unread_only=false returns verbatim bodies.");
+    // Make sure the previous directive wording does not creep back in.
+    expect(compact).not.toContain("Use args.full=true args.unread_only=false for exact bodies.");
   });
 
   it("preserves the full read text for explicit verbose output", () => {

--- a/pinet-core/pinet-read-formatting.ts
+++ b/pinet-core/pinet-read-formatting.ts
@@ -206,7 +206,12 @@ export function formatPinetReadResultCompact(
     `Pinet read: ${result.messages.length} ${mode} message${result.messages.length === 1 ? "" : "s"}; unread ${result.unreadCountBefore}→${result.unreadCountAfter}${markedSuffix}${unreadThreadSuffix}.`,
   ];
 
-  if (options.threadId && result.messages.length > 0) {
+  // Show capped per-message previews for both thread-scoped and inbox-wide
+  // compact reads. Restricting previews to thread-scoped reads (the previous
+  // behavior) left inbox-wide `pinet action=read` callers with only the counts
+  // header, which pushed agents toward `full=true` just to see what arrived.
+  // The 3-message + 96-char cap already keeps the output bounded.
+  if (result.messages.length > 0) {
     const shownMessages = result.messages.slice(0, COMPACT_READ_TEXT_MESSAGE_LIMIT);
     lines.push(...shownMessages.map(formatCompactMessagePreview));
     const truncated = result.messages.length - shownMessages.length;
@@ -214,7 +219,9 @@ export function formatPinetReadResultCompact(
       lines.push(`… ${truncated} more message${truncated === 1 ? "" : "s"}.`);
     }
     if (truncated > 0 || shownMessages.some(isMessageBodyTruncated)) {
-      lines.push("Use args.full=true args.unread_only=false for exact bodies.");
+      // Stated as a diagnostic affordance rather than a directive so we don't
+      // actively push routine reads toward `full=true`.
+      lines.push("args.full=true args.unread_only=false returns verbatim bodies.");
     }
   }
 

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -528,8 +528,18 @@ describe("registerPinetTools", () => {
       };
     };
 
-    expect(result.content[0]?.text).toBe("Pinet read: 1 unread message; unread 1→0; marked 1.");
+    // Header summary line stays stable; inbox-wide compact reads now include the
+    // same capped per-message preview previously gated behind `thread_id`.
+    expect(result.content[0]?.text?.split("\n")[0]).toBe(
+      "Pinet read: 1 unread message; unread 1→0; marked 1.",
+    );
+    expect(result.content[0]?.text).toContain(
+      "- [steering] [agent/a2a:broker:worker #44] broker: please inspect important context",
+    );
+    // Preview must be truncated; raw long body stays out of the compact text.
+    expect(result.content[0]?.text).toContain("…");
     expect(result.content[0]?.text).not.toContain(longBody);
+    expect(result.content[0]?.text).not.toContain("keep exact body");
     expect(result.details.data.text).not.toContain(longBody);
     expect(result.details.data.details.messages[0]?.id).toBe(44);
     expect(result.details.data.details.messages[0]?.preview).toBeUndefined();
@@ -1716,10 +1726,13 @@ describe("registerPinetTools", () => {
       .render(200)
       .join("\n");
 
-    // Collapsed keeps the one-line summary (no per-message bodies).
+    // Collapsed keeps the header summary line and, since inbox-wide compact
+    // reads now include the same capped per-message previews as thread-scoped
+    // reads, surfaces them dimmed below the header so callers can act without
+    // expanding or opting into `full=true`.
     expect(collapsed).toContain("Pinet read: 2 unread messages");
-    expect(collapsed).not.toContain("please inspect #594");
-    // Expanded shows the per-message rows, not a JSON wall.
+    expect(collapsed).toContain("please inspect #594");
+    // Expanded shows the per-message rows in the rich view, not a JSON wall.
     expect(expanded).toContain("please inspect #594");
     expect(expanded).toContain("and #595");
     expect(expanded).not.toContain("[{");

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -225,7 +225,10 @@ const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> 
   send: [{ action: "send", args: { to: "@worker", message: "Please review PR #123" } }],
   read: [
     { action: "read", args: { thread_id: "a2a:<broker>:<worker>", limit: 20 } },
-    { action: "read", args: { unread_only: false, mark_read: false, full: true } },
+    // Compact non-`full` peek at the latest messages without consuming unread
+    // state. Use args.full=true only when verbatim bodies are actually needed
+    // — the default compact read already includes capped per-message previews.
+    { action: "read", args: { unread_only: false, mark_read: false, limit: 5 } },
   ],
   free: [{ action: "free", args: { note: "Wrapped up <issue>" } }],
   snooze: [

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -224,10 +224,15 @@ interface PinetRenderResultInput {
 const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> = {
   send: [{ action: "send", args: { to: "@worker", message: "Please review PR #123" } }],
   read: [
+    // Routine inbox drain: defaults are `unread_only: true` + `mark_read: true`,
+    // so this returns and consumes only this agent's unread rows. The compact
+    // output already includes capped per-message previews; no `full=true` needed.
+    { action: "read", args: { limit: 20 } },
+    // Same defaults, scoped to one thread.
     { action: "read", args: { thread_id: "a2a:<broker>:<worker>", limit: 20 } },
-    // Compact non-`full` peek at the latest messages without consuming unread
-    // state. Use args.full=true only when verbatim bodies are actually needed
-    // — the default compact read already includes capped per-message previews.
+    // Non-destructive latest-history peek (does NOT mark anything read or
+    // change unread state). Use only when you need to revisit recently-read
+    // context, not as a routine inbox read.
     { action: "read", args: { unread_only: false, mark_read: false, limit: 5 } },
   ],
   free: [{ action: "free", args: { note: "Wrapped up <issue>" } }],
@@ -1870,7 +1875,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
   registerAction({
     name: "read",
     description:
-      "Read this agent's durable SQLite-backed Pinet inbox context with unread/read semantics. Ordinary workers only see rows addressed to their own agent identity; broker coordination visibility is limited to broker-addressed inbox rows.",
+      "Read this agent's durable SQLite-backed Pinet inbox context with unread/read semantics. Defaults to draining unread rows (`unread_only: true`, `mark_read: true`) with compact per-message previews — no `full=true` required for routine reads. Override `unread_only`/`mark_read` only for a non-destructive latest-history peek. Ordinary workers only see rows addressed to their own agent identity; broker coordination visibility is limited to broker-addressed inbox rows.",
     parameters: Type.Object({
       thread_id: Type.Optional(
         Type.String({


### PR DESCRIPTION
Closes #841.

## Scope (after maintainer reassessment)

Earlier rounds of this PR added a pointer-line `summary="…"` suffix on every inbox notification. The maintainer was lukewarm and pointed out that **agents keep reaching for `full=true` on `pinet action=read` regardless** — the verbose output complaint that motivated #841 has its root cause inside the compact-read formatter and the dispatcher help itself, not on the pointer line.

Per direction, this PR is now narrowed to three small, targeted changes that reduce the pressure to use `full=true` instead of adding noisy summaries.

## Changes

1. **`pinet-core/pinet-read-formatting.ts`** — drop the `options.threadId &&` gate in `formatPinetReadResultCompact` so **inbox-wide compact reads also surface the same capped per-message previews** (3 messages, 96-char truncation) that thread-scoped reads already get. Previously inbox-wide reads returned only the counts header, which forced `full=true` just to see what arrived.

2. **`slack-bridge/pinet-tools.ts`** — replace the second `read` example in `PINET_DISPATCHER_EXAMPLES`:
   - **before:** `{ action: "read", args: { unread_only: false, mark_read: false, full: true } }`
   - **after:** `{ action: "read", args: { unread_only: false, mark_read: false, limit: 5 } }`
   `full=true` stays documented in the schema; it is no longer primed as the second-choice default in the dispatcher catalog.

3. **`pinet-core/pinet-read-formatting.ts`** — soften the truncation footer from a directive (`Use args.full=true args.unread_only=false for exact bodies.`) to an affordance statement (`args.full=true args.unread_only=false returns verbatim bodies.`). Same diagnostic remains discoverable; nothing actively pushes routine reads toward full output.

## What was reverted

Earlier commits on this branch (`buildInboxBodyPreview` + ` summary="…"` suffix on broker-backed Slack and Pinet inbox pointer lines, and a broader 240-char compact-read body preview) were dropped per the maintainer reassessment. The branch was reset to `main` and rebuilt from the three small changes above.

## Tests

- New `formatPinetReadResultCompact` cases:
  - inbox-wide compact reads now include the per-message preview line.
  - truncated previews still mention `full=true args.unread_only=false`, but only as a verbatim affordance (assert the old directive wording does not creep back).
- Updated `slack-bridge/pinet-tools.test.ts`:
  - the inbox-wide compact-read test asserts the per-message preview is present in the compact text (and the long body / `keep exact body` is still excluded).
  - the TUI collapsed-render test now expects the dimmed preview line below the header.

## Validation

- `pnpm --filter @pinet/pinet-core build`
- `pnpm --filter @pinet/pinet-core test`
- `pnpm --filter @pinet/slack-bridge test` → 81 files / 1443 tests passing
- `pnpm prepush` → 10/10 lint, 10/10 typecheck, 10/10 test

## Mergeability

`mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`.