### PR TITLE
refactor(slack-bridge): type follower inbox metadata

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -2213,6 +2213,8 @@ export interface FollowerThreadState {
   owner?: string;
 }
 
+export type FollowerInboxMessageMetadata = Record<string, unknown>;
+
 export interface FollowerInboxEntry {
   inboxId?: number;
   message: {
@@ -2221,7 +2223,7 @@ export interface FollowerInboxEntry {
     sender?: string;
     body?: string;
     createdAt?: string;
-    metadata: Record<string, unknown> | null;
+    metadata: FollowerInboxMessageMetadata | null;
   };
 }
 


### PR DESCRIPTION
## What

- Adds a named `FollowerInboxMessageMetadata` DTO for follower inbox entries.
- Applies it to the nested follower inbox message boundary.
- Keeps inbox sync/formatting behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
