### PR TITLE
refactor(pinet-core): type output option args

### DIFF
--- a/pinet-core/output-options.test.ts
+++ b/pinet-core/output-options.test.ts
@@ -30,7 +30,13 @@ describe("normalizePinetOutputOptions", () => {
     expect(() => normalizePinetOutputOptions({ format: "yaml" })).toThrow(
       'format must be "cli" or "json".',
     );
+    expect(() => normalizePinetOutputOptions({ "-f": 7 })).toThrow(
+      'format must be "cli" or "json".',
+    );
     expect(() => normalizePinetOutputOptions({ full: "true" })).toThrow(
+      "full must be a boolean when provided.",
+    );
+    expect(() => normalizePinetOutputOptions({ "--full": 1 })).toThrow(
       "full must be a boolean when provided.",
     );
   });

--- a/pinet-core/output-options.ts
+++ b/pinet-core/output-options.ts
@@ -1,11 +1,22 @@
 export type PinetOutputFormat = "cli" | "json";
 
+type PinetOutputFormatInput = string | number | boolean | null | undefined;
+type PinetOutputFullInput = boolean | string | number | null | undefined;
+
+export interface PinetOutputOptionsArgs {
+  format?: PinetOutputFormatInput;
+  f?: PinetOutputFormatInput;
+  "-f"?: PinetOutputFormatInput;
+  full?: PinetOutputFullInput;
+  "--full"?: PinetOutputFullInput;
+}
+
 export interface PinetOutputOptions {
   format: PinetOutputFormat;
   full: boolean;
 }
 
-export function normalizePinetOutputOptions(args: Record<string, unknown>): PinetOutputOptions {
+export function normalizePinetOutputOptions(args: PinetOutputOptionsArgs): PinetOutputOptions {
   const rawFormat = args.format ?? args.f ?? args["-f"];
   const format = rawFormat == null ? "cli" : String(rawFormat).trim().toLowerCase();
   if (format !== "cli" && format !== "json") {


### PR DESCRIPTION
## What

- Replaces the broad `Record<string, unknown>` output-options input with a named `PinetOutputOptionsArgs` DTO.
- Keeps existing runtime validation for format/full aliases.
- Adds coverage for invalid numeric `-f` and `--full` values.

Part of #862.

## Verified

- `pnpm --filter @pinet/pinet-core test -- output-options`
- `pnpm --filter @pinet/pinet-core typecheck`
- `pnpm --filter @pinet/pinet-core lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
