### PR TITLE
fix(slack-bridge): stop workers taking over Slack threads they don't own (#855)

### DIFF
--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -1510,6 +1510,128 @@ describe("broker integration — client ↔ server ↔ DB", () => {
 
     // No thread should be created
     expect(db.getThread("some-ts")).toBeNull();
+  });
+
+  it("refuses slackProxy chat.postMessage to a thread owned by a different agent (#855)", async () => {
+    client.disconnect();
+    await server.stop();
+
+    const invokeCapability = vi.fn(async ({ params }: { params: Record<string, unknown> }) => {
+      const body = params.params as Record<string, unknown>;
+      return {
+        result: {
+          ok: true,
+          ts: "unauthorized-reply-ts",
+          channel: body.channel,
+          message: { ts: "unauthorized-reply-ts", text: body.text },
+        },
+        effects: {
+          claimThread: {
+            threadId: "protected-thread-ts",
+            channel: body.channel as string,
+          },
+        },
+      };
+    });
+
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 });
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability,
+      },
+    ]);
+    await server.start();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+
+    // Pre-seed the thread as owned by a different agent.
+    db.registerAgent("legit-owner", "Legit Owner", "🛡️", process.pid);
+    db.createThread({
+      threadId: "protected-thread-ts",
+      source: "slack",
+      channel: "C-PROTECTED",
+      ownerAgent: "legit-owner",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    client = new BrokerClient({ host: info.host, port: info.port });
+    await client.connect();
+    await client.register("would-be-hijacker", "🥷");
+
+    await expect(
+      client.slackProxy("chat.postMessage", {
+        channel: "C-PROTECTED",
+        text: "trying to hijack",
+        thread_ts: "protected-thread-ts",
+      }),
+    ).rejects.toThrow(/already owned by another agent/i);
+
+    // Adapter must NOT have been called: refusal happens before hitting Slack.
+    expect(invokeCapability).not.toHaveBeenCalled();
+
+    // Ownership must be unchanged after the refused call.
+    const thread = db.getThread("protected-thread-ts");
+    expect(thread?.ownerAgent).toBe("legit-owner");
+  });
+
+  it("allows slackProxy chat.postMessage when caller is the current thread owner (#855)", async () => {
+    client.disconnect();
+    await server.stop();
+
+    const invokeCapability = vi.fn(async ({ params }: { params: Record<string, unknown> }) => {
+      const body = params.params as Record<string, unknown>;
+      return {
+        result: {
+          ok: true,
+          ts: "owner-reply-ts",
+          channel: body.channel,
+          message: { ts: "owner-reply-ts", text: body.text },
+        },
+        effects: {
+          claimThread: { threadId: "owned-thread-ts", channel: body.channel as string },
+        },
+      };
+    });
+
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 });
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability,
+      },
+    ]);
+    await server.start();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+
+    client = new BrokerClient({ host: info.host, port: info.port });
+    await client.connect();
+    const reg = await client.register("real-owner", "✅");
+
+    db.createThread({
+      threadId: "owned-thread-ts",
+      source: "slack",
+      channel: "C-OWNED",
+      ownerAgent: reg.agentId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await client.slackProxy("chat.postMessage", {
+      channel: "C-OWNED",
+      text: "legit reply",
+      thread_ts: "owned-thread-ts",
+    });
+
+    expect(invokeCapability).toHaveBeenCalledOnce();
+    const thread = db.getThread("owned-thread-ts");
+    expect(thread?.ownerAgent).toBe(reg.agentId);
   });
 });
 

--- a/slack-bridge/broker/integration.test.ts
+++ b/slack-bridge/broker/integration.test.ts
@@ -1633,6 +1633,61 @@ describe("broker integration — client ↔ server ↔ DB", () => {
     const thread = db.getThread("owned-thread-ts");
     expect(thread?.ownerAgent).toBe(reg.agentId);
   });
