### PR TITLE
refactor(openai-shaping): type settings JSON boundary

### DIFF
--- a/openai-execution-shaping/config.ts
+++ b/openai-execution-shaping/config.ts
@@ -40,9 +40,13 @@ export interface LoadConfigOptions {
   env?: NodeJS.ProcessEnv;
 }
 
-function parseJsonFile(filePath: string): unknown | null {
+type SettingsJsonPrimitive = string | number | boolean | null;
+type SettingsJsonValue = SettingsJsonPrimitive | SettingsJsonObject | SettingsJsonValue[];
+type SettingsJsonObject = { [key: string]: SettingsJsonValue };
+
+function parseJsonFile(filePath: string): SettingsJsonValue | null {
   try {
-    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as SettingsJsonValue;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[${SETTINGS_KEY}] Failed to parse config ${filePath}: ${message}`);
@@ -55,10 +59,10 @@ function readSettingsConfig(
 ): { path: string; raw: OpenAIExecutionShapingConfig } | null {
   if (!fs.existsSync(settingsPath)) return null;
   const parsed = parseJsonFile(settingsPath);
-  if (!parsed || typeof parsed !== "object") return null;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
 
-  const raw = (parsed as Record<string, unknown>)[SETTINGS_KEY];
-  if (!raw || typeof raw !== "object") return null;
+  const raw = parsed[SETTINGS_KEY];
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
 
   return {
     path: `${settingsPath}#${SETTINGS_KEY}`,

--- a/openai-execution-shaping/helpers.test.ts
+++ b/openai-execution-shaping/helpers.test.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveConfig } from "./config.js";
+import { loadConfig, resolveConfig } from "./config.js";
 import {
   buildAutoContinueMessage,
   buildExecutionShapingPrompt,
@@ -51,6 +54,33 @@ describe("resolveConfig", () => {
     expect(config.providerSet.has("openai")).toBe(true);
     expect(config.providerSet.has("openai-codex")).toBe(true);
     expect(config.providerSet.has("anthropic")).toBe(false);
+  });
+
+  it("ignores malformed settings roots and sections", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openai-shaping-config-"));
+    try {
+      const rootArrayPath = join(dir, "root-array.json");
+      writeFileSync(rootArrayPath, JSON.stringify([]));
+      expect(
+        loadConfig({
+          cwd: dir,
+          agentDir: dir,
+          env: { PI_OPENAI_EXECUTION_SHAPING_SETTINGS: rootArrayPath },
+        }).sourcePath,
+      ).toBeNull();
+
+      const sectionArrayPath = join(dir, "section-array.json");
+      writeFileSync(sectionArrayPath, JSON.stringify({ "openai-execution-shaping": [] }));
+      expect(
+        loadConfig({
+          cwd: dir,
+          agentDir: dir,
+          env: { PI_OPENAI_EXECUTION_SHAPING_SETTINGS: sectionArrayPath },
+        }).sourcePath,
+      ).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## What

- Adds named JSON DTOs for the OpenAI execution-shaping settings file boundary.
- Removes the explicit `unknown`/generic record parse path in `config.ts`.
- Rejects array roots/sections as malformed settings and covers those cases.

Part of #862.

## Verified

- `pnpm --filter @gugu910/pi-openai-execution-shaping test`
- `pnpm --filter @gugu910/pi-openai-execution-shaping typecheck`
- `pnpm --filter @gugu910/pi-openai-execution-shaping lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
