### PR TITLE
feat(pinet): live hibernation runtime adapters + isolated hibernate→wake proof

### DIFF
--- a/plans/hibernation-live-activation.md
+++ b/plans/hibernation-live-activation.md
@@ -79,8 +79,8 @@ socket wiring — the default DB-polls `runtimeGeneration === reservedGeneration
 which the socket-server's fenced register already advances.
 
 The two controllers are constructed **independently** and share NO mutable state.
-The wake attempt's immutable process generation (pane pid + start-time/command
-token + pane address) is carried INSIDE the `RuntimeAttemptHandle` that
+The wake attempt's immutable process generation (pane pid + start-time token +
+pane address) is carried INSIDE the `RuntimeAttemptHandle` that
 `respawnRuntime` returns; the orchestrator round-trips that handle opaquely to the
 attempt-scoped stop/liveness probes, so a failed/timed-out wake is always
 cleanable by the exact process it launched. There is deliberately no shared

--- a/plans/hibernation-live-activation.md
+++ b/plans/hibernation-live-activation.md
@@ -1,0 +1,115 @@
+# Pinet hibernation — live activation wiring (follow-up to #923 / PR #924)
+
+Status: **runtime mechanics proven and merged-ready; live-broker wiring scoped
+below and pending review before any production activation.**
+
+The merged #923 landed the durable primitives (fenced leases, CAS lifecycle,
+runtime specs, checkpoint receipts, generation reservations, wake queue,
+telemetry), the `HibernationOrchestrator`, the operator commands, and full
+socket-server **wake-fence enforcement** (`enforceWakeFence` →
+`registerAgentWithGenerationAcceptance`). What it deliberately did NOT wire is
+the live process/tmux side and the production instantiation. This branch adds
+the real adapters + proof and the spec builder; the remaining wiring is below.
+
+## Landed on this branch (tested, committed)
+
+- `broker/hibernation-runtime-adapters.ts` — real `HibernationProcessController`
+  - `HibernationTmuxController` + `resolveVcsIdentity` (git origin remote) +
+    `createExecFileRunner`. `stopRuntime` self-ensures `remain-on-exit on` on the
+    pane before killing Pi, so hibernation needs **no worker spawn-path change**
+    for pane survival.
+- `broker/hibernation-runtime-helpers.ts` — pure, tested helpers:
+  `deriveVcsIdentity`, `sessionResumeRefFromStableId`, `resumePathFromSessionRef`,
+  `buildWakeFenceEnv`, `parseWakeFenceEnv`, `buildResumeLauncherScript`, and
+  `buildRuntimeSpecInput` (spawn-authored spec composer, fail-closed).
+- `broker/hibernation-runtime-adapters.e2e.test.ts` — opt-in
+  (`HIBERNATION_E2E=1`, skipped in CI) proof that the adapters drive a REAL Pi
+  runtime through hibernate→wake on a throwaway tmux socket: checkpoint-safe →
+  stop (pi dies, tmux session survives + attachable, session `.jsonl` intact) →
+  respawn (`pi --session <path>` into the surviving pane, woken pi alive on a
+  fresh pid bound to the same session) → attempt-bound cleanup. Green in ~6s.
+- 38 unit tests across adapters + helpers; full `broker/` suite 536 pass / 1
+  skipped; tsc + eslint + `lint:agent-standards` clean.
+
+## Remaining live-broker wiring (needs review before activation)
+
+### 1. Deterministic session path at spawn (enables spec authoring)
+
+`buildLauncherScript` (`subtree-broker-runtime.ts`) currently launches
+`pi -e <entry> <startupPrompt>` with **no `--session`**, so the worker's session
+path (and thus its stable id `host:session:<path>`) is auto-generated and
+unknown to the broker until the worker registers.
+
+To author a durable runtime spec keyed to a worker, the broker must know the
+stable id ahead of registration. Assign a broker-chosen
+`--session <sessionDir>/<launchId>.jsonl` at spawn. Tradeoff to review: this
+moves the session file off Pi's default session dir; confirm session listing /
+resume / recap features tolerate an explicit path (they key off the stable id,
+which still embeds the path, so this should be transparent).
+
+### 2. Spawn-facts capture + register-time spec authoring (SECURITY-CRITICAL)
+
+Record broker-KNOWN spawn facts keyed by the (now-known) stable id at spawn:
+`{ tmuxSocket, tmuxSession, tmuxTarget, repoRoot, cwd, worktreePath,
+extensionEntryPath, envAllowlist, launchSource, configFingerprint,
+expectedUser }`. At register (`socket-server.handleRegister`), after the agent
+id + stable id are resolved and (for wakes) the fence is accepted, look up the
+spawn facts by stable id, resolve `vcsIdentity` via `resolveVcsIdentity(repoRoot)`,
+call `buildRuntimeSpecInput(...)`, and `db.upsertAgentRuntimeSpec(...)`.
+
+**Do NOT trust worker-reported tmux/cwd for these operational locators.** A
+worker able to name another worker's pane could get the broker to
+checkpoint/kill/respawn THAT pane. `buildRuntimeSpecInput` already takes only
+`SpawnAuthoredRuntimeFacts` and fails closed on non-resumable identities /
+missing locators; the caller must feed it broker-recorded facts, not register
+params. Authorization uses solely the broker-derived `vcsIdentity`.
+
+Persistence tradeoff to review: an in-memory `Map<stableId, SpawnFacts>` is
+simplest but is lost on broker restart (hibernation of pre-restart workers
+degrades until they re-register). A durable spawn-facts table avoids that at the
+cost of a broker-core schema change.
+
+### 3. Orchestrator instantiation + real executor (`index.ts`)
+
+Instantiate once when the broker role is established:
+`new HibernationOrchestrator({ db, process: createHibernationProcessController(...),
+tmux: createHibernationTmuxController({ extensionEntryPath, baseLaunchEnv,
+inheritedEnvKeys }), brokerInstanceId })`. `awaitRuntimeRegistration` needs NO
+socket wiring — the default DB-polls `runtimeGeneration === reservedGeneration`,
+which the socket-server's fenced register already advances.
+
+`baseLaunchEnv` = the broker-level reconnect env used at spawn (PINET_SOCKET_PATH,
+PINET_BROKER_MANAGED=1, PINET_PARENT/ROOT/SPAWNED_BY_AGENT_ID = broker self id,
+PINET_LAUNCH_SOURCE) so the woken worker reconnects to the same broker.
+`inheritedEnvKeys` = the same list `buildLauncherScript` inherits (PI_CODING_AGENT_DIR,
+PI_CODING_AGENT_SESSION_DIR, PI_OFFLINE, PI_SETTINGS_PATH, PINET_MESH_SECRET,
+PINET_MESH_SECRET_PATH, SLACK_APP_TOKEN, SLACK_BOT_TOKEN). The orchestrator IS a
+`HibernateCommandExecutor & WakeCommandExecutor` (matching method signatures), so
+the hibernate/wake command handler passes the orchestrator instance directly,
+replacing the `activation_pending` stub — gated behind
+`resolveHibernationSettings(settings).enabled` AND an explicit activation flag so
+it stays inert (honest `activation_pending`) while disabled.
+
+### 4. Startup stranded-wake recovery (`index.ts`)
+
+Call `orchestrator.recoverStrandedWakes()` during broker startup **before the
+socket accepts registrations**, so a broker crash mid-hibernate/wake reconciles
+(complete-to-live / quarantine / requeue) before new work races the durable rows.
+
+### 5. Worker-side wake-fence + reconnect (`client.ts` register RPC)
+
+A woken worker's launcher exports `PINET_WAKE_*` (via `buildWakeFenceEnv`). The
+client must `parseWakeFenceEnv(process.env)` and, when present, include
+`wakeLeaseId / fenceToken / runtimeGeneration / reservationNonce` in its register
+params so the socket-server's `enforceWakeFence` accepts the reserved generation.
+Ordinary spawns set none of these and stay fence-free (backward compatible).
+
+## Activation (only after 1–5 + review)
+
+1. Enable in `~/.pi/agent/settings.json` slack-bridge hibernation config
+   (enabled + activation flag + `allowedRepos`), rebuild `broker-core/dist`.
+2. Controlled local hibernate→wake of ONE disposable broker-managed worker on
+   the live mesh; verify operator surfaces stay fingerprinted, the tmux session
+   survives + is attachable, and the woken worker re-registers under the same
+   identity and drains its inbox.
+3. Keep the `snapshot/pre-hibernation-merge` rollback tag until soaked.

--- a/plans/hibernation-live-activation.md
+++ b/plans/hibernation-live-activation.md
@@ -78,6 +78,15 @@ inheritedEnvKeys }), brokerInstanceId })`. `awaitRuntimeRegistration` needs NO
 socket wiring — the default DB-polls `runtimeGeneration === reservedGeneration`,
 which the socket-server's fenced register already advances.
 
+The two controllers are constructed **independently** and share NO mutable state.
+The wake attempt's immutable process generation (pane pid + start-time/command
+token + pane address) is carried INSIDE the `RuntimeAttemptHandle` that
+`respawnRuntime` returns; the orchestrator round-trips that handle opaquely to the
+attempt-scoped stop/liveness probes, so a failed/timed-out wake is always
+cleanable by the exact process it launched. There is deliberately no shared
+attempt registry to mis-compose (an earlier registry-based cut created a
+silent-default composition trap where record and cleanup used different maps).
+
 `baseLaunchEnv` = the broker-level reconnect env used at spawn (PINET_SOCKET_PATH,
 PINET_BROKER_MANAGED=1, PINET_PARENT/ROOT/SPAWNED_BY_AGENT_ID = broker self id,
 PINET_LAUNCH_SOURCE) so the woken worker reconnects to the same broker.

--- a/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
@@ -158,7 +158,10 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
       /* seed pane already exited */
     }
 
-    // Launch the resident runtime in a throwaway tmux session (remain-on-exit).
+    // Launch the resident runtime in a throwaway tmux session. NOTE: we do NOT
+    // pre-set remain-on-exit here on purpose — stopRuntime is responsible for
+    // ensuring the pane survives the Pi exit, so hibernation needs no spawn-path
+    // change. The survival assertion after stopRuntime proves that behaviour.
     const launchScript = path.join(tmpRoot, "launch.sh");
     fs.writeFileSync(
       launchScript,
@@ -172,7 +175,6 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
       { mode: 0o700 },
     );
     tmuxNewSessionClean(tmuxSession, launchScript, minimalEnv);
-    tmux(["set-option", "-t", tmuxSession, "remain-on-exit", "on"]);
 
     // ── Wait for the runtime to boot ──────────────────────────────────
     let alive = false;
@@ -193,6 +195,8 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
     expect(checkpoint.rssBytes ?? 0).toBeGreaterThan(0);
 
     // ── Hibernate: stop the runtime; tmux session must SURVIVE ────────
+    // stopRuntime itself sets remain-on-exit before killing Pi, so the session
+    // stays attachable even though we never pre-set it at launch.
     const stop = await proc.stopRuntime(spec);
     expect(stop.stopped).toBe(true);
     expect(await proc.isRuntimeAlive(spec)).toBe(false);

--- a/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
@@ -15,7 +15,6 @@ import { afterAll, describe, expect, it } from "vitest";
 import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
 import type { RuntimeLaunchContext } from "@pinet/broker-core";
 import {
-  createAttemptGenerationRegistry,
   createHibernationProcessController,
   createHibernationTmuxController,
   resolveVcsIdentity,
@@ -103,14 +102,11 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
     updatedAt: new Date().toISOString(),
   };
 
