### PR TITLE
feat: add model-aware compaction extension

### DIFF
--- a/model-aware-compaction/LICENSE
+++ b/model-aware-compaction/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/model-aware-compaction/README.md
+++ b/model-aware-compaction/README.md
@@ -1,0 +1,55 @@
+# @gugu910/pi-model-aware-compaction
+
+A Pi extension that triggers proactive compaction at different active-context token limits for different models. It adapts Pi's shipped `trigger-compact.ts` example to multi-model and subagent workloads.
+
+## Install
+
+```bash
+pi install npm:@gugu910/pi-model-aware-compaction
+```
+
+For local development from a clone of this repository, load the source directly:
+
+```bash
+pi --extension /path/to/extensions/model-aware-compaction/index.ts
+```
+
+## Configure
+
+The extension is disabled by default. Add this to project `.pi/settings.json` or global `~/.pi/agent/settings.json`:
+
+```json
+{
+  "model-aware-compaction": {
+    "enabled": true,
+    "rules": [
+      { "model": "openai/gpt-5-mini", "activeContextTokens": 100000 },
+      { "model": "anthropic/claude-sonnet-4-6", "activeContextTokens": 100000 },
+      { "model": "example-proxy/*", "activeContextTokens": 136000 }
+    ],
+    "customInstructions": "Preserve decisions, files changed, validation results, and next steps.",
+    "debug": false
+  }
+}
+```
+
+Rules are evaluated in order. `*` wildcards are supported, such as `example-proxy/*`.
+
+## Behavior
+
+After each `turn_end`, the extension reads `ctx.getContextUsage()` and the active `ctx.model`. When usage first exceeds the matching rule's `activeContextTokens`, it calls `ctx.compact()`. It prevents duplicate calls while compaction is in flight and re-arms after usage drops below the threshold, the model changes, a session starts, or compaction fails.
+
+Run `/model-aware-compaction-status` to inspect the active model, usage, matched threshold, state, and loaded rules.
+
+## Limitation
+
+Pi's extension API makes `ctx.compact()` fire-and-forget. This package is therefore proactive best effort, not an atomic `compact-before-next-provider-request` barrier. Debug logs make trigger/completion/failure visible so that race behavior can be measured. Upstream model-specific settings or an awaitable/deferred compaction seam would provide a stronger guarantee.
+
+## Development
+
+```bash
+pnpm --filter @gugu910/pi-model-aware-compaction lint
+pnpm --filter @gugu910/pi-model-aware-compaction typecheck
+pnpm --filter @gugu910/pi-model-aware-compaction test
+pnpm --filter @gugu910/pi-model-aware-compaction build
+```

--- a/model-aware-compaction/config.test.ts
+++ b/model-aware-compaction/config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveConfig } from "./config.js";
+
+describe("resolveConfig", () => {
+  it("is disabled by default with useful example rules", () => {
+    const config = resolveConfig();
+    expect(config.enabled).toBe(false);
+    expect(config.rules).toContainEqual({
+      model: "openai/gpt-5-mini",
+      activeContextTokens: 100_000,
+    });
+  });
+
+  it("keeps valid configured rules and drops malformed entries", () => {
+    const config = resolveConfig({
+      enabled: true,
+      rules: [
+        { model: "anthropic/*", activeContextTokens: 90_000 },
+        { model: "", activeContextTokens: 1 },
+        { model: "openai/*", activeContextTokens: -1 },
+      ],
+    });
+    expect(config.rules).toEqual([{ model: "anthropic/*", activeContextTokens: 90_000 }]);
+  });
+});

