### PR TITLE
feat(transport-core): extract shared async primitives (sleep/withTimeout/backoff)

### DIFF
--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -1,4 +1,5 @@
 import * as net from "node:net";
+import { computeBackoffDelay, withTimeout } from "@pinet/transport-core/async";
 import { readMeshSecret } from "./auth.js";
 import { DEFAULT_SOCKET_PATH as PINET_DEFAULT_SOCKET_PATH } from "./paths.js";
 import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
@@ -108,30 +109,13 @@ export const MAX_RECONNECT_DELAY_MS = 30000;
 export const HEARTBEAT_INTERVAL_MS = 5000;
 export const HEARTBEAT_METADATA_PROVIDER_TIMEOUT_MS = 2500;
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
-    timer.unref?.();
-    promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (error: unknown) => {
-        clearTimeout(timer);
-        reject(error instanceof Error ? error : new Error(String(error)));
-      },
-    );
-  });
-}
-
-/** Compute reconnect delay with exponential backoff and jitter. */
+/** Compute reconnect delay with exponential backoff and jitter (±25%). */
 export function computeReconnectDelay(attempt: number, random = Math.random()): number {
-  const baseDelay = INITIAL_RECONNECT_DELAY_MS * Math.pow(2, attempt);
-  const capped = Math.min(baseDelay, MAX_RECONNECT_DELAY_MS);
-  // Add jitter: ±25%
-  const jitter = capped * (0.75 + random * 0.5);
-  return Math.round(jitter);
+  return computeBackoffDelay(attempt, {
+    initialMs: INITIAL_RECONNECT_DELAY_MS,
+    maxMs: MAX_RECONNECT_DELAY_MS,
+    random,
+  });
 }
 
 // ─── Pending request tracker ─────────────────────────────

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -11,6 +11,7 @@ import {
   buildRuntimeScopeCarrier,
   type RuntimeScopeCarrier,
 } from "@pinet/transport-core";
+import { createAbortError, isAbortError, sleep } from "@pinet/transport-core/async";
 import type { ReactionCommandSettings } from "./reaction-triggers.js";
 import { buildPinetReadPointer } from "./broker-inbound-persistence.js";
 import { matchesToolPattern } from "./guardrails.js";
@@ -871,35 +872,10 @@ export interface AbortableOperationTracker {
   isAborting(): boolean;
 }
 
-export function createAbortError(message = "Operation aborted"): Error {
-  const error = new Error(message);
-  error.name = "AbortError";
-  return error;
-}
-
-export function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
-}
+export { createAbortError, isAbortError };
 
 export function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) {
-    return Promise.reject(createAbortError());
-  }
-
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-
-    function onAbort(): void {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", onAbort);
-      reject(createAbortError());
-    }
-
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
+  return sleep(ms, { signal });
 }
 
 export function createAbortableOperationTracker(): AbortableOperationTracker {
@@ -3967,11 +3943,7 @@ export async function callSlackAPI(
       throw new Error(`Slack ${method}: rate limited after ${maxRetries} retries`);
     }
     const wait = Number(res.headers.get("retry-after") ?? "3");
-    if (signal) {
-      await abortableDelay(wait * 1000, signal);
-    } else {
-      await new Promise((resolve) => setTimeout(resolve, wait * 1000));
-    }
+    await sleep(wait * 1000, { signal });
     return callSlackAPI(method, token, body, { signal, retryCount: retryCount + 1 });
   }
 

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { sleep } from "@pinet/transport-core/async";
 import { summarizePinetStableId } from "./pinet-session-formatting.js";
 import type { AgentSessionSummary } from "./broker/types.js";
 import type { PinetReadOptions, PinetReadResult } from "@pinet/pinet-core/pinet-read-formatting";
@@ -150,12 +151,6 @@ function sanitizePathSegment(value: string): string {
 
 function randomSuffix(): string {
   return Math.random().toString(36).slice(2, 8);
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 export function buildSubtreeBrokerPaths(stableId: string): SubtreeBrokerPaths {
@@ -535,7 +530,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
         });
       }
 