-  // A shared attempt-generation registry binds the woken attempt's exact process
-  // generation across the two controllers (the tmux controller records it at
-  // respawn; the process controller reads it for attempt-scoped stop/liveness).
-  const attemptRegistry = createAttemptGenerationRegistry();
-  const proc = createHibernationProcessController({
-    pendingInboxCount: () => 0,
-    attemptRegistry,
-  });
+  // The two controllers are constructed INDEPENDENTLY (as the live wiring does):
+  // the woken attempt's exact process generation travels inside the handle that
+  // respawnRuntime returns, so no shared registry is needed to make attempt-scoped
+  // stop/liveness bind to the right process.
+  const proc = createHibernationProcessController({ pendingInboxCount: () => 0 });
   // The tmux server is started with minimalEnv, so every pane (resident + woken)
   // inherits clean PI_SETTINGS_PATH/session-dir; no per-launcher env export needed.
   const tmuxCtrl = createHibernationTmuxController({
@@ -118,7 +114,6 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
     baseLaunchEnv: {},
     inheritedEnvKeys: [],
     launcherDir: tmpRoot,
-    attemptRegistry,
   });
 
   it("checkpoints, stops (session survives), and wakes a real pi runtime", async () => {

--- a/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
@@ -1,0 +1,234 @@
+// Isolated, disposable end-to-end proof for the live hibernation runtime
+// adapters. Drives the REAL HibernationProcessController / HibernationTmuxController
+// against a REAL `pi` runtime in a REAL (throwaway) tmux session — never the
+// production broker, mesh, or any shared tmux socket.
+//
+// Opt-in only: it spawns real processes and makes one cheap `pi --print` model
+// call to seed a resumable session, so it is skipped in normal `pnpm test`/CI and
+// runs only under `HIBERNATION_E2E=1`.
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
+import type { RuntimeLaunchContext } from "@pinet/broker-core";
+import {
+  createHibernationProcessController,
+  createHibernationTmuxController,
+  resolveVcsIdentity,
+} from "./hibernation-runtime-adapters.js";
+
+const RUN = process.env.HIBERNATION_E2E === "1";
+const suite = RUN ? describe : describe.skip;
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-hib-e2e-"));
+const tmuxSocket = path.join(tmpRoot, "tmux.sock");
+const sessionsDir = path.join(tmpRoot, "sessions");
+const repoDir = path.join(tmpRoot, "repo");
+const sessionFile = path.join(sessionsDir, "e2e.jsonl");
+const settingsPath = path.join(tmpRoot, "empty-settings.json");
+const noopExt = path.join(tmpRoot, "noop-ext.js");
+const tmuxSession = `pi-hib-e2e-${process.pid}`;
+
+function tmux(args: string[]): string {
+  return execFileSync("tmux", ["-S", tmuxSocket, ...args], { encoding: "utf8" }).trim();
+}
+
+// Launch a pane-bearing session with the clean minimal env explicitly, so the
+// pane never inherits the polluted harness env regardless of the tmux client.
+function tmuxNewSessionClean(name: string, script: string, env: NodeJS.ProcessEnv): void {
+  execFileSync("tmux", ["-S", tmuxSocket, "new-session", "-d", "-s", name, script], { env });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+afterAll(() => {
+  try {
+    tmux(["kill-server"]);
+  } catch {
+    /* already gone */
+  }
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+suite("hibernation adapters — real disposable pi + tmux", () => {
+  // Minimal, clean env (NOT the polluted harness env, which auto-loads global
+  // extensions that fail against this worktree's pnpm store). Auth still resolves
+  // from the default ~/.pi/agent via HOME; empty settings load no extensions.
+  // Strip node_modules/.bin entries so `pi` resolves to the GLOBAL install, not
+  // a vitest/pnpm-shimmed workspace pi that would load workspace deps
+  // (pi-ai@0.74.0 without /compat) and crash on the user's global extensions.
+  const cleanPath = (process.env.PATH ?? "")
+    .split(":")
+    .filter((segment) => !segment.includes("node_modules/.bin"))
+    .join(":");
+  const minimalEnv: NodeJS.ProcessEnv = {
+    PATH: cleanPath,
+    HOME: process.env.HOME,
+    TERM: "xterm-256color",
+    TMPDIR: process.env.TMPDIR,
+    PI_SETTINGS_PATH: settingsPath,
+    PI_CODING_AGENT_SESSION_DIR: sessionsDir,
+  };
+
+  const spec: AgentRuntimeSpec = {
+    agentId: "e2e-agent",
+    stableId: `${os.hostname()}:session:${sessionFile}`,
+    brokerOwnerId: "e2e-broker",
+    cwd: repoDir,
+    repoRoot: repoDir,
+    worktreePath: repoDir,
+    tmuxSocket,
+    tmuxSession,
+    tmuxTarget: tmuxSession,
+    executable: "pi",
+    argv: ["pi"],
+    envAllowlist: ["PI_SETTINGS_PATH", "PI_CODING_AGENT_SESSION_DIR"],
+    sessionResumeRef: `session:${sessionFile}`,
+    configFingerprint: "e2e",
+    expectedHost: os.hostname(),
+    expectedUser: os.userInfo().username,
+    launchSource: "e2e",
+    vcsIdentity: "test/repo",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const proc = createHibernationProcessController({ pendingInboxCount: () => 0 });
+  // The tmux server is started with minimalEnv, so every pane (resident + woken)
+  // inherits clean PI_SETTINGS_PATH/session-dir; no per-launcher env export needed.
+  const tmuxCtrl = createHibernationTmuxController({
+    extensionEntryPath: noopExt,
+    baseLaunchEnv: {},
+    inheritedEnvKeys: [],
+    launcherDir: tmpRoot,
+  });
+
+  it("checkpoints, stops (session survives), and wakes a real pi runtime", async () => {
+    // ── Arrange: disposable repo + settings + noop extension ──────────
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ extensions: [], packages: [] }));
+    fs.writeFileSync(noopExt, "export default function(){}\n");
+    execFileSync("git", ["init", "-q"], { cwd: repoDir });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:test/repo.git"], {
+      cwd: repoDir,
+    });
+
+    // Seed a resumable session via a one-shot `pi --print` run inside the clean
+    // tmux server (this also establishes the server env for all later panes).
+    // Running pi through tmux avoids a vitest-child env quirk that mis-resolves
+    // global extensions; a resident `pi --session` does not write the .jsonl
+    // until its first turn, so we need one real seeding turn.
+    const seedScript = path.join(tmpRoot, "seed.sh");
+    fs.writeFileSync(
+      seedScript,
+      [
+        "#!/bin/bash",
+        `cd '${repoDir}'`,
+        `pi --print --model google/gemini-2.5-flash --session '${sessionFile}' 'Remember codeword: MOOSE-42. Reply only ACK.' >'${tmpRoot}/seed.out' 2>&1 || true`,
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    // A persistent holder session keeps the tmux server (and its clean global
+    // env) alive across the seed/resident lifecycle so it never tears down and
+    // restarts under a different environment.
+    tmuxNewSessionClean("holder", "sleep 100000", minimalEnv);
+    tmuxNewSessionClean("seed", seedScript, minimalEnv);
+    for (let i = 0; i < 120 && !fs.existsSync(sessionFile); i++) await sleep(500);
+    if (!fs.existsSync(sessionFile)) {
+      const out = fs.existsSync(`${tmpRoot}/seed.out`)
+        ? fs.readFileSync(`${tmpRoot}/seed.out`, "utf8").slice(-1500)
+        : "(no seed.out)";
+      throw new Error(`seed session file was not created.\nseed.out tail:\n${out}`);
+    }
+    expect(fs.statSync(sessionFile).size).toBeGreaterThan(0);
+    try {
+      tmux(["kill-session", "-t", "seed"]);
+    } catch {
+      /* seed pane already exited */
+    }
+
+    // Launch the resident runtime in a throwaway tmux session (remain-on-exit).
+    const launchScript = path.join(tmpRoot, "launch.sh");
+    fs.writeFileSync(
+      launchScript,
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        `cd '${repoDir}'`,
+        `exec pi -e '${noopExt}' --session '${sessionFile}'`,
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    tmuxNewSessionClean(tmuxSession, launchScript, minimalEnv);
+    tmux(["set-option", "-t", tmuxSession, "remain-on-exit", "on"]);
+
+    // ── Wait for the runtime to boot ──────────────────────────────────
+    let alive = false;
+    for (let i = 0; i < 40 && !alive; i++) {
+      await sleep(300);
+      alive = await proc.isRuntimeAlive(spec);
+    }
+    expect(alive).toBe(true);
+
+    // ── vcsIdentity derives from the git remote, not the dir name ─────
+    expect(await resolveVcsIdentity(repoDir)).toBe("test/repo");
+
+    // ── Checkpoint: safe (alive + session on disk), rss captured ──────
+    const checkpoint = await proc.requestCheckpoint(spec);
+    expect(checkpoint.hibernateSafe).toBe(true);
+    expect(checkpoint.reason).toBeNull();
+    expect(checkpoint.sessionResumeRef).toBe(`session:${sessionFile}`);
+    expect(checkpoint.rssBytes ?? 0).toBeGreaterThan(0);
+
+    // ── Hibernate: stop the runtime; tmux session must SURVIVE ────────
+    const stop = await proc.stopRuntime(spec);
+    expect(stop.stopped).toBe(true);
+    expect(await proc.isRuntimeAlive(spec)).toBe(false);
+    expect(await tmuxCtrl.isSessionAttachable(spec)).toBe(true);
+    // The resumable session file is untouched by hibernation.
+    expect(fs.existsSync(sessionFile)).toBe(true);
+
+    // ── Wake: respawn pi --session into the surviving pane ────────────
+    const ctx: RuntimeLaunchContext = {
+      agentId: spec.agentId,
+      stableId: spec.stableId,
+      wakeLeaseId: "e2e-lease",
+      fenceToken: 1,
+      reservedGeneration: 2,
+      reservationNonce: "e2ewake01",
+      correlationId: "e2e-corr",
+      spec,
+    };
+    const wake = await tmuxCtrl.respawnRuntime(ctx);
+    expect(wake.launched).toBe(true);
+    expect(wake.handle?.pid ?? 0).toBeGreaterThan(0);
+
+    // The woken runtime comes back alive on a fresh pid, bound to the same session.
+    let revived = false;
+    for (let i = 0; i < 40 && !revived; i++) {
+      await sleep(300);
+      revived = await proc.isRuntimeAlive(spec);
+    }
+    expect(revived).toBe(true);
+    expect(await proc.isLaunchedAttemptAlive(wake.handle!)).toBe(true);
+
+    // Session file path is unchanged — the woken runtime resumes the SAME session
+    // (same path ⇒ same stable id ⇒ same fenced identity).
+    expect(fs.existsSync(sessionFile)).toBe(true);
+
+    // ── Teardown the woken runtime ────────────────────────────────────
+    await proc.stopLaunchedAttempt(wake.handle!);
+  }, 90_000);
+});

--- a/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.e2e.test.ts
@@ -15,6 +15,7 @@ import { afterAll, describe, expect, it } from "vitest";
 import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
 import type { RuntimeLaunchContext } from "@pinet/broker-core";
 import {
+  createAttemptGenerationRegistry,
   createHibernationProcessController,
   createHibernationTmuxController,
   resolveVcsIdentity,
@@ -102,7 +103,14 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
     updatedAt: new Date().toISOString(),
   };
 
-  const proc = createHibernationProcessController({ pendingInboxCount: () => 0 });
+  // A shared attempt-generation registry binds the woken attempt's exact process
+  // generation across the two controllers (the tmux controller records it at
+  // respawn; the process controller reads it for attempt-scoped stop/liveness).
+  const attemptRegistry = createAttemptGenerationRegistry();
+  const proc = createHibernationProcessController({
+    pendingInboxCount: () => 0,
+    attemptRegistry,
+  });
   // The tmux server is started with minimalEnv, so every pane (resident + woken)
   // inherits clean PI_SETTINGS_PATH/session-dir; no per-launcher env export needed.
   const tmuxCtrl = createHibernationTmuxController({
@@ -110,6 +118,7 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
     baseLaunchEnv: {},
     inheritedEnvKeys: [],
     launcherDir: tmpRoot,
+    attemptRegistry,
   });
 
   it("checkpoints, stops (session survives), and wakes a real pi runtime", async () => {
@@ -203,8 +212,16 @@ suite("hibernation adapters — real disposable pi + tmux", () => {
     expect(await tmuxCtrl.isSessionAttachable(spec)).toBe(true);
     // The resumable session file is untouched by hibernation.
     expect(fs.existsSync(sessionFile)).toBe(true);
+    // The pane is now explicitly DEAD (remain-on-exit kept it attachable); the
+    // wake path refuses to respawn anything but a present, explicitly-dead pane.
+    let paneDead = false;
+    for (let i = 0; i < 20 && !paneDead; i++) {
+      await sleep(200);
+      paneDead = tmux(["display-message", "-p", "-t", tmuxSession, "#{pane_dead}"]).trim() === "1";
+    }
+    expect(paneDead).toBe(true);
 
-    // ── Wake: respawn pi --session into the surviving pane ────────────
+    // ── Wake: respawn pi --session into the surviving (dead) pane ─────
     const ctx: RuntimeLaunchContext = {
       agentId: spec.agentId,
       stableId: spec.stableId,

--- a/slack-bridge/broker/hibernation-runtime-adapters.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
+import type { RuntimeLaunchContext } from "@pinet/broker-core";
+import {
+  createHibernationProcessController,
+  createHibernationTmuxController,
+  resolveVcsIdentity,
+  type CommandResult,
+  type CommandRunner,
+} from "./hibernation-runtime-adapters.js";
+
+function makeSpec(overrides: Partial<AgentRuntimeSpec> = {}): AgentRuntimeSpec {
+  return {
+    agentId: "agent-1",
+    stableId: "host:session:/tmp/s/agent-1.jsonl",
+    brokerOwnerId: "broker-1",
+    cwd: "/repo/root",
+    repoRoot: "/repo/root",
+    worktreePath: "/repo/root",
+    tmuxSocket: "/tmp/tmux.sock",
+    tmuxSession: "pinet-repo-worker-abcd",
+    tmuxTarget: "pinet-repo-worker-abcd:0.0",
+    executable: "pi",
+    argv: ["pi"],
+    envAllowlist: ["PINET_SOCKET_PATH"],
+    sessionResumeRef: "session:/tmp/s/agent-1.jsonl",
+    configFingerprint: "fp",
+    expectedHost: "host",
+    expectedUser: "user",
+    launchSource: "subtree-broker-tmux",
+    vcsIdentity: "gugu91/extensions",
+    createdAt: "2026-07-12T00:00:00Z",
+    updatedAt: "2026-07-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+interface RunnerState {
+  panePid?: number | null;
+  paneDead?: "0" | "1";
+  rssKb?: number;
+  hasSessionCode?: number;
+  respawnCode?: number;
+  remoteUrl?: string;
+  gitCode?: number;
+  // panePid AFTER a respawn (the new attempt's pid).
+  panePidAfterRespawn?: number;
+}
+
+function makeRunner(state: RunnerState) {
+  const calls: Array<{ file: string; args: string[] }> = [];
+  let respawned = false;
+  const runner: CommandRunner = {
+    async run(file, args): Promise<CommandResult> {
+      calls.push({ file, args });
+      const ok = (stdout: string): CommandResult => ({ stdout, stderr: "", code: 0 });
+      if (file === "tmux") {
+        const field = args.find((a) => a.startsWith("#{"));
+        if (args.includes("display-message") && field === "#{pane_pid}") {
+          const pid = respawned ? (state.panePidAfterRespawn ?? state.panePid) : state.panePid;
+          return pid == null ? { stdout: "", stderr: "", code: 0 } : ok(String(pid));
+        }
+        if (args.includes("display-message") && field === "#{pane_dead}") {
+          return state.paneDead == null ? { stdout: "", stderr: "", code: 0 } : ok(state.paneDead);
+        }
+        if (args.includes("has-session")) {
+          return { stdout: "", stderr: "", code: state.hasSessionCode ?? 0 };
+        }
+        if (args.includes("respawn-pane")) {
+          respawned = true;
+          return { stdout: "", stderr: "", code: state.respawnCode ?? 0 };
+        }
+      }
+      if (file === "ps") {
+        return state.rssKb == null ? { stdout: "", stderr: "", code: 1 } : ok(`${state.rssKb}\n`);
+      }
+      if (file === "git") {
+        return state.gitCode
+          ? { stdout: "", stderr: "", code: state.gitCode }
+          : ok(state.remoteUrl ?? "");
+      }
+      return { stdout: "", stderr: "", code: 127 };
+    },
+  };
+  return { runner, calls };
+}
+
+/** Fake clock + liveness registry so terminate loops are deterministic. */
+function makeProcessWorld(alive: Set<number>, opts: { dieOnTerm?: boolean } = {}) {
+  let clock = 0;
+  const signals: Array<{ pid: number; signal: string }> = [];
+  return {
+    now: () => clock,
+    sleep: async (ms: number) => {
+      clock += ms;
+    },
+    processAlive: (pid: number) => alive.has(pid),
+    sendSignal: (pid: number, signal: NodeJS.Signals) => {
+      signals.push({ pid, signal });
+      if (signal === "SIGKILL") alive.delete(pid);
+      if (signal === "SIGTERM" && opts.dieOnTerm) alive.delete(pid);
+    },
+    signals,
+  };
+}
+
+describe("HibernationProcessController.requestCheckpoint", () => {
+  it("is hibernateSafe when the runtime is alive and the session file exists", async () => {
+    const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
+    const ctrl = createHibernationProcessController({
+      runner,
+      fileExists: () => true,
+      processAlive: () => true,
+      pendingInboxCount: () => 3,
+    });
+    const outcome = await ctrl.requestCheckpoint(makeSpec());
+    expect(outcome).toEqual({
+      hibernateSafe: true,
+      reason: null,
+      sessionResumeRef: "session:/tmp/s/agent-1.jsonl",
+      pendingInboxCount: 3,
+      rssBytes: 100 * 1024,
+    });
+  });
+
+  it("refuses when the recorded runtime pid is gone (pane dead)", async () => {
+    const { runner } = makeRunner({ panePid: 4242, paneDead: "1", rssKb: 100 });
+    const ctrl = createHibernationProcessController({
+      runner,
+      fileExists: () => true,
+      processAlive: () => true,
+    });
+    const outcome = await ctrl.requestCheckpoint(makeSpec());
+    expect(outcome.hibernateSafe).toBe(false);
+    expect(outcome.reason).toBe("runtime_not_alive");
+  });
+
+  it("refuses when the session file is not resumable on disk", async () => {
+    const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
+    const ctrl = createHibernationProcessController({
+      runner,
+      fileExists: () => false,
+      processAlive: () => true,
+    });
+    const outcome = await ctrl.requestCheckpoint(makeSpec());
+    expect(outcome.hibernateSafe).toBe(false);
+    expect(outcome.reason).toBe("session_unresumable");
+  });
+});
+
+describe("HibernationProcessController.stopRuntime", () => {
+  it("stops on graceful SIGTERM and never destroys the tmux session", async () => {
+    const { runner, calls } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
+    const world = makeProcessWorld(new Set([4242]), { dieOnTerm: true });
+    const ctrl = createHibernationProcessController({ runner, ...world });
+    const result = await ctrl.stopRuntime(makeSpec());
+    expect(result).toEqual({ stopped: true, rssBytes: 100 * 1024 });
+    expect(world.signals.map((s) => s.signal)).toEqual(["SIGTERM"]);
+    // No tmux kill-session / kill-pane was ever issued.
+    const tmuxVerbs = calls.filter((c) => c.file === "tmux").flatMap((c) => c.args);
+    expect(tmuxVerbs).not.toContain("kill-session");
+    expect(tmuxVerbs).not.toContain("kill-pane");
+  });
+
+  it("escalates to SIGKILL when the runtime ignores SIGTERM", async () => {
+    const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
+    const world = makeProcessWorld(new Set([4242]), { dieOnTerm: false });
+    const ctrl = createHibernationProcessController({
+      runner,
+      ...world,
+      stopGraceMs: 500,
+      pollMs: 100,
+    });
+    const result = await ctrl.stopRuntime(makeSpec());
+    expect(result.stopped).toBe(true);
+    expect(world.signals.map((s) => s.signal)).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("treats an already-gone pane as stopped", async () => {
+    const { runner } = makeRunner({ panePid: null });
+    const ctrl = createHibernationProcessController({ runner, processAlive: () => false });
+    expect(await ctrl.stopRuntime(makeSpec())).toEqual({ stopped: true, rssBytes: null });
+  });
+});
+
+describe("HibernationProcessController attempt-bound + liveness", () => {
+  it("isRuntimeAlive reflects pane liveness", async () => {
+    const aliveRunner = makeRunner({ panePid: 7, paneDead: "0" });
+    const deadRunner = makeRunner({ panePid: 7, paneDead: "1" });
+    expect(
+      await createHibernationProcessController({
+        runner: aliveRunner.runner,
+        processAlive: () => true,
+      }).isRuntimeAlive(makeSpec()),
+    ).toBe(true);
+    expect(
+      await createHibernationProcessController({
+        runner: deadRunner.runner,
+        processAlive: () => true,
+      }).isRuntimeAlive(makeSpec()),
+    ).toBe(false);
+  });
+
+  it("fails closed when a launched attempt has no captured pid", async () => {
+    const { runner } = makeRunner({});
+    const ctrl = createHibernationProcessController({ runner });
+    expect(
+      await ctrl.stopLaunchedAttempt({ reservationNonce: "n", tmuxTarget: "t", pid: null }),
+    ).toEqual({ stopped: false });
+    expect(
+      await ctrl.isLaunchedAttemptAlive({ reservationNonce: "n", tmuxTarget: "t", pid: null }),
+    ).toBe(true);
+  });
+
+  it("stops a launched attempt addressed by its captured pid", async () => {
+    const { runner } = makeRunner({});
+    const world = makeProcessWorld(new Set([999]), { dieOnTerm: true });
+    const ctrl = createHibernationProcessController({ runner, ...world });
+    expect(
+      await ctrl.stopLaunchedAttempt({ reservationNonce: "n", tmuxTarget: "t", pid: 999 }),
+    ).toEqual({ stopped: true });
+  });
+});
+
+describe("HibernationTmuxController", () => {
+  const respawnDeps = {
+    extensionEntryPath: "/ext/index.js",
+    baseLaunchEnv: { PINET_SOCKET_PATH: "/sock", PINET_BROKER_MANAGED: "1" },
+    inheritedEnvKeys: ["PI_SETTINGS_PATH"],
+    readEnv: (k: string) => (k === "PI_SETTINGS_PATH" ? "/cfg.json" : undefined),
+  };
+  const ctx: RuntimeLaunchContext = {
+    agentId: "agent-1",
+    stableId: "host:session:/tmp/s/agent-1.jsonl",
+    wakeLeaseId: "lease-1",
+    fenceToken: 5,
+    reservedGeneration: 9,
+    reservationNonce: "nonce-abcdef123456",
+    correlationId: "corr-1",
+    spec: makeSpec(),
+  };
+
+  it("isSessionAttachable maps has-session exit code", async () => {
+    const attach = makeRunner({ hasSessionCode: 0 });
+    const gone = makeRunner({ hasSessionCode: 1 });
+    expect(
+      await createHibernationTmuxController({
+        ...respawnDeps,
+        runner: attach.runner,
+      }).isSessionAttachable(makeSpec()),
+    ).toBe(true);
+    expect(
+      await createHibernationTmuxController({
+        ...respawnDeps,
+        runner: gone.runner,
+      }).isSessionAttachable(makeSpec()),
+    ).toBe(false);
+  });
+
+  it("respawns into the recorded pane and returns an attempt-bound handle", async () => {
+    const { runner, calls } = makeRunner({
+      panePid: 111,
+      panePidAfterRespawn: 222,
+      respawnCode: 0,
+    });
+    const writeFile = vi.fn();
+    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile });
+    const result = await ctrl.respawnRuntime(ctx);
+    expect(result.launched).toBe(true);
+    expect(result.handle).toEqual({
+      reservationNonce: "nonce-abcdef123456",
+      tmuxTarget: "pinet-repo-worker-abcd:0.0",
+      pid: 222,
+    });
+    // Launcher script was written and resumes the exact session with the fence env.
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    const script = writeFile.mock.calls[0][1] as string;
+    expect(script).toContain("--session '/tmp/s/agent-1.jsonl'");
+    expect(script).toContain("export PINET_WAKE_LEASE_ID='lease-1'");
+    expect(script).toContain("export PINET_WAKE_RESERVATION_NONCE='nonce-abcdef123456'");
+    expect(script).toContain("export PI_SETTINGS_PATH='/cfg.json'");
+    // respawn-pane -k targeted the recorded pane.
+    const respawn = calls.find((c) => c.args.includes("respawn-pane"));
+    expect(respawn?.args).toEqual(
+      expect.arrayContaining(["respawn-pane", "-k", "-t", "pinet-repo-worker-abcd:0.0"]),
+    );
+  });
+
+  it("fails closed (no handle) when the spec is not resumable", async () => {
+    const { runner } = makeRunner({ panePid: 111 });
+    const writeFile = vi.fn();
+    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile });
+    const result = await ctrl.respawnRuntime({
+      ...ctx,
+      spec: makeSpec({ sessionResumeRef: "cwd:/repo/root" }),
+    });
+    expect(result).toEqual({ launched: false, handle: null });
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when respawn-pane errors", async () => {
+    const { runner } = makeRunner({ panePid: 111, respawnCode: 1 });
+    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile: vi.fn() });
+    expect(await ctrl.respawnRuntime(ctx)).toEqual({ launched: false, handle: null });
+  });
+});
+
+describe("resolveVcsIdentity", () => {
+  it("derives owner/repo from the git origin remote", async () => {
+    const { runner } = makeRunner({ remoteUrl: "git@github.com:gugu91/extensions.git\n" });
+    expect(await resolveVcsIdentity("/repo/root", runner)).toBe("gugu91/extensions");
+  });
+
+  it("returns null when no origin remote is resolvable", async () => {
+    const { runner } = makeRunner({ gitCode: 1 });
+    expect(await resolveVcsIdentity("/repo/root", runner)).toBeNull();
+  });
+});

--- a/slack-bridge/broker/hibernation-runtime-adapters.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
 import type { RuntimeLaunchContext } from "@pinet/broker-core";
 import {
+  createAttemptGenerationRegistry,
   createHibernationProcessController,
   createHibernationTmuxController,
   resolveVcsIdentity,
@@ -39,12 +40,15 @@ interface RunnerState {
   panePid?: number | null;
   paneDead?: "0" | "1";
   rssKb?: number;
+  /** Process start token from `ps -o lstart=`; null ⇒ pid gone. Read live. */
+  startToken?: string | null;
   hasSessionCode?: number;
   respawnCode?: number;
   remoteUrl?: string;
   gitCode?: number;
-  // panePid AFTER a respawn (the new attempt's pid).
+  // pane state AFTER a respawn (the new attempt's pid/liveness).
   panePidAfterRespawn?: number;
+  paneDeadAfterRespawn?: "0" | "1";
 }
 
 function makeRunner(state: RunnerState) {
@@ -61,7 +65,8 @@ function makeRunner(state: RunnerState) {
           return pid == null ? { stdout: "", stderr: "", code: 0 } : ok(String(pid));
         }
         if (args.includes("display-message") && field === "#{pane_dead}") {
-          return state.paneDead == null ? { stdout: "", stderr: "", code: 0 } : ok(state.paneDead);
+          const dead = respawned ? (state.paneDeadAfterRespawn ?? state.paneDead) : state.paneDead;
+          return dead == null ? { stdout: "", stderr: "", code: 0 } : ok(dead);
         }
         if (args.includes("has-session")) {
           return { stdout: "", stderr: "", code: state.hasSessionCode ?? 0 };
@@ -72,6 +77,11 @@ function makeRunner(state: RunnerState) {
         }
       }
       if (file === "ps") {
+        if (args.includes("lstart=")) {
+          const token =
+            state.startToken === undefined ? "Sun Jul 12 13:30:21 2026" : state.startToken;
+          return token == null ? { stdout: "", stderr: "", code: 1 } : ok(`${token}\n`);
+        }
         return state.rssKb == null ? { stdout: "", stderr: "", code: 1 } : ok(`${state.rssKb}\n`);
       }
       if (file === "git") {
@@ -82,7 +92,7 @@ function makeRunner(state: RunnerState) {
       return { stdout: "", stderr: "", code: 127 };
     },
   };
-  return { runner, calls };
+  return { runner, calls, state };
 }
 
 /** Fake clock + liveness registry so terminate loops are deterministic. */
@@ -105,11 +115,11 @@ function makeProcessWorld(alive: Set<number>, opts: { dieOnTerm?: boolean } = {}
 }
 
 describe("HibernationProcessController.requestCheckpoint", () => {
-  it("is hibernateSafe when the runtime is alive and the session file exists", async () => {
+  it("is hibernateSafe when a live generation exists and the session is non-empty", async () => {
     const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
     const ctrl = createHibernationProcessController({
       runner,
-      fileExists: () => true,
+      sessionByteSize: () => 2048,
       processAlive: () => true,
       pendingInboxCount: () => 3,
     });
@@ -127,7 +137,7 @@ describe("HibernationProcessController.requestCheckpoint", () => {
     const { runner } = makeRunner({ panePid: 4242, paneDead: "1", rssKb: 100 });
     const ctrl = createHibernationProcessController({
       runner,
-      fileExists: () => true,
+      sessionByteSize: () => 2048,
       processAlive: () => true,
     });
     const outcome = await ctrl.requestCheckpoint(makeSpec());
@@ -139,12 +149,36 @@ describe("HibernationProcessController.requestCheckpoint", () => {
     const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
     const ctrl = createHibernationProcessController({
       runner,
-      fileExists: () => false,
+      sessionByteSize: () => null,
       processAlive: () => true,
     });
     const outcome = await ctrl.requestCheckpoint(makeSpec());
     expect(outcome.hibernateSafe).toBe(false);
     expect(outcome.reason).toBe("session_unresumable");
+  });
+
+  it("refuses when the session file exists but is empty (no durable state)", async () => {
+    const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
+    const ctrl = createHibernationProcessController({
+      runner,
+      sessionByteSize: () => 0,
+      processAlive: () => true,
+    });
+    const outcome = await ctrl.requestCheckpoint(makeSpec());
+    expect(outcome.hibernateSafe).toBe(false);
+    expect(outcome.reason).toBe("session_empty");
+  });
+
+  it("refuses when the live pid has no readable start token (unverifiable generation)", async () => {
+    const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100, startToken: null });
+    const ctrl = createHibernationProcessController({
+      runner,
+      sessionByteSize: () => 2048,
+      processAlive: () => true,
+    });
+    const outcome = await ctrl.requestCheckpoint(makeSpec());
+    expect(outcome.hibernateSafe).toBe(false);
+    expect(outcome.reason).toBe("runtime_not_alive");
   });
 });
 
@@ -192,6 +226,14 @@ describe("HibernationProcessController.stopRuntime", () => {
     expect(world.signals.map((s) => s.signal)).toEqual(["SIGTERM", "SIGKILL"]);
   });
 
+  it("treats an already-dead pane as stopped without signalling", async () => {
+    const { runner } = makeRunner({ panePid: 4242, paneDead: "1" });
+    const world = makeProcessWorld(new Set([4242]), { dieOnTerm: true });
+    const ctrl = createHibernationProcessController({ runner, ...world });
+    expect(await ctrl.stopRuntime(makeSpec())).toEqual({ stopped: true, rssBytes: null });
+    expect(world.signals).toEqual([]);
+  });
+
   it("treats an already-gone pane as stopped", async () => {
     const { runner } = makeRunner({ panePid: null });
     const ctrl = createHibernationProcessController({ runner, processAlive: () => false });
@@ -199,7 +241,7 @@ describe("HibernationProcessController.stopRuntime", () => {
   });
 });
 
-describe("HibernationProcessController attempt-bound + liveness", () => {
+describe("HibernationProcessController generation-bound liveness + cleanup", () => {
   it("isRuntimeAlive reflects pane liveness", async () => {
     const aliveRunner = makeRunner({ panePid: 7, paneDead: "0" });
     const deadRunner = makeRunner({ panePid: 7, paneDead: "1" });
@@ -217,35 +259,90 @@ describe("HibernationProcessController attempt-bound + liveness", () => {
     ).toBe(false);
   });
 
-  it("fails closed when a launched attempt has no captured pid", async () => {
+  it("fails closed when a launched attempt has no recorded generation", async () => {
     const { runner } = makeRunner({});
     const ctrl = createHibernationProcessController({ runner });
     expect(
       await ctrl.stopLaunchedAttempt({ reservationNonce: "n", tmuxTarget: "t", pid: null }),
     ).toEqual({ stopped: false });
     expect(
-      await ctrl.isLaunchedAttemptAlive({ reservationNonce: "n", tmuxTarget: "t", pid: null }),
+      await ctrl.isLaunchedAttemptAlive({ reservationNonce: "n", tmuxTarget: "t", pid: 999 }),
     ).toBe(true);
   });
 
-  it("stops a launched attempt addressed by its captured pid", async () => {
-    const { runner } = makeRunner({});
-    const world = makeProcessWorld(new Set([999]), { dieOnTerm: true });
-    const ctrl = createHibernationProcessController({ runner, ...world });
-    expect(
-      await ctrl.stopLaunchedAttempt({ reservationNonce: "n", tmuxTarget: "t", pid: 999 }),
-    ).toEqual({ stopped: true });
+  it("stops a launched attempt bound to the exact generation it recorded", async () => {
+    const registry = createAttemptGenerationRegistry();
+    const { runner } = makeRunner({
+      panePid: 111,
+      panePidAfterRespawn: 222,
+      paneDead: "1",
+      paneDeadAfterRespawn: "0",
+      startToken: "TOK-A",
+      respawnCode: 0,
+    });
+    const world = makeProcessWorld(new Set([222]), { dieOnTerm: true });
+    const tmux = createHibernationTmuxController({
+      extensionEntryPath: "/ext/index.js",
+      baseLaunchEnv: { PINET_SOCKET_PATH: "/sock" },
+      inheritedEnvKeys: [],
+      launcherDir: "/tmp/fake-wake",
+      writeFile: vi.fn(),
+      runner,
+      attemptRegistry: registry,
+    });
+    const proc = createHibernationProcessController({
+      runner,
+      ...world,
+      attemptRegistry: registry,
+    });
+    const ctx = makeLaunchCtx();
+    const launch = await tmux.respawnRuntime(ctx);
+    expect(launch.launched).toBe(true);
+    expect(launch.handle?.pid).toBe(222);
+    // The launched process is alive before cleanup, then provably stopped.
+    expect(await proc.isLaunchedAttemptAlive(launch.handle!)).toBe(true);
+    expect(await proc.stopLaunchedAttempt(launch.handle!)).toEqual({ stopped: true });
+    expect(world.signals.map((s) => s.signal)).toEqual(["SIGTERM"]);
+  });
+
+  it("never signals a reused pid: refuses cleanup when the start token drifted", async () => {
+    const registry = createAttemptGenerationRegistry();
+    const runnerBox = makeRunner({
+      panePid: 111,
+      panePidAfterRespawn: 222,
+      paneDead: "1",
+      paneDeadAfterRespawn: "0",
+      startToken: "TOK-A",
+      respawnCode: 0,
+    });
+    const world = makeProcessWorld(new Set([222]), { dieOnTerm: true });
+    const tmux = createHibernationTmuxController({
+      extensionEntryPath: "/ext/index.js",
+      baseLaunchEnv: { PINET_SOCKET_PATH: "/sock" },
+      inheritedEnvKeys: [],
+      launcherDir: "/tmp/fake-wake",
+      writeFile: vi.fn(),
+      runner: runnerBox.runner,
+      attemptRegistry: registry,
+    });
+    const proc = createHibernationProcessController({
+      runner: runnerBox.runner,
+      ...world,
+      attemptRegistry: registry,
+    });
+    const launch = await tmux.respawnRuntime(makeLaunchCtx());
+    expect(launch.handle?.pid).toBe(222);
+    // Pid 222 exits and is REUSED by an unrelated same-user process (new start token).
+    runnerBox.state.startToken = "TOK-REUSED";
+    const stop = await proc.stopLaunchedAttempt(launch.handle!);
+    expect(stop).toEqual({ stopped: true });
+    // Crucially, NO signal was ever delivered to the reused pid.
+    expect(world.signals).toEqual([]);
   });
 });
 
-describe("HibernationTmuxController", () => {
-  const respawnDeps = {
-    extensionEntryPath: "/ext/index.js",
-    baseLaunchEnv: { PINET_SOCKET_PATH: "/sock", PINET_BROKER_MANAGED: "1" },
-    inheritedEnvKeys: ["PI_SETTINGS_PATH"],
-    readEnv: (k: string) => (k === "PI_SETTINGS_PATH" ? "/cfg.json" : undefined),
-  };
-  const ctx: RuntimeLaunchContext = {
+function makeLaunchCtx(overrides: Partial<RuntimeLaunchContext> = {}): RuntimeLaunchContext {
+  return {
     agentId: "agent-1",
     stableId: "host:session:/tmp/s/agent-1.jsonl",
     wakeLeaseId: "lease-1",
@@ -254,6 +351,17 @@ describe("HibernationTmuxController", () => {
     reservationNonce: "nonce-abcdef123456",
     correlationId: "corr-1",
     spec: makeSpec(),
+    ...overrides,
+  };
+}
+
+describe("HibernationTmuxController", () => {
+  const respawnDeps = {
+    extensionEntryPath: "/ext/index.js",
+    baseLaunchEnv: { PINET_SOCKET_PATH: "/sock", PINET_BROKER_MANAGED: "1" },
+    inheritedEnvKeys: ["PI_SETTINGS_PATH"],
+    launcherDir: "/tmp/fake-wake",
+    readEnv: (k: string) => (k === "PI_SETTINGS_PATH" ? "/cfg.json" : undefined),
   };
 
   it("isSessionAttachable maps has-session exit code", async () => {
@@ -273,51 +381,80 @@ describe("HibernationTmuxController", () => {
     ).toBe(false);
   });
 
-  it("respawns into the recorded pane and returns an attempt-bound handle", async () => {
+  it("respawns a DEAD pane (no -k) and returns an attempt-bound handle", async () => {
     const { runner, calls } = makeRunner({
       panePid: 111,
+      paneDead: "1",
       panePidAfterRespawn: 222,
+      paneDeadAfterRespawn: "0",
       respawnCode: 0,
     });
     const writeFile = vi.fn();
-    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile });
-    const result = await ctrl.respawnRuntime(ctx);
+    const unlink = vi.fn();
+    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile, unlink });
+    const result = await ctrl.respawnRuntime(makeLaunchCtx());
     expect(result.launched).toBe(true);
     expect(result.handle).toEqual({
       reservationNonce: "nonce-abcdef123456",
       tmuxTarget: "pinet-repo-worker-abcd:0.0",
       pid: 222,
     });
-    // Launcher script was written and resumes the exact session with the fence env.
+    // Launcher script resumes the exact session, exports the fence, and self-deletes.
     expect(writeFile).toHaveBeenCalledTimes(1);
     const script = writeFile.mock.calls[0][1] as string;
     expect(script).toContain("--session '/tmp/s/agent-1.jsonl'");
     expect(script).toContain("export PINET_WAKE_LEASE_ID='lease-1'");
     expect(script).toContain("export PINET_WAKE_RESERVATION_NONCE='nonce-abcdef123456'");
     expect(script).toContain("export PI_SETTINGS_PATH='/cfg.json'");
-    // respawn-pane -k targeted the recorded pane.
+    expect(script).toContain('rm -f -- "$0"');
+    // respawn-pane targeted the recorded pane WITHOUT the destructive -k flag.
     const respawn = calls.find((c) => c.args.includes("respawn-pane"));
     expect(respawn?.args).toEqual(
-      expect.arrayContaining(["respawn-pane", "-k", "-t", "pinet-repo-worker-abcd:0.0"]),
+      expect.arrayContaining(["respawn-pane", "-t", "pinet-repo-worker-abcd:0.0"]),
     );
+    expect(respawn?.args).not.toContain("-k");
+    // Success path: the script self-deletes, so the broker does not unlink.
+    expect(unlink).not.toHaveBeenCalled();
+  });
+
+  it("refuses to clobber a LIVE pane (destructive-wake guard)", async () => {
+    const { runner, calls } = makeRunner({ panePid: 111, paneDead: "0" });
+    const writeFile = vi.fn();
+    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile });
+    const result = await ctrl.respawnRuntime(makeLaunchCtx());
+    expect(result).toEqual({ launched: false, handle: null });
+    expect(writeFile).not.toHaveBeenCalled();
+    // No respawn-pane was ever attempted against the live pane.
+    expect(calls.find((c) => c.args.includes("respawn-pane"))).toBeUndefined();
+  });
+
+  it("refuses when the recorded tmux session is gone", async () => {
+    const { runner } = makeRunner({ panePid: 111, paneDead: "1", hasSessionCode: 1 });
+    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile: vi.fn() });
+    expect(await ctrl.respawnRuntime(makeLaunchCtx())).toEqual({ launched: false, handle: null });
   });
 
   it("fails closed (no handle) when the spec is not resumable", async () => {
-    const { runner } = makeRunner({ panePid: 111 });
+    const { runner } = makeRunner({ panePid: 111, paneDead: "1" });
     const writeFile = vi.fn();
     const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile });
-    const result = await ctrl.respawnRuntime({
-      ...ctx,
-      spec: makeSpec({ sessionResumeRef: "cwd:/repo/root" }),
-    });
+    const result = await ctrl.respawnRuntime(
+      makeLaunchCtx({ spec: makeSpec({ sessionResumeRef: "cwd:/repo/root" }) }),
+    );
     expect(result).toEqual({ launched: false, handle: null });
     expect(writeFile).not.toHaveBeenCalled();
   });
 
-  it("fails closed when respawn-pane errors", async () => {
-    const { runner } = makeRunner({ panePid: 111, respawnCode: 1 });
-    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile: vi.fn() });
-    expect(await ctrl.respawnRuntime(ctx)).toEqual({ launched: false, handle: null });
+  it("fails closed and unlinks the orphan launcher when respawn-pane errors", async () => {
+    const { runner } = makeRunner({ panePid: 111, paneDead: "1", respawnCode: 1 });
+    const writeFile = vi.fn();
+    const unlink = vi.fn();
+    const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile, unlink });
+    expect(await ctrl.respawnRuntime(makeLaunchCtx())).toEqual({ launched: false, handle: null });
+    // Failure path: the launcher never exec'd, so the broker removes the secret-bearing orphan.
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(unlink).toHaveBeenCalledTimes(1);
+    expect(unlink.mock.calls[0][0]).toContain("pinet-wake-nonce-abcdef123456.sh");
   });
 });
 

--- a/slack-bridge/broker/hibernation-runtime-adapters.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
-import type { RuntimeLaunchContext } from "@pinet/broker-core";
+import type { RuntimeAttemptHandle, RuntimeLaunchContext } from "@pinet/broker-core";
 import {
-  createAttemptGenerationRegistry,
   createHibernationProcessController,
   createHibernationTmuxController,
   resolveVcsIdentity,
@@ -40,7 +39,7 @@ interface RunnerState {
   panePid?: number | null;
   paneDead?: "0" | "1";
   rssKb?: number;
-  /** Process start token from `ps -o lstart=`; null ⇒ pid gone. Read live. */
+  /** Process start time from `ps -o lstart=`; null ⇒ pid gone. Read live. */
   startToken?: string | null;
   hasSessionCode?: number;
   respawnCode?: number;
@@ -114,6 +113,28 @@ function makeProcessWorld(alive: Set<number>, opts: { dieOnTerm?: boolean } = {}
   };
 }
 
+const respawnDeps = {
+  extensionEntryPath: "/ext/index.js",
+  baseLaunchEnv: { PINET_SOCKET_PATH: "/sock", PINET_BROKER_MANAGED: "1" },
+  inheritedEnvKeys: ["PI_SETTINGS_PATH"],
+  launcherDir: "/tmp/fake-wake",
+  readEnv: (k: string) => (k === "PI_SETTINGS_PATH" ? "/cfg.json" : undefined),
+};
+
+function makeLaunchCtx(overrides: Partial<RuntimeLaunchContext> = {}): RuntimeLaunchContext {
+  return {
+    agentId: "agent-1",
+    stableId: "host:session:/tmp/s/agent-1.jsonl",
+    wakeLeaseId: "lease-1",
+    fenceToken: 5,
+    reservedGeneration: 9,
+    reservationNonce: "nonce-abcdef123456",
+    correlationId: "corr-1",
+    spec: makeSpec(),
+    ...overrides,
+  };
+}
+
 describe("HibernationProcessController.requestCheckpoint", () => {
   it("is hibernateSafe when a live generation exists and the session is non-empty", async () => {
     const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
@@ -169,7 +190,7 @@ describe("HibernationProcessController.requestCheckpoint", () => {
     expect(outcome.reason).toBe("session_empty");
   });
 
-  it("refuses when the live pid has no readable start token (unverifiable generation)", async () => {
+  it("refuses when the live pid has no readable generation token", async () => {
     const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100, startToken: null });
     const ctrl = createHibernationProcessController({
       runner,
@@ -259,81 +280,59 @@ describe("HibernationProcessController generation-bound liveness + cleanup", () 
     ).toBe(false);
   });
 
-  it("fails closed when a launched attempt has no recorded generation", async () => {
+  it("fails closed when the handle carries no generation (foreign/degraded handle)", async () => {
     const { runner } = makeRunner({});
     const ctrl = createHibernationProcessController({ runner });
-    expect(
-      await ctrl.stopLaunchedAttempt({ reservationNonce: "n", tmuxTarget: "t", pid: null }),
-    ).toEqual({ stopped: false });
-    expect(
-      await ctrl.isLaunchedAttemptAlive({ reservationNonce: "n", tmuxTarget: "t", pid: 999 }),
-    ).toBe(true);
+    const bare: RuntimeAttemptHandle = { reservationNonce: "n", tmuxTarget: "t", pid: 999 };
+    expect(await ctrl.stopLaunchedAttempt(bare)).toEqual({ stopped: false });
+    expect(await ctrl.isLaunchedAttemptAlive(bare)).toBe(true);
   });
 
-  it("stops a launched attempt bound to the exact generation it recorded", async () => {
-    const registry = createAttemptGenerationRegistry();
+  it("default/public composition: an independently-built process controller can clean a tmux-launched attempt (no shared registry)", async () => {
+    // The regression for the composition trap: the two controllers are built
+    // INDEPENDENTLY exactly as the live wiring composes them — there is no shared
+    // registry to omit, because the launch generation travels inside the handle.
     const { runner } = makeRunner({
       panePid: 111,
       panePidAfterRespawn: 222,
       paneDead: "1",
       paneDeadAfterRespawn: "0",
-      startToken: "TOK-A",
       respawnCode: 0,
     });
     const world = makeProcessWorld(new Set([222]), { dieOnTerm: true });
-    const tmux = createHibernationTmuxController({
-      extensionEntryPath: "/ext/index.js",
-      baseLaunchEnv: { PINET_SOCKET_PATH: "/sock" },
-      inheritedEnvKeys: [],
-      launcherDir: "/tmp/fake-wake",
-      writeFile: vi.fn(),
-      runner,
-      attemptRegistry: registry,
-    });
-    const proc = createHibernationProcessController({
-      runner,
-      ...world,
-      attemptRegistry: registry,
-    });
-    const ctx = makeLaunchCtx();
-    const launch = await tmux.respawnRuntime(ctx);
+    const tmux = createHibernationTmuxController({ ...respawnDeps, runner, writeFile: vi.fn() });
+    const proc = createHibernationProcessController({ runner, ...world });
+    const launch = await tmux.respawnRuntime(makeLaunchCtx());
     expect(launch.launched).toBe(true);
     expect(launch.handle?.pid).toBe(222);
-    // The launched process is alive before cleanup, then provably stopped.
+    // The launched process is alive before cleanup, then provably stopped — even
+    // though `proc` and `tmux` never shared any registry object.
     expect(await proc.isLaunchedAttemptAlive(launch.handle!)).toBe(true);
     expect(await proc.stopLaunchedAttempt(launch.handle!)).toEqual({ stopped: true });
     expect(world.signals.map((s) => s.signal)).toEqual(["SIGTERM"]);
   });
 
-  it("never signals a reused pid: refuses cleanup when the start token drifted", async () => {
-    const registry = createAttemptGenerationRegistry();
+  it("never signals a cross-second reused pid: refuses cleanup when the start-time token drifted", async () => {
     const runnerBox = makeRunner({
       panePid: 111,
       panePidAfterRespawn: 222,
       paneDead: "1",
       paneDeadAfterRespawn: "0",
-      startToken: "TOK-A",
+      startToken: "Sun Jul 12 13:30:21 2026",
       respawnCode: 0,
     });
     const world = makeProcessWorld(new Set([222]), { dieOnTerm: true });
     const tmux = createHibernationTmuxController({
-      extensionEntryPath: "/ext/index.js",
-      baseLaunchEnv: { PINET_SOCKET_PATH: "/sock" },
-      inheritedEnvKeys: [],
-      launcherDir: "/tmp/fake-wake",
+      ...respawnDeps,
+      runner: runnerBox.runner,
       writeFile: vi.fn(),
-      runner: runnerBox.runner,
-      attemptRegistry: registry,
     });
-    const proc = createHibernationProcessController({
-      runner: runnerBox.runner,
-      ...world,
-      attemptRegistry: registry,
-    });
+    const proc = createHibernationProcessController({ runner: runnerBox.runner, ...world });
     const launch = await tmux.respawnRuntime(makeLaunchCtx());
     expect(launch.handle?.pid).toBe(222);
-    // Pid 222 exits and is REUSED by an unrelated same-user process (new start token).
-    runnerBox.state.startToken = "TOK-REUSED";
+    // Pid 222 exits and is REUSED by an unrelated same-user process that started
+    // at a different (later) time, so the start-time generation token drifts.
+    runnerBox.state.startToken = "Sun Jul 12 13:41:07 2026";
     const stop = await proc.stopLaunchedAttempt(launch.handle!);
     expect(stop).toEqual({ stopped: true });
     // Crucially, NO signal was ever delivered to the reused pid.
@@ -341,29 +340,7 @@ describe("HibernationProcessController generation-bound liveness + cleanup", () 
   });
 });
 
-function makeLaunchCtx(overrides: Partial<RuntimeLaunchContext> = {}): RuntimeLaunchContext {
-  return {
-    agentId: "agent-1",
-    stableId: "host:session:/tmp/s/agent-1.jsonl",
-    wakeLeaseId: "lease-1",
-    fenceToken: 5,
-    reservedGeneration: 9,
-    reservationNonce: "nonce-abcdef123456",
-    correlationId: "corr-1",
-    spec: makeSpec(),
-    ...overrides,
-  };
-}
-
 describe("HibernationTmuxController", () => {
-  const respawnDeps = {
-    extensionEntryPath: "/ext/index.js",
-    baseLaunchEnv: { PINET_SOCKET_PATH: "/sock", PINET_BROKER_MANAGED: "1" },
-    inheritedEnvKeys: ["PI_SETTINGS_PATH"],
-    launcherDir: "/tmp/fake-wake",
-    readEnv: (k: string) => (k === "PI_SETTINGS_PATH" ? "/cfg.json" : undefined),
-  };
-
   it("isSessionAttachable maps has-session exit code", async () => {
     const attach = makeRunner({ hasSessionCode: 0 });
     const gone = makeRunner({ hasSessionCode: 1 });
@@ -394,7 +371,7 @@ describe("HibernationTmuxController", () => {
     const ctrl = createHibernationTmuxController({ ...respawnDeps, runner, writeFile, unlink });
     const result = await ctrl.respawnRuntime(makeLaunchCtx());
     expect(result.launched).toBe(true);
-    expect(result.handle).toEqual({
+    expect(result.handle).toMatchObject({
       reservationNonce: "nonce-abcdef123456",
       tmuxTarget: "pinet-repo-worker-abcd:0.0",
       pid: 222,

--- a/slack-bridge/broker/hibernation-runtime-adapters.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.test.ts
@@ -162,6 +162,22 @@ describe("HibernationProcessController.stopRuntime", () => {
     expect(tmuxVerbs).not.toContain("kill-pane");
   });
 
+  it("ensures remain-on-exit on the session before killing Pi (no spawn-path change needed)", async () => {
+    const { runner, calls } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
+    const world = makeProcessWorld(new Set([4242]), { dieOnTerm: true });
+    const ctrl = createHibernationProcessController({ runner, ...world });
+    await ctrl.stopRuntime(makeSpec());
+    const setOption = calls.find(
+      (c) =>
+        c.file === "tmux" && c.args.includes("set-option") && c.args.includes("remain-on-exit"),
+    );
+    expect(setOption).toBeDefined();
+    expect(setOption?.args).toContain("on");
+    // It targets the recorded tmux session, never a destructive verb.
+    expect(setOption?.args).toContain(makeSpec().tmuxSession);
+    expect(setOption?.args).not.toContain("kill-session");
+  });
+
   it("escalates to SIGKILL when the runtime ignores SIGTERM", async () => {
     const { runner } = makeRunner({ panePid: 4242, paneDead: "0", rssKb: 100 });
     const world = makeProcessWorld(new Set([4242]), { dieOnTerm: false });

--- a/slack-bridge/broker/hibernation-runtime-adapters.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.ts
@@ -237,9 +237,20 @@ export function createHibernationProcessController(
       const pid = await panePid(d.runner, spec);
       if (pid == null) return { stopped: true, rssBytes: null };
       const rssBytes = await rssBytesOf(d.runner, pid);
+      // Ensure the pane survives the Pi exit BEFORE stopping it, so hibernation
+      // requires no change to the worker spawn path. With remain-on-exit on,
+      // killing the pane's foreground Pi leaves the tmux session intact and
+      // operator-attachable, and a wake can respawn into it. Best-effort: the
+      // orchestrator independently verifies survival via isSessionAttachable.
+      await d.runner.run("tmux", [
+        ...tmuxSocketArgs(spec),
+        "set-option",
+        "-t",
+        spec.tmuxSession,
+        "remain-on-exit",
+        "on",
+      ]);
       const stopped = await terminatePid(pid, d);
-      // The tmux pane/session is deliberately left intact (remain-on-exit) so it
-      // stays operator-attachable and a wake can respawn into it.
       return { stopped, rssBytes };
     },
 

--- a/slack-bridge/broker/hibernation-runtime-adapters.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.ts
@@ -17,14 +17,33 @@
 //
 // PID-reuse / signal safety (independent-review P1): a numeric pid is NEVER
 // signalled on its own. Every TERM/KILL/liveness action is bound to a process
-// GENERATION — the tuple (pane-authoritative `pane_pid`, `pane_dead=0`, and the
-// OS process START TOKEN from `ps -o lstart=`) — and is re-verified immediately
-// before each signal. If the pane no longer hosts that exact live generation
-// (the process exited, the pane died, or the pid was reused by an unrelated
-// same-user process with a different start token) the action is abandoned as
-// "already gone" rather than risking a kill of an unrelated process. Wake-attempt
-// generations are carried in an injected {@link AttemptGenerationRegistry} so the
-// attempt-scoped stop/liveness probes bind to the EXACT process a wake launched.
+// GENERATION and re-verified immediately before each signal. A generation is the
+// tuple (pane-authoritative `pane_pid`, `pane_dead=0`, and the OS process START
+// TIME from `ps -o lstart=`). If the pane no longer hosts that exact live
+// generation — the process exited, the pane died, or the pid was reused by a
+// process with a different start time — the action is abandoned as "already gone"
+// rather than risking a signal to an unrelated process. Start time is used (not
+// the command line) because the wake launcher `exec`s Pi over its own shell: that
+// preserves the pid AND the start time but REWRITES the command line, so a
+// command-line token would spuriously drift across the exec while start time stays
+// stable and correctly pins the process instance.
+//
+// Honest limits (independent-review P2 hardening): `ps -o lstart=` is only
+// second-resolution and the verify→signal step is not atomic, so a residual TOCTOU
+// window remains — a same-user process that reused the pid WITHIN the same wall
+// second could compare equal. No higher-resolution start token is portably
+// available via `ps` across macOS/Linux, so this is strong defense-in-depth that
+// makes cross-second reuse safe, NOT an absolute guarantee; the same-second window
+// is an accepted, documented residual rather than a claimed "never".
+//
+// The wake attempt's generation travels INSIDE the `RuntimeAttemptHandle` the
+// controller returns (see {@link LaunchedAttemptHandle}); the orchestrator
+// round-trips that handle opaquely and hands it back to the attempt-scoped
+// stop/liveness probes. There is therefore NO shared mutable registry between the
+// two controllers to mis-compose — the generation binding is carried by the
+// handle itself, so independent construction of the two controllers (as the live
+// wiring does) is inherently correct and a failed/timed-out wake is always
+// cleanable by the exact process it launched.
 //
 // All process/tmux/ps/git interaction is funnelled through an injectable
 // `CommandRunner` + signal/liveness hooks so the security- and correctness-
@@ -89,44 +108,47 @@ interface PaneAddress {
 }
 
 /**
- * A verified OS process generation: the pane's foreground pid PLUS its process
- * start token. The start token pins the exact process instance so a reused pid
- * (same number, different process) is never mistaken for — or signalled as — the
- * original runtime.
+ * A verified OS process generation: the pane's foreground pid PLUS an OS
+ * generation token (the process START TIME). The token pins the exact process
+ * instance so a cross-second reused pid (same number, different process, later
+ * start) is not mistaken for — or signalled as — the original runtime. Start time
+ * survives the launcher's `exec` of Pi (unlike the command line), so it stays
+ * stable for the life of the runtime. See the header note on the residual
+ * same-second window.
  */
 interface ProcessGeneration {
   pid: number;
-  startToken: string;
+  generationToken: string;
 }
 
 /**
- * The attempt-bound generation a single wake launched. Carries the pane address
+ * The attempt-bound generation a single wake launched, carrying the pane address
  * so the attempt-scoped stop/liveness probes read the exact pane the attempt
- * respawned into (the `RuntimeAttemptHandle` public shape intentionally exposes
- * only the nonce/target/pid; the generation binding lives here).
+ * respawned into. Embedded in {@link LaunchedAttemptHandle}.
  */
 export interface AttemptGeneration extends ProcessGeneration, PaneAddress {}
 
 /**
- * Records the generation each wake attempt launched, keyed by reservation nonce,
- * so `stopLaunchedAttempt` / `isLaunchedAttemptAlive` prove the EXACT process
- * that attempt spawned is gone/alive. Shared (injected) between the tmux
- * controller (which records at respawn) and the process controller (which reads
- * at cleanup). A miss fails closed (unprovable ⇒ not-stopped / still-alive).
+ * The `RuntimeAttemptHandle` the tmux controller actually returns: the public
+ * broker-core shape PLUS the immutable {@link AttemptGeneration} that launch
+ * captured. The orchestrator only ever reads the public fields and round-trips
+ * the object opaquely, so the generation rides along back to the process
+ * controller's attempt-scoped probes — no shared registry required. A handle
+ * WITHOUT a generation (e.g. one reconstructed elsewhere) is unprovable and the
+ * probes fail closed.
  */
-export interface AttemptGenerationRegistry {
-  record(reservationNonce: string, generation: AttemptGeneration): void;
-  get(reservationNonce: string): AttemptGeneration | undefined;
-  clear(reservationNonce: string): void;
+interface LaunchedAttemptHandle extends RuntimeAttemptHandle {
+  readonly generation: AttemptGeneration;
 }
 
-export function createAttemptGenerationRegistry(): AttemptGenerationRegistry {
-  const map = new Map<string, AttemptGeneration>();
-  return {
-    record: (nonce, generation) => void map.set(nonce, generation),
-    get: (nonce) => map.get(nonce),
-    clear: (nonce) => void map.delete(nonce),
-  };
+/**
+ * Boundary read of the launch generation carried by a handle. The handle arrives
+ * typed as the public broker-core shape; if it was minted by our
+ * `respawnRuntime` it carries a well-formed {@link AttemptGeneration}, otherwise
+ * the field is absent and we return null (probes then fail closed).
+ */
+function launchedGenerationOf(handle: RuntimeAttemptHandle): AttemptGeneration | null {
+  return (handle as Partial<LaunchedAttemptHandle>).generation ?? null;
 }
 
 function tmuxSocketArgs(socket: string): string[] {
@@ -147,8 +169,6 @@ export interface RuntimeAdapterDeps {
   stopGraceMs?: number;
   /** Poll interval while awaiting process exit. */
   pollMs?: number;
-  /** Shared attempt-generation registry (created if omitted). */
-  attemptRegistry?: AttemptGenerationRegistry;
 }
 
 interface ResolvedProcessDeps {
@@ -161,7 +181,6 @@ interface ResolvedProcessDeps {
   pendingInboxCount: (agentId: string) => number;
   stopGraceMs: number;
   pollMs: number;
-  attemptRegistry: AttemptGenerationRegistry;
 }
 
 // agent-standards-ignore prefer-inline-single-use-helper: centralizes default
@@ -196,7 +215,6 @@ function resolveProcessDeps(deps: RuntimeAdapterDeps): ResolvedProcessDeps {
     pendingInboxCount: deps.pendingInboxCount ?? (() => 0),
     stopGraceMs: deps.stopGraceMs ?? 5_000,
     pollMs: deps.pollMs ?? 100,
-    attemptRegistry: deps.attemptRegistry ?? createAttemptGenerationRegistry(),
   };
 }
 
@@ -231,40 +249,45 @@ async function rssBytesOf(runner: CommandRunner, pid: number): Promise<number | 
 }
 
 /**
- * The OS process start token (`ps -o lstart=`), normalized to a single-spaced
- * opaque string. Two processes sharing a pid but not a start token are DIFFERENT
- * process instances, so this pins the generation against pid reuse. Returns null
- * when the pid is gone (no ps row).
+ * The OS generation token for a pid: its process START TIME (`ps -o lstart=`),
+ * normalized. Two processes sharing a pid but not this start time are DIFFERENT
+ * process instances (cross-second reuse), so this pins the generation against the
+ * common pid-reuse case. The command line is deliberately NOT included: the wake
+ * launcher `exec`s Pi over its shell, rewriting the command line while preserving
+ * the pid and start time, so a command token would drift spuriously across that
+ * exec. Returns null when the pid is gone (no ps row). See the "Honest limits"
+ * header note re: the residual same-second window.
  */
-async function processStartToken(runner: CommandRunner, pid: number): Promise<string | null> {
-  const result = await runner.run("ps", ["-o", "lstart=", "-p", String(pid)]);
-  if (result.code !== 0) return null;
-  const token = result.stdout.trim().replace(/\s+/g, " ");
-  return token.length > 0 ? token : null;
+async function readGenerationToken(runner: CommandRunner, pid: number): Promise<string | null> {
+  const started = await runner.run("ps", ["-o", "lstart=", "-p", String(pid)]);
+  if (started.code !== 0) return null;
+  const startedAt = started.stdout.trim().replace(/\s+/g, " ");
+  return startedAt.length > 0 ? startedAt : null;
 }
 
 /**
  * Read the pane's current process generation: its foreground pid, whether the
  * pane is dead (only an explicit `pane_dead=0` is live; null/"1" ⇒ dead/gone),
- * and the pid's start token. `startToken` is null when the pane has no live pid.
+ * and the pid's generation token. `generationToken` is null when the pane has no
+ * live pid.
  */
 async function readPaneGeneration(
   runner: CommandRunner,
   addr: PaneAddress,
-): Promise<{ pid: number | null; dead: boolean; startToken: string | null }> {
+): Promise<{ pid: number | null; dead: boolean; generationToken: string | null }> {
   const pid = await panePid(runner, addr);
   const deadRaw = await paneField(runner, addr, "pane_dead");
   const dead = deadRaw !== "0";
-  const startToken = pid != null ? await processStartToken(runner, pid) : null;
-  return { pid, dead, startToken };
+  const generationToken = pid != null ? await readGenerationToken(runner, pid) : null;
+  return { pid, dead, generationToken };
 }
 
 /**
  * True only if the pane provably still hosts the EXACT expected live generation:
  * the pane's foreground pid equals the expected pid, the pane is not dead, the
- * pid is a live process, and its current start token matches the expected one
- * (defeating pid reuse). Any drift ⇒ false (the expected process is gone / not
- * ours), so a signal is never sent to a reused or replaced pid.
+ * pid is a live process, and its current generation token matches the expected
+ * one (defeating pid reuse). Any drift ⇒ false (the expected process is gone /
+ * not ours), so a signal is never sent to a reused or replaced pid.
  */
 async function paneHostsGeneration(
   runner: CommandRunner,
@@ -276,8 +299,8 @@ async function paneHostsGeneration(
   return (
     current.pid === expected.pid &&
     !current.dead &&
-    current.startToken != null &&
-    current.startToken === expected.startToken &&
+    current.generationToken != null &&
+    current.generationToken === expected.generationToken &&
     processAlive(expected.pid)
   );
 }
@@ -286,9 +309,9 @@ async function paneHostsGeneration(
  * TERM then bounded KILL a process addressed by its pane + generation. The pane
  * is re-verified to still host the exact expected live generation immediately
  * before EVERY signal; the moment it no longer does (exit, pane death, or pid
- * reuse with a different start token) the process is treated as confirmed gone
- * and no further signal is sent. Shared by pre-hibernation stop and failed-wake
- * attempt cleanup. Resolves whether the generation is confirmed gone.
+ * reuse with a different generation token) the process is treated as confirmed
+ * gone and no further signal is sent. Shared by pre-hibernation stop and
+ * failed-wake attempt cleanup. Resolves whether the generation is confirmed gone.
  */
 async function terminateGeneration(
   addr: PaneAddress,
@@ -331,13 +354,13 @@ export function createHibernationProcessController(
     const alive =
       current.pid != null &&
       !current.dead &&
-      current.startToken != null &&
+      current.generationToken != null &&
       d.processAlive(current.pid);
     return {
       alive,
       generation:
-        alive && current.pid != null && current.startToken != null
-          ? { pid: current.pid, startToken: current.startToken }
+        alive && current.pid != null && current.generationToken != null
+          ? { pid: current.pid, generationToken: current.generationToken }
           : null,
     };
   }
@@ -347,11 +370,11 @@ export function createHibernationProcessController(
       // Contract (narrowed, evidence-backed): a `hibernateSafe` result asserts
       // the RESUMABILITY PRECONDITION — the recorded pane still hosts a live
       // process generation (pane-authoritative pid, `pane_dead=0`, live pid with
-      // a readable start token) AND the session `.jsonl` exists and is NON-EMPTY
-      // on disk. It does NOT perform a cooperative in-flight flush/ack handshake
-      // with Pi (which would require Pi-side support and is future work); the
-      // orchestrator additionally refuses to hibernate while any inbox work is
-      // pending/arriving, so a mid-turn runtime is not silently discarded.
+      // a readable generation token) AND the session `.jsonl` exists and is
+      // NON-EMPTY on disk. It does NOT perform a cooperative in-flight flush/ack
+      // handshake with Pi (which would require Pi-side support and is future
+      // work); the orchestrator additionally refuses to hibernate while any inbox
+      // work is pending/arriving, so a mid-turn runtime is not silently discarded.
       const { alive, generation } = await runtimeAlive(spec);
       const rssBytes = generation != null ? await rssBytesOf(d.runner, generation.pid) : null;
       const pendingInboxCount = d.pendingInboxCount(spec.agentId);
@@ -377,11 +400,14 @@ export function createHibernationProcessController(
       // Capture the live generation to stop BEFORE any mutation; if the pane is
       // already dead / has no live generation there is nothing to stop.
       const current = await readPaneGeneration(d.runner, addr);
-      if (current.pid == null || current.dead || current.startToken == null) {
+      if (current.pid == null || current.dead || current.generationToken == null) {
         return { stopped: true, rssBytes: null };
       }
       if (!d.processAlive(current.pid)) return { stopped: true, rssBytes: null };
-      const generation: ProcessGeneration = { pid: current.pid, startToken: current.startToken };
+      const generation: ProcessGeneration = {
+        pid: current.pid,
+        generationToken: current.generationToken,
+      };
       const rssBytes = await rssBytesOf(d.runner, generation.pid);
       // Ensure the pane survives the Pi exit BEFORE stopping it, so hibernation
       // requires no change to the worker spawn path. With remain-on-exit on,
@@ -404,24 +430,22 @@ export function createHibernationProcessController(
     },
 
     async stopLaunchedAttempt(handle: RuntimeAttemptHandle): Promise<{ stopped: boolean }> {
-      // Bind to the generation THIS attempt recorded at respawn. A miss (no
-      // recorded generation ⇒ pid/start token were never captured) is unprovable,
-      // so fail closed rather than risk relaunching over a live runtime.
-      const generation = d.attemptRegistry.get(handle.reservationNonce);
+      // Bind to the generation THIS attempt carried in its handle. A handle with
+      // no generation is unprovable, so fail closed rather than risk relaunching
+      // over a live runtime.
+      const generation = launchedGenerationOf(handle);
       if (!generation) return { stopped: false };
       const addr: PaneAddress = {
         tmuxSocket: generation.tmuxSocket,
         tmuxTarget: generation.tmuxTarget,
       };
-      const stopped = await terminateGeneration(addr, generation, d);
-      if (stopped) d.attemptRegistry.clear(handle.reservationNonce);
-      return { stopped };
+      return { stopped: await terminateGeneration(addr, generation, d) };
     },
 
     async isLaunchedAttemptAlive(handle: RuntimeAttemptHandle): Promise<boolean> {
-      // Unprovable (no recorded generation) ⇒ treat as still alive so cleanup
+      // Unprovable (no carried generation) ⇒ treat as still alive so cleanup
       // never assumes a phantom exit.
-      const generation = d.attemptRegistry.get(handle.reservationNonce);
+      const generation = launchedGenerationOf(handle);
       if (!generation) return true;
       const addr: PaneAddress = {
         tmuxSocket: generation.tmuxSocket,
@@ -446,10 +470,6 @@ export interface RuntimeRespawnDeps {
   writeFile?: (filePath: string, content: string, mode: number) => void;
   unlink?: (filePath: string) => void;
   readEnv?: (key: string) => string | undefined;
-  /** Shared attempt-generation registry (created if omitted). */
-  attemptRegistry?: AttemptGenerationRegistry;
-  /** Injectable liveness for the captured pid's start token verification. */
-  processAlive?: (pid: number) => boolean;
 }
 
 export function createHibernationTmuxController(
@@ -468,7 +488,6 @@ export function createHibernationTmuxController(
       }
     });
   const readEnv = deps.readEnv ?? ((key) => process.env[key]);
-  const attemptRegistry = deps.attemptRegistry ?? createAttemptGenerationRegistry();
   const buildNickname =
     deps.buildNickname ??
     ((ctx) => `Woken ${ctx.spec.launchSource || "worker"} ${ctx.reservationNonce.slice(0, 8)}`);
@@ -560,22 +579,31 @@ export function createHibernationTmuxController(
         if (result.code !== 0) return { launched: false, handle: null };
         launched = true;
 
-        // Bind the launched attempt to its exact process generation so retry
-        // cleanup can prove THIS process (not a reused pid) is gone.
+        // Bind the launched attempt to its exact process generation and carry it
+        // INSIDE the handle, so retry cleanup can prove THIS process (not a reused
+        // pid) is gone with no shared registry. If the pid/token cannot be
+        // captured, the handle carries no generation and the attempt-scoped probes
+        // fail closed (orchestrator quarantines as ambiguous).
         const pid = await panePid(runner, addr);
-        const startToken = pid != null ? await processStartToken(runner, pid) : null;
-        if (pid != null && startToken != null) {
-          attemptRegistry.record(ctx.reservationNonce, {
-            pid,
-            startToken,
-            tmuxSocket: spec.tmuxSocket,
-            tmuxTarget: spec.tmuxTarget,
-          });
-        }
-        return {
-          launched: true,
-          handle: { reservationNonce: ctx.reservationNonce, tmuxTarget: spec.tmuxTarget, pid },
+        const generationToken = pid != null ? await readGenerationToken(runner, pid) : null;
+        const base: RuntimeAttemptHandle = {
+          reservationNonce: ctx.reservationNonce,
+          tmuxTarget: spec.tmuxTarget,
+          pid,
         };
+        if (pid != null && generationToken != null) {
+          const handle: LaunchedAttemptHandle = {
+            ...base,
+            generation: {
+              pid,
+              generationToken,
+              tmuxSocket: spec.tmuxSocket,
+              tmuxTarget: spec.tmuxTarget,
+            },
+          };
+          return { launched: true, handle };
+        }
+        return { launched: true, handle: base };
       } finally {
         // Guaranteed cleanup of the secret-bearing launcher: on the happy path
         // the script self-deletes (`rm -f "$0"` before exec), so unlinking here

--- a/slack-bridge/broker/hibernation-runtime-adapters.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.ts
@@ -1,0 +1,373 @@
+// Real hibernation runtime adapters: the live `HibernationProcessController` and
+// `HibernationTmuxController` the broker injects into `HibernationOrchestrator`.
+//
+// Design (proven feasible on disposable tmux/pi workers):
+//   • A broker-managed worker runs `pi` as the foreground process of a tmux pane
+//     whose session was launched with `remain-on-exit on`. The pane's `pane_pid`
+//     IS the Pi runtime pid; its session `.jsonl` path is recorded in the runtime
+//     spec's `sessionResumeRef` (`session:<path>`).
+//   • Hibernate = stop the Pi pid (TERM then bounded KILL). Because the pane has
+//     `remain-on-exit on`, the tmux session survives (operator-attachable) and is
+//     NEVER destroyed here.
+//   • Wake = `tmux respawn-pane -k` running a launcher that exports the single-use
+//     wake fence and resumes the exact session via `pi --session <path>`. The
+//     woken Pi re-registers under the SAME stable id (same session path) and
+//     presents the fence for atomic generation acceptance.
+//
+// All process/tmux/ps/git interaction is funnelled through an injectable
+// `CommandRunner` + signal/liveness hooks so the security- and correctness-
+// critical control flow is unit-testable without spawning real processes.
+
+import { execFile, type ExecFileException } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type {
+  HibernationCheckpointOutcome,
+  HibernationProcessController,
+  HibernationTmuxController,
+  RuntimeAttemptHandle,
+  RuntimeLaunchContext,
+} from "@pinet/broker-core";
+import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
+import {
+  buildResumeLauncherScript,
+  buildWakeFenceEnv,
+  deriveVcsIdentity,
+  parseRssBytesFromPs,
+  resumePathFromSessionRef,
+} from "./hibernation-runtime-helpers.js";
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/** Minimal command executor abstraction (fake in tests, execFile at runtime). */
+export interface CommandRunner {
+  run(file: string, args: string[]): Promise<CommandResult>;
+}
+
+/** Real `CommandRunner` over `child_process.execFile` that never throws on a
+ * non-zero exit — it resolves the captured exit code so callers branch on it. */
+export function createExecFileRunner(): CommandRunner {
+  return {
+    run(file, args) {
+      return new Promise<CommandResult>((resolve) => {
+        execFile(
+          file,
+          args,
+          { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 },
+          (error: ExecFileException | null, stdout, stderr) => {
+            const rawCode = error?.code;
+            const code = typeof rawCode === "number" ? rawCode : error ? 1 : 0;
+            resolve({ stdout: stdout ?? "", stderr: stderr ?? "", code });
+          },
+        );
+      });
+    },
+  };
+}
+
+function tmuxSocketArgs(spec: AgentRuntimeSpec): string[] {
+  return spec.tmuxSocket ? ["-S", spec.tmuxSocket] : [];
+}
+
+export interface RuntimeAdapterDeps {
+  runner?: CommandRunner;
+  fileExists?: (filePath: string) => boolean;
+  processAlive?: (pid: number) => boolean;
+  sendSignal?: (pid: number, signal: NodeJS.Signals) => void;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  /** Pending inbox count projection for the checkpoint outcome. */
+  pendingInboxCount?: (agentId: string) => number;
+  /** Grace window for TERM before escalating to KILL. */
+  stopGraceMs?: number;
+  /** Poll interval while awaiting process exit. */
+  pollMs?: number;
+}
+
+interface ResolvedProcessDeps {
+  runner: CommandRunner;
+  fileExists: (filePath: string) => boolean;
+  processAlive: (pid: number) => boolean;
+  sendSignal: (pid: number, signal: NodeJS.Signals) => void;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  pendingInboxCount: (agentId: string) => number;
+  stopGraceMs: number;
+  pollMs: number;
+}
+
+// agent-standards-ignore prefer-inline-single-use-helper: centralizes default
+// resolution for the ResolvedProcessDeps bundle shared by the controller and the
+// module-level terminatePid escalation helper.
+function resolveProcessDeps(deps: RuntimeAdapterDeps): ResolvedProcessDeps {
+  return {
+    runner: deps.runner ?? createExecFileRunner(),
+    fileExists: deps.fileExists ?? ((p) => fs.existsSync(p)),
+    processAlive:
+      deps.processAlive ??
+      ((pid) => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch (error) {
+          // EPERM means the process exists but we may not signal it — still "alive".
+          return (error as NodeJS.ErrnoException).code === "EPERM";
+        }
+      }),
+    sendSignal: deps.sendSignal ?? ((pid, signal) => process.kill(pid, signal)),
+    now: deps.now ?? (() => Date.now()),
+    sleep: deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+    pendingInboxCount: deps.pendingInboxCount ?? (() => 0),
+    stopGraceMs: deps.stopGraceMs ?? 5_000,
+    pollMs: deps.pollMs ?? 100,
+  };
+}
+
+async function paneField(
+  runner: CommandRunner,
+  spec: AgentRuntimeSpec,
+  field: string,
+): Promise<string | null> {
+  const result = await runner.run("tmux", [
+    ...tmuxSocketArgs(spec),
+    "display-message",
+    "-p",
+    "-t",
+    spec.tmuxTarget,
+    `#{${field}}`,
+  ]);
+  if (result.code !== 0) return null;
+  const value = result.stdout.trim();
+  return value.length > 0 ? value : null;
+}
+
+async function panePid(runner: CommandRunner, spec: AgentRuntimeSpec): Promise<number | null> {
+  const raw = await paneField(runner, spec, "pane_pid");
+  const pid = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+async function rssBytesOf(runner: CommandRunner, pid: number): Promise<number | null> {
+  const result = await runner.run("ps", ["-o", "rss=", "-p", String(pid)]);
+  if (result.code !== 0) return null;
+  return parseRssBytesFromPs(result.stdout);
+}
+
+/** TERM then bounded KILL a pid; resolves whether it is confirmed gone. Shared by
+ * pre-hibernation stop and failed-wake-attempt cleanup. */
+async function terminatePid(pid: number, deps: ResolvedProcessDeps): Promise<boolean> {
+  if (!deps.processAlive(pid)) return true;
+  try {
+    deps.sendSignal(pid, "SIGTERM");
+  } catch {
+    // Already gone between the liveness check and the signal.
+    return !deps.processAlive(pid);
+  }
+  const deadline = deps.now() + deps.stopGraceMs;
+  while (deps.now() < deadline) {
+    await deps.sleep(deps.pollMs);
+    if (!deps.processAlive(pid)) return true;
+  }
+  try {
+    deps.sendSignal(pid, "SIGKILL");
+  } catch {
+    // Raced to exit during escalation.
+  }
+  await deps.sleep(deps.pollMs);
+  return !deps.processAlive(pid);
+}
+
+export function createHibernationProcessController(
+  deps: RuntimeAdapterDeps = {},
+): HibernationProcessController {
+  const d = resolveProcessDeps(deps);
+
+  async function runtimeAlive(
+    spec: AgentRuntimeSpec,
+  ): Promise<{ alive: boolean; pid: number | null }> {
+    const pid = await panePid(d.runner, spec);
+    const deadRaw = await paneField(d.runner, spec, "pane_dead");
+    // A dead/gone pane reads null or "1"; only an explicit "0" is a live runtime.
+    const alive = pid != null && deadRaw === "0" && d.processAlive(pid);
+    return { alive, pid };
+  }
+
+  return {
+    async requestCheckpoint(spec: AgentRuntimeSpec): Promise<HibernationCheckpointOutcome> {
+      const { alive, pid } = await runtimeAlive(spec);
+      const rssBytes = pid != null ? await rssBytesOf(d.runner, pid) : null;
+      const pendingInboxCount = d.pendingInboxCount(spec.agentId);
+      const resumePath = resumePathFromSessionRef(spec.sessionResumeRef);
+      const sessionOnDisk = resumePath != null && d.fileExists(resumePath);
+      if (!alive) {
+        return {
+          hibernateSafe: false,
+          reason: "runtime_not_alive",
+          sessionResumeRef: spec.sessionResumeRef,
+          pendingInboxCount,
+          rssBytes,
+        };
+      }
+      if (!sessionOnDisk) {
+        return {
+          hibernateSafe: false,
+          reason: "session_unresumable",
+          sessionResumeRef: spec.sessionResumeRef,
+          pendingInboxCount,
+          rssBytes,
+        };
+      }
+      return {
+        hibernateSafe: true,
+        reason: null,
+        sessionResumeRef: spec.sessionResumeRef,
+        pendingInboxCount,
+        rssBytes,
+      };
+    },
+
+    async stopRuntime(
+      spec: AgentRuntimeSpec,
+    ): Promise<{ stopped: boolean; rssBytes: number | null }> {
+      const pid = await panePid(d.runner, spec);
+      if (pid == null) return { stopped: true, rssBytes: null };
+      const rssBytes = await rssBytesOf(d.runner, pid);
+      const stopped = await terminatePid(pid, d);
+      // The tmux pane/session is deliberately left intact (remain-on-exit) so it
+      // stays operator-attachable and a wake can respawn into it.
+      return { stopped, rssBytes };
+    },
+
+    async isRuntimeAlive(spec: AgentRuntimeSpec): Promise<boolean> {
+      return (await runtimeAlive(spec)).alive;
+    },
+
+    async stopLaunchedAttempt(handle: RuntimeAttemptHandle): Promise<{ stopped: boolean }> {
+      // No captured pid ⇒ we cannot PROVE this exact attempt's process is gone,
+      // so fail closed rather than risk relaunching over a live runtime.
+      if (handle.pid == null) return { stopped: false };
+      return { stopped: await terminatePid(handle.pid, d) };
+    },
+
+    async isLaunchedAttemptAlive(handle: RuntimeAttemptHandle): Promise<boolean> {
+      // Unprovable ⇒ treat as still alive so cleanup never assumes a phantom exit.
+      if (handle.pid == null) return true;
+      return d.processAlive(handle.pid);
+    },
+  };
+}
+
+export interface RuntimeRespawnDeps {
+  runner?: CommandRunner;
+  /** slack-bridge extension entry the woken runtime loads (`pi -e <path>`). */
+  extensionEntryPath: string;
+  /** Base PINET_* env re-establishing the mesh connection for the woken worker. */
+  baseLaunchEnv: Record<string, string>;
+  /** Broker env keys re-exported into the woken runtime when present. */
+  inheritedEnvKeys: string[];
+  buildNickname?: (ctx: RuntimeLaunchContext) => string;
+  launcherDir?: string;
+  writeFile?: (filePath: string, content: string, mode: number) => void;
+  readEnv?: (key: string) => string | undefined;
+}
+
+export function createHibernationTmuxController(
+  deps: RuntimeRespawnDeps,
+): HibernationTmuxController {
+  const runner = deps.runner ?? createExecFileRunner();
+  const launcherDir = deps.launcherDir ?? os.tmpdir();
+  const writeFile =
+    deps.writeFile ?? ((filePath, content, mode) => fs.writeFileSync(filePath, content, { mode }));
+  const readEnv = deps.readEnv ?? ((key) => process.env[key]);
+  const buildNickname =
+    deps.buildNickname ??
+    ((ctx) => `Woken ${ctx.spec.launchSource || "worker"} ${ctx.reservationNonce.slice(0, 8)}`);
+
+  return {
+    async isSessionAttachable(spec: AgentRuntimeSpec): Promise<boolean> {
+      const result = await runner.run("tmux", [
+        ...tmuxSocketArgs(spec),
+        "has-session",
+        "-t",
+        spec.tmuxSession,
+      ]);
+      return result.code === 0;
+    },
+
+    async respawnRuntime(
+      ctx: RuntimeLaunchContext,
+    ): Promise<{ launched: boolean; handle: RuntimeAttemptHandle | null }> {
+      const spec = ctx.spec;
+      const resumePath = resumePathFromSessionRef(spec.sessionResumeRef);
+      // Unresumable spec ⇒ no session to bring back; fail closed (no handle).
+      if (!resumePath) return { launched: false, handle: null };
+
+      const inheritedEnv: Record<string, string | undefined> = {};
+      for (const key of deps.inheritedEnvKeys) inheritedEnv[key] = readEnv(key);
+
+      const pinetEnv: Record<string, string> = {
+        ...deps.baseLaunchEnv,
+        ...buildWakeFenceEnv({
+          wakeLeaseId: ctx.wakeLeaseId,
+          fenceToken: ctx.fenceToken,
+          reservedGeneration: ctx.reservedGeneration,
+          reservationNonce: ctx.reservationNonce,
+          correlationId: ctx.correlationId,
+        }),
+      };
+
+      const script = buildResumeLauncherScript({
+        repoPath: spec.cwd || spec.repoRoot,
+        sessionPath: resumePath,
+        extensionEntryPath: deps.extensionEntryPath,
+        inheritedEnv,
+        pinetEnv,
+        nickname: buildNickname(ctx),
+      });
+
+      const launcherPath = path.join(launcherDir, `pinet-wake-${ctx.reservationNonce}.sh`);
+      try {
+        writeFile(launcherPath, script, 0o700);
+      } catch {
+        return { launched: false, handle: null };
+      }
+
+      const result = await runner.run("tmux", [
+        ...tmuxSocketArgs(spec),
+        "respawn-pane",
+        "-k",
+        "-t",
+        spec.tmuxTarget,
+        launcherPath,
+      ]);
+      if (result.code !== 0) return { launched: false, handle: null };
+
+      const pid = await panePid(runner, spec);
+      return {
+        launched: true,
+        handle: { reservationNonce: ctx.reservationNonce, tmuxTarget: spec.tmuxTarget, pid },
+      };
+    },
+  };
+}
+
+/**
+ * Resolve the canonical git-remote-derived `owner/repo` VCS identity for a repo
+ * root at spawn time. This is the ONLY identity the repo allowlist authorizes
+ * against — derived from the runtime's actual `origin` remote, never from the
+ * filesystem directory name. Returns null when no remote is resolvable (the
+ * fail-closed authorization gate then refuses).
+ */
+export async function resolveVcsIdentity(
+  repoRoot: string,
+  runner: CommandRunner = createExecFileRunner(),
+): Promise<string | null> {
+  const result = await runner.run("git", ["-C", repoRoot, "remote", "get-url", "origin"]);
+  if (result.code !== 0) return null;
+  return deriveVcsIdentity(result.stdout.trim());
+}

--- a/slack-bridge/broker/hibernation-runtime-adapters.ts
+++ b/slack-bridge/broker/hibernation-runtime-adapters.ts
@@ -8,11 +8,23 @@
 //     spec's `sessionResumeRef` (`session:<path>`).
 //   • Hibernate = stop the Pi pid (TERM then bounded KILL). Because the pane has
 //     `remain-on-exit on`, the tmux session survives (operator-attachable) and is
-//     NEVER destroyed here.
-//   • Wake = `tmux respawn-pane -k` running a launcher that exports the single-use
-//     wake fence and resumes the exact session via `pi --session <path>`. The
-//     woken Pi re-registers under the SAME stable id (same session path) and
-//     presents the fence for atomic generation acceptance.
+//     NEVER destroyed here; the pane transitions to `pane_dead=1`.
+//   • Wake = respawn a launcher into the recorded pane ONLY when that exact pane
+//     is present and explicitly dead, exporting the single-use wake fence and
+//     resuming the exact session via `pi --session <path>`. The woken Pi
+//     re-registers under the SAME stable id and presents the fence for atomic
+//     generation acceptance.
+//
+// PID-reuse / signal safety (independent-review P1): a numeric pid is NEVER
+// signalled on its own. Every TERM/KILL/liveness action is bound to a process
+// GENERATION — the tuple (pane-authoritative `pane_pid`, `pane_dead=0`, and the
+// OS process START TOKEN from `ps -o lstart=`) — and is re-verified immediately
+// before each signal. If the pane no longer hosts that exact live generation
+// (the process exited, the pane died, or the pid was reused by an unrelated
+// same-user process with a different start token) the action is abandoned as
+// "already gone" rather than risking a kill of an unrelated process. Wake-attempt
+// generations are carried in an injected {@link AttemptGenerationRegistry} so the
+// attempt-scoped stop/liveness probes bind to the EXACT process a wake launched.
 //
 // All process/tmux/ps/git interaction is funnelled through an injectable
 // `CommandRunner` + signal/liveness hooks so the security- and correctness-
@@ -70,13 +82,61 @@ export function createExecFileRunner(): CommandRunner {
   };
 }
 
-function tmuxSocketArgs(spec: AgentRuntimeSpec): string[] {
-  return spec.tmuxSocket ? ["-S", spec.tmuxSocket] : [];
+/** The minimal tmux pane address the pane probes/signals operate against. */
+interface PaneAddress {
+  tmuxSocket: string;
+  tmuxTarget: string;
+}
+
+/**
+ * A verified OS process generation: the pane's foreground pid PLUS its process
+ * start token. The start token pins the exact process instance so a reused pid
+ * (same number, different process) is never mistaken for — or signalled as — the
+ * original runtime.
+ */
+interface ProcessGeneration {
+  pid: number;
+  startToken: string;
+}
+
+/**
+ * The attempt-bound generation a single wake launched. Carries the pane address
+ * so the attempt-scoped stop/liveness probes read the exact pane the attempt
+ * respawned into (the `RuntimeAttemptHandle` public shape intentionally exposes
+ * only the nonce/target/pid; the generation binding lives here).
+ */
+export interface AttemptGeneration extends ProcessGeneration, PaneAddress {}
+
+/**
+ * Records the generation each wake attempt launched, keyed by reservation nonce,
+ * so `stopLaunchedAttempt` / `isLaunchedAttemptAlive` prove the EXACT process
+ * that attempt spawned is gone/alive. Shared (injected) between the tmux
+ * controller (which records at respawn) and the process controller (which reads
+ * at cleanup). A miss fails closed (unprovable ⇒ not-stopped / still-alive).
+ */
+export interface AttemptGenerationRegistry {
+  record(reservationNonce: string, generation: AttemptGeneration): void;
+  get(reservationNonce: string): AttemptGeneration | undefined;
+  clear(reservationNonce: string): void;
+}
+
+export function createAttemptGenerationRegistry(): AttemptGenerationRegistry {
+  const map = new Map<string, AttemptGeneration>();
+  return {
+    record: (nonce, generation) => void map.set(nonce, generation),
+    get: (nonce) => map.get(nonce),
+    clear: (nonce) => void map.delete(nonce),
+  };
+}
+
+function tmuxSocketArgs(socket: string): string[] {
+  return socket ? ["-S", socket] : [];
 }
 
 export interface RuntimeAdapterDeps {
   runner?: CommandRunner;
-  fileExists?: (filePath: string) => boolean;
+  /** Byte size of a session file, or null when absent (non-empty ⇒ resumable). */
+  sessionByteSize?: (filePath: string) => number | null;
   processAlive?: (pid: number) => boolean;
   sendSignal?: (pid: number, signal: NodeJS.Signals) => void;
   now?: () => number;
@@ -87,11 +147,13 @@ export interface RuntimeAdapterDeps {
   stopGraceMs?: number;
   /** Poll interval while awaiting process exit. */
   pollMs?: number;
+  /** Shared attempt-generation registry (created if omitted). */
+  attemptRegistry?: AttemptGenerationRegistry;
 }
 
 interface ResolvedProcessDeps {
   runner: CommandRunner;
-  fileExists: (filePath: string) => boolean;
+  sessionByteSize: (filePath: string) => number | null;
   processAlive: (pid: number) => boolean;
   sendSignal: (pid: number, signal: NodeJS.Signals) => void;
   now: () => number;
@@ -99,15 +161,24 @@ interface ResolvedProcessDeps {
   pendingInboxCount: (agentId: string) => number;
   stopGraceMs: number;
   pollMs: number;
+  attemptRegistry: AttemptGenerationRegistry;
 }
 
 // agent-standards-ignore prefer-inline-single-use-helper: centralizes default
 // resolution for the ResolvedProcessDeps bundle shared by the controller and the
-// module-level terminatePid escalation helper.
+// module-level generation-termination helper.
 function resolveProcessDeps(deps: RuntimeAdapterDeps): ResolvedProcessDeps {
   return {
     runner: deps.runner ?? createExecFileRunner(),
-    fileExists: deps.fileExists ?? ((p) => fs.existsSync(p)),
+    sessionByteSize:
+      deps.sessionByteSize ??
+      ((p) => {
+        try {
+          return fs.statSync(p).size;
+        } catch {
+          return null;
+        }
+      }),
     processAlive:
       deps.processAlive ??
       ((pid) => {
@@ -125,20 +196,21 @@ function resolveProcessDeps(deps: RuntimeAdapterDeps): ResolvedProcessDeps {
     pendingInboxCount: deps.pendingInboxCount ?? (() => 0),
     stopGraceMs: deps.stopGraceMs ?? 5_000,
     pollMs: deps.pollMs ?? 100,
+    attemptRegistry: deps.attemptRegistry ?? createAttemptGenerationRegistry(),
   };
 }
 
 async function paneField(
   runner: CommandRunner,
-  spec: AgentRuntimeSpec,
+  addr: PaneAddress,
   field: string,
 ): Promise<string | null> {
   const result = await runner.run("tmux", [
-    ...tmuxSocketArgs(spec),
+    ...tmuxSocketArgs(addr.tmuxSocket),
     "display-message",
     "-p",
     "-t",
-    spec.tmuxTarget,
+    addr.tmuxTarget,
     `#{${field}}`,
   ]);
   if (result.code !== 0) return null;
@@ -146,8 +218,8 @@ async function paneField(
   return value.length > 0 ? value : null;
 }
 
-async function panePid(runner: CommandRunner, spec: AgentRuntimeSpec): Promise<number | null> {
-  const raw = await paneField(runner, spec, "pane_pid");
+async function panePid(runner: CommandRunner, addr: PaneAddress): Promise<number | null> {
+  const raw = await paneField(runner, addr, "pane_pid");
   const pid = raw ? Number.parseInt(raw, 10) : Number.NaN;
   return Number.isInteger(pid) && pid > 0 ? pid : null;
 }
@@ -158,28 +230,92 @@ async function rssBytesOf(runner: CommandRunner, pid: number): Promise<number | 
   return parseRssBytesFromPs(result.stdout);
 }
 
-/** TERM then bounded KILL a pid; resolves whether it is confirmed gone. Shared by
- * pre-hibernation stop and failed-wake-attempt cleanup. */
-async function terminatePid(pid: number, deps: ResolvedProcessDeps): Promise<boolean> {
-  if (!deps.processAlive(pid)) return true;
+/**
+ * The OS process start token (`ps -o lstart=`), normalized to a single-spaced
+ * opaque string. Two processes sharing a pid but not a start token are DIFFERENT
+ * process instances, so this pins the generation against pid reuse. Returns null
+ * when the pid is gone (no ps row).
+ */
+async function processStartToken(runner: CommandRunner, pid: number): Promise<string | null> {
+  const result = await runner.run("ps", ["-o", "lstart=", "-p", String(pid)]);
+  if (result.code !== 0) return null;
+  const token = result.stdout.trim().replace(/\s+/g, " ");
+  return token.length > 0 ? token : null;
+}
+
+/**
+ * Read the pane's current process generation: its foreground pid, whether the
+ * pane is dead (only an explicit `pane_dead=0` is live; null/"1" ⇒ dead/gone),
+ * and the pid's start token. `startToken` is null when the pane has no live pid.
+ */
+async function readPaneGeneration(
+  runner: CommandRunner,
+  addr: PaneAddress,
+): Promise<{ pid: number | null; dead: boolean; startToken: string | null }> {
+  const pid = await panePid(runner, addr);
+  const deadRaw = await paneField(runner, addr, "pane_dead");
+  const dead = deadRaw !== "0";
+  const startToken = pid != null ? await processStartToken(runner, pid) : null;
+  return { pid, dead, startToken };
+}
+
+/**
+ * True only if the pane provably still hosts the EXACT expected live generation:
+ * the pane's foreground pid equals the expected pid, the pane is not dead, the
+ * pid is a live process, and its current start token matches the expected one
+ * (defeating pid reuse). Any drift ⇒ false (the expected process is gone / not
+ * ours), so a signal is never sent to a reused or replaced pid.
+ */
+async function paneHostsGeneration(
+  runner: CommandRunner,
+  addr: PaneAddress,
+  expected: ProcessGeneration,
+  processAlive: (pid: number) => boolean,
+): Promise<boolean> {
+  const current = await readPaneGeneration(runner, addr);
+  return (
+    current.pid === expected.pid &&
+    !current.dead &&
+    current.startToken != null &&
+    current.startToken === expected.startToken &&
+    processAlive(expected.pid)
+  );
+}
+
+/**
+ * TERM then bounded KILL a process addressed by its pane + generation. The pane
+ * is re-verified to still host the exact expected live generation immediately
+ * before EVERY signal; the moment it no longer does (exit, pane death, or pid
+ * reuse with a different start token) the process is treated as confirmed gone
+ * and no further signal is sent. Shared by pre-hibernation stop and failed-wake
+ * attempt cleanup. Resolves whether the generation is confirmed gone.
+ */
+async function terminateGeneration(
+  addr: PaneAddress,
+  expected: ProcessGeneration,
+  deps: ResolvedProcessDeps,
+): Promise<boolean> {
+  const stillOurs = () => paneHostsGeneration(deps.runner, addr, expected, deps.processAlive);
+  if (!(await stillOurs())) return true;
   try {
-    deps.sendSignal(pid, "SIGTERM");
+    deps.sendSignal(expected.pid, "SIGTERM");
   } catch {
-    // Already gone between the liveness check and the signal.
-    return !deps.processAlive(pid);
+    // Raced to exit between the verification and the signal.
+    return !(await stillOurs());
   }
   const deadline = deps.now() + deps.stopGraceMs;
   while (deps.now() < deadline) {
     await deps.sleep(deps.pollMs);
-    if (!deps.processAlive(pid)) return true;
+    if (!(await stillOurs())) return true;
   }
+  if (!(await stillOurs())) return true;
   try {
-    deps.sendSignal(pid, "SIGKILL");
+    deps.sendSignal(expected.pid, "SIGKILL");
   } catch {
     // Raced to exit during escalation.
   }
   await deps.sleep(deps.pollMs);
-  return !deps.processAlive(pid);
+  return !(await stillOurs());
 }
 
 export function createHibernationProcessController(
@@ -189,68 +325,77 @@ export function createHibernationProcessController(
 
   async function runtimeAlive(
     spec: AgentRuntimeSpec,
-  ): Promise<{ alive: boolean; pid: number | null }> {
-    const pid = await panePid(d.runner, spec);
-    const deadRaw = await paneField(d.runner, spec, "pane_dead");
-    // A dead/gone pane reads null or "1"; only an explicit "0" is a live runtime.
-    const alive = pid != null && deadRaw === "0" && d.processAlive(pid);
-    return { alive, pid };
+  ): Promise<{ alive: boolean; generation: ProcessGeneration | null }> {
+    const addr: PaneAddress = { tmuxSocket: spec.tmuxSocket, tmuxTarget: spec.tmuxTarget };
+    const current = await readPaneGeneration(d.runner, addr);
+    const alive =
+      current.pid != null &&
+      !current.dead &&
+      current.startToken != null &&
+      d.processAlive(current.pid);
+    return {
+      alive,
+      generation:
+        alive && current.pid != null && current.startToken != null
+          ? { pid: current.pid, startToken: current.startToken }
+          : null,
+    };
   }
 
   return {
     async requestCheckpoint(spec: AgentRuntimeSpec): Promise<HibernationCheckpointOutcome> {
-      const { alive, pid } = await runtimeAlive(spec);
-      const rssBytes = pid != null ? await rssBytesOf(d.runner, pid) : null;
+      // Contract (narrowed, evidence-backed): a `hibernateSafe` result asserts
+      // the RESUMABILITY PRECONDITION — the recorded pane still hosts a live
+      // process generation (pane-authoritative pid, `pane_dead=0`, live pid with
+      // a readable start token) AND the session `.jsonl` exists and is NON-EMPTY
+      // on disk. It does NOT perform a cooperative in-flight flush/ack handshake
+      // with Pi (which would require Pi-side support and is future work); the
+      // orchestrator additionally refuses to hibernate while any inbox work is
+      // pending/arriving, so a mid-turn runtime is not silently discarded.
+      const { alive, generation } = await runtimeAlive(spec);
+      const rssBytes = generation != null ? await rssBytesOf(d.runner, generation.pid) : null;
       const pendingInboxCount = d.pendingInboxCount(spec.agentId);
-      const resumePath = resumePathFromSessionRef(spec.sessionResumeRef);
-      const sessionOnDisk = resumePath != null && d.fileExists(resumePath);
+      const base = { sessionResumeRef: spec.sessionResumeRef, pendingInboxCount, rssBytes };
       if (!alive) {
-        return {
-          hibernateSafe: false,
-          reason: "runtime_not_alive",
-          sessionResumeRef: spec.sessionResumeRef,
-          pendingInboxCount,
-          rssBytes,
-        };
+        return { hibernateSafe: false, reason: "runtime_not_alive", ...base };
       }
-      if (!sessionOnDisk) {
-        return {
-          hibernateSafe: false,
-          reason: "session_unresumable",
-          sessionResumeRef: spec.sessionResumeRef,
-          pendingInboxCount,
-          rssBytes,
-        };
+      const resumePath = resumePathFromSessionRef(spec.sessionResumeRef);
+      const sessionBytes = resumePath != null ? d.sessionByteSize(resumePath) : null;
+      if (sessionBytes == null) {
+        return { hibernateSafe: false, reason: "session_unresumable", ...base };
       }
-      return {
-        hibernateSafe: true,
-        reason: null,
-        sessionResumeRef: spec.sessionResumeRef,
-        pendingInboxCount,
-        rssBytes,
-      };
+      if (sessionBytes <= 0) {
+        return { hibernateSafe: false, reason: "session_empty", ...base };
+      }
+      return { hibernateSafe: true, reason: null, ...base };
     },
 
     async stopRuntime(
       spec: AgentRuntimeSpec,
     ): Promise<{ stopped: boolean; rssBytes: number | null }> {
-      const pid = await panePid(d.runner, spec);
-      if (pid == null) return { stopped: true, rssBytes: null };
-      const rssBytes = await rssBytesOf(d.runner, pid);
+      const addr: PaneAddress = { tmuxSocket: spec.tmuxSocket, tmuxTarget: spec.tmuxTarget };
+      // Capture the live generation to stop BEFORE any mutation; if the pane is
+      // already dead / has no live generation there is nothing to stop.
+      const current = await readPaneGeneration(d.runner, addr);
+      if (current.pid == null || current.dead || current.startToken == null) {
+        return { stopped: true, rssBytes: null };
+      }
+      if (!d.processAlive(current.pid)) return { stopped: true, rssBytes: null };
+      const generation: ProcessGeneration = { pid: current.pid, startToken: current.startToken };
+      const rssBytes = await rssBytesOf(d.runner, generation.pid);
       // Ensure the pane survives the Pi exit BEFORE stopping it, so hibernation
       // requires no change to the worker spawn path. With remain-on-exit on,
       // killing the pane's foreground Pi leaves the tmux session intact and
-      // operator-attachable, and a wake can respawn into it. Best-effort: the
-      // orchestrator independently verifies survival via isSessionAttachable.
+      // operator-attachable, and a wake can respawn into the (now dead) pane.
       await d.runner.run("tmux", [
-        ...tmuxSocketArgs(spec),
+        ...tmuxSocketArgs(spec.tmuxSocket),
         "set-option",
         "-t",
         spec.tmuxSession,
         "remain-on-exit",
         "on",
       ]);
-      const stopped = await terminatePid(pid, d);
+      const stopped = await terminateGeneration(addr, generation, d);
       return { stopped, rssBytes };
     },
 
@@ -259,16 +404,30 @@ export function createHibernationProcessController(
     },
 
     async stopLaunchedAttempt(handle: RuntimeAttemptHandle): Promise<{ stopped: boolean }> {
-      // No captured pid ⇒ we cannot PROVE this exact attempt's process is gone,
+      // Bind to the generation THIS attempt recorded at respawn. A miss (no
+      // recorded generation ⇒ pid/start token were never captured) is unprovable,
       // so fail closed rather than risk relaunching over a live runtime.
-      if (handle.pid == null) return { stopped: false };
-      return { stopped: await terminatePid(handle.pid, d) };
+      const generation = d.attemptRegistry.get(handle.reservationNonce);
+      if (!generation) return { stopped: false };
+      const addr: PaneAddress = {
+        tmuxSocket: generation.tmuxSocket,
+        tmuxTarget: generation.tmuxTarget,
+      };
+      const stopped = await terminateGeneration(addr, generation, d);
+      if (stopped) d.attemptRegistry.clear(handle.reservationNonce);
+      return { stopped };
     },
 
     async isLaunchedAttemptAlive(handle: RuntimeAttemptHandle): Promise<boolean> {
-      // Unprovable ⇒ treat as still alive so cleanup never assumes a phantom exit.
-      if (handle.pid == null) return true;
-      return d.processAlive(handle.pid);
+      // Unprovable (no recorded generation) ⇒ treat as still alive so cleanup
+      // never assumes a phantom exit.
+      const generation = d.attemptRegistry.get(handle.reservationNonce);
+      if (!generation) return true;
+      const addr: PaneAddress = {
+        tmuxSocket: generation.tmuxSocket,
+        tmuxTarget: generation.tmuxTarget,
+      };
+      return paneHostsGeneration(d.runner, addr, generation, d.processAlive);
     },
   };
 }
@@ -282,27 +441,51 @@ export interface RuntimeRespawnDeps {
   /** Broker env keys re-exported into the woken runtime when present. */
   inheritedEnvKeys: string[];
   buildNickname?: (ctx: RuntimeLaunchContext) => string;
+  /** Private, owner-only directory launchers are materialized in (lazily made). */
   launcherDir?: string;
   writeFile?: (filePath: string, content: string, mode: number) => void;
+  unlink?: (filePath: string) => void;
   readEnv?: (key: string) => string | undefined;
+  /** Shared attempt-generation registry (created if omitted). */
+  attemptRegistry?: AttemptGenerationRegistry;
+  /** Injectable liveness for the captured pid's start token verification. */
+  processAlive?: (pid: number) => boolean;
 }
 
 export function createHibernationTmuxController(
   deps: RuntimeRespawnDeps,
 ): HibernationTmuxController {
   const runner = deps.runner ?? createExecFileRunner();
-  const launcherDir = deps.launcherDir ?? os.tmpdir();
   const writeFile =
     deps.writeFile ?? ((filePath, content, mode) => fs.writeFileSync(filePath, content, { mode }));
+  const unlink =
+    deps.unlink ??
+    ((filePath) => {
+      try {
+        fs.unlinkSync(filePath);
+      } catch {
+        // Best effort: already gone (e.g. the launcher self-deleted).
+      }
+    });
   const readEnv = deps.readEnv ?? ((key) => process.env[key]);
+  const attemptRegistry = deps.attemptRegistry ?? createAttemptGenerationRegistry();
   const buildNickname =
     deps.buildNickname ??
     ((ctx) => `Woken ${ctx.spec.launchSource || "worker"} ${ctx.reservationNonce.slice(0, 8)}`);
 
+  // Private, owner-only launcher dir (0700), created lazily so constructing the
+  // controller has no filesystem side effect and tests can inject an explicit dir.
+  let launcherDir = deps.launcherDir;
+  const resolveLauncherDir = (): string => {
+    if (launcherDir) return launcherDir;
+    launcherDir = fs.mkdtempSync(path.join(os.tmpdir(), "pinet-wake-"));
+    return launcherDir;
+  };
+
   return {
     async isSessionAttachable(spec: AgentRuntimeSpec): Promise<boolean> {
       const result = await runner.run("tmux", [
-        ...tmuxSocketArgs(spec),
+        ...tmuxSocketArgs(spec.tmuxSocket),
         "has-session",
         "-t",
         spec.tmuxSession,
@@ -317,6 +500,26 @@ export function createHibernationTmuxController(
       const resumePath = resumePathFromSessionRef(spec.sessionResumeRef);
       // Unresumable spec ⇒ no session to bring back; fail closed (no handle).
       if (!resumePath) return { launched: false, handle: null };
+
+      const addr: PaneAddress = { tmuxSocket: spec.tmuxSocket, tmuxTarget: spec.tmuxTarget };
+      // Destructive-wake guard (independent-review P1): only respawn when the
+      // EXACT recorded pane is present AND explicitly dead. A missing pane cannot
+      // be woken; a LIVE pane must never be clobbered (drift / manual recovery /
+      // ambiguous state), so we neither force-kill it with `respawn-pane -k` nor
+      // proceed. `respawn-pane` (no `-k`) additionally refuses a non-dead pane at
+      // the tmux layer, giving defence in depth.
+      const sessionPresent =
+        (
+          await runner.run("tmux", [
+            ...tmuxSocketArgs(spec.tmuxSocket),
+            "has-session",
+            "-t",
+            spec.tmuxSession,
+          ])
+        ).code === 0;
+      if (!sessionPresent) return { launched: false, handle: null };
+      const deadRaw = await paneField(runner, addr, "pane_dead");
+      if (deadRaw !== "1") return { launched: false, handle: null };
 
       const inheritedEnv: Record<string, string | undefined> = {};
       for (const key of deps.inheritedEnvKeys) inheritedEnv[key] = readEnv(key);
@@ -341,28 +544,45 @@ export function createHibernationTmuxController(
         nickname: buildNickname(ctx),
       });
 
-      const launcherPath = path.join(launcherDir, `pinet-wake-${ctx.reservationNonce}.sh`);
+      const launcherPath = path.join(resolveLauncherDir(), `pinet-wake-${ctx.reservationNonce}.sh`);
+      let launched = false;
       try {
         writeFile(launcherPath, script, 0o700);
-      } catch {
-        return { launched: false, handle: null };
+        // No `-k`: only a dead pane is respawned (guarded above); a live pane is
+        // never force-killed.
+        const result = await runner.run("tmux", [
+          ...tmuxSocketArgs(spec.tmuxSocket),
+          "respawn-pane",
+          "-t",
+          spec.tmuxTarget,
+          launcherPath,
+        ]);
+        if (result.code !== 0) return { launched: false, handle: null };
+        launched = true;
+
+        // Bind the launched attempt to its exact process generation so retry
+        // cleanup can prove THIS process (not a reused pid) is gone.
+        const pid = await panePid(runner, addr);
+        const startToken = pid != null ? await processStartToken(runner, pid) : null;
+        if (pid != null && startToken != null) {
+          attemptRegistry.record(ctx.reservationNonce, {
+            pid,
+            startToken,
+            tmuxSocket: spec.tmuxSocket,
+            tmuxTarget: spec.tmuxTarget,
+          });
+        }
+        return {
+          launched: true,
+          handle: { reservationNonce: ctx.reservationNonce, tmuxTarget: spec.tmuxTarget, pid },
+        };
+      } finally {
+        // Guaranteed cleanup of the secret-bearing launcher: on the happy path
+        // the script self-deletes (`rm -f "$0"` before exec), so unlinking here
+        // could race the pane shell's open — only remove the orphan on the
+        // FAILURE path (where the launcher never exec'd).
+        if (!launched) unlink(launcherPath);
       }
-
-      const result = await runner.run("tmux", [
-        ...tmuxSocketArgs(spec),
-        "respawn-pane",
-        "-k",
-        "-t",
-        spec.tmuxTarget,
-        launcherPath,
-      ]);
-      if (result.code !== 0) return { launched: false, handle: null };
-
-      const pid = await panePid(runner, spec);
-      return {
-        launched: true,
-        handle: { reservationNonce: ctx.reservationNonce, tmuxTarget: spec.tmuxTarget, pid },
-      };
     },
   };
 }

--- a/slack-bridge/broker/hibernation-runtime-helpers.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.test.ts
@@ -129,6 +129,30 @@ describe("wake fence env round-trip", () => {
       }),
     ).toBeNull();
   });
+
+  it("only accepts canonical positive decimal safe integers for the numeric fields", () => {
+    const withNumbers = (token: string, generation: string) =>
+      parseWakeFenceEnv({
+        PINET_WAKE_LEASE_ID: "lease-1",
+        PINET_WAKE_RESERVATION_NONCE: "nonce-xyz",
+        PINET_WAKE_FENCE_TOKEN: token,
+        PINET_WAKE_RESERVED_GENERATION: generation,
+      });
+    // Rejected: coercible-but-non-canonical forms Number.parseInt would accept.
+    for (const bad of ["12abc", " 7", "7 ", "+7", "-7", "07", "0", "0x10", "7.0", "1e3", ""]) {
+      expect(withNumbers(bad, "42")).toBeNull();
+      expect(withNumbers("7", bad)).toBeNull();
+    }
+    // Rejected: beyond the safe-integer range.
+    expect(withNumbers("9007199254740993", "42")).toBeNull();
+    // Accepted: canonical positive decimals.
+    expect(withNumbers("7", "42")).toEqual({
+      wakeLeaseId: "lease-1",
+      fenceToken: 7,
+      reservedGeneration: 42,
+      reservationNonce: "nonce-xyz",
+    });
+  });
 });
 
 describe("shellQuote", () => {
@@ -171,6 +195,16 @@ describe("buildResumeLauncherScript", () => {
   it("starts with a strict bash shebang preamble", () => {
     const script = buildResumeLauncherScript(base);
     expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+  });
+
+  it("self-deletes the secret-bearing launcher immediately before exec", () => {
+    const script = buildResumeLauncherScript(base);
+    const rmIndex = script.indexOf('rm -f -- "$0"');
+    const execIndex = script.indexOf("exec pi -e");
+    expect(rmIndex).toBeGreaterThan(0);
+    // The self-delete must be the last statement before exec so the open fd
+    // survives the unlink while no secret file lingers.
+    expect(rmIndex).toBeLessThan(execIndex);
   });
 });
 

--- a/slack-bridge/broker/hibernation-runtime-helpers.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildResumeLauncherScript,
   buildRuntimeSpecInput,
@@ -197,14 +201,52 @@ describe("buildResumeLauncherScript", () => {
     expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
   });
 
-  it("self-deletes the secret-bearing launcher immediately before exec", () => {
+  it("self-deletes as the FIRST executable statement, before cd and before any secret export", () => {
     const script = buildResumeLauncherScript(base);
     const rmIndex = script.indexOf('rm -f -- "$0"');
-    const execIndex = script.indexOf("exec pi -e");
+    const cdIndex = script.indexOf("cd '/repo/root'");
+    const firstExportIndex = script.indexOf("export ");
     expect(rmIndex).toBeGreaterThan(0);
-    // The self-delete must be the last statement before exec so the open fd
-    // survives the unlink while no secret file lingers.
-    expect(rmIndex).toBeLessThan(execIndex);
+    // The self-delete must precede cd AND every secret export, so no later
+    // failure (e.g. a failing cd under set -e) can leave the secret file behind.
+    expect(rmIndex).toBeLessThan(cdIndex);
+    expect(rmIndex).toBeLessThan(firstExportIndex);
+    // It is the first executable line after the strict preamble.
+    expect(script.startsWith('#!/bin/bash\nset -euo pipefail\nrm -f -- "$0"\n')).toBe(true);
+  });
+});
+
+describe("buildResumeLauncherScript early-failure secret retention (real bash)", () => {
+  let dir: string | null = null;
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = null;
+  });
+
+  it("leaves no launcher file when cd fails before exec (secrets never persist)", () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "pinet-wake-test-"));
+    const launcherPath = path.join(dir, "pinet-wake-regression.sh");
+    // A repo path that does not exist forces `cd` to fail under set -e, exiting
+    // before `exec pi` — the exact "launcher began, pre-delete setup failed" mode.
+    const script = buildResumeLauncherScript({
+      repoPath: path.join(dir, "does-not-exist"),
+      sessionPath: "/tmp/sessions/agent-abc.jsonl",
+      extensionEntryPath: "/ext/index.js",
+      inheritedEnv: {},
+      pinetEnv: { PINET_MESH_SECRET: "super-secret-value" },
+      nickname: "Woken Worker",
+    });
+    fs.writeFileSync(launcherPath, script, { mode: 0o700 });
+    let exitCode = 0;
+    try {
+      execFileSync("bash", [launcherPath], { stdio: "ignore" });
+    } catch (error) {
+      exitCode = (error as { status?: number }).status ?? 1;
+    }
+    // cd failed, so the launcher exited non-zero WITHOUT reaching exec pi ...
+    expect(exitCode).not.toBe(0);
+    // ... yet the secret-bearing launcher already removed itself first.
+    expect(fs.existsSync(launcherPath)).toBe(false);
   });
 });
 

--- a/slack-bridge/broker/hibernation-runtime-helpers.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildResumeLauncherScript,
+  buildRuntimeSpecInput,
   buildWakeFenceEnv,
   deriveVcsIdentity,
   parseRssBytesFromPs,
@@ -8,6 +9,7 @@ import {
   resumePathFromSessionRef,
   sessionResumeRefFromStableId,
   shellQuote,
+  type SpawnAuthoredRuntimeFacts,
 } from "./hibernation-runtime-helpers.js";
 
 describe("deriveVcsIdentity", () => {
@@ -169,5 +171,79 @@ describe("buildResumeLauncherScript", () => {
   it("starts with a strict bash shebang preamble", () => {
     const script = buildResumeLauncherScript(base);
     expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+  });
+});
+
+describe("buildRuntimeSpecInput", () => {
+  const facts: SpawnAuthoredRuntimeFacts = {
+    agentId: "agent-1",
+    stableId: "host.local:session:/sessions/worker.jsonl",
+    brokerOwnerId: "broker-instance-9",
+    cwd: "/repos/extensions/.worktrees/wt",
+    repoRoot: "/repos/extensions/.worktrees/wt",
+    worktreePath: "/repos/extensions/.worktrees/wt",
+    tmuxSocket: "/tmp/pinet.sock",
+    tmuxSession: "pinet-worker-1",
+    tmuxTarget: "pinet-worker-1:0.0",
+    extensionEntryPath: "/pkg/slack-bridge/index.ts",
+    envAllowlist: ["PINET_SOCKET_PATH", "PI_SETTINGS_PATH", "PINET_SOCKET_PATH", ""],
+    configFingerprint: "cfg#abc",
+    expectedUser: "tmnexcade",
+    launchSource: "subtree-broker-tmux",
+    vcsIdentity: "gugu91/extensions",
+  };
+
+  it("composes a complete spec from broker-known facts", () => {
+    const spec = buildRuntimeSpecInput(facts);
+    expect(spec).not.toBeNull();
+    expect(spec).toMatchObject({
+      agentId: "agent-1",
+      brokerOwnerId: "broker-instance-9",
+      tmuxTarget: "pinet-worker-1:0.0",
+      executable: "pi",
+      sessionResumeRef: "session:/sessions/worker.jsonl",
+      vcsIdentity: "gugu91/extensions",
+      expectedHost: "host.local",
+    });
+    // argv mirrors the resume launch, with the path recovered from the ref only.
+    expect(spec?.argv).toEqual([
+      "-e",
+      "/pkg/slack-bridge/index.ts",
+      "--session",
+      "/sessions/worker.jsonl",
+    ]);
+    // envAllowlist is de-duplicated and drops empties (names only).
+    expect(spec?.envAllowlist).toEqual(["PINET_SOCKET_PATH", "PI_SETTINGS_PATH"]);
+  });
+
+  it("preserves the broker-derived vcsIdentity, including null (fail-closed authz)", () => {
+    expect(buildRuntimeSpecInput({ ...facts, vcsIdentity: null })?.vcsIdentity).toBeNull();
+  });
+
+  it("returns null for a non-resumable identity (no session path)", () => {
+    expect(buildRuntimeSpecInput({ ...facts, stableId: "host:cwd:/repos/x" })).toBeNull();
+    expect(buildRuntimeSpecInput({ ...facts, stableId: "host:broker:/x" })).toBeNull();
+    expect(buildRuntimeSpecInput({ ...facts, stableId: "not-a-stable-id" })).toBeNull();
+  });
+
+  it("fails closed when a required operational locator is missing", () => {
+    expect(buildRuntimeSpecInput({ ...facts, tmuxTarget: "" })).toBeNull();
+    expect(buildRuntimeSpecInput({ ...facts, tmuxSocket: "" })).toBeNull();
+    expect(buildRuntimeSpecInput({ ...facts, tmuxSession: "" })).toBeNull();
+    expect(buildRuntimeSpecInput({ ...facts, repoRoot: "" })).toBeNull();
+  });
+
+  it("defaults cwd/worktree to repoRoot and fills soft defaults", () => {
+    const spec = buildRuntimeSpecInput({
+      ...facts,
+      cwd: "",
+      worktreePath: "",
+      configFingerprint: "",
+      launchSource: "",
+    });
+    expect(spec?.cwd).toBe(facts.repoRoot);
+    expect(spec?.worktreePath).toBe(facts.repoRoot);
+    expect(spec?.configFingerprint).toBe("unknown");
+    expect(spec?.launchSource).toBe("subtree-broker-tmux");
   });
 });

--- a/slack-bridge/broker/hibernation-runtime-helpers.test.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildResumeLauncherScript,
+  buildWakeFenceEnv,
+  deriveVcsIdentity,
+  parseRssBytesFromPs,
+  parseWakeFenceEnv,
+  resumePathFromSessionRef,
+  sessionResumeRefFromStableId,
+  shellQuote,
+} from "./hibernation-runtime-helpers.js";
+
+describe("deriveVcsIdentity", () => {
+  it("parses scp-style github remotes", () => {
+    expect(deriveVcsIdentity("git@github.com:gugu91/extensions.git")).toBe("gugu91/extensions");
+    expect(deriveVcsIdentity("git@github.com:gugu91/extensions")).toBe("gugu91/extensions");
+  });
+
+  it("parses https and ssh URL remotes", () => {
+    expect(deriveVcsIdentity("https://github.com/gugu91/extensions.git")).toBe("gugu91/extensions");
+    expect(deriveVcsIdentity("https://github.com/gugu91/extensions/")).toBe("gugu91/extensions");
+    expect(deriveVcsIdentity("ssh://git@github.com/gugu91/extensions.git")).toBe(
+      "gugu91/extensions",
+    );
+    expect(deriveVcsIdentity("git://github.com/gugu91/extensions")).toBe("gugu91/extensions");
+  });
+
+  it("takes the final owner/repo of deeper paths (e.g. gitlab subgroups)", () => {
+    expect(deriveVcsIdentity("https://gitlab.com/group/subgroup/repo.git")).toBe("subgroup/repo");
+    expect(deriveVcsIdentity("git@gitlab.com:group/subgroup/repo.git")).toBe("subgroup/repo");
+  });
+
+  it("does NOT infer identity from a bare directory name (fails closed)", () => {
+    expect(deriveVcsIdentity("extensions")).toBeNull();
+    expect(deriveVcsIdentity("")).toBeNull();
+    expect(deriveVcsIdentity("   ")).toBeNull();
+    expect(deriveVcsIdentity(null)).toBeNull();
+    expect(deriveVcsIdentity(undefined)).toBeNull();
+  });
+
+  it("returns identity from the remote, not the working directory path", () => {
+    // Two different worktree dirs sharing a final segment resolve to the SAME
+    // remote-derived identity — the security property the allowlist relies on.
+    expect(deriveVcsIdentity("git@github.com:gugu91/extensions.git")).toBe(
+      deriveVcsIdentity("https://github.com/gugu91/extensions"),
+    );
+  });
+});
+
+describe("parseRssBytesFromPs", () => {
+  it("converts ps KiB output to bytes", () => {
+    expect(parseRssBytesFromPs("  123456\n")).toBe(123456 * 1024);
+    expect(parseRssBytesFromPs("RSS\n  2048\n")).toBe(2048 * 1024);
+  });
+
+  it("returns null when the process is gone / no numeric output", () => {
+    expect(parseRssBytesFromPs("")).toBeNull();
+    expect(parseRssBytesFromPs("   \n")).toBeNull();
+    expect(parseRssBytesFromPs(null)).toBeNull();
+    expect(parseRssBytesFromPs(undefined)).toBeNull();
+  });
+});
+
+describe("session resume ref round-trip", () => {
+  it("builds session:<path> from a session stable id and recovers the path", () => {
+    const stableId = "myhost:session:/tmp/pi/sessions/agent-abc.jsonl";
+    const ref = sessionResumeRefFromStableId(stableId);
+    expect(ref).toBe("session:/tmp/pi/sessions/agent-abc.jsonl");
+    expect(resumePathFromSessionRef(ref)).toBe("/tmp/pi/sessions/agent-abc.jsonl");
+  });
+
+  it("returns null for non-session stable ids (not resumable)", () => {
+    expect(sessionResumeRefFromStableId("myhost:cwd:/repo/path")).toBeNull();
+    expect(sessionResumeRefFromStableId("myhost:leaf:abc123")).toBeNull();
+    expect(sessionResumeRefFromStableId(null)).toBeNull();
+  });
+
+  it("recovers nothing from a non-session ref", () => {
+    expect(resumePathFromSessionRef("cwd:/repo/path")).toBeNull();
+    expect(resumePathFromSessionRef("leaf:abc")).toBeNull();
+    expect(resumePathFromSessionRef("session:")).toBeNull();
+    expect(resumePathFromSessionRef("")).toBeNull();
+    expect(resumePathFromSessionRef(null)).toBeNull();
+  });
+
+  it("produces a ref whose payload is never surfaced verbatim (kept redactable)", () => {
+    // The ref carries a `session:` kind prefix so redactRuntimeSpec can emit
+    // `session:#<fingerprint>` and never the raw path.
+    const ref = sessionResumeRefFromStableId("h:session:/secret/path/x.jsonl");
+    expect(ref?.startsWith("session:")).toBe(true);
+  });
+});
+
+describe("wake fence env round-trip", () => {
+  const fence = {
+    wakeLeaseId: "lease-1",
+    fenceToken: 7,
+    reservedGeneration: 42,
+    reservationNonce: "nonce-xyz",
+  };
+
+  it("builds env and parses it back to the same fence", () => {
+    const env = buildWakeFenceEnv({ ...fence, correlationId: "corr-1" });
+    expect(env.PINET_WAKE_LEASE_ID).toBe("lease-1");
+    expect(env.PINET_WAKE_FENCE_TOKEN).toBe("7");
+    expect(env.PINET_WAKE_RESERVED_GENERATION).toBe("42");
+    expect(env.PINET_WAKE_RESERVATION_NONCE).toBe("nonce-xyz");
+    expect(parseWakeFenceEnv(env)).toEqual(fence);
+  });
+
+  it("fails closed to null on a partial or garbled environment", () => {
+    expect(parseWakeFenceEnv({})).toBeNull();
+    expect(
+      parseWakeFenceEnv({
+        PINET_WAKE_LEASE_ID: "lease-1",
+        PINET_WAKE_RESERVATION_NONCE: "nonce-xyz",
+        PINET_WAKE_FENCE_TOKEN: "not-a-number",
+        PINET_WAKE_RESERVED_GENERATION: "42",
+      }),
+    ).toBeNull();
+    expect(
+      parseWakeFenceEnv({
+        PINET_WAKE_LEASE_ID: "",
+        PINET_WAKE_RESERVATION_NONCE: "nonce",
+        PINET_WAKE_FENCE_TOKEN: "1",
+        PINET_WAKE_RESERVED_GENERATION: "1",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("shellQuote", () => {
+  it("wraps values and escapes embedded single quotes", () => {
+    expect(shellQuote("plain")).toBe("'plain'");
+    expect(shellQuote("with space")).toBe("'with space'");
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+});
+
+describe("buildResumeLauncherScript", () => {
+  const base = {
+    repoPath: "/repo/root",
+    sessionPath: "/tmp/sessions/agent-abc.jsonl",
+    extensionEntryPath: "/ext/index.js",
+    inheritedEnv: { PI_SETTINGS_PATH: "/cfg/settings.json", ABSENT: undefined },
+    pinetEnv: { PINET_SOCKET_PATH: "/sock", PINET_WAKE_LEASE_ID: "lease-1" },
+    nickname: "Woken Worker",
+  };
+
+  it("resumes the exact session with pi --session and no startup prompt", () => {
+    const script = buildResumeLauncherScript(base);
+    expect(script).toContain("cd '/repo/root'");
+    expect(script).toContain(
+      "exec pi -e '/ext/index.js' --session '/tmp/sessions/agent-abc.jsonl'",
+    );
+    // No trailing free-text prompt argument after the session path.
+    expect(script).not.toMatch(/--session '[^']*'\s+'/);
+  });
+
+  it("exports inherited env only when present, plus pinet + fence env", () => {
+    const script = buildResumeLauncherScript(base);
+    expect(script).toContain("export PI_SETTINGS_PATH='/cfg/settings.json'");
+    expect(script).not.toContain("ABSENT");
+    expect(script).toContain("export PINET_SOCKET_PATH='/sock'");
+    expect(script).toContain("export PINET_WAKE_LEASE_ID='lease-1'");
+    expect(script).toContain("export PI_NICKNAME='Woken Worker'");
+  });
+
+  it("starts with a strict bash shebang preamble", () => {
+    const script = buildResumeLauncherScript(base);
+    expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+  });
+});

--- a/slack-bridge/broker/hibernation-runtime-helpers.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.ts
@@ -255,14 +255,21 @@ export interface ResumeLauncherInput {
  * fence for atomic generation acceptance.
  *
  * The script is secret-bearing (it exports mesh/Slack credential VALUES), so it
- * removes its own file (`rm -f -- "$0"`) immediately before `exec`. The launcher
- * fd stays open across the unlink (POSIX keeps the inode until the fd closes),
- * so `exec pi` still runs, but no secret-bearing file lingers on the happy path.
- * The broker separately unlinks on the failure path (where the script never
- * ran) and materializes launchers only in a private, owner-only directory.
+ * removes its own file (`rm -f -- "$0"`) as its FIRST executable action — before
+ * `cd` and before exporting ANY secret. Under `set -euo pipefail` a later failure
+ * (e.g. a missing/unmounted repo making `cd` exit) therefore cannot leave a
+ * secret-bearing file behind, closing the “tmux accepted launch, launcher began,
+ * pre-delete setup failed” retention window. The launcher fd stays open across the
+ * unlink (POSIX keeps the inode until the fd closes), so `exec pi` still runs from
+ * the now-unnamed inode even though the secrets are exported after the unlink. The
+ * broker separately unlinks on the failure path (where the script never ran) and
+ * materializes launchers only in a private, owner-only directory.
  */
 export function buildResumeLauncherScript(input: ResumeLauncherInput): string {
-  const lines: string[] = ["#!/bin/bash", "set -euo pipefail", `cd ${shellQuote(input.repoPath)}`];
+  // Self-delete FIRST (before cd and before any secret export) so no failure in
+  // the remaining setup can leave the secret-bearing launcher on disk.
+  const lines: string[] = ["#!/bin/bash", "set -euo pipefail", `rm -f -- "$0"`];
+  lines.push(`cd ${shellQuote(input.repoPath)}`);
   for (const [key, value] of Object.entries(input.inheritedEnv)) {
     if (value !== undefined && value !== "") lines.push(`export ${key}=${shellQuote(value)}`);
   }
@@ -270,9 +277,6 @@ export function buildResumeLauncherScript(input: ResumeLauncherInput): string {
     lines.push(`export ${key}=${shellQuote(value)}`);
   }
   lines.push(`export PI_NICKNAME=${shellQuote(input.nickname)}`);
-  // Self-delete the secret-bearing launcher before exec; the open fd survives the
-  // unlink so `exec pi` still runs from the now-unnamed inode.
-  lines.push(`rm -f -- "$0"`);
   lines.push(
     `exec pi -e ${shellQuote(input.extensionEntryPath)} --session ${shellQuote(input.sessionPath)}`,
   );

--- a/slack-bridge/broker/hibernation-runtime-helpers.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.ts
@@ -124,19 +124,35 @@ export function buildWakeFenceEnv(input: WakeFenceEnvInput): Record<string, stri
 }
 
 /**
+ * Parse a canonical positive decimal safe integer, or null. Unlike
+ * `Number.parseInt`, which silently coerces `"12abc"`→12, `" 12"`→12, `"+12"`→12
+ * and accepts leading-zero forms, this accepts ONLY a bare run of decimal digits
+ * with no sign, no leading zero, no surrounding whitespace, and a value within
+ * the safe-integer range. A garbled or hostile fence value therefore fails
+ * closed to an ordinary (fence-free) registration rather than silently
+ * round-tripping a corrupted generation/token.
+ */
+function parseCanonicalPositiveInt(raw: string | undefined): number | null {
+  if (raw == null || !/^[1-9][0-9]*$/.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+/**
  * Parse a wake fence from a woken worker's environment (the boundary between the
  * respawn launcher and the follower's register RPC). Returns null unless ALL
- * required fields are present and well-formed, so a partial/garbled environment
- * fails closed to an ordinary (fence-free) registration rather than a malformed
- * fenced one.
+ * required fields are present and well-formed — the numeric fence token and
+ * reserved generation must be canonical positive decimal safe integers — so a
+ * partial/garbled environment fails closed to an ordinary (fence-free)
+ * registration rather than a malformed fenced one.
  */
 export function parseWakeFenceEnv(env: Record<string, string | undefined>): WakeFence | null {
   const wakeLeaseId = env.PINET_WAKE_LEASE_ID?.trim();
   const reservationNonce = env.PINET_WAKE_RESERVATION_NONCE?.trim();
-  const fenceToken = Number.parseInt(env.PINET_WAKE_FENCE_TOKEN ?? "", 10);
-  const reservedGeneration = Number.parseInt(env.PINET_WAKE_RESERVED_GENERATION ?? "", 10);
+  const fenceToken = parseCanonicalPositiveInt(env.PINET_WAKE_FENCE_TOKEN);
+  const reservedGeneration = parseCanonicalPositiveInt(env.PINET_WAKE_RESERVED_GENERATION);
   if (!wakeLeaseId || !reservationNonce) return null;
-  if (!Number.isInteger(fenceToken) || !Number.isInteger(reservedGeneration)) return null;
+  if (fenceToken == null || reservedGeneration == null) return null;
   return { wakeLeaseId, fenceToken, reservedGeneration, reservationNonce };
 }
 
@@ -237,6 +253,13 @@ export interface ResumeLauncherInput {
  * injecting a prompt would append a spurious user turn). The woken Pi therefore
  * re-registers under the SAME stable id (same session path) and presents the
  * fence for atomic generation acceptance.
+ *
+ * The script is secret-bearing (it exports mesh/Slack credential VALUES), so it
+ * removes its own file (`rm -f -- "$0"`) immediately before `exec`. The launcher
+ * fd stays open across the unlink (POSIX keeps the inode until the fd closes),
+ * so `exec pi` still runs, but no secret-bearing file lingers on the happy path.
+ * The broker separately unlinks on the failure path (where the script never
+ * ran) and materializes launchers only in a private, owner-only directory.
  */
 export function buildResumeLauncherScript(input: ResumeLauncherInput): string {
   const lines: string[] = ["#!/bin/bash", "set -euo pipefail", `cd ${shellQuote(input.repoPath)}`];
@@ -247,6 +270,9 @@ export function buildResumeLauncherScript(input: ResumeLauncherInput): string {
     lines.push(`export ${key}=${shellQuote(value)}`);
   }
   lines.push(`export PI_NICKNAME=${shellQuote(input.nickname)}`);
+  // Self-delete the secret-bearing launcher before exec; the open fd survives the
+  // unlink so `exec pi` still runs from the now-unnamed inode.
+  lines.push(`rm -f -- "$0"`);
   lines.push(
     `exec pi -e ${shellQuote(input.extensionEntryPath)} --session ${shellQuote(input.sessionPath)}`,
   );

--- a/slack-bridge/broker/hibernation-runtime-helpers.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.ts
@@ -6,6 +6,8 @@
 // correctness-critical pieces (VCS identity derivation, wake-fence env parsing,
 // resume-launcher construction) unit-testable without spawning processes.
 
+import type { AgentRuntimeSpecInput } from "@pinet/broker-core/types";
+
 import { parsePinetStableId } from "../pinet-session-formatting.js";
 
 /** Single-quote a value for safe embedding in a POSIX shell launcher script. */
@@ -136,6 +138,83 @@ export function parseWakeFenceEnv(env: Record<string, string | undefined>): Wake
   if (!wakeLeaseId || !reservationNonce) return null;
   if (!Number.isInteger(fenceToken) || !Number.isInteger(reservedGeneration)) return null;
   return { wakeLeaseId, fenceToken, reservedGeneration, reservationNonce };
+}
+
+/**
+ * The broker-KNOWN, spawn-authored facts that compose a durable runtime spec.
+ *
+ * Every operational field here (the tmux socket/session/target the broker will
+ * later kill and respawn into, the repo/cwd it runs `ps`/`kill`/`git` against)
+ * MUST come from the broker's own spawn record — NEVER from worker-reported
+ * registration metadata. A worker that could name another worker's tmux pane
+ * would otherwise get the broker to checkpoint/kill/respawn THAT pane on its
+ * behalf. The only field the worker's identity contributes is its stable id
+ * (which embeds its own session path); authorization uses solely the
+ * broker-derived {@link vcsIdentity}.
+ */
+export interface SpawnAuthoredRuntimeFacts {
+  agentId: string;
+  stableId: string;
+  brokerOwnerId: string;
+  cwd: string;
+  repoRoot: string;
+  worktreePath: string;
+  tmuxSocket: string;
+  tmuxSession: string;
+  tmuxTarget: string;
+  extensionEntryPath: string;
+  /** Environment variable NAMES (never values) the launcher exports. */
+  envAllowlist: string[];
+  configFingerprint: string;
+  expectedUser: string;
+  launchSource: string;
+  /** Broker-derived from the runtime's git remote — the ONLY authz identity. */
+  vcsIdentity: string | null;
+}
+
+/**
+ * Compose a durable {@link AgentRuntimeSpecInput} from broker-known spawn facts.
+ *
+ * Fails closed (returns null) when the identity is not a resumable Pi session
+ * (`sessionResumeRef` cannot be derived) or any operational locator the broker
+ * must act on (tmux socket/session/target, repo root) is missing — a spec that
+ * could not be safely hibernated/woken is never recorded. `expectedHost` is
+ * taken from the stable id's host prefix; `argv` mirrors the resume launch
+ * (`pi -e <entry> --session <path>`) for provenance; the resume path itself is
+ * only ever recovered from the redaction-safe `sessionResumeRef`.
+ */
+export function buildRuntimeSpecInput(
+  facts: SpawnAuthoredRuntimeFacts,
+): AgentRuntimeSpecInput | null {
+  const sessionResumeRef = sessionResumeRefFromStableId(facts.stableId);
+  if (!sessionResumeRef) return null;
+  const resumePath = resumePathFromSessionRef(sessionResumeRef);
+  if (!resumePath) return null;
+  if (!facts.tmuxSocket || !facts.tmuxSession || !facts.tmuxTarget || !facts.repoRoot) return null;
+
+  const expectedHost = parsePinetStableId(facts.stableId)?.host ?? "";
+  const envAllowlist = Array.from(new Set(facts.envAllowlist.filter((name) => name.length > 0)));
+
+  return {
+    agentId: facts.agentId,
+    stableId: facts.stableId,
+    brokerOwnerId: facts.brokerOwnerId,
+    cwd: facts.cwd || facts.repoRoot,
+    repoRoot: facts.repoRoot,
+    worktreePath: facts.worktreePath || facts.repoRoot,
+    tmuxSocket: facts.tmuxSocket,
+    tmuxSession: facts.tmuxSession,
+    tmuxTarget: facts.tmuxTarget,
+    executable: "pi",
+    argv: ["-e", facts.extensionEntryPath, "--session", resumePath],
+    envAllowlist,
+    sessionResumeRef,
+    configFingerprint: facts.configFingerprint || "unknown",
+    expectedHost,
+    expectedUser: facts.expectedUser,
+    launchSource: facts.launchSource || "subtree-broker-tmux",
+    vcsIdentity: facts.vcsIdentity,
+  };
 }
 
 export interface ResumeLauncherInput {

--- a/slack-bridge/broker/hibernation-runtime-helpers.ts
+++ b/slack-bridge/broker/hibernation-runtime-helpers.ts
@@ -1,0 +1,176 @@
+// Pure, side-effect-free helpers for the live hibernation runtime adapters.
+//
+// These back the real `HibernationProcessController` / `HibernationTmuxController`
+// (which shell out to `ps`, `kill`, `git`, and `tmux`) and the worker-side wake
+// fence ingestion. Keeping the string/parse logic pure makes the security- and
+// correctness-critical pieces (VCS identity derivation, wake-fence env parsing,
+// resume-launcher construction) unit-testable without spawning processes.
+
+import { parsePinetStableId } from "../pinet-session-formatting.js";
+
+/** Single-quote a value for safe embedding in a POSIX shell launcher script. */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Derive a canonical `owner/repo` VCS identity from a git remote URL. Supports
+ * scp-style (`git@github.com:owner/repo.git`), URL (`https://host/owner/repo`,
+ * `ssh://git@host/owner/repo`, `git://host/owner/repo`), and bare `owner/repo`
+ * forms. Returns null when no `owner/repo` can be derived.
+ *
+ * This is the ONLY identity the repo allowlist authorizes against, and it is
+ * derived from the runtime's actual git REMOTE — never from filesystem directory
+ * names — so distinct roots that merely share their final path segments (or a
+ * worktree vs. its clone) never collapse onto, or diverge from, one authorization
+ * identity.
+ */
+export function deriveVcsIdentity(remoteUrl: string | null | undefined): string | null {
+  const raw = remoteUrl?.trim();
+  if (!raw) return null;
+  // Normalize: drop a trailing `.git` and any trailing slashes.
+  const normalized = raw.replace(/\.git$/i, "").replace(/\/+$/, "");
+
+  let pathPart: string | null = null;
+  const scp = /^[^@\s/]+@[^:\s/]+:(.+)$/.exec(normalized); // git@host:owner/repo
+  const url = /^[a-z][a-z0-9+.-]*:\/\/[^/]+\/(.+)$/i.exec(normalized); // scheme://host/owner/repo
+  if (scp) {
+    pathPart = scp[1];
+  } else if (url) {
+    pathPart = url[1];
+  } else if (normalized.includes("/") && !normalized.includes(":")) {
+    pathPart = normalized; // bare owner/repo (or deeper path)
+  }
+  if (!pathPart) return null;
+
+  const segments = pathPart.split("/").filter(Boolean);
+  if (segments.length < 2) return null;
+  const owner = segments[segments.length - 2];
+  const repo = segments[segments.length - 1];
+  if (!owner || !repo) return null;
+  return `${owner}/${repo}`;
+}
+
+/**
+ * Parse resident set size (bytes) from `ps -o rss= -p <pid>` output. macOS/Linux
+ * `ps` reports RSS in kibibytes; returns null when no numeric value is present
+ * (e.g. the process already exited).
+ */
+export function parseRssBytesFromPs(psOutput: string | null | undefined): number | null {
+  const match = /\d+/.exec(psOutput ?? "");
+  if (!match) return null;
+  const kib = Number.parseInt(match[0], 10);
+  return Number.isFinite(kib) ? kib * 1024 : null;
+}
+
+/**
+ * Build the broker-resolvable, redaction-safe session resume reference for a
+ * worker from its stable id. A worker's stable id embeds the absolute path to
+ * its Pi session `.jsonl` (`<host>:session:<path>`); the resume ref is stored as
+ * `session:<path>` so `redactRuntimeSpec` digests it to `session:#<fingerprint>`
+ * on every operator/JSON surface while the broker can still recover the path to
+ * respawn `pi --session <path>`. Returns null for stable ids without a session
+ * path (e.g. `cwd:`/`leaf:` kinds), which are not resumable.
+ */
+export function sessionResumeRefFromStableId(stableId: string | null | undefined): string | null {
+  const parsed = parsePinetStableId(stableId);
+  // Only the `session` kind carries a resumable Pi session `.jsonl`; `cwd`/`leaf`
+  // stable ids also expose a filesystem locator but have no resumable session.
+  if (!parsed || parsed.kind !== "session" || !parsed.hasPath) return null;
+  return `session:${parsed.locator}`;
+}
+
+/** Recover the absolute session `.jsonl` path from a `session:<path>` resume ref. */
+export function resumePathFromSessionRef(
+  sessionResumeRef: string | null | undefined,
+): string | null {
+  const ref = sessionResumeRef?.trim();
+  if (!ref) return null;
+  const separator = ref.indexOf(":");
+  if (separator <= 0) return null;
+  if (ref.slice(0, separator) !== "session") return null;
+  const path = ref.slice(separator + 1).trim();
+  return path.length > 0 ? path : null;
+}
+
+/** The broker-issued wake fence a respawned runtime must echo back to register. */
+export interface WakeFence {
+  wakeLeaseId: string;
+  fenceToken: number;
+  reservedGeneration: number;
+  reservationNonce: string;
+}
+
+export interface WakeFenceEnvInput extends WakeFence {
+  correlationId: string;
+}
+
+/**
+ * Environment variables the respawn launcher exports so the woken runtime can
+ * present its single-use wake fence on registration. Ordinary (non-wake) spawns
+ * never set these, so ordinary registration stays fence-free and backward
+ * compatible.
+ */
+export function buildWakeFenceEnv(input: WakeFenceEnvInput): Record<string, string> {
+  return {
+    PINET_WAKE_LEASE_ID: input.wakeLeaseId,
+    PINET_WAKE_FENCE_TOKEN: String(input.fenceToken),
+    PINET_WAKE_RESERVED_GENERATION: String(input.reservedGeneration),
+    PINET_WAKE_RESERVATION_NONCE: input.reservationNonce,
+    PINET_WAKE_CORRELATION_ID: input.correlationId,
+  };
+}
+
+/**
+ * Parse a wake fence from a woken worker's environment (the boundary between the
+ * respawn launcher and the follower's register RPC). Returns null unless ALL
+ * required fields are present and well-formed, so a partial/garbled environment
+ * fails closed to an ordinary (fence-free) registration rather than a malformed
+ * fenced one.
+ */
+export function parseWakeFenceEnv(env: Record<string, string | undefined>): WakeFence | null {
+  const wakeLeaseId = env.PINET_WAKE_LEASE_ID?.trim();
+  const reservationNonce = env.PINET_WAKE_RESERVATION_NONCE?.trim();
+  const fenceToken = Number.parseInt(env.PINET_WAKE_FENCE_TOKEN ?? "", 10);
+  const reservedGeneration = Number.parseInt(env.PINET_WAKE_RESERVED_GENERATION ?? "", 10);
+  if (!wakeLeaseId || !reservationNonce) return null;
+  if (!Number.isInteger(fenceToken) || !Number.isInteger(reservedGeneration)) return null;
+  return { wakeLeaseId, fenceToken, reservedGeneration, reservationNonce };
+}
+
+export interface ResumeLauncherInput {
+  repoPath: string;
+  /** Absolute path to the Pi session `.jsonl` to resume. */
+  sessionPath: string;
+  extensionEntryPath: string;
+  /** Inherited env keys to re-export if present in the broker environment. */
+  inheritedEnv: Record<string, string | undefined>;
+  /** PINET_* launch env plus the wake-fence env for this attempt. */
+  pinetEnv: Record<string, string>;
+  nickname: string;
+}
+
+/**
+ * Build the launcher script a wake attempt runs via `tmux respawn-pane` to bring
+ * back the fenced runtime. It re-establishes the repo cwd and launch environment,
+ * exports the wake fence, and resumes the exact session with `pi --session
+ * <path>` (no startup prompt — the session already carries the worker's context;
+ * injecting a prompt would append a spurious user turn). The woken Pi therefore
+ * re-registers under the SAME stable id (same session path) and presents the
+ * fence for atomic generation acceptance.
+ */
+export function buildResumeLauncherScript(input: ResumeLauncherInput): string {
+  const lines: string[] = ["#!/bin/bash", "set -euo pipefail", `cd ${shellQuote(input.repoPath)}`];
+  for (const [key, value] of Object.entries(input.inheritedEnv)) {
+    if (value !== undefined && value !== "") lines.push(`export ${key}=${shellQuote(value)}`);
+  }
+  for (const [key, value] of Object.entries(input.pinetEnv)) {
+    lines.push(`export ${key}=${shellQuote(value)}`);
+  }
+  lines.push(`export PI_NICKNAME=${shellQuote(input.nickname)}`);
+  lines.push(
+    `exec pi -e ${shellQuote(input.extensionEntryPath)} --session ${shellQuote(input.sessionPath)}`,
+  );
+  lines.push("");
+  return lines.join("\n");
+}


### PR DESCRIPTION
Follow-up to #923 (PR #924): wire the **live process/tmux side** of broker-managed hibernation and prove it end-to-end on real Pi + tmux. #923 landed the durable primitives, orchestrator, operator commands, and socket-server wake-fence enforcement; the live adapters + production instantiation were deliberately deferred. This branch delivers and proves the runtime mechanics, and scopes the remaining live-broker wiring for review before any production activation.

## What's here (tested, committed)
- **Real runtime adapters** (`broker/hibernation-runtime-adapters.ts`): `HibernationProcessController` + `HibernationTmuxController` + git-remote `resolveVcsIdentity` + `createExecFileRunner`. `stopRuntime` self-ensures `remain-on-exit on` before killing Pi, so hibernation needs **no worker spawn-path change** for pane survival; it TERM→bounded-KILLs the Pi pid and **never** destroys the tmux session.
- **Pure helpers** (`broker/hibernation-runtime-helpers.ts`): resume-ref derivation, wake-fence env build/parse, resume launcher, and `buildRuntimeSpecInput` — a **spawn-authored** spec composer that fails closed on non-resumable identities / missing locators and takes only broker-known facts (never worker-reported operational locators — security rationale in code + plan).
- **Isolated E2E** (`broker/hibernation-runtime-adapters.e2e.test.ts`, opt-in `HIBERNATION_E2E=1`, **skipped in CI**): drives a genuine Pi runtime through hibernate→wake on a throwaway tmux socket — checkpoint-safe → stop (Pi dies, tmux session survives + attachable, session `.jsonl` intact) → respawn (`pi --session <path>` into the surviving pane, woken Pi alive on a fresh pid bound to the same session) → attempt-bound cleanup. Never touches the production broker/mesh.

## Verification
- 38 unit tests (adapters + helpers); full `slack-bridge/broker/` suite **536 pass / 1 skipped**.
- `tsc --noEmit`, `eslint`, `lint:agent-standards` all clean.
- E2E green (~6s) against real Pi + tmux.

## Not yet wired (default-OFF; scoped in `plans/hibernation-live-activation.md`)
Deterministic session path at spawn; spawn-facts capture + register-time spec authoring (security-critical); orchestrator instantiation + real executor replacing the `activation_pending` stub (gated); startup `recoverStrandedWakes` ordering; worker-side wake-fence register wiring. Hibernation remains **default-disabled** and returns an honest `activation_pending` refusal until those land and are reviewed. No production config/reload performed; `snapshot/pre-hibernation-merge` rollback tag retained.
