### PR TITLE
ci: trim redundant test work

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -93,6 +93,11 @@ jobs:
       - name: Build packages
         run: pnpm build:packages
 
+      - name: Verify package build assets
+        run: |
+          test -f slack-bridge/dist/prompts/broker/tmux.md
+          grep -q "PRIORITIZED ISSUE GATE" slack-bridge/dist/prompts/broker/tmux.md
+
   format:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -145,11 +150,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Build test package dependencies
-        run: pnpm build:test-deps
-
       - name: Run tests
         run: pnpm test
+        env:
+          SKIP_SLACK_BRIDGE_PACKAGE_BUILD_TEST: "1"
 
   nvim-smoke:
     runs-on: ubuntu-latest
@@ -175,12 +179,13 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install Neovim
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: v0.10.4
 
       - name: Run Neovim smoke tests
-        run: pnpm --filter @gugu910/pi-nvim-bridge test
+        run: pnpm --filter @gugu910/pi-nvim-bridge test nvim-lua.test.ts
 
   quality:
     runs-on: ubuntu-latest

--- a/slack-bridge/broker-prompt-loader.test.ts
+++ b/slack-bridge/broker-prompt-loader.test.ts
@@ -303,19 +303,24 @@ describe("packaged default broker prompt", () => {
 
   // This exercises the real package build, including declaration emit; loaded worktrees and
   // pre-push runs can exceed Vitest's default 5s timeout even though the build path is expected
-  // for publish readiness.
-  it("copies prompt assets into dist/prompts so the packaged tmux.md is loadable", async () => {
-    await execFileAsync("node", ["../scripts/build-package.mjs"], { cwd: process.cwd() });
+  // for publish readiness. CI's dedicated build job runs the full package build and verifies this
+  // asset, so the separate test job can skip this duplicate build without losing coverage.
+  it.skipIf(process.env.SKIP_SLACK_BRIDGE_PACKAGE_BUILD_TEST === "1")(
+    "copies prompt assets into dist/prompts so the packaged tmux.md is loadable",
+    async () => {
+      await execFileAsync("node", ["../scripts/build-package.mjs"], { cwd: process.cwd() });
 
-    const distPromptPath = path.join(process.cwd(), "dist", "prompts", "broker", "tmux.md");
-    await expect(fs.access(distPromptPath)).resolves.toBeUndefined();
-    const result = await loadBrokerPrompt({
-      workspaceRoot,
-      homeDir,
-      defaultPromptPath: distPromptPath,
-    });
+      const distPromptPath = path.join(process.cwd(), "dist", "prompts", "broker", "tmux.md");
+      await expect(fs.access(distPromptPath)).resolves.toBeUndefined();
+      const result = await loadBrokerPrompt({
+        workspaceRoot,
+        homeDir,
+        defaultPromptPath: distPromptPath,
+      });
 
-    expect(result.source).toBe("packaged");
-    expect(result.content).toContain("PRIORITIZED ISSUE GATE");
-  }, 60_000);
+      expect(result.source).toBe("packaged");
+      expect(result.content).toContain("PRIORITIZED ISSUE GATE");
+    },
+    60_000,
+  );
 });

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -13,7 +13,7 @@ import {
   HEARTBEAT_METADATA_PROVIDER_TIMEOUT_MS,
   computeReconnectDelay,
 } from "./client.js";
