### PR TITLE
refactor(pinet-core): name read message metadata DTO

### DIFF
--- a/pinet-core/pinet-read-formatting.ts
+++ b/pinet-core/pinet-read-formatting.ts
@@ -4,7 +4,10 @@ import {
   type PinetMailClass,
 } from "@pinet/broker-core/mail-classification";
 
-export type PinetReadMessageMetadata = Record<string, unknown>;
+export type PinetReadMetadataValue = unknown;
+export interface PinetReadMessageMetadata {
+  [key: string]: PinetReadMetadataValue;
+}
 
 export interface PinetInboxItem {
   inboxId: number;


### PR DESCRIPTION
## What

- Adds a named metadata DTO for Pinet read message formatting.
- Replaces the inline `Record<string, unknown>` alias with explicit `PinetReadMessageMetadata` / `PinetReadMetadataValue` names.
- Keeps broker message metadata compatibility and read formatting behavior unchanged.

Part of #862.

## Verified

- `pnpm --filter @pinet/pinet-core test -- pinet-read-formatting`
- `pnpm --filter @pinet/pinet-core typecheck`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/pinet-core lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
