### PR TITLE
refactor(slack-bridge): type slack request body

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -855,11 +855,18 @@ function serializeSlackFormValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
+export type SlackRequestBody = Record<string, unknown>;
+
+export interface SlackApiRequest {
+  url: string;
+  init: RequestInit;
+}
+
 export function buildSlackRequest(
   method: string,
   token: string,
-  body?: Record<string, unknown>,
-): { url: string; init: RequestInit } {
+  body?: SlackRequestBody,
+): SlackApiRequest {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
   };


### PR DESCRIPTION
## What

- Adds named DTOs for Slack API request bodies and generated request envelopes.
- Applies the DTO at the Slack request-building boundary.
- Keeps request serialization behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
