### PR TITLE
refactor(slack-bridge): type pinet control command message

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -795,11 +795,15 @@ function extractPinetSkinStatusVocabulary(value: unknown): PinetSkinStatusVocabu
   return Object.keys(vocabulary).length > 0 ? vocabulary : undefined;
 }
 
-export function extractPinetControlCommand(message: {
+export interface PinetControlCommandMessage {
   threadId?: string;
   body?: string;
-  metadata?: Record<string, unknown> | null;
-}): PinetControlCommand | null {
+  metadata?: PinetControlMetadata | null;
+}
+
+export function extractPinetControlCommand(
+  message: PinetControlCommandMessage,
+): PinetControlCommand | null {
   const metadata = message.metadata ?? {};
   if (metadata.scheduledWakeup === true) return null;
 


### PR DESCRIPTION
## What

- Adds a named `PinetControlCommandMessage` DTO for control command extraction.
- Reuses the existing Pinet control metadata type at that boundary.
- Keeps control command extraction behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
