### PR TITLE
ci: parallelize quality checks

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,9 +9,13 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TELEMETRY_DISABLED: "1"
+
 jobs:
-  quality:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -32,18 +36,176 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Run lint checks
+        run: pnpm lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Run type checks
+        run: pnpm typecheck
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build packages
+        run: pnpm build:packages
+
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install StyLua
         run: npm install --global @johnnymorganz/stylua-bin@2.0.2
+
+      - name: Run format checks
+        run: pnpm format:check
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build test package dependencies
+        run: pnpm build:test-deps
+
+      - name: Run tests
+        run: pnpm test
+
+  nvim-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.1
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install Neovim
         run: |
           sudo apt-get update
           sudo apt-get install -y neovim
 
-      - name: Run quality checks
-        run: pnpm check
+      - name: Run Neovim smoke tests
+        run: pnpm --filter @gugu910/pi-nvim-bridge test
 
-      - name: Run tests
-        run: pnpm test
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs:
+      - lint
+      - typecheck
+      - build
+      - format
+      - test
+      - nvim-smoke
+    if: ${{ always() }}
+    steps:
+      - name: Verify quality jobs
+        run: |
+          echo "lint: ${{ needs.lint.result }}"
+          echo "typecheck: ${{ needs.typecheck.result }}"
+          echo "build: ${{ needs.build.result }}"
+          echo "format: ${{ needs.format.result }}"
+          echo "test: ${{ needs.test.result }}"
+          echo "nvim-smoke: ${{ needs.nvim-smoke.result }}"
+
+          [[ "${{ needs.lint.result }}" == "success" ]]
+          [[ "${{ needs.typecheck.result }}" == "success" ]]
+          [[ "${{ needs.build.result }}" == "success" ]]
+          [[ "${{ needs.format.result }}" == "success" ]]
+          [[ "${{ needs.test.result }}" == "success" ]]
+          [[ "${{ needs.nvim-smoke.result }}" == "success" ]]

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -40,7 +40,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run *.test.ts"
+    "test": "vitest run --config ../vitest.config.ts *.test.ts"
   },
   "dependencies": {
     "@pinet/transport-core": "file:../transport-core"

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -29,7 +29,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --config ../vitest.config.ts"
   },
   "dependencies": {
     "@pinet/transport-core": "file:../transport-core"

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -42,7 +42,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --config ../vitest.config.ts"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/neon-psql/package.json
+++ b/neon-psql/package.json
@@ -39,7 +39,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --config ../vitest.config.ts"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/nvim-bridge/package.json
+++ b/nvim-bridge/package.json
@@ -37,7 +37,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --config ../vitest.config.ts"
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.34.49"

--- a/openai-execution-shaping/package.json
+++ b/openai-execution-shaping/package.json
@@ -36,7 +36,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --config ../vitest.config.ts"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typecheck": "turbo run typecheck",
     "build": "turbo run build",
     "build:packages": "node ./scripts/build-all.mjs",
+    "build:test-deps": "node ./scripts/build-all.mjs --test-deps",
     "test": "turbo run test && node --test scripts/*.test.mjs",
     "deploy:slack": "node --experimental-strip-types ./slack-bridge/deploy-manifest.ts",
     "publish:npm": "node ./scripts/publish-npm-packages.mjs",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -32,7 +32,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run *.test.ts"
+    "test": "vitest run --config ../vitest.config.ts *.test.ts"
   },
   "dependencies": {
     "@pinet/broker-core": "file:../broker-core",

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -1,33 +1,89 @@
 #!/usr/bin/env node
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-// Keep this in dependency order so package exports that point at dist/*.js are
-// available before downstream packages are imported by pi from a Git checkout.
-const packages = [
-  "transport-core",
-  "broker-core",
-  "pinet-core",
-  "imessage-bridge",
-  "slack-api",
-  "nvim-bridge",
-  "neon-psql",
-  "openai-execution-shaping",
-  "model-aware-compaction",
-  "slack-bridge",
+// Keep tiers in dependency order so package exports that point at dist/*.js are
+// available before downstream packages emit declarations or are imported by pi
+// from a Git checkout. Workspaces within a tier have no dist-export dependency
+// on each other and can build in parallel.
+export const buildTiers = [
+  [
+    "transport-core",
+    "nvim-bridge",
+    "neon-psql",
+    "slack-api",
+    "openai-execution-shaping",
+    "model-aware-compaction",
+  ],
+  ["broker-core", "imessage-bridge"],
+  ["pinet-core"],
+  ["slack-bridge"],
 ];
 
-for (const workspace of packages) {
-  const result = spawnSync(process.execPath, ["../scripts/build-package.mjs"], {
-    cwd: path.join(repoRoot, workspace),
-    stdio: "inherit",
-  });
+// The test suite imports most packages from TypeScript source via Vitest aliases,
+// but slack-bridge has a publish-readiness test that builds its package. That
+// declaration emit needs these upstream dist-export packages to exist first.
+export const testDependencyTiers = [
+  ["transport-core"],
+  ["broker-core", "imessage-bridge"],
+  ["pinet-core"],
+];
 
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+export function flattenBuildTiers(tiers = buildTiers) {
+  return tiers.flat();
+}
+
+function buildWorkspace(workspace) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["../scripts/build-package.mjs"], {
+      cwd: path.join(repoRoot, workspace),
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const suffix = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      reject(new Error(`${workspace} build failed with ${suffix}`));
+    });
+  });
+}
+
+export async function buildAll(tiers = buildTiers) {
+  for (const tier of tiers) {
+    const results = await Promise.allSettled(tier.map((workspace) => buildWorkspace(workspace)));
+    const failures = results.flatMap((result) => {
+      if (result.status === "fulfilled") {
+        return [];
+      }
+
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      return [reason];
+    });
+
+    if (failures.length > 0) {
+      throw new Error(
+        `Build tier failed:\n${failures.map((failure) => `- ${failure}`).join("\n")}`,
+      );
+    }
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;
+if (import.meta.url === invokedPath) {
+  try {
+    const tiers = process.argv.includes("--test-deps") ? testDependencyTiers : buildTiers;
+    await buildAll(tiers);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
   }
 }

--- a/scripts/build-all.test.mjs
+++ b/scripts/build-all.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildTiers, flattenBuildTiers, testDependencyTiers } from "./build-all.mjs";
+
+const expectedBuildPackages = [
+  "transport-core",
+  "broker-core",
+  "pinet-core",
+  "imessage-bridge",
+  "slack-api",
+  "nvim-bridge",
+  "neon-psql",
+  "openai-execution-shaping",
+  "model-aware-compaction",
+  "slack-bridge",
+];
+
+const distExportDependencies = {
+  "broker-core": ["transport-core"],
+  "imessage-bridge": ["transport-core"],
+  "pinet-core": ["broker-core", "transport-core"],
+  "slack-bridge": ["broker-core", "imessage-bridge", "pinet-core", "transport-core"],
+};
+
+test("build tiers cover every dist-building package exactly once", () => {
+  const flattened = flattenBuildTiers();
+
+  assert.deepEqual([...flattened].sort(), [...expectedBuildPackages].sort());
+  assert.equal(new Set(flattened).size, flattened.length);
+});
+
+test("build tiers keep dist-export dependencies in earlier tiers", () => {
+  assertTierDependencies(buildTiers, distExportDependencies);
+});
+
+test("test dependency tiers cover only the dist exports needed before tests", () => {
+  assert.deepEqual(flattenBuildTiers(testDependencyTiers), [
+    "transport-core",
+    "broker-core",
+    "imessage-bridge",
+    "pinet-core",
+  ]);
+  assertTierDependencies(testDependencyTiers, {
+    "broker-core": ["transport-core"],
+    "imessage-bridge": ["transport-core"],
+    "pinet-core": ["broker-core", "transport-core"],
+  });
+});
+
+function assertTierDependencies(tiers, dependenciesByPackage) {
+  const tierByPackage = new Map();
+  tiers.forEach((tier, tierIndex) => {
+    tier.forEach((workspace) => tierByPackage.set(workspace, tierIndex));
+  });
+
+  for (const [workspace, dependencies] of Object.entries(dependenciesByPackage)) {
+    const workspaceTier = tierByPackage.get(workspace);
+    assert.notEqual(workspaceTier, undefined, `${workspace} is missing from build tiers`);
+
+    for (const dependency of dependencies) {
+      const dependencyTier = tierByPackage.get(dependency);
+      assert.notEqual(dependencyTier, undefined, `${dependency} is missing from build tiers`);
+      assert.ok(
+        dependencyTier < workspaceTier,
+        `${dependency} must build before ${workspace} because package exports resolve to dist`,
+      );
+    }
+  }
+}

--- a/slack-api/package.json
+++ b/slack-api/package.json
@@ -37,7 +37,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --config ../vitest.config.ts"
   },
   "dependencies": {
     "@slack/web-api": "^7.9.1"

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -46,7 +46,7 @@
     "prepack": "pnpm run build",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --config ../vitest.config.ts"
   },
   "dependencies": {
     "@pinet/broker-core": "file:../broker-core",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,8 +17,44 @@ export default defineConfig({
         replacement: fileURLToPath(new URL("./imessage-bridge/index.ts", import.meta.url)),
       },
       {
+        find: /^@gugu910\/pi-pinet-core$/,
+        replacement: fileURLToPath(new URL("./pinet-core/index.ts", import.meta.url)),
+      },
+      {
+        find: /^@gugu910\/pi-pinet-core\/(.+)$/,
+        replacement: `${fileURLToPath(new URL("./pinet-core/", import.meta.url))}$1.ts`,
+      },
+      {
         find: /^@gugu910\/pi-transport-core$/,
         replacement: fileURLToPath(new URL("./transport-core/index.ts", import.meta.url)),
+      },
+      {
+        find: /^@pinet\/broker-core$/,
+        replacement: fileURLToPath(new URL("./broker-core/index.ts", import.meta.url)),
+      },
+      {
+        find: /^@pinet\/broker-core\/(.+)$/,
+        replacement: `${fileURLToPath(new URL("./broker-core/", import.meta.url))}$1.ts`,
+      },
+      {
+        find: /^@pinet\/imessage-bridge$/,
+        replacement: fileURLToPath(new URL("./imessage-bridge/index.ts", import.meta.url)),
+      },
+      {
+        find: /^@pinet\/pinet-core$/,
+        replacement: fileURLToPath(new URL("./pinet-core/index.ts", import.meta.url)),
+      },
+      {
+        find: /^@pinet\/pinet-core\/(.+)$/,
+        replacement: `${fileURLToPath(new URL("./pinet-core/", import.meta.url))}$1.ts`,
+      },
+      {
+        find: /^@pinet\/transport-core$/,
+        replacement: fileURLToPath(new URL("./transport-core/index.ts", import.meta.url)),
+      },
+      {
+        find: /^@pinet\/transport-core\/(.+)$/,
+        replacement: `${fileURLToPath(new URL("./transport-core/", import.meta.url))}$1.ts`,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Split the single sequential Quality job into parallel lint, typecheck, format, test, and Neovim smoke jobs, with an aggregate `quality` job to preserve the existing check name.
- Use `pnpm install --ignore-scripts` in CI jobs so static checks do not pay the postinstall package-build cost.
- Centralize Vitest package aliases so tests run against TS source, then build only the dist-export dependencies needed by the slack-bridge publish-readiness test.
- Parallelize `scripts/build-all.mjs` tiers for faster package export builds and add coverage for the build ordering.

## Baseline
Latest successful main run was ~1m50s wall-clock: install 16s, StyLua 5s, Neovim 12s, quality checks 38s, tests 24s. The install step spent ~14s in `postinstall` build-all.

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm check`
- clean dist, `pnpm build:test-deps`
- `pnpm test`
- `pnpm build:packages`
- push hook: `pnpm lint && pnpm typecheck && pnpm test`
