### PR TITLE
Rewrite Pinet READMEs in GOV.UK style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,361 +1,219 @@
-# extensions
+# Extensions
 
-Pi extensions monorepo — Slack, Neovim, and Neon Postgres integrations for
-the [pi coding agent](https://github.com/nicholasgasior/pi-coding-agent).
+Get Pinet working in your Slack workspace in 10 minutes. This repository provides pi coding agent extensions for Slack, Neovim, and Neon Postgres.
 
-Current state: the repo has moved from the initial **50+ merged PRs in a
-single day** sprint into a broader Pinet stabilization and docs pass, with a
-broker/follower Slack mesh, durable Pinet lanes/inbox state, Slack canvases, scheduled
-wake-ups, worktree guardrails, checked-in Slack manifest deploy tooling,
-optional mesh auth, and a browser-playwright workspace package for
-interactive browsing and screenshots.
+## What Pinet does
 
-## Extensions
+Pinet connects pi coding agents to Slack. It runs a broker that coordinates work, routes messages, and keeps multiple agents working together. The system can:
 
-| Package                                     | Description                                                                     |
-| ------------------------------------------- | ------------------------------------------------------------------------------- |
-| [`transport-core`](transport-core/)         | Transport-neutral message contracts shared across transport packages            |
-| [`browser-playwright`](browser-playwright/) | Supported Anthropic-sandbox browsing path; Playwright-first single browser tool |
-| [`slack-bridge`](slack-bridge/)             | Slack assistant app (Pinet) — broker mesh, inbox, canvases, deploy tooling      |
-| [`slack-api`](slack-api/)                   | Typed Slack Web API client + CLI generated from OpenAPI                         |
-| [`imessage-bridge`](imessage-bridge/)       | macOS/iMessage send-first transport package + readiness helpers                 |
-| [`nvim-bridge`](nvim-bridge/)               | Neovim editor context sync; PiComms disabled pending Pinet adapter replacement  |
-| [`neon-psql`](neon-psql/)                   | Config-driven Neon tunnel + `psql` tool                                         |
-| [`types`](types/)                           | Shared ambient type declarations                                                |
+- respond to Slack messages and commands
+- coordinate multiple agents working on different tasks
+- support pull request review workflows
+- recover from stale claims and surface pending backlog
+- keep you informed about what agents are doing
 
-## Current state snapshot
+## Get started
 
-- **Broker mesh** — Slack-bridge now runs a broker/follower Pinet workflow with
-  routing, inbox sync, broadcast channels, reload/unfollow controls,
-  scheduled wake-ups, and optional/configurable shared-secret mesh auth.
-- **Slack tooling** — the Slack extension includes canvases, uploads,
-  modals, bookmarks, pinning, exports, and a root `pnpm deploy:slack` command
-  for pushing `slack-bridge/manifest.yaml` via the Slack App Manifest API.
-- **Browser automation** — the repo now carries a dedicated
-  [`browser-playwright`](browser-playwright/README.md)
-  workspace package as the supported browsing path in the Anthropic sandbox,
-  with reusable sessions, multi-tab browsing, request guardrails, and
-  workspace-local screenshot artifacts. Local `agent-browser` daemon
-  compatibility is explicitly not a support goal for this path.
-- **Recent wave** — browser-playwright landed alongside the Pinet v0.1.1 prep,
-  mesh-secret optionality, auth-mismatch clarification, and refreshed mesh-auth
-  docs ([#282](https://github.com/gugu91/extensions/pull/282),
-  [#288](https://github.com/gugu91/extensions/pull/288),
-  [#289](https://github.com/gugu91/extensions/pull/289),
-  [#292](https://github.com/gugu91/extensions/pull/292),
-  [#294](https://github.com/gugu91/extensions/pull/294)).
+### Install from npm
 
-## Philosophy
-
-### How Pinet was built
-
-Pinet was not just designed on paper and then implemented by hand. It was built
-mostly unsupervised by the kind of system it enables: a self-coordinating mesh
-of coding agents working through Slack, GitHub, and linked git worktrees.
-
-The core operating model is simple:
-
-- **A broker coordinates, but does not write code.** The broker agent watches
-  Slack, files and routes work, nudges stalled threads, tracks ownership, and
-  keeps the system coherent. The actual implementation work stays with worker
-  agents in isolated worktrees.
-- **Workers ship end-to-end.** Worker agents pick up issues, write code, add
-  tests, run checks, push branches, and open PRs without waiting for a human to
-  micromanage every step.
-- **Agents review other agents.** The mesh does not stop at code generation:
-  agents review each other's PRs, handle rebases, resolve conflicts, and repair
-  broken branches autonomously when `main` moves underneath them.
-- **Personality is a feature, not garnish.** Named agents like Rocket Dolphin,
-  Silent Crocodile, Solar Mantis, and Ultra Rabbit make a busy multi-agent
-  system legible. When dozens of tasks are moving at once, memorable identities
-  make status, ownership, and accountability visible to humans.
-- **The mesh is expected to self-repair.** The RALPH loop watches for stalls,
-  reassigns stuck work, nudges long-running threads, and reaps dead or ghosted
-  agents so the system can keep moving even when parts of it fail.
-
-This is not a toy demo. During the current buildout, the mesh merged **50+ PRs
-in a single day** with minimal human intervention. The system was doing real
-engineering work: implementing features, reviewing changes, recovering from
-failures, and keeping momentum through rebases and broker hiccups.
-
-Humans still matter, but in a deliberately high-leverage role: **set
-priorities, approve merges, and provide the API tokens and environment** that
-let the mesh operate. The goal is not to remove humans from the loop; it is to
-move them up a level, from doing every step manually to steering a system that
-can coordinate and execute most of the work itself.
-
-## Quick start
-
-```bash
-# Install dependencies in this checkout
-pnpm install
-
-# Run all checks
-pnpm lint && pnpm typecheck && pnpm test
-```
-
-### Fresh worktree bootstrap
-
-For a fresh git worktree, bootstrap dependencies in that checkout before
-running `pnpm lint`, `pnpm typecheck`, `pnpm test`, or `pnpm prepush`:
-
-```bash
-git worktree add .worktrees/<name> -b <branch>
-cd .worktrees/<name>
-pnpm install --frozen-lockfile
-```
-
-Dependency bootstrap is per checkout/worktree, not a one-time repo setup step.
-If the lane exercises live browser launches and no compatible host browser is
-available, install the Playwright browser binaries from the package directory:
-
-```bash
-cd browser-playwright
-npx playwright install chromium
-```
-
-## Local extension development
-
-This repo now uses pnpm workspaces + Turborepo for **repo-internal monorepo
-tooling**. It is **not** yet a supported root-level `pi install git:...`
-package target.
-
-For the published Pinet Slack bridge pi package, install from npm:
+Install the Slack bridge package:
 
 ```bash
 pi install npm:@pinet/slack-bridge
-pi install npm:@pinet/slack-bridge@0.1.0 # pinned version
 ```
 
-For local development, load individual extensions directly:
+Or pin a specific version:
 
 ```bash
-ln -s "$(pwd)/slack-bridge"       ~/.pi/agent/extensions/slack-bridge
-ln -s "$(pwd)/nvim-bridge"        ~/.pi/agent/extensions/nvim-bridge
-ln -s "$(pwd)/neon-psql"          ~/.pi/agent/extensions/neon-psql
-ln -s "$(pwd)/browser-playwright" ~/.pi/agent/extensions/browser-playwright
+pi install npm:@pinet/slack-bridge@0.2.2
 ```
 
-See each extension's README for configuration details.
+### Set up your Slack app
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app
+2. Choose 'From a manifest'
+3. Select your workspace
+4. Paste the contents of [`slack-bridge/manifest.yaml`](slack-bridge/manifest.yaml)
+5. Create the app
+
+### Get your tokens
+
+You need two tokens from Slack:
+
+- App-Level Token: go to Basic Information → App-Level Tokens → Generate (add `connections:write` scope)
+- Bot Token: go to OAuth & Permissions → Install to Workspace → copy the Bot User OAuth Token
+
+### Configure Pinet
+
+Add your tokens, runtime mode, and access rules to `~/.pi/agent/settings.json`:
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-your-bot-token",
+    "appToken": "xapp-your-app-token",
+    "runtimeMode": "single",
+    "allowedUsers": ["U_YOUR_USER_ID"]
+  }
+}
+```
+
+Start pi. Pinet appears in your Slack sidebar.
+
+## Current features
+
+The repository includes these extensions:
+
+| Package                                     | Description                                             |
+| ------------------------------------------- | ------------------------------------------------------- |
+| [`transport-core`](transport-core/)         | Message contracts shared across transport packages      |
+| [`browser-playwright`](browser-playwright/) | Browser automation with Playwright                      |
+| [`slack-bridge`](slack-bridge/)             | Slack integration with broker mesh, inbox, and canvases |
+| [`slack-api`](slack-api/)                   | Typed Slack Web API client                              |
+| [`imessage-bridge`](imessage-bridge/)       | macOS iMessage transport                                |
+| [`nvim-bridge`](nvim-bridge/)               | Neovim editor context sync                              |
+| [`neon-psql`](neon-psql/)                   | Neon Postgres tunnel                                    |
+| [`types`](types/)                           | Shared type declarations                                |
+
+Recent updates include:
+
+- broker mesh for coordinating multiple agents
+- Slack canvases, uploads, modals, bookmarks, and pins
+- scheduled wake-ups and inbox sync
+- browser automation with reusable sessions
+- optional shared-secret mesh authentication
+
+## How Pinet works
+
+### Architecture
+
+Pinet uses a broker-worker model. One agent acts as the broker. It watches Slack, assigns work, and keeps track of what each worker is doing. Worker agents pick up tasks, write code, run tests, and open pull requests.
+
+The system can review its own code. Agents review each other's pull requests, handle rebases, and fix broken branches when the main branch moves.
+
+### Self-repair
+
+The RALPH loop monitors broker health. It:
+
+- checks worker presence every 5 minutes
+- releases stale thread claims when owners disappear
+- observes pending backlog while broker maintenance handles assignment
+- triggers scheduled wake-ups
+
+### Agent identity
+
+Named agents make the system easier to follow. When you see 'Rocket Dolphin' or 'Silent Crocodile' in Slack, you know which agent is working on what. This helps when dozens of tasks are moving at once.
 
 ## Development
 
-This repo uses [pnpm workspaces](https://pnpm.io/workspaces) +
-[Turborepo](https://turbo.build/repo) for build orchestration with local
-caching.
+### Work in a git worktree
 
-### Commands
+Never work directly on main. Create a worktree for your changes:
 
-| Command             | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `pnpm lint`         | ESLint across all extensions (turbo-cached)                     |
-| `pnpm typecheck`    | TypeScript strict check (turbo-cached)                          |
-| `pnpm test`         | Vitest — all tests (turbo-cached)                               |
-| `pnpm deploy:slack` | Validate and push `slack-bridge/manifest.yaml` to the Slack app |
-| `pnpm prepush`      | lint + typecheck + test (runs on git push)                      |
-| `pnpm format`       | Prettier + Stylua                                               |
-| `pnpm check`        | lint + typecheck + format check                                 |
+```bash
+git worktree add .worktrees/my-feature -b feat/my-feature
+cd .worktrees/my-feature
+pnpm install --frozen-lockfile
+```
+
+### Run checks
+
+```bash
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript
+pnpm test         # Vitest
+pnpm prepush      # All checks (runs on git push)
+```
 
 ### Structure
 
 ```
 extensions/
-├── transport-core/     # @pinet/transport-core
-│   ├── index.ts        #   canonical transport message contracts
-│   └── package.json    #   workspace package
-├── browser-playwright/ # @gugu910/pi-browser-playwright
-│   ├── index.ts        #   Playwright-first single `browser` tool entry point
-│   ├── helpers.ts      #   security defaults + install guidance
-│   └── package.json    #   workspace package + pi manifest
-├── slack-bridge/       # @pinet/slack-bridge
-│   ├── broker/         #   message routing, socket server, adapters
-│   ├── index.ts        #   extension entry point
-│   └── package.json    #   workspace package + pi manifest
-├── slack-api/          # @gugu910/pi-slack-api
-│   ├── generated/      #   generated typed Slack Web API client
-│   ├── cli.ts          #   CLI wrapper around generated methods
-│   └── package.json    #   workspace package + pi manifest
-├── imessage-bridge/    # @pinet/imessage-bridge
-│   ├── mvp.ts          #   local macOS/iMessage readiness helpers
-│   ├── send.ts         #   AppleScript send-first transport helper
-│   └── package.json    #   standalone workspace package
-├── nvim-bridge/        # @gugu910/pi-nvim-bridge
-│   ├── nvim/           #   Neovim Lua plugin
-│   ├── index.ts        #   extension entry point
-│   └── package.json
-├── neon-psql/          # @gugu910/pi-neon-psql
-│   ├── index.ts        #   extension entry point
-│   └── package.json
-├── types/              # @gugu910/pi-ext-types (shared .d.ts)
+├── transport-core/       # Message contracts
+├── browser-playwright/   # Browser automation
+├── slack-bridge/         # Slack integration
+├── slack-api/           # Slack API client
+├── imessage-bridge/     # iMessage transport
+├── nvim-bridge/         # Neovim sync
+├── neon-psql/          # Postgres tunnel
+├── types/              # Type declarations
 ├── plans/              # Architecture docs
-├── .pi/                # Pi config (skills, agents)
-├── turbo.json          # Turborepo task config
-├── pnpm-workspace.yaml # Workspace packages
-└── package.json        # Root — dev deps + scripts
+├── .pi/                # Pi configuration
+├── turbo.json          # Build orchestration
+└── package.json        # Root configuration
 ```
 
-### Extension tool-surface design principles
+### Local development
 
-All extensions should use token-efficient progressive discovery for
-agent-facing surfaces. This is especially important for Pinet / `slack-bridge`,
-where broad Slack/Pinet action families can otherwise bloat every agent turn
-(see #566 and #581).
-
-1. **Hot tool schemas stay small.** Keep only the few per-turn, high-signal
-   execution tools registered as dedicated tools, and justify additions by
-   expected usage and token footprint.
-2. **Cold paths stay discoverable.** Large homogeneous action families should
-   sit behind compact dispatchers with structured `help` and per-action schema
-   discovery instead of many cold one-off tools.
-3. **Warm knowledge moves to skills/docs.** Formatting examples, API recipes,
-   templates, and recovery playbooks belong in lazily loaded skills or docs —
-   not in always-present prompts or tool schemas.
-4. **Responses are contracts.** Prefer structured response envelopes such as
-   `{ status, data, errors, warnings }` with typed error classes and recovery
-   hints so agents can recover without an extra human turn.
-5. **Guardrails name the executable action.** Dispatcher actions should expose
-   stable guardrail names (for example `slack:upload`) so blocking and
-   confirmation policies remain precise even when many actions share one tool.
-6. **Reviews check token cost.** New Slack/Pinet tools, dispatcher actions, or
-   prompt surfaces should include token-footprint tradeoffs in design and review
-   rather than expanding the always-loaded surface by default.
-
-### Adding a new extension
-
-1. Create a directory with `index.ts` and `package.json`
-2. Add a `pi` key to `package.json` pointing at the entry file
-3. Add the directory to `pnpm-workspace.yaml`
-4. Add `tsconfig.json` extending the root config
-5. Add `eslint.config.mjs` re-exporting the root config
-6. If the extension has tests, add `vitest.config.ts` and a `test` script
-
-### Test policy
-
-See [`plans/test-policy.md`](plans/test-policy.md) for merge-ready test
-expectations and the required smoke checklist.
-
-## npm publish readiness
-
-The publishable Pinet/Slack package set is tracked in
-[`plans/npm-publish.md`](plans/npm-publish.md) and executed through the manual
-[`Publish npm packages`](.github/workflows/npm-publish.yml) GitHub Actions
-workflow. The workflow supports manual dry-run/publish dispatches and release-tag
-publishes from `vX.Y.Z` tags. It intentionally has no package target selector; it
-always validates or publishes the full set in dependency order.
-
-Safe readiness checks are the default path:
-
-1. Open **Actions → Publish npm packages → Run workflow**.
-2. Leave `dry_run=true`.
-3. Confirm the workflow runs `scripts/publish-npm-packages.mjs --dry-run` for
-   the full `@pinet/*` package set and does not request npm credentials.
-
-The same dry-run path can be run locally with `pnpm publish:npm`; it defaults to
-readiness only and has no package target selector. The one-time npm org package
-creation bootstrap path is `pnpm bootstrap:npm`, which also defaults to dry-run
-and prints the full `@pinet/*` package set it would publish.
-
-Real publishes are intentionally harder to trigger. Maintainers can either
-manually dispatch from `main` with `dry_run=false` and `release_approval` exactly
-`publish all`, or push a release tag named `vX.Y.Z` after the version bump has
-merged to the current `main` tip. Tag-triggered publishes validate that the tag
-commit equals the current `origin/main` tip and that all five `@pinet/*` package
-versions equal the tag version before the protected publish job can request the
-`npm-publish` environment. Both real publish paths require maintainer approval of
-the protected `npm-publish` environment. The publish job uses npm Trusted
-Publishing / GitHub OIDC with `npm publish --provenance`; it does not use a
-long-lived npm token. Maintainers must also configure npm Trusted Publishers for
-every package in the npm `pinet` org settings
-(`https://www.npmjs.com/settings/pinet/packages`) before real publish. The live
-GitHub `npm-publish` environment must also be verified out-of-band by a
-maintainer before tag releases are considered ready: it should require approval
-and allow deployments from `main` plus release tags matching `v*.*.*`. That tag
-environment allowance does not replace the workflow guard that requires the tag
-commit to equal the current `origin/main` tip.
-If npm requires packages to exist before Trusted Publishing can be configured,
-a `pinet` org owner/admin may use the guarded local bootstrap script only after
-maintainer-approved versions are set:
+For development, link extensions directly:
 
 ```bash
-node ./scripts/bootstrap-npm-packages.mjs \
-  --bootstrap-publish \
-  --confirm "bootstrap @pinet packages"
+ln -s "$(pwd)/slack-bridge" ~/.pi/agent/extensions/slack-bridge
+ln -s "$(pwd)/nvim-bridge" ~/.pi/agent/extensions/nvim-bridge
+ln -s "$(pwd)/neon-psql" ~/.pi/agent/extensions/neon-psql
+ln -s "$(pwd)/browser-playwright" ~/.pi/agent/extensions/browser-playwright
 ```
 
-The maintainer must already be logged in with `npm login` as a `pinet` org
-owner/admin. This repo does not add token automation. Immediately after any
-successful bootstrap, configure Trusted Publishing for every `@pinet/*` package
-and use the GitHub Actions workflow for normal future publishes.
+## Philosophy
 
-The publish and bootstrap scripts still refuse placeholder `0.0.0` versions and
-versions that already exist on npm.
+### Built by the system it enables
 
-Normal tag-release procedure:
+Pinet was built by agents coordinating through Slack and GitHub. During development, the mesh merged over 50 pull requests in a single day with minimal human intervention.
 
-1. Bump all five `@pinet/*` package versions to the same version, update
-   `pnpm-lock.yaml`, and add a maintainer-approved `CHANGELOG.md` entry.
-2. Open and merge that version-bump PR to `main` after dry-run/readiness is
-   green.
-3. Create and push a `vX.Y.Z` tag on the current `main` tip after the merge. The
-   tag-triggered workflow validates the tag commit equals the current
-   `origin/main` tip and every publishable package version equals `X.Y.Z` before
-   any dry-run/publish step, dry-runs the full set, then waits for `npm-publish`
-   environment approval before publishing.
+The broker coordinates but does not write code. Workers ship end to end. They write code, add tests, run checks, push branches, and open pull requests. Agents review other agents' work. The mesh self-repairs when things break.
 
-Do not publish, tag, or bump package versions as part of readiness-only changes;
-record release notes in `CHANGELOG.md` only when a maintainer approves a real
-versioned release.
+### Human leverage
 
-## Git workflow
+Humans set priorities, approve merges, and provide API tokens. The system handles coordination and execution. The goal is to move humans up a level — from doing every step to steering a system that coordinates itself.
 
-1. Branch from `main` — use `feat/`, `fix/`, `chore/` prefixes
-2. Write tests for any new logic
-3. Run `pnpm lint && pnpm typecheck && pnpm test`
-4. Create a PR — merge to `main`
+## Configuration reference
 
-## Contributors
+See [full configuration options](slack-bridge/README.md#configure-pinet) for all settings.
 
-This repo is built by a mesh of human and AI agents coordinating via
-[Pinet](slack-bridge/README.md). Names are procedural and can rotate across
-sessions, so this section is a snapshot of the agents visible in today's work.
-Entries are sourced from the relevant PR, Pinet, and PiComms trail rather than
-`git shortlog` alone.
+Key settings:
 
-### Today's agents (2026-04-08)
+- `botToken` and `appToken`: required Slack tokens
+- `allowedUsers`: limit access to specific Slack users
+- `defaultChannel`: where Pinet posts updates
+- `ralphLoopIntervalMs`: how often RALPH checks for stalls (default 5 minutes)
+- `meshSecret` or `meshSecretPath`: optional shared-secret authentication
 
-| Agent                       | Contribution                                                                                                                                                                                                                                                                                                                                                                                                              |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🦔 **Ember Ivory Hedgehog** | Coordinated the read-only post-merge sweep, opened [#296](https://github.com/gugu91/extensions/issues/296), and turned the browser/Pinet docs drift into a focused README refresh lane.                                                                                                                                                                                                                                   |
-| 🦥 **Stellar Ebony Sloth**  | Traced the canonical contributor/acknowledgement locations, confirmed the root README drift after [#282](https://github.com/gugu91/extensions/pull/282), [#289](https://github.com/gugu91/extensions/pull/289), [#292](https://github.com/gugu91/extensions/pull/292), and [#294](https://github.com/gugu91/extensions/pull/294), then refreshed the snapshot in [#296](https://github.com/gugu91/extensions/issues/296). |
-| 🐧 **Patch Puffin**         | Approved the Pinet v0.1.1 release-prep metadata and publish-surface review in [PR #288](https://github.com/gugu91/extensions/pull/288).                                                                                                                                                                                                                                                                                   |
+## Troubleshooting
 
-### Today's agents (2026-04-03)
+### Pinet does not appear in Slack
 
-| Agent                          | Contribution                                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------------------------ |
-| 🐢 **Thunder Emerald Turtle**  | Merge queue operator (11 PRs rebased & merged), phantom subagent pollution fix (#237 / PR #244). |
-| 🦙 **Cobalt Slate Llama**      | RALPH "maintain momentum" message tweak (#246), RALPH broker self-nudge fix (#241 / PR #242).    |
-| 🐘 **Jade Rust Elephant**      | Auto-reload on reconnect (#238 / PR #243).                                                       |
-| 🦝 **Silver Coral Raccoon**    | npm publish preflight for all 4 packages.                                                        |
-| 🐢 **Orbit Lime Turtle 2**     | PR #242 code review.                                                                             |
-| 🐘 **Scarlet Bronze Elephant** | PR #244 code review.                                                                             |
-| 🫎 **Slate Emerald Moose**     | PR #243 code review.                                                                             |
+Check that:
 
-### Today's agents (2026-04-02)
+- both tokens are in your settings.json
+- the Slack app is installed to your workspace
+- pi is running
 
-| Agent                     | Contribution                                                                                                                                                                                        |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🐇 **Ultra Rabbit**       | Built file uploads, scheduled messages, pinning, thread export, the activity log, and the philosophy docs.                                                                                          |
-| 🦩 **Cosmic Crane**       | Shipped Slack canvases, broker-specific naming, Block Kit support, the remaining RALPH timestamp work, neon-psql execution-path tests, the broker control-plane canvas, and the thread-routing fix. |
-| 🐊 **Silent Crocodile**   | Shipped the deploy command, agent personalities, reaction triggers, user presence checks, the dedup fix, and Slack modals.                                                                          |
-| 🐬 **Rocket Dolphin**     | Handled video research, Slack CLI research, the `slack-api` package, npm-readiness work, worktree cleanup, and the idle/free signal.                                                                |
-| 🐻 **Crystal Blush Bear** | Fixed the phone input bug in `ai-recruiter`.                                                                                                                                                        |
+### Commands do not work
 
-### Maintainers
+Check that:
 
-- **Will** — coordinates the agent mesh, reviews the flood of PRs, and keeps the
-  whole worktree-first workflow pointed in roughly the right direction.
+- you are in the allowed users list (or `allowAllWorkspaceUsers` is true)
+- the bot has the required scopes (see manifest.yaml)
+- Socket Mode is enabled in your Slack app
 
-## License
+### Agents get stuck
 
-MIT. See [`LICENSE`](LICENSE).
+RALPH checks for stalls every 5 minutes by default. You can:
+
+- reduce `ralphLoopIntervalMs` for faster recovery
+- run `/pinet status` inside pi to check Pinet state
+- use `/pinet logs` inside pi or check your configured log channel for errors
+
+## Next steps
+
+- Read the [Slack bridge documentation](slack-bridge/) for detailed configuration
+- See [architecture plans](plans/) for design decisions
+- Join the discussion in your Slack workspace
+
+## Repository information
+
+- GitHub: [github.com/gugu91/extensions](https://github.com/gugu91/extensions)
+- License: MIT
+- Package manager: pnpm with workspaces
+- Build tool: Turborepo with local caching
+- Node version: 22 or later

--- a/pinet-core/README.md
+++ b/pinet-core/README.md
@@ -1,20 +1,26 @@
 # @pinet/pinet-core
 
-Runtime-core helpers for Pinet that are independent of any Slack adapter.
+Runtime helpers for Pinet that work independently of Slack.
 
-Current seam:
+## What it does
 
-- Pinet output option normalization (`cli` default, explicit `json`/`full` opt-ins)
-- durable Pinet read result text/detail formatting
-- scheduled wake-up time parsing and thread ID helpers
+This package provides:
 
-`@pinet/slack-bridge` still composes the extension and preserves compatibility wrappers, but these helpers now live behind package exports so future extraction can move one boundary at a time.
+- output option normalisation (defaults to `cli`, accepts `json` or `full`)
+- durable read result formatting
+- scheduled wake-up time parsing
+- thread ID helpers
 
-Design proposal: `plans/slack-split-proposal.md`
+## How it works
+
+The package exports helpers that `@pinet/slack-bridge` uses internally. These functions handle Pinet operations without depending on Slack adapters.
+
+The helpers live behind package exports. Future changes can move functionality one boundary at a time.
+
+See the design proposal in `plans/slack-split-proposal.md`.
 
 ## Publishing
 
-This package is included in the full npm publish set tracked in
-[`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
-workflow's default dry-run/readiness path for validation; do not publish, tag, or
-bump versions without explicit maintainer release approval.
+This package is part of the npm publish set in [`../plans/npm-publish.md`](../plans/npm-publish.md).
+
+Do not publish, tag, or bump versions without maintainer approval. Use the GitHub Actions workflow for validation.

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -1,157 +1,185 @@
 # slack-bridge (Pinet)
 
-Slack assistant integration for [pi](https://github.com/badlogic/pi-mono) — multi-agent broker, thread routing, and inbox tools powered by Socket Mode.
+Connect pi coding agents to Slack. Pinet provides multi-agent coordination, thread routing, and inbox tools through Socket Mode.
 
-## Install
+## Install Pinet
 
-Install the latest Pinet Slack bridge pi package:
+Install the latest version:
 
 ```bash
 pi install npm:@pinet/slack-bridge
 ```
 
-Or pin an exact published version for reproducible installs:
+Pin a specific version:
 
 ```bash
-pi install npm:@pinet/slack-bridge@0.1.0
+pi install npm:@pinet/slack-bridge@0.2.2
 ```
 
-For package managers or local inspection, the npm package is also installable directly:
+For direct npm installation:
 
 ```bash
 npm install @pinet/slack-bridge
 ```
 
-## Package metadata and publishing
+## What you need
 
-This package declares pi package/gallery metadata in [`package.json`](./package.json):
+- a Slack workspace where you can install apps
+- Node.js 22 or later
+- pi installed on your system
 
-- `keywords` includes `pi-package` for gallery discovery.
-- `pi.extensions` points at the built extension entrypoint, `./dist/index.js`.
-- `pi.skills` points at the bundled skill directory, `./skills`.
-- No `pi.image` or `pi.video` preview is declared yet because this package does
-  not currently include a reviewed gallery image/video asset.
+## Set up your Slack app
 
-The published tarball is expected to include the package metadata, README,
-Slack app manifest, built `dist/` files, bundled `skills/`, and LICENSE. Verify
-that locally with:
+### Create the app
 
-```bash
-cd slack-bridge
-npm pack --dry-run
-```
+1. Go to [api.slack.com/apps](https://api.slack.com/apps)
+2. Select 'Create New App'
+3. Choose 'From a manifest'
+4. Select your workspace
+5. Paste the contents of [`manifest.yaml`](./manifest.yaml)
+6. If you want a different Slack command, change `features.slash_commands[0].command` before creating and set `slackCommandName` or `slackCommandNames` in `settings.json`
+7. Select 'Create'
 
-This package is included in the full npm publish set tracked in
-[`../plans/npm-publish.md`](../plans/npm-publish.md). Use the GitHub Actions
-workflow's default dry-run/readiness path for validation; do not publish, tag, or
-bump versions without explicit maintainer release approval.
+The manifest configures Socket Mode, the assistant view, bot scopes, event subscriptions, and slash commands automatically.
 
-## Prerequisites
+### Get your tokens
 
-- A Slack workspace where you have permission to install apps
-- Node.js 22+ (uses native `fetch` and `WebSocket`)
-- [pi](https://github.com/badlogic/pi-mono) installed
+Generate two tokens:
 
-## Slack App Setup
+| Token           | Where to find it                                                                | Format       |
+| --------------- | ------------------------------------------------------------------------------- | ------------ |
+| App-Level Token | Basic Information → App-Level Tokens → Generate (add `connections:write` scope) | `xapp-1-...` |
+| Bot Token       | OAuth & Permissions → Install to Workspace → Bot User OAuth Token               | `xoxb-...`   |
 
-### 1. Create the app
+### Required bot scopes
 
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App**
-2. Choose **From a manifest**
-3. Select your workspace
-4. Paste the contents of [`manifest.yaml`](./manifest.yaml) from this directory
-5. If the Slack app is not named Pinet, change `features.slash_commands[0].command` before creating the app (for example, Oathgate uses `/oathgate` instead of the packaged `/pinet` default)
-6. Click **Create**
-
-The manifest configures Socket Mode, the assistant view, all required bot scopes, event subscriptions, and the packaged Pinet slash-command default automatically.
-
-### 2. Generate tokens
-
-You need two tokens:
-
-| Token               | Where to find it                                                                 | Looks like   |
-| ------------------- | -------------------------------------------------------------------------------- | ------------ |
-| **App-Level Token** | Basic Information → App-Level Tokens → Generate (with `connections:write` scope) | `xapp-1-...` |
-| **Bot Token**       | OAuth & Permissions → Install to Workspace → Bot User OAuth Token                | `xoxb-...`   |
-
-### 3. Required bot scopes
-
-These are included in the manifest, but for reference:
+The manifest includes these scopes:
 
 ```
 app_mentions:read    assistant:write      bookmarks:read
 bookmarks:write      canvases:read        canvases:write
 channels:history     channels:read        chat:write
-commands             files:read           files:write          groups:history
-groups:read          im:history           im:read
-im:write             pins:read            pins:write
-reactions:read       reactions:write      users:read
+commands             files:read           files:write
+groups:history       groups:read          im:history
+im:read              im:write             pins:read
+pins:write           reactions:read       reactions:write
+users:read
 ```
 
-`commands` is required for the Slack slash-command surface (`/<app> agents list [all]`). `files:read` is required because Slack exposes canvas comment pagination through `files.info`, even when the target is first validated via canvas-specific APIs.
+The `commands` scope enables slash commands. The `files:read` scope is needed because Slack uses `files.info` for canvas comment pagination.
 
-Slack thread shimmer/status updates use `assistant.threads.setStatus`; Slack's 2026 scope update allows this method with the existing `chat:write` bot scope, so no new `assistant:write` scope is needed for status-only support.
+## Configure Pinet
 
-## Configuration
-
-Add your tokens to `~/.pi/agent/settings.json`:
+Add tokens, runtime mode, and access rules to `~/.pi/agent/settings.json`:
 
 ```json
 {
   "slack-bridge": {
     "botToken": "xoxb-your-bot-token",
-    "appToken": "xapp-your-app-token"
+    "appToken": "xapp-your-app-token",
+    "runtimeMode": "single",
+    "allowedUsers": ["U_YOUR_USER_ID"]
   }
 }
 ```
 
-That's it for a minimal setup. Start pi and Pinet appears in Slack's sidebar.
+Pinet stays off unless you set `runtimeMode`, `autoConnect`, or `autoFollow`. Start pi after you configure access.
 
-### Environment variables (alternative)
+### Use environment variables instead
 
 ```bash
 export SLACK_BOT_TOKEN="xoxb-..."
 export SLACK_APP_TOKEN="xapp-..."
 ```
 
-Settings in `settings.json` take priority over env vars.
+Settings in `settings.json` override environment variables.
 
-### Optional Pinet mesh auth
+## Control who can use Pinet
 
-Shared-secret mesh auth is **optional**. You can configure it with either settings keys or environment variables:
+Slack access is default-deny. Configure one of these:
 
-```json
-{
-  "slack-bridge": {
-    "meshSecret": "shared-secret"
-  }
-}
-```
+- `allowedUsers`: list specific Slack user IDs
+- `allowAllWorkspaceUsers: true`: allow everyone in the workspace
+
+Example with specific users:
 
 ```json
 {
   "slack-bridge": {
-    "meshSecretPath": "/Users/alice/.config/pi/pinet.secret"
+    "botToken": "xoxb-...",
+    "appToken": "xapp-...",
+    "allowedUsers": ["U_USER_ID_1", "U_USER_ID_2"]
   }
 }
 ```
+
+Find user IDs by selecting a user's profile in Slack and choosing 'Copy member ID'.
+
+## Optional settings
+
+### Mesh authentication
+
+Shared-secret authentication is optional. Configure it with settings or environment variables:
+
+Settings:
+
+```json
+{
+  "slack-bridge": {
+    "meshSecret": "your-shared-secret"
+  }
+}
+```
+
+Or use a file:
+
+```json
+{
+  "slack-bridge": {
+    "meshSecretPath": "/path/to/secret.txt"
+  }
+}
+```
+
+Environment variables:
 
 ```bash
-export PINET_MESH_SECRET="shared-secret"
+export PINET_MESH_SECRET="your-shared-secret"
 # or
-export PINET_MESH_SECRET_PATH="$HOME/.config/pi/pinet.secret"
+export PINET_MESH_SECRET_PATH="/path/to/secret.txt"
 ```
 
-Behavior and precedence:
+How it works:
 
-- `slack-bridge.meshSecret` and `slack-bridge.meshSecretPath` override the environment fallbacks.
-- Inline secrets win over secret paths. If `meshSecret` or `PINET_MESH_SECRET` is set, the corresponding `*Path` value is ignored.
-- If all four values are unset, broker/follower mesh auth is disabled.
-- A broker started with `meshSecretPath` creates the secret file if it does not exist yet.
-- A follower started with `meshSecretPath` does **not** create the file. If the configured file is missing, follow fails with a clear error telling you to point at an existing file, provide `meshSecret` directly, or leave both unset to disable shared-secret auth.
-- A follower configured for mesh auth will fail closed against an older/no-auth broker with a clear compatibility error. It will **not** silently retry as an unauthenticated follower.
+- settings override environment variables
+- inline secrets override file paths
+- if nothing is set, mesh auth is disabled
+- brokers create the secret file if it does not exist
+- followers need an existing file or will show an error
 
-### Full settings reference
+### Require mentions in channels
+
+Make Pinet respond only when mentioned in specific channels:
+
+```json
+{
+  "slack-bridge": {
+    "ingressGuard": {
+      "requireMention": {
+        "channels": ["C_CHANNEL_ID"],
+        "mixedParticipantThreads": {
+          "enabled": true,
+          "trustedUsers": ["U_TRUSTED_USER"]
+        }
+      }
+    }
+  }
+}
+```
+
+This is separate from `allowedUsers`. Authorization decides who can use Pinet. The guard decides when a mention is needed.
+
+### All configuration options
 
 ```json
 {
@@ -159,25 +187,32 @@ Behavior and precedence:
     "botToken": "xoxb-...",
     "appToken": "xapp-...",
     "runtimeMode": "single",
-    "allowedUsers": ["U_EXAMPLE_MEMBER_ID"],
+    "allowedUsers": ["U_USER_ID"],
+    "allowAllWorkspaceUsers": false,
     "ingressGuard": {
       "requireMention": {
-        "channels": ["C_EXTERNAL_CHANNEL_ID"],
+        "channels": ["C_CHANNEL_ID"],
         "mixedParticipantThreads": {
           "enabled": true,
-          "trustedUsers": ["U_EXAMPLE_MEMBER_ID"]
+          "trustedUsers": ["U_USER_ID"]
         }
       }
     },
-    "defaultChannel": "C_EXAMPLE_CHANNEL_ID",
+    "defaultChannel": "C_CHANNEL_ID",
     "logChannel": "#pinet-logs",
     "logLevel": "actions",
-    "autoFollow": true,
+    "autoConnect": false,
+    "autoFollow": false,
     "ralphLoopIntervalMs": 300000,
     "ralphSnoozeAfterEmptyCycles": 0,
     "ralphSnoozeDurationMs": 1800000,
-    "meshSecretPath": "/Users/alice/.config/pi/pinet.secret",
-    "suggestedPrompts": [{ "title": "Status", "message": "What are you working on?" }],
+    "meshSecretPath": "/path/to/secret",
+    "suggestedPrompts": [
+      {
+        "title": "Status",
+        "message": "What are you working on?"
+      }
+    ],
     "security": {
       "readOnly": false,
       "requireConfirmation": ["slack:create_channel"],
@@ -187,450 +222,255 @@ Behavior and precedence:
 }
 ```
 
-Slack access is now **default-deny** unless you configure one of these explicitly:
+| Setting                  | Description                                            | Default              |
+| ------------------------ | ------------------------------------------------------ | -------------------- |
+| `botToken`               | Bot User OAuth Token (required)                        | none                 |
+| `appToken`               | App-Level Token for Socket Mode (required)             | none                 |
+| `runtimeMode`            | How Pinet runs (`off`, `single`, `broker`, `follower`) | `off`                |
+| `allowedUsers`           | Slack user IDs who can use Pinet                       | none                 |
+| `allowAllWorkspaceUsers` | Allow all workspace members                            | `false`              |
+| `defaultChannel`         | Where to post updates                                  | none                 |
+| `logChannel`             | Where to post logs                                     | none                 |
+| `logLevel`               | What to log (`errors`, `actions`, `verbose`)           | `actions`            |
+| `autoConnect`            | Start as a single instance when `runtimeMode` is unset | `false`              |
+| `autoFollow`             | Start as follower if broker exists                     | `false`              |
+| `ralphLoopIntervalMs`    | How often to check for stalls (milliseconds)           | `300000` (5 minutes) |
+| `meshSecret`             | Shared secret for mesh auth                            | none                 |
+| `meshSecretPath`         | File containing shared secret                          | none                 |
 
-- `allowedUsers` / `SLACK_ALLOWED_USERS` — allow only specific Slack user IDs
-- `allowAllWorkspaceUsers: true` / `SLACK_ALLOW_ALL_WORKSPACE_USERS=true` — explicit workspace-wide opt-in
+## Using Pinet
 
-Optional explicit invocation guard: `ingressGuard.requireMention` is off by default. Set `channels` to Slack channel IDs where otherwise-actionable messages must mention the bot (`@pinet` / `<@bot>`), and set `mixedParticipantThreads.enabled: true` with `trustedUsers` to require a mention in Pinet-owned Slack threads once anyone outside `trustedUsers` plus the bot has participated. This guard is orthogonal to `allowedUsers`: sender authorization still decides who may invoke Pinet; the guard only decides when an explicit mention is required.
+### In Slack
 
-| Key                            | Required | Description                                                                                                            |
-| ------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `botToken`                     | **yes**  | Bot User OAuth Token (`xoxb-...`)                                                                                      |
-| `appToken`                     | **yes**  | App-Level Token for Socket Mode (`xapp-...`)                                                                           |
-| `allowedUsers`                 | no       | Slack user IDs that can interact; when unset, access is denied unless `allowAllWorkspaceUsers` is true                 |
-| `allowAllWorkspaceUsers`       | no       | Explicit opt-in for workspace-wide Slack access when you do not want a user allowlist                                  |
-| `ingressGuard.requireMention`  | no       | Optional Slack ingress guard requiring `@pinet` in configured channel IDs and/or mixed-participant Pinet-owned threads |
-| `defaultChannel`               | no       | Default channel for the `slack` dispatcher `post_channel` action                                                       |
-| `logChannel`                   | no       | Channel for broker activity logs                                                                                       |
-| `logLevel`                     | no       | `"errors"`, `"actions"` (default), or `"verbose"`                                                                      |
-| `runtimeMode`                  | no       | Explicit startup mode: `"off"`, `"single"`, `"broker"`, or `"follower"`                                                |
-| `autoConnect`                  | no       | Legacy compatibility alias for `runtimeMode: "single"`                                                                 |
-| `autoFollow`                   | no       | Legacy compatibility alias for follower startup when a broker socket exists                                            |
-| `ralphLoopIntervalMs`          | no       | Broker RALPH maintenance cadence in milliseconds; defaults to `300000` (5 minutes), valid range `1000`-`2147483647`    |
-| `ralphSnoozeAfterEmptyCycles`  | no       | Broker RALPH auto-snooze trigger after N empty cycles; defaults to `0` (disabled), valid range `0`-`100`               |
-| `ralphSnoozeDurationMs`        | no       | Broker RALPH auto-snooze duration in milliseconds; defaults to `1800000` (30 minutes), valid range `60000`-`86400000`  |
-| `skinTheme`                    | no       | Pinet presentation skin selected at broker startup/reload (`default`, `foundation`, `cosmere`, or free-form)           |
-| `slackCommandName`             | no       | Slack web app slash command name for `agents list`; defaults to `/pinet`, or `/oathgate` for Oathgate/Cosmere skins    |
-| `slackCommandNames`            | no       | Optional list of accepted/deployed Slack slash command aliases when one app needs multiple command names               |
-| `meshSecret`                   | no       | Optional inline Pinet shared secret; overrides `meshSecretPath` and env fallbacks                                      |
-| `meshSecretPath`               | no       | Optional path to a shared-secret file; broker creates it if missing, followers require an existing file                |
-| `suggestedPrompts`             | no       | Prompts shown when a user opens a new conversation                                                                     |
-| `security.readOnly`            | no       | Runtime-block write-capable tools for Slack-triggered turns, including core tools like `bash`, `edit`, and `write`     |
-| `security.requireConfirmation` | no       | Runtime-require Slack approval before matching tools execute; core tools need a specific Slack thread context          |
-| `security.blockedTools`        | no       | Runtime-block matching tools for Slack-triggered turns, including core tools                                           |
+Talk to Pinet:
 
-## Scope carrier model (compatibility-first)
+- Direct message: open a DM with Pinet
+- In channels: mention `@pinet` (or your app name)
+- Slack slash command: type `/pinet agents list` or `/pinet agents list all`
 
-Slack/Pinet now threads a first-class runtime `scope` carrier through shared message contracts and runtime metadata.
+### Pi commands
 
-For this first slice:
+Run these inside pi.
 
-- **workspace/install scope** is carried as compatibility-first metadata for Slack
-- **instance scope** is also carried as a first-class compatibility carrier
-- today’s single-workspace deployments use one default compatibility scope
-- a missing or empty Slack `teamId` stays **unknown** — the bridge does not invent a fake workspace ID
-- these carriers are metadata only in this slice; enforcement and multi-install behavior land later in `#547` / `#550`
+Main commands:
 
-## Usage
+- `/pinet` - show available commands
+- `/pinet status` - show current Pinet status
+- `/pinet logs` - show recent broker activity logs
+- `/pinet rename [name]` - rename this agent
+- `/pinet free` - mark this agent idle
 
-Once configured, Pinet appears in Slack's sidebar. Users open it, type a message, and the pi agent responds.
+Coordinator commands:
 
-```
-User opens Pinet in Slack sidebar
-  └─► types a message
-        └─► 👀 reaction appears (thinking)
-              └─► message queued for pi agent
-                    └─► agent responds via slack_send
-                          └─► 👀 removed, reply appears in thread
-```
+- `/pinet start` or `/pinet broker` - become the broker
+- `/pinet follow` - become a follower
+- `/pinet unfollow` - disconnect from broker
+- `/pinet reload <agent>` - ask another agent to reload
+- `/pinet exit <agent>` - ask another agent to exit
+- `/pinet snooze [duration|off|status]` - quiet empty RALPH cycles
+- `/pinet subtree [start|status|spawn|stop]` - manage subtree broker mode
 
-Messages queue while the agent is busy. When the agent finishes, it automatically drains the inbox and responds.
+### From pi
 
-### Reaction triggers
-
-Slack emoji reactions are ignored by default: they do not enqueue Pinet work, trigger reviews, steer agents, interrupt owners, or cause broker/worker replies. To opt in deliberately, configure `reactionCommands` for the exact emoji aliases that should become structured Pinet requests from the reacted-to Slack message. Even configured reactions are accepted only inside an already authorized Pinet thread (for example a thread with a current Pinet owner, or persisted Slack assistant-thread context). Reaction authorization is deny-by-default: it requires an explicit broker-backed authorization gate, and a thread the adapter has merely seen or cached never qualifies on its own. Reactions in ordinary, uninvoked Slack channel threads remain no-op — even from authorized users — and they do not enqueue work, persist thread state, claim ownership, or receive a Slack ACK. Messages and interactive events from users outside the allowlist also never mint known-thread state that could later admit reactions or replies. Pinet adds ✅ only when it accepts an opt-in reaction-triggered request. If it cannot process an accepted opted-in reaction, it adds ❌; check broker logs for the underlying Slack/API error. When Slack cannot return the reacted message text, Pinet can still route configured reactions when the message timestamp itself identifies an already authorized thread; otherwise it ignores the reaction safely.
-
-### Available tools
-
-Slack-bridge uses progressive disclosure to keep the per-turn tool surface
-small:
-
-| Tool          | Description                                                                 |
-| ------------- | --------------------------------------------------------------------------- |
-| `slack_inbox` | Hot-path inbox drain for pending incoming Slack messages                    |
-| `slack_send`  | Hot-path reply tool for Slack assistant threads                             |
-| `slack`       | Dispatcher for all non-hot Slack actions; call `action: "help"` for schemas |
-
-Cold Slack actions live behind the `slack` dispatcher:
-
-| Dispatcher action      | Description                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------- |
-| `react`                | Add an emoji reaction to a message                                                |
-| `read`                 | Read messages from a thread                                                       |
-| `upload`               | Upload files, snippets, or diffs into Slack                                       |
-| `file`                 | Download Slack-hosted files to a controlled local temp cache by file ID           |
-| `schedule`             | Schedule a message for later delivery                                             |
-| `post_channel`         | Post to a channel (by name or ID)                                                 |
-| `delete`               | Delete a bot-posted message or an entire thread                                   |
-| `read_channel`         | Read channel history or a thread in a channel                                     |
-| `create_channel`       | Create a new Slack channel                                                        |
-| `project_create`       | Create a project channel + RFC canvas + bot invite in one call                    |
-| `pin`                  | Pin or unpin a message                                                            |
-| `bookmark`             | Add, list, or remove channel bookmarks                                            |
-| `export`               | Export a thread as markdown, plain text, or JSON                                  |
-| `presence`             | Check if users are active, away, or in DND                                        |
-| `canvas_comments_read` | Read comments attached to a verified canvas by canvas ID or channel canvas lookup |
-| `canvas_create`        | Create a standalone or channel canvas                                             |
-| `canvas_update`        | Append, prepend, or replace canvas content                                        |
-| `modal_open`           | Open a modal from a trigger interaction                                           |
-| `modal_push`           | Push a new step onto a modal stack                                                |
-| `modal_update`         | Update an existing open modal                                                     |
-| `confirm_action`       | Request user confirmation before a dangerous action                               |
-
-Use `slack` with `action: "help"` for the action catalogue, or
-`action: "help", args: { "topic": "canvas_update" }` for a specific JSON
-schema and example invocations. Dispatcher responses use a consistent
-`{ "status", "data", "errors", "warnings" }` envelope. Guardrails match
-cold Slack actions as `slack:<action>` (for example `slack:upload` or
-`slack:canvas_update`); legacy `slack_<action>` patterns are accepted during
-migration.
-
-#### Tool and workflow usage notes
-
-- **Reply where the work arrived.** Use `slack_send` for assistant-thread
-  replies. If a task was delivered in a Slack thread, acknowledge briefly,
-  do the work, report blockers immediately, and finish with the outcome. If
-  you know only a channel/thread pair, use dispatcher action `post_channel`
-  with `channel` and optional `thread_ts` instead.
-- **Channel posting is explicit.** `post_channel` posts to a named channel or
-  channel ID. When `channel` is omitted, it first resolves a provided
-  `thread_ts` to a tracked thread channel, then falls back to `defaultChannel`
-  from settings. `slack_send` is intentionally narrower and resolves the
-  current tracked assistant thread/DM context.
-- **Rich messages use Block Kit JSON.** Pass `blocks` directly to
-  `slack_send` or `post_channel`; keep `text` as the notification/fallback.
-  Block Kit builder tools are not registered by this package. Load the bundled
-  `slack-bridge` skill for copyable status-report, button, code, and diff
-  templates. The package also bundles `pinet-skin-creator` for safely drafting
-  or reviewing curated Pinet skin descriptors and character/status-vocabulary
-  pools before changing runtime skin wiring.
-- **Modal helpers are patterns, not hot tools.** Use dispatcher actions
-  `modal_open`, `modal_push`, and `modal_update` with Slack view JSON. Open or
-  push immediately after receiving a fresh `trigger_id`; Slack trigger IDs
-  expire quickly. Include `thread_ts` when submissions should route back to an
-  original assistant thread.
-- **Uploads are for bulky artifacts.** Use `upload` for logs, screenshots,
-  long diffs, and generated files instead of large inline messages. Inline
-  uploads require `filename`; path uploads are guarded and must stay within the
-  current working directory or system temp directory. `slack_send` also accepts
-  `files: [{ path, filename?, title?, filetype? }]` so one assistant-thread
-  reply can contain both text and local binary attachments in the same Slack
-  file upload message. Slack external file uploads cannot include Block Kit in
-  that same message, so omit `blocks` when sending files or send a separate
-  block-only reply.
-- **Inbound Slack files are fetched explicitly.** Incoming file-share messages
-  preserve safe `slackFiles` metadata such as file ID, name, type, size, and
-  permalink, but private Slack download URLs are not exposed in normal tool
-  output. To inspect raw content, call dispatcher action `file` with
-  `op: "download"`, `file_id`, and optionally `thread_ts`, `message_ts`, and
-  `channel`. The bot fetches the file with Slack bot auth, stores it under the
-  system temp `pi-slack-files` cache with best-effort TTL cleanup, and returns a
-  descriptor containing the local path, filename, type, size, SHA-256, expiry,
-  and residual privacy risks.
-- **Upload host egress note.** The second upload leg goes to Slack file upload
-  hosts (`files.slack.com`/`uploads.slack.com`) for the raw payload. In
-  environments with restricted egress this can fail with `403` (proxy
-  allowlist) or DNS errors after `files.getUploadURLExternal`; verify the proxy
-  allowlist first, or route through an environment that can reach those hosts.
-- **Upload metadata note.** Slack snippet uploads attempt to use inferred
-  `snippet_type` values for inline content and retry with plain upload metadata
-  when Slack returns `invalid_arguments`, preserving syntax highlighting for
-  supported types while avoiding hard failures on unsupported snippet types.
-- **Canvases are long-lived docs.** `canvas_create` creates standalone or
-  channel canvases. If Slack rejects channel tab creation with
-  `canvas_tab_creation_failed`, it falls back to a standalone canvas attached to
-  the channel, attempts to bookmark the canvas URL, and returns the fallback
-  `canvas_id` for future `canvas_update` calls. `canvas_update` can append,
-  prepend, replace the whole canvas, or replace a matched section;
-  `canvas_comments_read` is read-only and limited to verified canvas targets.
-- **Scheduling, pins, and bookmarks are durable affordances.** Use `schedule`
-  for delayed reminders instead of waiting; use `pin` for important thread
-  messages; use `bookmark` for persistent channel-header links to repos,
-  dashboards, docs, or runbooks.
-- **Presence helps choose timing.** Use `presence` before pinging humans when
-  active/away/DND status affects routing or whether to schedule a follow-up.
-- **Destructive actions stay constrained.** `delete` can remove only messages
-  posted by the current bot and every delete call requires `confirm: true`.
-  Whole-thread deletion additionally requires `thread: true` and succeeds only
-  when every message in the target thread belongs to the current bot. Prefer
-  asking for explicit approval before destructive cleanup.
-- **Confirm guarded actions in the same thread.** If guardrails require
-  confirmation, call `confirm_action` with the target `thread_ts`, exact tool
-  name, and the exact action string required by the guarded tool. The safest
-  flow is: attempt the guarded call, copy the `requires confirmation for action
-...` string from the error, request confirmation, wait for the user's approval
-  via `slack_inbox`, then retry the guarded call unchanged. Batched
-  multi-thread Slack turns cannot satisfy a single-thread confirmation.
-- **Plain emoji reactions are not tasks.** Slack emoji reactions are ignored
-  unless `reactionCommands` explicitly opts that emoji into structured
-  reaction-trigger handling and the reacted message belongs to an already
-  authorized Pinet thread. If an opt-in reaction-triggered request or a Block
-  Kit/modal interaction payload arrives through `slack_inbox` with metadata,
-  treat it as a user instruction tied to the referenced Slack thread or
-  message.
-
-#### Common dispatcher examples
-
-Reply in the current Slack assistant thread with Block Kit:
+Use the Pinet dispatcher for agent coordination:
 
 ```json
 {
-  "text": "Deploy complete — branch main, checks passed.",
-  "blocks": [
-    {
-      "type": "section",
-      "fields": [
-        { "type": "mrkdwn", "text": "*Branch*\n`main`" },
-        { "type": "mrkdwn", "text": "*Checks*\n✅ lint/typecheck/test" }
-      ]
-    }
-  ]
-}
-```
-
-Post a channel/thread update through the dispatcher:
-
-```json
-{
-  "action": "post_channel",
+  "action": "send",
   "args": {
-    "channel": "#pinet-logs",
-    "thread_ts": "1712345678.000100",
-    "text": "PR #123 is ready for review."
+    "to": "@worker",
+    "message": "Please review PR #123"
   }
 }
 ```
 
-Upload a generated diff snippet:
+Common actions:
+
+- `send` - send a message to an agent or broker-only channel
+- `read` - read this agent's inbox
+- `schedule` - schedule a future wake-up
+- `free` - mark this agent idle
+- `help` - discover actions and schemas
+
+Use `slack_send` for hot-path Slack replies. Use the `slack` dispatcher for uploads, canvases, pins, bookmarks, and other Slack actions.
+
+## Architecture
+
+### Broker and followers
+
+Pinet can run as:
+
+- single - one instance handles everything
+- broker - coordinates and routes messages
+- follower - receives work from the broker
+
+The broker:
+
+- watches Slack for messages
+- assigns work to agents
+- tracks who owns what
+- syncs state across followers
+
+Followers:
+
+- connect to the broker
+- receive assigned work
+- stay in sync automatically
+
+### RALPH maintenance loop
+
+RALPH keeps broker state healthy. It:
+
+- runs every 5 minutes by default
+- checks worker presence
+- releases stale claims held by unavailable workers
+- observes pending backlog while broker maintenance handles assignment
+- triggers wake-ups
+
+Configure RALPH:
 
 ```json
 {
-  "action": "upload",
-  "args": {
-    "content": "diff --git a/README.md b/README.md\n...",
-    "filename": "docs.diff",
-    "filetype": "diff",
-    "title": "Docs changes",
-    "thread_ts": "1712345678.000100"
+  "slack-bridge": {
+    "ralphLoopIntervalMs": 120000,
+    "ralphSnoozeAfterEmptyCycles": 3,
+    "ralphSnoozeDurationMs": 1800000
   }
 }
 ```
 
-Request confirmation before a guarded destructive action after copying the
-exact action string from the guardrail error:
+### Inbox and threading
 
-```json
-{
-  "action": "confirm_action",
-  "args": {
-    "thread_ts": "1712345678.000100",
-    "tool": "slack:delete",
-    "action": "channel=#pinet-logs | thread_ts=1712345678.000100 | ts=1712345678.000200 | thread=false"
-  }
-}
-```
+Pinet maintains an inbox for each agent. Messages are:
 
-#### Canvas comment inspection
+- routed based on thread ownership
+- queued when agents are busy
+- marked read when processed
+- preserved across restarts
 
-The `canvas_comments_read` dispatcher action is intentionally narrow:
+Thread ownership ensures continuity. Once an agent owns a thread, it keeps receiving those messages.
 
-- it validates the target with `canvases.sections.lookup` before reading comment pages via `files.info`
-- it needs `files:read` because Slack exposes canvas comments through the file API surface
-- it will **not** inspect generic Slack files, non-canvas file comments, or full canvas body/history
+## Troubleshooting
 
-### Slash commands
+### Socket Mode connection issues
 
-| Command                    | Description                                                |
-| -------------------------- | ---------------------------------------------------------- |
-| `/pinet <action>`          | Unified Pinet command surface; run `/pinet help` for usage |
-| `/pinet status`            | Show connection status, threads, and agent identity        |
-| `/pinet rename`            | Change the agent's display name                            |
-| `/pinet logs`              | Show recent broker activity log entries                    |
-| `/<app> agents list [all]` | Slack-native broker roster, workload, task, and lane view  |
+If you see 'WebSocket error' or connection failures:
 
-## Runtime modes
+1. Check your app token is valid
+2. Verify Socket Mode is enabled in your Slack app
+3. Check network connectivity
+4. Look for rate limiting (Slack allows 10 connections per app)
 
-`slack-bridge` now treats runtime mode as an explicit concept:
+### Permission errors
 
-| Mode       | Meaning                                                                                                                                                                  |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `off`      | Slack bridge is loaded, but **no Slack Socket Mode ingress** and no coordination runtime are started.                                                                    |
-| `single`   | One local Pi session owns Slack ingress and local thread/inbox ownership only. No broker DB/socket/client, no RALPH/control plane, no mesh auth, no multi-agent surface. |
-| `broker`   | The session runs the broker coordination runtime.                                                                                                                        |
-| `follower` | The session connects to an existing broker as a worker runtime.                                                                                                          |
+If Pinet cannot perform actions:
 
-Startup selection:
+1. Check the bot is in the channel (invite with `/invite @pinet`)
+2. Verify bot scopes match the manifest
+3. Reinstall the app to update permissions
+4. Check `allowedUsers` includes the right user IDs
 
-- `runtimeMode` is the explicit startup selector.
-- `autoConnect` is a legacy compatibility alias for `runtimeMode: "single"`.
-- `autoFollow` is a legacy compatibility alias for `runtimeMode: "follower"` when a broker socket is available.
-- explicit `runtimeMode` wins over the legacy flags.
-- `/pinet start` and `/pinet follow` still switch the live session into broker/follower runtimes explicitly.
+### Messages not received
 
-## Scope carriers (compatibility-first)
+If Pinet does not respond:
 
-`slack-bridge` now emits first-class runtime scope carriers in shared transport contracts and agent runtime metadata.
+1. Check Socket Mode shows 'Connected' in Slack app settings
+2. Verify event subscriptions are enabled
+3. Check `allowedUsers` or `allowAllWorkspaceUsers`
+4. Look in the log channel for errors
+5. Try `/pinet status` to check if Pinet is running
 
-- `scope.workspace` models the current Slack install/workspace scope.
-- `scope.instance` models the current broker/runtime instance scope.
-- in the first slice, both stay **compatibility-first**: today’s singleton runtime gets one default compatibility scope
-- if Slack omits `team_id`, the carrier keeps the workspace id **unknown** instead of inventing a fake one
-- this slice is metadata/plumbing only: it does **not** change routing, enforcement, or multi-install orchestration yet
+### Stalled agents
 
-## Pinet (Multi-Agent Mode)
+If work gets stuck:
 
-Pinet supports a broker/follower architecture for coordinating multiple pi agents over Slack.
+1. Check `/pinet status` for current state.
+2. Check `/pinet logs` for repeated failures.
+3. Wait for RALPH to run automatically.
+4. Reduce `ralphLoopIntervalMs` for faster recovery if needed.
 
-### Runtime composition boundary
+## Package information
 
-Broker startup is composed as Pinet core plus injected transport adapter factories. `broker-runtime.ts` starts the broker DB/socket/router and skin/agent state, then calls `createAdapterBindings` to attach transports. The packaged Slack bridge passes `createSlackPinetRuntimeAdapterFactory(...)`, while tests use an in-memory non-Slack adapter to demonstrate the same boundary without Slack tokens or Slack-specific metadata. Adapter factories return `MessageAdapter` bindings; the core wires inbound delivery, registers adapters on the broker, and connects them.
+### Publishing metadata
 
-### Quick start
+The package declares pi metadata in [`package.json`](./package.json):
 
-**Broker** (one per mesh — coordinates routing and health):
+- `keywords` includes `pi-package` for gallery discovery
+- `pi.extensions` points to `./dist/index.js`
+- `pi.skills` points to bundled skills
+- No preview assets yet
 
-```
-/pinet start
-```
-
-**Follower** (workers that connect to the broker):
-
-```
-/pinet follow
-```
-
-Or set `"runtimeMode": "follower"` in settings (or the legacy `"autoFollow": true`) to auto-connect when a broker is running.
-
-### Broker prompt MD
-
-Broker coordination policy is loaded from Markdown. Configure `slack-bridge.brokerPrompt` to choose a packaged prompt preset such as `tmux` or to point at a custom Markdown file path. Relative paths resolve under the current repo/worktree root; `~/...` paths resolve under the user home directory. When no setting is present, the broker scans for the first valid prompt in this order:
-
-1. workspace override: `.pi/slack-bridge/tmux.md` under the current repo/worktree root
-2. user-local override: `~/.pi/agent/slack-bridge/tmux.md`
-3. packaged default: `dist/prompts/broker/tmux.md`
-
-Invalid higher-priority files (unsafe symlink/path escape, unreadable file, oversized content, invalid UTF-8/binary-looking content, or empty file) emit a concise warning and fall through to lower-priority candidates. Warnings identify only the candidate kind and reason; prompt bodies and private paths are not echoed.
-
-The packaged `tmux.md` captures the default fully autonomous / unchained broker operating policy: the broker coordinates and never implements, delegates to repo-scoped workers, starts fresh tmux-backed workers on the Mac mini for new repo-scoped tasks/lanes unless a maintainer explicitly asks for reuse, marks broker-launched followers with `PINET_BROKER_MANAGED=1 PINET_BROKER_AGENT_ID=<current-broker-agent-id> PINET_LAUNCH_SOURCE=broker-tmux PINET_TMUX_SESSION=<session>` so PID ownership is inspectable, records tmux session/socket and repo/worktree metadata in durable lane state, keeps completed workers available for a one-hour follow-up grace period, routes follow-up back to the same Pi instance when possible, asks grace-expired healthy idle broker-managed workers to exit only when inspectable Pinet signals or the worker confirm they are free, fails closed by reporting ambiguous cleanup candidates, prunes old broker-managed tmux capacity instead of recycling stale context into new lanes, observes RALPH loop maintenance expectations, handles Slack thread ownership/reporting caveats, and describes GitHub/secret handling without exposing secrets.
-
-Only broker prompt content is replaceable. Broker runtime/tool restrictions remain code-owned and are appended after the loaded MD prompt, including the forbidden local `Agent` path and broker `edit`/`write` blocking. Followers keep append-only worker guidance and do not load broker prompt MD. Prompt changes are picked up on `/pinet start` / runtime restart; this slice does not hot-reload per turn.
-
-### Multi-agent tools
-
-| Tool    | Description                                                                                                                                                                            |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pinet` | Pinet dispatcher with token-efficient `action`-based routing (`help`, `send`, `read`, `free`, `snooze`, `schedule`, `agents`, `sessions`, `lanes`, `ports`, `spawn`, `reload`, `exit`) |
-
-Use the dispatcher for Pinet tool actions: `pinet action=send`, `pinet action=read`, `pinet action=free`, `pinet action=snooze`, `pinet action=schedule`, `pinet action=agents`, `pinet action=sessions`, `pinet action=lanes`, `pinet action=ports`, `pinet action=spawn`, `pinet action=reload`, and `pinet action=exit`. Use slash commands for UI lifecycle transitions: `/pinet start`, `/pinet follow`, `/pinet unfollow`, and `/pinet subtree start`. Dedicated direct Pinet tools (`pinet_message`, `pinet_read`, `pinet_agents`, `pinet_free`, `pinet_schedule`) are no longer registered. Legacy `pinet_*` guardrail patterns still match dispatcher action names, and legacy send policies such as `pinet_send` or `pinet_message` also cover `pinet action=send`, so existing security configs fail closed during migration.
-
-Worker-owned subtree brokers let a follower worker supervise its own child mesh without registering those children in the central broker. Run `/pinet subtree start` (alias: `/pinet subbroker start`) from a follower worker. The worker remains connected to the central broker as a normal worker, and it also starts a separate broker socket/database under `~/.pi/pinet-subtrees/<worker>/`. Child workers launched by this worker receive `PINET_SOCKET_PATH`, `PINET_PARENT_AGENT_ID`, `PINET_ROOT_AGENT_ID`, `PINET_LAUNCH_ID`, `PINET_SUBTREE_ROLE`, and related metadata, so they follow the worker's subtree broker instead of the central Pinet broker.
-
-Use `pinet action=spawn args.repo=<repo> args.task=<task> [args.role=<role>] [args.lane_id=<lane>]` or `/pinet subtree spawn repo=<repo> [role=<role>] [lane=<lane>] <task>` to launch a tmux-backed child worker, wait for it to register in the subtree broker, and deliver the task over private Pinet A2A. Use `pinet action=agents args.scope=subtree args.full=true` from the supervising worker to list subtree children, `pinet action=send args.to=<child> args.message=<message>` to reply/control them, `pinet action=read` to read child reports, and `pinet action=exit args.target=<child>` or `/pinet subtree stop` to clean them up. The central broker sees only the supervising worker; the subtree DB contains the child roster and messages.
-
-Dispatcher content defaults to terse CLI-style confirmations/summaries for noisy reads, sends, agent lists, and session lookups. Bulky read/agent/session payloads are compacted in `data.details` by default, including when `args.format="json"` (or `args.f` / `args["-f"]`) renders the dispatcher envelope in content. Use `args.full=true` / `args["--full"]=true` only when you need verbose text and full structured debug details such as exact message bodies, agent metadata, stable session IDs, or local session JSONL paths.
-
-`pinet action=agents` shows a broker-safe session reference (`session:<digest>`) alongside pid in verbose roster output without exposing raw local paths by default. Use `pinet action=sessions args.agent_name="Frozen Hazel Whale"` to search live and historical worker sessions by display name; the search also accepts `agent_id`, `thread_id`, `repo`, `worktree_path`, `tmux_session`, `since`, `until`, and `limit`. Default output redacts path-bearing stable IDs; add `args.full=true` (or JSON plus `full`) only in local/debug contexts when the broker needs the exact stable ID or Pi session JSONL path for inspection/resume.
-
-Durable Pinet inbox notifications are classified as `steering`, `fwup`, or `maintenance/context` from explicit metadata or message cues. Follower prompts receive compact pointers such as `pinet action=read args.thread_id=...` instead of the full durable message body; agents use `pinet action=read` to retrieve the actual context. Delivery, read/ack state, and mail classification remain separate.
-
-Scheduled Pinet wake-ups use the same durable read surface: due wake-ups are persisted/stamped as Pinet follow-up mail and surfaced through compact `pinet action=read` pointers rather than direct reminder-body prompts. Wake-up bodies and metadata are treated as mail content only; they do not trigger Pinet remote-control commands such as `/exit`, `/reload`, or structured `pinet:control` JSON.
-
-Durable lane metadata is stored in SQLite and can be inspected/updated with `pinet action=lanes`. PM-mode lanes can record the accountable follower/PM, implementation lead, participant roles (`pm`, `lead`, `implementer`, `reviewer`, `second_pass_reviewer`, etc.), linked issue/PR, state, and summary. The `detached` lane state means a lane is manually supervised by a human; broker/RALPH/status surfaces keep it visible but should not treat it as normal auto-reassignment work without explicit human/broker action.
-
-Durable local port leases are stored in SQLite and can be managed with `pinet action=ports`. Use `op=acquire` with `purpose` and `ttl_ms` to reserve either a requested `port` (for example `3000`) or the first free port in `min_port..max_port` (default `49152..65535`, host default `127.0.0.1`). Use `op=renew` with `lease_id` and `ttl_ms`, `op=release`, `op=status`, `op=list`, or `op=expire`. Follower RPC access is scoped to the caller-owned leases; broker-local maintenance can still expire all stale leases. Active leases are unique by `(host, port)`; broker maintenance expires stale leases conservatively, and process-kill behavior should be layered on explicit cleanup hooks rather than hidden in lease acquisition.
-
-Broker-mode ghost cleanup is deliberately conservative. The broker stores follower PIDs in the agent registry, but it only sends real process signals for ghosts that registered with broker-managed launch metadata (`PINET_BROKER_MANAGED=1`) and still verify as Pi follower processes. Reaping sends `SIGTERM` first and schedules a bounded `SIGKILL` only if the same verified broker-managed process remains; unmarked or mismatched PIDs are never killed.
-
-RALPH snooze quiets non-urgent empty maintenance cycles without disabling human-triggered routing. Use `/pinet snooze 30m no work available` or `pinet action=snooze args.op=set args.duration=30m` to quiet the broker manually, `/pinet snooze off` or `op=clear` to wake it, and `/pinet status` / Home tab to inspect snooze state. An empty cycle means no active live workers, no active tracked assignments, no visible RALPH anomalies, no pending backlog, no assigned backlog from broker maintenance, no maintenance anomalies, no pending task-assignment report, and no tracked task progress change. If active work, anomalies, or task progress appears during snooze, RALPH wakes and reports normally. Auto-snooze is opt-in via `ralphSnoozeAfterEmptyCycles`; the default is disabled.
-
-### Pinet command surface
-
-Use `/pinet <action> [args]` for mesh lifecycle and broker operations. In the Slack web app, use `/<app> agents list [all]` for the Slack-native broker roster/current-work view: `/pinet agents list` for the Pinet app, or `/oathgate agents list` for an Oathgate-named app. Set `slackCommandName` (or `slackCommandNames`) in `slack-bridge` settings before deploying the manifest when the Slack command should match a non-default app name.
-
-| Command                                    | Description                                                                   |
-| ------------------------------------------ | ----------------------------------------------------------------------------- |
-| `/pinet start`                             | Start as the mesh broker                                                      |
-| `/pinet follow`                            | Connect as a follower worker                                                  |
-| `/pinet unfollow`                          | Disconnect from the broker                                                    |
-| `/pinet reload <agent>`                    | Ask another agent to reload                                                   |
-| `/pinet exit <agent>`                      | Ask another agent to exit                                                     |
-| `/pinet free`                              | Mark this agent as idle                                                       |
-| `/pinet snooze [duration/off/status]`      | Quiet empty RALPH cycles while preserving human-triggered wake/route behavior |
-| `/pinet subtree [start/status/spawn/stop]` | Run this worker as a local subtree broker for child followers                 |
-
-### Pinet skins
-
-Pinet skin selection is configuration-driven. Set `skinTheme` under the `slack-bridge` settings object (for example, `"skinTheme": "foundation"`) and restart/reload the broker; broker startup applies the configured presentation to broker and follower registrations. Skin selection updates mesh presentation only: names, emoji palette, persona/tone guidance, and optional display vocabulary for statuses. Core roles and states stay skin-neutral (`broker`, `worker`, `idle`, `working`, routing, repo, and guardrails are not redefined by skins).
-
-Built-in skins:
-
-- `default` / `classic` — preserves the current whimsical animal names, animal emoji palette, and playful-but-focused persona.
-- `foundation` / `foundation/space` / `space` — JSON descriptor with curated institutional sci-fi characters, full-name aliases, and archive, relay, frontier, and crisis-room flavor.
-- `cosmere` / `cosmere-inspired` / `oathgate` — JSON descriptor with curated/prebaked 1–3 word identities, static emoji, and whimsical Mistborn/Stormlight/Emberdark-inspired agents, spren, artifacts, places, and jokes while avoiding exact third-party character names.
-
-Free-form themes are still accepted as deterministic legacy/custom presentation themes. Shipped non-default skins live in `skins/*.json`; use the bundled `pinet-skin-creator` skill to author and review curated character/name/persona/status-vocabulary pools before adding runtime descriptors.
-
-### How it works
-
-- The **broker** runs Slack Socket Mode, routes messages to agents, and monitors health via the RALPH loop. The loop defaults to every 5 minutes and can be configured with `ralphLoopIntervalMs` under `slack-bridge` settings.
-- **Followers** connect to the broker over a local Unix socket, poll for work, and report results
-- Agents can optionally authenticate using a shared local secret (`meshSecret` or `meshSecretPath`); when both are unset, mesh auth is disabled
-- Thread ownership is first-responder-wins — the first agent to reply claims the thread
-
-## Security
-
-- **User access**: Slack access is default-deny. Set `allowedUsers` for a narrow allowlist, or `allowAllWorkspaceUsers: true` only if you explicitly want workspace-wide access
-- **Tool guardrails**: `security.readOnly`, `security.requireConfirmation`, and `security.blockedTools` are runtime-enforced for Slack-triggered turns, including core tools such as `bash`, `edit`, and `write`
-- **Guardrail posture**: If Slack/Pinet access is enabled for admitted users and `security.readOnly`, `security.blockedTools`, and `security.requireConfirmation` are all effectively empty (`readOnly !== true` and both arrays are absent or empty), the bridge emits a startup/runtime warning and `/pinet status` shows `Guardrails: empty (warn-first posture; behavior unchanged)`. This is visibility-only: it does **not** auto-enable `readOnly`, block startup, or require an acknowledgement flow.
-- **Mesh authentication**: Optional. Configure `meshSecret` or `meshSecretPath` (or `PINET_MESH_SECRET` / `PINET_MESH_SECRET_PATH`) to require a shared secret; leave them unset to disable shared-secret auth. Configured followers fail closed on missing secret files or older/no-auth brokers rather than silently downgrading.
-
-Find Slack user IDs: click a user's profile → **More** → **Copy member ID**.
-
----
-
-## Development
-
-### Build
+Check the package contents:
 
 ```bash
-pnpm run build
+cd slack-bridge
+npm pack --dry-run
 ```
 
-### Lint / Typecheck / Test
+### Development
+
+Build the package:
 
 ```bash
-pnpm lint
-pnpm typecheck
+cd slack-bridge
+pnpm build
+```
+
+Run tests:
+
+```bash
 pnpm test
 ```
 
-### Deploy manifest to Slack
+Deploy the Slack manifest:
 
 ```bash
 pnpm deploy:slack
 ```
 
-Requires `appId` and `appConfigToken` in settings (or `SLACK_APP_ID` / `SLACK_APP_CONFIG_TOKEN` env vars). The deploy path rewrites `features.slash_commands` from `slackCommandName` / `slackCommandNames` (or the configured `skinTheme`) before validating and uploading, so set `slackCommandName: "/oathgate"` for an Oathgate app and leave it unset for the packaged Pinet `/pinet` default.
+## Security
 
-### Architecture
+### Default-deny access
 
-- **Socket Mode** — outbound WebSocket, no public URL needed
-- **Zero runtime npm deps** — native `fetch`, `WebSocket`, `node:sqlite` (Node 22+)
-- **Hybrid inbox** — queue when busy, auto-drain when idle
-- **Reactions** — 👀 as a lightweight "thinking" indicator
-- **Thread persistence** — thread state survives `/reload`
+Pinet requires explicit configuration to allow users. Without `allowedUsers` or `allowAllWorkspaceUsers`, nobody can use it.
 
-## License
+### Token safety
 
-MIT. See [`LICENSE`](./LICENSE).
+- Never commit tokens to git
+- Use environment variables in production
+- Rotate tokens regularly
+- Use separate apps for development and production
+
+### Confirmation for dangerous actions
+
+Configure confirmation for sensitive operations:
+
+```json
+{
+  "slack-bridge": {
+    "security": {
+      "requireConfirmation": ["slack:create_channel", "slack:upload", "slack:delete"]
+    }
+  }
+}
+```
+
+### Read-only mode
+
+Prevent all modifications:
+
+```json
+{
+  "slack-bridge": {
+    "security": {
+      "readOnly": true
+    }
+  }
+}
+```
+
+## Support
+
+- [GitHub repository](https://github.com/gugu91/extensions)
+- [Architecture documentation](../plans/)
+- Check the log channel in Slack for runtime issues


### PR DESCRIPTION
## Summary
- Rewrite the root README, `slack-bridge/README.md`, and `pinet-core/README.md` in clearer GOV.UK style.
- Keep this PR focused on README text only so it is easy to review.
- Leave the richer HTML documentation site to a separate PR.

Part of #852.

## Testing
- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- push pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`
