### PR TITLE
fix(slack): stop Markdown ** leaking into outbound Pinet Slack messages (#848)

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -2408,6 +2408,28 @@ describe("SlackAdapter — send", () => {
     expect(body.thread_ts).toBe("100.200");
   });
 
+  it("normalizes Markdown **bold** to Slack *bold* on the wire (issue #848)", async () => {
+    fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
+
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+
+    await adapter.send({
+      threadId: "100.200",
+      channel: "C123",
+      content: {
+        text: "Status: *done* and **also done** plus **one more**",
+        markdown: "Status: *done* and **also done** plus **one more**",
+      },
+    } as OutboundMessage);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.text).toBe("Status: *done* and *also done* plus *one more*");
+  });
+
   it("includes agent metadata when agentName is provided", async () => {
     fetchMock.mockResolvedValue(mockSlackResponse({ message: { ts: "1.1" } }));
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -41,6 +41,7 @@ import {
   SlackThreadStatusManager,
 } from "../../slack-thread-status.js";
 import { performSlackUploads, prepareSlackUpload } from "../../slack-upload.js";
+import { convertMarkdownBoldToSlackMrkdwn } from "../../slack-mrkdwn.js";
 import type {
   AdapterCapabilityRequest,
   AdapterCapabilityResult,
@@ -235,9 +236,10 @@ export class SlackAdapter implements MessageAdapter {
         : msg.blocks && msg.blocks.length > 0
           ? msg.blocks
           : undefined;
+    const outboundText = convertMarkdownBoldToSlackMrkdwn(msg.content?.text ?? msg.text);
     const body: Record<string, unknown> = {
       channel: msg.channel,
-      text: msg.content?.text ?? msg.text,
+      text: outboundText,
       thread_ts: msg.threadId,
       ...(slackBlocks ? { blocks: slackBlocks } : {}),
     };
@@ -280,7 +282,7 @@ export class SlackAdapter implements MessageAdapter {
         uploads,
         channelId: msg.channel,
         threadTs: msg.threadId,
-        initialComment: msg.content?.text ?? msg.text,
+        initialComment: outboundText,
         slack: this.callSlack.bind(this),
         token: this.config.botToken,
       });

--- a/slack-bridge/slack-mrkdwn.test.ts
+++ b/slack-bridge/slack-mrkdwn.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { convertMarkdownBoldToSlackMrkdwn } from "./slack-mrkdwn.js";
+
+describe("convertMarkdownBoldToSlackMrkdwn", () => {
+  it("converts Markdown **bold** to Slack *bold*", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("**bold**")).toBe("*bold*");
+    expect(convertMarkdownBoldToSlackMrkdwn("a **bold** word")).toBe("a *bold* word");
+  });
+
+  it("handles the mixed-rendering case from issue #848", () => {
+    // Slack `*already*` should survive; Markdown `**leaky**` should be converted.
+    const input = "Status: *done* and **also done** plus **one more**";
+    expect(convertMarkdownBoldToSlackMrkdwn(input)).toBe(
+      "Status: *done* and *also done* plus *one more*",
+    );
+  });
+
+  it("converts multiple bold spans on one line without merging them", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("**a** and **b**")).toBe("*a* and *b*");
+  });
+
+  it("leaves existing Slack mrkdwn single-asterisk bold untouched", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("*already slack*")).toBe("*already slack*");
+  });
+
+  it("leaves Slack italic (_text_) untouched", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("_italic_ and **bold**")).toBe("_italic_ and *bold*");
+  });
+
+  it("does not touch ** inside an inline code span", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("use `a**b` literally")).toBe("use `a**b` literally");
+    expect(convertMarkdownBoldToSlackMrkdwn("`**not bold**` but **bold**")).toBe(
+      "`**not bold**` but *bold*",
+    );
+  });
+
+  it("does not touch ** inside a fenced code block", () => {
+    const input = "```\nx = a ** b\n```\nthen **bold**";
+    expect(convertMarkdownBoldToSlackMrkdwn(input)).toBe("```\nx = a ** b\n```\nthen *bold*");
+  });
+
+  it("preserves Slack-style links", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("see <https://x.test|the **docs**>")).toBe(
+      "see <https://x.test|the *docs*>",
+    );
+  });
+
+  it("does not mangle Markdown links (no bold present)", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("[text](https://x.test)")).toBe(
+      "[text](https://x.test)",
+    );
+  });
+
+  it("leaves bullet lists intact while converting bold inside them", () => {
+    const input = "- **first**\n- second\n- *third*";
+    expect(convertMarkdownBoldToSlackMrkdwn(input)).toBe("- *first*\n- second\n- *third*");
+  });
+
+  it("leaves stray/unbalanced ** untouched", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("just ** two stars")).toBe("just ** two stars");
+  });
+
+  it("does not convert spaced-out ** markers (not valid bold)", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("** not bold **")).toBe("** not bold **");
+  });
+
+  it("returns the input unchanged when there is no double asterisk", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("plain text")).toBe("plain text");
+  });
+
+  it("handles bold spanning multiple words and punctuation", () => {
+    expect(convertMarkdownBoldToSlackMrkdwn("**Root cause:** found it")).toBe(
+      "*Root cause:* found it",
+    );
+  });
+});

