### PR TITLE
refactor(slack-bridge): type pinet mesh agent metadata

### DIFF
--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -21,6 +21,8 @@ import { extractTaskAssignmentsFromMessage } from "./task-assignments.js";
 
 const execFileAsync = promisify(execFile);
 
+export type PinetMeshOpsAgentMetadata = Record<string, unknown>;
+
 export interface PinetMeshOpsAgentRecord {
   emoji: string;
   name: string;
@@ -29,7 +31,7 @@ export interface PinetMeshOpsAgentRecord {
   stableId?: string | null;
   session?: AgentSessionSummary | null;
   status: "working" | "idle";
-  metadata: Record<string, unknown> | null;
+  metadata: PinetMeshOpsAgentMetadata | null;
   lastHeartbeat: string;
   lastSeen?: string;
   disconnectedAt?: string | null;


### PR DESCRIPTION
## What

- Adds a named `PinetMeshOpsAgentMetadata` DTO for Pinet mesh agent records.
- Applies it to the agent list record boundary.
- Keeps mesh agent listing behavior unchanged.

Part of #862.

## Verified

- `env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH pnpm --filter @pinet/slack-bridge test -- pinet-mesh`
- `pnpm --filter @pinet/slack-bridge typecheck`
- `pnpm --filter @pinet/slack-bridge lint`
- `pnpm lint:agent-standards`
- `pnpm format:check:ts`
