### PR TITLE
fix: address gpt-5.5 code review of the Pinet website

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -57,5 +57,8 @@ the site in step.
 
 ## Deploy
 
-Not wired up yet. For GitHub Pages or similar, set `site` (and `base` for
-project sub-paths) in `astro.config.mjs`, then publish `dist/`.
+Deployed on Vercel: project `tmustiers-projects/pinet`, root directory
+`website/`, production alias <https://pinet-mesh.vercel.app>. Deploys are
+CLI-driven for now (`vercel deploy --prod` from the repo root); native git
+integration waits on the Vercel GitHub App being installed for
+`gugu91/extensions`. `site` is set in `astro.config.mjs`.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -14,9 +14,9 @@ import MeshDiagram from "../components/MeshDiagram.astro";
       <h1>One gateway.<br />One message primitive.<br />Many agents.</h1>
       <p class="dek">
         Pinet is a local-first coordination layer for <a
-          href="https://github.com/badlogic/pi-mono">pi</a> coding agents. One broker routes every
-        message, whether it arrives from Slack or is typed at the broker's own terminal. It keeps
-        a mesh of named worker agents shipping: writing code, reviewing each other's pull
+          href="https://github.com/badlogic/pi-mono">pi</a> coding agents. One broker runs the
+        mesh: it routes every Slack message, and you can talk to it directly at its own terminal.
+        It keeps named worker agents shipping: writing code, reviewing each other's pull
         requests, and repairing themselves when something stalls.
       </p>
       <span class="cmd"><span class="prompt">$ </span>pi install npm:@pinet/slack-bridge</span>
@@ -104,8 +104,8 @@ import MeshDiagram from "../components/MeshDiagram.astro";
             <span class="clause-title">Work &amp; reply.</span>
             <p>
               The agent acknowledges, does the work (code, tests, PRs), and replies in the same
-              thread with <code>slack_send</code>. Every message ends in a reply or a visible
-              failure; nothing drops silently.
+              thread with <code>slack_send</code>. If the agent stalls instead, the RALPH loop
+              picks the thread up, so messages do not just disappear.
             </p>
           </div>
         </li>

--- a/website/src/pages/slack-bridge.astro
+++ b/website/src/pages/slack-bridge.astro
@@ -234,7 +234,9 @@ users:read</code></pre>
           <dt>confirmation gates</dt>
           <dd>
             Require explicit confirmation per action:
-            <code>{'"requireConfirmation": ["slack:create_channel", "slack:upload", "slack:delete"]'}</code>
+            <code
+              >{'"security": { "requireConfirmation": ["slack:create_channel", "slack:upload", "slack:delete"] }'}</code
+            >
           </dd>
         </div>
         <div>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -398,8 +398,15 @@ tr:last-child td {
     display: block;
   }
 
+  /* Visually hidden, not display:none: header text stays available
+     to screen readers ahead of the stacked rows. */
   thead {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
 
   tr {


### PR DESCRIPTION
Follow-up to #863, which was merged while its review pass was still running. A gpt-5.5 (xhigh) reviewer produced a request-changes verdict; this PR lands the fixes. Full review posted on #863.

## Fixes

- **Critical** — `slack-bridge.astro`: the confirmation-gates snippet showed `requireConfirmation` at the top level of `slack-bridge` config, but the parser and `slack-bridge/README.md` expect it under `security`. The snippet now shows `"security": { "requireConfirmation": [...] }`.
- **Warning** — `index.astro` hero: no longer claims the broker "routes every message" typed at its terminal. It routes Slack messages; you talk to it directly at its own terminal.
- **Warning** — `index.astro` §02: "every message ends in a reply or a visible failure" softened to what the docs support: RALPH picks up stalled threads.
- **Warning** — `website/README.md`: deploy section updated from "Not wired up yet" to the actual Vercel setup.
- **Nit** — `global.css`: stacked-table `thead` is visually hidden (clip) rather than `display: none`, keeping header text available to screen readers.

## Adjudicated, not changed

The reviewer flagged the terminal-ingress framing on the core page and diagram too. Those wordings ("you can type to it in its own terminal", "talk to it there") describe the broker being a pi session — literally true — so they stay. Only the hero overstated routing semantics.

## Verification

- `pnpm build` clean; impeccable detector zero findings across all three pages
- Zero horizontal overflow at 390px; `security` snippet and hero visually verified