### PR TITLE
refactor(slack-bridge): type modal view object

### DIFF
--- a/slack-bridge/slack-modals.ts
+++ b/slack-bridge/slack-modals.ts
@@ -1,8 +1,12 @@
-export type SlackModalView = Record<string, unknown>;
+export type SlackModalObject = Record<string, unknown>;
+
+export interface SlackModalView extends SlackModalObject {
+  type: "modal";
+}
 
 const PI_SLACK_MODAL_CONTEXT_KEY = "__piSlackModalContext";
 
-function isSlackModalObject(value: unknown): value is Record<string, unknown> {
+function isSlackModalObject(value: unknown): value is SlackModalObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 


### PR DESCRIPTION
## What

- Adds a named `SlackModalObject` boundary type for modal JSON objects.
- Narrows `SlackModalView` to the validated modal view shape.
- Keeps modal private metadata encoding/decoding behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- slack-modals`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
