### PR TITLE
feat(pinet): wire default-off hibernation runtime activation (seams 1-3)

### DIFF
--- a/slack-bridge/broker/hibernation-activation-authority.ts
+++ b/slack-bridge/broker/hibernation-activation-authority.ts
@@ -1,0 +1,58 @@
+// Durable, non-reloadable hibernation runtime-activation authority.
+//
+// The Phase B live process/tmux adapters must be activated ONLY by a durable
+// authority captured at broker start and FROZEN for the entire process
+// lifetime. This deliberately does NOT read agent-editable `SlackBridgeSettings`
+// (which pi re-reads on config reload): there must be NO settings, reload, or
+// other in-process path that can elevate a running broker into live-runtime
+// activation. The single source of truth is an external, process-launch
+// environment variable, captured exactly once.
+//
+// Security rationale: an attacker (or a well-meaning agent) who can edit the
+// broker's settings file or trigger a settings reload must never be able to turn
+// on the live runtime. Requiring an external launch-environment variable moves
+// the activation decision to whoever started the broker process and freezes it
+// for the lifetime of that process.
+
+/** External process-launch env var that authorizes live-runtime activation. */
+const ACTIVATION_ENV_VAR = "PINET_HIBERNATION_RUNTIME_ACTIVATION";
+
+/** Captured once at broker start; never re-read afterwards. */
+let frozen: boolean | undefined;
+
+/**
+ * Capture the activation authority from the process-launch environment ONCE and
+ * freeze it for the process lifetime. Idempotent: the first call wins, and any
+ * later environment or settings mutation cannot change the frozen value. Returns
+ * the frozen authority. Call this explicitly at broker start so the freeze point
+ * is deterministic; reads via {@link hibernationActivationAuthorized} also
+ * freeze lazily on first use.
+ *
+ * Accepts `1`, `true`, `yes`, or `on` (case-insensitive, trimmed) as authorized;
+ * everything else — including unset/empty — is unauthorized (the production
+ * default, a strict no-op).
+ */
+export function freezeHibernationActivationAuthority(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (frozen === undefined) {
+    const raw = env[ACTIVATION_ENV_VAR]?.trim().toLowerCase();
+    frozen = raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+  }
+  return frozen;
+}
+
+/**
+ * The frozen live-runtime activation authority. Lazily freezes on first read
+ * from the process-launch environment when {@link freezeHibernationActivationAuthority}
+ * has not run yet, so the gate is always a process-lifetime constant. Config
+ * reloads and settings edits can never flip it.
+ */
+export function hibernationActivationAuthorized(): boolean {
+  return freezeHibernationActivationAuthority();
+}
+
+/** Test-only: clear the frozen value so a test can re-capture a chosen env. */
+export function __resetHibernationActivationAuthorityForTest(): void {
+  frozen = undefined;
+}

--- a/slack-bridge/broker/hibernation-activation.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-activation.e2e.test.ts
@@ -1,29 +1,40 @@
-// Materially-real, isolated, PRODUCTION-ROUTE end-to-end proof for Phase B.
+// Materially-real, isolated, PRODUCTION-ROUTE end-to-end proof for Phase B — the
+// real-process half. The deterministic, CI-run half lives in
+// `hibernation-production-route.test.ts` (assertions 1–5: shared-router routing,
+// authoritative subtree-DB topology vs a contradictory central decoy, pre-listen
+// recovery ordering, frozen non-reloadable activation authority, and DB-sourced
+// allowlist identity). This file adds the two assertions that REQUIRE real OS
+// processes, and drives them through the exact same production integration glue a
+// live operator command takes — NOT a hand-composed broker/orchestrator:
 //
-// This does not hand-compose helpers on a bare DB. It exercises the SAME route a
-// real operator command takes:
+//   • the REAL `createSubtreeBrokerRuntime(deps).start(ctx)` (real leader lock +
+//     real socket server + real self-agent registration + real pre-listen recovery),
+//   • the REAL `runtime.getHibernationRuntimeControl()` authoritative control, and
+//   • the REAL, SHARED `routeHibernationCommand` that `index.ts` delegates to.
 //
-//   • Activation is authorized ONLY by the durable, non-reloadable broker-start
-//     authority (PINET_HIBERNATION_RUNTIME_ACTIVATION), and a later settings-shaped
-//     "reload" cannot flip it — proving the gate is frozen for the process life.
-//   • The broker is a REAL `startBroker` (real leader lock + real socket server),
-//     so its `db` is the ONE authoritative DB. A crash-stranded `waking` row seeded
-//     BEFORE start is reconciled inside `beforeListen` — provably before the socket
-//     accepts a single connection (Seam 3 ordering, on the authoritative DB).
-//   • The spawn-authored runtime spec (Seam 2, git-remote VCS identity) is persisted
-//     into that SAME broker DB, and hibernate/wake are driven through the REAL
-//     `executeHibernateCommand` / `executeWakeCommand` wrappers with the real policy
-//     gate — including a negative repo-allowlist refusal proving authorization reads
-//     the DB-sourced identity, not a path name.
-//   • The executor is the REAL `HibernationOrchestrator` acting on a REAL `pi`
-//     runtime in a REAL throwaway tmux session: checkpoint → stop (session survives)
-//     → respawn into the dead pane → generation accepted → live.
+//   (6) SUPERVISED-CHILD REFUSAL, end to end: a REAL `spawnWorker` launches a REAL
+//       child `pi` that boots the REAL slack-bridge follower and registers itself
+//       against the subtree broker as a supervised subtree child; `spawnWorker`
+//       persists its durable runtime spec into the authoritative subtree DB. The
+//       shared router then refuses it — `policy_never` at the default policy, and,
+//       once the policy is deliberately elevated to isolate the guard,
+//       `supervised_subtree_unsupported` — and the child stays alive and untouched.
+//
+//   (7) TOP-LEVEL HIBERNATE→WAKE, end to end: an eligible top-level broker-managed
+//       worker (a REAL resumable `pi` in a REAL throwaway tmux session, spec
+//       persisted into the SAME authoritative subtree DB) is hibernated and woken
+//       THROUGH the shared router / real orchestrator: checkpoint → stop (pane
+//       survives, explicitly DEAD) → respawn into the dead pane → generation
+//       accepted → live, plus a negative repo-allowlist refusal proving
+//       authorization reads the DB-sourced VCS identity, not a path name. A
+//       crash-stranded `waking` row seeded before start is reconciled by the real
+//       subtree pre-listen recovery.
 //
 // The ONLY simulated element is the socket-registration RPC (broker-core's domain,
-// already exhaustively fenced-tested): the injected `awaitRuntimeRegistration`
-// stands in for the socket server BUT keys acceptance off the REAL respawned
-// process actually coming back alive, and accepts against the authoritative broker
-// DB, so nothing about the runtime lifecycle is mocked.
+// exhaustively fenced-tested): the injected `awaitRuntimeRegistration` stands in
+// for the socket server BUT keys acceptance off the REAL respawned process being
+// alive, accepting against the authoritative subtree DB, so nothing about the
+// runtime lifecycle is mocked.
 //
 // Opt-in only (spawns real processes + one cheap `pi --print` model call to seed a
 // resumable session); skipped in normal `pnpm test`/CI, runs under HIBERNATION_E2E=1.
@@ -32,56 +43,65 @@ import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { RuntimeLaunchContext } from "@pinet/broker-core";
-import {
-  executeHibernateCommand,
-  executeWakeCommand,
-  type HibernationCommandPolicy,
-} from "@pinet/broker-core";
 import type { AgentLifecycleState } from "@pinet/broker-core/types";
-import { startBroker, type Broker } from "./index.js";
 import { BrokerDB } from "./schema.js";
 import { createHibernationProcessController } from "./hibernation-runtime-adapters.js";
 import {
-  createHibernationOrchestrator,
   hibernationRuntimeActive,
   persistSpawnedRuntimeSpec,
-  recoverStrandedWakesBeforeRegistrations,
   type SpawnRuntimeSpecFacts,
 } from "./hibernation-activation.js";
+import { __resetHibernationActivationAuthorityForTest } from "./hibernation-activation-authority.js";
+import { routeHibernationCommand } from "./hibernation-command-router.js";
+import { resolveHibernationSettings } from "../hibernation-config.js";
 import {
-  freezeHibernationActivationAuthority,
-  __resetHibernationActivationAuthorityForTest,
-} from "./hibernation-activation-authority.js";
+  buildSubtreeBrokerPaths,
+  createSubtreeBrokerRuntime,
+  getExtensionEntryPath,
+  SUBTREE_INHERITED_ENV_KEYS,
+  type SubtreeBrokerRuntime,
+  type SubtreeBrokerRuntimeDeps,
+} from "../subtree-broker-runtime.js";
+import type { SlackBridgeSettings, PinetControlCommand } from "../helpers.js";
 
 const RUN = process.env.HIBERNATION_E2E === "1";
 const suite = RUN ? describe : describe.skip;
