### PR TITLE
refactor(slack-bridge): type scope probe bodies

### DIFF
--- a/slack-bridge/slack-scope-diagnostics.ts
+++ b/slack-bridge/slack-scope-diagnostics.ts
@@ -1,11 +1,49 @@
 import { buildSlackRequest } from "./helpers.js";
 import type { SlackResult } from "./slack-api.js";
 
+export type SlackScopeDiagnosticsSurface = "files" | "bookmarks" | "pins";
+
+export type SlackScopeProbeBody = Record<string, unknown>;
+
+interface SlackFileInfoScopeProbeBody extends SlackScopeProbeBody {
+  file: string;
+}
+
+interface SlackCompleteUploadScopeProbeFile {
+  id: string;
+  title: string;
+}
+
+interface SlackCompleteUploadScopeProbeBody extends SlackScopeProbeBody {
+  files: SlackCompleteUploadScopeProbeFile[];
+  channel_id: string;
+}
+
+interface SlackChannelScopeProbeBody extends SlackScopeProbeBody {
+  channel_id: string;
+}
+
+interface SlackBookmarkRemoveScopeProbeBody extends SlackChannelScopeProbeBody {
+  bookmark_id: string;
+}
+
+interface SlackPinnedItemScopeProbeBody extends SlackScopeProbeBody {
+  channel: string;
+  timestamp?: string;
+}
+
+export type SlackScopeProbeRequestBody =
+  | SlackFileInfoScopeProbeBody
+  | SlackCompleteUploadScopeProbeBody
+  | SlackChannelScopeProbeBody
+  | SlackBookmarkRemoveScopeProbeBody
+  | SlackPinnedItemScopeProbeBody;
+
 interface SlackScopeProbe {
   key: string;
-  surface: "files" | "bookmarks" | "pins";
+  surface: SlackScopeDiagnosticsSurface;
   method: string;
-  body: Record<string, unknown>;
+  body: SlackScopeProbeRequestBody;
   expectedScopes: string[];
   okErrors: string[];
 }
@@ -19,7 +57,7 @@ export type SlackScopeDiagnosticsStatus =
 
 export interface SlackScopeProbeResult {
   key: string;
-  surface: "files" | "bookmarks" | "pins";
+  surface: SlackScopeDiagnosticsSurface;
   method: string;
   expectedScopes: string[];
   status: "ok" | "missing" | "unavailable";
@@ -33,7 +71,7 @@ export interface SlackScopeDiagnostics {
   status: SlackScopeDiagnosticsStatus;
   checkedAt: string | null;
   summary: string;
-  surfaces: Array<"files" | "bookmarks" | "pins">;
+  surfaces: SlackScopeDiagnosticsSurface[];
   missingScopes: string[];
   results: SlackScopeProbeResult[];
   error?: string;
@@ -263,7 +301,7 @@ export async function detectSlackScopeDiagnostics(
   );
   const surfaces = uniqueSorted(
     results.flatMap((result) => (result.status === "missing" ? [result.surface] : [])),
-  ) as Array<"files" | "bookmarks" | "pins">;
+  ) as SlackScopeDiagnosticsSurface[];
 
   if (missingScopes.length > 0) {
     return {


### PR DESCRIPTION
## What

- Adds named DTOs for Slack scope diagnostic probe request bodies.
- Reuses a named surface type across diagnostics results.
- Keeps Slack scope drift probing behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- slack-scope-diagnostics`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
