### PR TITLE
Add Pinet HTML documentation site

### DIFF
--- a/.github/workflows/deploy-docs.yml.disabled
+++ b/.github/workflows/deploy-docs.yml.disabled
@@ -1,0 +1,81 @@
+# GitHub Pages deployment workflow
+#
+# IMPORTANT: This workflow is disabled by default.
+# To enable GitHub Pages deployment:
+#
+# 1. Rename this file from deploy-docs.yml.disabled to deploy-docs.yml
+# 2. Go to Settings > Pages in your repository
+# 3. Set Source to 'GitHub Actions'
+# 4. Commit and push the renamed file
+#
+# The workflow will then deploy on pushes to main.
+# For manual control, use the workflow_dispatch trigger.
+
+name: Deploy documentation to GitHub Pages
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+
+  # Automatic deployment on main (when enabled)
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '**.md'
+
+# Sets permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set up Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build static documentation site
+        run: pnpm docs:build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,41 @@
+name: Check documentation
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "**.md"
+      - "scripts/build-docs-site.mjs"
+      - "scripts/build-docs-site.test.mjs"
+      - ".github/workflows/docs-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "**.md"
+      - "scripts/build-docs-site.mjs"
+      - "scripts/build-docs-site.test.mjs"
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check documentation site
+        run: pnpm docs:check

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+docs/_site/
 .pnpm-store/
 # Turbo cache artifacts
 .turbo/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,62 @@
