### PR TITLE
refactor(slack-bridge): type pinet session details

### DIFF
--- a/slack-bridge/pinet-session-formatting.ts
+++ b/slack-bridge/pinet-session-formatting.ts
@@ -13,6 +13,30 @@ export interface ParsedPinetStableId {
   hasPath: boolean;
 }
 
+export type PinetSessionFullDetails = AgentSessionSearchInfo & {
+  session: AgentSessionSummary | null;
+  jsonlPath?: string;
+};
+
+export interface PinetSessionCompactDetails {
+  agentId: string;
+  agentName: string;
+  emoji: string;
+  pid: number;
+  status: AgentSessionSearchInfo["status"];
+  health: "disconnected" | "live";
+  session: string | null;
+  sessionKind: AgentSessionKind | null;
+  host: string | null;
+  repo: string | null;
+  branch: string | null;
+  tmuxSession: string | null;
+  lastSeen: string;
+  disconnectedAt: string | null;
+  relatedThreadIds: string[];
+  matchedBy: string[];
+}
+
 function stableIdDigest(stableId: string): string {
   return crypto.createHash("sha256").update(stableId).digest("hex").slice(0, 12);
 }
@@ -72,7 +96,7 @@ export function getPinetSessionFilename(stableId: string | null | undefined): st
 
 export function buildPinetSessionFullDetails(
   session: AgentSessionSearchInfo,
-): Record<string, unknown> {
+): PinetSessionFullDetails {
   const summary = summarizePinetStableId(session.stableId);
   const sessionPath = getPinetSessionPath(session.stableId);
   return {
@@ -84,7 +108,7 @@ export function buildPinetSessionFullDetails(
 
 export function buildPinetSessionCompactDetails(
   session: AgentSessionSearchInfo,
-): Record<string, unknown> {
+): PinetSessionCompactDetails {
   const summary = summarizePinetStableId(session.stableId);
   return {
     agentId: session.agentId,


### PR DESCRIPTION
## What

- Adds named detail DTOs for compact/full Pinet session formatting.
- Replaces generic `Record<string, unknown>` return types with explicit session detail shapes.
- Keeps the serialized fields and path redaction behavior unchanged.

Part of #862.

## Verified

- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