-import type { BrokerConnectOpts } from "./client.js";
+import type { BrokerClientOptions, BrokerConnectOpts } from "./client.js";
 import { RPC_AGENT_NAME_CONFLICT, RPC_METHOD_NOT_FOUND } from "./types.js";
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -27,6 +27,10 @@ interface MockServer {
   respondTo: (conn: net.Socket, id: number, result: unknown) => void;
   respondError: (conn: net.Socket, id: number, code: number, message: string) => void;
   connectOpts: BrokerConnectOpts;
+}
+
+function createFastReconnectClientOptions(connectOpts: BrokerConnectOpts): BrokerClientOptions {
+  return { ...connectOpts, reconnectDelayMs: () => 5 };
 }
 
 function createMockServer(port = 0): Promise<MockServer> {
@@ -1601,7 +1605,7 @@ describe("BrokerClient — exponential backoff", () => {
 
   it("reconnectAttempt starts at 0 and increments after disconnect", async () => {
     const mock = await createMockServer();
-    const client = new BrokerClient(mock.connectOpts);
+    const client = new BrokerClient(createFastReconnectClientOptions(mock.connectOpts));
     await client.connect();
     expect(client.getReconnectAttempt()).toBe(0);
 
@@ -1682,7 +1686,7 @@ describe("BrokerClient — onReconnect callback", () => {
   it("scheduleReconnect fires onDisconnect then onReconnect after server restart", async () => {
     const mock = await createMockServer();
     const port = mock.port;
-    const client = new BrokerClient(mock.connectOpts);
+    const client = new BrokerClient(createFastReconnectClientOptions(mock.connectOpts));
     let disconnectFired = false;
     let reconnectFired = false;
 
@@ -1727,7 +1731,7 @@ describe("BrokerClient — onReconnect callback", () => {
   it("keeps retrying until it can reconnect and re-register with stable identity", async () => {
     let mock = await createMockServer();
     const port = mock.port;
-    const client = new BrokerClient(mock.connectOpts);
+    const client = new BrokerClient(createFastReconnectClientOptions(mock.connectOpts));
     let disconnectFired = false;
     let reconnectFired = false;
 
@@ -1801,7 +1805,7 @@ describe("BrokerClient — onReconnect callback", () => {
   it("re-requests broker-assigned identity after reconnect when the original name was blank", async () => {
     let mock = await createMockServer();
     const port = mock.port;
-    const client = new BrokerClient(mock.connectOpts);
+    const client = new BrokerClient(createFastReconnectClientOptions(mock.connectOpts));
     let disconnectFired = false;
     let reconnectFired = false;
 
@@ -1877,7 +1881,7 @@ describe("BrokerClient — onReconnect callback", () => {
   it("stops reconnecting and surfaces a terminal error when an explicit name collides on reconnect", async () => {
     let mock = await createMockServer();
     const port = mock.port;
-    const client = new BrokerClient(mock.connectOpts);
+    const client = new BrokerClient(createFastReconnectClientOptions(mock.connectOpts));
     let disconnectFired = false;
     let reconnectFired = false;
     let reconnectFailed: Error | null = null;
@@ -1953,7 +1957,7 @@ describe("BrokerClient — onReconnect callback", () => {
     expect(client.getReconnectAttempt()).toBe(0);
     expect(client.getRegisteredIdentity()).toBeNull();
 
-    await new Promise((resolve) => setTimeout(resolve, INITIAL_RECONNECT_DELAY_MS + 250));
+    await new Promise((resolve) => setTimeout(resolve, 25));
     expect(mock.received).toHaveLength(1);
 
     client.disconnect();

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -219,12 +219,22 @@ export interface BrokerClientAuthOptions {
   meshSecretPath?: string;
 }
 
+export interface BrokerClientTimingOptions {
+  /** @internal Allows tests to exercise reconnect behavior without waiting for production backoff. */
+  reconnectDelayMs?: (attempt: number) => number;
+}
+
+export type BrokerClientOptions = BrokerConnectOpts &
+  BrokerClientAuthOptions &
+  BrokerClientTimingOptions;
+
 // ─── BrokerClient ────────────────────────────────────────
 
 export class BrokerClient {
   private readonly connectOpts: BrokerConnectOpts;
   private readonly meshSecret: string | null;
   private readonly meshSecretPath: string | null;
+  private readonly reconnectDelayMs: (attempt: number) => number;
   private socket: net.Socket | null = null;
   private connected = false;
   private shuttingDown = false;
@@ -246,7 +256,12 @@ export class BrokerClient {
   private readonly pending = new Map<number, PendingRequest>();
   private buffer = "";
 
-  constructor(opts?: string | (BrokerConnectOpts & BrokerClientAuthOptions)) {
+  constructor(opts?: string | BrokerClientOptions) {
+    this.reconnectDelayMs =
+      typeof opts === "object" && opts !== null
+        ? (opts.reconnectDelayMs ?? computeReconnectDelay)
+        : computeReconnectDelay;
+
     if (opts === undefined) {
       this.connectOpts = { path: DEFAULT_SOCKET_PATH };
       this.meshSecret = null;
@@ -786,7 +801,7 @@ export class BrokerClient {
 
   private scheduleReconnect(): void {
     if (this.shuttingDown || this.reconnectTimer) return;
-    const delay = computeReconnectDelay(this.reconnectAttempt);
+    const delay = this.reconnectDelayMs(this.reconnectAttempt);
     this.reconnectAttempt++;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,7 @@
         "../vitest.config.ts",
         "../pnpm-lock.yaml"
       ],
+      "env": ["SKIP_SLACK_BRIDGE_PACKAGE_BUILD_TEST"],
       "outputs": [],
       "passThroughEnv": ["TMPDIR"]
     }


### PR DESCRIPTION
## Summary
- Speed up BrokerClient reconnect tests by injecting a short reconnect delay in tests instead of waiting for production backoff timers.
- Remove duplicate package-build work from the CI test job; the build job still runs the full package build and now verifies the packaged broker prompt asset.
- Install Neovim from a prebuilt setup action and narrow the smoke job to the single Lua smoke test file.

## Measured impact
- Recent main Quality runs after the first CI split were ~51-62s wall-clock, with `test` at ~39-53s and apt-based `nvim-smoke` sometimes reaching ~41s.
- This PR CI completed in ~42s wall-clock. Slowest jobs are now `build` 29s and `test` 29s; `nvim-smoke` is down to 19s.

## Verification
- clean dist, `SKIP_SLACK_BRIDGE_PACKAGE_BUILD_TEST=1 pnpm test`
- `pnpm build:packages`
- verified `slack-bridge/dist/prompts/broker/tmux.md` exists and contains `PRIORITIZED ISSUE GATE`
- default `pnpm test`
- `pnpm check`
- `git diff --check`
- GitHub Actions Quality: https://github.com/gugu91/extensions/actions/runs/28908374392