-      await delay(1_000);
+      await sleep(1_000);
     }
 
     throw new Error(
@@ -573,7 +568,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       .filter((agent) => isSubtreeChildAgent(agent, agentId));
     await Promise.all(children.map(requestChildExit));
     if (children.length > 0) {
-      await delay(SUBTREE_CHILD_EXIT_GRACE_MS);
+      await sleep(SUBTREE_CHILD_EXIT_GRACE_MS);
     }
 
     const tmuxSocketPath = findTmuxSocketPath();

--- a/transport-core/README.md
+++ b/transport-core/README.md
@@ -8,6 +8,11 @@ Tiny transport-neutral contracts package for the `extensions` repo.
 - canonical `OutboundMessage` contract
 - normalized outbound `content` shape for transport-aware rendering with plain-text fallback
 - canonical `MessageAdapter` transport interface
+- shared zero-dependency async primitives via the `@pinet/transport-core/async`
+  subpath: `sleep` (abortable delay), `withTimeout`, `computeBackoffDelay`
+  (capped + jittered exponential backoff), and `AbortError`/`TimeoutError`
+  helpers. Retry _drivers_ stay bespoke at call sites; this module only owns
+  the primitives they compose.
 
 ## What stays out of scope
 

--- a/transport-core/async.test.ts
+++ b/transport-core/async.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  computeBackoffDelay,
+  createAbortError,
+  createTimeoutError,
+  isAbortError,
+  isTimeoutError,
+  sleep,
+  withTimeout,
+} from "./async.ts";
+
+test("createAbortError produces an Error recognized by isAbortError", () => {
+  const error = createAbortError();
+  assert.equal(error.name, "AbortError");
+  assert.equal(error.message, "Operation aborted");
+  assert.equal(isAbortError(error), true);
+});
+
+test("createAbortError accepts a custom message", () => {
+  assert.equal(createAbortError("shutdown").message, "shutdown");
+});
+
+test("isAbortError rejects non-abort values", () => {
+  assert.equal(isAbortError(new Error("nope")), false);
+  assert.equal(isAbortError("AbortError"), false);
+  assert.equal(isAbortError(undefined), false);
+});
+
+test("sleep resolves after the delay without a signal", async () => {
+  await sleep(5);
+});
+
+test("sleep rejects immediately when the signal is already aborted", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(sleep(60_000, { signal: controller.signal }), isAbortError);
+});
+
+test("sleep rejects with an AbortError when aborted mid-flight", async () => {
+  const controller = new AbortController();
+  const pending = sleep(60_000, { signal: controller.signal });
+  controller.abort();
+  await assert.rejects(pending, isAbortError);
+});
+
+test("sleep resolves normally when the signal never aborts", async () => {
+  const controller = new AbortController();
+  await sleep(5, { signal: controller.signal });
+});
+
+test("createTimeoutError produces an Error recognized by isTimeoutError", () => {
+  const error = createTimeoutError(250);
+  assert.equal(error.name, "TimeoutError");
+  assert.equal(error.message, "Timed out after 250ms");
+  assert.equal(isTimeoutError(error), true);
+});
+
+test("createTimeoutError prefixes an optional label", () => {
+  assert.equal(createTimeoutError(250, "Heartbeat").message, "Heartbeat timed out after 250ms");
+});
+
+test("isTimeoutError rejects non-timeout values", () => {
+  assert.equal(isTimeoutError(createAbortError()), false);
+  assert.equal(isTimeoutError("TimeoutError"), false);
+});
+
+test("withTimeout resolves with the wrapped value when it settles in time", async () => {
+  assert.equal(await withTimeout(Promise.resolve("ok"), 1_000), "ok");
+});
+
+test("withTimeout rejects with a TimeoutError when the promise is too slow", async () => {
+  const slow = new Promise<void>((resolve) => {
+    setTimeout(resolve, 60_000).unref?.();
+  });
+  await assert.rejects(withTimeout(slow, 5), {
+    name: "TimeoutError",
+    message: "Timed out after 5ms",
+  });
+});
+
+test("withTimeout includes the label in the timeout message", async () => {
+  const slow = new Promise<void>((resolve) => {
+    setTimeout(resolve, 60_000).unref?.();
+  });
+  await assert.rejects(withTimeout(slow, 5, "Metadata provider"), {
+    name: "TimeoutError",
+    message: "Metadata provider timed out after 5ms",
+  });
+});
+
+test("withTimeout passes through Error rejections from the wrapped promise", async () => {
+  const failure = new Error("boom");
+  await assert.rejects(withTimeout(Promise.reject(failure), 1_000), (error) => error === failure);
+});
+
+test("withTimeout normalizes non-Error rejections", async () => {
+  await assert.rejects(
+    withTimeout(Promise.reject("boom"), 1_000),
+    (error) => error instanceof Error && error.message === "boom",
+  );
+});
+
+test("computeBackoffDelay grows exponentially before the cap", () => {
+  const options = { initialMs: 1_000, maxMs: 30_000, jitterRatio: 0, random: 0 };
+  assert.equal(computeBackoffDelay(0, options), 1_000);
+  assert.equal(computeBackoffDelay(1, options), 2_000);
+  assert.equal(computeBackoffDelay(2, options), 4_000);
+  assert.equal(computeBackoffDelay(3, options), 8_000);
+});
+
+test("computeBackoffDelay caps at maxMs", () => {
+  const options = { initialMs: 1_000, maxMs: 30_000, jitterRatio: 0, random: 0 };
+  assert.equal(computeBackoffDelay(10, options), 30_000);
+  assert.equal(computeBackoffDelay(50, options), 30_000);
+});
+
+test("computeBackoffDelay treats negative attempts as attempt zero", () => {
+  const options = { initialMs: 1_000, maxMs: 30_000, jitterRatio: 0, random: 0 };
+  assert.equal(computeBackoffDelay(-3, options), 1_000);
+});
+
+test("computeBackoffDelay applies ±25% jitter by default", () => {
+  const low = computeBackoffDelay(0, { initialMs: 1_000, maxMs: 30_000, random: 0 });
+  const high = computeBackoffDelay(0, { initialMs: 1_000, maxMs: 30_000, random: 0.999999 });
+  assert.equal(low, 750);
+  assert.ok(high <= 1_250);
+  assert.ok(high >= 1_249);
+  assert.equal(computeBackoffDelay(0, { initialMs: 1_000, maxMs: 30_000, random: 0.5 }), 1_000);
+});
+
+test("computeBackoffDelay honors a custom growth factor", () => {
+  const options = { initialMs: 100, maxMs: 100_000, factor: 3, jitterRatio: 0, random: 0 };
+  assert.equal(computeBackoffDelay(2, options), 900);
+});
+
+test("computeBackoffDelay matches the historical reconnect-delay formula", () => {
+  // Parity with slack-bridge computeReconnectDelay: capped * (0.75 + random * 0.5).
+  for (const attempt of [0, 1, 3, 7]) {
+    for (const random of [0, 0.25, 0.5, 0.99]) {
+      const capped = Math.min(1_000 * Math.pow(2, attempt), 30_000);
+      assert.equal(
+        computeBackoffDelay(attempt, { initialMs: 1_000, maxMs: 30_000, random }),
+        Math.round(capped * (0.75 + random * 0.5)),
+      );
+    }
+  }
+});

