### PR TITLE
refactor(slack-bridge): type dnd presence timestamps

### DIFF
--- a/slack-bridge/slack-presence.ts
+++ b/slack-bridge/slack-presence.ts
@@ -23,11 +23,13 @@ export interface SlackPresenceSnapshot {
   online?: boolean;
 }
 
+export type SlackPresenceTimestampValue = string | number | null | undefined;
+
 export interface SlackDndInfoLike {
-  dnd_enabled?: unknown;
-  next_dnd_end_ts?: unknown;
-  snooze_enabled?: unknown;
-  snooze_endtime?: unknown;
+  dnd_enabled?: boolean | null;
+  next_dnd_end_ts?: SlackPresenceTimestampValue;
+  snooze_enabled?: boolean | null;
+  snooze_endtime?: SlackPresenceTimestampValue;
 }
 
 export function stripSlackUserReference(value: string): string {
@@ -89,7 +91,7 @@ export function findSlackPresenceDirectoryUser(
   return null;
 }
 
-function parsePositiveTs(value: unknown): number | undefined {
+function parsePositiveTs(value: SlackPresenceTimestampValue): number | undefined {
   if (typeof value === "number" && Number.isFinite(value) && value > 0) {
     return value;
   }


### PR DESCRIPTION
## What

- Adds a named Slack presence timestamp value type for DND/snooze API fields.
- Narrows DND booleans away from broad `unknown` while keeping string/number timestamp compatibility.
- Leaves presence formatting and lookup behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --dir slack-bridge vitest run --config ../vitest.config.ts slack-presence.test.ts`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
