### PR TITLE
refactor(slack-bridge): name slack request body dto

### DIFF
--- a/slack-bridge/slack-request-runtime.test.ts
+++ b/slack-bridge/slack-request-runtime.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSlackRequestRuntime } from "./slack-request-runtime.js";
+import { createSlackRequestRuntime, type SlackRequestBody } from "./slack-request-runtime.js";
 
 const slackApiState = vi.hoisted(() => ({
   callSlackApi: vi.fn(),
@@ -45,7 +45,7 @@ describe("createSlackRequestRuntime", () => {
       async (
         _method: string,
         _token: string,
-        _body?: Record<string, unknown>,
+        _body?: SlackRequestBody,
         options?: { signal?: AbortSignal },
       ) =>
         new Promise((_resolve, reject) => {

--- a/slack-bridge/slack-request-runtime.ts
+++ b/slack-bridge/slack-request-runtime.ts
@@ -1,10 +1,12 @@
 import { createAbortableOperationTracker } from "./helpers.js";
 import { callSlackApi, type SlackResult } from "./slack-api.js";
 
+export type SlackRequestBody = NonNullable<Parameters<typeof callSlackApi>[2]>;
+
 export type SlackRequestCall = (
   method: string,
   token: string,
-  body?: Record<string, unknown>,
+  body?: SlackRequestBody,
 ) => Promise<SlackResult>;
 
 export interface SlackRequestRuntime {


### PR DESCRIPTION
## What

- Replaces the request runtime `Record<string, unknown>` body parameter with a named `SlackRequestBody` DTO derived from the Slack API boundary.
- Updates the runtime test mock to use the named body type.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --dir slack-bridge vitest run slack-request-runtime.test.ts`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
