### PR TITLE
refactor(slack-bridge): type thread transfer metadata

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -458,15 +458,28 @@ function formatPinetInboxPointer(entry: FollowerInboxEntry): string {
   return buildPinetReadPointer(entry.message.threadId ?? "");
 }
 
+type ThreadTransferMetadata = Record<string, unknown>;
+
+interface ThreadOwnershipTransferPayload extends Record<string, unknown> {
+  threadId?: string;
+  source?: string;
+  channel?: string;
+}
+
+interface TransferredSlackThreadContext {
+  threadId: string;
+  channel?: string;
+}
+
 function getTransferredSlackThreadContext(
-  metadata: Record<string, unknown> | null,
-): { threadId: string; channel?: string } | null {
+  metadata: ThreadTransferMetadata | null,
+): TransferredSlackThreadContext | null {
   const transfer = metadata?.threadOwnershipTransfer;
   if (!transfer || typeof transfer !== "object" || Array.isArray(transfer)) {
     return null;
   }
 
-  const raw = transfer as Record<string, unknown>;
+  const raw = transfer as ThreadOwnershipTransferPayload;
   const threadId = typeof raw.threadId === "string" ? raw.threadId.trim() : "";
   if (!threadId) {
     return null;


### PR DESCRIPTION
## What

- Adds named DTOs for Slack thread-ownership transfer metadata.
- Uses the DTO when formatting Pinet inbox transfer suffixes.
- Keeps formatting behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
