### PR TITLE
chore(release): prepare Pinet 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.1] - 2026-06-26
+
+Pinet v0.2.1 keeps the coordinated `@pinet/*` package set aligned and adds `@pinet/model-aware-compaction` as its sixth package.
+
+### Version verification
+
+- `pi-extensions` — `0.2.1` (private repo package)
+- `@pinet/transport-core` — `0.2.1`
+- `@pinet/broker-core` — `0.2.1`
+- `@pinet/pinet-core` — `0.2.1`
+- `@pinet/imessage-bridge` — `0.2.1`
+- `@pinet/slack-bridge` — `0.2.1`
+- `@pinet/model-aware-compaction` — `0.2.1` (initial release)
+
+### Release highlights
+
+- Adds model-aware proactive compaction with ordered exact or wildcard model rules and active-context token limits.
+- Prevents duplicate compactions while one is in flight and adds optional diagnostics plus `/model-aware-compaction-status`.
+- Keeps the existing Pinet libraries and bridges version-aligned on `0.2.1`.
+- Includes the compact Pinet read-help refinements merged after `0.2.0`.
+
+### Included pull requests since v0.2.0
+
+- [#842](https://github.com/gugu91/extensions/pull/842) — docs(pinet): make compact read defaults explicit
+- [#844](https://github.com/gugu91/extensions/pull/844) — feat: add model-aware compaction extension
+
 ## [0.2.0] - 2026-06-17
 
 Pinet v0.2.0 is the first coordinated `@pinet/*` package release cut from the current `main` branch. It intentionally includes only work already merged through PR #829 and aligns all publishable Pinet packages on the same version.

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/README.md
+++ b/model-aware-compaction/README.md
@@ -1,11 +1,11 @@
-# @gugu910/pi-model-aware-compaction
+# @pinet/model-aware-compaction
 
 A Pi extension that triggers proactive compaction at different active-context token limits for different models. It adapts Pi's shipped `trigger-compact.ts` example to multi-model and subagent workloads.
 
 ## Install
 
 ```bash
-pi install npm:@gugu910/pi-model-aware-compaction
+pi install npm:@pinet/model-aware-compaction
 ```
 
 For local development from a clone of this repository, load the source directly:
@@ -48,8 +48,8 @@ Pi's extension API makes `ctx.compact()` fire-and-forget. This package is theref
 ## Development
 
 ```bash
-pnpm --filter @gugu910/pi-model-aware-compaction lint
-pnpm --filter @gugu910/pi-model-aware-compaction typecheck
-pnpm --filter @gugu910/pi-model-aware-compaction test
-pnpm --filter @gugu910/pi-model-aware-compaction build
+pnpm --filter @pinet/model-aware-compaction lint
+pnpm --filter @pinet/model-aware-compaction typecheck
+pnpm --filter @pinet/model-aware-compaction test
+pnpm --filter @pinet/model-aware-compaction build
 ```

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@gugu910/pi-model-aware-compaction",
-  "version": "0.0.0",
+  "name": "@pinet/model-aware-compaction",
+  "version": "0.2.1",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
@@ -44,5 +44,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -11,6 +11,7 @@ The publish workflow always validates or publishes the full npm org `pinet` pack
 3. `@pinet/pinet-core` from `pinet-core/`
 4. `@pinet/imessage-bridge` from `imessage-bridge/`
 5. `@pinet/slack-bridge` from `slack-bridge/`
+6. `@pinet/model-aware-compaction` from `model-aware-compaction/`
 
 There is intentionally no workflow target selector or script target flag. Real releases publish the shared core packages and Slack bridge package together so dependency versions stay aligned and operators cannot accidentally publish only a subset.
 
@@ -58,7 +59,7 @@ Manual real publishes require all of these gates before the publish job can run:
 
 Tag-triggered real publishes require all of these gates before the publish job can run:
 
-- A maintainer-approved version-bump PR has landed on `main`, with all five `@pinet/*` package versions and `pnpm-lock.yaml` aligned.
+- A maintainer-approved version-bump PR has landed on `main`, with all six `@pinet/*` package versions and `pnpm-lock.yaml` aligned.
 - A `vX.Y.Z` tag points at the current `main` tip after the version-bump PR merges.
 - The non-environment preflight job fetches `origin/main` and confirms the tag commit equals the current `origin/main` tip.
 - The same preflight job confirms every full-set package version equals `X.Y.Z`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,11 @@ importers:
         specifier: file:../transport-core
         version: link:../transport-core
 
-  model-aware-compaction: {}
+  model-aware-compaction:
+    dependencies:
+      "@earendil-works/pi-coding-agent":
+        specifier: ">=0.74.0"
+        version: 0.74.0(ws@8.20.0)(zod@4.3.6)
 
   neon-psql:
     devDependencies:

--- a/scripts/npm-publish-helpers.mjs
+++ b/scripts/npm-publish-helpers.mjs
@@ -9,6 +9,7 @@ export const publishPackages = Object.freeze([
   { directory: "pinet-core", packageName: "@pinet/pinet-core" },
   { directory: "imessage-bridge", packageName: "@pinet/imessage-bridge" },
   { directory: "slack-bridge", packageName: "@pinet/slack-bridge" },
+  { directory: "model-aware-compaction", packageName: "@pinet/model-aware-compaction" },
 ]);
 
 export const publishPackageDirectories = Object.freeze(

--- a/scripts/npm-publish-helpers.test.mjs
+++ b/scripts/npm-publish-helpers.test.mjs
@@ -51,6 +51,7 @@ test("getPublishPackages returns the full publish set in dependency order", () =
     "pinet-core",
     "imessage-bridge",
     "slack-bridge",
+    "model-aware-compaction",
   ]);
 });
 

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- align the full coordinated `@pinet/*` set on **0.2.1**
- add `@pinet/model-aware-compaction` as the sixth coordinated package and its initial release
- add package-scoped release notes covering changes since v0.2.0
- extend the existing GitHub Actions/OIDC publisher, tag-version validation, bootstrap/readiness tooling, tests, and release docs to include the new package

## Version set
- `@pinet/transport-core@0.2.1`
- `@pinet/broker-core@0.2.1`
- `@pinet/pinet-core@0.2.1`
- `@pinet/imessage-bridge@0.2.1`
- `@pinet/slack-bridge@0.2.1`
- `@pinet/model-aware-compaction@0.2.1`

## Validation
- `pnpm prepush` — all workspace lint, typecheck, and tests passed
- `node scripts/validate-npm-tag-version.mjs refs/tags/v0.2.1` — validates all six packages
- `pnpm publish:npm` — coordinated dry-run passed for all six packages
- model-aware compaction tarball: 9 files, 5.0 kB, JavaScript + declarations included
- public package surface scan contains no internal provider/model identifiers

## Release handoff
After merge, publish only through `.github/workflows/npm-publish.yml` using GitHub Actions/OIDC. The new `@pinet/model-aware-compaction` npm package may require one-time package creation and Trusted Publisher setup for `gugu91/extensions`, workflow `npm-publish.yml`, environment `npm-publish`. No npm publish, tag, or GitHub release is performed by this PR.
