### PR TITLE
refactor(slack-bridge): type slack api call body

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -3968,7 +3968,7 @@ function formatSlackApiResponseMetadata(data: SlackResult): string {
 export async function callSlackAPI(
   method: string,
   token: string,
-  body?: Record<string, unknown>,
+  body?: SlackRequestBody,
   options: CallSlackAPIOptions = {},
 ): Promise<SlackResult> {
   const { signal, retryCount = 0 } = options;


### PR DESCRIPTION
## What

- Reuses the named `SlackRequestBody` DTO at the Slack API call boundary.
- Keeps request construction and retry behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