--- a/slack-bridge/slack-mrkdwn.ts
+++ b/slack-bridge/slack-mrkdwn.ts
@@ -1,0 +1,59 @@
+/**
+ * Outbound Slack mrkdwn normalization.
+ *
+ * Pi agents frequently emit standard Markdown bold (`**bold**`) in their
+ * replies. Slack's `chat.postMessage` `text` field is rendered as *mrkdwn*,
+ * where bold is a single asterisk (`*bold*`). When a message mixes both
+ * conventions, Slack renders the single-asterisk spans correctly but leaks the
+ * literal `**` markers for the Markdown-style spans (see issue #848).
+ *
+ * This module converts Markdown `**bold**` to Slack `*bold*` on the outbound
+ * path while leaving already-Slack-formatted text untouched. It deliberately
+ * keeps the surface tight:
+ *  - Only double-asterisk bold is rewritten. Single `*…*` / `_…_` spans, which
+ *    are already valid Slack mrkdwn, are preserved.
+ *  - Content inside inline code spans and fenced code blocks is never touched,
+ *    so literal `**` shown as code stays literal.
+ */
+
+// Matches fenced code blocks (```…```) and inline code spans (`…`). Fenced
+// blocks are listed first so they win over inline spans during masking.
+const CODE_SEGMENT = /```[\s\S]*?```|`[^`\n]*`/g;
+
+// Matches Markdown-style **bold** spans on a single line. The bold text must
+// begin and end with a non-whitespace character so we don't match stray/odd
+// markers, spaced-out `** … **`, or collide with already-Slack `*…*` emphasis.
+const MARKDOWN_BOLD = /\*\*(?=\S)(.*?\S)\*\*/g;
+
+// Private Use Area sentinels are extremely unlikely to appear in real message
+// text and avoid the control characters that `no-control-regex` rejects.
+const PLACEHOLDER_PREFIX = "\uE000mrkdwn-code-";
+const PLACEHOLDER_SUFFIX = "\uE001";
+
+/**
+ * Convert Markdown `**bold**` to Slack `*bold*` while preserving inline code,
+ * fenced code blocks, and existing Slack mrkdwn emphasis.
+ */
+export function convertMarkdownBoldToSlackMrkdwn(text: string): string {
+  if (!text.includes("**")) {
+    return text;
+  }
+
+  const codeSegments: string[] = [];
+  const masked = text.replace(CODE_SEGMENT, (match) => {
+    const token = `${PLACEHOLDER_PREFIX}${codeSegments.length}${PLACEHOLDER_SUFFIX}`;
+    codeSegments.push(match);
+    return token;
+  });
+
+  const converted = masked.replace(MARKDOWN_BOLD, (_match, inner: string) => `*${inner}*`);
+
+  if (codeSegments.length === 0) {
+    return converted;
+  }
+
+  return converted.replace(
+    /\uE000mrkdwn-code-(\d+)\uE001/g,
+    (_match, index: string) => codeSegments[Number(index)] ?? "",
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #848 — mixed Markdown/Slack bold rendering where outbound Pinet Slack replies showed correctly-bolded spans next to literal `**` markers in the same message.

## Root cause

Pi agents frequently emit standard Markdown bold (`**bold**`) in their replies. Slack's `chat.postMessage` renders the `text` field as **mrkdwn**, where bold is a *single* asterisk (`*bold*`). The outbound broker Slack adapter posted the agent text verbatim with no Markdown→mrkdwn normalization, so:

- single-asterisk spans the agent happened to write rendered correctly, while
- double-asterisk Markdown spans leaked the literal `**` markers.

This is exactly the mixed symptom in Thomas's screenshot.

## Fix

- New `slack-bridge/slack-mrkdwn.ts`: `convertMarkdownBoldToSlackMrkdwn()` rewrites `**bold**` → `*bold*`.
  - Inline code spans (`` `…` ``) and fenced code blocks (```` ``` ````) are masked first, so literal `**` shown as code stays intact.
  - Only double-asterisk bold is touched. Existing Slack `*…*` bold, `_…_` italics, links, and bullets are left untouched (avoids over-converting already-Slack-formatted text).
  - Spaced-out / unbalanced `**` markers are left alone.
- Applied at the single choke point: the broker Slack adapter `send()` (both `chat.postMessage` `text` and the file-upload `initialComment`). This covers broker self-sends and follower-relayed worker replies, since both ultimately post through the broker's Slack adapter. The stored DB message body keeps the original text.

## Validation

- New `slack-bridge/slack-mrkdwn.test.ts` covers: mixed `**bold**` + Slack `*bold*` (the screenshot case), multiple spans per line, code spans/blocks, Slack + Markdown links, bullets, italics, and unbalanced markers.
- New adapter test asserts the converted text lands on the `chat.postMessage` wire body.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` all green (slack-bridge 1440/1440; full workspace passes).

> Note: one unrelated pre-existing test (`helpers.test.ts` mesh-auth env fallback) fails only when `PINET_MESH_SECRET` is set in the shell env; it passes with that env unset and is untouched by this change.
