### PR TITLE
refactor(slack-bridge): type pinet skin descriptor objects

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -3050,17 +3050,19 @@ const PINET_BUILT_IN_SKIN_FILES = ["foundation", "cosmere"] as const;
 
 let cachedBuiltInPinetSkinDescriptors: readonly BuiltInPinetSkinDescriptor[] | null = null;
 
-function isPinetSkinObject(value: unknown): value is Record<string, unknown> {
+type PinetSkinDescriptorObject = Record<string, unknown>;
+
+function isPinetSkinObject(value: unknown): value is PinetSkinDescriptorObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function readStringProperty(value: Record<string, unknown>, key: string): string | null {
+function readStringProperty(value: PinetSkinDescriptorObject, key: string): string | null {
   const property = value[key];
   return typeof property === "string" && property.trim().length > 0 ? property.trim() : null;
 }
 
 function readStringArrayProperty(
-  value: Record<string, unknown>,
+  value: PinetSkinDescriptorObject,
   key: string,
   required = true,
 ): string[] | null {


### PR DESCRIPTION
## What

- Adds a named DTO for Pinet skin descriptor object validation.
- Applies it to the skin descriptor object guard and string readers.
- Keeps built-in skin parsing behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
