### PR TITLE
chore(release): prepare Pinet 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.3] - 2026-06-30
+
+Pinet v0.2.3 keeps the coordinated `@pinet/*` package set aligned and ships the Slack/Pinet fixes merged after v0.2.2.
+
+### Version verification
+
+- `pi-extensions` — `0.2.3` (private repo package)
+- `@pinet/transport-core` — `0.2.3`
+- `@pinet/broker-core` — `0.2.3`
+- `@pinet/pinet-core` — `0.2.3`
+- `@pinet/imessage-bridge` — `0.2.3`
+- `@pinet/slack-bridge` — `0.2.3`
+- `@pinet/model-aware-compaction` — `0.2.3`
+
+### Release highlights
+
+- Adds worker-session lookup support to the Pinet mesh/API surface, including broker schema, client, socket-server, tool output, and formatting coverage.
+- Requires explicit invocation before guarded Slack contexts can route into Pinet, preventing passive channel/thread traffic from being treated as an authorized assistant request.
+- Fixes Slack Markdown bold rendering by adding a focused Slack-markdown conversion path and regression coverage.
+
+### Included pull requests since v0.2.2
+
+- [#837](https://github.com/gugu91/extensions/pull/837) — Add Pinet worker session lookup
+- [#838](https://github.com/gugu91/extensions/pull/838) — fix(slack-bridge): require explicit invocation in guarded Slack contexts
+- [#840](https://github.com/gugu91/extensions/pull/840) — Fix Slack Markdown bold rendering
+
 ## [0.2.2] - 2026-06-26
 
 Pinet v0.2.2 keeps the coordinated `@pinet/*` package set aligned and fixes proactive compaction interrupting active model/tool loops.

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- bump the coordinated Pinet publish set and private root package from 0.2.2 to 0.2.3
- add the 0.2.3 CHANGELOG entry covering PRs #837, #838, and #840
- keep publish scope aligned with the documented full @pinet/* package set; no publish/tag/merge action taken

## Release notes
Included since v0.2.2:
- #837 Add Pinet worker session lookup
- #838 Require explicit invocation in guarded Slack contexts
- #840 Fix Slack Markdown bold rendering

## Validation
- pnpm install --frozen-lockfile
- pnpm prepush
- pnpm publish:npm (dry-run; all six @pinet/* packages packed/published in dry-run mode)
- npm view check: @pinet/*@0.2.3 not currently published; @pinet/model-aware-compaction@0.2.2 appears absent while the other five 0.2.2 packages exist, so 0.2.3 is the safe next coordinated full-set version

## Maintainer approval required before release
- merge this PR to main
- either dispatch the npm publish workflow from main with dry_run=false and release_approval exactly `publish all`, or create tag `v0.2.3` on the current main tip after merge
- approve the protected `npm-publish` environment when the workflow reaches the publish job
