### PR TITLE
refactor(model-compaction): type settings JSON boundary

### DIFF
--- a/model-aware-compaction/config.test.ts
+++ b/model-aware-compaction/config.test.ts
@@ -1,5 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveConfig } from "./config.js";
+import { loadConfig, resolveConfig } from "./config.js";
 
 describe("resolveConfig", () => {
   it("is disabled by default with useful example rules", () => {
@@ -21,5 +24,32 @@ describe("resolveConfig", () => {
       ],
     });
     expect(config.rules).toEqual([{ model: "anthropic/*", activeContextTokens: 90_000 }]);
+  });
+
+  it("loads object settings and ignores malformed settings shapes", () => {
+    const root = mkdtempSync(join(tmpdir(), "model-aware-compaction-"));
+    try {
+      const projectPi = join(root, ".pi");
+      mkdirSync(projectPi);
+      const settingsPath = join(projectPi, "settings.json");
+      writeFileSync(settingsPath, JSON.stringify({ "model-aware-compaction": [] }));
+      expect(loadConfig(root, root).sourcePath).toBeNull();
+
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          "model-aware-compaction": {
+            enabled: true,
+            rules: [{ model: "openai/*", activeContextTokens: 120_000 }],
+          },
+        }),
+      );
+      const loaded = loadConfig(root, root);
+      expect(loaded.enabled).toBe(true);
+      expect(loaded.rules).toEqual([{ model: "openai/*", activeContextTokens: 120_000 }]);
+      expect(loaded.sourcePath).toBe(`${settingsPath}#model-aware-compaction`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/model-aware-compaction/config.ts
+++ b/model-aware-compaction/config.ts
@@ -24,12 +24,17 @@ export interface ResolvedConfig {
   sourcePath: string | null;
 }
 
+type SettingsJsonPrimitive = string | number | boolean | null;
+type SettingsJsonValue = SettingsJsonPrimitive | SettingsJsonObject | SettingsJsonValue[];
+type SettingsJsonObject = { [key: string]: SettingsJsonValue };
+
 function parseSettings(
   path: string,
 ): { raw: ModelAwareCompactionConfig; sourcePath: string } | null {
   if (!fs.existsSync(path)) return null;
   try {
-    const parsed = JSON.parse(fs.readFileSync(path, "utf8")) as Record<string, unknown>;
+    const parsed = JSON.parse(fs.readFileSync(path, "utf8")) as SettingsJsonValue;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
     const value = parsed[SETTINGS_KEY];
     if (!value || typeof value !== "object" || Array.isArray(value)) return null;
     return { raw: value as ModelAwareCompactionConfig, sourcePath: `${path}#${SETTINGS_KEY}` };


### PR DESCRIPTION
## What

- Adds named JSON DTOs for the model-aware compaction settings-file boundary.
- Removes the direct `Record<string, unknown>` JSON parse cast from `config.ts`.
- Covers malformed array settings plus a valid project settings load.

Part of #862.

## Verified

- `pnpm --filter @pinet/model-aware-compaction test -- config`
- `pnpm --filter @pinet/model-aware-compaction typecheck`
- `pnpm --filter @pinet/model-aware-compaction lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