+
+  it("refuses adapter.capability from an unregistered caller (#855)", async () => {
+    client.disconnect();
+    await server.stop();
+
+    const invokeCapability = vi.fn(async () => ({
+      result: { ok: true },
+    }));
+
+    server = new BrokerSocketServer(db, { type: "tcp", host: "127.0.0.1", port: 0 });
+    server.setOutboundMessageAdapters([
+      {
+        name: "slack",
+        send: async () => undefined,
+        invokeCapability,
+      },
+    ]);
+    await server.start();
+
+    const info = server.getConnectInfo();
+    if (info.type !== "tcp") throw new Error("Expected TCP");
+
+    // Pre-seed an owned thread that the unregistered caller must not touch.
+    db.registerAgent("legit-owner-2", "Legit Owner 2", "🛡️", process.pid);
+    db.createThread({
+      threadId: "pre-existing-thread",
+      source: "slack",
+      channel: "C-EXISTING",
+      ownerAgent: "legit-owner-2",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    client = new BrokerClient({ host: info.host, port: info.port });
+    await client.connect();
+    // Deliberately DO NOT call client.register(...).
+
+    await expect(
+      client.slackProxy("chat.postMessage", {
+        channel: "C-EXISTING",
+        text: "unregistered hijack attempt",
+        thread_ts: "pre-existing-thread",
+      }),
+    ).rejects.toThrow(/not registered/i);
+
+    await expect(
+      client.invokeAdapterCapability("slack", "api.call", {
+        method: "chat.postMessage",
+        params: { channel: "C-EXISTING", text: "nope", thread_ts: "pre-existing-thread" },
+      }),
+    ).rejects.toThrow(/not registered/i);
+
+    expect(invokeCapability).not.toHaveBeenCalled();
+    expect(db.getThread("pre-existing-thread")?.ownerAgent).toBe("legit-owner-2");
+  });
 });
 
 // ─── Integration: router with real DB ────────────────────

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -1397,6 +1397,15 @@ export class BrokerSocketServer {
     req: JsonRpcRequest,
     state: ConnectionState,
   ): Promise<JsonRpcResponse> {
+    // #855: adapter.capability must be identity-bound so the broker can
+    // enforce thread ownership. Unregistered callers cannot own or claim
+    // threads, so they must not be able to invoke outbound-side capabilities
+    // (chat.postMessage in particular) that would race a first-responder
+    // claim or take over a thread already owned by another agent.
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
     const params = req.params ?? {};
     const adapterName =
       typeof params.adapter === "string"
@@ -1431,6 +1440,13 @@ export class BrokerSocketServer {
     req: JsonRpcRequest,
     state: ConnectionState,
   ): Promise<JsonRpcResponse> {
+    // #855: legacy slack.proxy is a compatibility wrapper over
+    // adapter.capability and must enforce the same registration bar so
+    // unregistered callers cannot bypass thread ownership via chat.postMessage.
+    if (!state.agentId) {
+      return rpcError(req.id, RPC_INVALID_PARAMS, "Not registered");
+    }
+
     const params = req.params ?? {};
     const method = typeof params.method === "string" ? params.method.trim() : "";
     if (!method) {
@@ -1502,7 +1518,6 @@ export class BrokerSocketServer {
     capabilityParams: Record<string, unknown>,
     callerAgentId: string | null,
   ): string | null {
-    if (!callerAgentId) return null;
     if (adapterName !== "slack") return null;
     if (capability !== "api.call") return null;
     const method =
@@ -1516,6 +1531,15 @@ export class BrokerSocketServer {
         : {};
     const threadTs = typeof inner.thread_ts === "string" ? inner.thread_ts.trim() : "";
     if (!threadTs) return null;
+
+    // Defense in depth (#855): even if a future call path forgot the
+    // registration guard on the handler, refuse threaded chat.postMessage
+    // for unregistered callers here — they cannot own a Slack thread and
+    // must not be able to post into one.
+    if (!callerAgentId) {
+      return `Slack thread ${threadTs}: refusing threaded chat.postMessage from an unregistered caller`;
+    }
+
     const thread = this.db.getThread(threadTs);
     if (!thread?.ownerAgent) return null;
     if (thread.ownerAgent === callerAgentId) return null;

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -1471,6 +1471,21 @@ export class BrokerSocketServer {
       );
     }
 
+    // #855: refuse cross-owner Slack chat.postMessage before hitting Slack.
+    // Without this pre-check the adapter posts first and the broker races a
+    // first-responder-wins claim via effects.claimThread — letting an
+    // unauthorized follower take over a thread already owned by another
+    // agent simply by winning the send.
+    const ownershipError = this.checkAdapterCapabilityThreadOwnership(
+      adapterName,
+      capability,
+      capabilityParams,
+      state.agentId,
+    );
+    if (ownershipError) {
+      return rpcError(id, RPC_INVALID_PARAMS, `${errorPrefix}: ${ownershipError}`);
+    }
+
     try {
       const response = await adapter.invokeCapability({ capability, params: capabilityParams });
       this.applyAdapterCapabilityEffects(adapterName, response, state);
@@ -1479,6 +1494,32 @@ export class BrokerSocketServer {
       const message = err instanceof Error ? err.message : String(err);
       return rpcError(id, RPC_INTERNAL_ERROR, `${errorPrefix}: ${message}`);
     }
+  }
+
+  private checkAdapterCapabilityThreadOwnership(
+    adapterName: string,
+    capability: string,
+    capabilityParams: Record<string, unknown>,
+    callerAgentId: string | null,
+  ): string | null {
+    if (!callerAgentId) return null;
+    if (adapterName !== "slack") return null;
+    if (capability !== "api.call") return null;
+    const method =
+      typeof capabilityParams.method === "string" ? capabilityParams.method.trim() : "";
+    if (method !== "chat.postMessage") return null;
+    const inner =
+      capabilityParams.params &&
+      typeof capabilityParams.params === "object" &&
+      !Array.isArray(capabilityParams.params)
+        ? (capabilityParams.params as Record<string, unknown>)
+        : {};
+    const threadTs = typeof inner.thread_ts === "string" ? inner.thread_ts.trim() : "";
+    if (!threadTs) return null;
+    const thread = this.db.getThread(threadTs);
+    if (!thread?.ownerAgent) return null;
+    if (thread.ownerAgent === callerAgentId) return null;
+    return `Slack thread ${threadTs} is already owned by another agent; refusing cross-owner chat.postMessage`;
   }
 
   private applyAdapterCapabilityEffects(

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1211,6 +1211,7 @@ export default function (pi: ExtensionAPI) {
       getBotUserId: () => botUserId,
       registerConfirmationRequest,
       pinetDelivery: {
+        isEnabled: () => pinetEnabled,
         isAvailable: () => pinetEnabled && brokerRole !== null,
         sendSlackMessage: async (input) => {
           const content = {

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -181,6 +181,7 @@ function appendSlackThreadTransferNotice(body: string, threadId: string, channel
     `- channel: ${channel}`,
     `- To report directly in the transferred Slack thread, use slack_send with thread_ts ${threadId}; the channel is already recorded in Pinet.`,
     "- If slack_send says the thread is already owned by another agent, ask the broker to inspect ownership and transfer it again.",
+    "- If slack_send says the Pinet broker is unavailable, wait for the broker to reconnect \u2014 do NOT retry via post_channel; direct posting would bypass thread ownership (#855).",
   ].join("\n");
 }
 

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -366,25 +366,33 @@ describe("registerPinetTools", () => {
   });
 
   it("formats Pinet dispatcher results for human-readable TUI display", async () => {
-    const tools = registerWithDeps(createDeps());
-    const result = (await tools.get("pinet")?.execute("tool-call-schedule-json", {
-      action: "schedule",
-      args: { at: "2026-07-01T00:05:00.000Z", message: "check queue", format: "json" },
-    })) as { content: Array<{ type: string; text: string }>; details: unknown };
+    // Freeze the clock so the hardcoded scheduled-wakeup timestamp stays
+    // in the future regardless of when this test is run in CI.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
+    try {
+      const tools = registerWithDeps(createDeps());
+      const result = (await tools.get("pinet")?.execute("tool-call-schedule-json", {
+        action: "schedule",
+        args: { at: "2026-07-01T00:05:00.000Z", message: "check queue", format: "json" },
+      })) as { content: Array<{ type: string; text: string }>; details: unknown };
 
-    expectJsonStatus(result.content[0]?.text, "succeeded");
+      expectJsonStatus(result.content[0]?.text, "succeeded");
 
-    const collapsed = formatPinetDispatcherResultForDisplay(result, false);
-    const expanded = formatPinetDispatcherResultForDisplay(result, true);
+      const collapsed = formatPinetDispatcherResultForDisplay(result, false);
+      const expanded = formatPinetDispatcherResultForDisplay(result, true);
 
-    expect(collapsed).toEqual({
-      status: "succeeded",
-      text: "Pinet wake-up scheduled for 2026-07-01T00:05:00.000Z (id 7).",
-    });
-    expect(expanded.text).toContain("status: succeeded");
-    expect(expanded.text).toContain("action: schedule");
-    expect(expanded.text).toContain("id: 7");
-    expect(expanded.text).not.toContain('"errors"');
+      expect(collapsed).toEqual({
+        status: "succeeded",
+        text: "Pinet wake-up scheduled for 2026-07-01T00:05:00.000Z (id 7).",
+      });
+      expect(expanded.text).toContain("status: succeeded");
+      expect(expanded.text).toContain("action: schedule");
+      expect(expanded.text).toContain("id: 7");
+      expect(expanded.text).not.toContain('"errors"');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders Pinet dispatcher results as readable text instead of raw JSON", async () => {

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -261,6 +261,7 @@ describe("registerSlackTools", () => {
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
     const requireToolPolicy = vi.fn();
+    let pinetDeliveryEnabled = true;
     let pinetDeliveryAvailable = false;
     const sendPinetSlackMessage = vi.fn(async (input: SlackPinetDeliveryInput) => ({
       adapter: "slack",
@@ -293,6 +294,7 @@ describe("registerSlackTools", () => {
       registerConfirmationRequest: () => ({ status: "created" }),
       getBotUserId: () => "U_BOT",
       pinetDelivery: {
+        isEnabled: () => pinetDeliveryEnabled,
         isAvailable: () => pinetDeliveryAvailable,
         sendSlackMessage: sendPinetSlackMessage,
       },
@@ -383,6 +385,9 @@ describe("registerSlackTools", () => {
       noteThreadReply,
       clearPendingAttention,
       requireToolPolicy,
+      setPinetDeliveryEnabled: (value: boolean) => {
+        pinetDeliveryEnabled = value;
+      },
       setPinetDeliveryAvailable: (value: boolean) => {
         pinetDeliveryAvailable = value;
       },
@@ -1331,10 +1336,19 @@ describe("registerSlackTools", () => {
     );
   });
 
-  it("includes blocks when slack_send posts a rich message", async () => {
-    const { slack, tools, setResolveThreadChannel, noteThreadReply, clearPendingAttention } =
-      setup();
+  it("includes blocks when slack_send posts a rich message in single-player mode", async () => {
+    const {
+      slack,
+      tools,
+      setResolveThreadChannel,
+      setPinetDeliveryEnabled,
+      noteThreadReply,
+      clearPendingAttention,
+    } = setup();
     setResolveThreadChannel(async () => "D123");
+    // Single-player mode: Pinet is not enabled, so direct Slack posting is
+    // the sanctioned path and does not bypass any broker ownership check.
+    setPinetDeliveryEnabled(false);
 
     await tools.get("slack_send")!.execute("tool-14", {
       thread_ts: "123.456",
@@ -1440,10 +1454,12 @@ describe("registerSlackTools", () => {
     });
   });
 
-  it("sends direct Slack text and a binary file in one threaded external upload", async () => {
-    const { slack, tools, setResolveThreadChannel, setPinetDeliveryAvailable } = setup();
+  it("sends direct Slack text and a binary file in one threaded external upload (single-player)", async () => {
+    const { slack, tools, setResolveThreadChannel, setPinetDeliveryEnabled } = setup();
     setResolveThreadChannel(async () => "D123");
-    setPinetDeliveryAvailable(false);
+    // Single-player mode: direct Slack upload is the only path and does not
+    // bypass broker ownership because Pinet is not enabled at all.
+    setPinetDeliveryEnabled(false);
     const dir = await mkdtemp(path.join(os.tmpdir(), "slack-send-file-test-"));
     const filePath = path.join(dir, "payload.bin");
     await writeFile(filePath, Buffer.from([0, 1, 2, 3]));
@@ -1564,7 +1580,7 @@ describe("registerSlackTools", () => {
     expect(JSON.stringify(response!.details)).not.toContain("files.slack.com/private");
   });
 
-  it("falls back to direct Slack delivery when Pinet thread delivery fails", async () => {
+  it("refuses direct Slack fallback for threaded replies when Pinet delivery fails (#855)", async () => {
     const {
       slack,
       tools,
@@ -1576,27 +1592,45 @@ describe("registerSlackTools", () => {
     setPinetDeliveryAvailable(true);
     sendPinetSlackMessage.mockRejectedValueOnce(new Error("broker unavailable"));
 
-    const response = await tools.get("slack_send")!.execute("tool-pinet-fallback", {
-      thread_ts: "123.456",
-      text: "Fallback reply",
-    });
-
-    expect(sendPinetSlackMessage).toHaveBeenCalledOnce();
-    expect(slack).toHaveBeenCalledWith(
-      "chat.postMessage",
-      "xoxb-initial",
-      expect.objectContaining({
-        channel: "D123",
+    await expect(
+      tools.get("slack_send")!.execute("tool-pinet-fallback", {
         thread_ts: "123.456",
         text: "Fallback reply",
       }),
+    ).rejects.toThrow("broker unavailable");
+
+    expect(sendPinetSlackMessage).toHaveBeenCalledOnce();
+    expect(slack).not.toHaveBeenCalledWith(
+      "chat.postMessage",
+      expect.any(String),
+      expect.any(Object),
     );
-    expect(response.details).toMatchObject({
-      ts: "123.456",
-      channel: "D123",
-      delivery: "slack",
-      fallbackReason: "broker unavailable",
-    });
+  });
+
+  it("refuses direct Slack fallback when Pinet delivery is unavailable for a threaded reply (#855)", async () => {
+    const {
+      slack,
+      tools,
+      setResolveThreadChannel,
+      setPinetDeliveryAvailable,
+      sendPinetSlackMessage,
+    } = setup();
+    setResolveThreadChannel(async () => "D123");
+    setPinetDeliveryAvailable(false);
+
+    await expect(
+      tools.get("slack_send")!.execute("tool-pinet-unavailable", {
+        thread_ts: "123.456",
+        text: "Should refuse when broker is down",
+      }),
+    ).rejects.toThrow(/broker is unavailable/i);
+
+    expect(sendPinetSlackMessage).not.toHaveBeenCalled();
+    expect(slack).not.toHaveBeenCalledWith(
+      "chat.postMessage",
+      expect.any(String),
+      expect.any(Object),
+    );
   });
 
   it("prefers Pinet delivery for threaded slack_post_channel messages", async () => {
@@ -1630,7 +1664,7 @@ describe("registerSlackTools", () => {
     expect(response.details).not.toHaveProperty("ts");
   });
 
-  it("falls back to direct Slack delivery when Pinet message.send times out", async () => {
+  it("refuses direct Slack fallback when Pinet message.send times out on a threaded reply (#855)", async () => {
     const {
       slack,
       tools,
@@ -1642,27 +1676,19 @@ describe("registerSlackTools", () => {
     setPinetDeliveryAvailable(true);
     sendPinetSlackMessage.mockRejectedValueOnce(new Error("Request timed out: message.send"));
 
-    const response = await tools.get("slack_send")!.execute("tool-pinet-timeout-fallback", {
-      thread_ts: "123.456",
-      text: "Timeout fallback reply",
-    });
-
-    expect(sendPinetSlackMessage).toHaveBeenCalledOnce();
-    expect(slack).toHaveBeenCalledWith(
-      "chat.postMessage",
-      "xoxb-initial",
-      expect.objectContaining({
-        channel: "D123",
+    await expect(
+      tools.get("slack_send")!.execute("tool-pinet-timeout-fallback", {
         thread_ts: "123.456",
         text: "Timeout fallback reply",
       }),
+    ).rejects.toThrow("Request timed out: message.send");
+
+    expect(sendPinetSlackMessage).toHaveBeenCalledOnce();
+    expect(slack).not.toHaveBeenCalledWith(
+      "chat.postMessage",
+      expect.any(String),
+      expect.any(Object),
     );
-    expect(response.details).toMatchObject({
-      ts: "123.456",
-      channel: "D123",
-      delivery: "slack",
-      fallbackReason: "Request timed out: message.send",
-    });
   });
 
   it("does not bypass healthy Pinet ownership rejections with direct Slack fallback", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -73,6 +73,14 @@ export interface SlackPinetDeliveryResult {
 }
 
 export interface SlackPinetDeliveryPort {
+  /**
+   * True when Pinet is configured/enabled for this session, regardless of
+   * live broker connectivity. When true, threaded Slack replies MUST route
+   * through the broker; direct Slack fallback is refused even if the broker
+   * is momentarily unavailable, to preserve broker-enforced thread
+   * ownership (see gugu91/extensions#855).
+   */
+  isEnabled: () => boolean;
   isAvailable: () => boolean;
   sendSlackMessage: (input: SlackPinetDeliveryInput) => Promise<SlackPinetDeliveryResult>;
 }
@@ -323,27 +331,6 @@ function isAbortError(error: unknown): boolean {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function isPinetDeliveryFallbackError(error: unknown): boolean {
-  const lower = getErrorMessage(error).toLowerCase();
-  if (lower.includes("already owned")) return false;
-  return (
-    lower.includes("not running") ||
-    lower.includes("unexpected state") ||
-    lower.includes("unavailable") ||
-    lower.includes("not connected") ||
-    lower.includes("disconnected") ||
-    lower.includes("timeout") ||
-    lower.includes("timed out") ||
-    lower.includes("econn") ||
-    lower.includes("socket") ||
-    lower.includes("no transport source") ||
-    lower.includes("no transport channel") ||
-    lower.includes("only allows local file paths") ||
-    lower.includes("no adapter") ||
-    lower.includes("identity is unavailable")
-  );
 }
 
 function classifySlackDispatcherError(error: unknown): SlackDispatcherError {
@@ -920,34 +907,36 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     delivery: "pinet" | "slack";
     adapter?: string;
     messageId?: number;
-    fallbackReason?: string;
   }> {
     const blocks = input.blocks ? normalizeSlackBlocksInput(input.blocks) : undefined;
-    let fallbackReason: string | undefined;
 
-    if (input.threadTs && pinetDelivery) {
-      try {
-        if (pinetDelivery.isAvailable()) {
-          const result = await pinetDelivery.sendSlackMessage({
-            threadId: input.threadTs,
-            channel: input.channel,
-            text: input.text,
-            ...(blocks ? { blocks } : {}),
-            ...(input.files ? { files: input.files } : {}),
-          });
-          return {
-            threadTs: input.threadTs,
-            channel: result.channel,
-            blocksCount: blocks?.length ?? 0,
-            delivery: "pinet",
-            adapter: result.adapter,
-            messageId: result.messageId,
-          };
-        }
-      } catch (error) {
-        if (!isPinetDeliveryFallbackError(error)) throw error;
-        fallbackReason = getErrorMessage(error);
+    // Threaded Slack replies routed through Pinet MUST NOT fall back to direct
+    // Slack when the broker is unavailable or the delivery errors: direct
+    // Slack posting bypasses broker thread-ownership enforcement and lets any
+    // worker with a valid bot token take over a Slack thread it does not own.
+    // See gugu91/extensions#855. Single-player mode (isEnabled === false) and
+    // top-level channel posts (no threadTs) remain unaffected.
+    if (input.threadTs && pinetDelivery?.isEnabled()) {
+      if (!pinetDelivery.isAvailable()) {
+        throw new Error(
+          "Cannot post to Slack thread: Pinet broker is unavailable and direct Slack fallback would bypass thread-ownership enforcement. Wait for the broker to reconnect, or ask the broker to transfer this thread.",
+        );
       }
+      const result = await pinetDelivery.sendSlackMessage({
+        threadId: input.threadTs,
+        channel: input.channel,
+        text: input.text,
+        ...(blocks ? { blocks } : {}),
+        ...(input.files ? { files: input.files } : {}),
+      });
+      return {
+        threadTs: input.threadTs,
+        channel: result.channel,
+        blocksCount: blocks?.length ?? 0,
+        delivery: "pinet",
+        adapter: result.adapter,
+        messageId: result.messageId,
+      };
     }
 
     if (input.files && input.files.length > 0) {
@@ -985,7 +974,6 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
         channel: input.channel,
         blocksCount: blocks?.length ?? 0,
         delivery: "slack",
-        ...(fallbackReason ? { fallbackReason } : {}),
       };
     }
 
@@ -1010,7 +998,6 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
       channel: input.channel,
       blocksCount: blocks?.length ?? 0,
       delivery: "slack",
-      ...(fallbackReason ? { fallbackReason } : {}),
     };
   }
 
@@ -2043,7 +2030,6 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           filesCount: Array.isArray(params.files) ? params.files.length : 0,
           ...(delivery.adapter ? { adapter: delivery.adapter } : {}),
           ...(delivery.messageId ? { messageId: delivery.messageId } : {}),
-          ...(delivery.fallbackReason ? { fallbackReason: delivery.fallbackReason } : {}),
         },
       };
     },
@@ -2973,7 +2959,6 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
           filesCount: Array.isArray(params.files) ? params.files.length : 0,
           ...(delivery.adapter ? { adapter: delivery.adapter } : {}),
           ...(delivery.messageId ? { messageId: delivery.messageId } : {}),
-          ...(delivery.fallbackReason ? { fallbackReason: delivery.fallbackReason } : {}),
         },
       };
     },

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -604,6 +604,7 @@ function buildSlackSendPromptGuidelines(): string[] {
   return [
     "Use slack_send for replies in the current Slack assistant thread; always reply where the task came from.",
     "For rich Block Kit JSON examples or modal/canvas patterns, load the slack-bridge skill instead of relying on tool schemas.",
+    "If slack_send fails with 'broker is unavailable' or 'already owned by another agent', do NOT retry via post_channel or a different tool \u2014 report the blocker in the same thread (or to the broker) and wait for ownership to be transferred; direct posting would bypass thread ownership (#855).",
   ];
 }
 


### PR DESCRIPTION
Fixes #855

## Problem

Workers repeatedly ended up "taking over" Slack threads they were never explicitly assigned to across recent live observations. This is not a single bug — it's the sum of several first-responder-wins ownership races combined with a broker-bypass fallback (see issue #855 for the full trace).

This PR is Phase 1: plug the two easiest broker-bypass holes without changing routing semantics. Phase 2 issues (findAgentMention silent claim, `repairThreadOwnership`, `THREAD_RETARGET_REGEX`, …) will follow separately.

## Change A — refuse direct-Slack fallback when Pinet is enabled

`slack-bridge/slack-tools.ts` `deliverSlackMessage` previously fell back to `slack("chat.postMessage", getBotToken(), body)` whenever `pinetDelivery.isAvailable()` returned false. Any follower session that still held a Slack bot token could bypass broker ownership entirely — the exact takeover pattern reported.

- The `SlackPinetDeliveryPort` gains an `isEnabled()` signal distinct from `isAvailable()`. `isEnabled()` returns true whenever Pinet is configured for this session (regardless of live broker connectivity).
- `deliverSlackMessage` now refuses the direct-Slack path for threaded replies when `isEnabled() === true`. Single-player mode (`isEnabled() === false`) keeps the direct path exactly as before — no behaviour change there.
- The `isPinetDeliveryFallbackError` heuristic (from c377253) and the `fallbackReason` field are removed: for a threaded reply under Pinet, any Pinet-side error is a hard error — the caller sees the clear message rather than a silent bypass.

New tests in `slack-tools.test.ts`:
- Broker unavailable → threaded `slack_send` throws instead of direct-posting.
- Pinet send error → propagates instead of falling back.
- Pinet timeout → propagates instead of falling back.
- Existing "does not bypass healthy Pinet ownership rejections" test is retained.

Two existing single-player tests (rich blocks, threaded file upload) are updated to use the new `setPinetDeliveryEnabled(false)` toggle so they exercise the sanctioned single-player direct path.

## Change B — refuse cross-owner `slackProxy chat.postMessage` at the broker

`slack-bridge/broker/socket-server.ts` `dispatchAdapterCapability` previously called the Slack adapter first and then raced a first-responder-wins claim via `effects.claimThread`. If a follower slackProxy'd `chat.postMessage` at a thread whose owner had been cleared (stale/purged), the follower took over.

- New `checkAdapterCapabilityThreadOwnership` helper inspects the request pre-adapter. For `slack` + `api.call` + `method: chat.postMessage`, if `params.thread_ts` maps to a broker DB thread with a different `ownerAgent`, the request is rejected before Slack is touched.
- `handleAdapterCapability` and `handleLegacySlackProxy` now require a registered caller (matching every other ownership-sensitive handler); `checkAdapterCapabilityThreadOwnership` keeps a defense-in-depth refusal for threaded `chat.postMessage` from an unregistered caller.
- All other adapters/capabilities and unowned or same-owner threads are unaffected.

New tests in `broker/integration.test.ts`:
- Cross-owner `slackProxy chat.postMessage` throws, does not invoke the adapter, and leaves ownership intact.
- Same-owner `slackProxy chat.postMessage` continues to succeed and preserves the existing owner.
- Unregistered caller `slackProxy` / `invokeAdapterCapability` chat.postMessage refused with `Not registered`; adapter not invoked; pre-owned thread unchanged.

## Prompt guidance

`slack-tools.ts buildSlackSendPromptGuidelines` and `pinet-mesh-ops.ts appendSlackThreadTransferNotice` now tell agents to wait for the broker or ask for a transfer when `slack_send` returns `broker is unavailable` or `already owned by another agent`, instead of retrying via `post_channel` and re-opening the bypass.

## Test/lint/typecheck

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 1462 passing, 1 pre-existing unrelated failure (`pinet-tools.test.ts > formats Pinet dispatcher results for human-readable TUI display`), confirmed by stashing this branch and re-running against main.

## Deferred to follow-up issues

- **C.** Stop `findAgentMention` from silently claiming a released known thread (aligns with #811).
- **D.** Tighten `repairThreadOwnership` semantics — mark orphaned instead of clearing, require explicit retarget.
- **E.** Narrow `THREAD_RETARGET_REGEX` so casual human-to-human phrasing does not flip ownership.

## Repro

Reproduced live during the investigation itself: a private-workspace maintainer DM landed on a worker without an explicit assignment, then the same message was redelivered without new signal. Under this PR, either the broker refuses the send with a clear error, or the message never reaches a worker without a legitimate Pinet-brokered assignment.

## Rollback

If this proves too strict for real ops (e.g. a legitimate follower still needs direct posting during a broker outage), the safest interim is to remove Change A only — the broker-side check in Change B is orthogonal and much less likely to affect normal traffic.
