### PR TITLE
refactor(nvim): name rpc JSON boundary

### DIFF
--- a/nvim-bridge/helpers.ts
+++ b/nvim-bridge/helpers.ts
@@ -42,9 +42,15 @@ export type CommentRpcRequest =
       };
     };
 
-function asObject(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== "object" || value === null) return null;
-  return value as Record<string, unknown>;
+type NvimRpcJsonPrimitive = string | number | boolean | null;
+export type NvimRpcJsonValue = NvimRpcJsonPrimitive | NvimRpcJsonObject | NvimRpcJsonValue[];
+export interface NvimRpcJsonObject {
+  [key: string]: NvimRpcJsonValue;
+}
+
+function asNvimRpcObject(value: unknown): NvimRpcJsonObject | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as NvimRpcJsonObject;
 }
 
 export function toPositiveInteger(value: unknown): number | null {
@@ -75,7 +81,7 @@ export function formatContext(state: EditorState): string {
 }
 
 export function parseNvimEvent(value: unknown): NvimEvent | null {
-  const event = asObject(value);
+  const event = asNvimRpcObject(value);
   if (!event || typeof event.type !== "string") return null;
 
   switch (event.type) {
@@ -127,7 +133,7 @@ export function parseNvimEvent(value: unknown): NvimEvent | null {
 }
 
 export function parseCommentRpcRequest(value: unknown): CommentRpcRequest | null {
-  const request = asObject(value);
+  const request = asNvimRpcObject(value);
   if (
     !request ||
     typeof request.id !== "string" ||
@@ -138,7 +144,7 @@ export function parseCommentRpcRequest(value: unknown): CommentRpcRequest | null
   }
 
   if (request.type === "comment.list" || request.type === "comment.sync") {
-    const payload = asObject(request.payload) ?? {};
+    const payload = asNvimRpcObject(request.payload) ?? {};
     const limit = toPositiveInteger(payload.limit);
     return {
       id: request.id,
@@ -151,7 +157,7 @@ export function parseCommentRpcRequest(value: unknown): CommentRpcRequest | null
   }
 
   if (request.type === "comment.list_all") {
-    const payload = asObject(request.payload) ?? {};
+    const payload = asNvimRpcObject(request.payload) ?? {};
     const limit = toPositiveInteger(payload.limit);
     return {
       id: request.id,
@@ -163,10 +169,10 @@ export function parseCommentRpcRequest(value: unknown): CommentRpcRequest | null
   }
 
   if (request.type === "comment.add") {
-    const payload = asObject(request.payload);
+    const payload = asNvimRpcObject(request.payload);
     if (!payload || typeof payload.body !== "string") return null;
 
-    const context = asObject(payload.context);
+    const context = asNvimRpcObject(payload.context);
 
     return {
       id: request.id,

--- a/nvim-bridge/index.ts
+++ b/nvim-bridge/index.ts
@@ -5,7 +5,13 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import * as path from "node:path";
-import { formatContext, parseNvimEvent, type EditorState, type NvimEvent } from "./helpers.js";
+import {
+  formatContext,
+  parseNvimEvent,
+  type EditorState,
+  type NvimEvent,
+  type NvimRpcJsonValue,
+} from "./helpers.js";
 
 type NvimCommand = { type: "open_file"; file: string; line?: number };
 
@@ -209,7 +215,7 @@ export default function (pi: ExtensionAPI) {
           if (!line.trim()) continue;
 
           try {
-            const parsed = JSON.parse(line) as unknown;
+            const parsed = JSON.parse(line) as NvimRpcJsonValue;
             const event = parseNvimEvent(parsed);
             if (!event) continue;
 


### PR DESCRIPTION
## What

- Adds named nvim RPC JSON DTO types for incoming editor messages.
- Routes object parsing through a named nvim RPC boundary instead of a generic record helper.
- Types the socket JSON parse result with the named boundary DTO before event validation.

Part of #862.

## Verified

- `pnpm --filter @gugu910/pi-nvim-bridge test -- index`
- `pnpm --filter @gugu910/pi-nvim-bridge typecheck`
- `pnpm --filter @gugu910/pi-nvim-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