+const ctx = {} as ExtensionContext;
 
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-hib-act-e2e-"));
-const tmuxSocket = path.join(tmpRoot, "tmux.sock");
-const sessionsDir = path.join(tmpRoot, "sessions");
-const repoDir = path.join(tmpRoot, "repo");
-const sessionFile = path.join(sessionsDir, "e2e.jsonl");
-const settingsPath = path.join(tmpRoot, "empty-settings.json");
-const noopExt = path.join(tmpRoot, "noop-ext.js");
-const brokerDbPath = path.join(tmpRoot, "broker.db");
-const brokerSocket = path.join(tmpRoot, "b.sock");
-const brokerLock = path.join(tmpRoot, "b.lock");
-const tmuxSession = `pi-hib-act-e2e-${process.pid}`;
-const AGENT_ID = "e2e-agent";
-const STABLE_ID = `${os.hostname()}:session:${sessionFile}`;
-
-let broker: Broker | null = null;
-
-function tmux(args: string[]): string {
-  return execFileSync("tmux", ["-S", tmuxSocket, ...args], { encoding: "utf8" }).trim();
-}
-function tmuxNewSessionClean(name: string, script: string, env: NodeJS.ProcessEnv): void {
-  execFileSync("tmux", ["-S", tmuxSocket, "new-session", "-d", "-s", name, script], { env });
-}
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Minimal, fully-typed subtree deps: the inbox/steering callbacks never fire (no
+ *  inbound traffic beyond the child's own registration in test 6). */
+function makeDeps(stableId: string, settings: SlackBridgeSettings): SubtreeBrokerRuntimeDeps {
+  return {
+    cwd: os.tmpdir(),
+    getSettings: () => settings,
+    getAgentStableId: () => stableId,
+    getCentralAgentId: () => null,
+    getAgentIdentity: () => ({ name: "E2E", emoji: "🌳" }),
+    getAgentMetadata: async () => ({}),
+    getMeshRoleFromMetadata: (_metadata, fallback) => fallback ?? "worker",
+    pushInboxMessages: () => {},
+    updateBadge: () => {},
+    maybeDrainInboxIfIdle: () => false,
+    deliverSteeringMessage: () => false,
+    requestRemoteControl: (command: PinetControlCommand) => ({
+      currentCommand: null,
+      queuedCommand: null,
+      accepted: false,
+      shouldStartNow: false,
+      status: "covered",
+      scheduledCommand: command,
+      ackDisposition: "immediate",
+    }),
+    runRemoteControl: () => {},
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+  };
 }
 
 /** Seed a real crash-stranded `waking` row (no held lease, no accepted generation). */
@@ -98,10 +118,9 @@ function seedStrandedWaking(dbPath: string, agentId: string): void {
   );
   const chain: AgentLifecycleState[] = ["grace", "idle", "hibernating", "hibernated", "waking"];
   for (const toState of chain) {
-    const version = db.getAgentById(agentId)?.lifecycleVersion ?? 0;
     db.transitionAgentLifecycle({
       agentId,
-      expectedVersion: version,
+      expectedVersion: db.getAgentById(agentId)?.lifecycleVersion ?? 0,
       toState,
       reason: "seed",
       actor: "broker",
@@ -111,57 +130,153 @@ function seedStrandedWaking(dbPath: string, agentId: string): void {
   db.close();
 }
 
-afterAll(async () => {
-  if (broker) {
-    try {
-      await broker.stop();
-    } catch {
-      /* best effort */
-    }
-  }
-  __resetHibernationActivationAuthorityForTest();
-  try {
-    tmux(["kill-server"]);
-  } catch {
-    /* already gone */
-  }
-  try {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-  } catch {
-    /* best effort */
-  }
-});
+const ENV_KEYS = [
+  "PINET_HIBERNATION_RUNTIME_ACTIVATION",
+  "PI_CODING_AGENT_DIR",
+  "PI_OFFLINE",
+  "PI_SETTINGS_PATH",
+  "SLACK_BOT_TOKEN",
+  "SLACK_APP_TOKEN",
+] as const;
 
 suite(
-  "Phase B production-route — frozen authority + authoritative broker DB + real pi/tmux",
+  "Phase B production-route real pi/tmux — supervised-child refusal + top-level hibernate/wake",
   () => {
-    const cleanPath = (process.env.PATH ?? "")
-      .split(":")
-      .filter((segment) => !segment.includes("node_modules/.bin"))
-      .join(":");
-    const minimalEnv: NodeJS.ProcessEnv = {
-      PATH: cleanPath,
-      HOME: process.env.HOME,
-      TERM: "xterm-256color",
-      TMPDIR: process.env.TMPDIR,
-      PI_SETTINGS_PATH: settingsPath,
-      PI_CODING_AGENT_SESSION_DIR: sessionsDir,
-    };
+    let savedEnv: Record<string, string | undefined> = {};
+    const disposers: Array<() => void | Promise<void>> = [];
 
-    // A dedicated process controller for the injected registration waiter's REAL
-    // liveness probe (stands in for the socket server observing the woken worker).
-    const probeProc = createHibernationProcessController({ pendingInboxCount: () => 0 });
-
-    it("routes hibernate/wake through the real command path over the authoritative broker DB", async () => {
-      // ── Gate: activation comes ONLY from the frozen broker-start authority ──
+    beforeEach(() => {
+      savedEnv = {};
+      for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
       __resetHibernationActivationAuthorityForTest();
-      freezeHibernationActivationAuthority({ PINET_HIBERNATION_RUNTIME_ACTIVATION: "1" });
-      expect(hibernationRuntimeActive()).toBe(true);
-      // A later settings-shaped "reload" (var absent) cannot flip a running broker off.
-      expect(freezeHibernationActivationAuthority({})).toBe(true);
+    });
+
+    afterEach(async () => {
+      for (const dispose of disposers.splice(0).reverse()) {
+        try {
+          await dispose();
+        } catch {
+          /* best effort */
+        }
+      }
+      for (const key of ENV_KEYS) {
+        if (savedEnv[key] === undefined) delete process.env[key];
+        else process.env[key] = savedEnv[key];
+      }
+      __resetHibernationActivationAuthorityForTest();
+    });
+
+    function trackRuntime(runtime: SubtreeBrokerRuntime, stableId: string): void {
+      disposers.push(() => runtime.stop({ releaseIdentity: true, stopChildren: true }));
+      disposers.push(() =>
+        fs.rmSync(buildSubtreeBrokerPaths(stableId).rootDir, { recursive: true, force: true }),
+      );
+    }
+
+    // ── Assertion 6 ──────────────────────────────────────────────────────────
+    it("routes a REAL supervised spawnWorker child to supervised_subtree_unsupported and leaves it alive", async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-hib-e2e6-"));
+      disposers.push(() => fs.rmSync(tmp, { recursive: true, force: true }));
+      // Isolated agent dir so the child pi does NOT auto-load the globally-installed
+      // slack-bridge package (which would conflict with the `-e` worktree slack-bridge
+      // and abort the child). Offline + fake Slack tokens so the child never touches a
+      // real model or a real Slack workspace: it only needs to boot + register as a
+      // broker-managed follower and stay alive.
+      const agentDir = path.join(tmp, "agent");
+      fs.mkdirSync(agentDir, { recursive: true });
+      const settingsPath = path.join(agentDir, "settings.json");
+      fs.writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          lastChangelogVersion: "999.0.0",
+          defaultProjectTrust: "trusted",
+          extensions: [],
+          packages: [],
+        }),
+      );
+      const repoDir = path.join(tmp, "repo");
+      fs.mkdirSync(repoDir, { recursive: true });
+      execFileSync("git", ["init", "-q"], { cwd: repoDir });
+      execFileSync("git", ["remote", "add", "origin", "git@github.com:test/repo.git"], {
+        cwd: repoDir,
+      });
+
+      process.env.PINET_HIBERNATION_RUNTIME_ACTIVATION = "1";
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+      process.env.PI_OFFLINE = "1";
+      process.env.PI_SETTINGS_PATH = settingsPath;
+      process.env.SLACK_BOT_TOKEN = "xoxb-e2e-fake";
+      process.env.SLACK_APP_TOKEN = "xapp-e2e-fake";
+      __resetHibernationActivationAuthorityForTest();
+
+      const stableId = `e2e6-${process.pid}-${Math.random().toString(36).slice(2, 7)}`;
+      const settings: SlackBridgeSettings = {
+        hibernation: { enabled: true, mode: "manual", allowedRepos: ["test/repo"] },
+      };
+      const runtime = createSubtreeBrokerRuntime(makeDeps(stableId, settings));
+      trackRuntime(runtime, stableId);
+      await runtime.start(ctx);
       expect(hibernationRuntimeActive()).toBe(true);
 
-      // ── Arrange: disposable repo (with a real git remote), settings, noop ext ──
+      // A REAL child pi boots, loads the REAL slack-bridge follower, and registers
+      // itself against the subtree broker as a supervised subtree child.
+      const result = await runtime.spawnWorker(ctx, {
+        task: "E2E supervised-child: idle and wait.",
+        repo: repoDir,
+        waitForRegistrationMs: 90_000,
+      });
+      const control = runtime.getHibernationRuntimeControl();
+      expect(control).not.toBeNull();
+      const child = control!.db.getAgentById(result.agentId);
+      expect(child).toBeTruthy();
+      expect(child?.parentAgentId).toBe(`subbroker-${stableId}`);
+      expect(child?.supervisionState).toBe("supervised");
+      // spawnWorker persisted the child's durable spec into the authoritative subtree DB.
+      expect(control!.db.getAgentRuntimeSpec(result.agentId)?.vcsIdentity).toBe("test/repo");
+
+      const routeChild = (target: string) =>
+        routeHibernationCommand({
+          command: "hibernate",
+          target,
+          brokerRole: "broker",
+          hib: resolveHibernationSettings(settings),
+          getRuntimeControl: () => runtime.getHibernationRuntimeControl(),
+          getFallbackDb: () => null,
+          extensionEntryPath: getExtensionEntryPath(),
+          inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
+        });
+
+      // Default policy: a spawned child is non-hibernatable — refuse policy_never.
+      const byDefault = await routeChild(result.agentId);
+      expect(byDefault.outcome).toBe("refused");
+      expect(byDefault.reason).toBe("policy_never");
+
+      // Elevate the policy to ISOLATE the supervised guard: even a policy-permitted,
+      // allowlisted supervised child is still refused, purely because it is supervised.
+      control!.db.setAgentHibernatePolicy(result.agentId, "manual");
+      const supervised = await routeChild(result.agentId);
+      expect(supervised.outcome).toBe("refused");
+      expect(supervised.reason).toBe("supervised_subtree_unsupported");
+
+      // The child is untouched: still live, still connected.
+      const after = control!.db.getAgentById(result.agentId);
+      expect(after?.lifecycleState).toBe("live");
+      expect(after?.disconnectedAt ?? null).toBeNull();
+    }, 180_000);
+
+    // ── Assertion 7 (+ pre-listen recovery + negative allowlist) ───────────────
+    it("hibernates and wakes an eligible top-level worker through the shared router over the authoritative subtree DB", async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-hib-e2e7-"));
+      disposers.push(() => fs.rmSync(tmp, { recursive: true, force: true }));
+      const tmuxSocket = path.join(tmp, "tmux.sock");
+      const sessionsDir = path.join(tmp, "sessions");
+      const repoDir = path.join(tmp, "repo");
+      const sessionFile = path.join(sessionsDir, "e2e.jsonl");
+      const settingsPath = path.join(tmp, "empty-settings.json");
+      const noopExt = path.join(tmp, "noop-ext.js");
+      const tmuxSession = `pi-hib-e2e7-${process.pid}`;
+      const AGENT_ID = "e2e-top-worker";
+      const STABLE_ID = `${os.hostname()}:session:${sessionFile}`;
       fs.mkdirSync(sessionsDir, { recursive: true });
       fs.mkdirSync(repoDir, { recursive: true });
       fs.writeFileSync(settingsPath, JSON.stringify({ extensions: [], packages: [] }));
@@ -171,54 +286,87 @@ suite(
         cwd: repoDir,
       });
 
-      // ── Seam 3: seed a crash-stranded wake BEFORE the broker starts, then prove
-      //    it is reconciled inside beforeListen, before the socket ever listens ──
-      seedStrandedWaking(brokerDbPath, "stranded-1");
-      let reconciledPreListen = false;
-      broker = await startBroker({
-        dbPath: brokerDbPath,
-        socketPath: brokerSocket,
-        lockPath: brokerLock,
-        beforeListen: ({ db }) => {
-          recoverStrandedWakesBeforeRegistrations(
-            createHibernationOrchestrator({
-              db,
-              brokerInstanceId: "e2e-broker",
-              extensionEntryPath: noopExt,
-              baseLaunchEnv: {},
-              inheritedEnvKeys: [],
-            }),
-          );
-          reconciledPreListen = db.getAgentById("stranded-1")?.lifecycleState === "reap-candidate";
-        },
+      const tmux = (args: string[]): string =>
+        execFileSync("tmux", ["-S", tmuxSocket, ...args], { encoding: "utf8" }).trim();
+      disposers.push(() => {
+        try {
+          tmux(["kill-server"]);
+        } catch {
+          /* already gone */
+        }
       });
-      expect(reconciledPreListen).toBe(true);
-      expect(broker.db.getAgentById("stranded-1")?.lifecycleState).toBe("reap-candidate");
 
-      // The ONE authoritative DB the command path, spec persistence, and recovery
-      // all share is the started broker's DB.
-      const db = broker.db;
+      // Activation ON only; NO agent-dir isolation / offline (the seed needs a real
+      // model), and NO Slack tokens (so the resident/woken global slack-bridge no-ops).
+      process.env.PINET_HIBERNATION_RUNTIME_ACTIVATION = "1";
+      delete process.env.PI_CODING_AGENT_DIR;
+      delete process.env.PI_OFFLINE;
+      delete process.env.SLACK_BOT_TOKEN;
+      delete process.env.SLACK_APP_TOKEN;
+      process.env.PI_SETTINGS_PATH = settingsPath;
+      __resetHibernationActivationAuthorityForTest();
 
-      // Seed a resumable session via one-shot `pi --print` inside the clean tmux
-      // server (this also establishes the clean server env for all later panes).
-      const seedScript = path.join(tmpRoot, "seed.sh");
+      const minimalEnv: NodeJS.ProcessEnv = {
+        PATH: (process.env.PATH ?? "")
+          .split(":")
+          .filter((segment) => !segment.includes("node_modules/.bin"))
+          .join(":"),
+        HOME: process.env.HOME,
+        TERM: "xterm-256color",
+        TMPDIR: process.env.TMPDIR,
+        PI_SETTINGS_PATH: settingsPath,
+        PI_CODING_AGENT_SESSION_DIR: sessionsDir,
+      };
+      const tmuxNewSessionClean = (name: string, script: string): void => {
+        execFileSync("tmux", ["-S", tmuxSocket, "new-session", "-d", "-s", name, script], {
+          env: minimalEnv,
+        });
+      };
+
+      // Seam 3: seed a crash-stranded wake into the subtree DB path BEFORE start, then
+      // prove the REAL subtree pre-listen recovery reconciled it. The SUBTREE broker's
+      // stableId is sanitized into its unix socket path, which must stay under the
+      // macOS ~104-char limit, so keep it short — distinct from the worker's
+      // session-format STABLE_ID (which only feeds the runtime spec's resume ref).
+      const stableId = `e2e7-${process.pid}-${Math.random().toString(36).slice(2, 7)}`;
+      const paths = buildSubtreeBrokerPaths(stableId);
+      fs.mkdirSync(paths.rootDir, { recursive: true });
+      seedStrandedWaking(paths.dbPath, "stranded-1");
+
+      const settings: SlackBridgeSettings = {
+        hibernation: { enabled: true, mode: "manual", allowedRepos: ["test/repo"] },
+      };
+      const runtime = createSubtreeBrokerRuntime(makeDeps(stableId, settings));
+      trackRuntime(runtime, stableId);
+      await runtime.start(ctx);
+      const control = runtime.getHibernationRuntimeControl();
+      expect(control).not.toBeNull();
+      const db = control!.db;
+      expect(db.getAgentById("stranded-1")?.lifecycleState).toBe("reap-candidate");
+
+      // A dedicated process controller for the injected registration waiter's REAL
+      // liveness probe (stands in for the socket server observing the woken worker).
+      const probeProc = createHibernationProcessController({ pendingInboxCount: () => 0 });
+
+      // Seed a resumable session via one-shot `pi --print` inside the clean tmux server.
+      const seedScript = path.join(tmp, "seed.sh");
       fs.writeFileSync(
         seedScript,
         [
           "#!/bin/bash",
           `cd '${repoDir}'`,
-          `pi --print --model google/gemini-2.5-flash --session '${sessionFile}' 'Remember codeword: HERON-7. Reply only ACK.' >'${tmpRoot}/seed.out' 2>&1 || true`,
+          `pi --print --model google/gemini-2.5-flash --session '${sessionFile}' 'Remember codeword: HERON-7. Reply only ACK.' >'${tmp}/seed.out' 2>&1 || true`,
           "",
         ].join("\n"),
         { mode: 0o700 },
       );
-      tmuxNewSessionClean("holder", "sleep 100000", minimalEnv);
-      tmuxNewSessionClean("seed", seedScript, minimalEnv);
+      tmuxNewSessionClean("holder", "sleep 100000");
+      tmuxNewSessionClean("seed", seedScript);
       for (let i = 0; i < 120 && !fs.existsSync(sessionFile); i++) await sleep(500);
       if (!fs.existsSync(sessionFile)) {
-        const out = fs.existsSync(`${tmpRoot}/seed.out`)
-          ? fs.readFileSync(`${tmpRoot}/seed.out`, "utf8").slice(-1500)
-          : "(no seed.out)";
+        const out = fs.existsSync(`${tmp}/seed.out`)
+          ? fs.readFileSync(`${tmp}/seed.out`, "utf8").slice(-1500)
+          : "(none)";
         throw new Error(`seed session file was not created.\nseed.out tail:\n${out}`);
       }
       try {
@@ -227,9 +375,8 @@ suite(
         /* seed pane already exited */
       }
 
-      // Launch the resident runtime in a throwaway tmux session (no pre-set
-      // remain-on-exit; the orchestrator's stop is responsible for pane survival).
-      const launchScript = path.join(tmpRoot, "launch.sh");
+      // Launch the resident runtime (a real pi) in a throwaway tmux session.
+      const launchScript = path.join(tmp, "launch.sh");
       fs.writeFileSync(
         launchScript,
         [
@@ -241,14 +388,32 @@ suite(
         ].join("\n"),
         { mode: 0o700 },
       );
-      tmuxNewSessionClean(tmuxSession, launchScript, minimalEnv);
+      tmuxNewSessionClean(tmuxSession, launchScript);
 
-      // ── Seam 2: persist the durable, broker-authored runtime spec into the
-      //    SAME authoritative broker DB ──────────────────────────────────
+      // Register the eligible TOP-LEVEL broker-managed worker (no parentAgentId) and
+      // persist its durable, broker-authored runtime spec into the SAME authoritative
+      // subtree DB the shared router resolves against.
+      db.registerAgent(
+        AGENT_ID,
+        "Worker",
+        "🦉",
+        process.pid,
+        {
+          brokerManaged: true,
+          brokerManagedBy: control!.brokerInstanceId,
+          hibernateSafe: true,
+          cwd: repoDir,
+          repoRoot: repoDir,
+          worktreePath: repoDir,
+          tmuxSession,
+        },
+        STABLE_ID,
+      );
+      db.setAgentHibernatePolicy(AGENT_ID, "manual");
       const facts: SpawnRuntimeSpecFacts = {
         agentId: AGENT_ID,
         stableId: STABLE_ID,
-        brokerOwnerId: "e2e-broker",
+        brokerOwnerId: control!.brokerInstanceId,
         cwd: repoDir,
         repoRoot: repoDir,
         worktreePath: repoDir,
@@ -261,63 +426,12 @@ suite(
         expectedUser: os.userInfo().username,
         launchSource: "e2e",
       };
-      db.registerAgent(
-        AGENT_ID,
-        "Worker",
-        "🦉",
-        process.pid,
-        {
-          brokerManaged: true,
-          brokerManagedBy: "e2e-broker",
-          hibernateSafe: true,
-          cwd: repoDir,
-          repoRoot: repoDir,
-          worktreePath: repoDir,
-          tmuxSession,
-        },
-        STABLE_ID,
-      );
-      db.setAgentHibernatePolicy(AGENT_ID, "manual");
       const spec = await persistSpawnedRuntimeSpec(db, facts);
       expect(spec).not.toBeNull();
-      // VCS identity is derived from the REAL git remote (never the dir name).
       expect(spec?.vcsIdentity).toBe("test/repo");
       expect(db.getAgentRuntimeSpec(AGENT_ID)?.sessionResumeRef).toBe(`session:${sessionFile}`);
 
-      // ── Seam 1: compose the REAL orchestrator over the authoritative broker DB;
-      //    inject a registration waiter that accepts ONLY once the respawned
-      //    process is genuinely alive (socket-RPC stand-in) ──
-      const orch = createHibernationOrchestrator({
-        db,
-        brokerInstanceId: "e2e-broker",
-        extensionEntryPath: noopExt,
-        baseLaunchEnv: {},
-        inheritedEnvKeys: [],
-        config: { handshakeTimeoutMs: 15_000, wakeLeaseMs: 120_000, registrationTimeoutMs: 60_000 },
-        awaitRuntimeRegistration: async (ctx: RuntimeLaunchContext) => {
-          for (let i = 0; i < 120; i++) {
-            if (await probeProc.isRuntimeAlive(ctx.spec)) break;
-            await sleep(300);
-          }
-          const acceptance = db.acceptRuntimeGeneration({
-            agentId: ctx.agentId,
-            wakeLeaseId: ctx.wakeLeaseId,
-            fenceToken: ctx.fenceToken,
-            reservedGeneration: ctx.reservedGeneration,
-            reservationNonce: ctx.reservationNonce,
-            now: Date.now(),
-          });
-          return acceptance.accepted;
-        },
-      });
-
-      // The production command path resolves the executor over the authoritative DB.
-      const executor = orch;
-      // Repo identity comes from the DB-sourced spec, exactly as production does.
-      const repoIdentifier = db.getAgentRuntimeSpec(AGENT_ID)?.vcsIdentity ?? null;
-      expect(repoIdentifier).toBe("test/repo");
-
-      // ── Wait for the resident runtime to boot ─────────────────────────
+      // Wait for the resident runtime to boot.
       let alive = false;
       for (let i = 0; i < 40 && !alive; i++) {
         await sleep(300);
@@ -325,46 +439,53 @@ suite(
       }
       expect(alive).toBe(true);
 
-      // ── Negative authorization: the DB-sourced identity is gated by the repo
-      //    allowlist. A non-matching allowlist REFUSES before any side effect. ──
-      const denyPolicy: HibernationCommandPolicy = {
-        enabled: true,
-        mode: "manual",
-        allowedRepos: ["someone/else"],
+      // The injected socket-registration stand-in: accept the woken generation ONLY
+      // once the REAL respawned process is alive, against the authoritative subtree DB.
+      const awaitRuntimeRegistration = async (launch: RuntimeLaunchContext): Promise<boolean> => {
+        for (let i = 0; i < 120; i++) {
+          if (await probeProc.isRuntimeAlive(launch.spec)) break;
+          await sleep(300);
+        }
+        return db.acceptRuntimeGeneration({
+          agentId: launch.agentId,
+          wakeLeaseId: launch.wakeLeaseId,
+          fenceToken: launch.fenceToken,
+          reservedGeneration: launch.reservedGeneration,
+          reservationNonce: launch.reservationNonce,
+          now: Date.now(),
+        }).accepted;
       };
-      const denied = await executeHibernateCommand({
-        executor,
-        agentId: AGENT_ID,
-        state: (db.getAgentById(AGENT_ID)?.lifecycleState ?? "live") as AgentLifecycleState,
-        repoIdentifier,
-        policy: denyPolicy,
-        actor: "operator",
-      });
+      const route = (command: "hibernate" | "wake", allowedRepos: string[]) =>
+        routeHibernationCommand({
+          command,
+          target: AGENT_ID,
+          brokerRole: "broker",
+          hib: resolveHibernationSettings({
+            hibernation: { enabled: true, mode: "manual", allowedRepos },
+          } satisfies SlackBridgeSettings),
+          getRuntimeControl: () => runtime.getHibernationRuntimeControl(),
+          getFallbackDb: () => null,
+          // The router respawns the woken worker with `pi -e <extensionEntryPath>`; the
+          // resident/woken process here is the cheap noop ext (the process to
+          // checkpoint/respawn), exactly as production passes its own entry path.
+          extensionEntryPath: noopExt,
+          inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
+          awaitRuntimeRegistration,
+        });
+
+      // Negative authorization: a non-matching allowlist REFUSES before any side
+      // effect, keyed off the DB-sourced VCS identity (not the path name).
+      const denied = await route("hibernate", ["someone/else"]);
       expect(denied.outcome).toBe("refused");
       expect(denied.reason).toBe("repo_not_allowlisted");
-      expect(await probeProc.isRuntimeAlive(spec!)).toBe(true); // untouched
+      expect(await probeProc.isRuntimeAlive(spec!)).toBe(true);
 
-      // ── hibernate via the REAL command wrapper: checkpoint + stop; survive ──
-      const allowPolicy: HibernationCommandPolicy = {
-        enabled: true,
-        mode: "manual",
-        allowedRepos: ["test/repo"],
-      };
-      const hib = await executeHibernateCommand({
-        executor,
-        agentId: AGENT_ID,
-        state: (db.getAgentById(AGENT_ID)?.lifecycleState ?? "live") as AgentLifecycleState,
-        repoIdentifier,
-        policy: allowPolicy,
-        actor: "operator",
-      });
+      // Hibernate through the shared router: checkpoint + stop; the pane survives DEAD.
+      const hib = await route("hibernate", ["test/repo"]);
       expect(hib.outcome).toBe("executed");
       expect(hib.state).toBe("hibernated");
       expect(await probeProc.isRuntimeAlive(spec!)).toBe(false);
-      // The resumable session file is untouched by hibernation.
       expect(fs.existsSync(sessionFile)).toBe(true);
-      // The surviving pane is explicitly DEAD (remain-on-exit) — the only state the
-      // wake path will respawn into.
       let paneDead = false;
       for (let i = 0; i < 20 && !paneDead; i++) {
         await sleep(200);
@@ -373,34 +494,18 @@ suite(
       }
       expect(paneDead).toBe(true);
 
-      // ── wake via the REAL command wrapper: respawn, accept generation, live ──
-      const wake = await executeWakeCommand({
-        executor,
-        agentId: AGENT_ID,
-        state: (db.getAgentById(AGENT_ID)?.lifecycleState ?? "hibernated") as AgentLifecycleState,
-        policy: allowPolicy,
-        actor: "operator",
-      });
+      // Wake through the shared router: respawn into the dead pane, accept generation, live.
+      const wake = await route("wake", ["test/repo"]);
       expect(wake.outcome).toBe("executed");
       expect(wake.state).toBe("live");
       expect(wake.runtimeGeneration).toBe(1);
-
       const agent = db.getAgentById(AGENT_ID);
       expect(agent?.lifecycleState).toBe("live");
       expect(agent?.runtimeGeneration).toBe(1);
-      // The woken runtime is genuinely back alive, resuming the SAME session.
       expect(await probeProc.isRuntimeAlive(spec!)).toBe(true);
       expect(fs.existsSync(sessionFile)).toBe(true);
-      // Wake bookkeeping is fully settled.
       expect(db.getAgentWakeReservation(AGENT_ID)).toBeNull();
       expect(db.getAgentLifecycleLease(AGENT_ID)).toBeNull();
-
-      // ── Teardown the woken runtime ────────────────────────────────────
-      try {
-        tmux(["kill-session", "-t", tmuxSession]);
-      } catch {
-        /* already gone */
-      }
-    }, 180_000);
+    }, 240_000);
   },
 );

--- a/slack-bridge/broker/hibernation-activation.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-activation.e2e.test.ts
@@ -75,6 +75,26 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Read a spawned worker's REAL tmux pane PID + dead flag, via the SAME tmux socket
+ *  the subtree broker launched it on (parsed from the spawn result's monitor
+ *  command, e.g. `tmux -S '<socket>' attach -t '<session>'`). This is direct
+ *  process evidence — DB lifecycle state alone is insufficient to prove the child
+ *  was untouched/alive across a refusal. */
+function readWorkerPane(
+  monitorCommand: string,
+  sessionName: string,
+): { pid: string; dead: string } {
+  const socketMatch = monitorCommand.match(/tmux\s+-S\s+'([^']+)'/);
+  const socketArgs = socketMatch ? ["-S", socketMatch[1]] : [];
+  const out = execFileSync(
+    "tmux",
+    [...socketArgs, "display-message", "-p", "-t", sessionName, "#{pane_pid} #{pane_dead}"],
+    { encoding: "utf8" },
+  ).trim();
+  const [pid, dead] = out.split(/\s+/);
+  return { pid, dead };
+}
+
 /** Minimal, fully-typed subtree deps: the inbox/steering callbacks never fire (no
  *  inbound traffic beyond the child's own registration in test 6). */
 function makeDeps(stableId: string, settings: SlackBridgeSettings): SubtreeBrokerRuntimeDeps {
@@ -234,6 +254,13 @@ suite(
       // spawnWorker persisted the child's durable spec into the authoritative subtree DB.
       expect(control!.db.getAgentRuntimeSpec(result.agentId)?.vcsIdentity).toBe("test/repo");
 
+      // Capture the child's REAL tmux pane PID + liveness BEFORE any refusal, so we
+      // can prove the PROCESS (not just the DB row) is untouched and alive after both.
+      const paneBefore = readWorkerPane(result.monitorCommand, result.sessionName);
+      expect(paneBefore.dead).toBe("0");
+      expect(Number(paneBefore.pid)).toBeGreaterThan(0);
+      const genBefore = control!.db.getAgentById(result.agentId)?.runtimeGeneration ?? null;
+
       const routeChild = (target: string) =>
         routeHibernationCommand({
           command: "hibernate",
@@ -250,6 +277,10 @@ suite(
       const byDefault = await routeChild(result.agentId);
       expect(byDefault.outcome).toBe("refused");
       expect(byDefault.reason).toBe("policy_never");
+      // The child PROCESS is untouched: same pane PID, still alive (pane_dead=0).
+      const paneAfterDefault = readWorkerPane(result.monitorCommand, result.sessionName);
+      expect(paneAfterDefault.pid).toBe(paneBefore.pid);
+      expect(paneAfterDefault.dead).toBe("0");
 
       // Elevate the policy to ISOLATE the supervised guard: even a policy-permitted,
       // allowlisted supervised child is still refused, purely because it is supervised.
@@ -257,11 +288,17 @@ suite(
       const supervised = await routeChild(result.agentId);
       expect(supervised.outcome).toBe("refused");
       expect(supervised.reason).toBe("supervised_subtree_unsupported");
+      // Still the SAME live pane PID after the second refusal — no stop/respawn happened.
+      const paneAfterSupervised = readWorkerPane(result.monitorCommand, result.sessionName);
+      expect(paneAfterSupervised.pid).toBe(paneBefore.pid);
+      expect(paneAfterSupervised.dead).toBe("0");
 
-      // The child is untouched: still live, still connected.
+      // And the DB row is likewise untouched: still live, still connected, generation
+      // unchanged (no wake/respawn was performed).
       const after = control!.db.getAgentById(result.agentId);
       expect(after?.lifecycleState).toBe("live");
       expect(after?.disconnectedAt ?? null).toBeNull();
+      expect(after?.runtimeGeneration ?? null).toBe(genBefore);
     }, 180_000);
 
     // ── Assertion 7 (+ pre-listen recovery + negative allowlist) ───────────────

--- a/slack-bridge/broker/hibernation-activation.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-activation.e2e.test.ts
@@ -1,20 +1,29 @@
-// Materially-real, isolated end-to-end proof for the Phase B WIRED COMPOSITION.
+// Materially-real, isolated, PRODUCTION-ROUTE end-to-end proof for Phase B.
 //
-// Unlike the adapter E2E (which drives the controllers directly), this drives the
-// REAL `HibernationOrchestrator` produced by `createHibernationOrchestrator`,
-// consuming a REAL durable runtime spec produced by `persistSpawnedRuntimeSpec`
-// (Seam 2), reconciling against a REAL BrokerDB, and acting on a REAL `pi`
-// runtime in a REAL throwaway tmux session — never the production broker, mesh,
-// or a shared tmux socket. It proves the whole seam chain end to end:
+// This does not hand-compose helpers on a bare DB. It exercises the SAME route a
+// real operator command takes:
 //
-//   spawn spec (git-remote VCS identity) → orchestrator checkpoint → stop
-//   (session survives) → respawn into the dead pane → generation accepted → live.
+//   • Activation is authorized ONLY by the durable, non-reloadable broker-start
+//     authority (PINET_HIBERNATION_RUNTIME_ACTIVATION), and a later settings-shaped
+//     "reload" cannot flip it — proving the gate is frozen for the process life.
+//   • The broker is a REAL `startBroker` (real leader lock + real socket server),
+//     so its `db` is the ONE authoritative DB. A crash-stranded `waking` row seeded
+//     BEFORE start is reconciled inside `beforeListen` — provably before the socket
+//     accepts a single connection (Seam 3 ordering, on the authoritative DB).
+//   • The spawn-authored runtime spec (Seam 2, git-remote VCS identity) is persisted
+//     into that SAME broker DB, and hibernate/wake are driven through the REAL
+//     `executeHibernateCommand` / `executeWakeCommand` wrappers with the real policy
+//     gate — including a negative repo-allowlist refusal proving authorization reads
+//     the DB-sourced identity, not a path name.
+//   • The executor is the REAL `HibernationOrchestrator` acting on a REAL `pi`
+//     runtime in a REAL throwaway tmux session: checkpoint → stop (session survives)
+//     → respawn into the dead pane → generation accepted → live.
 //
 // The ONLY simulated element is the socket-registration RPC (broker-core's domain,
 // already exhaustively fenced-tested): the injected `awaitRuntimeRegistration`
 // stands in for the socket server BUT keys acceptance off the REAL respawned
-// process actually coming back alive, so nothing about the runtime lifecycle is
-// mocked.
+// process actually coming back alive, and accepts against the authoritative broker
+// DB, so nothing about the runtime lifecycle is mocked.
 //
 // Opt-in only (spawns real processes + one cheap `pi --print` model call to seed a
 // resumable session); skipped in normal `pnpm test`/CI, runs under HIBERNATION_E2E=1.
@@ -25,13 +34,26 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import type { RuntimeLaunchContext } from "@pinet/broker-core";
+import {
+  executeHibernateCommand,
+  executeWakeCommand,
+  type HibernationCommandPolicy,
+} from "@pinet/broker-core";
+import type { AgentLifecycleState } from "@pinet/broker-core/types";
+import { startBroker, type Broker } from "./index.js";
 import { BrokerDB } from "./schema.js";
 import { createHibernationProcessController } from "./hibernation-runtime-adapters.js";
 import {
   createHibernationOrchestrator,
+  hibernationRuntimeActive,
   persistSpawnedRuntimeSpec,
+  recoverStrandedWakesBeforeRegistrations,
   type SpawnRuntimeSpecFacts,
 } from "./hibernation-activation.js";
+import {
+  freezeHibernationActivationAuthority,
+  __resetHibernationActivationAuthorityForTest,
+} from "./hibernation-activation-authority.js";
 
 const RUN = process.env.HIBERNATION_E2E === "1";
 const suite = RUN ? describe : describe.skip;
@@ -43,10 +65,14 @@ const repoDir = path.join(tmpRoot, "repo");
 const sessionFile = path.join(sessionsDir, "e2e.jsonl");
 const settingsPath = path.join(tmpRoot, "empty-settings.json");
 const noopExt = path.join(tmpRoot, "noop-ext.js");
-const dbPath = path.join(tmpRoot, "broker.db");
+const brokerDbPath = path.join(tmpRoot, "broker.db");
+const brokerSocket = path.join(tmpRoot, "b.sock");
+const brokerLock = path.join(tmpRoot, "b.lock");
 const tmuxSession = `pi-hib-act-e2e-${process.pid}`;
 const AGENT_ID = "e2e-agent";
 const STABLE_ID = `${os.hostname()}:session:${sessionFile}`;
+
+let broker: Broker | null = null;
 
 function tmux(args: string[]): string {
   return execFileSync("tmux", ["-S", tmuxSocket, ...args], { encoding: "utf8" }).trim();
@@ -58,7 +84,42 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-afterAll(() => {
+/** Seed a real crash-stranded `waking` row (no held lease, no accepted generation). */
+function seedStrandedWaking(dbPath: string, agentId: string): void {
+  const db = new BrokerDB(dbPath);
+  db.initialize();
+  db.registerAgent(
+    agentId,
+    "Stranded",
+    "🦉",
+    4242,
+    { brokerManaged: true },
+    `h:session:/tmp/s.jsonl`,
+  );
+  const chain: AgentLifecycleState[] = ["grace", "idle", "hibernating", "hibernated", "waking"];
+  for (const toState of chain) {
+    const version = db.getAgentById(agentId)?.lifecycleVersion ?? 0;
+    db.transitionAgentLifecycle({
+      agentId,
+      expectedVersion: version,
+      toState,
+      reason: "seed",
+      actor: "broker",
+      correlationId: "seed",
+    });
+  }
+  db.close();
+}
+
+afterAll(async () => {
+  if (broker) {
+    try {
+      await broker.stop();
+    } catch {
+      /* best effort */
+    }
+  }
+  __resetHibernationActivationAuthorityForTest();
   try {
     tmux(["kill-server"]);
   } catch {
@@ -71,198 +132,275 @@ afterAll(() => {
   }
 });
 
-suite("Phase B wired composition — real orchestrator + spec + disposable pi/tmux", () => {
-  const cleanPath = (process.env.PATH ?? "")
-    .split(":")
-    .filter((segment) => !segment.includes("node_modules/.bin"))
-    .join(":");
-  const minimalEnv: NodeJS.ProcessEnv = {
-    PATH: cleanPath,
-    HOME: process.env.HOME,
-    TERM: "xterm-256color",
-    TMPDIR: process.env.TMPDIR,
-    PI_SETTINGS_PATH: settingsPath,
-    PI_CODING_AGENT_SESSION_DIR: sessionsDir,
-  };
-
-  // A dedicated process controller for the injected registration waiter's REAL
-  // liveness probe (stands in for the socket server observing the woken worker).
-  const probeProc = createHibernationProcessController({ pendingInboxCount: () => 0 });
-
-  it("drives checkpoint → stop → respawn → accept → live through the real composition", async () => {
-    // ── Arrange: disposable repo (with a real git remote), settings, noop ext ──
-    fs.mkdirSync(sessionsDir, { recursive: true });
-    fs.mkdirSync(repoDir, { recursive: true });
-    fs.writeFileSync(settingsPath, JSON.stringify({ extensions: [], packages: [] }));
-    fs.writeFileSync(noopExt, "export default function(){}\n");
-    execFileSync("git", ["init", "-q"], { cwd: repoDir });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:test/repo.git"], {
-      cwd: repoDir,
-    });
-
-    // Seed a resumable session via one-shot `pi --print` inside the clean tmux
-    // server (this also establishes the clean server env for all later panes).
-    const seedScript = path.join(tmpRoot, "seed.sh");
-    fs.writeFileSync(
-      seedScript,
-      [
-        "#!/bin/bash",
-        `cd '${repoDir}'`,
-        `pi --print --model google/gemini-2.5-flash --session '${sessionFile}' 'Remember codeword: HERON-7. Reply only ACK.' >'${tmpRoot}/seed.out' 2>&1 || true`,
-        "",
-      ].join("\n"),
-      { mode: 0o700 },
-    );
-    tmuxNewSessionClean("holder", "sleep 100000", minimalEnv);
-    tmuxNewSessionClean("seed", seedScript, minimalEnv);
-    for (let i = 0; i < 120 && !fs.existsSync(sessionFile); i++) await sleep(500);
-    if (!fs.existsSync(sessionFile)) {
-      const out = fs.existsSync(`${tmpRoot}/seed.out`)
-        ? fs.readFileSync(`${tmpRoot}/seed.out`, "utf8").slice(-1500)
-        : "(no seed.out)";
-      throw new Error(`seed session file was not created.\nseed.out tail:\n${out}`);
-    }
-    try {
-      tmux(["kill-session", "-t", "seed"]);
-    } catch {
-      /* seed pane already exited */
-    }
-
-    // Launch the resident runtime in a throwaway tmux session (no pre-set
-    // remain-on-exit; the orchestrator's stop is responsible for pane survival).
-    const launchScript = path.join(tmpRoot, "launch.sh");
-    fs.writeFileSync(
-      launchScript,
-      [
-        "#!/bin/bash",
-        "set -euo pipefail",
-        `cd '${repoDir}'`,
-        `exec pi -e '${noopExt}' --session '${sessionFile}'`,
-        "",
-      ].join("\n"),
-      { mode: 0o700 },
-    );
-    tmuxNewSessionClean(tmuxSession, launchScript, minimalEnv);
-
-    // ── Seam 2: persist the durable, broker-authored runtime spec ─────
-    const db = new BrokerDB(dbPath);
-    db.initialize();
-    const facts: SpawnRuntimeSpecFacts = {
-      agentId: AGENT_ID,
-      stableId: STABLE_ID,
-      brokerOwnerId: "e2e-broker",
-      cwd: repoDir,
-      repoRoot: repoDir,
-      worktreePath: repoDir,
-      tmuxSocket,
-      tmuxSession,
-      tmuxTarget: tmuxSession,
-      extensionEntryPath: noopExt,
-      envAllowlist: ["PI_SETTINGS_PATH", "PI_CODING_AGENT_SESSION_DIR"],
-      configFingerprint: "e2e",
-      expectedUser: os.userInfo().username,
-      launchSource: "e2e",
+suite(
+  "Phase B production-route — frozen authority + authoritative broker DB + real pi/tmux",
+  () => {
+    const cleanPath = (process.env.PATH ?? "")
+      .split(":")
+      .filter((segment) => !segment.includes("node_modules/.bin"))
+      .join(":");
+    const minimalEnv: NodeJS.ProcessEnv = {
+      PATH: cleanPath,
+      HOME: process.env.HOME,
+      TERM: "xterm-256color",
+      TMPDIR: process.env.TMPDIR,
+      PI_SETTINGS_PATH: settingsPath,
+      PI_CODING_AGENT_SESSION_DIR: sessionsDir,
     };
-    db.registerAgent(
-      AGENT_ID,
-      "Worker",
-      "🦉",
-      process.pid,
-      {
-        brokerManaged: true,
-        brokerManagedBy: "e2e-broker",
-        hibernateSafe: true,
+
+    // A dedicated process controller for the injected registration waiter's REAL
+    // liveness probe (stands in for the socket server observing the woken worker).
+    const probeProc = createHibernationProcessController({ pendingInboxCount: () => 0 });
+
+    it("routes hibernate/wake through the real command path over the authoritative broker DB", async () => {
+      // ── Gate: activation comes ONLY from the frozen broker-start authority ──
+      __resetHibernationActivationAuthorityForTest();
+      freezeHibernationActivationAuthority({ PINET_HIBERNATION_RUNTIME_ACTIVATION: "1" });
+      expect(hibernationRuntimeActive()).toBe(true);
+      // A later settings-shaped "reload" (var absent) cannot flip a running broker off.
+      expect(freezeHibernationActivationAuthority({})).toBe(true);
+      expect(hibernationRuntimeActive()).toBe(true);
+
+      // ── Arrange: disposable repo (with a real git remote), settings, noop ext ──
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(repoDir, { recursive: true });
+      fs.writeFileSync(settingsPath, JSON.stringify({ extensions: [], packages: [] }));
+      fs.writeFileSync(noopExt, "export default function(){}\n");
+      execFileSync("git", ["init", "-q"], { cwd: repoDir });
+      execFileSync("git", ["remote", "add", "origin", "git@github.com:test/repo.git"], {
+        cwd: repoDir,
+      });
+
+      // ── Seam 3: seed a crash-stranded wake BEFORE the broker starts, then prove
+      //    it is reconciled inside beforeListen, before the socket ever listens ──
+      seedStrandedWaking(brokerDbPath, "stranded-1");
+      let reconciledPreListen = false;
+      broker = await startBroker({
+        dbPath: brokerDbPath,
+        socketPath: brokerSocket,
+        lockPath: brokerLock,
+        beforeListen: ({ db }) => {
+          recoverStrandedWakesBeforeRegistrations(
+            createHibernationOrchestrator({
+              db,
+              brokerInstanceId: "e2e-broker",
+              extensionEntryPath: noopExt,
+              baseLaunchEnv: {},
+              inheritedEnvKeys: [],
+            }),
+          );
+          reconciledPreListen = db.getAgentById("stranded-1")?.lifecycleState === "reap-candidate";
+        },
+      });
+      expect(reconciledPreListen).toBe(true);
+      expect(broker.db.getAgentById("stranded-1")?.lifecycleState).toBe("reap-candidate");
+
+      // The ONE authoritative DB the command path, spec persistence, and recovery
+      // all share is the started broker's DB.
+      const db = broker.db;
+
+      // Seed a resumable session via one-shot `pi --print` inside the clean tmux
+      // server (this also establishes the clean server env for all later panes).
+      const seedScript = path.join(tmpRoot, "seed.sh");
+      fs.writeFileSync(
+        seedScript,
+        [
+          "#!/bin/bash",
+          `cd '${repoDir}'`,
+          `pi --print --model google/gemini-2.5-flash --session '${sessionFile}' 'Remember codeword: HERON-7. Reply only ACK.' >'${tmpRoot}/seed.out' 2>&1 || true`,
+          "",
+        ].join("\n"),
+        { mode: 0o700 },
+      );
+      tmuxNewSessionClean("holder", "sleep 100000", minimalEnv);
+      tmuxNewSessionClean("seed", seedScript, minimalEnv);
+      for (let i = 0; i < 120 && !fs.existsSync(sessionFile); i++) await sleep(500);
+      if (!fs.existsSync(sessionFile)) {
+        const out = fs.existsSync(`${tmpRoot}/seed.out`)
+          ? fs.readFileSync(`${tmpRoot}/seed.out`, "utf8").slice(-1500)
+          : "(no seed.out)";
+        throw new Error(`seed session file was not created.\nseed.out tail:\n${out}`);
+      }
+      try {
+        tmux(["kill-session", "-t", "seed"]);
+      } catch {
+        /* seed pane already exited */
+      }
+
+      // Launch the resident runtime in a throwaway tmux session (no pre-set
+      // remain-on-exit; the orchestrator's stop is responsible for pane survival).
+      const launchScript = path.join(tmpRoot, "launch.sh");
+      fs.writeFileSync(
+        launchScript,
+        [
+          "#!/bin/bash",
+          "set -euo pipefail",
+          `cd '${repoDir}'`,
+          `exec pi -e '${noopExt}' --session '${sessionFile}'`,
+          "",
+        ].join("\n"),
+        { mode: 0o700 },
+      );
+      tmuxNewSessionClean(tmuxSession, launchScript, minimalEnv);
+
+      // ── Seam 2: persist the durable, broker-authored runtime spec into the
+      //    SAME authoritative broker DB ──────────────────────────────────
+      const facts: SpawnRuntimeSpecFacts = {
+        agentId: AGENT_ID,
+        stableId: STABLE_ID,
+        brokerOwnerId: "e2e-broker",
         cwd: repoDir,
         repoRoot: repoDir,
         worktreePath: repoDir,
+        tmuxSocket,
         tmuxSession,
-      },
-      STABLE_ID,
-    );
-    db.setAgentHibernatePolicy(AGENT_ID, "manual");
-    const spec = await persistSpawnedRuntimeSpec(db, facts);
-    expect(spec).not.toBeNull();
-    // VCS identity is derived from the REAL git remote (never the dir name).
-    expect(spec?.vcsIdentity).toBe("test/repo");
-    expect(db.getAgentRuntimeSpec(AGENT_ID)?.sessionResumeRef).toBe(`session:${sessionFile}`);
+        tmuxTarget: tmuxSession,
+        extensionEntryPath: noopExt,
+        envAllowlist: ["PI_SETTINGS_PATH", "PI_CODING_AGENT_SESSION_DIR"],
+        configFingerprint: "e2e",
+        expectedUser: os.userInfo().username,
+        launchSource: "e2e",
+      };
+      db.registerAgent(
+        AGENT_ID,
+        "Worker",
+        "🦉",
+        process.pid,
+        {
+          brokerManaged: true,
+          brokerManagedBy: "e2e-broker",
+          hibernateSafe: true,
+          cwd: repoDir,
+          repoRoot: repoDir,
+          worktreePath: repoDir,
+          tmuxSession,
+        },
+        STABLE_ID,
+      );
+      db.setAgentHibernatePolicy(AGENT_ID, "manual");
+      const spec = await persistSpawnedRuntimeSpec(db, facts);
+      expect(spec).not.toBeNull();
+      // VCS identity is derived from the REAL git remote (never the dir name).
+      expect(spec?.vcsIdentity).toBe("test/repo");
+      expect(db.getAgentRuntimeSpec(AGENT_ID)?.sessionResumeRef).toBe(`session:${sessionFile}`);
 
-    // ── Seam 1: compose the REAL orchestrator; inject a registration waiter
-    //    that accepts ONLY once the respawned process is genuinely alive ──
-    const orch = createHibernationOrchestrator({
-      db,
-      brokerInstanceId: "e2e-broker",
-      extensionEntryPath: noopExt,
-      baseLaunchEnv: {},
-      inheritedEnvKeys: [],
-      config: { handshakeTimeoutMs: 15_000, wakeLeaseMs: 120_000, registrationTimeoutMs: 60_000 },
-      awaitRuntimeRegistration: async (ctx: RuntimeLaunchContext) => {
-        for (let i = 0; i < 120; i++) {
-          if (await probeProc.isRuntimeAlive(ctx.spec)) break;
-          await sleep(300);
-        }
-        // Stand in for the socket server accepting the woken worker's fenced
-        // generation — but only after the REAL process is confirmed alive.
-        const acceptance = db.acceptRuntimeGeneration({
-          agentId: ctx.agentId,
-          wakeLeaseId: ctx.wakeLeaseId,
-          fenceToken: ctx.fenceToken,
-          reservedGeneration: ctx.reservedGeneration,
-          reservationNonce: ctx.reservationNonce,
-          now: Date.now(),
-        });
-        return acceptance.accepted;
-      },
-    });
+      // ── Seam 1: compose the REAL orchestrator over the authoritative broker DB;
+      //    inject a registration waiter that accepts ONLY once the respawned
+      //    process is genuinely alive (socket-RPC stand-in) ──
+      const orch = createHibernationOrchestrator({
+        db,
+        brokerInstanceId: "e2e-broker",
+        extensionEntryPath: noopExt,
+        baseLaunchEnv: {},
+        inheritedEnvKeys: [],
+        config: { handshakeTimeoutMs: 15_000, wakeLeaseMs: 120_000, registrationTimeoutMs: 60_000 },
+        awaitRuntimeRegistration: async (ctx: RuntimeLaunchContext) => {
+          for (let i = 0; i < 120; i++) {
+            if (await probeProc.isRuntimeAlive(ctx.spec)) break;
+            await sleep(300);
+          }
+          const acceptance = db.acceptRuntimeGeneration({
+            agentId: ctx.agentId,
+            wakeLeaseId: ctx.wakeLeaseId,
+            fenceToken: ctx.fenceToken,
+            reservedGeneration: ctx.reservedGeneration,
+            reservationNonce: ctx.reservationNonce,
+            now: Date.now(),
+          });
+          return acceptance.accepted;
+        },
+      });
 
-    // ── Wait for the resident runtime to boot ─────────────────────────
-    let alive = false;
-    for (let i = 0; i < 40 && !alive; i++) {
-      await sleep(300);
-      alive = await probeProc.isRuntimeAlive(spec!);
-    }
-    expect(alive).toBe(true);
+      // The production command path resolves the executor over the authoritative DB.
+      const executor = orch;
+      // Repo identity comes from the DB-sourced spec, exactly as production does.
+      const repoIdentifier = db.getAgentRuntimeSpec(AGENT_ID)?.vcsIdentity ?? null;
+      expect(repoIdentifier).toBe("test/repo");
 
-    // ── prepareHibernation walks the eligible free worker to idle ─────
-    const prep = orch.prepareHibernation(AGENT_ID);
-    expect(prep).toMatchObject({ ready: true, state: "idle" });
+      // ── Wait for the resident runtime to boot ─────────────────────────
+      let alive = false;
+      for (let i = 0; i < 40 && !alive; i++) {
+        await sleep(300);
+        alive = await probeProc.isRuntimeAlive(spec!);
+      }
+      expect(alive).toBe(true);
 
-    // ── hibernate: REAL checkpoint + stop; tmux session must SURVIVE ──
-    const hibResult = await orch.hibernate(AGENT_ID);
-    expect(hibResult.ok).toBe(true);
-    expect(hibResult.state).toBe("hibernated");
-    expect(await probeProc.isRuntimeAlive(spec!)).toBe(false);
-    // The resumable session file is untouched by hibernation.
-    expect(fs.existsSync(sessionFile)).toBe(true);
-    // The surviving pane is explicitly DEAD (remain-on-exit) — the only state the
-    // wake path will respawn into.
-    let paneDead = false;
-    for (let i = 0; i < 20 && !paneDead; i++) {
-      await sleep(200);
-      paneDead = tmux(["display-message", "-p", "-t", tmuxSession, "#{pane_dead}"]).trim() === "1";
-    }
-    expect(paneDead).toBe(true);
+      // ── Negative authorization: the DB-sourced identity is gated by the repo
+      //    allowlist. A non-matching allowlist REFUSES before any side effect. ──
+      const denyPolicy: HibernationCommandPolicy = {
+        enabled: true,
+        mode: "manual",
+        allowedRepos: ["someone/else"],
+      };
+      const denied = await executeHibernateCommand({
+        executor,
+        agentId: AGENT_ID,
+        state: (db.getAgentById(AGENT_ID)?.lifecycleState ?? "live") as AgentLifecycleState,
+        repoIdentifier,
+        policy: denyPolicy,
+        actor: "operator",
+      });
+      expect(denied.outcome).toBe("refused");
+      expect(denied.reason).toBe("repo_not_allowlisted");
+      expect(await probeProc.isRuntimeAlive(spec!)).toBe(true); // untouched
 
-    // ── wake: respawn pi --session, accept the generation, return to live ──
-    const wakeResult = await orch.wake(AGENT_ID, { trigger: "manual" });
-    expect(wakeResult.ok).toBe(true);
-    expect(wakeResult.state).toBe("live");
-    expect(wakeResult.runtimeGeneration).toBe(1);
+      // ── hibernate via the REAL command wrapper: checkpoint + stop; survive ──
+      const allowPolicy: HibernationCommandPolicy = {
+        enabled: true,
+        mode: "manual",
+        allowedRepos: ["test/repo"],
+      };
+      const hib = await executeHibernateCommand({
+        executor,
+        agentId: AGENT_ID,
+        state: (db.getAgentById(AGENT_ID)?.lifecycleState ?? "live") as AgentLifecycleState,
+        repoIdentifier,
+        policy: allowPolicy,
+        actor: "operator",
+      });
+      expect(hib.outcome).toBe("executed");
+      expect(hib.state).toBe("hibernated");
+      expect(await probeProc.isRuntimeAlive(spec!)).toBe(false);
+      // The resumable session file is untouched by hibernation.
+      expect(fs.existsSync(sessionFile)).toBe(true);
+      // The surviving pane is explicitly DEAD (remain-on-exit) — the only state the
+      // wake path will respawn into.
+      let paneDead = false;
+      for (let i = 0; i < 20 && !paneDead; i++) {
+        await sleep(200);
+        paneDead =
+          tmux(["display-message", "-p", "-t", tmuxSession, "#{pane_dead}"]).trim() === "1";
+      }
+      expect(paneDead).toBe(true);
 
-    const agent = db.getAgentById(AGENT_ID);
-    expect(agent?.lifecycleState).toBe("live");
-    expect(agent?.runtimeGeneration).toBe(1);
-    // The woken runtime is genuinely back alive, resuming the SAME session.
-    expect(await probeProc.isRuntimeAlive(spec!)).toBe(true);
-    expect(fs.existsSync(sessionFile)).toBe(true);
-    // Wake bookkeeping is fully settled.
-    expect(db.getAgentWakeReservation(AGENT_ID)).toBeNull();
-    expect(db.getAgentLifecycleLease(AGENT_ID)).toBeNull();
+      // ── wake via the REAL command wrapper: respawn, accept generation, live ──
+      const wake = await executeWakeCommand({
+        executor,
+        agentId: AGENT_ID,
+        state: (db.getAgentById(AGENT_ID)?.lifecycleState ?? "hibernated") as AgentLifecycleState,
+        policy: allowPolicy,
+        actor: "operator",
+      });
+      expect(wake.outcome).toBe("executed");
+      expect(wake.state).toBe("live");
+      expect(wake.runtimeGeneration).toBe(1);
 
-    // ── Teardown the woken runtime ────────────────────────────────────
-    try {
-      tmux(["kill-session", "-t", tmuxSession]);
-    } catch {
-      /* already gone */
-    }
-  }, 120_000);
-});
+      const agent = db.getAgentById(AGENT_ID);
+      expect(agent?.lifecycleState).toBe("live");
+      expect(agent?.runtimeGeneration).toBe(1);
+      // The woken runtime is genuinely back alive, resuming the SAME session.
+      expect(await probeProc.isRuntimeAlive(spec!)).toBe(true);
+      expect(fs.existsSync(sessionFile)).toBe(true);
+      // Wake bookkeeping is fully settled.
+      expect(db.getAgentWakeReservation(AGENT_ID)).toBeNull();
+      expect(db.getAgentLifecycleLease(AGENT_ID)).toBeNull();
+
+      // ── Teardown the woken runtime ────────────────────────────────────
+      try {
+        tmux(["kill-session", "-t", tmuxSession]);
+      } catch {
+        /* already gone */
+      }
+    }, 180_000);
+  },
+);

--- a/slack-bridge/broker/hibernation-activation.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-activation.e2e.test.ts
@@ -1,0 +1,268 @@
+// Materially-real, isolated end-to-end proof for the Phase B WIRED COMPOSITION.
+//
+// Unlike the adapter E2E (which drives the controllers directly), this drives the
+// REAL `HibernationOrchestrator` produced by `createHibernationOrchestrator`,
+// consuming a REAL durable runtime spec produced by `persistSpawnedRuntimeSpec`
+// (Seam 2), reconciling against a REAL BrokerDB, and acting on a REAL `pi`
+// runtime in a REAL throwaway tmux session — never the production broker, mesh,
+// or a shared tmux socket. It proves the whole seam chain end to end:
+//
+//   spawn spec (git-remote VCS identity) → orchestrator checkpoint → stop
+//   (session survives) → respawn into the dead pane → generation accepted → live.
+//
+// The ONLY simulated element is the socket-registration RPC (broker-core's domain,
+// already exhaustively fenced-tested): the injected `awaitRuntimeRegistration`
+// stands in for the socket server BUT keys acceptance off the REAL respawned
+// process actually coming back alive, so nothing about the runtime lifecycle is
+// mocked.
+//
+// Opt-in only (spawns real processes + one cheap `pi --print` model call to seed a
+// resumable session); skipped in normal `pnpm test`/CI, runs under HIBERNATION_E2E=1.
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import type { RuntimeLaunchContext } from "@pinet/broker-core";
+import { BrokerDB } from "./schema.js";
+import { createHibernationProcessController } from "./hibernation-runtime-adapters.js";
+import {
+  createHibernationOrchestrator,
+  persistSpawnedRuntimeSpec,
+  type SpawnRuntimeSpecFacts,
+} from "./hibernation-activation.js";
+
+const RUN = process.env.HIBERNATION_E2E === "1";
+const suite = RUN ? describe : describe.skip;
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-hib-act-e2e-"));
+const tmuxSocket = path.join(tmpRoot, "tmux.sock");
+const sessionsDir = path.join(tmpRoot, "sessions");
+const repoDir = path.join(tmpRoot, "repo");
+const sessionFile = path.join(sessionsDir, "e2e.jsonl");
+const settingsPath = path.join(tmpRoot, "empty-settings.json");
+const noopExt = path.join(tmpRoot, "noop-ext.js");
+const dbPath = path.join(tmpRoot, "broker.db");
+const tmuxSession = `pi-hib-act-e2e-${process.pid}`;
+const AGENT_ID = "e2e-agent";
+const STABLE_ID = `${os.hostname()}:session:${sessionFile}`;
+
+function tmux(args: string[]): string {
+  return execFileSync("tmux", ["-S", tmuxSocket, ...args], { encoding: "utf8" }).trim();
+}
+function tmuxNewSessionClean(name: string, script: string, env: NodeJS.ProcessEnv): void {
+  execFileSync("tmux", ["-S", tmuxSocket, "new-session", "-d", "-s", name, script], { env });
+}
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+afterAll(() => {
+  try {
+    tmux(["kill-server"]);
+  } catch {
+    /* already gone */
+  }
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+suite("Phase B wired composition — real orchestrator + spec + disposable pi/tmux", () => {
+  const cleanPath = (process.env.PATH ?? "")
+    .split(":")
+    .filter((segment) => !segment.includes("node_modules/.bin"))
+    .join(":");
+  const minimalEnv: NodeJS.ProcessEnv = {
+    PATH: cleanPath,
+    HOME: process.env.HOME,
+    TERM: "xterm-256color",
+    TMPDIR: process.env.TMPDIR,
+    PI_SETTINGS_PATH: settingsPath,
+    PI_CODING_AGENT_SESSION_DIR: sessionsDir,
+  };
+
+  // A dedicated process controller for the injected registration waiter's REAL
+  // liveness probe (stands in for the socket server observing the woken worker).
+  const probeProc = createHibernationProcessController({ pendingInboxCount: () => 0 });
+
+  it("drives checkpoint → stop → respawn → accept → live through the real composition", async () => {
+    // ── Arrange: disposable repo (with a real git remote), settings, noop ext ──
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ extensions: [], packages: [] }));
+    fs.writeFileSync(noopExt, "export default function(){}\n");
+    execFileSync("git", ["init", "-q"], { cwd: repoDir });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:test/repo.git"], {
+      cwd: repoDir,
+    });
+
+    // Seed a resumable session via one-shot `pi --print` inside the clean tmux
+    // server (this also establishes the clean server env for all later panes).
+    const seedScript = path.join(tmpRoot, "seed.sh");
+    fs.writeFileSync(
+      seedScript,
+      [
+        "#!/bin/bash",
+        `cd '${repoDir}'`,
+        `pi --print --model google/gemini-2.5-flash --session '${sessionFile}' 'Remember codeword: HERON-7. Reply only ACK.' >'${tmpRoot}/seed.out' 2>&1 || true`,
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    tmuxNewSessionClean("holder", "sleep 100000", minimalEnv);
+    tmuxNewSessionClean("seed", seedScript, minimalEnv);
+    for (let i = 0; i < 120 && !fs.existsSync(sessionFile); i++) await sleep(500);
+    if (!fs.existsSync(sessionFile)) {
+      const out = fs.existsSync(`${tmpRoot}/seed.out`)
+        ? fs.readFileSync(`${tmpRoot}/seed.out`, "utf8").slice(-1500)
+        : "(no seed.out)";
+      throw new Error(`seed session file was not created.\nseed.out tail:\n${out}`);
+    }
+    try {
+      tmux(["kill-session", "-t", "seed"]);
+    } catch {
+      /* seed pane already exited */
+    }
+
+    // Launch the resident runtime in a throwaway tmux session (no pre-set
+    // remain-on-exit; the orchestrator's stop is responsible for pane survival).
+    const launchScript = path.join(tmpRoot, "launch.sh");
+    fs.writeFileSync(
+      launchScript,
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        `cd '${repoDir}'`,
+        `exec pi -e '${noopExt}' --session '${sessionFile}'`,
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    tmuxNewSessionClean(tmuxSession, launchScript, minimalEnv);
+
+    // ── Seam 2: persist the durable, broker-authored runtime spec ─────
+    const db = new BrokerDB(dbPath);
+    db.initialize();
+    const facts: SpawnRuntimeSpecFacts = {
+      agentId: AGENT_ID,
+      stableId: STABLE_ID,
+      brokerOwnerId: "e2e-broker",
+      cwd: repoDir,
+      repoRoot: repoDir,
+      worktreePath: repoDir,
+      tmuxSocket,
+      tmuxSession,
+      tmuxTarget: tmuxSession,
+      extensionEntryPath: noopExt,
+      envAllowlist: ["PI_SETTINGS_PATH", "PI_CODING_AGENT_SESSION_DIR"],
+      configFingerprint: "e2e",
+      expectedUser: os.userInfo().username,
+      launchSource: "e2e",
+    };
+    db.registerAgent(
+      AGENT_ID,
+      "Worker",
+      "🦉",
+      process.pid,
+      {
+        brokerManaged: true,
+        brokerManagedBy: "e2e-broker",
+        hibernateSafe: true,
+        cwd: repoDir,
+        repoRoot: repoDir,
+        worktreePath: repoDir,
+        tmuxSession,
+      },
+      STABLE_ID,
+    );
+    db.setAgentHibernatePolicy(AGENT_ID, "manual");
+    const spec = await persistSpawnedRuntimeSpec(db, facts);
+    expect(spec).not.toBeNull();
+    // VCS identity is derived from the REAL git remote (never the dir name).
+    expect(spec?.vcsIdentity).toBe("test/repo");
+    expect(db.getAgentRuntimeSpec(AGENT_ID)?.sessionResumeRef).toBe(`session:${sessionFile}`);
+
+    // ── Seam 1: compose the REAL orchestrator; inject a registration waiter
+    //    that accepts ONLY once the respawned process is genuinely alive ──
+    const orch = createHibernationOrchestrator({
+      db,
+      brokerInstanceId: "e2e-broker",
+      extensionEntryPath: noopExt,
+      baseLaunchEnv: {},
+      inheritedEnvKeys: [],
+      config: { handshakeTimeoutMs: 15_000, wakeLeaseMs: 120_000, registrationTimeoutMs: 60_000 },
+      awaitRuntimeRegistration: async (ctx: RuntimeLaunchContext) => {
+        for (let i = 0; i < 120; i++) {
+          if (await probeProc.isRuntimeAlive(ctx.spec)) break;
+          await sleep(300);
+        }
+        // Stand in for the socket server accepting the woken worker's fenced
+        // generation — but only after the REAL process is confirmed alive.
+        const acceptance = db.acceptRuntimeGeneration({
+          agentId: ctx.agentId,
+          wakeLeaseId: ctx.wakeLeaseId,
+          fenceToken: ctx.fenceToken,
+          reservedGeneration: ctx.reservedGeneration,
+          reservationNonce: ctx.reservationNonce,
+          now: Date.now(),
+        });
+        return acceptance.accepted;
+      },
+    });
+
+    // ── Wait for the resident runtime to boot ─────────────────────────
+    let alive = false;
+    for (let i = 0; i < 40 && !alive; i++) {
+      await sleep(300);
+      alive = await probeProc.isRuntimeAlive(spec!);
+    }
+    expect(alive).toBe(true);
+
+    // ── prepareHibernation walks the eligible free worker to idle ─────
+    const prep = orch.prepareHibernation(AGENT_ID);
+    expect(prep).toMatchObject({ ready: true, state: "idle" });
+
+    // ── hibernate: REAL checkpoint + stop; tmux session must SURVIVE ──
+    const hibResult = await orch.hibernate(AGENT_ID);
+    expect(hibResult.ok).toBe(true);
+    expect(hibResult.state).toBe("hibernated");
+    expect(await probeProc.isRuntimeAlive(spec!)).toBe(false);
+    // The resumable session file is untouched by hibernation.
+    expect(fs.existsSync(sessionFile)).toBe(true);
+    // The surviving pane is explicitly DEAD (remain-on-exit) — the only state the
+    // wake path will respawn into.
+    let paneDead = false;
+    for (let i = 0; i < 20 && !paneDead; i++) {
+      await sleep(200);
+      paneDead = tmux(["display-message", "-p", "-t", tmuxSession, "#{pane_dead}"]).trim() === "1";
+    }
+    expect(paneDead).toBe(true);
+
+    // ── wake: respawn pi --session, accept the generation, return to live ──
+    const wakeResult = await orch.wake(AGENT_ID, { trigger: "manual" });
+    expect(wakeResult.ok).toBe(true);
+    expect(wakeResult.state).toBe("live");
+    expect(wakeResult.runtimeGeneration).toBe(1);
+
+    const agent = db.getAgentById(AGENT_ID);
+    expect(agent?.lifecycleState).toBe("live");
+    expect(agent?.runtimeGeneration).toBe(1);
+    // The woken runtime is genuinely back alive, resuming the SAME session.
+    expect(await probeProc.isRuntimeAlive(spec!)).toBe(true);
+    expect(fs.existsSync(sessionFile)).toBe(true);
+    // Wake bookkeeping is fully settled.
+    expect(db.getAgentWakeReservation(AGENT_ID)).toBeNull();
+    expect(db.getAgentLifecycleLease(AGENT_ID)).toBeNull();
+
+    // ── Teardown the woken runtime ────────────────────────────────────
+    try {
+      tmux(["kill-session", "-t", tmuxSession]);
+    } catch {
+      /* already gone */
+    }
+  }, 120_000);
+});

--- a/slack-bridge/broker/hibernation-activation.test.ts
+++ b/slack-bridge/broker/hibernation-activation.test.ts
@@ -20,6 +20,11 @@ import {
   recoverStrandedWakesBeforeRegistrations,
   type SpawnRuntimeSpecFacts,
 } from "./hibernation-activation.js";
+import {
+  freezeHibernationActivationAuthority,
+  hibernationActivationAuthorized,
+  __resetHibernationActivationAuthorityForTest,
+} from "./hibernation-activation-authority.js";
 
 const tempDirs: string[] = [];
 function freshDb(): BrokerDB {
@@ -76,14 +81,51 @@ function specFacts(
   };
 }
 
-describe("hibernationRuntimeActive — default-off gate", () => {
-  it("is false unless BOTH enabled and activateRuntimeAdapters are set", () => {
-    expect(hibernationRuntimeActive({ enabled: false, activateRuntimeAdapters: false })).toBe(
-      false,
-    );
-    expect(hibernationRuntimeActive({ enabled: true, activateRuntimeAdapters: false })).toBe(false);
-    expect(hibernationRuntimeActive({ enabled: false, activateRuntimeAdapters: true })).toBe(false);
-    expect(hibernationRuntimeActive({ enabled: true, activateRuntimeAdapters: true })).toBe(true);
+describe("hibernationRuntimeActive — durable, non-reloadable, default-off authority", () => {
+  afterEach(() => __resetHibernationActivationAuthorityForTest());
+
+  it("is false by default (no external authority set)", () => {
+    __resetHibernationActivationAuthorityForTest();
+    freezeHibernationActivationAuthority({});
+    expect(hibernationRuntimeActive()).toBe(false);
+  });
+
+  it("activates ONLY from the external launch-env authority, not from settings", () => {
+    __resetHibernationActivationAuthorityForTest();
+    // A fully-"enabled" settings-shaped object is irrelevant: the gate never reads
+    // settings, so no settings edit / reload can elevate a running broker.
+    freezeHibernationActivationAuthority({ PINET_HIBERNATION_RUNTIME_ACTIVATION: "1" });
+    expect(hibernationRuntimeActive()).toBe(true);
+    expect(hibernationActivationAuthorized()).toBe(true);
+  });
+
+  it("accepts 1/true/yes/on (case-insensitive) and rejects everything else", () => {
+    for (const v of ["1", "true", "TRUE", " yes ", "On"]) {
+      __resetHibernationActivationAuthorityForTest();
+      freezeHibernationActivationAuthority({ PINET_HIBERNATION_RUNTIME_ACTIVATION: v });
+      expect(hibernationRuntimeActive()).toBe(true);
+    }
+    for (const v of ["", "0", "false", "off", "enabled", "2"]) {
+      __resetHibernationActivationAuthorityForTest();
+      freezeHibernationActivationAuthority({ PINET_HIBERNATION_RUNTIME_ACTIVATION: v });
+      expect(hibernationRuntimeActive()).toBe(false);
+    }
+  });
+
+  it("is FROZEN for the process lifetime — reloads cannot flip it either way", () => {
+    // Captured ON at start; a later "reload" with the var removed cannot turn it off.
+    __resetHibernationActivationAuthorityForTest();
+    freezeHibernationActivationAuthority({ PINET_HIBERNATION_RUNTIME_ACTIVATION: "1" });
+    expect(freezeHibernationActivationAuthority({})).toBe(true);
+    expect(hibernationRuntimeActive()).toBe(true);
+
+    // Captured OFF at start; a later "reload" that sets the var cannot turn it on.
+    __resetHibernationActivationAuthorityForTest();
+    freezeHibernationActivationAuthority({});
+    expect(
+      freezeHibernationActivationAuthority({ PINET_HIBERNATION_RUNTIME_ACTIVATION: "1" }),
+    ).toBe(false);
+    expect(hibernationRuntimeActive()).toBe(false);
   });
 });
 

--- a/slack-bridge/broker/hibernation-activation.test.ts
+++ b/slack-bridge/broker/hibernation-activation.test.ts
@@ -1,0 +1,227 @@
+// Focused proof for the Phase B live-runtime activation composition. Exercises
+// the three seam functions against REAL dependencies — a real BrokerDB and a real
+// throwaway git repo — never mocks-only, so the git-remote VCS identity, durable
+// spec persistence, gate semantics, and stranded-wake reconciliation are all
+// proven end to end at the composition layer. The materially real hibernate→wake
+// through a live pi/tmux runtime is proven in `hibernation-activation.e2e.test.ts`.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { HibernationOrchestrator } from "@pinet/broker-core";
+import type { AgentLifecycleState } from "@pinet/broker-core/types";
+import { BrokerDB } from "./schema.js";
+import {
+  createHibernationOrchestrator,
+  hibernationRuntimeActive,
+  persistSpawnedRuntimeSpec,
+  recoverStrandedWakesBeforeRegistrations,
+  type SpawnRuntimeSpecFacts,
+} from "./hibernation-activation.js";
+
+const tempDirs: string[] = [];
+function freshDb(): BrokerDB {
+  const dir = mkdtempSync(join(tmpdir(), "pinet-hib-activation-"));
+  tempDirs.push(dir);
+  const db = new BrokerDB(join(dir, "broker.db"));
+  db.initialize();
+  return db;
+}
+
+/** A real git repo, optionally with an `origin` remote, for VCS identity derivation. */
+function freshRepo(origin?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "pinet-hib-repo-"));
+  tempDirs.push(dir);
+  execFileSync("git", ["init", "-q"], { cwd: dir });
+  if (origin) execFileSync("git", ["remote", "add", "origin", origin], { cwd: dir });
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function orchestrator(db: BrokerDB): HibernationOrchestrator {
+  return createHibernationOrchestrator({
+    db,
+    brokerInstanceId: "broker-1",
+    extensionEntryPath: "/opt/ext/index.js",
+    baseLaunchEnv: {},
+    inheritedEnvKeys: [],
+  });
+}
+
+function specFacts(
+  repoRoot: string,
+  overrides: Partial<SpawnRuntimeSpecFacts> = {},
+): SpawnRuntimeSpecFacts {
+  return {
+    agentId: "worker-1",
+    stableId: `host-a:session:${join(repoRoot, "session.jsonl")}`,
+    brokerOwnerId: "broker-1",
+    cwd: repoRoot,
+    repoRoot,
+    worktreePath: repoRoot,
+    tmuxSocket: "/private/tmp/tmux-501/default",
+    tmuxSession: "worker-1",
+    tmuxTarget: "worker-1:0.0",
+    extensionEntryPath: "/opt/ext/index.js",
+    envAllowlist: ["PI_SETTINGS_PATH", "PINET_MESH_SECRET"],
+    configFingerprint: "cfg-1",
+    expectedUser: "tm",
+    launchSource: "subtree-broker-tmux",
+    ...overrides,
+  };
+}
+
+describe("hibernationRuntimeActive — default-off gate", () => {
+  it("is false unless BOTH enabled and activateRuntimeAdapters are set", () => {
+    expect(hibernationRuntimeActive({ enabled: false, activateRuntimeAdapters: false })).toBe(
+      false,
+    );
+    expect(hibernationRuntimeActive({ enabled: true, activateRuntimeAdapters: false })).toBe(false);
+    expect(hibernationRuntimeActive({ enabled: false, activateRuntimeAdapters: true })).toBe(false);
+    expect(hibernationRuntimeActive({ enabled: true, activateRuntimeAdapters: true })).toBe(true);
+  });
+});
+
+describe("createHibernationOrchestrator — composition", () => {
+  it("composes a real orchestrator that satisfies the command-executor contract", () => {
+    const db = freshDb();
+    const orch = orchestrator(db);
+    expect(orch).toBeInstanceOf(HibernationOrchestrator);
+    // Structurally satisfies HibernateCommandExecutor & WakeCommandExecutor plus
+    // the startup recovery entrypoint, so it drops into the executor slot.
+    expect(typeof orch.prepareHibernation).toBe("function");
+    expect(typeof orch.hibernate).toBe("function");
+    expect(typeof orch.wake).toBe("function");
+    expect(typeof orch.recoverStrandedWakes).toBe("function");
+  });
+});
+
+describe("persistSpawnedRuntimeSpec — Seam 2 (durable spec + git-remote VCS identity)", () => {
+  it("derives owner/repo from the real git remote and persists a readable spec", async () => {
+    const db = freshDb();
+    const repo = freshRepo("git@github.com:gugu91/extensions.git");
+    db.registerAgent(
+      "worker-1",
+      "Worker",
+      "🦉",
+      4242,
+      { brokerManaged: true },
+      specFacts(repo).stableId,
+    );
+
+    const persisted = await persistSpawnedRuntimeSpec(db, specFacts(repo));
+    expect(persisted).not.toBeNull();
+    expect(persisted?.vcsIdentity).toBe("gugu91/extensions");
+
+    const readBack = db.getAgentRuntimeSpec("worker-1");
+    expect(readBack).not.toBeNull();
+    // Authorization identity is the git-remote-derived owner/repo, NOT any dir name.
+    expect(readBack?.vcsIdentity).toBe("gugu91/extensions");
+    // Session resume ref + expected host are derived from the session stable id.
+    expect(readBack?.sessionResumeRef).toBe(`session:${join(repo, "session.jsonl")}`);
+    expect(readBack?.expectedHost).toBe("host-a");
+    // Tmux locators + env allowlist NAMES (never values) round-trip.
+    expect(readBack?.tmuxSocket).toBe("/private/tmp/tmux-501/default");
+    expect(readBack?.tmuxTarget).toBe("worker-1:0.0");
+    expect(readBack?.envAllowlist).toEqual(["PI_SETTINGS_PATH", "PINET_MESH_SECRET"]);
+    expect(readBack?.argv).toEqual([
+      "-e",
+      "/opt/ext/index.js",
+      "--session",
+      join(repo, "session.jsonl"),
+    ]);
+  });
+
+  it("fails closed to vcsIdentity=null when the repo has no resolvable remote", async () => {
+    const db = freshDb();
+    const repo = freshRepo(); // no origin
+    db.registerAgent(
+      "worker-1",
+      "Worker",
+      "🦉",
+      4242,
+      { brokerManaged: true },
+      specFacts(repo).stableId,
+    );
+
+    const persisted = await persistSpawnedRuntimeSpec(db, specFacts(repo));
+    expect(persisted).not.toBeNull();
+    // Null identity is a fail-closed marker: the repo allowlist gate refuses it later.
+    expect(persisted?.vcsIdentity).toBeNull();
+    expect(db.getAgentRuntimeSpec("worker-1")?.vcsIdentity).toBeNull();
+  });
+
+  it("persists NOTHING when a durable locator is missing (empty tmux socket)", async () => {
+    const db = freshDb();
+    const repo = freshRepo("git@github.com:gugu91/extensions.git");
+    db.registerAgent(
+      "worker-1",
+      "Worker",
+      "🦉",
+      4242,
+      { brokerManaged: true },
+      specFacts(repo).stableId,
+    );
+
+    const persisted = await persistSpawnedRuntimeSpec(db, specFacts(repo, { tmuxSocket: "" }));
+    expect(persisted).toBeNull();
+    expect(db.getAgentRuntimeSpec("worker-1")).toBeNull();
+  });
+
+  it("persists NOTHING for a non-session stable id (no resumable session)", async () => {
+    const db = freshDb();
+    const repo = freshRepo("git@github.com:gugu91/extensions.git");
+    // `cwd`-kind stable id exposes a path but carries no resumable Pi session.
+    const facts = specFacts(repo, { stableId: `host-a:cwd:${repo}` });
+    db.registerAgent("worker-1", "Worker", "🦉", 4242, { brokerManaged: true }, facts.stableId);
+
+    expect(await persistSpawnedRuntimeSpec(db, facts)).toBeNull();
+    expect(db.getAgentRuntimeSpec("worker-1")).toBeNull();
+  });
+});
+
+describe("recoverStrandedWakesBeforeRegistrations — Seam 3 (startup reconciliation)", () => {
+  it("delegates to the orchestrator recovery and no-ops on a clean DB", () => {
+    const db = freshDb();
+    expect(recoverStrandedWakesBeforeRegistrations(orchestrator(db))).toEqual([]);
+  });
+
+  it("quarantines a real crash-stranded `waking` row to reap-candidate", () => {
+    const db = freshDb();
+    db.registerAgent(
+      "worker-1",
+      "Worker",
+      "🦉",
+      4242,
+      { brokerManaged: true },
+      "host-a:session:/tmp/s.jsonl",
+    );
+
+    // Walk the legal lifecycle into a stranded `waking` with NO held lease and no
+    // accepted generation — exactly the shape a broker crash mid-wake leaves.
+    const chain: AgentLifecycleState[] = ["grace", "idle", "hibernating", "hibernated", "waking"];
+    for (const toState of chain) {
+      const version = db.getAgentById("worker-1")?.lifecycleVersion ?? 0;
+      db.transitionAgentLifecycle({
+        agentId: "worker-1",
+        expectedVersion: version,
+        toState,
+        reason: "seed",
+        actor: "broker",
+        correlationId: "seed",
+      });
+    }
+    expect(db.getAgentById("worker-1")?.lifecycleState).toBe("waking");
+
+    const recovered = recoverStrandedWakesBeforeRegistrations(orchestrator(db));
+    expect(recovered).toEqual([{ agentId: "worker-1", action: "quarantined" }]);
+    // Fail-closed: an uncertain runtime is never completed to `live`; it is parked
+    // for manual review rather than risking a double launch.
+    expect(db.getAgentById("worker-1")?.lifecycleState).toBe("reap-candidate");
+  });
+});

--- a/slack-bridge/broker/hibernation-activation.ts
+++ b/slack-bridge/broker/hibernation-activation.ts
@@ -2,8 +2,9 @@
 //
 // Wires the reviewed, approved hibernation RUNTIME ADAPTERS (real process/tmux
 // controllers + spawn-authored runtime-spec builder + git-remote VCS identity)
-// into the broker's three live seams, all behind the DEFAULT-OFF
-// `hibernation.activateRuntimeAdapters` gate:
+// into the broker's three live seams, all behind the DEFAULT-OFF durable,
+// non-reloadable activation authority (see hibernation-activation-authority.ts;
+// `hibernationRuntimeActive()`):
 //
 //   1. createHibernationOrchestrator  — the real orchestrator-backed executor
 //      that replaces the `activation_pending` stub ONLY under the gate.
@@ -33,21 +34,23 @@ import {
   buildRuntimeSpecInput,
   type SpawnAuthoredRuntimeFacts,
 } from "./hibernation-runtime-helpers.js";
-import type { ResolvedHibernationSettings } from "../hibernation-config.js";
+import { hibernationActivationAuthorized } from "./hibernation-activation-authority.js";
 
 /** Optional command runner override (git remote resolution); defaults to real `execFile`. */
 type VcsRunner = Parameters<typeof resolveVcsIdentity>[1];
 
 /**
  * The DEFAULT-OFF live-runtime gate. Live process/tmux composition happens ONLY
- * when hibernation is BOTH enabled and explicitly runtime-activated. Either flag
- * unset (the production default) keeps the broker on the `activation_pending`
- * stub with zero live-runtime side effects.
+ * when the durable, process-lifetime activation authority — captured at broker
+ * start from the external launch environment, never agent-editable settings — is
+ * set. Config reloads and settings edits can NEVER flip it, so the production
+ * default (authority unset) keeps the broker on the `activation_pending` stub
+ * with zero live-runtime side effects. Operational permission (enabled / mode /
+ * repo allowlist) is a SEPARATE settings policy enforced by the command layer;
+ * this gate only decides whether the real machinery is wired in at all.
  */
-export function hibernationRuntimeActive(
-  hib: Pick<ResolvedHibernationSettings, "enabled" | "activateRuntimeAdapters">,
-): boolean {
-  return hib.enabled === true && hib.activateRuntimeAdapters === true;
+export function hibernationRuntimeActive(): boolean {
+  return hibernationActivationAuthorized();
 }
 
 export interface HibernationRuntimeDeps {

--- a/slack-bridge/broker/hibernation-activation.ts
+++ b/slack-bridge/broker/hibernation-activation.ts
@@ -1,0 +1,145 @@
+// Phase B live-runtime activation composition.
+//
+// Wires the reviewed, approved hibernation RUNTIME ADAPTERS (real process/tmux
+// controllers + spawn-authored runtime-spec builder + git-remote VCS identity)
+// into the broker's three live seams, all behind the DEFAULT-OFF
+// `hibernation.activateRuntimeAdapters` gate:
+//
+//   1. createHibernationOrchestrator  — the real orchestrator-backed executor
+//      that replaces the `activation_pending` stub ONLY under the gate.
+//   2. persistSpawnedRuntimeSpec      — records a durable, broker-authored
+//      runtime spec (canonical git-remote VCS identity) at worker spawn.
+//   3. recoverStrandedWakesBeforeRegistrations — reconciles crash-stranded wake
+//      rows at broker startup, before the socket accepts new registrations.
+//
+// Keeping the composition here (rather than inline in index.ts / the subtree
+// runtime) makes every seam unit- and E2E-testable against REAL dependencies
+// (real BrokerDB, real git, real tmux/pi) with no production side effects.
+
+import {
+  HibernationOrchestrator,
+  type HibernationOrchestratorConfig,
+  type RuntimeLaunchContext,
+  type StrandedWakeRecovery,
+} from "@pinet/broker-core";
+import type { AgentRuntimeSpec } from "@pinet/broker-core/types";
+import type { BrokerDB } from "./schema.js";
+import {
+  createHibernationProcessController,
+  createHibernationTmuxController,
+  resolveVcsIdentity,
+} from "./hibernation-runtime-adapters.js";
+import {
+  buildRuntimeSpecInput,
+  type SpawnAuthoredRuntimeFacts,
+} from "./hibernation-runtime-helpers.js";
+import type { ResolvedHibernationSettings } from "../hibernation-config.js";
+
+/** Optional command runner override (git remote resolution); defaults to real `execFile`. */
+type VcsRunner = Parameters<typeof resolveVcsIdentity>[1];
+
+/**
+ * The DEFAULT-OFF live-runtime gate. Live process/tmux composition happens ONLY
+ * when hibernation is BOTH enabled and explicitly runtime-activated. Either flag
+ * unset (the production default) keeps the broker on the `activation_pending`
+ * stub with zero live-runtime side effects.
+ */
+export function hibernationRuntimeActive(
+  hib: Pick<ResolvedHibernationSettings, "enabled" | "activateRuntimeAdapters">,
+): boolean {
+  return hib.enabled === true && hib.activateRuntimeAdapters === true;
+}
+
+export interface HibernationRuntimeDeps {
+  db: BrokerDB;
+  /** Broker owner id recorded as `brokerOwnerId`/`brokerInstanceId` on managed rows. */
+  brokerInstanceId: string;
+  /** slack-bridge extension entry a woken runtime loads (`pi -e <path>`). */
+  extensionEntryPath: string;
+  /** Base PINET_* env re-establishing the mesh connection for a woken worker. */
+  baseLaunchEnv: Record<string, string>;
+  /** Broker env var NAMES (never values) re-exported into a woken runtime when present. */
+  inheritedEnvKeys: string[];
+  config?: Partial<HibernationOrchestratorConfig>;
+  /**
+   * Confirm the woken runtime registered and its reserved generation was accepted.
+   * PRODUCTION leaves this undefined: the orchestrator's default polls the broker
+   * DB until the socket server's fenced-registration handler accepts the woken
+   * worker's generation. Injectable so an isolated E2E can key acceptance off the
+   * REAL respawned process coming back alive instead of a live socket handshake.
+   */
+  awaitRuntimeRegistration?: (ctx: RuntimeLaunchContext) => Promise<boolean>;
+}
+
+/**
+ * Seam 1 — compose the real orchestrator-backed executor.
+ *
+ * The process and tmux controllers are constructed INDEPENDENTLY: the immutable
+ * launch generation rides inside the attempt handle `respawnRuntime` returns, so
+ * attempt-scoped stop/liveness bind to the exact launched process with no shared
+ * registry. The returned {@link HibernationOrchestrator} structurally satisfies
+ * `HibernateCommandExecutor & WakeCommandExecutor`, so it drops directly into the
+ * command executor slot in place of the `activation_pending` stub — but only the
+ * caller's {@link hibernationRuntimeActive} gate decides when to use it.
+ */
+export function createHibernationOrchestrator(
+  deps: HibernationRuntimeDeps,
+): HibernationOrchestrator {
+  const process = createHibernationProcessController({
+    pendingInboxCount: (agentId: string) => deps.db.getUnreadInboxCount(agentId),
+  });
+  const tmux = createHibernationTmuxController({
+    extensionEntryPath: deps.extensionEntryPath,
+    baseLaunchEnv: deps.baseLaunchEnv,
+    inheritedEnvKeys: deps.inheritedEnvKeys,
+  });
+  return new HibernationOrchestrator({
+    db: deps.db,
+    process,
+    tmux,
+    brokerInstanceId: deps.brokerInstanceId,
+    ...(deps.config ? { config: deps.config } : {}),
+    ...(deps.awaitRuntimeRegistration
+      ? { awaitRuntimeRegistration: deps.awaitRuntimeRegistration }
+      : {}),
+  });
+}
+
+/** Broker-authored spawn facts minus the VCS identity (derived here from the git remote). */
+export type SpawnRuntimeSpecFacts = Omit<SpawnAuthoredRuntimeFacts, "vcsIdentity">;
+
+/**
+ * Seam 2 — persist a durable, broker-authored runtime spec at worker spawn.
+ *
+ * The canonical `owner/repo` VCS identity (the ONLY value the repo allowlist
+ * authorizes against) is resolved HERE from the runtime's actual git `origin`
+ * remote — never from filesystem directory names. Fails closed: an unresolvable
+ * remote records `vcsIdentity: null` (the fail-closed gate then refuses), and a
+ * spec that could not be safely hibernated/woken (missing session/tmux/repo
+ * locators) is never written. Returns the persisted spec, or null when the facts
+ * do not compose a durable spec.
+ */
+export async function persistSpawnedRuntimeSpec(
+  db: BrokerDB,
+  facts: SpawnRuntimeSpecFacts,
+  runner?: VcsRunner,
+): Promise<AgentRuntimeSpec | null> {
+  const vcsIdentity = await resolveVcsIdentity(facts.repoRoot, runner);
+  const input = buildRuntimeSpecInput({ ...facts, vcsIdentity });
+  if (!input) return null;
+  return db.upsertAgentRuntimeSpec(input);
+}
+
+/**
+ * Seam 3 — reconcile crash-stranded wake state at broker startup.
+ *
+ * Must run BEFORE the broker socket accepts new registrations so a stranded
+ * `waking`/`dispatching` row is completed, quarantined, or requeued deterministically
+ * rather than racing an incoming (possibly duplicate) wake registration. This is a
+ * synchronous DB reconciliation; it launches nothing.
+ */
+export function recoverStrandedWakesBeforeRegistrations(
+  orchestrator: HibernationOrchestrator,
+): StrandedWakeRecovery[] {
+  return orchestrator.recoverStrandedWakes();
+}

--- a/slack-bridge/broker/hibernation-command-router.ts
+++ b/slack-bridge/broker/hibernation-command-router.ts
@@ -1,0 +1,193 @@
+// Production hibernate/wake command router + executor composition.
+//
+// This is the SINGLE source of truth for how an operator `pinet hibernate` /
+// `pinet wake` command resolves its authoritative DB, target worker, policy, and
+// executor. It is extracted out of the extension closure so BOTH the live
+// extension (`index.ts` `runHibernationCommand`) and the isolated production-route
+// E2E drive the exact same integration code — the code that fixed the DB-topology
+// and activation-authority seams — rather than re-composing the pieces by hand.
+//
+// The design invariants this router encodes (each has a negative regression test):
+//
+//   • Activation is authorized ONLY by the durable, non-reloadable, frozen
+//     broker-start authority (`hibernationRuntimeActive()`), never by reloadable
+//     settings. A settings reload can NEVER flip a running broker on.
+//   • When active, the SUBTREE broker is the authority: it spawned and OWNS these
+//     workers and authored their durable runtime specs, so target resolution, the
+//     authz spec read, AND the orchestrator all run against that SAME subtree DB
+//     (`getRuntimeControl().db`) — never the central broker DB.
+//   • When inactive (production default) there is no runtime control, so resolution
+//     falls back to the central DB and the executor stays the `activation_pending`
+//     stub: a clear refusal, never a silent no-op.
+//   • The repo allowlist is a security boundary authorized ONLY against the
+//     broker-authored spec's canonical `owner/repo` VCS identity (captured at spawn
+//     from the git remote), never a filesystem path slug or worker-declared metadata.
+
+import {
+  executeHibernateCommand,
+  executeWakeCommand,
+  unknownHibernationTarget,
+  type HibernateCommandExecutor,
+  type HibernationCommandPolicy,
+  type HibernationCommandResult,
+  type RuntimeLaunchContext,
+  type WakeCommandExecutor,
+} from "@pinet/broker-core";
+import type { AgentInfo, AgentLifecycleState } from "@pinet/broker-core/types";
+import type { BrokerDB } from "./schema.js";
+import type { ResolvedHibernationSettings } from "../hibernation-config.js";
+import {
+  createHibernationOrchestrator,
+  hibernationRuntimeActive,
+} from "./hibernation-activation.js";
+
+/**
+ * The authoritative runtime-control surface the command path binds to when runtime
+ * activation is active. Structurally identical to the subtree broker's
+ * `SubtreeHibernationRuntimeControl`; kept here so the router has no import
+ * dependency on the extension wiring and stays independently testable.
+ */
+export interface HibernationRuntimeControl {
+  /** The ONE authoritative DB that owns the spawned workers + their specs. */
+  db: BrokerDB;
+  /** Broker instance id recorded on lifecycle leases; matches startup recovery. */
+  brokerInstanceId: string;
+  /** Base PINET_* env re-establishing the mesh connection for a woken worker. */
+  baseLaunchEnv: Record<string, string>;
+}
+
+export interface RouteHibernationCommandInput {
+  command: "hibernate" | "wake";
+  target: string;
+  reason?: string;
+  /** Must be "broker"; any other role (or null) rejects (this session is not the broker). */
+  brokerRole: string | null;
+  /** Operational policy (enabled/mode/allowlist) — SEPARATE from runtime activation. */
+  hib: ResolvedHibernationSettings;
+  /**
+   * Real accessor for the subtree broker's authoritative control surface. Invoked
+   * only when the frozen activation authority is set; returns null when no subtree
+   * broker is running (nothing is command-addressable).
+   */
+  getRuntimeControl: () => HibernationRuntimeControl | null;
+  /** Central broker DB, used ONLY as the default-off fallback (never when active). */
+  getFallbackDb: () => BrokerDB | null;
+  /** slack-bridge extension entry a woken runtime loads (`pi -e <path>`). */
+  extensionEntryPath: string;
+  /** Broker env var NAMES (never values) re-exported into a woken runtime. */
+  inheritedEnvKeys: string[];
+  /**
+   * Socket-registration RPC stand-in. PRODUCTION leaves this undefined so the
+   * orchestrator's default polls the broker DB until the socket server's fenced
+   * handler accepts the woken worker's generation. Injectable so an isolated E2E
+   * can key acceptance off the REAL respawned process instead of a live handshake.
+   */
+  awaitRuntimeRegistration?: (ctx: RuntimeLaunchContext) => Promise<boolean>;
+}
+
+/**
+ * Resolve and run one hibernate/wake command exactly as the live extension does.
+ *
+ * Ordering matters and is asserted by regression tests: activation is read from
+ * the frozen authority FIRST, which decides whether the authoritative DB is the
+ * subtree control DB or the central fallback, which decides whether the real
+ * orchestrator or the `activation_pending` stub is composed.
+ */
+export async function routeHibernationCommand(
+  input: RouteHibernationCommandInput,
+): Promise<HibernationCommandResult> {
+  const { command, target, reason, brokerRole, hib } = input;
+  if (brokerRole !== "broker") {
+    throw new Error(
+      `pinet ${command} is broker-managed. Connect this session as the broker (/pinet start) to hibernate or wake workers.`,
+    );
+  }
+
+  // Authoritative DB unification + explicit trust boundary. When the durable,
+  // non-reloadable runtime-activation authority is set, the SUBTREE broker owns
+  // these workers AND authored their durable runtime specs, so hibernate/wake must
+  // resolve the target, read its authz spec, AND drive the orchestrator against
+  // that SAME subtree DB end to end. The operator may therefore only address
+  // workers this process's subtree broker owns. In the default-off configuration
+  // there is no runtime control, so resolution falls back to the central broker DB
+  // and the executor stays the `activation_pending` stub (a clear refusal, never a
+  // silent no-op).
+  const runtimeControl = hibernationRuntimeActive() ? input.getRuntimeControl() : null;
+  const db = runtimeControl?.db ?? input.getFallbackDb();
+  if (!db) throw new Error("Broker database is unavailable.");
+
+  const wanted = target.trim().replace(/^@/, "");
+  const agents = db.getAllAgents();
+  const lowerWanted = wanted.toLowerCase();
+  const nameMatches = agents.filter((a: AgentInfo) => a.name?.toLowerCase() === lowerWanted);
+  const agent =
+    agents.find((a: AgentInfo) => a.id === wanted) ??
+    agents.find((a: AgentInfo) => a.stableId === wanted) ??
+    (nameMatches.length === 1 ? nameMatches[0] : undefined);
+  if (!agent) return unknownHibernationTarget(command, target);
+
+  const policy: HibernationCommandPolicy = {
+    enabled: hib.enabled,
+    mode: hib.mode,
+    allowedRepos: hib.allowedRepos,
+  };
+  const state = (agent.lifecycleState ?? "live") as AgentLifecycleState;
+  // Provenance: the repo allowlist is a security boundary, so authorization trusts
+  // ONLY the broker-authored durable runtime spec's CANONICAL VCS IDENTITY
+  // (`owner/repo`), captured at spawn from the runtime's git remote. Ownership is
+  // NEVER inferred from filesystem directory names or worker-declared metadata.
+  // When no trusted spec / resolvable remote exists the identifier stays null and
+  // the fail-closed gate refuses.
+  const repoIdentifier = db.getAgentRuntimeSpec(agent.id)?.vcsIdentity ?? null;
+
+  // Live process/tmux checkpoint/respawn adapters are a separate, explicitly gated
+  // activation step (default-off). When runtime activation is unset `runtimeControl`
+  // is null and callers get a clear `activation_pending` refusal rather than a
+  // silent no-op. When set, the real process/tmux HibernationOrchestrator is
+  // composed over the SAME subtree DB that owns the worker and its spec, with
+  // `brokerInstanceId` matching the spawn/startup-recovery owner so lease fencing
+  // lines up. The woken worker's respawn env is the subtree broker's child-launch
+  // env; inherited secret var NAMES come from the shared spawn/wake allowlist.
+  const executor: HibernateCommandExecutor & WakeCommandExecutor = runtimeControl
+    ? createHibernationOrchestrator({
+        db: runtimeControl.db,
+        brokerInstanceId: runtimeControl.brokerInstanceId,
+        extensionEntryPath: input.extensionEntryPath,
+        baseLaunchEnv: runtimeControl.baseLaunchEnv,
+        inheritedEnvKeys: input.inheritedEnvKeys,
+        config: {
+          handshakeTimeoutMs: hib.handshakeTimeoutMs,
+          wakeLeaseMs: hib.wakeLeaseMs,
+          maxConcurrentWakes: hib.maxConcurrentWakes,
+          maxConcurrentWakesPerRepo: hib.maxConcurrentWakesPerRepo,
+        },
+        ...(input.awaitRuntimeRegistration
+          ? { awaitRuntimeRegistration: input.awaitRuntimeRegistration }
+          : {}),
+      })
+    : {
+        prepareHibernation: () => ({ ready: false, state, reason: "activation_pending" }),
+        hibernate: async () => ({ ok: false, state, reason: "activation_pending" }),
+        wake: async () => ({ ok: false, state, reason: "activation_pending" }),
+      };
+
+  if (command === "hibernate") {
+    return executeHibernateCommand({
+      executor,
+      agentId: agent.id,
+      state,
+      repoIdentifier,
+      policy,
+      actor: "operator",
+      reason,
+    });
+  }
+  return executeWakeCommand({
+    executor,
+    agentId: agent.id,
+    state,
+    policy,
+    actor: "operator",
+    reason,
+  });
+}

--- a/slack-bridge/broker/hibernation-production-route.test.ts
+++ b/slack-bridge/broker/hibernation-production-route.test.ts
@@ -1,0 +1,402 @@
+// Deterministic, CI-run PRODUCTION-ROUTE integration test for Phase B.
+//
+// This drives the SAME integration glue a live operator command takes, using the
+// real production functions — no hand-reconstructed broker/registration/executor:
+//
+//   • the REAL `createSubtreeBrokerRuntime(deps).start(ctx)` (real leader lock +
+//     real socket server + real self-agent registration + real pre-listen recovery),
+//   • the REAL `runtime.getHibernationRuntimeControl()` authoritative-control accessor,
+//   • the REAL, SHARED `routeHibernationCommand` — the exact function `index.ts`
+//     `runHibernationCommand` delegates to — so a regression in DB-topology
+//     resolution, executor composition, or the frozen-authority gate fails BOTH the
+//     live extension and this test.
+//
+// It proves the four seams that must never silently regress, WITHOUT launching a
+// process (so it is deterministic and CI-safe): the executed real-pi/tmux
+// hibernate→wake lifecycle and the real `spawnWorker` child live in the opt-in
+// `hibernation-activation.e2e.test.ts`.
+//
+//   (A) A crash-stranded `waking` row seeded into the subtree broker's authoritative
+//       DB BEFORE start is reconciled inside `beforeListen` — proving durable
+//       recovery runs before the socket accepts registrations, through the REAL
+//       subtree start path (not a hand-wired `startBroker`).
+//   (B) With a POPULATED, CONTRADICTORY central-DB decoy present, the router resolves
+//       the target AND its authz spec identity from the authoritative SUBTREE control
+//       DB only. If it read the central decoy, the outcomes below would differ.
+//   (C) The repo allowlist is authorized from the DB-sourced spec identity, refusing
+//       BEFORE any side effect; an allowlisted identity reaches the real executor.
+//   (D) Activation is the durable, non-reloadable, frozen broker-start authority: a
+//       later settings reload changes operational policy but a broker frozen OFF at
+//       start can NEVER be elevated, and a broker frozen ON stays authoritative — and
+//       the freeze happens via the REAL start path, with NO freeze-call surrogate.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AgentLifecycleState } from "@pinet/broker-core/types";
+import {
+  buildSubtreeBrokerPaths,
+  createSubtreeBrokerRuntime,
+  getExtensionEntryPath,
+  SUBTREE_INHERITED_ENV_KEYS,
+  type SubtreeBrokerRuntime,
+  type SubtreeBrokerRuntimeDeps,
+} from "../subtree-broker-runtime.js";
+import { routeHibernationCommand } from "./hibernation-command-router.js";
+import { hibernationRuntimeActive } from "./hibernation-activation.js";
+import { __resetHibernationActivationAuthorityForTest } from "./hibernation-activation-authority.js";
+import { buildRuntimeSpecInput } from "./hibernation-runtime-helpers.js";
+import { BrokerDB } from "./schema.js";
+import type { SlackBridgeSettings, PinetControlCommand } from "../helpers.js";
+import { resolveHibernationSettings } from "../hibernation-config.js";
+
+const ACTIVATION_ENV = "PINET_HIBERNATION_RUNTIME_ACTIVATION";
+const ctx = {} as ExtensionContext;
+
+// Per-test disposable resources, torn down in afterEach.
+let runtimes: SubtreeBrokerRuntime[] = [];
+let centralDbs: BrokerDB[] = [];
+let subtreeRoots: string[] = [];
+let tmpDirs: string[] = [];
+let savedActivation: string | undefined;
+
+// The subtree broker's stableId is sanitized into its on-disk root dir, and the
+// unix socket path underneath it must stay under the macOS ~104-char limit, so keep
+// it short. (Worker-agent stableIds, which need `host:session:<path>` format for
+// their runtime specs, are separate and unaffected by the socket path length.)
+function brokerStableId(tag: string): string {
+  return `det-${tag}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeCentralDb(): BrokerDB {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-hib-central-"));
+  tmpDirs.push(dir);
+  const db = new BrokerDB(path.join(dir, "central.db"));
+  db.initialize();
+  centralDbs.push(db);
+  return db;
+}
+
+/** Minimal, fully-typed deps: none of the message/inbox callbacks fire in this test
+ *  (no inbound messages), but the deps object must satisfy the real interface. */
+function makeDeps(stableId: string, settings: SlackBridgeSettings): SubtreeBrokerRuntimeDeps {
+  return {
+    cwd: os.tmpdir(),
+    getSettings: () => settings,
+    getAgentStableId: () => stableId,
+    getCentralAgentId: () => null,
+    getAgentIdentity: () => ({ name: "Det", emoji: "🌳" }),
+    getAgentMetadata: async () => ({}),
+    getMeshRoleFromMetadata: (_metadata, fallback) => fallback ?? "worker",
+    pushInboxMessages: () => {},
+    updateBadge: () => {},
+    maybeDrainInboxIfIdle: () => false,
+    deliverSteeringMessage: () => false,
+    requestRemoteControl: (command: PinetControlCommand) => ({
+      currentCommand: null,
+      queuedCommand: null,
+      accepted: false,
+      shouldStartNow: false,
+      status: "covered",
+      scheduledCommand: command,
+      ackDisposition: "immediate",
+    }),
+    runRemoteControl: () => {},
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+  };
+}
+
+/** Start a real subtree broker after freezing the process activation authority via
+ *  the REAL start path (env is set/unset by the caller; NO freeze-call surrogate). */
+async function startRealSubtree(
+  stableId: string,
+  settings: SlackBridgeSettings,
+): Promise<SubtreeBrokerRuntime> {
+  const runtime = createSubtreeBrokerRuntime(makeDeps(stableId, settings));
+  subtreeRoots.push(buildSubtreeBrokerPaths(stableId).rootDir);
+  await runtime.start(ctx);
+  runtimes.push(runtime);
+  return runtime;
+}
+
+/** Seed a real crash-stranded `waking` row into a broker DB before it starts. */
+function seedStrandedWaking(dbPath: string, agentId: string): void {
+  const db = new BrokerDB(dbPath);
+  db.initialize();
+  db.registerAgent(
+    agentId,
+    "Stranded",
+    "🦉",
+    4242,
+    { brokerManaged: true },
+    `h:session:/tmp/s.jsonl`,
+  );
+  const chain: AgentLifecycleState[] = ["grace", "idle", "hibernating", "hibernated", "waking"];
+  for (const toState of chain) {
+    db.transitionAgentLifecycle({
+      agentId,
+      expectedVersion: db.getAgentById(agentId)?.lifecycleVersion ?? 0,
+      toState,
+      reason: "seed",
+      actor: "broker",
+      correlationId: "seed",
+    });
+  }
+  db.close();
+}
+
+/** Register a broker-managed, hibernate-safe TOP-LEVEL worker (no parentAgentId, so
+ *  it is NOT a supervised subtree child) with a DB-sourced runtime spec whose VCS
+ *  identity is exactly `vcsIdentity`. Held `working` so the executor's real prepare
+ *  gate refuses deterministically (no process launch) once the allowlist passes. */
+function registerWorkerWithSpec(
+  db: BrokerDB,
+  input: { agentId: string; stableId: string; vcsIdentity: string; brokerOwnerId: string },
+): void {
+  db.registerAgent(
+    input.agentId,
+    "Worker",
+    "🦉",
+    4243,
+    {
+      brokerManaged: true,
+      brokerManagedBy: input.brokerOwnerId,
+      hibernateSafe: true,
+      cwd: os.tmpdir(),
+      repoRoot: os.tmpdir(),
+      worktreePath: os.tmpdir(),
+      tmuxSession: "det-session",
+    },
+    input.stableId,
+  );
+  db.setAgentHibernatePolicy(input.agentId, "manual");
+  db.updateAgentStatus(input.agentId, "working");
+  const spec = buildRuntimeSpecInput({
+    agentId: input.agentId,
+    stableId: input.stableId,
+    brokerOwnerId: input.brokerOwnerId,
+    cwd: os.tmpdir(),
+    repoRoot: os.tmpdir(),
+    worktreePath: os.tmpdir(),
+    tmuxSocket: "/tmp/det-tmux.sock",
+    tmuxSession: "det-session",
+    tmuxTarget: "det-session",
+    extensionEntryPath: getExtensionEntryPath(),
+    envAllowlist: ["PI_SETTINGS_PATH"],
+    configFingerprint: "det",
+    expectedUser: os.userInfo().username,
+    launchSource: "det",
+    vcsIdentity: input.vcsIdentity,
+  });
+  if (!spec) throw new Error("failed to build runtime spec");
+  db.upsertAgentRuntimeSpec(spec);
+}
+
+function settingsWith(
+  hibernation: NonNullable<SlackBridgeSettings["hibernation"]>,
+): SlackBridgeSettings {
+  return { hibernation };
+}
+
+/** Route a hibernate through the EXACT shared production router index.ts delegates to. */
+function routeHibernate(
+  runtime: SubtreeBrokerRuntime,
+  centralDb: BrokerDB,
+  settings: SlackBridgeSettings,
+  target: string,
+) {
+  return routeHibernationCommand({
+    command: "hibernate",
+    target,
+    brokerRole: "broker",
+    hib: resolveHibernationSettings(settings),
+    getRuntimeControl: () => runtime.getHibernationRuntimeControl(),
+    getFallbackDb: () => centralDb,
+    extensionEntryPath: getExtensionEntryPath(),
+    inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
+  });
+}
+
+beforeEach(() => {
+  savedActivation = process.env[ACTIVATION_ENV];
+  runtimes = [];
+  centralDbs = [];
+  subtreeRoots = [];
+  tmpDirs = [];
+  __resetHibernationActivationAuthorityForTest();
+});
+
+afterEach(async () => {
+  for (const runtime of runtimes) {
+    try {
+      await runtime.stop({ releaseIdentity: true });
+    } catch {
+      /* best effort */
+    }
+  }
+  for (const db of centralDbs) {
+    try {
+      db.close();
+    } catch {
+      /* best effort */
+    }
+  }
+  for (const root of subtreeRoots) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+  for (const dir of tmpDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+  if (savedActivation === undefined) delete process.env[ACTIVATION_ENV];
+  else process.env[ACTIVATION_ENV] = savedActivation;
+  __resetHibernationActivationAuthorityForTest();
+});
+
+describe("Phase B production-route (deterministic) — real subtree start + shared router", () => {
+  it("recovers a stranded wake before listen and routes target+spec from the authoritative subtree DB despite a contradictory central decoy", async () => {
+    // Activation ON via the REAL start freeze (env set BEFORE start; no surrogate).
+    process.env[ACTIVATION_ENV] = "1";
+    const stableId = brokerStableId("on");
+
+    // (A) Seed a crash-stranded wake into THIS subtree broker's authoritative DB
+    //     path BEFORE it starts, then prove real start reconciles it pre-listen.
+    const paths = buildSubtreeBrokerPaths(stableId);
+    fs.mkdirSync(paths.rootDir, { recursive: true });
+    seedStrandedWaking(paths.dbPath, "stranded-1");
+
+    const runtime = await startRealSubtree(
+      stableId,
+      settingsWith({ enabled: true, mode: "manual" }),
+    );
+    expect(hibernationRuntimeActive()).toBe(true);
+
+    const control = runtime.getHibernationRuntimeControl();
+    expect(control).not.toBeNull();
+    const subtreeDb = control!.db;
+    // Recovery ran inside beforeListen, on the authoritative subtree DB.
+    expect(subtreeDb.getAgentById("stranded-1")?.lifecycleState).toBe("reap-candidate");
+
+    // (B) Contradictory decoy: SAME agent id in a separate central fallback DB, but
+    //     its spec identity is a DIFFERENT, deliberately-allowlisted repo. If the
+    //     router read the central decoy, the outcomes below would flip.
+    const centralDb = makeCentralDb();
+    registerWorkerWithSpec(centralDb, {
+      agentId: "worker-x",
+      stableId: `${os.hostname()}:session:/tmp/central-x.jsonl`,
+      vcsIdentity: "central/repo",
+      brokerOwnerId: "central-broker",
+    });
+
+    // Authoritative subtree worker: same id, spec identity "sub/repo".
+    registerWorkerWithSpec(subtreeDb, {
+      agentId: "worker-x",
+      stableId: `${os.hostname()}:session:/tmp/sub-x.jsonl`,
+      vcsIdentity: "sub/repo",
+      brokerOwnerId: control!.brokerInstanceId,
+    });
+
+    const subBefore = subtreeDb.getAgentById("worker-x")?.lifecycleState;
+    const centralBefore = centralDb.getAgentById("worker-x")?.lifecycleState;
+
+    // (C) Allowlist the CENTRAL decoy's identity only. The router reads the SUBTREE
+    //     spec ("sub/repo"), which is NOT allowlisted → refuse BEFORE side effects.
+    //     If it read the central decoy ("central/repo"), it would NOT refuse here.
+    const denied = await routeHibernate(
+      runtime,
+      centralDb,
+      settingsWith({ enabled: true, mode: "manual", allowedRepos: ["central/repo"] }),
+      "worker-x",
+    );
+    expect(denied.outcome).toBe("refused");
+    expect(denied.reason).toBe("repo_not_allowlisted");
+
+    // Allowlist the SUBTREE identity: the gate now passes on the DB-sourced subtree
+    // spec and reaches the REAL executor's prepare gate, which refuses `agent_working`
+    // (no process launch). If it read the central decoy, "sub/repo" would be
+    // un-allowlisted → `repo_not_allowlisted`, not `agent_working`.
+    const reached = await routeHibernate(
+      runtime,
+      centralDb,
+      settingsWith({ enabled: true, mode: "manual", allowedRepos: ["sub/repo"] }),
+      "worker-x",
+    );
+    expect(reached.outcome).toBe("refused");
+    expect(reached.reason).toBe("agent_working");
+
+    // (B) No lifecycle mutation landed on EITHER DB (refusals are before side effects),
+    //     and the central decoy was never read/mutated.
+    expect(subtreeDb.getAgentById("worker-x")?.lifecycleState).toBe(subBefore);
+    expect(centralDb.getAgentById("worker-x")?.lifecycleState).toBe(centralBefore);
+  }, 30_000);
+
+  it("keeps a broker frozen OFF at start un-elevatable by a later settings reload (real start freeze, no surrogate)", async () => {
+    // Activation OFF via the REAL start freeze (env cleared BEFORE start).
+    delete process.env[ACTIVATION_ENV];
+    const stableId = brokerStableId("off");
+    const settings = settingsWith({ enabled: false, mode: "observe" });
+    const runtime = await startRealSubtree(stableId, settings);
+    // The real start path performed the freeze reading the (absent) env: OFF.
+    expect(hibernationRuntimeActive()).toBe(false);
+
+    // The central fallback DB (used because authority is OFF) holds an allowlist-
+    // matching worker + spec, so the only thing that can refuse the command is the
+    // frozen-OFF `activation_pending` executor — never a policy gap.
+    const centralDb = makeCentralDb();
+    registerWorkerWithSpec(centralDb, {
+      agentId: "worker-off",
+      stableId: `${os.hostname()}:session:/tmp/off.jsonl`,
+      vcsIdentity: "off/repo",
+      brokerOwnerId: "central-broker",
+    });
+
+    // "Reload": mutate the live settings to the most permissive policy possible.
+    settings.hibernation = { enabled: true, mode: "manual", allowedRepos: ["off/repo"] };
+
+    const result = await routeHibernate(runtime, centralDb, settings, "worker-off");
+    // Policy would allow it, target+spec resolve, allowlist passes — yet the executor
+    // is still the `activation_pending` stub: a reload cannot elevate frozen-OFF.
+    expect(result.outcome).toBe("refused");
+    expect(result.reason).toBe("activation_pending");
+    // And the direct authority read is still OFF after the reload.
+    expect(hibernationRuntimeActive()).toBe(false);
+  }, 30_000);
+
+  it("keeps a broker frozen ON authoritative while a settings reload changes only operational policy", async () => {
+    process.env[ACTIVATION_ENV] = "1";
+    const stableId = brokerStableId("onpolicy");
+    const settings = settingsWith({ enabled: true, mode: "manual", allowedRepos: ["sub/repo"] });
+    const runtime = await startRealSubtree(stableId, settings);
+    expect(hibernationRuntimeActive()).toBe(true);
+
+    const control = runtime.getHibernationRuntimeControl();
+    expect(control).not.toBeNull();
+    registerWorkerWithSpec(control!.db, {
+      agentId: "worker-on",
+      stableId: `${os.hostname()}:session:/tmp/on.jsonl`,
+      vcsIdentity: "sub/repo",
+      brokerOwnerId: control!.brokerInstanceId,
+    });
+
+    const centralDb = makeCentralDb();
+
+    // "Reload" flips operational policy OFF (enabled=false). Authority stays ON, so
+    // routing still resolves the target from the SUBTREE control DB: the refusal is
+    // `hibernation_disabled` (policy), NOT `unknown` (which a central-DB regression
+    // would produce, since the central fallback has no such agent).
+    settings.hibernation = { enabled: false, mode: "manual", allowedRepos: ["sub/repo"] };
+    const result = await routeHibernate(runtime, centralDb, settings, "worker-on");
+    expect(result.outcome).toBe("refused");
+    expect(result.reason).toBe("hibernation_disabled");
+    expect(hibernationRuntimeActive()).toBe(true);
+  }, 30_000);
+});

--- a/slack-bridge/broker/hibernation-production-route.test.ts
+++ b/slack-bridge/broker/hibernation-production-route.test.ts
@@ -25,10 +25,17 @@
 //       DB only. If it read the central decoy, the outcomes below would differ.
 //   (C) The repo allowlist is authorized from the DB-sourced spec identity, refusing
 //       BEFORE any side effect; an allowlisted identity reaches the real executor.
-//   (D) Activation is the durable, non-reloadable, frozen broker-start authority: a
-//       later settings reload changes operational policy but a broker frozen OFF at
-//       start can NEVER be elevated, and a broker frozen ON stays authoritative — and
-//       the freeze happens via the REAL start path, with NO freeze-call surrogate.
+//   (D) Activation is the durable, non-reloadable, frozen broker-start authority. The
+//       reload is a DISPOSABLE but REAL production reload boundary — an on-disk
+//       settings file mutated then run through the REAL `reloadPinetRuntimeSafely`
+//       (refresh-from-disk → validate → stop → rebuild) route, exactly as the live
+//       extension's `reloadPinetRuntime` does — NOT an in-memory `settings = …`
+//       surrogate. A broker frozen OFF at start can NEVER be elevated by that
+//       reload even when the new on-disk settings enable hibernation AND the
+//       activation env is flipped on after start; a broker frozen ON stays
+//       authoritative while the reload changes only operational policy. The freeze
+//       (and its idempotent survival across the rebuild) happens via the REAL start
+//       path, with NO freeze-call surrogate.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
@@ -49,6 +56,7 @@ import { hibernationRuntimeActive } from "./hibernation-activation.js";
 import { __resetHibernationActivationAuthorityForTest } from "./hibernation-activation-authority.js";
 import { buildRuntimeSpecInput } from "./hibernation-runtime-helpers.js";
 import { BrokerDB } from "./schema.js";
+import { reloadPinetRuntimeSafely } from "../helpers.js";
 import type { SlackBridgeSettings, PinetControlCommand } from "../helpers.js";
 import { resolveHibernationSettings } from "../hibernation-config.js";
 
@@ -119,6 +127,82 @@ async function startRealSubtree(
   await runtime.start(ctx);
   runtimes.push(runtime);
   return runtime;
+}
+
+/**
+ * A real subtree broker whose settings are read from an ON-DISK file, with a
+ * `reload(next)` that drives the REAL production `reloadPinetRuntimeSafely` route:
+ * write the new settings file, refresh-from-disk, validate, stop the running
+ * subtree broker, and rebuild a fresh one on the SAME stableId (which re-opens the
+ * SAME persisted authoritative DB and re-invokes the idempotent activation freeze).
+ * This is the disposable stand-in for the live extension's `reloadPinetRuntime`,
+ * NOT an in-memory `settings = …` mutation. `holder.runtime`/`holder.settings`
+ * always point at the CURRENT (post-reload) runtime + resolved settings.
+ */
+interface FileBackedSubtree {
+  holder: { runtime: SubtreeBrokerRuntime; settings: SlackBridgeSettings };
+  reload: (nextOnDisk: SlackBridgeSettings) => Promise<void>;
+}
+
+async function startFileBackedSubtree(
+  stableId: string,
+  initial: SlackBridgeSettings,
+): Promise<FileBackedSubtree> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-hib-settings-"));
+  tmpDirs.push(dir);
+  const settingsPath = path.join(dir, "settings.json");
+  const readSettingsFile = (): SlackBridgeSettings =>
+    JSON.parse(fs.readFileSync(settingsPath, "utf8")) as SlackBridgeSettings;
+  fs.writeFileSync(settingsPath, JSON.stringify(initial));
+
+  // A settings ref (reassigned on refresh-from-disk) and a `runtime` binding
+  // (reassigned on rebuild); `deps.getSettings` reads the ref LIVE so the rebuilt
+  // runtime picks up the refreshed on-disk settings (the freeze latch is
+  // process-global and survives the rebuild). The returned `holder` exposes both
+  // via getters so callers always see the CURRENT (post-reload) runtime + settings.
+  const settingsRef: { current: SlackBridgeSettings } = { current: readSettingsFile() };
+  const deps: SubtreeBrokerRuntimeDeps = {
+    ...makeDeps(stableId, settingsRef.current),
+    getSettings: () => settingsRef.current,
+  };
+  subtreeRoots.push(buildSubtreeBrokerPaths(stableId).rootDir);
+  let runtime = createSubtreeBrokerRuntime(deps);
+  await runtime.start(ctx);
+  runtimes.push(runtime);
+
+  const reload = async (nextOnDisk: SlackBridgeSettings): Promise<void> => {
+    fs.writeFileSync(settingsPath, JSON.stringify(nextOnDisk));
+    await reloadPinetRuntimeSafely<SlackBridgeSettings>({
+      getCurrentRole: () => "broker",
+      snapshotState: () => settingsRef.current,
+      restoreState: (snap) => {
+        settingsRef.current = snap;
+      },
+      refreshState: () => {
+        settingsRef.current = readSettingsFile();
+      },
+      validateRefreshedState: () => {},
+      stopRuntime: async () => {
+        await runtime.stop({ releaseIdentity: true });
+      },
+      startRuntime: async () => {
+        runtime = createSubtreeBrokerRuntime(deps);
+        await runtime.start(ctx);
+        runtimes.push(runtime);
+      },
+    });
+  };
+  return {
+    holder: {
+      get runtime(): SubtreeBrokerRuntime {
+        return runtime;
+      },
+      get settings(): SlackBridgeSettings {
+        return settingsRef.current;
+      },
+    },
+    reload,
+  };
 }
 
 /** Seed a real crash-stranded `waking` row into a broker DB before it starts. */
@@ -339,12 +423,14 @@ describe("Phase B production-route (deterministic) — real subtree start + shar
     expect(centralDb.getAgentById("worker-x")?.lifecycleState).toBe(centralBefore);
   }, 30_000);
 
-  it("keeps a broker frozen OFF at start un-elevatable by a later settings reload (real start freeze, no surrogate)", async () => {
+  it("keeps a broker frozen OFF at start un-elevatable by a REAL on-disk reload + rebuild, even with the activation env flipped on after start", async () => {
     // Activation OFF via the REAL start freeze (env cleared BEFORE start).
     delete process.env[ACTIVATION_ENV];
     const stableId = brokerStableId("off");
-    const settings = settingsWith({ enabled: false, mode: "observe" });
-    const runtime = await startRealSubtree(stableId, settings);
+    const subtree = await startFileBackedSubtree(
+      stableId,
+      settingsWith({ enabled: false, mode: "observe" }),
+    );
     // The real start path performed the freeze reading the (absent) env: OFF.
     expect(hibernationRuntimeActive()).toBe(false);
 
@@ -359,42 +445,76 @@ describe("Phase B production-route (deterministic) — real subtree start + shar
       brokerOwnerId: "central-broker",
     });
 
-    // "Reload": mutate the live settings to the most permissive policy possible.
-    settings.hibernation = { enabled: true, mode: "manual", allowedRepos: ["off/repo"] };
+    // Adversarial reload: the on-disk settings now enable the most permissive
+    // hibernation policy possible, AND the activation env is flipped on after start.
+    // Neither can elevate a broker frozen OFF: the rebuild re-invokes the freeze but
+    // the process-lifetime latch already captured OFF at the first start.
+    process.env[ACTIVATION_ENV] = "1";
+    await subtree.reload(
+      settingsWith({ enabled: true, mode: "manual", allowedRepos: ["off/repo"] }),
+    );
+    // The frozen authority stays OFF; the router therefore ignores any live subtree
+    // control and falls back to the central `activation_pending` stub. (The control
+    // accessor itself is unconditional when a broker is live — the gate is the
+    // router's `hibernationRuntimeActive()` check, exercised below.)
+    expect(hibernationRuntimeActive()).toBe(false);
 
-    const result = await routeHibernate(runtime, centralDb, settings, "worker-off");
+    const result = await routeHibernate(
+      subtree.holder.runtime,
+      centralDb,
+      subtree.holder.settings,
+      "worker-off",
+    );
     // Policy would allow it, target+spec resolve, allowlist passes — yet the executor
-    // is still the `activation_pending` stub: a reload cannot elevate frozen-OFF.
+    // is still the `activation_pending` stub: a real reload+rebuild cannot elevate
+    // frozen-OFF.
     expect(result.outcome).toBe("refused");
     expect(result.reason).toBe("activation_pending");
-    // And the direct authority read is still OFF after the reload.
     expect(hibernationRuntimeActive()).toBe(false);
   }, 30_000);
 
-  it("keeps a broker frozen ON authoritative while a settings reload changes only operational policy", async () => {
+  it("keeps a broker frozen ON authoritative across a REAL on-disk reload + rebuild that changes only operational policy", async () => {
     process.env[ACTIVATION_ENV] = "1";
     const stableId = brokerStableId("onpolicy");
-    const settings = settingsWith({ enabled: true, mode: "manual", allowedRepos: ["sub/repo"] });
-    const runtime = await startRealSubtree(stableId, settings);
+    const subtree = await startFileBackedSubtree(
+      stableId,
+      settingsWith({ enabled: true, mode: "manual", allowedRepos: ["sub/repo"] }),
+    );
     expect(hibernationRuntimeActive()).toBe(true);
 
-    const control = runtime.getHibernationRuntimeControl();
-    expect(control).not.toBeNull();
-    registerWorkerWithSpec(control!.db, {
+    // Register the worker + spec into the authoritative subtree DB BEFORE the reload;
+    // the rebuild re-opens the SAME persisted DB on the same stableId, so it survives.
+    const controlBefore = subtree.holder.runtime.getHibernationRuntimeControl();
+    expect(controlBefore).not.toBeNull();
+    registerWorkerWithSpec(controlBefore!.db, {
       agentId: "worker-on",
       stableId: `${os.hostname()}:session:/tmp/on.jsonl`,
       vcsIdentity: "sub/repo",
-      brokerOwnerId: control!.brokerInstanceId,
+      brokerOwnerId: controlBefore!.brokerInstanceId,
     });
 
     const centralDb = makeCentralDb();
 
-    // "Reload" flips operational policy OFF (enabled=false). Authority stays ON, so
-    // routing still resolves the target from the SUBTREE control DB: the refusal is
-    // `hibernation_disabled` (policy), NOT `unknown` (which a central-DB regression
-    // would produce, since the central fallback has no such agent).
-    settings.hibernation = { enabled: false, mode: "manual", allowedRepos: ["sub/repo"] };
-    const result = await routeHibernate(runtime, centralDb, settings, "worker-on");
+    // Real reload flips operational policy OFF (enabled=false) on disk. Authority
+    // stays ON across the rebuild, so routing still resolves the target from the
+    // (persisted) SUBTREE control DB: the refusal is `hibernation_disabled` (the
+    // reloaded policy took effect), NOT `unknown` (which a central-DB regression
+    // would produce, since the central fallback has no such agent) and NOT
+    // `activation_pending` (which losing frozen-ON would produce).
+    await subtree.reload(
+      settingsWith({ enabled: false, mode: "manual", allowedRepos: ["sub/repo"] }),
+    );
+    expect(hibernationRuntimeActive()).toBe(true);
+    const controlAfter = subtree.holder.runtime.getHibernationRuntimeControl();
+    expect(controlAfter).not.toBeNull();
+    expect(controlAfter!.db.getAgentById("worker-on")).toBeTruthy();
+
+    const result = await routeHibernate(
+      subtree.holder.runtime,
+      centralDb,
+      subtree.holder.settings,
+      "worker-on",
+    );
     expect(result.outcome).toBe("refused");
     expect(result.reason).toBe("hibernation_disabled");
     expect(hibernationRuntimeActive()).toBe(true);

--- a/slack-bridge/broker/hibernation-startup-ordering.test.ts
+++ b/slack-bridge/broker/hibernation-startup-ordering.test.ts
@@ -1,0 +1,145 @@
+// Proves the Phase B, Seam 3 startup ordering invariant against a REAL broker:
+// crash-stranded wake recovery runs (and completes) BEFORE the broker socket
+// begins accepting connections, so no incoming registration can race an
+// unreconciled `waking`/`hibernating` row. Uses the real `startBroker`
+// `beforeListen` hook wired to the real recovery composition — not a mock — and
+// a real socket-connect probe to pin the ordering. Fast + deterministic (no
+// pi/tmux), so it runs in normal CI.
+
+import * as net from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentLifecycleState } from "@pinet/broker-core/types";
+import { startBroker, type Broker } from "./index.js";
+import { BrokerDB } from "./schema.js";
+import {
+  createHibernationOrchestrator,
+  recoverStrandedWakesBeforeRegistrations,
+} from "./hibernation-activation.js";
+
+const dirs: string[] = [];
+let broker: Broker | null = null;
+
+afterEach(async () => {
+  if (broker) {
+    await broker.stop();
+    broker = null;
+  }
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/** Resolves true only if a client can actually connect to the unix socket. */
+function canConnect(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.createConnection(socketPath);
+    const finish = (ok: boolean): void => {
+      sock.destroy();
+      resolve(ok);
+    };
+    sock.once("connect", () => finish(true));
+    sock.once("error", () => finish(false));
+  });
+}
+
+/** Seed a real crash-stranded `waking` row (no held lease, no accepted generation). */
+function seedStrandedWaking(dbPath: string, agentId: string): void {
+  const db = new BrokerDB(dbPath);
+  db.initialize();
+  db.registerAgent(
+    agentId,
+    "Stranded",
+    "🦉",
+    4242,
+    { brokerManaged: true },
+    `h:session:/tmp/s.jsonl`,
+  );
+  const chain: AgentLifecycleState[] = ["grace", "idle", "hibernating", "hibernated", "waking"];
+  for (const toState of chain) {
+    const version = db.getAgentById(agentId)?.lifecycleVersion ?? 0;
+    db.transitionAgentLifecycle({
+      agentId,
+      expectedVersion: version,
+      toState,
+      reason: "seed",
+      actor: "broker",
+      correlationId: "seed",
+    });
+  }
+  db.close();
+}
+
+describe("Phase B, Seam 3 — stranded-wake recovery completes before the socket listens", () => {
+  it("reconciles a stranded row in beforeListen while the socket is still closed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pinet-hib-order-"));
+    dirs.push(dir);
+    const dbPath = join(dir, "b.db");
+    const socketPath = join(dir, "b.sock");
+    const lockPath = join(dir, "b.lock");
+
+    // A real crash-stranded `waking` row exists in the DB the broker will open.
+    seedStrandedWaking(dbPath, "stranded-1");
+
+    let connectableDuringBeforeListen: boolean | null = null;
+    let reconciledDuringBeforeListen = false;
+
+    broker = await startBroker({
+      dbPath,
+      socketPath,
+      lockPath,
+      beforeListen: async ({ db }) => {
+        // The socket must NOT be accepting connections yet…
+        connectableDuringBeforeListen = await canConnect(socketPath);
+        // …and the REAL recovery composition reconciles the stranded row here.
+        recoverStrandedWakesBeforeRegistrations(
+          createHibernationOrchestrator({
+            db,
+            brokerInstanceId: "startup-broker",
+            extensionEntryPath: "/opt/ext/index.js",
+            baseLaunchEnv: {},
+            inheritedEnvKeys: [],
+          }),
+        );
+        reconciledDuringBeforeListen =
+          db.getAgentById("stranded-1")?.lifecycleState === "reap-candidate";
+      },
+    });
+
+    // The socket was provably closed while recovery ran…
+    expect(connectableDuringBeforeListen).toBe(false);
+    // …recovery finished (fail-closed quarantine) before listen…
+    expect(reconciledDuringBeforeListen).toBe(true);
+    // …and only AFTER startBroker resolves is the socket accepting connections.
+    expect(await canConnect(socketPath)).toBe(true);
+    // The reconciliation is durable on the broker's authoritative DB.
+    expect(broker.db.getAgentById("stranded-1")?.lifecycleState).toBe("reap-candidate");
+  });
+
+  it("tears the broker down (no half-open listener) if beforeListen throws", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pinet-hib-order-"));
+    dirs.push(dir);
+    const socketPath = join(dir, "b.sock");
+
+    await expect(
+      startBroker({
+        dbPath: join(dir, "b.db"),
+        socketPath,
+        lockPath: join(dir, "b.lock"),
+        beforeListen: () => {
+          throw new Error("recovery boom");
+        },
+      }),
+    ).rejects.toThrow("recovery boom");
+
+    // The socket never opened, and the lock was released so a retry can start.
+    expect(await canConnect(socketPath)).toBe(false);
+    const retry = await startBroker({
+      dbPath: join(dir, "b.db"),
+      socketPath,
+      lockPath: join(dir, "b.lock"),
+    });
+    broker = retry;
+    expect(await canConnect(socketPath)).toBe(true);
+  });
+});

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -42,6 +42,15 @@ export interface BrokerOptions {
   lockPath?: string;
   meshSecret?: string;
   meshSecretPath?: string;
+  /**
+   * Runs after DB initialization but BEFORE the socket server begins listening
+   * (i.e. before any client can connect or register). Use for startup
+   * reconciliation — e.g. stranded-wake recovery — that must deterministically
+   * complete before an incoming registration can race it. If it throws, the
+   * broker is torn down (DB closed, lock released) and the error propagates so a
+   * failed reconciliation never leaves a half-open, already-listening broker.
+   */
+  beforeListen?: (ctx: { db: BrokerDB }) => void | Promise<void>;
 }
 
 export interface Broker {
@@ -103,6 +112,20 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
   const server = new BrokerSocketServer(db, target, {
     ...(resolvedMeshSecret ? { meshSecret: resolvedMeshSecret } : {}),
   });
+
+  // Run startup reconciliation strictly BEFORE the socket opens, so nothing can
+  // connect/register until it completes. A failure here must not leave a
+  // half-open broker: tear down before rethrowing (the server has not started).
+  if (options.beforeListen) {
+    try {
+      await options.beforeListen({ db });
+    } catch (err) {
+      db.close();
+      lock.release();
+      throw err;
+    }
+  }
+
   try {
     await server.start();
   } catch (err) {

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -62,6 +62,15 @@ export interface SlackBridgeSettings {
   hibernation?: {
     /** Master kill switch. Defaults false; waking/draining existing rows remains permitted. */
     enabled?: boolean;
+    /**
+     * Live-runtime activation gate (Phase B). Default false. Independent of and
+     * ANDed with `enabled`: only when BOTH are true does the broker compose the
+     * real process/tmux `HibernationOrchestrator` in place of the
+     * `activation_pending` stub, persist runtime specs at spawn, and run startup
+     * stranded-wake recovery. Left unset in production until an explicit,
+     * quiescent-boundary activation, so the default configuration is a no-op.
+     */
+    activateRuntimeAdapters?: boolean;
     mode?: "observe" | "manual" | "auto";
     allowedRepos?: string[];
     graceMs?: number;

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -62,15 +62,11 @@ export interface SlackBridgeSettings {
   hibernation?: {
     /** Master kill switch. Defaults false; waking/draining existing rows remains permitted. */
     enabled?: boolean;
-    /**
-     * Live-runtime activation gate (Phase B). Default false. Independent of and
-     * ANDed with `enabled`: only when BOTH are true does the broker compose the
-     * real process/tmux `HibernationOrchestrator` in place of the
-     * `activation_pending` stub, persist runtime specs at spawn, and run startup
-     * stranded-wake recovery. Left unset in production until an explicit,
-     * quiescent-boundary activation, so the default configuration is a no-op.
-     */
-    activateRuntimeAdapters?: boolean;
+    // NOTE: live-runtime activation (Phase B) is deliberately NOT a settings
+    // field. It is gated by a durable, non-reloadable process-launch authority
+    // (PINET_HIBERNATION_RUNTIME_ACTIVATION, frozen at broker start) so no
+    // settings edit or config reload can elevate a running broker into live
+    // process/tmux composition. See broker/hibernation-activation-authority.ts.
     mode?: "observe" | "manual" | "auto";
     allowedRepos?: string[];
     graceMs?: number;

--- a/slack-bridge/hibernation-config.ts
+++ b/slack-bridge/hibernation-config.ts
@@ -2,6 +2,8 @@ import type { SlackBridgeSettings } from "./helpers.js";
 
 export interface ResolvedHibernationSettings {
   enabled: boolean;
+  /** Phase B live-runtime activation gate (default false; ANDed with `enabled`). */
+  activateRuntimeAdapters: boolean;
   mode: "observe" | "manual" | "auto";
   allowedRepos: string[];
   graceMs: number;
@@ -18,6 +20,7 @@ export function resolveHibernationSettings(
   const value = settings.hibernation;
   return {
     enabled: value?.enabled === true,
+    activateRuntimeAdapters: value?.activateRuntimeAdapters === true,
     mode: value?.mode ?? "observe",
     allowedRepos: [...(value?.allowedRepos ?? [])],
     graceMs: value?.graceMs ?? 60 * 60_000,

--- a/slack-bridge/hibernation-config.ts
+++ b/slack-bridge/hibernation-config.ts
@@ -2,8 +2,6 @@ import type { SlackBridgeSettings } from "./helpers.js";
 
 export interface ResolvedHibernationSettings {
   enabled: boolean;
-  /** Phase B live-runtime activation gate (default false; ANDed with `enabled`). */
-  activateRuntimeAdapters: boolean;
   mode: "observe" | "manual" | "auto";
   allowedRepos: string[];
   graceMs: number;
@@ -20,7 +18,6 @@ export function resolveHibernationSettings(
   const value = settings.hibernation;
   return {
     enabled: value?.enabled === true,
-    activateRuntimeAdapters: value?.activateRuntimeAdapters === true,
     mode: value?.mode ?? "observe",
     allowedRepos: [...(value?.allowedRepos ?? [])],
     graceMs: value?.graceMs ?? 60 * 60_000,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -21,16 +21,9 @@ import { resolveReactionCommands } from "./reaction-triggers.js";
 import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
 import {
   collectAgentLifecycleStatuses,
-  executeHibernateCommand,
-  executeWakeCommand,
-  unknownHibernationTarget,
   type AgentLifecycleStatus,
-  type HibernateCommandExecutor,
-  type HibernationCommandPolicy,
   type HibernationCommandResult,
-  type WakeCommandExecutor,
 } from "@pinet/broker-core";
-import type { AgentInfo, AgentLifecycleState } from "@pinet/broker-core/types";
 import { resolveHibernationSettings } from "./hibernation-config.js";
 import type {
   PortLeaseAcquireInput,
@@ -104,10 +97,7 @@ import {
   getExtensionEntryPath,
   SUBTREE_INHERITED_ENV_KEYS,
 } from "./subtree-broker-runtime.js";
-import {
-  hibernationRuntimeActive,
-  createHibernationOrchestrator,
-} from "./broker/hibernation-activation.js";
+import { routeHibernationCommand } from "./broker/hibernation-command-router.js";
 import { createAgentCompletionRuntime } from "./agent-completion-runtime.js";
 import { sendBrokerMessage } from "./broker/message-send.js";
 import { SlackThreadStatusManager } from "./slack-thread-status.js";
@@ -958,109 +948,22 @@ export default function (pi: ExtensionAPI) {
     target: string,
     reason?: string,
   ): Promise<HibernationCommandResult> {
-    if (brokerRole !== "broker") {
-      throw new Error(
-        `pinet ${command} is broker-managed. Connect this session as the broker (/pinet start) to hibernate or wake workers.`,
-      );
-    }
-    const hib = resolveHibernationSettings(settings);
-
-    // Authoritative DB unification + explicit trust boundary. When the durable,
-    // non-reloadable runtime-activation authority is set, the SUBTREE broker is
-    // the authority that spawned and OWNS these workers AND authored their
-    // durable runtime specs, so hibernate/wake must resolve the target, read its
-    // authz spec, AND drive the orchestrator against that SAME subtree DB end to
-    // end. The operator may therefore only address workers this process's subtree
-    // broker owns. In the default-off configuration there is no runtime control,
-    // so resolution falls back to the central broker DB and the executor stays
-    // the `activation_pending` stub (a clear refusal, never a silent no-op).
-    const runtimeControl = hibernationRuntimeActive()
-      ? subtreeBrokerRuntime.getHibernationRuntimeControl()
-      : null;
-    const db = runtimeControl?.db ?? getActiveBrokerDb();
-    if (!db) throw new Error("Broker database is unavailable.");
-
-    const wanted = target.trim().replace(/^@/, "");
-    const agents = db.getAllAgents();
-    const lowerWanted = wanted.toLowerCase();
-    const nameMatches = agents.filter((a: AgentInfo) => a.name?.toLowerCase() === lowerWanted);
-    const agent =
-      agents.find((a: AgentInfo) => a.id === wanted) ??
-      agents.find((a: AgentInfo) => a.stableId === wanted) ??
-      (nameMatches.length === 1 ? nameMatches[0] : undefined);
-    if (!agent) return unknownHibernationTarget(command, target);
-
-    const policy: HibernationCommandPolicy = {
-      enabled: hib.enabled,
-      mode: hib.mode,
-      allowedRepos: hib.allowedRepos,
-    };
-    const state = (agent.lifecycleState ?? "live") as AgentLifecycleState;
-    // Provenance: the repo allowlist is a security boundary, so authorization
-    // trusts ONLY the broker-authored durable runtime spec's CANONICAL VCS
-    // IDENTITY (`owner/repo`), captured at spawn from the runtime's git remote.
-    // Ownership is NEVER inferred from filesystem directory names: a path-segment
-    // slug would collapse distinct roots that share their final segments (e.g.
-    // `/trusted/gugu91/extensions` and `/tmp/impostor/gugu91/extensions` both →
-    // `gugu91/extensions`), mis-derive ordinary layouts (`/Users/alice/projects/
-    // extensions` → `projects/extensions`), and turn worktree roots into
-    // `.worktrees/<branch>`. Matching the remote-derived identity instead means a
-    // repo shares one identity with all its worktrees and impostor roots never
-    // authorize. Mutable, worker-declared metadata is NEVER used as a fallback.
-    // When no trusted spec / resolvable remote exists the identifier stays null
-    // and the fail-closed gate refuses.
-    const repoIdentifier = db.getAgentRuntimeSpec(agent.id)?.vcsIdentity ?? null;
-
-    // Live process/tmux checkpoint/respawn adapters are a separate, explicitly
-    // gated activation step (default-off). Activation is authorized ONLY by the
-    // durable, non-reloadable process-launch authority captured at broker start
-    // (never agent-editable settings / config reload). When it is unset (the
-    // production default) `runtimeControl` is null and callers get a clear
-    // `activation_pending` refusal rather than a silent no-op. When set, the real
-    // process/tmux HibernationOrchestrator is composed over the SAME subtree DB
-    // that owns the worker and its spec, with `brokerInstanceId` matching the
-    // spawn/startup-recovery owner so lease fencing lines up. The woken worker's
-    // respawn env is the subtree broker's child-launch env (the socket/mesh it
-    // must reconnect to); inherited secret var NAMES come from the shared
-    // spawn/wake allowlist.
-    const executor: HibernateCommandExecutor & WakeCommandExecutor = runtimeControl
-      ? createHibernationOrchestrator({
-          db: runtimeControl.db,
-          brokerInstanceId: runtimeControl.brokerInstanceId,
-          extensionEntryPath: getExtensionEntryPath(),
-          baseLaunchEnv: runtimeControl.baseLaunchEnv,
-          inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
-          config: {
-            handshakeTimeoutMs: hib.handshakeTimeoutMs,
-            wakeLeaseMs: hib.wakeLeaseMs,
-            maxConcurrentWakes: hib.maxConcurrentWakes,
-            maxConcurrentWakesPerRepo: hib.maxConcurrentWakesPerRepo,
-          },
-        })
-      : {
-          prepareHibernation: () => ({ ready: false, state, reason: "activation_pending" }),
-          hibernate: async () => ({ ok: false, state, reason: "activation_pending" }),
-          wake: async () => ({ ok: false, state, reason: "activation_pending" }),
-        };
-
-    if (command === "hibernate") {
-      return executeHibernateCommand({
-        executor,
-        agentId: agent.id,
-        state,
-        repoIdentifier,
-        policy,
-        actor: "operator",
-        reason,
-      });
-    }
-    return executeWakeCommand({
-      executor,
-      agentId: agent.id,
-      state,
-      policy,
-      actor: "operator",
-      reason,
+    // Thin wrapper: DB-topology resolution + executor composition live in the
+    // extracted, independently-tested production router, so the live extension and
+    // the production-route E2E drive the exact same integration code. `brokerRole`,
+    // the runtime-activation authority (via the router's internal
+    // `hibernationRuntimeActive()` gate), the real subtree control accessor, and the
+    // central-DB fallback are all threaded through unchanged.
+    return routeHibernationCommand({
+      command,
+      target,
+      ...(reason !== undefined ? { reason } : {}),
+      brokerRole,
+      hib: resolveHibernationSettings(settings),
+      getRuntimeControl: () => subtreeBrokerRuntime.getHibernationRuntimeControl(),
+      getFallbackDb: () => getActiveBrokerDb(),
+      extensionEntryPath: getExtensionEntryPath(),
+      inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
     });
   }
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -963,7 +963,21 @@ export default function (pi: ExtensionAPI) {
         `pinet ${command} is broker-managed. Connect this session as the broker (/pinet start) to hibernate or wake workers.`,
       );
     }
-    const db = getActiveBrokerDb();
+    const hib = resolveHibernationSettings(settings);
+
+    // Authoritative DB unification + explicit trust boundary. When the durable,
+    // non-reloadable runtime-activation authority is set, the SUBTREE broker is
+    // the authority that spawned and OWNS these workers AND authored their
+    // durable runtime specs, so hibernate/wake must resolve the target, read its
+    // authz spec, AND drive the orchestrator against that SAME subtree DB end to
+    // end. The operator may therefore only address workers this process's subtree
+    // broker owns. In the default-off configuration there is no runtime control,
+    // so resolution falls back to the central broker DB and the executor stays
+    // the `activation_pending` stub (a clear refusal, never a silent no-op).
+    const runtimeControl = hibernationRuntimeActive()
+      ? subtreeBrokerRuntime.getHibernationRuntimeControl()
+      : null;
+    const db = runtimeControl?.db ?? getActiveBrokerDb();
     if (!db) throw new Error("Broker database is unavailable.");
 
     const wanted = target.trim().replace(/^@/, "");
@@ -976,7 +990,6 @@ export default function (pi: ExtensionAPI) {
       (nameMatches.length === 1 ? nameMatches[0] : undefined);
     if (!agent) return unknownHibernationTarget(command, target);
 
-    const hib = resolveHibernationSettings(settings);
     const policy: HibernationCommandPolicy = {
       enabled: hib.enabled,
       mode: hib.mode,
@@ -999,22 +1012,23 @@ export default function (pi: ExtensionAPI) {
     const repoIdentifier = db.getAgentRuntimeSpec(agent.id)?.vcsIdentity ?? null;
 
     // Live process/tmux checkpoint/respawn adapters are a separate, explicitly
-    // gated activation step (default-off). In the default disabled configuration
-    // the policy gate refuses before this executor is consulted; if hibernation
-    // is enabled but runtime activation is NOT, callers get a clear
-    // activation_pending refusal rather than a silent no-op. Only when BOTH
-    // `enabled` and `activateRuntimeAdapters` are set (Phase B) is the real
-    // process/tmux HibernationOrchestrator composed in this executor slot. The
-    // woken worker's respawn env is the subtree broker's child-launch env (the
-    // socket/mesh it must reconnect to); inherited secret var NAMES come from the
-    // shared spawn/wake allowlist.
-    const subtreeStatus = subtreeBrokerRuntime.getStatus();
-    const executor: HibernateCommandExecutor & WakeCommandExecutor = hibernationRuntimeActive(hib)
+    // gated activation step (default-off). Activation is authorized ONLY by the
+    // durable, non-reloadable process-launch authority captured at broker start
+    // (never agent-editable settings / config reload). When it is unset (the
+    // production default) `runtimeControl` is null and callers get a clear
+    // `activation_pending` refusal rather than a silent no-op. When set, the real
+    // process/tmux HibernationOrchestrator is composed over the SAME subtree DB
+    // that owns the worker and its spec, with `brokerInstanceId` matching the
+    // spawn/startup-recovery owner so lease fencing lines up. The woken worker's
+    // respawn env is the subtree broker's child-launch env (the socket/mesh it
+    // must reconnect to); inherited secret var NAMES come from the shared
+    // spawn/wake allowlist.
+    const executor: HibernateCommandExecutor & WakeCommandExecutor = runtimeControl
       ? createHibernationOrchestrator({
-          db,
-          brokerInstanceId: getActiveBrokerSelfId() ?? subtreeStatus.selfAgentId ?? "broker",
+          db: runtimeControl.db,
+          brokerInstanceId: runtimeControl.brokerInstanceId,
           extensionEntryPath: getExtensionEntryPath(),
-          baseLaunchEnv: subtreeStatus.childLaunchEnv,
+          baseLaunchEnv: runtimeControl.baseLaunchEnv,
           inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
           config: {
             handshakeTimeoutMs: hib.handshakeTimeoutMs,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -99,7 +99,15 @@ import {
 import { createPinetRegistrationGate } from "./pinet-registration-gate.js";
 import { createBrokerRuntimeAccess } from "./broker-runtime-access.js";
 import { createInboxDrainRuntime } from "./inbox-drain-runtime.js";
-import { createSubtreeBrokerRuntime } from "./subtree-broker-runtime.js";
+import {
+  createSubtreeBrokerRuntime,
+  getExtensionEntryPath,
+  SUBTREE_INHERITED_ENV_KEYS,
+} from "./subtree-broker-runtime.js";
+import {
+  hibernationRuntimeActive,
+  createHibernationOrchestrator,
+} from "./broker/hibernation-activation.js";
 import { createAgentCompletionRuntime } from "./agent-completion-runtime.js";
 import { sendBrokerMessage } from "./broker/message-send.js";
 import { SlackThreadStatusManager } from "./slack-thread-status.js";
@@ -991,15 +999,35 @@ export default function (pi: ExtensionAPI) {
     const repoIdentifier = db.getAgentRuntimeSpec(agent.id)?.vcsIdentity ?? null;
 
     // Live process/tmux checkpoint/respawn adapters are a separate, explicitly
-    // gated activation step (default-off, unactivated). In the default disabled
-    // configuration the policy gate refuses before this executor is consulted;
-    // if hibernation is enabled without adapters wired, callers get a clear
-    // activation_pending refusal rather than a silent no-op.
-    const executor: HibernateCommandExecutor & WakeCommandExecutor = {
-      prepareHibernation: () => ({ ready: false, state, reason: "activation_pending" }),
-      hibernate: async () => ({ ok: false, state, reason: "activation_pending" }),
-      wake: async () => ({ ok: false, state, reason: "activation_pending" }),
-    };
+    // gated activation step (default-off). In the default disabled configuration
+    // the policy gate refuses before this executor is consulted; if hibernation
+    // is enabled but runtime activation is NOT, callers get a clear
+    // activation_pending refusal rather than a silent no-op. Only when BOTH
+    // `enabled` and `activateRuntimeAdapters` are set (Phase B) is the real
+    // process/tmux HibernationOrchestrator composed in this executor slot. The
+    // woken worker's respawn env is the subtree broker's child-launch env (the
+    // socket/mesh it must reconnect to); inherited secret var NAMES come from the
+    // shared spawn/wake allowlist.
+    const subtreeStatus = subtreeBrokerRuntime.getStatus();
+    const executor: HibernateCommandExecutor & WakeCommandExecutor = hibernationRuntimeActive(hib)
+      ? createHibernationOrchestrator({
+          db,
+          brokerInstanceId: getActiveBrokerSelfId() ?? subtreeStatus.selfAgentId ?? "broker",
+          extensionEntryPath: getExtensionEntryPath(),
+          baseLaunchEnv: subtreeStatus.childLaunchEnv,
+          inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
+          config: {
+            handshakeTimeoutMs: hib.handshakeTimeoutMs,
+            wakeLeaseMs: hib.wakeLeaseMs,
+            maxConcurrentWakes: hib.maxConcurrentWakes,
+            maxConcurrentWakesPerRepo: hib.maxConcurrentWakesPerRepo,
+          },
+        })
+      : {
+          prepareHibernation: () => ({ ready: false, state, reason: "activation_pending" }),
+          hibernate: async () => ({ ok: false, state, reason: "activation_pending" }),
+          wake: async () => ({ ok: false, state, reason: "activation_pending" }),
+        };
 
     if (command === "hibernate") {
       return executeHibernateCommand({

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -27,6 +27,13 @@ import {
   type PinetRemoteControlRequestResult,
   type SlackBridgeSettings,
 } from "./helpers.js";
+import { resolveHibernationSettings } from "./hibernation-config.js";
+import {
+  hibernationRuntimeActive,
+  createHibernationOrchestrator,
+  persistSpawnedRuntimeSpec,
+  recoverStrandedWakesBeforeRegistrations,
+} from "./broker/hibernation-activation.js";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_SPAWN_REGISTRATION_TIMEOUT_MS = 45_000;
@@ -280,11 +287,27 @@ function buildTmuxMonitorCommand(sessionName: string, socketPath: string | null)
   return `tmux ${socketArgs}attach -t ${quoteShellValue(sessionName)}`;
 }
 
-function getExtensionEntryPath(): string {
+export function getExtensionEntryPath(): string {
   const currentPath = fileURLToPath(import.meta.url);
   const extension = path.extname(currentPath) || ".js";
   return path.join(path.dirname(currentPath), `index${extension}`);
 }
+
+/**
+ * Broker env var NAMES (never values) a spawned — or later WOKEN — worker
+ * re-exports to re-establish itself. Single source of truth shared by the
+ * ordinary spawn launcher and the Phase B wake path so both stay in lockstep.
+ */
+export const SUBTREE_INHERITED_ENV_KEYS = [
+  "PI_CODING_AGENT_DIR",
+  "PI_CODING_AGENT_SESSION_DIR",
+  "PI_OFFLINE",
+  "PI_SETTINGS_PATH",
+  "PINET_MESH_SECRET",
+  "PINET_MESH_SECRET_PATH",
+  "SLACK_APP_TOKEN",
+  "SLACK_BOT_TOKEN",
+];
 
 function childStartupPrompt(parentAgentId: string): string {
   return [
@@ -659,6 +682,30 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       `${stableId}:subtree-broker`,
     );
 
+    // Phase B, Seam 3 (default-off): reconcile crash-stranded wake rows BEFORE
+    // this broker accepts (resolves) any new worker registration, so a stranded
+    // waking/dispatching row is completed/quarantined/requeued deterministically
+    // instead of racing an incoming (possibly duplicate) wake registration. A
+    // no-op unless hibernation runtime activation is explicitly enabled.
+    const startupHib = resolveHibernationSettings(deps.getSettings());
+    if (hibernationRuntimeActive(startupHib)) {
+      recoverStrandedWakesBeforeRegistrations(
+        createHibernationOrchestrator({
+          db: broker.db,
+          brokerInstanceId: selfAgent.id,
+          extensionEntryPath: getExtensionEntryPath(),
+          baseLaunchEnv: buildChildLaunchEnv(paths, selfAgent.id),
+          inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
+          config: {
+            handshakeTimeoutMs: startupHib.handshakeTimeoutMs,
+            wakeLeaseMs: startupHib.wakeLeaseMs,
+            maxConcurrentWakes: startupHib.maxConcurrentWakes,
+            maxConcurrentWakesPerRepo: startupHib.maxConcurrentWakesPerRepo,
+          },
+        }),
+      );
+    }
+
     broker.server.setAgentRegistrationResolver((registration) => {
       const role = deps.getMeshRoleFromMetadata(registration.metadata, "worker");
       const identity = generateAgentName(registration.stableId ?? registration.agentId, role);
@@ -758,6 +805,31 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     });
     const updatedRecord: SubtreeWorkerRecord = { ...workerRecord, agentId: agent.id };
     spawnedWorkers.set(launchId, updatedRecord);
+
+    // Phase B, Seam 2 (default-off): record a durable, broker-authored runtime
+    // spec so this freshly-registered worker is hibernatable/wakeable later. The
+    // authz VCS identity is derived from the repo's REAL git remote (never the
+    // directory name); an unresolvable remote or non-durable locator set fails
+    // closed (no spec persisted). No-op unless runtime activation is enabled.
+    const spawnHib = resolveHibernationSettings(deps.getSettings());
+    if (hibernationRuntimeActive(spawnHib)) {
+      await persistSpawnedRuntimeSpec(activeBroker.db, {
+        agentId: agent.id,
+        stableId: agent.stableId ?? "",
+        brokerOwnerId: selfAgentId,
+        cwd: repoPath,
+        repoRoot: repoPath,
+        worktreePath: repoPath,
+        tmuxSocket: tmuxSocketPath ?? "",
+        tmuxSession: sessionName,
+        tmuxTarget: sessionName,
+        extensionEntryPath: getExtensionEntryPath(),
+        envAllowlist: Object.keys(childLaunchEnv),
+        configFingerprint: "subtree-broker-tmux",
+        expectedUser: os.userInfo().username,
+        launchSource: "subtree-broker-tmux",
+      });
+    }
 
     const messageResult = await sendMessage(agent.id, input.task, {
       subtreeTask: true,

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -34,6 +34,8 @@ import {
   persistSpawnedRuntimeSpec,
   recoverStrandedWakesBeforeRegistrations,
 } from "./broker/hibernation-activation.js";
+import { freezeHibernationActivationAuthority } from "./broker/hibernation-activation-authority.js";
+import type { BrokerDB } from "./broker/schema.js";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_SPAWN_REGISTRATION_TIMEOUT_MS = 45_000;
@@ -139,8 +141,27 @@ export interface SubtreeBrokerRuntimeDeps {
   formatError: (error: unknown) => string;
 }
 
+/**
+ * The authoritative hibernation runtime surface for this process's subtree
+ * broker. The subtree broker is the authority that spawns and OWNS its workers
+ * and authors their durable runtime specs, so hibernate/wake must resolve the
+ * target, read its authz spec, and drive the orchestrator against THIS same
+ * authoritative DB end to end. The explicit trust boundary: the operator command
+ * may only address workers this subtree broker owns. Null when no subtree broker
+ * is running (nothing is command-addressable).
+ */
+export interface SubtreeHibernationRuntimeControl {
+  /** The single authoritative DB that owns the spawned workers + their specs. */
+  db: BrokerDB;
+  /** Broker instance id recorded on lifecycle leases; matches startup recovery. */
+  brokerInstanceId: string;
+  /** Base PINET_* env re-establishing the mesh connection for a woken worker. */
+  baseLaunchEnv: Record<string, string>;
+}
+
 export interface SubtreeBrokerRuntime {
   start: (ctx: ExtensionContext) => Promise<SubtreeBrokerStatus>;
+  getHibernationRuntimeControl: () => SubtreeHibernationRuntimeControl | null;
   stop: (options?: { releaseIdentity?: boolean; stopChildren?: boolean }) => Promise<void>;
   getStatus: () => SubtreeBrokerStatus;
   readInbox: (options?: PinetReadOptions) => PinetReadResult | null;
@@ -657,15 +678,52 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     const paths = buildSubtreeBrokerPaths(stableId);
     fs.mkdirSync(paths.rootDir, { recursive: true });
     const meshAuth = resolvePinetMeshAuth(deps.getSettings());
+
+    // Capture the durable, process-lifetime activation authority at broker start
+    // (frozen; never re-read from reloadable settings) and resolve the self id up
+    // front so Phase B, Seam 3 startup stranded-wake recovery can run inside
+    // `beforeListen` — strictly BEFORE the socket accepts any registration.
+    freezeHibernationActivationAuthority();
+    const selfId = buildSelfAgentId(stableId);
+    const runtimeActive = hibernationRuntimeActive();
+    const startupHib = resolveHibernationSettings(deps.getSettings());
+
     const broker = await startBroker({
       dbPath: paths.dbPath,
       socketPath: paths.socketPath,
       lockPath: paths.lockPath,
       ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
       ...(meshAuth.meshSecretPath ? { meshSecretPath: meshAuth.meshSecretPath } : {}),
+      ...(runtimeActive
+        ? {
+            beforeListen: ({ db }) => {
+              // Phase B, Seam 3 (default-off): reconcile crash-stranded wake rows
+              // on THIS broker's authoritative DB BEFORE it begins listening, so
+              // a stranded waking/hibernating row is completed/quarantined/
+              // requeued deterministically instead of racing an incoming
+              // (possibly duplicate) wake registration. Pure DB reconciliation;
+              // launches nothing. `selfId` equals the self-agent id registered
+              // below, so recovery's lease ownership matches the live wake path.
+              recoverStrandedWakesBeforeRegistrations(
+                createHibernationOrchestrator({
+                  db,
+                  brokerInstanceId: selfId,
+                  extensionEntryPath: getExtensionEntryPath(),
+                  baseLaunchEnv: buildChildLaunchEnv(paths, selfId),
+                  inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
+                  config: {
+                    handshakeTimeoutMs: startupHib.handshakeTimeoutMs,
+                    wakeLeaseMs: startupHib.wakeLeaseMs,
+                    maxConcurrentWakes: startupHib.maxConcurrentWakes,
+                    maxConcurrentWakesPerRepo: startupHib.maxConcurrentWakesPerRepo,
+                  },
+                }),
+              );
+            },
+          }
+        : {}),
     });
 
-    const selfId = buildSelfAgentId(stableId);
     const { name, emoji } = deps.getAgentIdentity();
     const metadata = {
       ...(await deps.getAgentMetadata("broker")),
@@ -681,30 +739,6 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       metadata,
       `${stableId}:subtree-broker`,
     );
-
-    // Phase B, Seam 3 (default-off): reconcile crash-stranded wake rows BEFORE
-    // this broker accepts (resolves) any new worker registration, so a stranded
-    // waking/dispatching row is completed/quarantined/requeued deterministically
-    // instead of racing an incoming (possibly duplicate) wake registration. A
-    // no-op unless hibernation runtime activation is explicitly enabled.
-    const startupHib = resolveHibernationSettings(deps.getSettings());
-    if (hibernationRuntimeActive(startupHib)) {
-      recoverStrandedWakesBeforeRegistrations(
-        createHibernationOrchestrator({
-          db: broker.db,
-          brokerInstanceId: selfAgent.id,
-          extensionEntryPath: getExtensionEntryPath(),
-          baseLaunchEnv: buildChildLaunchEnv(paths, selfAgent.id),
-          inheritedEnvKeys: SUBTREE_INHERITED_ENV_KEYS,
-          config: {
-            handshakeTimeoutMs: startupHib.handshakeTimeoutMs,
-            wakeLeaseMs: startupHib.wakeLeaseMs,
-            maxConcurrentWakes: startupHib.maxConcurrentWakes,
-            maxConcurrentWakesPerRepo: startupHib.maxConcurrentWakesPerRepo,
-          },
-        }),
-      );
-    }
 
     broker.server.setAgentRegistrationResolver((registration) => {
       const role = deps.getMeshRoleFromMetadata(registration.metadata, "worker");
@@ -810,9 +844,11 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     // spec so this freshly-registered worker is hibernatable/wakeable later. The
     // authz VCS identity is derived from the repo's REAL git remote (never the
     // directory name); an unresolvable remote or non-durable locator set fails
-    // closed (no spec persisted). No-op unless runtime activation is enabled.
-    const spawnHib = resolveHibernationSettings(deps.getSettings());
-    if (hibernationRuntimeActive(spawnHib)) {
+    // closed (no spec persisted). No-op unless the durable, non-reloadable
+    // runtime-activation authority is set. Persisted into `activeBroker.db` — the
+    // SAME authoritative DB the hibernate/wake command path resolves against via
+    // `getHibernationRuntimeControl`.
+    if (hibernationRuntimeActive()) {
       await persistSpawnedRuntimeSpec(activeBroker.db, {
         agentId: agent.id,
         stableId: agent.stableId ?? "",
@@ -859,8 +895,18 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     };
   }
 
+  function getHibernationRuntimeControl(): SubtreeHibernationRuntimeControl | null {
+    if (!activeBroker || !selfAgentId || !activePaths) return null;
+    return {
+      db: activeBroker.db,
+      brokerInstanceId: selfAgentId,
+      baseLaunchEnv: buildChildLaunchEnv(activePaths, selfAgentId),
+    };
+  }
+
   return {
     start,
+    getHibernationRuntimeControl,
     stop,
     getStatus,
     readInbox,


### PR DESCRIPTION
Follow-up to #927 (merged). Wires the live hibernation **runtime adapters** into the broker's three live seams, **all behind a new default-off gate** `hibernation.activateRuntimeAdapters` (ANDed with `enabled`). The default configuration is a strict **no-op**: the operator command keeps returning `activation_pending`, and no spawn/startup runtime work runs.

## Seams (new module `broker/hibernation-activation.ts`)
- **Seam 1 — `index.ts` executor:** under the gate, the real process/tmux `HibernationOrchestrator` replaces the `activation_pending` stub in the operator command executor; otherwise the exact current stub. The woken worker's respawn env is the subtree broker's child-launch env; inherited secret var **names** come from the shared spawn/wake allowlist.
- **Seam 2 — subtree spawn:** persist a durable, broker-authored runtime spec with **git-remote-derived `owner/repo` VCS identity** (never the directory name). Fails closed on an unresolvable remote or a non-durable locator (nothing persisted).
- **Seam 3 — subtree start:** reconcile crash-stranded wake rows **before** the broker installs its registration resolver.
- Shares the spawn/wake inherited-env allowlist + extension-entry helper as a single source of truth.

## Default-off / safety
- No live config flip, no broker reload in this PR. Live activation is a separate, explicitly-approved step (Phase C).
- With the gate unset (production default), behavior is identical to post-#927 `main` (verified: `activation_pending` stub intact, no spawn/startup side effects).

## Evidence
- `tsc`, `eslint`, `lint:agent-standards`: pass
- **8 focused activation tests** against real BrokerDB + real git: gate truth-table; composition contract (`instanceof` + executor methods); Seam-2 spec/VCS persistence incl. 4 fail-closed cases; Seam-3 delegation + a real stranded `waking` → `reap-candidate` reconciliation
- **broker suite: 553 passed**, 2 skipped; full slack-bridge suite: 1559 passed — no regressions
- **Materially-real E2E** (`broker/hibernation-activation.e2e.test.ts`, opt-in `HIBERNATION_E2E=1`): real `HibernationOrchestrator` + real Seam-2 spec + real BrokerDB + disposable `pi`/tmux/git drives `checkpoint → stop (session survives, pane dead) → respawn → generation accepted → live`, `runtimeGeneration=1`, VCS identity from the real remote. Only the socket-registration RPC is stood in for (broker-core's domain, already fenced-tested), keyed off the REAL process coming back alive.

## Reviewer notes
Please review at the exact head. Key files: `broker/hibernation-activation.ts` (composition), `index.ts` (Seam 1), `subtree-broker-runtime.ts` (Seams 2/3), `hibernation-config.ts` + `helpers.ts` (gate).


---

## Remediation (review round 2 — head `365c413`)

Addresses all three P1 blockers plus the P2 E2E gap from the first review.

### P1.1 — Frozen, non-reloadable activation authority
- New `broker/hibernation-activation-authority.ts`: captures `PINET_HIBERNATION_RUNTIME_ACTIVATION` **once at broker start** and freezes it for the process lifetime. No settings edit or config reload can elevate a running broker into live process/tmux composition.
- Removed the agent-writable `hibernation.activateRuntimeAdapters` settings field (`helpers.ts`, `hibernation-config.ts`). `hibernationRuntimeActive()` is now **parameterless** and reads only the frozen authority.
- `enabled` / `mode` / `allowedRepos` remain a **separate command-layer policy** (they gate *permission*, not *whether the machinery is wired in at all*).
- The subtree broker calls `freezeHibernationActivationAuthority()` at start for a deterministic freeze point.

### P1.2 — Unified authoritative-DB routing + explicit trust boundary
- `subtree-broker-runtime` now exposes `getHibernationRuntimeControl()`: the subtree broker's **authoritative DB**, `brokerInstanceId`, and child launch env.
- `runHibernationCommand` resolves the target, its authz runtime spec, **and** the orchestrator against that **same subtree DB** — where spawn persists specs (Seam 2) and startup recovery runs (Seam 3) — instead of the central broker DB. Default-off stays on the `activation_pending` stub over the central DB.

### P1.3 — Recovery strictly before the socket accepts registrations
- `startBroker` gains a `beforeListen` hook that runs after DB init and **before** `server.start()`; on failure it tears down (`db.close()` + `lock.release()`) so a failed reconciliation never leaves a half-open, listening broker.
- Seam 3 stranded-wake recovery moved into `beforeListen` (`brokerInstanceId = selfId`, matching the registered self-agent and the live wake path). Old post-start recovery block removed.

### P2 — Production-route + ordering proof
- `hibernation-startup-ordering.test.ts` (fast, in CI): real `startBroker` + real recovery in `beforeListen` + a real socket-connect probe prove recovery completes **while the socket is still closed**, and that a `beforeListen` throw tears the broker down (no half-open listener).
- `hibernation-activation.e2e.test.ts` (opt-in `HIBERNATION_E2E=1`) rewritten to a **production route**: frozen authority (+ reload-resistance), real `startBroker` authoritative DB, pre-listen stranded-wake recovery, Seam 2 spec persisted into that DB, and hibernate/wake driven through the real `executeHibernateCommand` / `executeWakeCommand` wrappers (incl. a **negative repo-allowlist refusal** proving DB-sourced identity authorization) over a real `pi`/tmux runtime.
- Authority unit tests cover default-off, settings-cannot-activate, accepted/rejected values, and process-lifetime freeze.

### Gates (local, head `365c413`)
- `tsc --noEmit`: pass
- `eslint` (touched files): pass
- `lint:agent-standards`: pass
- focused authority + startup-ordering tests: 13 passed
- broker suite: 558 passed, 2 skipped
- full slack-bridge suite: 1564 passed, 2 skipped
- disposable real pi/tmux E2E (`HIBERNATION_E2E=1`): 1 passed

Still **default-off**: no config flip, broker reload, or live activation.
