### PR TITLE
refactor(browser-playwright): name args input DTO

### DIFF
--- a/browser-playwright/index.ts
+++ b/browser-playwright/index.ts
@@ -35,6 +35,7 @@ import {
   parseBrowserToolRequest,
   requireStringArg,
   type BrowserAction,
+  type BrowserArgsInput,
   type BrowserArtifactPayload,
   type BrowserJsonObject,
   type BrowserResultPayload,
@@ -1281,7 +1282,7 @@ export default function browserPlaywrightExtension(pi: ExtensionAPI) {
         action: params.action as BrowserAction,
         session_id: params.session_id,
         page_id: params.page_id,
-        args: params.args,
+        args: params.args as BrowserArgsInput | undefined,
         input_json: params.input_json,
       });
 

--- a/browser-playwright/protocol.ts
+++ b/browser-playwright/protocol.ts
@@ -23,7 +23,7 @@ export interface BrowserJsonObject {
   [key: string]: BrowserJsonValue;
 }
 export type BrowserArgs = Record<string, BrowserScalar>;
-export type BrowserArgsInput = Record<string, unknown>;
+export type BrowserArgsInput = BrowserJsonObject;
 export type BrowserResultPayload = BrowserJsonObject;
 export type BrowserArtifactPayload = BrowserJsonObject;
 
@@ -180,9 +180,9 @@ const BROWSER_ACTION_SCHEMAS: Record<BrowserAction, BrowserActionSchema> = {
 function parseInputJson(raw: string | undefined): BrowserArgs {
   if (!raw) return {};
 
-  let parsed: unknown;
+  let parsed: BrowserJsonValue;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(raw) as BrowserJsonValue;
   } catch (error) {
     throw new Error(
       `input_json must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
@@ -192,7 +192,10 @@ function parseInputJson(raw: string | undefined): BrowserArgs {
   return parseArgsObject(parsed, "input_json");
 }
 
-function parseArgsObject(raw: unknown, source: "args" | "input_json"): BrowserArgs {
+function parseArgsObject(
+  raw: BrowserArgsInput | BrowserJsonValue | undefined,
+  source: "args" | "input_json",
+): BrowserArgs {
   if (raw === undefined) return {};
   if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error(`${source} must be a JSON object.`);


### PR DESCRIPTION
## What

- Reuses the named browser JSON DTO for structured browser args input.
- Types `input_json` parsing through the browser JSON boundary before scalar-arg validation.
- Keeps the TypeBox external params handoff explicit at the tool boundary.

Part of #862.

## Verified

- `pnpm --filter @gugu910/pi-browser-playwright test -- protocol`
- `pnpm --filter @gugu910/pi-browser-playwright typecheck`
- `pnpm --filter @gugu910/pi-browser-playwright lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
