### PR TITLE
refactor(openai-shaping): type message details dto

### DIFF
--- a/openai-execution-shaping/index.ts
+++ b/openai-execution-shaping/index.ts
@@ -30,13 +30,18 @@ interface CompatibleExtensionContext extends ExtensionContext {
   hasUI?: boolean;
 }
 
+interface OpenAIExecutionShapingMessageDetails {
+  reason?: string;
+  attempt?: number;
+}
+
 interface CompatibleExtensionAPI extends ExtensionAPI {
   sendMessage(
     message: {
       customType: string;
       content: string;
       display: boolean;
-      details?: Record<string, unknown>;
+      details?: OpenAIExecutionShapingMessageDetails;
     },
     options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
   ): void;


### PR DESCRIPTION
## What

- Adds a named DTO for OpenAI execution-shaping extension message details.
- Replaces the generic `Record<string, unknown>` sendMessage details surface with the known reason/attempt shape.
- Keeps auto-continue behavior unchanged.

Part of #862.

## Verified

- `pnpm --filter @gugu910/pi-openai-execution-shaping typecheck`
- `pnpm --filter @gugu910/pi-openai-execution-shaping lint`
- `pnpm --filter @gugu910/pi-openai-execution-shaping test`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