--- a/model-aware-compaction/config.ts
+++ b/model-aware-compaction/config.ts
@@ -1,0 +1,79 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { join } from "node:path";
+import type { CompactionRule } from "./helpers.js";
+
+export const SETTINGS_KEY = "model-aware-compaction";
+const DEFAULT_RULES: CompactionRule[] = [
+  { model: "openai/gpt-5-mini", activeContextTokens: 100_000 },
+  { model: "anthropic/claude-sonnet-4-6", activeContextTokens: 100_000 },
+];
+
+export interface ModelAwareCompactionConfig {
+  enabled?: boolean;
+  rules?: Array<{ model?: string; activeContextTokens?: number }>;
+  customInstructions?: string;
+  debug?: boolean;
+}
+
+export interface ResolvedConfig {
+  enabled: boolean;
+  rules: CompactionRule[];
+  customInstructions?: string;
+  debug: boolean;
+  sourcePath: string | null;
+}
+
+function parseSettings(
+  path: string,
+): { raw: ModelAwareCompactionConfig; sourcePath: string } | null {
+  if (!fs.existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path, "utf8")) as Record<string, unknown>;
+    const value = parsed[SETTINGS_KEY];
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    return { raw: value as ModelAwareCompactionConfig, sourcePath: `${path}#${SETTINGS_KEY}` };
+  } catch (error) {
+    console.error(
+      `[${SETTINGS_KEY}] Failed to parse ${path}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+export function resolveConfig(
+  raw?: ModelAwareCompactionConfig | null,
+  sourcePath: string | null = null,
+): ResolvedConfig {
+  const configured = Array.isArray(raw?.rules)
+    ? raw.rules.flatMap((rule) => {
+        const model = typeof rule.model === "string" ? rule.model.trim() : "";
+        const tokens = rule.activeContextTokens;
+        return model && typeof tokens === "number" && Number.isInteger(tokens) && tokens > 0
+          ? [{ model, activeContextTokens: tokens }]
+          : [];
+      })
+    : [];
+  const customInstructions =
+    typeof raw?.customInstructions === "string" && raw.customInstructions.trim()
+      ? raw.customInstructions.trim()
+      : undefined;
+  return {
+    enabled: raw?.enabled === true,
+    rules: configured.length > 0 ? configured : DEFAULT_RULES,
+    customInstructions,
+    debug: raw?.debug === true,
+    sourcePath,
+  };
+}
+
+export function loadConfig(
+  cwd = process.cwd(),
+  agentDir = join(os.homedir(), ".pi", "agent"),
+): ResolvedConfig {
+  const project = parseSettings(join(cwd, ".pi", "settings.json"));
+  if (project) return resolveConfig(project.raw, project.sourcePath);
+  const global = parseSettings(join(agentDir, "settings.json"));
+  if (global) return resolveConfig(global.raw, global.sourcePath);
+  return resolveConfig();
+}

--- a/model-aware-compaction/eslint.config.mjs
+++ b/model-aware-compaction/eslint.config.mjs
@@ -1,0 +1,3 @@
+import rootConfig from "../eslint.config.mjs";
+
+export default [...rootConfig];

--- a/model-aware-compaction/helpers.test.ts
+++ b/model-aware-compaction/helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { decideCompaction, limitForModel, matchesModel, modelKey } from "./helpers.js";
+
+const rules = [
+  { model: "openai/gpt-5-mini", activeContextTokens: 100_000 },
+  { model: "example-proxy/*", activeContextTokens: 136_000 },
+];
+
+describe("model matching", () => {
+  it("normalizes provider-prefixed ids without doubling the provider", () => {
+    expect(modelKey({ provider: "OpenAI", id: "openai/gpt-5-mini" })).toBe("openai/gpt-5-mini");
+  });
+
+  it("supports exact and wildcard rules in declared order", () => {
+    expect(matchesModel("example-proxy/*", "example-proxy/frontier-model")).toBe(true);
+    expect(limitForModel(rules, "openai/gpt-5-mini")).toBe(100_000);
+    expect(limitForModel(rules, "example-proxy/frontier-model")).toBe(136_000);
+  });
+});
+
+describe("compaction decisions", () => {
+  const base = {
+    enabled: true,
+    model: { provider: "openai", id: "gpt-5-mini" },
+    rules,
+    inFlight: false,
+    triggeredModelKey: null,
+  };
+
+  it("triggers when the first observed turn is already over the model limit", () => {
+    expect(decideCompaction({ ...base, tokens: 100_001 })).toMatchObject({
+      shouldCompact: true,
+      reason: "over-limit",
+    });
+  });
+
+  it("does not trigger below the limit", () => {
+    expect(decideCompaction({ ...base, tokens: 100_000 })).toMatchObject({
+      shouldCompact: false,
+      reason: "below-limit",
+    });
+  });
+
+  it("suppresses duplicate attempts while in flight or already triggered", () => {
+    expect(decideCompaction({ ...base, tokens: 120_000, inFlight: true })).toMatchObject({
+      shouldCompact: false,
+      reason: "in-flight",
+    });
+    expect(
+      decideCompaction({ ...base, tokens: 120_000, triggeredModelKey: "openai/gpt-5-mini" }),
+    ).toMatchObject({ shouldCompact: false, reason: "already-triggered" });
+  });
+});

--- a/model-aware-compaction/helpers.ts
+++ b/model-aware-compaction/helpers.ts
@@ -1,0 +1,69 @@
+export interface ModelIdentity {
+  provider?: string;
+  id?: string;
+}
+
+export interface CompactionRule {
+  model: string;
+  activeContextTokens: number;
+}
+
+export interface CompactionDecision {
+  modelKey: string | null;
+  limit: number | null;
+  shouldCompact: boolean;
+  reason:
+    | "disabled"
+    | "unknown-model"
+    | "no-rule"
+    | "usage-unavailable"
+    | "below-limit"
+    | "already-triggered"
+    | "in-flight"
+    | "over-limit";
+}
+
+export function modelKey(model: ModelIdentity | undefined): string | null {
+  const provider = model?.provider?.trim().toLowerCase();
+  const id = model?.id?.trim().toLowerCase();
+  if (!provider || !id) return null;
+  const normalizedId = id.startsWith(`${provider}/`) ? id.slice(provider.length + 1) : id;
+  return `${provider}/${normalizedId}`;
+}
+
+export function matchesModel(pattern: string, key: string): boolean {
+  const normalized = pattern.trim().toLowerCase();
+  if (!normalized) return false;
+  const escaped = normalized.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*");
+  return new RegExp(`^${escaped}$`).test(key);
+}
+
+export function limitForModel(rules: CompactionRule[], key: string): number | null {
+  return rules.find((rule) => matchesModel(rule.model, key))?.activeContextTokens ?? null;
+}
+
+export function decideCompaction(input: {
+  enabled: boolean;
+  model: ModelIdentity | undefined;
+  tokens: number | null | undefined;
+  rules: CompactionRule[];
+  inFlight: boolean;
+  triggeredModelKey: string | null;
+}): CompactionDecision {
+  const key = modelKey(input.model);
+  if (!input.enabled)
+    return { modelKey: key, limit: null, shouldCompact: false, reason: "disabled" };
+  if (!key) return { modelKey: null, limit: null, shouldCompact: false, reason: "unknown-model" };
+  const limit = limitForModel(input.rules, key);
+  if (limit === null)
+    return { modelKey: key, limit: null, shouldCompact: false, reason: "no-rule" };
+  if (input.tokens === null || input.tokens === undefined || !Number.isFinite(input.tokens)) {
+    return { modelKey: key, limit, shouldCompact: false, reason: "usage-unavailable" };
+  }
+  if (input.tokens <= limit)
+    return { modelKey: key, limit, shouldCompact: false, reason: "below-limit" };
+  if (input.inFlight) return { modelKey: key, limit, shouldCompact: false, reason: "in-flight" };
+  if (input.triggeredModelKey === key)
+    return { modelKey: key, limit, shouldCompact: false, reason: "already-triggered" };
+  return { modelKey: key, limit, shouldCompact: true, reason: "over-limit" };
+}

--- a/model-aware-compaction/index.test.ts
+++ b/model-aware-compaction/index.test.ts
@@ -1,0 +1,97 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import extension from "./index.js";
+
+type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function harness() {
+  const handlers = new Map<string, Handler>();
+  const api = {
+    on: (event: string, handler: Handler) => handlers.set(event, handler),
+    registerCommand: vi.fn(),
+    sendMessage: vi.fn(),
+  } as unknown as ExtensionAPI;
+  extension(api);
+  return { handlers, api };
+}
+
+function context(tokens: number, compact = vi.fn()): ExtensionContext {
+  return {
+    cwd: process.cwd(),
+    hasUI: false,
+    ui: { notify: vi.fn(), setStatus: vi.fn() } as unknown as ExtensionContext["ui"],
+    sessionManager: {} as ExtensionContext["sessionManager"],
+    model: { provider: "openai", id: "gpt-5-mini" },
+    getContextUsage: () => ({ tokens, contextWindow: 400_000, percent: tokens / 4_000 }),
+    compact,
+  };
+}
+
+describe("extension wiring", () => {
+  it("does nothing while disabled", () => {
+    const { handlers } = harness();
+    const compact = vi.fn();
+    handlers.get("turn_end")?.({}, context(120_000, compact));
+    expect(compact).not.toHaveBeenCalled();
+  });
+
+  it("triggers once above the configured threshold and re-arms after completion plus lower usage", () => {
+    const { handlers } = harness();
+    const compact = vi.fn();
+    // Project settings take precedence; the test creates only the minimal extension config.
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
+    fs.mkdirSync(path.join(temp, ".pi"));
+    fs.writeFileSync(
+      path.join(temp, ".pi", "settings.json"),
+      JSON.stringify({
+        "model-aware-compaction": { enabled: true },
+      }),
+    );
+    try {
+      const ctx = { ...context(120_000, compact), cwd: temp };
+      handlers.get("turn_end")?.({}, ctx);
+      handlers.get("turn_end")?.({}, ctx);
+      expect(compact).toHaveBeenCalledTimes(1);
+
+      const options = compact.mock.calls[0]?.[0] as { onComplete?: () => void };
+      options.onComplete?.();
+      handlers.get("turn_end")?.({}, ctx);
+      expect(compact).toHaveBeenCalledTimes(1);
+
+      handlers.get("turn_end")?.(
+        {},
+        {
+          ...ctx,
+          getContextUsage: () => ({ tokens: 90_000, contextWindow: 400_000, percent: 22.5 }),
+        },
+      );
+      handlers.get("turn_end")?.({}, ctx);
+      expect(compact).toHaveBeenCalledTimes(2);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not clear the in-flight guard when a model selection event re-arms the threshold", () => {
+    const { handlers } = harness();
+    const compact = vi.fn();
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
+    fs.mkdirSync(path.join(temp, ".pi"));
+    fs.writeFileSync(
+      path.join(temp, ".pi", "settings.json"),
+      JSON.stringify({ "model-aware-compaction": { enabled: true } }),
+    );
+    try {
+      const ctx = { ...context(120_000, compact), cwd: temp };
+      handlers.get("turn_end")?.({}, ctx);
+      handlers.get("model_select")?.({}, ctx);
+      handlers.get("turn_end")?.({}, ctx);
+      expect(compact).toHaveBeenCalledTimes(1);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+});

--- a/model-aware-compaction/index.ts
+++ b/model-aware-compaction/index.ts
@@ -1,0 +1,119 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { loadConfig } from "./config.js";
+import { decideCompaction, modelKey, type ModelIdentity } from "./helpers.js";
+
+interface ContextUsage {
+  tokens: number | null;
+  contextWindow: number;
+  percent: number | null;
+}
+interface CompatibleContext extends ExtensionContext {
+  model?: ModelIdentity;
+  getContextUsage?: () => ContextUsage | undefined;
+  compact?: (options?: {
+    customInstructions?: string;
+    onComplete?: () => void;
+    onError?: (error: Error) => void;
+  }) => void;
+}
+interface CompatibleAPI extends ExtensionAPI {
+  sendMessage(
+    message: { customType: string; content: string; display: boolean },
+    options?: { triggerTurn?: boolean },
+  ): void;
+}
+
+const LOG_PREFIX = "[model-aware-compaction]";
+
+export default function modelAwareCompaction(pi: ExtensionAPI) {
+  const api = pi as CompatibleAPI;
+  let inFlight = false;
+  let triggeredModelKey: string | null = null;
+
+  const rearm = () => {
+    triggeredModelKey = null;
+  };
+
+  pi.on("session_start", rearm);
+  pi.on("model_select", rearm);
+
+  pi.on("turn_end", (_event, rawCtx) => {
+    const ctx = rawCtx as CompatibleContext;
+    const config = loadConfig(ctx.cwd);
+    const usage = ctx.getContextUsage?.();
+    const decision = decideCompaction({
+      enabled: config.enabled,
+      model: ctx.model,
+      tokens: usage?.tokens,
+      rules: config.rules,
+      inFlight,
+      triggeredModelKey,
+    });
+
+    if (decision.reason === "below-limit" && triggeredModelKey === decision.modelKey) {
+      triggeredModelKey = null;
+    }
+    if (!decision.shouldCompact || !ctx.compact || !decision.modelKey || decision.limit === null)
+      return;
+
+    inFlight = true;
+    triggeredModelKey = decision.modelKey;
+    const details = `model=${decision.modelKey} tokens=${usage?.tokens ?? "unknown"} limit=${decision.limit}`;
+    if (config.debug) {
+      console.error(`${LOG_PREFIX} triggered ${details}`);
+      if (ctx.hasUI) ctx.ui.notify(`Model-aware compaction started (${details})`, "info");
+    }
+
+    ctx.compact({
+      customInstructions: config.customInstructions,
+      onComplete: () => {
+        inFlight = false;
+        if (config.debug) {
+          console.error(`${LOG_PREFIX} completed ${details}`);
+          if (ctx.hasUI) ctx.ui.notify(`Model-aware compaction completed (${details})`, "info");
+        }
+      },
+      onError: (error) => {
+        inFlight = false;
+        triggeredModelKey = null;
+        console.error(`${LOG_PREFIX} failed ${details}: ${error.message}`);
+        if (config.debug && ctx.hasUI)
+          ctx.ui.notify(`Model-aware compaction failed: ${error.message}`, "error");
+      },
+    });
+  });
+
+  pi.registerCommand("model-aware-compaction-status", {
+    description: "Show model-aware proactive compaction status",
+    handler: async (_args, rawCtx) => {
+      const ctx = rawCtx as CompatibleContext;
+      const config = loadConfig(ctx.cwd);
+      const key = modelKey(ctx.model);
+      const usage = ctx.getContextUsage?.();
+      const decision = decideCompaction({
+        enabled: config.enabled,
+        model: ctx.model,
+        tokens: usage?.tokens,
+        rules: config.rules,
+        inFlight,
+        triggeredModelKey,
+      });
+      const lines = [
+        "**Model-aware compaction**",
+        "",
+        `- enabled: ${config.enabled ? "yes" : "no"}`,
+        `- current model: ${key ?? "unknown"}`,
+        `- current tokens: ${usage?.tokens ?? "unknown"}`,
+        `- matched limit: ${decision.limit ?? "none"}`,
+        `- state: ${inFlight ? "compacting" : decision.reason}`,
+        `- config: ${config.sourcePath ?? "defaults (disabled)"}`,
+        "- rules:",
+        ...config.rules.map((rule) => `  - ${rule.model}: ${rule.activeContextTokens}`),
+      ];
+      api.sendMessage(
+        { customType: "model-aware-compaction.status", content: lines.join("\n"), display: true },
+        { triggerTurn: false },
+      );
+    },
+  });
+}

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@gugu910/pi-model-aware-compaction",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Pi extension for proactive model-aware context compaction thresholds",
+  "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gugu91/extensions.git",
+    "directory": "model-aware-compaction"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "dist/"
+  ],
+  "keywords": [
+    "pi-package",
+    "compaction",
+    "context-window"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "scripts": {
+    "build": "node ../scripts/build-package.mjs",
+    "prepack": "pnpm run build",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {}
+}

--- a/model-aware-compaction/tsconfig.json
+++ b/model-aware-compaction/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["**/*.ts", "../types/**/*.d.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "imessage-bridge",
     "nvim-bridge",
     "neon-psql",
-    "openai-execution-shaping"
+    "openai-execution-shaping",
+    "model-aware-compaction"
   ],
   "dependencies": {
     "typescript": "^5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,8 @@ importers:
         specifier: file:../transport-core
         version: link:../transport-core
 
+  model-aware-compaction: {}
+
   neon-psql:
     devDependencies:
       "@earendil-works/pi-ai":

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ packages:
   - nvim-bridge
   - neon-psql
   - openai-execution-shaping
+  - model-aware-compaction

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -17,6 +17,7 @@ const packages = [
   "nvim-bridge",
   "neon-psql",
   "openai-execution-shaping",
+  "model-aware-compaction",
   "slack-bridge",
 ];
 

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -79,6 +79,14 @@ const packageConfigs = {
     vendorDirs: [],
     importRewrites: [],
   },
+  "model-aware-compaction": {
+    declaration: true,
+    excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
+    excludeFiles: new Set(),
+    excludePrefixes: [],
+    vendorDirs: [],
+    importRewrites: [],
+  },
 };
 
 const config = packageConfigs[packageName];

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -44,6 +44,15 @@ declare module "@earendil-works/pi-coding-agent" {
     isIdle?: () => boolean;
     ui: ExtensionUI;
     sessionManager: SessionManager;
+    model?: { provider?: string; id?: string };
+    getContextUsage?: () =>
+      | { tokens: number | null; contextWindow: number; percent: number | null }
+      | undefined;
+    compact?: (options?: {
+      customInstructions?: string;
+      onComplete?: (result?: unknown) => void;
+      onError?: (error: Error) => void;
+    }) => void;
   }
 
   export interface ToolUpdate {


### PR DESCRIPTION
Closes #843.

## Summary
- add npm-ready `@gugu910/pi-model-aware-compaction` package
- support ordered exact/wildcard model rules with active-context token limits
- trigger proactive compaction from `turn_end`, including when the first observed turn is already over limit
- suppress duplicate/in-flight attempts and re-arm after compaction, lower usage, model selection, or session start
- add debug diagnostics and `/model-aware-compaction-status`
- document configuration and Pi's current fire-and-forget compaction limitation

## Validation
- `pnpm --filter @gugu910/pi-model-aware-compaction lint`
- `pnpm --filter @gugu910/pi-model-aware-compaction typecheck`
- `pnpm --filter @gugu910/pi-model-aware-compaction test` — 10 tests passed
- `pnpm --filter @gugu910/pi-model-aware-compaction build` — JS + declarations emitted
- `pnpm prepush` — all workspace lint, typecheck, tests passed
- independent review findings addressed (in-flight guard, declaration output, local install docs)