--- a/transport-core/async.ts
+++ b/transport-core/async.ts
@@ -1,0 +1,123 @@
+// Shared async primitives for pi transports and bridges.
+//
+// These are the zero-dependency building blocks that were previously
+// hand-rolled per package (abortable delays, promise timeouts, jittered
+// exponential backoff). Retry *drivers* stay bespoke at call sites — this
+// module only owns the primitives they compose.
+
+/** Create an Error whose name is "AbortError", matching DOM abort semantics. */
+export function createAbortError(message = "Operation aborted"): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+/** True when the value is an Error whose name is "AbortError". */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export interface SleepOptions {
+  /** Optional signal that aborts the sleep early; the promise rejects with an AbortError. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Resolve after `ms` milliseconds. When `options.signal` is provided and
+ * aborts first, the timer is cleared and the promise rejects with an
+ * AbortError (also when the signal is already aborted on entry).
+ */
+export function sleep(ms: number, options: SleepOptions = {}): Promise<void> {
+  const { signal } = options;
+  if (!signal) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+
+  if (signal.aborted) {
+    return Promise.reject(createAbortError());
+  }
+
+  const abortSignal = signal;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      abortSignal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    function onAbort(): void {
+      clearTimeout(timer);
+      abortSignal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    }
+
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/** Create an Error whose name is "TimeoutError". */
+export function createTimeoutError(timeoutMs: number, label?: string): Error {
+  const error = new Error(
+    label ? `${label} timed out after ${timeoutMs}ms` : `Timed out after ${timeoutMs}ms`,
+  );
+  error.name = "TimeoutError";
+  return error;
+}
+
+/** True when the value is an Error whose name is "TimeoutError". */
+export function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
+
+/**
+ * Reject with a TimeoutError when the promise does not settle within
+ * `timeoutMs`. The guard timer is unref'd so it never keeps the process
+ * alive. Non-Error rejections from the wrapped promise are normalized to
+ * Error instances.
+ */
+export function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label?: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(createTimeoutError(timeoutMs, label)), timeoutMs);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+export interface BackoffOptions {
+  /** Delay for attempt 0, before capping and jitter. */
+  initialMs: number;
+  /** Upper bound applied before jitter. */
+  maxMs: number;
+  /** Exponential growth factor per attempt. Default 2. */
+  factor?: number;
+  /** Jitter as a ratio of the capped delay (±ratio). Default 0.25; 0 disables jitter. */
+  jitterRatio?: number;
+  /** Random sample in [0, 1). Injectable for deterministic tests; defaults to Math.random(). */
+  random?: number;
+}
+
+/**
+ * Compute a capped, jittered exponential-backoff delay for a retry attempt.
+ * Attempt numbers below zero are treated as zero. With the defaults the
+ * result is `min(initialMs * 2^attempt, maxMs)` scaled by a random factor
+ * in [0.75, 1.25), rounded to the nearest millisecond.
+ */
+export function computeBackoffDelay(attempt: number, options: BackoffOptions): number {
+  const factor = options.factor ?? 2;
+  const jitterRatio = options.jitterRatio ?? 0.25;
+  const random = options.random ?? Math.random();
+  const base = options.initialMs * Math.pow(factor, Math.max(0, attempt));
+  const capped = Math.min(base, options.maxMs);
+  const jittered = capped * (1 - jitterRatio + random * 2 * jitterRatio);
+  return Math.round(jittered);
+}

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -16,6 +16,7 @@
   "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./async": "./dist/async.js",
     "./package.json": "./package.json"
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
       "@pinet/imessage-bridge": ["./imessage-bridge/index.ts"],
       "@pinet/pinet-core": ["./pinet-core/index.ts"],
       "@pinet/pinet-core/*": ["./pinet-core/*.ts"],
-      "@pinet/transport-core": ["./transport-core/index.ts"]
+      "@pinet/transport-core": ["./transport-core/index.ts"],
+      "@pinet/transport-core/*": ["./transport-core/*.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
## Why

Follow-up to a "should we adopt Effect?" review: the answer was no (conflicts with the zero-runtime-dep convention, viral abstraction, interop friction at the pi ExtensionAPI boundary), but the review surfaced real duplication in hand-rolled async primitives across packages. This PR extracts those primitives into a shared zero-dependency module instead.

Survey findings: there are **no generic retry loops** in the repo — each retry driver (Slack 429, broker reconnect, socket-mode reconnect) is legitimately bespoke. The duplication is in the *primitives* they compose. So this ships exactly those, and deliberately **skips** a speculative `retry()`/`Semaphore` (zero call sites today).

## What

New `@pinet/transport-core/async` subpath export (mirrors the pinet-core subpath pattern):

- `sleep(ms, { signal? })` — abortable delay, rejects with `AbortError`
- `createAbortError` / `isAbortError` — moved from slack-bridge helpers
- `withTimeout(promise, ms, label?)` — unref'd guard timer, `TimeoutError`, normalizes non-Error rejections (behavior parity with the broker/client copy, plus an error name)
- `computeBackoffDelay(attempt, { initialMs, maxMs, factor?, jitterRatio?, random? })` — capped jittered exponential backoff; exact formula parity with `computeReconnectDelay` (test included)

Migrated call sites (packages already depending on transport-core):

- `slack-bridge/helpers.ts` — `abortableDelay` delegates to `sleep`; abort helpers re-exported (no churn for existing importers); `callSlackAPI` 429 wait unified for signal/no-signal branches
- `slack-bridge/broker/client.ts` — local `withTimeout` removed; `computeReconnectDelay` delegates to `computeBackoffDelay` (existing tests pass unchanged)
- `slack-bridge/subtree-broker-runtime.ts` — local `delay()` replaced

Deliberately **not** migrated: `neon-psql`/`browser-playwright` inline delays (would add a workspace dep for one `sleep(100)`).

## Notes for review

- Rebased onto `main` post-0.2.4/#861. Passes the new `agent-standards-lint`: tests use node:assert object/function predicates instead of `(error: unknown)` callbacks, and net explicit-`unknown` count across changed files is flat (the two remaining additions are the `isAbortError`/`isTimeoutError` type-guard signatures, one of which is the pre-existing guard moved from helpers).
- An earlier commit here fixed the stale `2026-07-01` schedule-test timestamp; dropped after `8c3d21a` landed the freeze-clock fix on `main`.
- 21 node:test cases in `transport-core/async.test.ts` (transport-core convention), including a parity test against the historical reconnect-delay formula.
- Root `tsconfig.json` gains `@pinet/transport-core/*` path mapping for source-level typecheck; runtime resolves via the new `./async` export in `transport-core/package.json`.
- Zero token-footprint impact: no new tools, prompts, or schemas.
- Full gate green: `pnpm lint` (incl. agent-standards), `pnpm typecheck`, `pnpm test` (11/11 tasks), `pnpm format:check`.