### PR TITLE
refactor(slack-bridge): type json object helper

### DIFF
--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -1076,8 +1076,10 @@ export interface AgentRoutingHint {
 const DEFAULT_AGENT_HEARTBEAT_TIMEOUT_MS = 15_000;
 const DEFAULT_AGENT_HEARTBEAT_INTERVAL_MS = 5_000;
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+type SlackBridgeJsonObject = Record<string, unknown>;
+
+function asRecord(value: unknown): SlackBridgeJsonObject | null {
+  return typeof value === "object" && value !== null ? (value as SlackBridgeJsonObject) : null;
 }
 
 function asString(value: unknown): string | undefined {


### PR DESCRIPTION
## What

- Adds a named `SlackBridgeJsonObject` DTO for Slack bridge object parsing.
- Uses it in the shared object-normalization helper.
- Keeps parsing behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- helpers`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
