### PR TITLE
chore(release): prepare Pinet 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.4] - 2026-07-06
+
+Pinet v0.2.4 keeps the coordinated `@pinet/*` package set aligned and ships the Slack-bridge thread-ownership hardening merged after the v0.2.3 release prep.
+
+### Version verification
+
+- `pi-extensions` — `0.2.4` (private repo package)
+- `@pinet/transport-core` — `0.2.4`
+- `@pinet/broker-core` — `0.2.4`
+- `@pinet/pinet-core` — `0.2.4`
+- `@pinet/imessage-bridge` — `0.2.4`
+- `@pinet/slack-bridge` — `0.2.4`
+- `@pinet/model-aware-compaction` — `0.2.4`
+
+### Release highlights
+
+- Stops followers from taking over Slack threads they do not own by refusing the direct-Slack `chat.postMessage` fallback in `deliverSlackMessage` whenever Pinet is enabled but the broker is unavailable.
+- Refuses cross-owner `slackProxy chat.postMessage` at the broker before the Slack API is called, closing the first-responder-wins claim race between `applyAdapterCapabilityEffects` and `router.claimThread`.
+- Requires a registered caller on `adapter.capability` and legacy `slack.proxy` (matching every other ownership-sensitive broker RPC) and keeps a defense-in-depth refusal for threaded `chat.postMessage` from unregistered callers.
+- Updates in-agent Slack guidance so agents wait for the broker or ask for a transfer on `broker is unavailable` / `already owned by another agent` instead of retrying via `post_channel`.
+- Freezes the clock in the `pinet-tools` schedule formatter test so CI stays deterministic past hardcoded fire-at timestamps.
+
+### Included pull requests since the v0.2.3 repo release prep
+
+- [#856](https://github.com/gugu91/extensions/pull/856) — fix(slack-bridge): stop workers taking over Slack threads they don't own (#855)
+- [#853](https://github.com/gugu91/extensions/pull/853) — docs: rewrite Pinet READMEs
+
 ## [0.2.3] - 2026-06-30
 
 Pinet v0.2.3 re-synchronizes the coordinated `@pinet/*` package set after the partial v0.2.2 npm publish, and includes the Slack/Pinet fixes merged after the v0.2.2 release prep.

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- Bump the coordinated Pinet package set and the private repo package from `0.2.3` to `0.2.4`.
- Add the `0.2.4` changelog entry for the Slack-bridge thread-ownership hardening merged after `0.2.3`.

## Release state
- Package set: `@pinet/transport-core`, `@pinet/broker-core`, `@pinet/pinet-core`, `@pinet/imessage-bridge`, `@pinet/slack-bridge`, `@pinet/model-aware-compaction`.
- `0.2.4` is not currently published for any package in the release set per `npm view <pkg>@0.2.4 version` checks (all return "not found").
- This PR does not publish, tag, or merge. Those remain maintainer-gated per `plans/npm-publish.md`.

## Included since 0.2.3
- [#856](https://github.com/gugu91/extensions/pull/856) — fix(slack-bridge): stop workers taking over Slack threads they don't own (#855)
- [#853](https://github.com/gugu91/extensions/pull/853) — docs: rewrite Pinet READMEs

## Validation
- `pnpm install --frozen-lockfile` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 1463 passing (0 failures now that #856 also fixed the pre-existing pinet-tools clock bug) ✅
- `pnpm publish:npm` — dry-run publish for all six `@pinet/*` packages succeeded ✅

## Confirmation-gated next steps
- Merge this PR after review/approval.
- Create the `v0.2.4` tag on the merged `main` tip if using the tag-triggered publish path.
- Approve/run the npm publish workflow with the required maintainer gates, or perform the documented maintainer-gated path. No local publish was run.
