### PR TITLE
refactor(neon-psql): type settings JSON boundary

### DIFF
--- a/neon-psql/settings.test.ts
+++ b/neon-psql/settings.test.ts
@@ -138,6 +138,17 @@ describe("loadConfig", () => {
     expect(result).toBeNull();
   });
 
+  it("ignores malformed array config roots and settings sections", () => {
+    const explicitPath = path.join(tmpDir, "explicit-array.json");
+    fs.writeFileSync(explicitPath, JSON.stringify([]));
+    expect(
+      loadConfig({ cwd, agentDir, extensionDir, env: { PI_NEON_PSQL_CONFIG: explicitPath } }),
+    ).toBeNull();
+
+    fs.writeFileSync(path.join(agentDir, "settings.json"), JSON.stringify({ "neon-psql": [] }));
+    expect(loadConfig({ cwd, agentDir, extensionDir, env: {} })).toBeNull();
+  });
+
   it("preserves absolute log paths", () => {
     const absoluteLogPath = path.join(tmpDir, "logs", "neon.log");
     fs.writeFileSync(

--- a/neon-psql/settings.ts
+++ b/neon-psql/settings.ts
@@ -82,9 +82,13 @@ export interface LoadConfigOptions {
   env?: NodeJS.ProcessEnv;
 }
 
-function readJsonFile(filePath: string): unknown | null {
+type ConfigJsonPrimitive = string | number | boolean | null;
+type ConfigJsonValue = ConfigJsonPrimitive | ConfigJsonObject | ConfigJsonValue[];
+type ConfigJsonObject = { [key: string]: ConfigJsonValue };
+
+function readJsonFile(filePath: string): ConfigJsonValue | null {
   try {
-    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as ConfigJsonValue;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[neon-psql] Failed to parse config ${filePath}: ${message}`);
@@ -95,7 +99,7 @@ function readJsonFile(filePath: string): unknown | null {
 function readConfigFile(filePath: string): RawConfigSource | null {
   if (!fs.existsSync(filePath)) return null;
   const parsed = readJsonFile(filePath);
-  if (!parsed || typeof parsed !== "object") return null;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
   return {
     raw: parsed as FileConfig,
     pathLabel: filePath,
@@ -105,10 +109,10 @@ function readConfigFile(filePath: string): RawConfigSource | null {
 function readSettingsConfig(settingsPath: string): RawConfigSource | null {
   if (!fs.existsSync(settingsPath)) return null;
   const parsed = readJsonFile(settingsPath);
-  if (!parsed || typeof parsed !== "object") return null;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
 
-  const raw = (parsed as Record<string, unknown>)[SETTINGS_KEY];
-  if (!raw || typeof raw !== "object") return null;
+  const raw = parsed[SETTINGS_KEY];
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
 
   return {
     raw: raw as FileConfig,


### PR DESCRIPTION
## What

- Adds named JSON DTOs for Neon psql config/settings file parsing.
- Removes explicit `unknown` and generic record casts from the settings boundary.
- Rejects malformed array config roots/sections with regression coverage.

Part of #862.

## Verified

- `pnpm --filter @gugu910/pi-neon-psql test -- settings`
- `pnpm --filter @gugu910/pi-neon-psql typecheck`
- `pnpm --filter @gugu910/pi-neon-psql lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
