### PR TITLE
refactor(transport-core): name JSON payload DTOs

### DIFF
--- a/transport-core/index.test.ts
+++ b/transport-core/index.test.ts
@@ -4,7 +4,9 @@ import {
   buildCompatibilityInstanceScope,
   buildCompatibilityWorkspaceScope,
   buildRuntimeScopeCarrier,
+  type AdapterCapabilityRequest,
   type InboundMessage,
+  type OutboundMessage,
 } from "./index.ts";
 
 test("buildCompatibilityWorkspaceScope keeps unknown workspace ids unknown while preserving compatibility mode", () => {
@@ -67,4 +69,22 @@ test("InboundMessage can carry first-class runtime scope metadata", () => {
 
   assert.equal(message.scope?.workspace?.workspaceId, "T123");
   assert.equal(message.scope?.instance?.compatibilityKey, "default");
+});
+
+test("transport payload DTOs carry JSON-compatible metadata and blocks", () => {
+  const message: OutboundMessage = {
+    threadId: "123.456",
+    channel: "C123",
+    text: "hello",
+    metadata: { attempt: 1, tags: ["owl", "transport"], nested: { ok: true } },
+    blocks: [{ type: "section", text: { type: "mrkdwn", text: "*hello*" } }],
+  };
+  const request: AdapterCapabilityRequest = {
+    capability: "thread.claim",
+    params: { threadId: message.threadId, dryRun: false },
+  };
+
+  assert.deepEqual(message.metadata?.nested, { ok: true });
+  assert.equal(message.blocks?.[0]?.type, "section");
+  assert.equal(request.params.threadId, "123.456");
 });

--- a/transport-core/index.ts
+++ b/transport-core/index.ts
@@ -1,5 +1,15 @@
 export type RuntimeScopeSource = "explicit" | "compatibility";
 
+export type TransportJsonPrimitive = string | number | boolean | null;
+export type TransportJsonValue =
+  | TransportJsonPrimitive
+  | TransportJsonObject
+  | TransportJsonValue[];
+export type TransportJsonObject = { [key: string]: TransportJsonValue };
+export type TransportRichBlock = TransportJsonObject;
+export type AdapterCapabilityParams = TransportJsonObject;
+export type AdapterCapabilityPayload = TransportJsonObject;
+
 export const DEFAULT_COMPATIBILITY_SCOPE_KEY = "default";
 
 export interface WorkspaceInstallScopeCarrier {
@@ -95,7 +105,7 @@ export interface InboundMessage {
   text: string;
   timestamp: string;
   isChannelMention?: boolean;
-  metadata?: Record<string, unknown>;
+  metadata?: TransportJsonObject;
   scope?: RuntimeScopeCarrier;
 }
 
@@ -107,7 +117,7 @@ export interface NormalizedMessageContent {
    * This remains intentionally Slack-shaped for the current publish-readiness
    * track while a future transport-neutral rich-content model is considered.
    */
-  slackBlocks?: ReadonlyArray<Record<string, unknown>>;
+  slackBlocks?: ReadonlyArray<TransportRichBlock>;
 }
 
 export interface OutboundAttachmentFile {
@@ -122,12 +132,12 @@ export interface OutboundMessage {
   channel: string;
   text: string;
   content?: NormalizedMessageContent;
-  blocks?: ReadonlyArray<Record<string, unknown>>;
+  blocks?: ReadonlyArray<TransportRichBlock>;
   files?: ReadonlyArray<OutboundAttachmentFile>;
   agentName?: string;
   agentEmoji?: string;
   agentOwnerToken?: string;
-  metadata?: Record<string, unknown>;
+  metadata?: TransportJsonObject;
   scope?: RuntimeScopeCarrier;
 }
 
@@ -142,11 +152,11 @@ export interface AdapterCapabilityEffects {
 
 export interface AdapterCapabilityRequest {
   capability: string;
-  params: Record<string, unknown>;
+  params: AdapterCapabilityParams;
 }
 
 export interface AdapterCapabilityResult {
-  result: Record<string, unknown>;
+  result: AdapterCapabilityPayload;
   effects?: AdapterCapabilityEffects;
 }
 


### PR DESCRIPTION
## What

- Adds named transport JSON DTOs for metadata, rich blocks, and adapter capability payloads.
- Replaces broad `Record<string, unknown>` transport contracts with those named JSON-compatible types.
- Adds a compile/runtime test covering metadata, block, and capability params payloads.

Part of #862.

## Verified

- `pnpm --filter @pinet/transport-core test`
- `pnpm --filter @pinet/transport-core typecheck`
- `pnpm --filter @pinet/transport-core lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
