### PR TITLE
refactor(slack-bridge): type imessage metadata dto

### DIFF
--- a/slack-bridge/imessage-tools.ts
+++ b/slack-bridge/imessage-tools.ts
@@ -5,6 +5,10 @@ import { getDefaultIMessageThreadId, normalizeIMessageRecipient } from "@pinet/i
 import type { Broker } from "./broker/index.js";
 import { sendBrokerMessage } from "./broker/message-send.js";
 
+export interface IMessageToolMetadata extends Record<string, unknown> {
+  recipient: string;
+}
+
 export interface IMessageToolSendInput {
   threadId: string;
   body: string;
@@ -14,7 +18,7 @@ export interface IMessageToolSendInput {
   agentName: string;
   agentEmoji: string;
   agentOwnerToken: string;
-  metadata: Record<string, unknown>;
+  metadata: IMessageToolMetadata;
 }
 
 export interface IMessageToolSendResult {


### PR DESCRIPTION
## What

- Adds a named `IMessageToolMetadata` DTO for iMessage send metadata.
- Replaces the generic metadata record on `IMessageToolSendInput` with the known recipient-bearing shape.
- Keeps iMessage send behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- imessage-tools`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
