### PR TITLE
chore(release): prepare Pinet 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.2] - 2026-06-26
+
+Pinet v0.2.2 keeps the coordinated `@pinet/*` package set aligned and fixes proactive compaction interrupting active model/tool loops.
+
+### Version verification
+
+- `pi-extensions` — `0.2.2` (private repo package)
+- `@pinet/transport-core` — `0.2.2`
+- `@pinet/broker-core` — `0.2.2`
+- `@pinet/pinet-core` — `0.2.2`
+- `@pinet/imessage-bridge` — `0.2.2`
+- `@pinet/slack-bridge` — `0.2.2`
+- `@pinet/model-aware-compaction` — `0.2.2`
+
+### Release highlights
+
+- Defers model-aware proactive compaction until `agent_end`, after the complete model/tool loop has settled.
+- Prevents manual compaction from aborting the model continuation that consumes a completed tool result.
+- Adds lifecycle regression coverage without injecting a synthetic continuation message.
+
+### Included pull requests since v0.2.1
+
+- [#846](https://github.com/gugu91/extensions/pull/846) — fix: compact after agent loop settles
+
 ## [0.2.1] - 2026-06-26
 
 Pinet v0.2.1 keeps the coordinated `@pinet/*` package set aligned and adds `@pinet/model-aware-compaction` as its sixth package.

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary

- bump the private root package and all six publishable `@pinet/*` packages to `0.2.2`
- document the model-aware compaction lifecycle fix merged in #846
- keep the coordinated package set aligned for the tag-driven npm release

## Validation

- `pnpm prepush`
- `pnpm publish:npm` (dry run for all six packages)
- `node ./scripts/validate-npm-tag-version.mjs refs/tags/v0.2.2`
- confirmed `0.2.2` is not already published for any package in the release set
- independent Opus release-diff review: no blockers

## Release procedure after merge

Create and push `v0.2.2` from the merged `main` tip. The existing `npm-publish.yml` workflow will verify that the tag matches every package manifest and that the tag commit is the current `origin/main` tip before publishing.
