### PR TITLE
fix: compact after agent loop settles

### DIFF
--- a/model-aware-compaction/README.md
+++ b/model-aware-compaction/README.md
@@ -37,7 +37,7 @@ Rules are evaluated in order. `*` wildcards are supported, such as `example-prox
 
 ## Behavior
 
-After each `turn_end`, the extension reads `ctx.getContextUsage()` and the active `ctx.model`. When usage first exceeds the matching rule's `activeContextTokens`, it calls `ctx.compact()`. It prevents duplicate calls while compaction is in flight and re-arms after usage drops below the threshold, the model changes, a session starts, or compaction fails.
+After each `agent_end`, the extension reads `ctx.getContextUsage()` and the active `ctx.model`. Waiting for `agent_end` is important: tool-using runs can emit several `turn_end` events, and Pi's `ctx.compact()` aborts an active agent operation before compacting. Triggering only after the complete model/tool loop has settled prevents compaction from discarding pending tool work. When usage first exceeds the matching rule's `activeContextTokens`, the extension calls `ctx.compact()`. It prevents duplicate calls while compaction is in flight and re-arms after usage drops below the threshold, the model changes, a session starts, or compaction fails.
 
 Run `/model-aware-compaction-status` to inspect the active model, usage, matched threshold, state, and loaded rules.
 

--- a/model-aware-compaction/index.test.ts
+++ b/model-aware-compaction/index.test.ts
@@ -8,14 +8,21 @@ import extension from "./index.js";
 type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
 
 function harness() {
-  const handlers = new Map<string, Handler>();
+  const handlers = new Map<string, Handler[]>();
   const api = {
-    on: (event: string, handler: Handler) => handlers.set(event, handler),
+    on: (event: string, handler: Handler) => {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    },
     registerCommand: vi.fn(),
     sendMessage: vi.fn(),
   } as unknown as ExtensionAPI;
   extension(api);
-  return { handlers, api };
+  const emit = (event: string, ctx: ExtensionContext) => {
+    for (const handler of handlers.get(event) ?? []) handler({}, ctx);
+  };
+  return { handlers, emit, api };
 }
 
 function context(tokens: number, compact = vi.fn()): ExtensionContext {
@@ -32,14 +39,38 @@ function context(tokens: number, compact = vi.fn()): ExtensionContext {
 
 describe("extension wiring", () => {
   it("does nothing while disabled", () => {
-    const { handlers } = harness();
+    const { emit } = harness();
     const compact = vi.fn();
-    handlers.get("turn_end")?.({}, context(120_000, compact));
+    emit("agent_end", context(120_000, compact));
     expect(compact).not.toHaveBeenCalled();
   });
 
+  it("waits for the complete agent loop before compacting", () => {
+    const { emit } = harness();
+    const compact = vi.fn();
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
+    fs.mkdirSync(path.join(temp, ".pi"));
+    fs.writeFileSync(
+      path.join(temp, ".pi", "settings.json"),
+      JSON.stringify({ "model-aware-compaction": { enabled: true } }),
+    );
+    try {
+      const ctx = { ...context(120_000, compact), cwd: temp };
+
+      // Tool-using runs can emit several turn_end events before agent_end.
+      emit("turn_end", ctx);
+      emit("turn_end", ctx);
+      expect(compact).not.toHaveBeenCalled();
+
+      emit("agent_end", ctx);
+      expect(compact).toHaveBeenCalledTimes(1);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
   it("triggers once above the configured threshold and re-arms after completion plus lower usage", () => {
-    const { handlers } = harness();
+    const { emit } = harness();
     const compact = vi.fn();
     // Project settings take precedence; the test creates only the minimal extension config.
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
@@ -52,23 +83,20 @@ describe("extension wiring", () => {
     );
     try {
       const ctx = { ...context(120_000, compact), cwd: temp };
-      handlers.get("turn_end")?.({}, ctx);
-      handlers.get("turn_end")?.({}, ctx);
+      emit("agent_end", ctx);
+      emit("agent_end", ctx);
       expect(compact).toHaveBeenCalledTimes(1);
 
       const options = compact.mock.calls[0]?.[0] as { onComplete?: () => void };
       options.onComplete?.();
-      handlers.get("turn_end")?.({}, ctx);
+      emit("agent_end", ctx);
       expect(compact).toHaveBeenCalledTimes(1);
 
-      handlers.get("turn_end")?.(
-        {},
-        {
-          ...ctx,
-          getContextUsage: () => ({ tokens: 90_000, contextWindow: 400_000, percent: 22.5 }),
-        },
-      );
-      handlers.get("turn_end")?.({}, ctx);
+      emit("agent_end", {
+        ...ctx,
+        getContextUsage: () => ({ tokens: 90_000, contextWindow: 400_000, percent: 22.5 }),
+      });
+      emit("agent_end", ctx);
       expect(compact).toHaveBeenCalledTimes(2);
     } finally {
       fs.rmSync(temp, { recursive: true, force: true });
@@ -76,7 +104,7 @@ describe("extension wiring", () => {
   });
 
   it("does not clear the in-flight guard when a model selection event re-arms the threshold", () => {
-    const { handlers } = harness();
+    const { emit } = harness();
     const compact = vi.fn();
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
     fs.mkdirSync(path.join(temp, ".pi"));
@@ -86,9 +114,9 @@ describe("extension wiring", () => {
     );
     try {
       const ctx = { ...context(120_000, compact), cwd: temp };
-      handlers.get("turn_end")?.({}, ctx);
-      handlers.get("model_select")?.({}, ctx);
-      handlers.get("turn_end")?.({}, ctx);
+      emit("agent_end", ctx);
+      emit("model_select", ctx);
+      emit("agent_end", ctx);
       expect(compact).toHaveBeenCalledTimes(1);
     } finally {
       fs.rmSync(temp, { recursive: true, force: true });

--- a/model-aware-compaction/index.ts
+++ b/model-aware-compaction/index.ts
@@ -37,7 +37,9 @@ export default function modelAwareCompaction(pi: ExtensionAPI) {
   pi.on("session_start", rearm);
   pi.on("model_select", rearm);
 
-  pi.on("turn_end", (_event, rawCtx) => {
+  // ctx.compact() aborts an active agent operation. Wait for the complete
+  // model/tool loop to settle so compaction cannot discard pending tool work.
+  pi.on("agent_end", (_event, rawCtx) => {
     const ctx = rawCtx as CompatibleContext;
     const config = loadConfig(ctx.cwd);
     const usage = ctx.getContextUsage?.();


### PR DESCRIPTION
## Summary

- trigger proactive compaction on `agent_end` instead of `turn_end`
- preserve the full model/tool loop before Pi's manual compaction aborts the active operation
- add regression coverage for repeated intermediate turns and document the lifecycle requirement

## Why

Tool-using runs emit a `turn_end` after the assistant requests tools and before the next model response consumes their results. In Pi 0.80.2, `ExtensionContext.compact()` starts manual compaction, whose `AgentSession.compact()` path disconnects from the agent and aborts the current operation. Calling it from an intermediate `turn_end` can therefore replace the expected continuation with an aborted assistant response.

`agent_end` is the final lifecycle event for the run, so no pending tool/model continuation remains to be discarded. This fix deliberately does not inject a synthetic continuation prompt.

## Verification

- `pnpm prepush`
- `pnpm --filter @pinet/model-aware-compaction build`
- `pnpm exec prettier --check model-aware-compaction/index.ts model-aware-compaction/index.test.ts model-aware-compaction/README.md`
- `git diff --check`
- deterministic Pi 0.80.2 `AgentSession` + faux-provider reproduction:
  - `turn_end` compaction: tool ran, final assistant response had `stopReason: "aborted"`
  - patched extension on `agent_end`: tool ran, final assistant response was `done` with `stopReason: "stop"`

## Upstream context

Pi 0.80.2's shipped `trigger-compact.ts` example currently calls `ctx.compact()` from `turn_end`, even though manual compaction aborts the active operation. I am reporting that API/example mismatch upstream separately.