+# Pinet documentation site
+
+This directory contains the source for the Pinet documentation site.
+
+The site uses Markdown source files and a small Node.js build script. It does not need Ruby, Jekyll, or extra npm packages.
+
+## Structure
+
+- `index.md` - start page
+- `setup.md` - installation and setup guide
+- `configuration.md` - configuration options
+- `usage.md` - how to use Pinet
+- `architecture.md` - system design and internals
+- `troubleshooting.md` - common problems and fixes
+- `reference.md` - tool and action reference
+- `_site/` - generated HTML output, not committed
+
+## Preview locally
+
+Build and serve the site:
+
+```bash
+pnpm docs:serve
+```
+
+Open http://localhost:4000.
+
+## Check the site
+
+Run:
+
+```bash
+pnpm docs:check
+```
+
+This checks that required pages exist, internal links resolve, and the static site can be generated.
+
+## Deploy to GitHub Pages
+
+The site is ready for GitHub Pages, but deployment is disabled until a maintainer approves it.
+
+To enable deployment:
+
+1. Rename `.github/workflows/deploy-docs.yml.disabled` to `.github/workflows/deploy-docs.yml`.
+2. Go to Settings → Pages in the GitHub repository.
+3. Set Source to 'GitHub Actions'.
+4. Commit and push the workflow change.
+
+The workflow will deploy `docs/_site` to GitHub Pages.
+
+## Documentation style
+
+Follow GOV.UK style:
+
+- use plain English
+- write in the active voice
+- keep sentences short
+- use sentence case for headings
+- avoid unnecessary jargon
+- do not use bold or italics for emphasis
+
+See `.pi/skills/govuk-style/` for the full style guide used for this rewrite.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,364 @@
+---
+layout: default
+title: Architecture
+---
+
+# Architecture
+
+How Pinet coordinates multiple agents through Slack.
+
+## System design
+
+### Core components
+
+Pinet has three main parts:
+
+1. Socket Mode connection - real-time link to Slack
+2. Message router - sends work to the right agent
+3. State manager - tracks threads, ownership, and inbox
+
+### Runtime modes
+
+Pinet runs in three modes:
+
+- single - one instance does everything
+- broker - coordinates and routes messages
+- follower - receives work from broker
+
+Most users need only single mode. Large deployments use broker and followers.
+
+## Broker architecture
+
+### What the broker does
+
+The broker is the coordinator. It:
+
+- maintains the Socket Mode connection
+- receives all Slack events
+- assigns work to agents
+- tracks thread ownership
+- syncs state to followers
+- runs the RALPH maintenance loop
+
+### Broker state
+
+The broker keeps track of:
+
+- active agents and their status
+- thread ownership mapping
+- inbox messages per agent
+- lane assignments
+- scheduled wake-ups
+
+### State persistence
+
+State is stored in:
+
+- SQLite for inbox and threads
+- memory for active connections
+- Slack for thread history
+
+State survives broker restarts but not follower restarts.
+
+## Follower architecture
+
+### What followers do
+
+Followers are workers. They:
+
+- connect to the broker through the configured broker transport
+- receive assigned messages
+- process their inbox
+- report status back
+- stay in sync automatically
+
+### Follower connection
+
+By default, broker and follower communication uses the local Pinet socket at `~/.pi/pinet.sock`. A broker can also use an explicit TCP listener when you configure one.
+
+The connection uses:
+
+- JSON message framing
+- optional shared-secret auth
+- automatic reconnection
+- heartbeat keep-alive
+
+### Message flow
+
+1. Slack sends event to broker
+2. Broker checks thread ownership
+3. Broker routes to correct agent
+4. Agent processes message
+5. Agent sends response through broker
+6. Broker sends to Slack
+
+## RALPH maintenance loop
+
+### Purpose
+
+RALPH (Routing, Assignment, Lifecycle, Presence, Health) keeps the system healthy.
+
+### What RALPH does
+
+Every 5 minutes, RALPH:
+
+1. Checks worker presence
+2. Expires stale broker state
+3. Clears orphaned thread claims
+4. Observes pending backlog while broker maintenance handles assignment
+5. Triggers scheduled wake-ups
+6. Compacts the inbox
+
+### Stall detection
+
+Work may need attention when:
+
+- a worker has disappeared
+- a thread owner is no longer available
+- pending backlog is not draining
+- a scheduled wake-up is due
+
+### Recovery actions
+
+RALPH recovers by:
+
+- releasing claims held by unavailable workers
+- reporting pending backlog so broker maintenance can assign it
+- nudging work that needs attention
+- alerting through the configured status path
+
+## Thread ownership
+
+### How ownership works
+
+When an agent first responds in a thread, it owns that thread. All future messages in the thread go to that agent.
+
+### Ownership transfer
+
+Ownership changes when:
+
+- a thread is explicitly claimed by another worker
+- the current owner becomes unavailable and the broker clears the stale claim
+- the thread claim expires according to broker state rules
+
+### Thread lifecycle
+
+1. User starts a thread
+2. Broker checks allowlists and thread control rules
+3. Broker routes to an existing owner, an explicit hint, a channel assignment, or an agent mention
+4. Worker responds and may claim the thread
+5. Thread claim is kept until it is released, replaced, or expires
+
+## Message routing
+
+### Routing rules
+
+Messages are routed by:
+
+1. Access allowlist and explicit thread controls
+2. Existing thread owner, when that worker is available
+3. Explicit worker hint
+4. Channel assignment
+5. Agent mention
+6. `unrouted`, when no route applies
+
+### New work
+
+New work is not automatically load-balanced. Configure channel assignments, mention a worker, or use broker controls to route work deliberately.
+
+### Priority messages
+
+High priority messages:
+
+- direct mentions
+- slash commands
+- error recovery
+- scheduled wake-ups
+
+These jump the queue in the inbox.
+
+## Inbox system
+
+### What the inbox stores
+
+Each agent has an inbox containing:
+
+- unread messages
+- thread context
+- scheduled tasks
+- deferred work
+
+### Inbox processing
+
+Agents process their inbox:
+
+1. Read oldest unread message
+2. Load thread context
+3. Generate response
+4. Mark as read
+5. Repeat
+
+### Inbox limits
+
+Default limits:
+
+- 1000 messages per agent
+- 30 days retention
+- 10MB per message
+- compact when 80% full
+
+## State synchronisation
+
+### Broker to follower sync
+
+The broker sends:
+
+- inbox updates
+- ownership changes
+- configuration updates
+- presence broadcasts
+
+### Follower to broker sync
+
+Followers send:
+
+- status updates
+- read receipts
+- error reports
+- heartbeats
+
+### Conflict resolution
+
+When conflicts occur:
+
+- broker state wins
+- timestamps break ties
+- RALPH fixes inconsistencies
+
+## Security architecture
+
+### Authentication
+
+Three levels:
+
+1. Slack tokens - app and bot tokens
+2. User allowlist - who can use Pinet
+3. Mesh secret - broker-follower auth
+
+### Authorisation
+
+Checks happen at:
+
+- Slack event receipt
+- command execution
+- tool invocation
+- state modification
+
+### Isolation
+
+Agents are isolated by:
+
+- separate inboxes
+- thread ownership
+- lane assignment
+- permission scopes
+
+## Performance characteristics
+
+### Throughput
+
+Typical limits:
+
+- 1 message/second per channel
+- 20 messages/minute workspace
+- 100 concurrent threads
+- 10 followers per broker
+
+### Latency
+
+Expected times:
+
+- Slack to broker: 50-200ms
+- broker routing: 10-50ms
+- follower sync: 100-500ms
+- full round trip: 200-1000ms
+
+### Scalability
+
+Scales by:
+
+- adding followers (horizontal)
+- increasing RALPH frequency
+- adjusting inbox limits
+- routing configuration
+
+## Failure modes
+
+### Broker failure
+
+When the broker fails:
+
+- followers continue current work
+- new messages queue in Slack
+- RALPH stops running
+- state stops syncing
+
+Recovery: restart broker or promote follower.
+
+### Follower failure
+
+When a follower fails:
+
+- its active claims can become stale
+- RALPH can release stale claims after health checks
+- other followers continue their current work
+- new messages route only when a valid owner, hint, assignment, or mention applies
+
+Recovery: restart the follower, clear stale claims, or route the work to another available worker.
+
+### Network partition
+
+If network splits:
+
+- followers reconnect automatically
+- messages queue until reconnection
+- state resyncs on reconnect
+- duplicates are prevented
+
+### Slack outage
+
+During Slack outage:
+
+- Socket Mode reconnects automatically
+- messages queue locally
+- sent when connection returns
+- no message loss
+
+## Extension points
+
+### Adding tools
+
+New tools register with:
+
+```javascript
+pi.registerTool("tool_name", {
+  // tool configuration
+});
+```
+
+### Custom routing
+
+Adapt routing with current broker controls:
+
+- explicit thread control
+- channel assignments
+- worker hints
+- agent mentions
+
+### State backends
+
+Pluggable storage for:
+
+- inbox (default: SQLite)
+- ownership (default: memory)
+- configuration (default: file)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,417 @@
+---
+layout: default
+title: Configuration
+---
+
+# Configuration
+
+Configure Pinet to work how you need it.
+
+## Configuration file
+
+Settings go in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-...",
+    "appToken": "xapp-..."
+  }
+}
+```
+
+## Required settings
+
+### Tokens
+
+You must provide both tokens:
+
+| Setting    | Description                     | Format     |
+| ---------- | ------------------------------- | ---------- |
+| `botToken` | Bot User OAuth Token            | `xoxb-...` |
+| `appToken` | App-Level Token for Socket Mode | `xapp-...` |
+
+Get these from your Slack app settings. See the [setup guide](setup.md).
+
+## Control access
+
+### Default behaviour
+
+Pinet uses default-deny. Nobody can use it until you configure access.
+
+### Allow specific users
+
+List Slack user IDs:
+
+```json
+{
+  "slack-bridge": {
+    "allowedUsers": ["U_USER_1", "U_USER_2"]
+  }
+}
+```
+
+### Allow all workspace members
+
+Enable workspace-wide access:
+
+```json
+{
+  "slack-bridge": {
+    "allowAllWorkspaceUsers": true
+  }
+}
+```
+
+### Require mentions in channels
+
+Make Pinet respond only when mentioned:
+
+```json
+{
+  "slack-bridge": {
+    "ingressGuard": {
+      "requireMention": {
+        "channels": ["C_CHANNEL_1", "C_CHANNEL_2"]
+      }
+    }
+  }
+}
+```
+
+In these channels, users must mention Pinet (`@pinet`) to get a response.
+
+### Mixed participant threads
+
+Require mentions when non-trusted users join a thread:
+
+```json
+{
+  "slack-bridge": {
+    "ingressGuard": {
+      "requireMention": {
+        "mixedParticipantThreads": {
+          "enabled": true,
+          "trustedUsers": ["U_TRUSTED_1"]
+        }
+      }
+    }
+  }
+}
+```
+
+## Runtime modes
+
+Pinet is off until you set `runtimeMode`, `autoConnect`, or `autoFollow`.
+
+### Single mode
+
+One Pinet instance handles everything:
+
+```json
+{
+  "slack-bridge": {
+    "runtimeMode": "single"
+  }
+}
+```
+
+### Broker mode
+
+Act as the coordinator:
+
+```json
+{
+  "slack-bridge": {
+    "runtimeMode": "broker"
+  }
+}
+```
+
+The broker:
+
+- watches Slack
+- assigns work
+- syncs state
+
+### Follower mode
+
+Connect to a broker:
+
+```json
+{
+  "slack-bridge": {
+    "runtimeMode": "follower"
+  }
+}
+```
+
+Followers:
+
+- receive work from the broker
+- stay in sync automatically
+
+### Auto-connect
+
+Start as a single Pinet instance without setting `runtimeMode`:
+
+```json
+{
+  "slack-bridge": {
+    "autoConnect": true
+  }
+}
+```
+
+### Auto-follow
+
+Start as follower if a broker exists:
+
+```json
+{
+  "slack-bridge": {
+    "autoFollow": true
+  }
+}
+```
+
+## Mesh authentication
+
+### No authentication (default)
+
+If you do not set mesh credentials, authentication is disabled.
+
+### Shared secret
+
+Use a password:
+
+```json
+{
+  "slack-bridge": {
+    "meshSecret": "your-secret-here"
+  }
+}
+```
+
+### Secret file
+
+Store the secret in a file:
+
+```json
+{
+  "slack-bridge": {
+    "meshSecretPath": "/path/to/secret.txt"
+  }
+}
+```
+
+The broker creates the file if missing. Followers need an existing file.
+
+### Environment variables
+
+Use environment variables instead:
+
+```bash
+export PINET_MESH_SECRET="your-secret"
+# or
+export PINET_MESH_SECRET_PATH="/path/to/secret.txt"
+```
+
+## Channels and logging
+
+### Default channel
+
+Where Pinet posts general updates:
+
+```json
+{
+  "slack-bridge": {
+    "defaultChannel": "C_CHANNEL_ID"
+  }
+}
+```
+
+### Log channel
+
+Where Pinet posts logs:
+
+```json
+{
+  "slack-bridge": {
+    "logChannel": "#pinet-logs"
+  }
+}
+```
+
+Use a channel ID or name with `#`.
+
+### Log level
+
+Control what gets logged:
+
+```json
+{
+  "slack-bridge": {
+    "logLevel": "actions"
+  }
+}
+```
+
+Options:
+
+- `errors` - errors only
+- `actions` - errors and actions (default)
+- `verbose` - detailed activity logs
+
+## RALPH maintenance
+
+### Check interval
+
+How often RALPH checks for problems (milliseconds):
+
+```json
+{
+  "slack-bridge": {
+    "ralphLoopIntervalMs": 120000
+  }
+}
+```
+
+Default: 300000 (5 minutes)
+
+### Snooze after empty cycles
+
+Pause RALPH after finding nothing to fix:
+
+```json
+{
+  "slack-bridge": {
+    "ralphSnoozeAfterEmptyCycles": 3,
+    "ralphSnoozeDurationMs": 1800000
+  }
+}
+```
+
+After 3 empty cycles, RALPH sleeps for 30 minutes.
+
+## Security
+
+### Read-only mode
+
+Prevent all modifications:
+
+```json
+{
+  "slack-bridge": {
+    "security": {
+      "readOnly": true
+    }
+  }
+}
+```
+
+### Require confirmation
+
+Ask before dangerous actions:
+
+```json
+{
+  "slack-bridge": {
+    "security": {
+      "requireConfirmation": ["slack:create_channel", "slack:upload", "slack:delete"]
+    }
+  }
+}
+```
+
+### Block specific tools
+
+Disable tools completely:
+
+```json
+{
+  "slack-bridge": {
+    "security": {
+      "blockedTools": ["dangerous_tool"]
+    }
+  }
+}
+```
+
+## User interface
+
+### Suggested prompts
+
+Add quick-access prompts:
+
+```json
+{
+  "slack-bridge": {
+    "suggestedPrompts": [
+      {
+        "title": "Status",
+        "message": "What are you working on?"
+      },
+      {
+        "title": "Help",
+        "message": "Show me what you can do"
+      }
+    ]
+  }
+}
+```
+
+These appear in the Slack interface.
+
+## Complete example
+
+A production configuration:
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-workspace-bot-token",
+    "appToken": "xapp-socket-mode-token",
+    "runtimeMode": "single",
+    "allowedUsers": ["U_ADMIN_1", "U_ADMIN_2"],
+    "defaultChannel": "C_PINET_GENERAL",
+    "logChannel": "#pinet-logs",
+    "logLevel": "actions",
+    "ralphLoopIntervalMs": 120000,
+    "meshSecretPath": "/home/pi/.config/pinet/secret",
+    "ingressGuard": {
+      "requireMention": {
+        "channels": ["C_PUBLIC_CHANNEL"],
+        "mixedParticipantThreads": {
+          "enabled": true,
+          "trustedUsers": ["U_ADMIN_1"]
+        }
+      }
+    },
+    "security": {
+      "requireConfirmation": ["slack:create_channel"]
+    },
+    "suggestedPrompts": [
+      {
+        "title": "Daily status",
+        "message": "/pinet status"
+      }
+    ]
+  }
+}
+```
+
+## Environment variables
+
+These settings can use environment variables as fallback:
+
+| Setting                  | Environment variable                    |
+| ------------------------ | --------------------------------------- |
+| `botToken`               | `SLACK_BOT_TOKEN`                       |
+| `appToken`               | `SLACK_APP_TOKEN`                       |
+| `allowedUsers`           | `SLACK_ALLOWED_USERS` (comma-separated) |
+| `allowAllWorkspaceUsers` | `SLACK_ALLOW_ALL_WORKSPACE_USERS`       |
+| `meshSecret`             | `PINET_MESH_SECRET`                     |
+| `meshSecretPath`         | `PINET_MESH_SECRET_PATH`                |
+
+Settings in `settings.json` override environment variables. Other settings are read from `settings.json`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: Pinet documentation
+---
+
+# Pinet documentation
+
+Get Pinet working in your Slack workspace in 10 minutes.
+
+## Quick start
+
+1. [Install Pinet](setup.md) - set up the Slack app and configure tokens
+2. [Configure access](configuration.md#control-access) - decide who can use Pinet
+3. [Use Pinet](usage.md) - send messages and run commands
+
+## What Pinet is
+
+Pinet connects pi coding agents to Slack. It coordinates multiple agents, routes messages, and keeps track of work.
+
+The system can:
+
+- respond to Slack messages
+- coordinate agents working on different tasks
+- review pull requests automatically
+- recover from failures
+- keep you informed about progress
+
+## Core concepts
+
+### Broker and workers
+
+One agent acts as the broker. It watches Slack, routes messages, and keeps worker state in sync. Worker agents pick up tasks, write code, and open pull requests.
+
+### Self-repair
+
+The RALPH loop checks worker presence every 5 minutes. It releases stale claims, observes pending backlog, and triggers scheduled wake-ups. Broker maintenance handles backlog assignment.
+
+### Agent identity
+
+Named agents like 'Rocket Dolphin' make it easy to see who is doing what.
+
+## Documentation
+
+- [Setup guide](setup.md) - install and configure Pinet
+- [Configuration](configuration.md) - all settings explained
+- [Usage](usage.md) - how to use Pinet
+- [Architecture](architecture.md) - how Pinet works
+- [Troubleshooting](troubleshooting.md) - fix common problems
+- [API reference](reference.md) - tool and action documentation
+
+## Get help
+
+- Check the [troubleshooting guide](troubleshooting.md)
+- Use `/pinet logs` or check your configured Slack log channel
+- Visit the [GitHub repository](https://github.com/gugu91/extensions)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,381 @@
+---
+layout: default
+title: API reference
+---
+
+# API reference
+
+Complete reference for Pinet tools and actions.
+
+## Pinet dispatcher
+
+Use the Pinet dispatcher for agent coordination. Use Slack tools for Slack-specific messages, uploads, canvases, pins, and bookmarks.
+
+### Actions
+
+#### send
+
+Send a message to a connected Pinet agent or broker-only broadcast channel:
+
+```json
+{
+  "action": "send",
+  "args": {
+    "to": "@worker",
+    "message": "Please review PR #123"
+  }
+}
+```
+
+Parameters:
+
+- `to` - agent name, agent ID, or broker-only broadcast channel
+- `message` - message body
+- `transfer_thread_id` - Slack or Pinet thread to transfer to the recipient (optional)
+
+#### read
+
+Read this agent's durable inbox:
+
+```json
+{
+  "action": "read",
+  "args": {
+    "unread_only": true,
+    "limit": 20
+  }
+}
+```
+
+Parameters:
+
+- `thread_id` - filter to one thread (optional)
+- `limit` - maximum messages, default 20 and maximum 100
+- `unread_only` - only unread messages, default true
+- `mark_read` - mark returned unread messages as read, default true
+
+#### schedule
+
+Schedule a future wake-up for the current Pinet agent:
+
+```json
+{
+  "action": "schedule",
+  "args": {
+    "delay": "30m",
+    "message": "Check queue state"
+  }
+}
+```
+
+Parameters:
+
+- `delay` - relative delay such as `5m`, `30s`, `1h30m`, or `1d`
+- `at` - absolute ISO 8601 UTC time, such as `2026-04-02T14:30:00Z`
+- `message` - reminder or wake-up message
+
+#### free
+
+Mark the agent as idle and ready for more work:
+
+```json
+{
+  "action": "free",
+  "args": {}
+}
+```
+
+#### help
+
+Discover actions and per-action schemas:
+
+```json
+{
+  "action": "help",
+  "args": {
+    "topic": "send"
+  }
+}
+```
+
+## Slack tools
+
+Use `slack_send` for hot-path Slack replies in the current thread. Use the `slack` dispatcher for colder Slack actions.
+
+### upload
+
+Upload a file or snippet to Slack:
+
+```json
+{
+  "action": "upload",
+  "args": {
+    "channel": "#general",
+    "content": "file contents",
+    "filename": "data.txt",
+    "title": "Data export"
+  }
+}
+```
+
+### canvas_create
+
+Create a Slack canvas:
+
+```json
+{
+  "action": "canvas_create",
+  "args": {
+    "channel": "#project",
+    "title": "Project plan",
+    "markdown": "# Project\n\n- task 1\n- task 2"
+  }
+}
+```
+
+### help
+
+Discover Slack dispatcher actions and schemas:
+
+```json
+{
+  "action": "help",
+  "args": {
+    "topic": "upload"
+  }
+}
+```
+
+## Commands
+
+Pinet has a narrow Slack slash command and a broader pi command.
+
+### Slack slash command
+
+#### /pinet agents list [all]
+
+List known agents. Add `all` to include inactive agents.
+
+If you rename the Slack command in the manifest, set `slackCommandName` or `slackCommandNames` in `settings.json`.
+
+### Pi command
+
+Run these inside pi.
+
+#### /pinet
+
+Show available commands and usage.
+
+#### /pinet status
+
+Show current Pinet status.
+
+#### /pinet logs
+
+Show recent broker activity logs.
+
+#### /pinet rename [name]
+
+Rename this Pinet agent.
+
+#### /pinet free
+
+Mark this agent as idle.
+
+#### /pinet start
+
+Start this session as the broker. `/pinet broker` is an alias.
+
+#### /pinet follow
+
+Connect as a follower to the broker. `/pinet worker` is an alias.
+
+#### /pinet unfollow
+
+Disconnect from the broker.
+
+#### /pinet reload <agent>
+
+Ask another agent to reload configuration.
+
+#### /pinet exit <agent>
+
+Ask another agent to exit.
+
+#### /pinet snooze [duration|off|status]
+
+Quiet empty RALPH cycles.
+
+#### /pinet subtree [start|status|spawn|stop]
+
+Run this worker as a subtree broker for child followers.
+
+## Configuration API
+
+Settings that affect behavior.
+
+### Core settings
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-...",
+    "appToken": "xapp-...",
+    "runtimeMode": "single"
+  }
+}
+```
+
+Pinet stays off unless you set `runtimeMode`, `autoConnect`, or `autoFollow`.
+
+### Access control
+
+```json
+{
+  "slack-bridge": {
+    "allowedUsers": ["U_USER_ID"],
+    "allowAllWorkspaceUsers": false
+  }
+}
+```
+
+### Runtime mode
+
+```json
+{
+  "slack-bridge": {
+    "runtimeMode": "single",
+    "autoConnect": true,
+    "autoFollow": true
+  }
+}
+```
+
+Use one startup option at a time. Valid `runtimeMode` values are `off`, `single`, `broker`, and `follower`.
+
+### Mesh authentication
+
+```json
+{
+  "slack-bridge": {
+    "meshSecret": "secret",
+    "meshSecretPath": "/path/to/secret"
+  }
+}
+```
+
+### Channels
+
+```json
+{
+  "slack-bridge": {
+    "defaultChannel": "C_CHANNEL_ID",
+    "logChannel": "#pinet-logs",
+    "logLevel": "actions"
+  }
+}
+```
+
+### RALPH settings
+
+```json
+{
+  "slack-bridge": {
+    "ralphLoopIntervalMs": 300000,
+    "ralphSnoozeAfterEmptyCycles": 3,
+    "ralphSnoozeDurationMs": 1800000
+  }
+}
+```
+
+### Security
+
+```json
+{
+  "slack-bridge": {
+    "security": {
+      "readOnly": false,
+      "requireConfirmation": ["slack:create_channel"],
+      "blockedTools": []
+    }
+  }
+}
+```
+
+## Slack dispatcher actions
+
+Use the `slack` dispatcher to discover and run Slack actions. Start with `help`, then request the schema for a specific action.
+
+### Common action families
+
+- `read_channel` - read channel history
+- `post_channel` - post to a channel
+- `upload` - upload a file or snippet
+- `react` - add or remove reactions
+- `pin` - manage pins
+- `bookmark` - manage bookmarks
+- `canvas_create` and `canvas_update` - manage canvases
+- `schedule` - schedule Slack messages
+- `create_channel` - create channels
+- `file` - read file metadata
+- `delete` - delete a Slack message or supported object
+
+Ask the dispatcher for the current action list:
+
+```json
+{
+  "action": "help",
+  "args": {}
+}
+```
+
+## Event types
+
+Events Pinet handles.
+
+### Message events
+
+- `message` - new message in subscribed channels, private channels, and DMs
+
+### App events
+
+- `app_mention` - bot mentioned
+- `app_home_opened` - app home viewed
+- `assistant_thread_started` - Slack assistant thread started
+- `assistant_thread_context_changed` - assistant thread context changed
+
+### Member events
+
+- `member_joined_channel` - user joined
+
+### Reaction events
+
+- `reaction_added` - reaction added
+
+## Error codes
+
+Common error responses.
+
+### Authentication errors
+
+- `invalid_auth` - bad token
+- `not_authed` - missing token
+- `account_inactive` - deactivated bot
+
+### Permission errors
+
+- `missing_scope` - needs more permissions
+- `not_in_channel` - bot not in channel
+- `user_not_authorized` - user not allowed
+
+### Rate limiting
+
+- `rate_limited` - too many requests
+- `msg_too_long` - message over 40,000 chars
+- `too_many_attachments` - over 100 attachments
+
+### State errors
+
+- `already_exists` - duplicate resource
+- `not_found` - resource missing
+- `invalid_state` - bad state transition

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,179 @@
+---
+layout: default
+title: Setup guide
+---
+
+# Setup guide
+
+Get Pinet running in 10 minutes.
+
+## Before you start
+
+You need:
+
+- a Slack workspace where you can install apps
+- Node.js 22 or later
+- pi installed
+
+## Step 1: install the package
+
+Install from npm:
+
+```bash
+pi install npm:@pinet/slack-bridge
+```
+
+Or pin a version:
+
+```bash
+pi install npm:@pinet/slack-bridge@0.2.2
+```
+
+## Step 2: create your Slack app
+
+### Use the app manifest
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps)
+2. Select **Create New App**
+3. Choose **From a manifest**
+4. Select your workspace
+5. Copy the manifest from [`slack-bridge/manifest.yaml`](https://github.com/gugu91/extensions/blob/main/slack-bridge/manifest.yaml)
+6. Paste it into the text box
+7. Select **Next**
+8. Review the settings
+9. Select **Create**
+
+The manifest sets up:
+
+- Socket Mode for real-time connection
+- all required bot scopes
+- event subscriptions
+- slash commands
+
+### Change the app name (optional)
+
+Before creating the app, you can change:
+
+- the app name in `display_information.name`
+- the Slack slash command in `features.slash_commands[0].command`
+
+For example, change `/pinet` to `/mybot`. If you do this by editing the manifest manually, also set `slackCommandName` or `slackCommandNames` in `settings.json` so the runtime recognises the command.
+
+## Step 3: get your tokens
+
+You need two tokens.
+
+### App-level token
+
+1. Go to **Basic Information**
+2. Scroll to **App-Level Tokens**
+3. Select **Generate Token and Scopes**
+4. Name it (for example, 'Socket Mode')
+5. Add the `connections:write` scope
+6. Select **Generate**
+7. Copy the token (starts with `xapp-`)
+
+### Bot token
+
+1. Go to **OAuth & Permissions**
+2. Select **Install to Workspace**
+3. Authorise the app
+4. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+
+## Step 4: configure pi
+
+Add tokens and choose a runtime mode in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-your-bot-token",
+    "appToken": "xapp-your-app-token",
+    "runtimeMode": "single"
+  }
+}
+```
+
+Pinet stays off unless you set `runtimeMode`, `autoConnect`, or `autoFollow`.
+
+## Step 5: control access
+
+By default, nobody can use Pinet. Choose one option before you test Pinet:
+
+### Allow specific users
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-...",
+    "appToken": "xapp-...",
+    "runtimeMode": "single",
+    "allowedUsers": ["U_USER_ID_1", "U_USER_ID_2"]
+  }
+}
+```
+
+Find user IDs:
+
+1. Select a user's profile in Slack
+2. Choose the three dots menu
+3. Select **Copy member ID**
+
+### Allow everyone in the workspace
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-...",
+    "appToken": "xapp-...",
+    "runtimeMode": "single",
+    "allowAllWorkspaceUsers": true
+  }
+}
+```
+
+## Step 6: start Pinet
+
+Start pi. Pinet appears in your Slack sidebar.
+
+Test it:
+
+1. Open a DM with Pinet.
+2. Say hello.
+3. Pinet responds.
+
+## Optional: set a default channel
+
+Tell Pinet where to post updates:
+
+```json
+{
+  "slack-bridge": {
+    "defaultChannel": "C_CHANNEL_ID"
+  }
+}
+```
+
+Find channel IDs:
+
+1. Right-click the channel name
+2. Select **View channel details**
+3. Copy the Channel ID at the bottom
+
+## Optional: use environment variables
+
+Instead of `settings.json`, use environment variables:
+
+```bash
+export SLACK_BOT_TOKEN="xoxb-..."
+export SLACK_APP_TOKEN="xapp-..."
+export SLACK_ALLOWED_USERS="U_USER_1,U_USER_2"
+```
+
+Settings in `settings.json` override environment variables.
+
+## Next steps
+
+- [Configure Pinet](configuration.md) for your needs
+- Learn [how to use Pinet](usage.md)
+- Understand the [architecture](architecture.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,310 @@
+---
+layout: default
+title: Troubleshooting
+---
+
+# Troubleshooting
+
+Fix common Pinet problems.
+
+## Pinet does not appear in Slack
+
+### Check your tokens
+
+Verify both tokens are in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "slack-bridge": {
+    "botToken": "xoxb-...",
+    "appToken": "xapp-..."
+  }
+}
+```
+
+### Check Socket Mode
+
+1. Go to your app at [api.slack.com/apps](https://api.slack.com/apps)
+2. Select **Socket Mode**
+3. Verify it shows **Enabled**
+4. Check **Connections** shows at least one active connection
+
+### Check the app is installed
+
+1. Go to **OAuth & Permissions**
+2. Look for **Bot User OAuth Token**
+3. If missing, select **Install to Workspace**
+
+### Check pi is running
+
+Verify pi started successfully. Look for startup messages mentioning Pinet.
+
+## Pinet does not respond
+
+### Check user permissions
+
+Verify you are allowed to use Pinet:
+
+```json
+{
+  "slack-bridge": {
+    "allowedUsers": ["YOUR_USER_ID"]
+  }
+}
+```
+
+Or enable for everyone:
+
+```json
+{
+  "slack-bridge": {
+    "allowAllWorkspaceUsers": true
+  }
+}
+```
+
+### Check the bot is in the channel
+
+Pinet must be a member of the channel. Invite it:
+
+```
+/invite @pinet
+```
+
+### Check mention requirements
+
+Some channels may require mentions. Try:
+
+```
+@pinet hello
+```
+
+### Check the log channel
+
+Look for errors in your configured log channel, or use `/pinet logs`.
+
+## Connection errors
+
+### WebSocket disconnections
+
+If you see 'WebSocket error':
+
+1. Check your internet connection
+2. Verify the app token is valid
+3. Check Slack's status page
+4. Look for rate limiting (10 connections max per app)
+
+### Rate limiting
+
+Slack limits:
+
+- 10 Socket Mode connections per app
+- 1 message per second per channel
+- 20 messages per minute workspace-wide
+
+If rate limited:
+
+- reduce message frequency
+- use fewer connections
+- wait for limits to reset
+
+### Network issues
+
+If behind a firewall:
+
+- WebSocket connections need port 443
+- Check proxy settings
+- Verify SSL certificates work
+
+## Permission errors
+
+### Cannot send messages
+
+Check the bot has these scopes:
+
+- `chat:write`
+- `channels:read`
+- `groups:read`
+
+Reinstall the app to update scopes.
+
+### Cannot read messages
+
+Check these scopes:
+
+- `channels:history`
+- `groups:history`
+- `im:history`
+
+### Cannot use slash commands
+
+Check:
+
+- `commands` scope is enabled
+- slash command is configured in the app
+- command name matches your configuration
+
+## Agent problems
+
+### Agents get stuck
+
+RALPH checks automatically every 5 minutes. If it is too noisy during quiet periods, use `/pinet snooze`, `/pinet snooze 30m`, or `/pinet snooze off`.
+
+### Dead agents persist
+
+Check `/pinet status` and `/pinet logs`. RALPH can release stale claims after health checks, but you may still need to restart or free the affected worker.
+
+### Work not assigned
+
+Check:
+
+- broker is running (`/pinet status`)
+- followers are connected
+- recent broker logs show incoming work (`/pinet logs`)
+
+## Broker and follower issues
+
+### Cannot become broker
+
+If `/pinet broker` fails:
+
+- check no other broker exists
+- verify mesh credentials match
+- check network connectivity
+
+### Follower cannot connect
+
+Check:
+
+- broker is running
+- mesh secrets match
+- both agents can access the broker socket or configured TCP listener
+- the broker and follower use compatible Pinet versions
+
+### State not syncing
+
+Verify:
+
+- all instances use same mesh secret
+- network is stable
+- no version mismatches
+
+## Message handling
+
+### Messages go to wrong agent
+
+This happens when thread ownership or routing hints are confused. Solutions:
+
+- start a new thread
+- mention the intended worker explicitly
+- ask the broker to clear or transfer the stale claim
+
+### Duplicate responses
+
+Check for:
+
+- multiple Pinet instances in single mode
+- misconfigured broker/follower setup
+- multiple apps with same token
+
+### Missing messages
+
+Verify:
+
+- Socket Mode connection is stable
+- event subscriptions are enabled
+- bot is in the channel
+
+## Configuration problems
+
+### Settings not loading
+
+Check:
+
+- file path is `~/.pi/agent/settings.json`
+- JSON syntax is valid
+- pi was restarted after changes
+
+### Environment variables ignored
+
+Settings.json overrides environment variables. Remove settings from file to use environment variables.
+
+### Mesh auth failures
+
+If authentication fails:
+
+- verify secrets match exactly
+- check file permissions on secret file
+- ensure broker started first
+
+## Performance issues
+
+### Slow responses
+
+Check:
+
+- RALPH interval (default 5 minutes)
+- number of active agents
+- Slack rate limits
+- network latency
+
+### High memory use
+
+Reduce:
+
+- inbox size limits
+- log retention
+- number of followers
+
+### Crashes
+
+Check logs for:
+
+- out of memory errors
+- uncaught exceptions
+- network timeouts
+
+## Common error messages
+
+### 'not_in_channel'
+
+The bot is not in the channel. Invite it with `/invite @pinet`.
+
+### 'missing_scope'
+
+The app needs more permissions. Check required scopes and reinstall.
+
+### 'account_inactive'
+
+The bot user was deactivated. Reactivate in Slack admin settings.
+
+### 'invalid_auth'
+
+Token is wrong or expired. Get new tokens from app settings.
+
+### 'user_not_authorized'
+
+User is not in `allowedUsers`. Add their ID or enable `allowAllWorkspaceUsers`.
+
+## Verbose logging
+
+Enable verbose logging:
+
+```json
+{
+  "slack-bridge": {
+    "logLevel": "verbose"
+  }
+}
+```
+
+This shows more activity, connection events, and detailed errors.
+
+## Get more help
+
+If problems persist:
+
+1. Check the [GitHub issues](https://github.com/gugu91/extensions/issues)
+2. Review [architecture documentation](architecture.md)
+3. Look at recent changes in the repository
+4. Check Slack's [API documentation](https://api.slack.com)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,258 @@
+---
+layout: default
+title: Using Pinet
+---
+
+# Using Pinet
+
+Talk to Pinet in Slack or use it from pi.
+
+## In Slack
+
+### Direct messages
+
+Open a DM with Pinet and send a message. Pinet responds directly.
+
+### In channels
+
+Mention Pinet in any channel:
+
+```
+@pinet what are you working on?
+```
+
+Pinet must be in the channel. Invite it with:
+
+```
+/invite @pinet
+```
+
+### Slack slash command
+
+The Slack slash command is narrow. Use it to list known agents:
+
+```bash
+/pinet agents list
+/pinet agents list all
+```
+
+Use Pinet commands inside pi for broker and worker control:
+
+- `/pinet` - show what Pinet can do
+- `/pinet status` - show current Pinet status
+- `/pinet logs` - show recent broker activity logs
+- `/pinet rename [name]` - rename this agent
+- `/pinet free` - mark this agent idle
+
+## From pi
+
+Use the Pinet dispatcher for agent-to-agent coordination. Use Slack tools for Slack-specific work.
+
+### Send a message to an agent
+
+```json
+{
+  "action": "send",
+  "args": {
+    "to": "@worker",
+    "message": "Please review PR #123"
+  }
+}
+```
+
+### Transfer a Slack thread while sending work
+
+```json
+{
+  "action": "send",
+  "args": {
+    "to": "@worker",
+    "message": "Please take this Slack thread and report back here.",
+    "transfer_thread_id": "1234567890.123456"
+  }
+}
+```
+
+### Read your inbox
+
+```json
+{
+  "action": "read",
+  "args": {
+    "unread_only": true,
+    "limit": 20
+  }
+}
+```
+
+## Common tasks
+
+### Check Pinet status
+
+See current Pinet state:
+
+```
+/pinet status
+```
+
+### View recent logs
+
+See recent broker activity logs:
+
+```
+/pinet logs
+```
+
+### Rename the agent
+
+Give the current agent a clearer name:
+
+```
+/pinet rename Docs Falcon
+```
+
+### Send files
+
+Use the Slack dispatcher upload action:
+
+```json
+{
+  "action": "upload",
+  "args": {
+    "channel": "#general",
+    "content": "file contents here",
+    "filename": "report.txt",
+    "title": "Daily report"
+  }
+}
+```
+
+### Use canvases
+
+Use the Slack dispatcher canvas action:
+
+```json
+{
+  "action": "canvas_create",
+  "args": {
+    "channel": "#project",
+    "title": "Project plan",
+    "markdown": "# Project\n\n- task 1\n- task 2"
+  }
+}
+```
+
+## Advanced usage
+
+### Coordinator commands
+
+Inside pi, users managing the Pinet mesh can run:
+
+- `/pinet start` or `/pinet broker` - become the broker
+- `/pinet follow` - connect to the broker
+- `/pinet unfollow` - disconnect from broker
+- `/pinet reload <agent>` - ask another agent to reload
+- `/pinet exit <agent>` - ask another agent to exit
+- `/pinet snooze [duration|off|status]` - quiet empty RALPH cycles
+- `/pinet subtree [start|status|spawn|stop]` - manage subtree broker mode
+
+### Thread ownership
+
+Pinet remembers who owns each thread. Messages in a thread go to the agent that started it.
+
+Transfer a thread by sending work to the new owner with `transfer_thread_id`:
+
+```json
+{
+  "action": "send",
+  "args": {
+    "to": "agent-id",
+    "message": "Please take over this thread.",
+    "transfer_thread_id": "1234567890.123456"
+  }
+}
+```
+
+### Scheduled messages
+
+Schedule a wake-up:
+
+```json
+{
+  "action": "schedule",
+  "args": {
+    "delay": "30m",
+    "message": "Check the deployment"
+  }
+}
+```
+
+Use `delay` for relative times such as `30m`, `1h30m`, or `1d`. Use `at` for an absolute ISO 8601 UTC time, such as `2026-04-02T14:30:00Z`.
+
+## Working with agents
+
+### Agent identity
+
+Each agent has a name like 'Rocket Dolphin' or 'Silent Crocodile'. This helps you track who is doing what.
+
+### Agent lanes
+
+Agents work in lanes. Each lane is a task or project. Use the Pinet `lanes` tool action from pi when you need durable lane state.
+
+### The broker
+
+One agent coordinates the others. The broker:
+
+- watches Slack
+- assigns work
+- tracks ownership
+- syncs state
+
+If the broker stops, followers continue their current work but cannot pick up new tasks.
+
+## Tips
+
+### Keep threads focused
+
+Start a new thread for each topic. This helps agents track context.
+
+### Use mentions wisely
+
+In busy channels, mention Pinet to ensure it sees your message:
+
+```
+@pinet can you help with this error?
+```
+
+### Check logs for issues
+
+If something goes wrong, check recent logs:
+
+```
+/pinet logs
+```
+
+### Let RALPH work
+
+RALPH runs every 5 minutes. If it becomes too noisy during quiet periods, use `/pinet snooze`, `/pinet snooze 30m`, or `/pinet snooze off`.
+
+## Security notes
+
+### Authorised users only
+
+Only configured users can use Pinet. Others see an error message.
+
+### Confirmation prompts
+
+Dangerous actions may require confirmation. Pinet will ask before proceeding.
+
+### Read-only mode
+
+In read-only mode, Pinet can read but not modify anything.
+
+## Get help
+
+- Check [troubleshooting](troubleshooting.md)
+- Look in the log channel
+- Run `/pinet help` for command help
+- Visit the [GitHub repository](https://github.com/gugu91/extensions)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "prepush": "pnpm lint && pnpm typecheck && pnpm test",
     "lint-staged": "lint-staged",
     "prepare": "node ./scripts/prepare.mjs",
-    "postinstall": "node ./scripts/build-all.mjs"
+    "postinstall": "node ./scripts/build-all.mjs",
+    "docs:check": "node ./scripts/build-docs-site.mjs --check",
+    "docs:build": "node ./scripts/build-docs-site.mjs",
+    "docs:serve": "pnpm docs:build && python3 -m http.server 4000 --directory docs/_site"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs,json,md,yml,yaml}": "prettier --write",

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docsDir = path.join(repoRoot, "docs");
+const siteDir = path.join(docsDir, "_site");
+const checkOnly = process.argv.includes("--check");
+
+const pages = [
+  { file: "index.md", title: "Start" },
+  { file: "setup.md", title: "Set up Pinet" },
+  { file: "configuration.md", title: "Configure Pinet" },
+  { file: "usage.md", title: "Use Pinet" },
+  { file: "architecture.md", title: "Architecture" },
+  { file: "troubleshooting.md", title: "Troubleshooting" },
+  { file: "reference.md", title: "Reference" },
+];
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function inlineMarkdown(value) {
+  let html = escapeHtml(value);
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
+    const [pathPart, anchorPart] = href.split("#", 2);
+    const rewrittenPath = pathPart.endsWith(".md") ? pathPart.replace(/\.md$/, ".html") : pathPart;
+    const target = anchorPart === undefined ? rewrittenPath : `${rewrittenPath}#${anchorPart}`;
+    return `<a href="${escapeHtml(target)}">${label}</a>`;
+  });
+  return html;
+}
+
+function stripFrontmatter(markdown) {
+  if (!markdown.startsWith("---\n")) return markdown;
+  const end = markdown.indexOf("\n---\n", 4);
+  return end === -1 ? markdown : markdown.slice(end + 5);
+}
+
+function markdownToHtml(markdown) {
+  const lines = stripFrontmatter(markdown).split(/\r?\n/);
+  const out = [];
+  let paragraph = [];
+  let list = null;
+  let table = null;
+  let code = null;
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    out.push(`<p>${inlineMarkdown(paragraph.join(" "))}</p>`);
+    paragraph = [];
+  };
+
+  const flushList = () => {
+    if (!list) return;
+    out.push(`<${list.type}>`);
+    for (const item of list.items) out.push(`<li>${inlineMarkdown(item)}</li>`);
+    out.push(`</${list.type}>`);
+    list = null;
+  };
+
+  const renderRow = (row, cellTag) =>
+    `<tr>${row.map((cell) => `<${cellTag}>${inlineMarkdown(cell)}</${cellTag}>`).join("")}</tr>`;
+
+  const flushTable = () => {
+    if (!table) return;
+    out.push("<table>");
+    if (table.hasHeader && table.rows.length > 0) {
+      out.push("<thead>");
+      out.push(renderRow(table.rows[0], "th"));
+      out.push("</thead>");
+      out.push("<tbody>");
+      for (const row of table.rows.slice(1)) out.push(renderRow(row, "td"));
+      out.push("</tbody>");
+    } else {
+      out.push("<tbody>");
+      for (const row of table.rows) out.push(renderRow(row, "td"));
+      out.push("</tbody>");
+    }
+    out.push("</table>");
+    table = null;
+  };
+
+  for (const line of lines) {
+    if (code) {
+      if (line.startsWith("```")) {
+        out.push(`<pre><code>${escapeHtml(code.lines.join("\n"))}</code></pre>`);
+        code = null;
+      } else {
+        code.lines.push(line);
+      }
+      continue;
+    }
+
+    if (line.startsWith("```")) {
+      flushParagraph();
+      flushList();
+      code = { lines: [] };
+      continue;
+    }
+
+    if (line.trim() === "") {
+      flushParagraph();
+      flushList();
+      flushTable();
+      continue;
+    }
+
+    const tableSeparator = line.match(/^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/);
+    if (tableSeparator && table) {
+      table.hasHeader = true;
+      continue;
+    }
+
+    if (line.trim().startsWith("|")) {
+      flushParagraph();
+      flushList();
+      const row = line
+        .trim()
+        .replace(/^\|/, "")
+        .replace(/\|$/, "")
+        .split("|")
+        .map((cell) => cell.trim());
+      table ??= { rows: [], hasHeader: false };
+      table.rows.push(row);
+      continue;
+    }
+
+    flushTable();
+
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      flushParagraph();
+      flushList();
+      flushTable();
+      const level = heading[1].length;
+      const text = heading[2].trim();
+      const id = text
+        .toLowerCase()
+        .replace(/`/g, "")
+        .replace(/[^a-z0-9\s-]/g, "")
+        .trim()
+        .replace(/\s+/g, "-");
+      out.push(`<h${level} id="${id}">${inlineMarkdown(text)}</h${level}>`);
+      continue;
+    }
+
+    const unordered = line.match(/^[-*]\s+(.+)$/);
+    if (unordered) {
+      flushParagraph();
+      flushTable();
+      if (!list || list.type !== "ul") {
+        flushList();
+        list = { type: "ul", items: [] };
+      }
+      list.items.push(unordered[1]);
+      continue;
+    }
+
+    const ordered = line.match(/^\d+\.\s+(.+)$/);
+    if (ordered) {
+      flushParagraph();
+      flushTable();
+      if (!list || list.type !== "ol") {
+        flushList();
+        list = { type: "ol", items: [] };
+      }
+      list.items.push(ordered[1]);
+      continue;
+    }
+
+    paragraph.push(line.trim());
+  }
+
+  flushParagraph();
+  flushList();
+  flushTable();
+  return out.join("\n");
+}
+
+function logoSvg() {
+  return `<svg class="pinet-logo" viewBox="0 0 800 800" aria-hidden="true" focusable="false"><path fill="currentColor" d="M120 120h360v120H240v120h240v120H240v200H120z"></path><path fill="currentColor" d="M520 320h160v360H520z"></path><path fill="currentColor" d="M360 520h120v160H360z"></path></svg>`;
+}
+
+function siteStyles() {
+  return `<style>
+    :root {
+      color-scheme: dark light;
+      --bg: #08090d;
+      --bg-2: #0f1118;
+      --panel: rgba(18, 21, 31, 0.86);
+      --panel-strong: #141823;
+      --text: #f4f1e8;
+      --muted: #aeb5c2;
+      --line: rgba(244, 241, 232, 0.16);
+      --accent: #d9ff4a;
+      --accent-2: #8cf7ff;
+      --shadow: rgba(0, 0, 0, 0.34);
+      --code-bg: #05060a;
+      --max: 72rem;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      background:
+        radial-gradient(circle at 15% 8%, rgba(217, 255, 74, 0.14), transparent 30rem),
+        radial-gradient(circle at 88% 18%, rgba(140, 247, 255, 0.13), transparent 34rem),
+        linear-gradient(180deg, var(--bg), var(--bg-2) 42rem, var(--bg));
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 18px;
+      line-height: 1.6;
+      margin: 0;
+      min-height: 100vh;
+    }
+    body::before {
+      background-image: linear-gradient(rgba(244, 241, 232, 0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(244, 241, 232, 0.035) 1px, transparent 1px);
+      background-size: 48px 48px;
+      content: "";
+      inset: 0;
+      pointer-events: none;
+      position: fixed;
+      mask-image: linear-gradient(to bottom, black, transparent 75%);
+    }
+    a { color: var(--accent-2); text-decoration-thickness: 0.08em; text-underline-offset: 0.18em; }
+    a:hover { color: var(--accent); }
+    .skip-link { background: var(--accent); color: #08090d; left: 1rem; padding: .6rem .9rem; position: absolute; top: -4rem; z-index: 5; }
+    .skip-link:focus { top: 1rem; }
+    .site-nav {
+      backdrop-filter: blur(18px);
+      background: rgba(8, 9, 13, 0.72);
+      border-bottom: 1px solid var(--line);
+      position: sticky;
+      top: 0;
+      z-index: 4;
+    }
+    .site-nav-inner { align-items: center; display: flex; gap: 1rem; justify-content: space-between; margin: 0 auto; max-width: var(--max); padding: .85rem 1rem; }
+    .brand { align-items: center; color: var(--text); display: inline-flex; font-weight: 800; gap: .65rem; letter-spacing: -.03em; text-decoration: none; }
+    .pinet-logo { height: 2rem; width: 2rem; }
+    .nav-links { align-items: center; display: flex; flex-wrap: wrap; gap: .7rem; justify-content: flex-end; }
+    .nav-links a { border: 1px solid transparent; border-radius: 999px; color: var(--muted); font-size: .9rem; padding: .3rem .62rem; text-decoration: none; }
+    .nav-links a:hover, .nav-links a[aria-current="page"] { border-color: var(--line); color: var(--text); }
+    .hero { margin: 0 auto; max-width: var(--max); padding: 5.5rem 1rem 3rem; text-align: center; }
+    .hero-mark { color: var(--accent); display: inline-block; filter: drop-shadow(0 1rem 2.5rem rgba(217, 255, 74, .18)); margin-bottom: 1.5rem; transform: rotate(-2deg); }
+    .hero-mark .pinet-logo { height: clamp(5rem, 14vw, 9rem); width: clamp(5rem, 14vw, 9rem); }
+    .eyebrow { color: var(--accent); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .82rem; letter-spacing: .16em; text-transform: uppercase; }
+    .hero h1 { font-size: clamp(3rem, 9vw, 7.8rem); letter-spacing: -.09em; line-height: .9; margin: .5rem 0 1rem; }
+    .hero h1 span { color: var(--accent); }
+    .hero-copy { color: var(--muted); font-size: clamp(1.15rem, 2vw, 1.45rem); margin: 0 auto; max-width: 48rem; }
+    .hero-actions { display: flex; flex-wrap: wrap; gap: .8rem; justify-content: center; margin-top: 1.8rem; }
+    .button { border: 1px solid var(--line); border-radius: 999px; color: var(--text); display: inline-flex; font-weight: 750; padding: .78rem 1.05rem; text-decoration: none; }
+    .button--primary { background: var(--accent); border-color: var(--accent); color: #08090d; }
+    .install-panel { margin: 2rem auto 0; max-width: 48rem; }
+    .terminal { background: var(--code-bg); border: 1px solid var(--line); border-radius: 1.2rem; box-shadow: 0 1.8rem 4rem var(--shadow); overflow: hidden; text-align: left; }
+    .terminal-bar { align-items: center; border-bottom: 1px solid var(--line); color: var(--muted); display: flex; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .78rem; justify-content: space-between; padding: .6rem .8rem; }
+    .dots { display: inline-flex; gap: .35rem; }
+    .dots span { background: var(--accent); border-radius: 50%; display: inline-block; height: .55rem; width: .55rem; }
+    .terminal pre { margin: 0; padding: 1rem; white-space: pre-wrap; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    code { background: rgba(244, 241, 232, .1); border-radius: .25rem; padding: .08rem .25rem; }
+    pre code { background: transparent; padding: 0; }
+    .section-wrap { margin: 0 auto; max-width: var(--max); padding: 2rem 1rem; }
+    .story-grid { display: grid; gap: 1rem; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 1.35rem; box-shadow: 0 1.25rem 3rem var(--shadow); padding: 1.2rem; position: relative; }
+    .panel::before, .panel::after { border-color: var(--accent); border-style: solid; content: ""; height: .8rem; opacity: .75; position: absolute; width: .8rem; }
+    .panel::before { border-width: 1px 0 0 1px; left: .7rem; top: .7rem; }
+    .panel::after { border-width: 0 1px 1px 0; bottom: .7rem; right: .7rem; }
+    .panel h2, .panel h3 { letter-spacing: -.04em; line-height: 1.05; margin: 0 0 .55rem; }
+    .panel p { color: var(--muted); margin-bottom: 0; }
+    .docs-layout { display: grid; gap: 2rem; grid-template-columns: minmax(12rem, 16rem) minmax(0, 45rem); margin: 0 auto; max-width: var(--max); padding: 3rem 1rem; }
+    .docs-sidebar { align-self: start; background: rgba(8, 9, 13, .64); border: 1px solid var(--line); border-radius: 1rem; padding: .85rem; position: sticky; top: 5.2rem; }
+    .docs-sidebar a { border-radius: .65rem; color: var(--muted); display: block; padding: .4rem .55rem; text-decoration: none; }
+    .docs-sidebar a:hover, .docs-sidebar a[aria-current="page"] { background: rgba(244, 241, 232, .08); color: var(--text); }
+    .docs-main { min-width: 0; }
+    .docs-card { background: rgba(18, 21, 31, .78); border: 1px solid var(--line); border-radius: 1.25rem; padding: clamp(1.2rem, 4vw, 2.2rem); }
+    .docs-card h1 { font-size: clamp(2.4rem, 6vw, 4.8rem); letter-spacing: -.07em; line-height: .95; margin-top: 0; }
+    .docs-card h2 { border-top: 1px solid var(--line); font-size: clamp(1.7rem, 3vw, 2.5rem); letter-spacing: -.05em; line-height: 1.05; margin-top: 2.2rem; padding-top: 1.4rem; }
+    .docs-card h3 { font-size: 1.35rem; margin-top: 1.6rem; }
+    .docs-card p, .docs-card li { color: var(--muted); }
+    .docs-card pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: .9rem; overflow-x: auto; padding: 1rem; }
+    .docs-card table { border-collapse: collapse; display: block; overflow-x: auto; width: 100%; }
+    .docs-card th, .docs-card td { border: 1px solid var(--line); padding: .55rem; text-align: left; }
+    .site-footer { border-top: 1px solid var(--line); color: var(--muted); margin-top: 3rem; padding: 2rem 1rem; text-align: center; }
+    @media (max-width: 52rem) {
+      .site-nav-inner { align-items: flex-start; flex-direction: column; }
+      .nav-links { justify-content: flex-start; }
+      .story-grid, .docs-layout { display: block; }
+      .panel { margin-bottom: 1rem; }
+      .docs-sidebar { margin-bottom: 1rem; position: static; }
+    }
+  </style>`;
+}
+
+function navLinks(currentFile) {
+  return pages
+    .map((page) => {
+      const href = page.file.replace(/\.md$/, ".html");
+      const current = page.file === currentFile ? ' aria-current="page"' : "";
+      return `<a href="${href}"${current}>${page.title}</a>`;
+    })
+    .join("\n");
+}
+
+function topNav(currentFile) {
+  return `<nav class="site-nav" aria-label="Primary">
+    <div class="site-nav-inner">
+      <a class="brand" href="index.html">${logoSvg()}<span>Pinet</span></a>
+      <div class="nav-links">
+        ${navLinks(currentFile)}
+        <a href="https://github.com/gugu91/extensions">GitHub</a>
+      </div>
+    </div>
+  </nav>`;
+}
+
+function landingPage() {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pinet - Slack control for Pi agents</title>
+  ${siteStyles()}
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  ${topNav("index.md")}
+  <main id="main">
+    <header class="hero">
+      <div class="hero-mark">${logoSvg()}</div>
+      <p class="eyebrow">Slack bridge for Pi</p>
+      <h1>Coordinate agents from <span>Slack</span></h1>
+      <p class="hero-copy">Pinet connects pi coding agents to Slack, routes work between workers, and keeps the thread readable while the work happens.</p>
+      <div class="hero-actions">
+        <a class="button button--primary" href="setup.html">Set up Pinet</a>
+        <a class="button" href="usage.html">Use Pinet</a>
+        <a class="button" href="reference.html">Read the reference</a>
+      </div>
+      <div class="install-panel">
+        <div class="terminal" aria-label="Example Pinet commands">
+          <div class="terminal-bar"><span class="dots"><span></span><span></span><span></span></span><span>pinet session</span></div>
+          <pre><code>$ /pinet start
+$ /pinet agents list all
+$ /pinet follow</code></pre>
+        </div>
+      </div>
+    </header>
+    <section class="section-wrap" aria-labelledby="why-pinet">
+      <div class="story-grid">
+        <article class="panel">
+          <h2 id="why-pinet">Work in threads</h2>
+          <p>Slack messages become agent tasks. Replies, blockers, and outcomes stay in the thread where the work started.</p>
+        </article>
+        <article class="panel">
+          <h2>Coordinate workers</h2>
+          <p>A broker can see available agents, assign work, and recover when a worker gets stuck.</p>
+        </article>
+        <article class="panel">
+          <h2>Keep control</h2>
+          <p>Pinet is off by default. Enable it explicitly and use allowlists plus guardrails for sensitive Slack actions.</p>
+        </article>
+      </div>
+    </section>
+    <section class="section-wrap" aria-labelledby="docs-title">
+      <article class="panel">
+        <p class="eyebrow">Documentation</p>
+        <h2 id="docs-title">Start with setup, then tune access</h2>
+        <p>Use the setup guide to configure Slack, then review configuration and usage before connecting production agents.</p>
+        <div class="hero-actions">
+          <a class="button button--primary" href="setup.html">Setup guide</a>
+          <a class="button" href="configuration.html">Configuration</a>
+          <a class="button" href="troubleshooting.html">Troubleshooting</a>
+        </div>
+      </article>
+    </section>
+  </main>
+  <footer class="site-footer">Pinet is part of the extensions workspace for Pi.</footer>
+</body>
+</html>`;
+}
+
+function pageTemplate(page, body) {
+  const nav = navLinks(page.file);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(page.title)} - Pinet documentation</title>
+  ${siteStyles()}
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  ${topNav(page.file)}
+  <div class="docs-layout">
+    <aside class="docs-sidebar" aria-label="Documentation navigation">${nav}</aside>
+    <main class="docs-main" id="main">
+      <article class="docs-card">${body}</article>
+    </main>
+  </div>
+  <footer class="site-footer">Pinet documentation. Deployment is disabled until a maintainer enables GitHub Pages.</footer>
+</body>
+</html>
+`;
+}
+
+async function validateInputs() {
+  const missing = pages.filter((page) => !existsSync(path.join(docsDir, page.file)));
+  if (missing.length > 0) {
+    throw new Error(`Missing documentation files: ${missing.map((page) => page.file).join(", ")}`);
+  }
+}
+
+async function validateLinks() {
+  const markdownFiles = (await readdir(docsDir)).filter((file) => file.endsWith(".md"));
+  const known = new Set(markdownFiles);
+  for (const file of markdownFiles) {
+    const markdown = await readFile(path.join(docsDir, file), "utf8");
+    for (const match of markdown.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
+      const href = match[1];
+      if (/^(https?:|mailto:|#)/.test(href)) continue;
+      const target = href.split("#")[0];
+      if (target === "") continue;
+      if (!known.has(target)) throw new Error(`Broken internal link in ${file}: ${href}`);
+    }
+  }
+}
+
+await validateInputs();
+await validateLinks();
+
+if (!checkOnly) await rm(siteDir, { recursive: true, force: true });
+await mkdir(siteDir, { recursive: true });
+
+for (const page of pages) {
+  const markdown = await readFile(path.join(docsDir, page.file), "utf8");
+  const html =
+    page.file === "index.md" ? landingPage() : pageTemplate(page, markdownToHtml(markdown));
+  await writeFile(path.join(siteDir, page.file.replace(/\.md$/, ".html")), html);
+}
+
+console.log(`Built Pinet documentation site in ${path.relative(repoRoot, siteDir)}`);

--- a/scripts/build-docs-site.test.mjs
+++ b/scripts/build-docs-site.test.mjs
@@ -1,0 +1,29 @@
+import { existsSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const siteDir = path.join(repoRoot, "docs", "_site");
+
+test("build-docs-site creates the static Pinet documentation site", () => {
+  rmSync(siteDir, { recursive: true, force: true });
+
+  execFileSync("node", ["scripts/build-docs-site.mjs"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+
+  for (const page of [
+    "index.html",
+    "setup.html",
+    "configuration.html",
+    "usage.html",
+    "architecture.html",
+    "troubleshooting.html",
+    "reference.html",
+  ]) {
+    assert.equal(existsSync(path.join(siteDir, page)), true, `${page} should exist`);
+  }
+});


### PR DESCRIPTION
## Summary
- Add a static HTML Pinet documentation site under `docs/` with a pi.dev-inspired landing page.
- Add setup, configuration, usage, architecture, troubleshooting, and reference pages generated from Markdown.
- Add `pnpm docs:check`, `pnpm docs:build`, `pnpm docs:serve`, and a Node test for the site generator.
- Add a docs check workflow and a disabled GitHub Pages deployment workflow.

Part of #852. This does not enable publishing or deployment.

## Safety
- GitHub Pages deployment is committed as `.github/workflows/deploy-docs.yml.disabled`.
- The workflow will not run unless a maintainer explicitly renames it and enables Pages.

## Testing
- `pnpm docs:check`
- `pnpm docs:build`
- `node --test scripts/*.test.mjs`
- `pnpm format:check:ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- push pre-push hook: `pnpm lint && pnpm typecheck && pnpm test`
