### PR TITLE
chore(release): prepare Pinet 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ version bumps and publish scope.
 
 ## [0.2.3] - 2026-06-30
 
-Pinet v0.2.3 keeps the coordinated `@pinet/*` package set aligned and includes the Slack/Pinet fixes merged after the v0.2.2 release prep.
+Pinet v0.2.3 re-synchronizes the coordinated `@pinet/*` package set after the partial v0.2.2 npm publish, and includes the Slack/Pinet fixes merged after the v0.2.2 release prep.
 
 ### Version verification
 
@@ -29,7 +29,7 @@ Pinet v0.2.3 keeps the coordinated `@pinet/*` package set aligned and includes t
 - Fixes Slack mrkdwn bold rendering by preserving `*bold*` output instead of converting it to unsupported double-asterisk Markdown.
 - Adds Pinet worker session lookup support so broker/operator tooling can resolve worker sessions more reliably.
 
-### Included pull requests since v0.2.2
+### Included pull requests since the v0.2.2 repo release prep
 
 - [#837](https://github.com/gugu91/extensions/pull/837) — Add Pinet worker session lookup
 - [#838](https://github.com/gugu91/extensions/pull/838) — Require explicit Pinet invocation in guarded Slack contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.3] - 2026-06-30
+
+Pinet v0.2.3 keeps the coordinated `@pinet/*` package set aligned and includes the Slack/Pinet fixes merged after the v0.2.2 release prep.
+
+### Version verification
+
+- `pi-extensions` — `0.2.3` (private repo package)
+- `@pinet/transport-core` — `0.2.3`
+- `@pinet/broker-core` — `0.2.3`
+- `@pinet/pinet-core` — `0.2.3`
+- `@pinet/imessage-bridge` — `0.2.3`
+- `@pinet/slack-bridge` — `0.2.3`
+- `@pinet/model-aware-compaction` — `0.2.3`
+
+### Release highlights
+
+- Requires explicit Pinet invocation before guarded Slack-context routing so uninvoked guarded Slack messages do not start unintended assistant work.
+- Fixes Slack mrkdwn bold rendering by preserving `*bold*` output instead of converting it to unsupported double-asterisk Markdown.
+- Adds Pinet worker session lookup support so broker/operator tooling can resolve worker sessions more reliably.
+
+### Included pull requests since v0.2.2
+
+- [#837](https://github.com/gugu91/extensions/pull/837) — Add Pinet worker session lookup
+- [#838](https://github.com/gugu91/extensions/pull/838) — Require explicit Pinet invocation in guarded Slack contexts
+- [#840](https://github.com/gugu91/extensions/pull/840) — Fix Slack Markdown bold rendering
+
 ## [0.2.2] - 2026-06-26
 
 Pinet v0.2.2 keeps the coordinated `@pinet/*` package set aligned and fixes proactive compaction interrupting active model/tool loops.

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -13,7 +13,7 @@ The publish workflow always validates or publishes the full npm org `pinet` pack
 5. `@pinet/slack-bridge` from `slack-bridge/`
 6. `@pinet/model-aware-compaction` from `model-aware-compaction/`
 
-There is intentionally no workflow target selector or script target flag. Real releases publish the shared core packages and Slack bridge package together so dependency versions stay aligned and operators cannot accidentally publish only a subset.
+There is intentionally no workflow target selector or script target flag. Real releases publish the shared core packages, bridges, and model-aware compaction package together so dependency versions stay aligned and operators cannot accidentally publish only a subset.
 
 ## Workflow and script
 

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -13,7 +13,7 @@ The publish workflow always validates or publishes the full npm org `pinet` pack
 5. `@pinet/slack-bridge` from `slack-bridge/`
 6. `@pinet/model-aware-compaction` from `model-aware-compaction/`
 
-There is intentionally no workflow target selector or script target flag. Real releases publish the shared core packages, bridges, and model-aware compaction package together so dependency versions stay aligned and operators cannot accidentally publish only a subset.
+There is intentionally no workflow target selector or script target flag. Real releases always attempt the shared core packages, bridges, and model-aware compaction package in dependency order so dependency versions stay aligned. npm publishes are sequential rather than atomic, so operators must verify the full package set after any real publish and treat a late failure as a partial-release recovery task.
 
 ## Workflow and script
 
@@ -26,7 +26,7 @@ Manual dispatch inputs:
 
 Tag-triggered publishes run only for `vX.Y.Z` tags. The readiness job validates every package in the full `@pinet/*` set has `package.json.version` equal to the tag version before any `npm publish --dry-run`; the preflight job also fetches `origin/main`, fails unless the tag commit equals the current `origin/main` tip, and repeats the package-version check before the protected publish job can request the `npm-publish` environment.
 
-Every run first executes the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order.
+Every run first executes the readiness job: install with `pnpm install --frozen-lockfile`, build packages in dependency order through `scripts/publish-npm-packages.mjs`, rewrite local `file:../...` workspace dependencies to exact package versions in the CI checkout, verify declared `dist/` JavaScript exports and declaration outputs exist, smoke-test public declaration imports, and run `npm publish --dry-run` in dependency order. After any real publish, verify every package in the full set exists on npm at the intended version with `npm view <package>@<version> version`.
 
 For local/readiness use, run the same script directly or through the safe npm script:
 
@@ -66,7 +66,7 @@ Tag-triggered real publishes require all of these gates before the publish job c
 - The `npm-publish` GitHub environment is approved by a maintainer after preflight passes.
 - The publish job has `id-token: write` and npm Trusted Publishers are configured for every package as above.
 
-The real publish job then reruns the same publish script with `--publish`, which uses `npm publish --provenance` and fails closed if any target package version already exists on npm.
+The real publish job then reruns the same publish script with `--publish`, which uses `npm publish --provenance` and fails closed if any target package version already exists on npm. Because npm does not roll back already-published packages when a later package fails, a partial publish must be recovered by preparing a new patch version for the entire set, documenting the partial state in the changelog/release notes, and publishing the new full set after maintainer approval.
 
 ## npm org and first-publish bootstrap
 

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- Bump the coordinated Pinet package set and private repo package to `0.2.3`.
- Add the `0.2.3` changelog entry for the Slack/Pinet fixes merged after `0.2.2` (#837, #838, #840).
- Refresh the npm publish plan wording so the full release set includes core packages, bridges, and model-aware compaction.

## Release state
- Package set: `@pinet/transport-core`, `@pinet/broker-core`, `@pinet/pinet-core`, `@pinet/imessage-bridge`, `@pinet/slack-bridge`, `@pinet/model-aware-compaction`.
- `0.2.3` is not currently published for any package in the release set per `npm view <pkg>@0.2.3 version` checks.
- This PR does not publish, tag, or merge. Those remain maintainer-gated.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm lint && pnpm typecheck && pnpm test`
- `pnpm publish:npm` (dry-run readiness across the full `@pinet/*` package set)
- Push pre-push hook reran `pnpm lint && pnpm typecheck && pnpm test`

## Confirmation-gated next steps
- Merge this PR after review/approval.
- Create `v0.2.3` tag on the merged `main` tip if using the tag-triggered publish path.
- Approve/run the npm publish workflow with the required maintainer gates, or perform the documented maintainer-gated path. No local publish was run.
