### PR TITLE
refactor(slack-api): type method resolution boundary

### DIFF
--- a/slack-api/cli-helpers.test.ts
+++ b/slack-api/cli-helpers.test.ts
@@ -3,7 +3,6 @@ import { WebClient } from "@slack/web-api";
 
 import {
   discoverMethods,
-  isJsonObject,
   mergeInput,
   parseCliValue,
   parseJsonObject,
@@ -40,6 +39,13 @@ describe("resolveMethod", () => {
     const client = new WebClient();
     expect(resolveMethod(client, "does.not.exist")).toBeNull();
     expect(resolveMethod(client, "noNamespace")).toBeNull();
+  });
+
+  it("returns null when an intermediate or final property is not callable", () => {
+    const client = new WebClient();
+    expect(resolveMethod(client, "chat.postMessage.nope")).toBeNull();
+    expect(resolveMethod(client, "chat.nope.call")).toBeNull();
+    expect(resolveMethod(client, "token.value")).toBeNull();
   });
 });
 
@@ -89,13 +95,5 @@ describe("mergeInput", () => {
       text: "after",
       unfurl_links: false,
     });
-  });
-});
-
-describe("isJsonObject", () => {
-  it("narrows plain objects", () => {
-    expect(isJsonObject({ ok: true })).toBe(true);
-    expect(isJsonObject(null)).toBe(false);
-    expect(isJsonObject([])).toBe(false);
   });
 });

--- a/slack-api/cli-helpers.ts
+++ b/slack-api/cli-helpers.ts
@@ -1,6 +1,30 @@
 import type { WebClient } from "@slack/web-api";
 
-export type JsonObject = Record<string, unknown>;
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+type SlackApiMethod = (input?: JsonObject) => Promise<JsonValue>;
+type SlackClientMember =
+  | SlackMethodContainer
+  | SlackApiMethod
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+type SlackMethodContainer = {
+  [memberName: string]: SlackClientMember;
+};
+
+function slackMethodContainerFor(client: WebClient): SlackMethodContainer {
+  return client as object as SlackMethodContainer;
+}
+
+function isSlackMethodContainer(value: SlackClientMember): value is SlackMethodContainer {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 /**
  * Discover callable Slack Web API methods by walking the WebClient prototype chain.
@@ -8,15 +32,16 @@ export type JsonObject = Record<string, unknown>;
  */
 export function discoverMethods(client: WebClient): string[] {
   const methods: string[] = [];
+  const root = slackMethodContainerFor(client);
 
-  for (const namespace of Object.keys(client)) {
-    const member = (client as unknown as Record<string, unknown>)[namespace];
-    if (typeof member !== "object" || member === null || typeof namespace !== "string") continue;
+  for (const namespace of Object.keys(root)) {
+    const member = root[namespace];
+    if (!isSlackMethodContainer(member)) continue;
     // Skip private/internal properties and known non-API namespaces
     if (namespace.startsWith("_") || namespace === "token" || namespace === "slackApiUrl") continue;
 
     for (const key of Object.keys(member)) {
-      if (typeof (member as Record<string, unknown>)[key] === "function") {
+      if (typeof member[key] === "function") {
         methods.push(`${namespace}.${key}`);
       }
     }
@@ -29,35 +54,31 @@ export function discoverMethods(client: WebClient): string[] {
 /**
  * Resolve a dot-notated method name to a callable function on the WebClient.
  */
-export function resolveMethod(
-  client: WebClient,
-  methodName: string,
-): ((...args: unknown[]) => Promise<unknown>) | null {
+export function resolveMethod(client: WebClient, methodName: string): SlackApiMethod | null {
   const parts = methodName.split(".");
   if (parts.length < 2) return null;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let target: any = client;
+  let target: SlackClientMember = slackMethodContainerFor(client);
   for (const part of parts) {
-    if (target == null || typeof target !== "object") return null;
+    if (!isSlackMethodContainer(target)) return null;
     target = target[part];
   }
 
-  return typeof target === "function" ? (target as (...args: unknown[]) => Promise<unknown>) : null;
+  return typeof target === "function" ? target : null;
 }
 
-export function parseCliValue(raw: string): unknown {
+export function parseCliValue(raw: string): JsonValue {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return "";
   if (trimmed === "true") return true;
   if (trimmed === "false") return false;
   if (trimmed === "null") return null;
   if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
-  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return JSON.parse(trimmed) as unknown;
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return JSON.parse(trimmed) as JsonValue;
   return raw;
 }
 
-export function parseKeyValueArg(entry: string): { key: string; value: unknown } {
+export function parseKeyValueArg(entry: string): { key: string; value: JsonValue } {
   const separatorIndex = entry.indexOf("=");
   if (separatorIndex <= 0) {
     throw new Error(`Expected KEY=VALUE, received: ${entry}`);
@@ -70,8 +91,8 @@ export function parseKeyValueArg(entry: string): { key: string; value: unknown }
 }
 
 export function parseJsonObject(raw: string): JsonObject {
-  const value = JSON.parse(raw) as unknown;
-  if (!isJsonObject(value)) {
+  const value = JSON.parse(raw) as JsonValue;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error("Expected a JSON object.");
   }
   return value;
@@ -79,15 +100,11 @@ export function parseJsonObject(raw: string): JsonObject {
 
 export function mergeInput(
   base: JsonObject,
-  entries: ReadonlyArray<{ key: string; value: unknown }>,
+  entries: ReadonlyArray<{ key: string; value: JsonValue }>,
 ): JsonObject {
   const merged: JsonObject = { ...base };
   for (const entry of entries) {
     merged[entry.key] = entry.value;
   }
   return merged;
-}
-
-export function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## What

- Replaces the `resolveMethod` `any` escape with a named Slack method-container boundary.
- Adds JSON DTO types for CLI inputs/results so `parseCliValue`, `parseJsonObject`, and merged params do not propagate explicit `unknown`.
- Inlines the one-use JSON-object guard into `parseJsonObject`.
- Adds regression coverage for non-callable/intermediate Slack method paths.

Part of #862.

## Verified

- `pnpm --filter @gugu910/pi-slack-api test`
- `pnpm --filter @gugu910/pi-slack-api typecheck`
- `pnpm --filter @gugu910/pi-slack-api lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
- `pnpm lint && pnpm typecheck && pnpm test`

Pre-push also reran `pnpm lint && pnpm typecheck && pnpm test`.
