### PR TITLE
refactor(slack-bridge): type pinet control metadata

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -707,14 +707,16 @@ export async function reloadPinetRuntimeSafely<State>(
   }
 }
 
-export interface PinetControlEnvelope {
+export type PinetControlMetadata = Record<string, unknown>;
+
+export interface PinetControlEnvelope extends PinetControlMetadata {
   type: "pinet:control";
   action: PinetControlCommand;
 }
 
 function parsePinetControlEnvelope(value: unknown): PinetControlCommand | null {
   if (typeof value !== "object" || value === null) return null;
-  const record = value as Record<string, unknown>;
+  const record = value as PinetControlMetadata;
   if (record.type !== "pinet:control") return null;
   return parsePinetControlCommand(record.action);
 }
@@ -760,8 +762,8 @@ export function buildPinetControlMessage(command: PinetControlCommand): string {
 
 export function normalizeOutgoingPinetControlMessage(
   body: string,
-  metadata?: Record<string, unknown>,
-): { body: string; metadata: Record<string, unknown> } | null {
+  metadata?: PinetControlMetadata,
+): { body: string; metadata: PinetControlMetadata } | null {
   const command = getPinetControlCommandFromText(body);
   if (!command) return null;
 


### PR DESCRIPTION
## What

- Adds a named `PinetControlMetadata` DTO for Slack bridge Pinet control envelopes.
- Uses it for control-envelope parsing and outgoing control message normalization.
- Keeps control command behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
