### PR TITLE
Add explicit Pinet steering delivery

### DIFF
--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -26,6 +26,7 @@ function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDe
     pushInboxMessages: vi.fn(),
     updateBadge: vi.fn(),
     maybeDrainInboxIfIdle: vi.fn(() => false),
+    deliverSteeringMessage: vi.fn(() => true),
     requestRemoteControl: vi.fn(() => ({
       accepted: true,
       shouldStartNow: false,

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -8,6 +8,7 @@ import {
   buildPinetOwnerToken,
   buildPinetSkinAssignment,
   DEFAULT_PINET_SKIN_THEME,
+  formatPinetSteeringMessage,
   normalizePinetSkinTheme,
   resolvePinetMeshAuth,
   syncBrokerInboxEntries,
@@ -92,6 +93,7 @@ export interface BrokerRuntimeDeps {
   pushInboxMessages: (messages: InboxMessage[]) => void;
   updateBadge: () => void;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
+  deliverSteeringMessage: (text: string, ctx: ExtensionContext) => boolean;
   requestRemoteControl: (
     command: PinetControlCommand,
     ctx: ExtensionContext,
@@ -303,6 +305,21 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
 
     for (const command of commandsToStart) {
       deps.runRemoteControl(command, ctx);
+    }
+
+    const steeredInboxIds: number[] = [];
+    for (const entry of synced.steeringEntries) {
+      try {
+        if (deps.deliverSteeringMessage(formatPinetSteeringMessage(entry), ctx)) {
+          steeredInboxIds.push(entry.inboxId);
+        }
+      } catch (error) {
+        ctx.ui.notify(`Pinet steering delivery failed: ${deps.formatError(error)}`, "error");
+      }
+    }
+
+    if (steeredInboxIds.length > 0) {
+      db.markDelivered(steeredInboxIds, agentId);
     }
 
     if (synced.inboxMessages.length === 0) {

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -5,11 +5,14 @@ import {
   type InboxMessage,
   type PinetControlCommand,
   type PinetRemoteControlRequestResult,
+  type PinetSteeringInboxEntry,
   type SlackBridgeSettings,
   buildFollowerRuntimeDiagnostic,
   buildPinetOwnerToken,
+  extractPinetSteeringInboxEntry,
   extractPinetControlCommand,
   formatPinetInboxMessages,
+  formatPinetSteeringMessage,
   getFollowerOwnedThreadReclaims,
   getFollowerReconnectUiUpdate,
   partitionFollowerInboxEntries,
@@ -74,6 +77,7 @@ export interface FollowerRuntimeDeps {
   deferControlAck: (command: PinetControlCommand, inboxId: number) => void;
   runRemoteControl: (command: PinetControlCommand, ctx: ExtensionContext) => void;
   deliverFollowUpMessage: (text: string) => boolean;
+  deliverSteeringMessage: (text: string, ctx: ExtensionContext) => boolean;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
   getRuntimeDiagnostic: () => FollowerRuntimeDiagnostic | null;
   setRuntimeDiagnostic: (diagnostic: FollowerRuntimeDiagnostic | null) => void;
@@ -313,8 +317,31 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
             return;
           }
 
-          const { nudges, agentMessages, regular } =
-            partitionFollowerInboxEntries(remainingEntries);
+          const steeringEntries: PinetSteeringInboxEntry[] = [];
+          const queuedEntries: typeof remainingEntries = [];
+          for (const entry of remainingEntries) {
+            const steering = extractPinetSteeringInboxEntry(entry);
+            if (steering) {
+              steeringEntries.push(steering);
+              continue;
+            }
+            queuedEntries.push(entry);
+          }
+
+          if (steeringEntries.length > 0) {
+            const deliveredSteeringIds: number[] = [];
+            for (const entry of steeringEntries) {
+              if (deps.deliverSteeringMessage(formatPinetSteeringMessage(entry), ctx)) {
+                deliveredSteeringIds.push(entry.inboxId);
+              }
+            }
+            if (deliveredSteeringIds.length > 0) {
+              markFollowerInboxIdsDelivered(deps.deliveryState, deliveredSteeringIds);
+              void flushDeliveredAcks();
+            }
+          }
+
+          const { nudges, agentMessages, regular } = partitionFollowerInboxEntries(queuedEntries);
 
           if (nudges.length > 0) {
             const nudgeText = nudges

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -18,6 +18,13 @@ import {
   buildPinetControlMetadata,
   buildPinetControlMessage,
   normalizeOutgoingPinetControlMessage,
+  getPinetSteeringMessageFromText,
+  buildPinetSteeringMetadata,
+  buildPinetSteeringMessage,
+  normalizeOutgoingPinetSteeringMessage,
+  extractPinetSteeringMessage,
+  extractPinetSteeringInboxEntry,
+  formatPinetSteeringMessage,
   buildPinetSkinAssignment,
   buildPinetSkinPromptGuideline,
   buildPinetOwnerToken,
@@ -1157,6 +1164,105 @@ describe("Pinet control helpers", () => {
   });
 });
 
+// ─── Pinet steering messages ────────────────────────────
+
+describe("Pinet steering helpers", () => {
+  it("detects explicit steering from structured JSON and slash text", () => {
+    expect(getPinetSteeringMessageFromText('{"type":"pinet:steer","message":"stop polling"}')).toBe(
+      "stop polling",
+    );
+    expect(getPinetSteeringMessageFromText("/steer stop polling")).toBe("stop polling");
+    expect(getPinetSteeringMessageFromText(" /steer   stop polling  ")).toBe("stop polling");
+    expect(getPinetSteeringMessageFromText("/steer")).toBeNull();
+    expect(getPinetSteeringMessageFromText("/steering stop polling")).toBeNull();
+    expect(getPinetSteeringMessageFromText("please /steer stop polling")).toBeNull();
+  });
+
+  it("builds and normalizes structured steering messages", () => {
+    expect(buildPinetSteeringMetadata("stop polling")).toEqual({
+      type: "pinet:steer",
+      message: "stop polling",
+    });
+    expect(buildPinetSteeringMessage("stop polling")).toBe(
+      '{"type":"pinet:steer","message":"stop polling"}',
+    );
+    expect(normalizeOutgoingPinetSteeringMessage("/steer stop polling", { custom: true })).toEqual({
+      body: '{"type":"pinet:steer","message":"stop polling"}',
+      metadata: {
+        custom: true,
+        type: "pinet:steer",
+        message: "stop polling",
+        kind: "pinet_steer",
+      },
+    });
+    expect(normalizeOutgoingPinetSteeringMessage("plain queued note")).toBeNull();
+  });
+
+  it("extracts steering from metadata, slash text, and configured reaction triggers", () => {
+    expect(
+      extractPinetSteeringMessage({
+        threadId: "a2a:sender:target",
+        body: "ignored",
+        metadata: { type: "pinet:steer", message: "use the cache" },
+      }),
+    ).toBe("use the cache");
+    expect(
+      extractPinetSteeringMessage({
+        threadId: "123.456",
+        body: "/steer answer the latest Slack question",
+        metadata: { channel: "D123" },
+      }),
+    ).toBe("answer the latest Slack question");
+    expect(
+      extractPinetSteeringMessage({
+        threadId: "123.456",
+        body: "Reaction trigger from Slack:\n- action: steer\n\nRequested action: prioritize this",
+        metadata: { reactionTrigger: true, reactionAction: "steer" },
+      }),
+    ).toContain("Reaction trigger from Slack");
+  });
+
+  it("does not treat scheduled wakeups or ordinary steering-class mail as runtime steering", () => {
+    expect(
+      extractPinetSteeringMessage({
+        threadId: "wakeup:worker-1",
+        body: "/steer wake up",
+        metadata: { scheduledWakeup: true, type: "pinet:steer", message: "wake up" },
+      }),
+    ).toBeNull();
+    expect(
+      extractPinetSteeringMessage({
+        threadId: "a2a:sender:target",
+        body: "ordinary task that mail classification may call steering",
+        metadata: { a2a: true, pinetMailClass: "steering" },
+      }),
+    ).toBeNull();
+  });
+
+  it("formats extracted steering entries as immediate steering prompts", () => {
+    const entry = extractPinetSteeringInboxEntry({
+      inboxId: 42,
+      message: {
+        threadId: "a2a:sender:target",
+        sender: "sender-agent",
+        body: "/steer stop polling",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        metadata: { a2a: true, senderAgent: "Sender Agent" },
+      },
+    });
+
+    expect(entry).toMatchObject({
+      inboxId: 42,
+      steeringText: "stop polling",
+    });
+    const prompt = formatPinetSteeringMessage(entry!);
+    expect(prompt).toContain("Pinet steering message:");
+    expect(prompt).toContain("inbox_id=42");
+    expect(prompt).toContain("stop polling");
+    expect(prompt).toContain("explicit steering semantics");
+  });
+});
+
 // ─── Safe reload orchestration ───────────────────────────
 
 describe("reloadPinetRuntimeSafely", () => {
@@ -1664,9 +1770,32 @@ describe("Pinet skin helpers", () => {
           metadata: { a2a: true, senderAgent: "sender-agent" },
         },
       },
+      {
+        inboxId: 15,
+        message: {
+          threadId: "123.456",
+          sender: "U123",
+          body: "/steer stop polling",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          metadata: { channel: "D123" },
+        },
+      },
     ]);
 
     expect(result.controlEntries).toEqual([{ inboxId: 11, command: "reload" }]);
+    expect(result.steeringEntries).toEqual([
+      {
+        inboxId: 15,
+        message: {
+          threadId: "123.456",
+          sender: "U123",
+          body: "/steer stop polling",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          metadata: { channel: "D123" },
+        },
+        steeringText: "stop polling",
+      },
+    ]);
 
     expect(result.inboxMessages).toEqual([
       {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -776,6 +776,79 @@ export function normalizeOutgoingPinetControlMessage(
   };
 }
 
+// ─── Pinet steering messages ────────────────────────────
+
+export interface PinetSteeringEnvelope extends PinetControlMetadata {
+  type: "pinet:steer";
+  message: string;
+}
+
+function normalizePinetSteeringText(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parsePinetSteeringEnvelope(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as PinetControlMetadata;
+  if (record.type !== "pinet:steer") return null;
+  return (
+    normalizePinetSteeringText(record.message) ??
+    normalizePinetSteeringText(record.text) ??
+    normalizePinetSteeringText(record.body)
+  );
+}
+
+function parseStructuredPinetSteeringMessageFromText(text: string | undefined): string | null {
+  const trimmed = text?.trim();
+  if (!trimmed) return null;
+
+  try {
+    return parsePinetSteeringEnvelope(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function parseLegacyPinetSteeringMessageFromText(text: string | undefined): string | null {
+  const trimmed = text?.trim();
+  if (!trimmed?.startsWith("/steer")) return null;
+  const nextChar = trimmed.charAt("/steer".length);
+  if (nextChar && !/\s/.test(nextChar)) return null;
+  return normalizePinetSteeringText(trimmed.slice("/steer".length));
+}
+
+export function getPinetSteeringMessageFromText(text: string | undefined): string | null {
+  return (
+    parseStructuredPinetSteeringMessageFromText(text) ??
+    parseLegacyPinetSteeringMessageFromText(text)
+  );
+}
+
+export function buildPinetSteeringMetadata(message: string): PinetSteeringEnvelope {
+  return { type: "pinet:steer", message };
+}
+
+export function buildPinetSteeringMessage(message: string): string {
+  return JSON.stringify(buildPinetSteeringMetadata(message));
+}
+
+export function normalizeOutgoingPinetSteeringMessage(
+  body: string,
+  metadata?: PinetControlMetadata,
+): { body: string; metadata: PinetControlMetadata } | null {
+  const message = getPinetSteeringMessageFromText(body);
+  if (!message) return null;
+
+  return {
+    body: buildPinetSteeringMessage(message),
+    metadata: {
+      ...(metadata ?? {}),
+      ...buildPinetSteeringMetadata(message),
+      kind: "pinet_steer",
+    },
+  };
+}
+
 export type PinetSkinStatusKey = "idle" | "working" | "healthy" | "stale" | "ghost" | "resumable";
 
 export type PinetSkinStatusVocabulary = Partial<Record<PinetSkinStatusKey, string>>;
@@ -827,6 +900,31 @@ export function extractPinetControlCommand(
 
   // Backward-compatible fallback for structured JSON or exact slash commands sent over a2a flows.
   return getPinetControlCommandFromText(message.body);
+}
+
+export function extractPinetSteeringMessage(message: {
+  threadId?: string;
+  body?: string;
+  metadata?: PinetControlMetadata | null;
+}): string | null {
+  const metadata = message.metadata ?? {};
+  if (metadata.scheduledWakeup === true) return null;
+
+  const metadataMessage =
+    parsePinetSteeringEnvelope(metadata) ??
+    (metadata.kind === "pinet_steer" || metadata.kind === "pinet_steering"
+      ? (normalizePinetSteeringText(metadata.message) ??
+        normalizePinetSteeringText(metadata.text) ??
+        normalizePinetSteeringText(metadata.body))
+      : null);
+
+  if (metadataMessage) return metadataMessage;
+
+  if (metadata.reactionTrigger === true && metadata.reactionAction === "steer") {
+    return normalizePinetSteeringText(message.body);
+  }
+
+  return getPinetSteeringMessageFromText(message.body);
 }
 // ─── Slack API encoding ──────────────────────────────────
 
@@ -2246,8 +2344,15 @@ export interface BrokerInboxControlEntry {
   command: PinetControlCommand;
 }
 
+export interface PinetSteeringInboxEntry {
+  inboxId: number;
+  message: FollowerInboxEntry["message"];
+  steeringText: string;
+}
+
 export interface BrokerInboxSyncResult {
   controlEntries: BrokerInboxControlEntry[];
+  steeringEntries: PinetSteeringInboxEntry[];
   inboxMessages: InboxMessage[];
 }
 
@@ -2363,8 +2468,44 @@ export function syncFollowerInboxEntries(
   };
 }
 
+export function extractPinetSteeringInboxEntry(
+  entry: FollowerInboxEntry,
+): PinetSteeringInboxEntry | null {
+  if (entry.inboxId == null) return null;
+
+  const steeringText = extractPinetSteeringMessage({
+    threadId: entry.message.threadId,
+    body: entry.message.body,
+    metadata: entry.message.metadata,
+  });
+  if (!steeringText) return null;
+
+  return {
+    inboxId: entry.inboxId,
+    message: entry.message,
+    steeringText,
+  };
+}
+
+export function formatPinetSteeringMessage(entry: PinetSteeringInboxEntry): string {
+  const threadTs = entry.message.threadId ?? "";
+  const sender = getPinetSenderLabel(entry.message);
+  const transferSuffix = formatPinetThreadTransferSuffix(entry);
+  const pointer = formatPinetInboxPointer(entry);
+
+  return [
+    "Pinet steering message:",
+    `[thread ${threadTs}] ${sender}: inbox_id=${entry.inboxId}${transferSuffix} ${pointer}`,
+    "",
+    entry.steeringText,
+    "",
+    "This message was sent with explicit steering semantics. Incorporate it now, even if it interrupts the active turn. Reply via pinet action=send when needed.",
+  ].join("\n");
+}
+
 export function syncBrokerInboxEntries(entries: FollowerInboxEntry[]): BrokerInboxSyncResult {
   const controlEntries: BrokerInboxControlEntry[] = [];
+  const steeringEntries: PinetSteeringInboxEntry[] = [];
   const inboxMessages: InboxMessage[] = [];
 
   for (const entry of entries) {
@@ -2385,6 +2526,12 @@ export function syncBrokerInboxEntries(entries: FollowerInboxEntry[]): BrokerInb
       continue;
     }
 
+    const steering = extractPinetSteeringInboxEntry(entry);
+    if (steering) {
+      steeringEntries.push(steering);
+      continue;
+    }
+
     const scope = extractRuntimeScopeCarrier(meta.scope);
     inboxMessages.push({
       channel: "",
@@ -2400,6 +2547,7 @@ export function syncBrokerInboxEntries(entries: FollowerInboxEntry[]): BrokerInb
 
   return {
     controlEntries,
+    steeringEntries,
     inboxMessages,
   };
 }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -249,6 +249,20 @@ export default function (pi: ExtensionAPI) {
   const { deliverFollowUpMessage, flushDeliveredFollowerAcks, drainInbox } = inboxDrainRuntime;
   drainInboxPort = drainInbox;
 
+  function deliverSteeringMessage(text: string, ctx: ExtensionContext): boolean {
+    try {
+      if (ctx.isIdle?.() ?? true) {
+        pi.sendUserMessage(text);
+      } else {
+        pi.sendUserMessage(text, { deliverAs: "steer" });
+      }
+      return true;
+    } catch (error) {
+      console.error(`[slack-bridge] Pinet steering delivery failed: ${msg(error)}`);
+      return false;
+    }
+  }
+
   // ─── Helpers ─────────────────────────────────────────
 
   const gitContextCache = createGitContextCache(() => probeGitContext(process.cwd()));
@@ -550,6 +564,7 @@ export default function (pi: ExtensionAPI) {
     },
     updateBadge,
     maybeDrainInboxIfIdle,
+    deliverSteeringMessage,
     requestRemoteControl,
     runRemoteControl,
     formatError: msg,
@@ -772,6 +787,7 @@ export default function (pi: ExtensionAPI) {
     },
     updateBadge,
     maybeDrainInboxIfIdle,
+    deliverSteeringMessage,
     requestRemoteControl,
     deferControlAck: deferBrokerControlAck,
     runRemoteControl,
@@ -1474,6 +1490,7 @@ export default function (pi: ExtensionAPI) {
     deferControlAck: deferFollowerControlAck,
     runRemoteControl,
     deliverFollowUpMessage,
+    deliverSteeringMessage,
     setExtStatus,
     getRuntimeDiagnostic: () => followerRuntimeDiagnostic,
     setRuntimeDiagnostic: (diagnostic) => {

--- a/slack-bridge/pinet-mesh-ops.test.ts
+++ b/slack-bridge/pinet-mesh-ops.test.ts
@@ -274,6 +274,27 @@ describe("createPinetMeshOps", () => {
     });
   });
 
+  it("normalizes broker direct steering messages before dispatch", async () => {
+    const { deps, insertedMessages } = createBrokerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    const result = await pinetMeshOps.sendPinetAgentMessage("worker-1", "/steer stop polling");
+
+    expect(result).toEqual({ messageId: 1, target: "Worker One" });
+    expect(insertedMessages).toHaveLength(1);
+    expect(insertedMessages[0]).toMatchObject({
+      threadId: "a2a:broker-1:worker-1",
+      body: '{"type":"pinet:steer","message":"stop polling"}',
+      metadata: {
+        senderAgent: "Broker Crane",
+        a2a: true,
+        type: "pinet:steer",
+        message: "stop polling",
+        kind: "pinet_steer",
+      },
+    });
+  });
+
   it("records broker task assignments and logs assignment activity", async () => {
     const { deps, recordTaskAssignment, logActivity } = createBrokerDeps();
     const pinetMeshOps = createPinetMeshOps(deps);
@@ -438,6 +459,20 @@ describe("createPinetMeshOps", () => {
       "worker-2",
       '{"type":"pinet:control","action":"exit"}',
       { type: "pinet:control", action: "exit" },
+    );
+    expect(result).toEqual({ messageId: 17, target: "worker-2" });
+  });
+
+  it("routes follower steering messages through the follower client", async () => {
+    const { deps, sendAgentMessage } = createFollowerDeps();
+    const pinetMeshOps = createPinetMeshOps(deps);
+
+    const result = await pinetMeshOps.sendPinetAgentMessage("worker-2", "/steer stop polling");
+
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      "worker-2",
+      '{"type":"pinet:steer","message":"stop polling"}',
+      { type: "pinet:steer", message: "stop polling", kind: "pinet_steer" },
     );
     expect(result).toEqual({ messageId: 17, target: "worker-2" });
   });

--- a/slack-bridge/pinet-mesh-ops.ts
+++ b/slack-bridge/pinet-mesh-ops.ts
@@ -1,6 +1,9 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { normalizeOutgoingPinetControlMessage } from "./helpers.js";
+import {
+  normalizeOutgoingPinetControlMessage,
+  normalizeOutgoingPinetSteeringMessage,
+} from "./helpers.js";
 import {
   dispatchBroadcastAgentMessage,
   dispatchDirectAgentMessage,
@@ -155,6 +158,14 @@ function prepareOutgoingPinetAgentMessage(
     return {
       body: control.body,
       metadata: control.metadata,
+    };
+  }
+
+  const steering = normalizeOutgoingPinetSteeringMessage(body, metadata);
+  if (steering) {
+    return {
+      body: steering.body,
+      metadata: steering.metadata,
     };
   }
 

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -245,7 +245,10 @@ interface PinetRenderResultInput {
 }
 
 const PINET_DISPATCHER_EXAMPLES: Record<string, Array<Record<string, unknown>>> = {
-  send: [{ action: "send", args: { to: "@worker", message: "Please review PR #123" } }],
+  send: [
+    { action: "send", args: { to: "@worker", message: "Please review PR #123" } },
+    { action: "send", args: { to: "@worker", message: "/steer stop polling" } },
+  ],
   read: [
     // Routine inbox drain: defaults are `unread_only: true` + `mark_read: true`,
     // so this returns and consumes only this agent's unread rows. The compact
@@ -2165,13 +2168,17 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
 
   registerAction({
     name: "send",
-    description: "Send a message to a connected Pinet agent or broker-only broadcast channel.",
+    description:
+      "Send a queued message to a connected Pinet agent or broker-only broadcast channel. Prefix the body with /steer to interrupt a busy recipient with explicit steering.",
     parameters: Type.Object({
       to: Type.String({
         description:
           "Target agent name/ID, or a broker-only broadcast channel like #extensions. Avoid #all for repo-specific issue/policy announcements.",
       }),
-      message: Type.String({ description: "Message body" }),
+      message: Type.String({
+        description:
+          "Message body. Use /steer <instruction> only when you explicitly need to steer a busy recipient immediately; otherwise messages remain queued.",
+      }),
       transfer_thread_id: Type.Optional(
         Type.String({
           description:

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -15,8 +15,10 @@ import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
 import type { AgentInfo, BrokerMessage } from "./broker/types.js";
 import {
   buildPinetOwnerToken,
+  formatPinetSteeringMessage,
   generateAgentName,
   normalizeOutgoingPinetControlMessage,
+  normalizeOutgoingPinetSteeringMessage,
   resolvePinetMeshAuth,
   syncBrokerInboxEntries,
   type FollowerInboxEntry,
@@ -121,6 +123,7 @@ export interface SubtreeBrokerRuntimeDeps {
   pushInboxMessages: (messages: InboxMessage[]) => void;
   updateBadge: () => void;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
+  deliverSteeringMessage: (text: string, ctx: ExtensionContext) => boolean;
   requestRemoteControl: (
     command: PinetControlCommand,
     ctx: ExtensionContext,
@@ -434,6 +437,21 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       broker.db.markDelivered([...handledControlInboxIds], agentId);
     }
 
+    const steeredInboxIds: number[] = [];
+    for (const entry of synced.steeringEntries) {
+      try {
+        if (deps.deliverSteeringMessage(formatPinetSteeringMessage(entry), ctx)) {
+          steeredInboxIds.push(entry.inboxId);
+        }
+      } catch (error) {
+        ctx.ui.notify(`Subtree Pinet steering failed: ${deps.formatError(error)}`, "error");
+      }
+    }
+
+    if (steeredInboxIds.length > 0) {
+      broker.db.markDelivered(steeredInboxIds, agentId);
+    }
+
     if (synced.inboxMessages.length === 0) return;
     deps.pushInboxMessages(synced.inboxMessages);
     deps.updateBadge();
@@ -467,9 +485,11 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     const targetAgent = resolveDirectAgentTarget(activeBroker.db.getAgents(), target);
     if (!targetAgent || targetAgent.id === selfAgentId) return null;
 
-    const control = normalizeOutgoingPinetControlMessage(body, metadata);
-    const finalBody = control?.body ?? body;
-    const finalMetadata = control?.metadata ?? metadata;
+    const normalized =
+      normalizeOutgoingPinetControlMessage(body, metadata) ??
+      normalizeOutgoingPinetSteeringMessage(body, metadata);
+    const finalBody = normalized?.body ?? body;
+    const finalMetadata = normalized?.metadata ?? metadata;
     const identity = deps.getAgentIdentity();
     const result = dispatchDirectAgentMessage(activeBroker.db, {
       senderAgentId: selfAgentId,


### PR DESCRIPTION
## Summary
- add explicit /steer and structured pinet:steer parsing without changing default queued mail behavior
- deliver steering rows immediately through Pi deliverAs=steer when recipients are busy
- normalize outgoing pinet send messages and document /steer usage

Fixes #915.

## Tests
- ./node_modules/.bin/prettier --check slack-bridge/helpers.ts slack-bridge/broker-runtime.ts slack-bridge/follower-runtime.ts slack-bridge/subtree-broker-runtime.ts slack-bridge/pinet-mesh-ops.ts slack-bridge/pinet-tools.ts slack-bridge/helpers.test.ts slack-bridge/pinet-mesh-ops.test.ts slack-bridge/broker-runtime.test.ts
- env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH ./node_modules/.bin/tsc -p slack-bridge/tsconfig.json --noEmit --pretty false
- env -u PINET_MESH_SECRET -u PINET_MESH_SECRET_PATH ./node_modules/.bin/vitest run --exclude '.worktrees/**' ./slack-bridge/helpers.test.ts ./slack-bridge/pinet-mesh-ops.test.ts ./slack-bridge/broker-runtime.test.ts