### PR TITLE
PoC: Claude Code as a Pinet mesh participant (headless worker + interactive follower)

### DIFF
--- a/claude-code-worker/LICENSE
+++ b/claude-code-worker/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Will Porcellini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/claude-code-worker/README.md
+++ b/claude-code-worker/README.md
@@ -1,0 +1,35 @@
+# @pinet/claude-code-worker
+
+Join the local Pinet mesh as a worker whose runtime is headless Claude Code.
+
+## What it does
+
+A standalone daemon (not a pi extension) that speaks the broker's JSON-RPC
+socket protocol directly:
+
+- authenticates with the mesh secret and registers as a worker agent
+  (broker-assigned identity by default, stable across restarts)
+- heartbeats with live metadata (workdir, repo, `runtime:claude-code` tags)
+- polls its inbox, claims Slack threads it works on, and executes each task
+  with `claude -p --dangerously-skip-permissions --output-format json`
+- maps mesh threads to Claude Code sessions so follow-ups resume context
+  (`--resume`)
+- sends replies back through the broker (Slack threads or agent-to-agent)
+- honors `exit` and `interrupt` control commands from the mesh
+
+## Run
+
+```bash
+pnpm --filter @pinet/claude-code-worker build
+node claude-code-worker/dist/cli.js --workdir ~/projects/my-repo
+```
+
+`--help` lists all options. Persistent config lives in
+`~/.pi/claude-code-worker/config.json`; session and identity state in the same
+directory.
+
+## Status
+
+Local trial. Not published; the broker client here is a lean local copy of the
+worker-lifecycle subset of `slack-bridge/broker/client.ts` pending a shared
+client extraction (see `plans/slack-split-proposal.md`).

--- a/claude-code-worker/README.md
+++ b/claude-code-worker/README.md
@@ -1,8 +1,10 @@
 # @pinet/claude-code-worker
 
-Join the local Pinet mesh as a worker whose runtime is headless Claude Code.
+Join the local Pinet mesh from Claude Code — as a headless worker daemon, or
+as an interactive follower (the Claude Code equivalent of `/pinet follow`).
+Design note: `plans/claude-code-follower.md`.
 
-## What it does
+## Headless worker (`pinet-claude-worker`)
 
 A standalone daemon (not a pi extension) that speaks the broker's JSON-RPC
 socket protocol directly:
@@ -27,6 +29,35 @@ node claude-code-worker/dist/cli.js --workdir ~/projects/my-repo
 `--help` lists all options. Persistent config lives in
 `~/.pi/claude-code-worker/config.json`; session and identity state in the same
 directory.
+
+## Interactive follower (`mcp` + `wait` subcommands)
+
+Makes a live interactive Claude Code session behave like `/pinet follow` in
+pi. Three parts:
+
+- **`pinet-claude-worker mcp`** — a stdio MCP server (register it in Claude
+  Code user scope as `pinet`). Embeds the follower bridge: broker
+  registration/heartbeat/poll/spool/ack/claim, exposed to the model as
+  `pinet_follow`, `pinet_read`, `pinet_send`, `pinet_agents`, `pinet_status`,
+  `pinet_unfollow`. Lives and dies with the session, so registration cleans
+  itself up.
+- **`pinet-claude-worker wait --socket <path>`** — the waiter: blocks on the
+  bridge's per-session socket until messages are pending, then exits. The
+  session runs it as a background task; its exit wakes the conversation —
+  Claude Code's equivalent of pi's follow-up message injection.
+- **the `pinet-follow` skill** (`skills/pinet-follow/SKILL.md`) — drives the
+  loop: follow → arm waiter → on wake read/handle/send → re-arm.
+
+Setup on a machine:
+
+```bash
+claude mcp add --scope user pinet -- node <repo>/claude-code-worker/dist/cli.js mcp
+ln -s <repo>/claude-code-worker/skills/pinet-follow ~/.claude/skills/pinet-follow
+```
+
+Then in any Claude Code session: `/pinet-follow`. Mesh `exit` control is
+honored; `interrupt`/`reload` are declined politely (interactive turns cannot
+be interrupted externally).
 
 ## Status
 

--- a/claude-code-worker/broker-client.test.ts
+++ b/claude-code-worker/broker-client.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  INITIAL_RECONNECT_DELAY_MS,
+  MAX_RECONNECT_DELAY_MS,
+  computeReconnectDelay,
+  splitJsonRpcLines,
+} from "./broker-client.js";
+
+describe("splitJsonRpcLines", () => {
+  it("returns complete lines and keeps the partial tail", () => {
+    const { lines, rest } = splitJsonRpcLines('{"id":1}\n{"id":2}\n{"id":3');
+    expect(lines).toEqual(['{"id":1}', '{"id":2}']);
+    expect(rest).toBe('{"id":3');
+  });
+
+  it("skips blank lines", () => {
+    const { lines, rest } = splitJsonRpcLines('\n\n{"id":1}\n\n');
+    expect(lines).toEqual(['{"id":1}']);
+    expect(rest).toBe("");
+  });
+});
+
+describe("computeReconnectDelay", () => {
+  it("backs off exponentially from the initial delay", () => {
+    expect(computeReconnectDelay(0)).toBe(INITIAL_RECONNECT_DELAY_MS);
+    expect(computeReconnectDelay(1)).toBe(INITIAL_RECONNECT_DELAY_MS * 2);
+  });
+
+  it("caps at the max delay", () => {
+    expect(computeReconnectDelay(20)).toBe(MAX_RECONNECT_DELAY_MS);
+  });
+});

--- a/claude-code-worker/broker-client.ts
+++ b/claude-code-worker/broker-client.ts
@@ -1,0 +1,357 @@
+import * as net from "node:net";
+
+/**
+ * Lean Pinet broker client for non-Pi worker runtimes.
+ *
+ * Speaks the broker's newline-delimited JSON-RPC 2.0 protocol over the local
+ * Unix socket. Covers the worker-lifecycle subset of the reference client in
+ * `slack-bridge/broker/client.ts`: auth, register, heartbeat, inbox poll/ack,
+ * thread claim, message send, status updates, and agent-to-agent messaging.
+ */
+
+export const REQUEST_TIMEOUT_MS = 5000;
+export const HEARTBEAT_INTERVAL_MS = 5000;
+export const INITIAL_RECONNECT_DELAY_MS = 1000;
+export const MAX_RECONNECT_DELAY_MS = 30000;
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface InboxItem {
+  inboxId: number;
+  message: {
+    id: number;
+    threadId: string;
+    source: string;
+    direction: string;
+    sender: string;
+    body: string;
+    metadata: Record<string, unknown> | null;
+    createdAt: string;
+  };
+}
+
+export interface RegistrationInput {
+  name: string;
+  emoji: string;
+  stableId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RegistrationResult {
+  agentId: string;
+  name: string;
+  emoji: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface MessageSendInput {
+  threadId: string;
+  body: string;
+  agentName?: string;
+  agentEmoji?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Split buffered socket data into complete JSON lines plus the trailing partial line. */
+export function splitJsonRpcLines(buffer: string): { lines: string[]; rest: string } {
+  const parts = buffer.split("\n");
+  const rest = parts.pop() ?? "";
+  return { lines: parts.filter((line) => line.trim().length > 0), rest };
+}
+
+/** Compute reconnect delay with exponential backoff, capped. */
+export function computeReconnectDelay(attempt: number): number {
+  return Math.min(INITIAL_RECONNECT_DELAY_MS * Math.pow(2, attempt), MAX_RECONNECT_DELAY_MS);
+}
+
+interface PendingRequest {
+  method: string;
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class WorkerBrokerClient {
+  private readonly socketPath: string;
+  private readonly meshSecret: string | null;
+  private socket: net.Socket | null = null;
+  private connected = false;
+  private shuttingDown = false;
+  private buffer = "";
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private registration: RegistrationInput | null = null;
+  private identity: RegistrationResult | null = null;
+  private heartbeatMetadataProvider: (() => Record<string, unknown> | undefined) | null = null;
+  private disconnectedHandler: (() => void) | null = null;
+  private reconnectedHandler: (() => void) | null = null;
+
+  constructor(options: { socketPath: string; meshSecret?: string | null }) {
+    this.socketPath = options.socketPath;
+    this.meshSecret = options.meshSecret?.trim() || null;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getIdentity(): RegistrationResult | null {
+    return this.identity ? { ...this.identity } : null;
+  }
+
+  onDisconnected(handler: () => void): void {
+    this.disconnectedHandler = handler;
+  }
+
+  onReconnected(handler: () => void): void {
+    this.reconnectedHandler = handler;
+  }
+
+  setHeartbeatMetadataProvider(provider: (() => Record<string, unknown> | undefined) | null): void {
+    this.heartbeatMetadataProvider = provider;
+  }
+
+  async connect(): Promise<void> {
+    this.shuttingDown = false;
+    await this.connectSocket();
+    if (this.meshSecret) {
+      await this.request("auth", { secret: this.meshSecret });
+    }
+  }
+
+  async register(input: RegistrationInput): Promise<RegistrationResult> {
+    this.registration = input;
+    const result = (await this.request("register", {
+      name: input.name,
+      emoji: input.emoji,
+      pid: process.pid,
+      ...(input.stableId ? { stableId: input.stableId } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    })) as RegistrationResult;
+    this.identity = result;
+    this.startHeartbeat();
+    return result;
+  }
+
+  async disconnectGracefully(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.stopHeartbeat();
+    if (this.connected) {
+      try {
+        await this.request("unregister");
+      } catch {
+        /* best effort */
+      }
+    }
+    this.destroySocket();
+  }
+
+  async pollInbox(): Promise<InboxItem[]> {
+    return (await this.request("inbox.poll")) as InboxItem[];
+  }
+
+  async ackMessages(ids: number[]): Promise<void> {
+    if (ids.length === 0) return;
+    await this.request("inbox.ack", { ids });
+  }
+
+  async messageSend(input: MessageSendInput): Promise<void> {
+    await this.request("message.send", {
+      threadId: input.threadId,
+      body: input.body,
+      ...(input.agentName ? { agentName: input.agentName } : {}),
+      ...(input.agentEmoji ? { agentEmoji: input.agentEmoji } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    });
+  }
+
+  async claimThread(threadId: string): Promise<{ claimed: boolean }> {
+    return (await this.request("thread.claim", { threadId })) as { claimed: boolean };
+  }
+
+  async updateStatus(status: "working" | "idle"): Promise<void> {
+    await this.request("status.update", { status });
+  }
+
+  async sendAgentMessage(
+    target: string,
+    body: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    await this.request("agent.message", {
+      targetAgent: target,
+      body,
+      ...(metadata ? { metadata } : {}),
+    });
+  }
+
+  // ─── Transport ───────────────────────────────────────
+
+  private request(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    if (!this.connected || !this.socket) {
+      return Promise.reject(new Error(`Not connected to broker (method: ${method})`));
+    }
+
+    const id = this.nextId++;
+    const line =
+      JSON.stringify({ jsonrpc: "2.0", id, method, ...(params ? { params } : {}) }) + "\n";
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Request timed out: ${method}`));
+      }, REQUEST_TIMEOUT_MS);
+
+      this.pending.set(id, { method, resolve, reject, timer });
+      this.socket!.write(line, "utf-8", (err) => {
+        if (err) {
+          clearTimeout(timer);
+          this.pending.delete(id);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  private onData(chunk: string): void {
+    const { lines, rest } = splitJsonRpcLines(this.buffer + chunk);
+    this.buffer = rest;
+    for (const line of lines) {
+      let msg: JsonRpcResponse;
+      try {
+        msg = JSON.parse(line) as JsonRpcResponse;
+      } catch {
+        continue;
+      }
+      const entry = this.pending.get(msg.id);
+      if (!entry) continue;
+      clearTimeout(entry.timer);
+      this.pending.delete(msg.id);
+      if (msg.error) {
+        entry.reject(new Error(`${entry.method} failed: ${msg.error.message}`));
+      } else {
+        entry.resolve(msg.result);
+      }
+    }
+  }
+
+  private connectSocket(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const sock = net.createConnection({ path: this.socketPath });
+
+      sock.on("connect", () => {
+        this.socket = sock;
+        this.connected = true;
+        this.buffer = "";
+        resolve();
+      });
+
+      sock.on("data", (chunk: Buffer) => {
+        this.onData(chunk.toString("utf-8"));
+      });
+
+      sock.on("close", () => {
+        const wasConnected = this.connected;
+        this.connected = false;
+        this.socket = null;
+        this.stopHeartbeat();
+        this.rejectAllPending(new Error("Socket closed"));
+        if (wasConnected && !this.shuttingDown) {
+          this.disconnectedHandler?.();
+          this.scheduleReconnect();
+        }
+      });
+
+      sock.on("error", (err: Error) => {
+        if (!this.connected) {
+          reject(err);
+        }
+      });
+    });
+  }
+
+  private destroySocket(): void {
+    this.rejectAllPending(new Error("Client disconnected"));
+    try {
+      this.socket?.destroy();
+    } catch {
+      /* ignore */
+    }
+    this.socket = null;
+    this.connected = false;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.shuttingDown || this.reconnectTimer) return;
+    const delay = computeReconnectDelay(this.reconnectAttempt);
+    this.reconnectAttempt++;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.reconnectOnce();
+    }, delay);
+    this.reconnectTimer.unref?.();
+  }
+
+  private async reconnectOnce(): Promise<void> {
+    try {
+      await this.connectSocket();
+      if (this.meshSecret) {
+        await this.request("auth", { secret: this.meshSecret });
+      }
+      if (this.registration) {
+        const result = (await this.request("register", {
+          name: this.registration.name,
+          emoji: this.registration.emoji,
+          pid: process.pid,
+          ...(this.registration.stableId ? { stableId: this.registration.stableId } : {}),
+          ...(this.registration.metadata ? { metadata: this.registration.metadata } : {}),
+        })) as RegistrationResult;
+        this.identity = result;
+        this.startHeartbeat();
+      }
+      this.reconnectAttempt = 0;
+      this.reconnectedHandler?.();
+    } catch {
+      this.destroySocket();
+      this.scheduleReconnect();
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.connected) return;
+      const metadata = this.heartbeatMetadataProvider?.();
+      void this.request("heartbeat", metadata ? { metadata } : undefined).catch(() => {
+        /* best effort */
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  private rejectAllPending(err: Error): void {
+    for (const [id, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(err);
+      this.pending.delete(id);
+    }
+  }
+}

--- a/claude-code-worker/broker-client.ts
+++ b/claude-code-worker/broker-client.ts
@@ -197,6 +197,10 @@ export class WorkerBrokerClient {
     });
   }
 
+  async listAgents(): Promise<unknown> {
+    return this.request("agents.list");
+  }
+
   // ─── Transport ───────────────────────────────────────
 
   private request(method: string, params?: Record<string, unknown>): Promise<unknown> {

--- a/claude-code-worker/claude-runner.test.ts
+++ b/claude-code-worker/claude-runner.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeArgs, parseClaudeJsonOutput } from "./claude-runner.js";
+
+describe("parseClaudeJsonOutput", () => {
+  it("parses a successful result object", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      result: "4",
+      session_id: "abc-123",
+      is_error: false,
+    });
+    expect(parseClaudeJsonOutput(stdout)).toEqual({
+      text: "4",
+      sessionId: "abc-123",
+      isError: false,
+    });
+  });
+
+  it("scans past trailing non-JSON noise", () => {
+    const stdout = [
+      "some warning line",
+      JSON.stringify({ type: "result", subtype: "success", result: "ok", session_id: "s1" }),
+      "",
+    ].join("\n");
+    expect(parseClaudeJsonOutput(stdout)?.text).toBe("ok");
+  });
+
+  it("flags error subtypes", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      subtype: "error_max_turns",
+      result: "partial",
+      session_id: "s2",
+    });
+    expect(parseClaudeJsonOutput(stdout)?.isError).toBe(true);
+  });
+
+  it("returns null when no result object exists", () => {
+    expect(parseClaudeJsonOutput("plain text output")).toBe(null);
+    expect(parseClaudeJsonOutput("")).toBe(null);
+  });
+});
+
+describe("buildClaudeArgs", () => {
+  it("always runs headless with permissions bypassed and json output", () => {
+    expect(buildClaudeArgs({})).toEqual([
+      "-p",
+      "--output-format",
+      "json",
+      "--dangerously-skip-permissions",
+    ]);
+  });
+
+  it("adds resume and model when provided", () => {
+    const args = buildClaudeArgs({ resumeSessionId: "sess-1", model: "opus" });
+    expect(args).toContain("--resume");
+    expect(args).toContain("sess-1");
+    expect(args).toContain("--model");
+    expect(args).toContain("opus");
+  });
+});

--- a/claude-code-worker/claude-runner.ts
+++ b/claude-code-worker/claude-runner.ts
@@ -1,0 +1,168 @@
+import { spawn } from "node:child_process";
+
+export interface ClaudeRunOptions {
+  claudeBin: string;
+  cwd: string;
+  prompt: string;
+  resumeSessionId?: string | null;
+  model?: string | null;
+  timeoutMs: number;
+  /** Abort kills the running task (used for mesh interrupt commands). */
+  signal?: AbortSignal;
+}
+
+export interface ClaudeRunResult {
+  ok: boolean;
+  text: string;
+  sessionId: string | null;
+  isError: boolean;
+  exitCode: number | null;
+  timedOut: boolean;
+  stderrTail: string;
+}
+
+interface ClaudeJsonResult {
+  type?: string;
+  subtype?: string;
+  result?: string;
+  session_id?: string;
+  is_error?: boolean;
+}
+
+const KILL_GRACE_MS = 10000;
+const OUTPUT_CAP_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Parse `claude -p --output-format json` stdout: a single JSON object, but be
+ * tolerant of stray non-JSON lines by scanning from the last line backwards
+ * for an object with type === "result".
+ */
+export function parseClaudeJsonOutput(
+  stdout: string,
+): { text: string; sessionId: string | null; isError: boolean } | null {
+  const lines = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("{"));
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    let parsed: ClaudeJsonResult;
+    try {
+      parsed = JSON.parse(lines[i]) as ClaudeJsonResult;
+    } catch {
+      continue;
+    }
+    if (parsed.type === "result") {
+      return {
+        text: typeof parsed.result === "string" ? parsed.result : "",
+        sessionId: typeof parsed.session_id === "string" ? parsed.session_id : null,
+        isError: parsed.is_error === true || parsed.subtype !== "success",
+      };
+    }
+  }
+  return null;
+}
+
+export function buildClaudeArgs(options: {
+  resumeSessionId?: string | null;
+  model?: string | null;
+}): string[] {
+  return [
+    "-p",
+    "--output-format",
+    "json",
+    "--dangerously-skip-permissions",
+    ...(options.resumeSessionId ? ["--resume", options.resumeSessionId] : []),
+    ...(options.model ? ["--model", options.model] : []),
+  ];
+}
+
+/** Run one headless Claude Code task; prompt is passed via stdin. */
+export function runClaudeTask(options: ClaudeRunOptions): Promise<ClaudeRunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(options.claudeBin, buildClaudeArgs(options), {
+      cwd: options.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+
+    const killChild = () => {
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, KILL_GRACE_MS).unref?.();
+    };
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      killChild();
+    }, options.timeoutMs);
+    timeout.unref?.();
+
+    const onAbort = () => killChild();
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (stdout.length < OUTPUT_CAP_BYTES) stdout += chunk.toString("utf-8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      if (stderr.length < OUTPUT_CAP_BYTES) stderr += chunk.toString("utf-8");
+    });
+
+    const settle = (exitCode: number | null, spawnError?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      options.signal?.removeEventListener("abort", onAbort);
+
+      const parsed = parseClaudeJsonOutput(stdout);
+      const stderrTail = stderr.slice(-2000);
+      if (spawnError) {
+        resolve({
+          ok: false,
+          text: `Failed to launch Claude Code: ${spawnError.message}`,
+          sessionId: null,
+          isError: true,
+          exitCode: null,
+          timedOut,
+          stderrTail,
+        });
+        return;
+      }
+      if (!parsed) {
+        resolve({
+          ok: false,
+          text: timedOut
+            ? `Task timed out after ${Math.round(options.timeoutMs / 60000)} minutes.`
+            : `Claude Code exited (code ${exitCode ?? "unknown"}) without a parseable result.`,
+          sessionId: null,
+          isError: true,
+          exitCode,
+          timedOut,
+          stderrTail,
+        });
+        return;
+      }
+      resolve({
+        ok: !parsed.isError && exitCode === 0,
+        text: parsed.text,
+        sessionId: parsed.sessionId,
+        isError: parsed.isError,
+        exitCode,
+        timedOut,
+        stderrTail,
+      });
+    };
+
+    child.on("error", (err) => settle(null, err));
+    child.on("close", (code) => settle(code));
+
+    child.stdin.write(options.prompt, "utf-8");
+    child.stdin.end();
+  });
+}

--- a/claude-code-worker/cli.ts
+++ b/claude-code-worker/cli.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import { resolveWorkerConfig } from "./config.js";
+import type { WorkerConfigOverrides } from "./config.js";
+import { ClaudeCodeWorker } from "./worker.js";
+
+function parseArgs(argv: string[]): WorkerConfigOverrides {
+  const overrides: WorkerConfigOverrides = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[++i];
+      if (value === undefined) throw new Error(`Missing value for ${arg}`);
+      return value;
+    };
+    switch (arg) {
+      case "--name":
+        overrides.name = next();
+        break;
+      case "--emoji":
+        overrides.emoji = next();
+        break;
+      case "--workdir":
+        overrides.workdir = next();
+        break;
+      case "--socket":
+        overrides.socketPath = next();
+        break;
+      case "--model":
+        overrides.model = next();
+        break;
+      case "--stable-id":
+        overrides.stableId = next();
+        break;
+      case "--state-dir":
+        overrides.stateDir = next();
+        break;
+      case "--claude-bin":
+        overrides.claudeBin = next();
+        break;
+      case "--task-timeout-mins":
+        overrides.taskTimeoutMs = Number(next()) * 60 * 1000;
+        break;
+      case "--help":
+        console.log(
+          [
+            "pinet-claude-worker — join the local Pinet mesh as a headless Claude Code worker",
+            "",
+            "Options:",
+            "  --name <name>            explicit agent name (default: broker assigns one)",
+            "  --emoji <emoji>          agent emoji (with --name)",
+            "  --workdir <path>         working directory for task runs (default: cwd)",
+            "  --socket <path>          broker socket (default: ~/.pi/pinet.sock)",
+            "  --model <model>          model override for claude CLI",
+            "  --stable-id <id>         stable identity across restarts",
+            "  --state-dir <path>       state dir (default: ~/.pi/claude-code-worker)",
+            "  --claude-bin <path>      claude executable (default: claude)",
+            "  --task-timeout-mins <n>  per-task timeout (default: 30)",
+            "",
+            "Config file: <state-dir>/config.json with the same keys as WorkerConfig.",
+          ].join("\n"),
+        );
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return overrides;
+}
+
+async function main(): Promise<void> {
+  const config = resolveWorkerConfig(parseArgs(process.argv.slice(2)));
+  const worker = new ClaudeCodeWorker(config);
+
+  const stop = (signal: string) => {
+    void worker.shutdown(`received ${signal}`).finally(() => process.exit(0));
+  };
+  process.on("SIGINT", () => stop("SIGINT"));
+  process.on("SIGTERM", () => stop("SIGTERM"));
+
+  await worker.start();
+}
+
+main().catch((err: unknown) => {
+  console.error(`[claude-code-worker] fatal: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/claude-code-worker/cli.ts
+++ b/claude-code-worker/cli.ts
@@ -1,9 +1,37 @@
 #!/usr/bin/env node
 import { resolveWorkerConfig } from "./config.js";
 import type { WorkerConfigOverrides } from "./config.js";
+import { runMcpServer } from "./mcp-server.js";
+import { runWaiter, DEFAULT_WAIT_TIMEOUT_MS } from "./waiter.js";
 import { ClaudeCodeWorker } from "./worker.js";
 
-function parseArgs(argv: string[]): WorkerConfigOverrides {
+const HELP = [
+  "pinet-claude-worker — Claude Code on the Pinet mesh",
+  "",
+  "Usage:",
+  "  pinet-claude-worker [options]           run the headless worker daemon",
+  "  pinet-claude-worker mcp [options]       run the follower-bridge MCP server (stdio)",
+  "  pinet-claude-worker wait --socket <p>   block until the bridge has pending messages",
+  "",
+  "Worker/mcp options:",
+  "  --name <name>            explicit agent name (default: broker assigns one)",
+  "  --emoji <emoji>          agent emoji (with --name)",
+  "  --workdir <path>         working directory for task runs (default: cwd)",
+  "  --socket <path>          broker socket (default: ~/.pi/pinet.sock)",
+  "  --model <model>          model override for claude CLI (worker only)",
+  "  --stable-id <id>         stable identity across restarts (worker only)",
+  "  --state-dir <path>       state dir (default: ~/.pi/claude-code-worker)",
+  "  --claude-bin <path>      claude executable (default: claude; worker only)",
+  "  --task-timeout-mins <n>  per-task timeout (default: 30; worker only)",
+  "",
+  "Wait options:",
+  "  --socket <path>          the bridge's waiter socket (from pinet_follow)",
+  "  --timeout-mins <n>       give up after n minutes (default: 50)",
+  "",
+  "Config file: <state-dir>/config.json with the same keys as WorkerConfig.",
+].join("\n");
+
+function parseWorkerArgs(argv: string[]): WorkerConfigOverrides {
   const overrides: WorkerConfigOverrides = {};
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -41,24 +69,7 @@ function parseArgs(argv: string[]): WorkerConfigOverrides {
         overrides.taskTimeoutMs = Number(next()) * 60 * 1000;
         break;
       case "--help":
-        console.log(
-          [
-            "pinet-claude-worker — join the local Pinet mesh as a headless Claude Code worker",
-            "",
-            "Options:",
-            "  --name <name>            explicit agent name (default: broker assigns one)",
-            "  --emoji <emoji>          agent emoji (with --name)",
-            "  --workdir <path>         working directory for task runs (default: cwd)",
-            "  --socket <path>          broker socket (default: ~/.pi/pinet.sock)",
-            "  --model <model>          model override for claude CLI",
-            "  --stable-id <id>         stable identity across restarts",
-            "  --state-dir <path>       state dir (default: ~/.pi/claude-code-worker)",
-            "  --claude-bin <path>      claude executable (default: claude)",
-            "  --task-timeout-mins <n>  per-task timeout (default: 30)",
-            "",
-            "Config file: <state-dir>/config.json with the same keys as WorkerConfig.",
-          ].join("\n"),
-        );
+        console.log(HELP);
         process.exit(0);
         break;
       default:
@@ -68,8 +79,40 @@ function parseArgs(argv: string[]): WorkerConfigOverrides {
   return overrides;
 }
 
-async function main(): Promise<void> {
-  const config = resolveWorkerConfig(parseArgs(process.argv.slice(2)));
+async function runWaitCommand(argv: string[]): Promise<void> {
+  let socketPath: string | null = null;
+  let timeoutMs = DEFAULT_WAIT_TIMEOUT_MS;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[++i];
+      if (value === undefined) throw new Error(`Missing value for ${arg}`);
+      return value;
+    };
+    switch (arg) {
+      case "--socket":
+        socketPath = next();
+        break;
+      case "--timeout-mins":
+        timeoutMs = Number(next()) * 60 * 1000;
+        break;
+      case "--help":
+        console.log(HELP);
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!socketPath) throw new Error("wait requires --socket <path> (from pinet_follow)");
+
+  const outcome = await runWaiter({ socketPath, timeoutMs });
+  console.log(outcome.text);
+  process.exit(outcome.exitCode);
+}
+
+async function runWorkerCommand(argv: string[]): Promise<void> {
+  const config = resolveWorkerConfig(parseWorkerArgs(argv));
   const worker = new ClaudeCodeWorker(config);
 
   const stop = (signal: string) => {
@@ -79,6 +122,22 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => stop("SIGTERM"));
 
   await worker.start();
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const command = argv[0];
+
+  if (command === "mcp") {
+    const config = resolveWorkerConfig(parseWorkerArgs(argv.slice(1)));
+    await runMcpServer(config);
+    return;
+  }
+  if (command === "wait") {
+    await runWaitCommand(argv.slice(1));
+    return;
+  }
+  await runWorkerCommand(argv);
 }
 
 main().catch((err: unknown) => {

--- a/claude-code-worker/config.test.ts
+++ b/claude-code-worker/config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { mergeConfig } from "./config.js";
+import type { WorkerConfig } from "./config.js";
+
+const defaults: WorkerConfig = {
+  socketPath: "/tmp/sock",
+  meshSecretPath: null,
+  name: "",
+  emoji: "",
+  stableId: "stable",
+  workdir: "/tmp",
+  claudeBin: "claude",
+  model: null,
+  taskTimeoutMs: 1000,
+  pollIntervalMs: 2000,
+  stateDir: "/tmp/state",
+};
+
+describe("mergeConfig", () => {
+  it("applies layers left to right", () => {
+    const merged = mergeConfig(defaults, { name: "file-name" }, { name: "cli-name" });
+    expect(merged.name).toBe("cli-name");
+  });
+
+  it("ignores undefined values in layers", () => {
+    const merged = mergeConfig(defaults, { name: undefined, workdir: "/work" });
+    expect(merged.name).toBe("");
+    expect(merged.workdir).toBe("/work");
+  });
+
+  it("does not mutate the defaults object", () => {
+    mergeConfig(defaults, { name: "x" });
+    expect(defaults.name).toBe("");
+  });
+});

--- a/claude-code-worker/config.ts
+++ b/claude-code-worker/config.ts
@@ -1,0 +1,131 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getDefaultMeshSecretPath, getDefaultSocketPath } from "@pinet/broker-core/paths";
+
+export interface WorkerConfig {
+  /** Broker Unix socket path. Env override: PINET_SOCKET_PATH. */
+  socketPath: string;
+  /** Mesh shared-secret file. Null disables auth. */
+  meshSecretPath: string | null;
+  /** Explicit agent name; empty string lets the broker assign an identity. */
+  name: string;
+  emoji: string;
+  /** Stable identity across restarts. */
+  stableId: string;
+  /** Default working directory for Claude Code task runs. */
+  workdir: string;
+  /** Claude Code executable. */
+  claudeBin: string;
+  /** Optional model override passed to claude CLI. */
+  model: string | null;
+  /** Hard timeout for a single task run. */
+  taskTimeoutMs: number;
+  /** Inbox poll interval. */
+  pollIntervalMs: number;
+  /** State directory (session map, logs). */
+  stateDir: string;
+}
+
+export interface WorkerConfigOverrides {
+  socketPath?: string;
+  meshSecretPath?: string | null;
+  name?: string;
+  emoji?: string;
+  stableId?: string;
+  workdir?: string;
+  claudeBin?: string;
+  model?: string | null;
+  taskTimeoutMs?: number;
+  pollIntervalMs?: number;
+  stateDir?: string;
+}
+
+export function getDefaultStateDir(): string {
+  return path.join(os.homedir(), ".pi", "claude-code-worker");
+}
+
+export function getDefaultConfigPath(): string {
+  return path.join(getDefaultStateDir(), "config.json");
+}
+
+/**
+ * Locate the mesh secret file the local broker uses, without reading its
+ * contents here: explicit override, then pi's slack-bridge settings, then the
+ * default path, then null (auth disabled).
+ */
+export function resolveMeshSecretPath(explicit?: string | null): string | null {
+  if (explicit === null) return null;
+  if (explicit && explicit.trim()) return explicit.trim();
+
+  const piSettingsPath = path.join(os.homedir(), ".pi", "agent", "settings.json");
+  try {
+    const settings = JSON.parse(fs.readFileSync(piSettingsPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const bridge = settings["slack-bridge"];
+    if (bridge && typeof bridge === "object") {
+      const configured = (bridge as Record<string, unknown>).meshSecretPath;
+      if (typeof configured === "string" && configured.trim()) {
+        return configured.trim();
+      }
+    }
+  } catch {
+    /* no pi settings — fall through */
+  }
+
+  const defaultPath = getDefaultMeshSecretPath();
+  return fs.existsSync(defaultPath) ? defaultPath : null;
+}
+
+function readConfigFile(configPath: string): WorkerConfigOverrides {
+  try {
+    return JSON.parse(fs.readFileSync(configPath, "utf-8")) as WorkerConfigOverrides;
+  } catch {
+    return {};
+  }
+}
+
+/** Merge defaults, config file, and explicit overrides (pure; no filesystem reads). */
+export function mergeConfig(
+  defaults: WorkerConfig,
+  ...layers: WorkerConfigOverrides[]
+): WorkerConfig {
+  const merged: WorkerConfig = { ...defaults };
+  for (const layer of layers) {
+    for (const [key, value] of Object.entries(layer)) {
+      if (value !== undefined) {
+        (merged as unknown as Record<string, unknown>)[key] = value;
+      }
+    }
+  }
+  return merged;
+}
+
+export function resolveWorkerConfig(overrides: WorkerConfigOverrides = {}): WorkerConfig {
+  const stateDir = overrides.stateDir ?? getDefaultStateDir();
+  const fileOverrides = readConfigFile(path.join(stateDir, "config.json"));
+
+  const defaults: WorkerConfig = {
+    socketPath: process.env.PINET_SOCKET_PATH?.trim() || getDefaultSocketPath(),
+    meshSecretPath: null,
+    name: "",
+    emoji: "",
+    stableId: `claude-code-worker:${os.hostname()}`,
+    workdir: process.cwd(),
+    claudeBin: "claude",
+    model: null,
+    taskTimeoutMs: 30 * 60 * 1000,
+    pollIntervalMs: 2000,
+    stateDir,
+  };
+
+  const merged = mergeConfig(defaults, fileOverrides, overrides);
+  merged.meshSecretPath = resolveMeshSecretPath(
+    overrides.meshSecretPath !== undefined
+      ? overrides.meshSecretPath
+      : fileOverrides.meshSecretPath,
+  );
+  return merged;
+}

--- a/claude-code-worker/eslint.config.mjs
+++ b/claude-code-worker/eslint.config.mjs
@@ -1,0 +1,3 @@
+import rootConfig from "../eslint.config.mjs";
+
+export default [...rootConfig];

--- a/claude-code-worker/follower-bridge.test.ts
+++ b/claude-code-worker/follower-bridge.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { InboxItem } from "./broker-client.js";
+import { formatPendingMessages, summarizeForWaiter, toPendingMessage } from "./follower-bridge.js";
+
+function makeItem(overrides: Partial<InboxItem["message"]> = {}, inboxId = 1): InboxItem {
+  return {
+    inboxId,
+    message: {
+      id: 100,
+      threadId: "slack:C123:456",
+      source: "slack",
+      direction: "inbound",
+      sender: "The Broker Lion",
+      body: "Please check the deploy",
+      metadata: null,
+      createdAt: "2026-07-06T10:00:00.000Z",
+      ...overrides,
+    },
+  };
+}
+
+describe("toPendingMessage", () => {
+  it("maps a regular thread item", () => {
+    const pending = toPendingMessage(makeItem());
+    expect(pending).toMatchObject({
+      inboxId: 1,
+      threadId: "slack:C123:456",
+      sender: "The Broker Lion",
+      a2a: false,
+    });
+  });
+
+  it("flags a2a threads", () => {
+    const pending = toPendingMessage(makeItem({ threadId: "a2a:one:two" }));
+    expect(pending.a2a).toBe(true);
+  });
+
+  it("flags a2a metadata", () => {
+    const pending = toPendingMessage(makeItem({ metadata: { a2a: true } }));
+    expect(pending.a2a).toBe(true);
+  });
+});
+
+describe("formatPendingMessages", () => {
+  it("reports emptiness", () => {
+    expect(formatPendingMessages([])).toBe("No pending mesh messages.");
+  });
+
+  it("numbers messages and includes threadId, sender, and body", () => {
+    const text = formatPendingMessages([
+      toPendingMessage(makeItem()),
+      toPendingMessage(makeItem({ threadId: "a2a:x:y", body: "ping" }, 2)),
+    ]);
+    expect(text).toContain("2 pending mesh message(s)");
+    expect(text).toContain("[1] thread (source: slack)");
+    expect(text).toContain("threadId: slack:C123:456");
+    expect(text).toContain("Please check the deploy");
+    expect(text).toContain("[2] agent-to-agent");
+    expect(text).toContain("pinet_send");
+  });
+
+  it("marks empty bodies", () => {
+    const text = formatPendingMessages([toPendingMessage(makeItem({ body: "  " }))]);
+    expect(text).toContain("(empty message)");
+  });
+
+  it("prefers senderDisplay over the raw sender id", () => {
+    const pending = toPendingMessage(makeItem({ sender: "a932d3ca-uuid", threadId: "a2a:x:y" }));
+    pending.senderDisplay = "The Broker Lion";
+    expect(formatPendingMessages([pending])).toContain('from "The Broker Lion"');
+    expect(summarizeForWaiter([pending])[0].startsWith("The Broker Lion:")).toBe(true);
+  });
+});
+
+describe("summarizeForWaiter", () => {
+  it("collapses whitespace and truncates long bodies", () => {
+    const long = "x".repeat(300);
+    const [summary] = summarizeForWaiter([toPendingMessage(makeItem({ body: `a\n\nb  ${long}` }))]);
+    expect(summary.startsWith("The Broker Lion: a b ")).toBe(true);
+    expect(summary.length).toBeLessThanOrEqual("The Broker Lion: ".length + 120);
+    expect(summary.endsWith("...")).toBe(true);
+  });
+});

--- a/claude-code-worker/follower-bridge.ts
+++ b/claude-code-worker/follower-bridge.ts
@@ -1,0 +1,424 @@
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { readMeshSecret } from "@pinet/broker-core/auth";
+import { WorkerBrokerClient } from "./broker-client.js";
+import type { InboxItem } from "./broker-client.js";
+import type { WorkerConfig } from "./config.js";
+import { extractControlCommand, isAgentToAgentItem } from "./prompts.js";
+
+/**
+ * Follower bridge: the mesh-mechanics half of an interactive follower.
+ *
+ * Owns the broker connection (register/heartbeat/poll/ack/claim/send) and a
+ * local spool of pending inbox items. The harness half (for Claude Code: the
+ * MCP server in `mcp-server.ts` plus the `wait` CLI subcommand) only delivers
+ * spool contents into a live conversation and routes replies back — the seam
+ * that later becomes `@pinet/follower-bridge` for other harnesses.
+ */
+
+export interface FollowResult {
+  name: string;
+  emoji: string;
+  agentId: string;
+  waiterSocketPath: string;
+}
+
+export interface PendingMessage {
+  inboxId: number;
+  threadId: string;
+  /** Raw sender as the broker reports it (agentId for a2a) — used for routing. */
+  sender: string;
+  /** Human-readable sender name when resolvable from the roster. */
+  senderDisplay?: string;
+  source: string;
+  body: string;
+  a2a: boolean;
+  createdAt: string;
+}
+
+interface WaiterResponse {
+  pending?: number;
+  summaries?: string[];
+  exit?: boolean;
+}
+
+interface ThreadRoute {
+  a2a: boolean;
+  sender: string;
+}
+
+export function toPendingMessage(item: InboxItem): PendingMessage {
+  return {
+    inboxId: item.inboxId,
+    threadId: item.message.threadId,
+    sender: item.message.sender,
+    source: item.message.source,
+    body: item.message.body ?? "",
+    a2a: isAgentToAgentItem(item),
+    createdAt: item.message.createdAt,
+  };
+}
+
+/** Human/model-readable rendering of pending messages for `pinet_read`. */
+export function formatPendingMessages(messages: PendingMessage[]): string {
+  if (messages.length === 0) return "No pending mesh messages.";
+  const blocks = messages.map((msg, i) => {
+    const kind = msg.a2a ? "agent-to-agent" : `thread (source: ${msg.source})`;
+    const who = msg.senderDisplay ?? msg.sender;
+    return [
+      `[${i + 1}] ${kind} from "${who}" — threadId: ${msg.threadId} (${msg.createdAt})`,
+      msg.body.trim() || "(empty message)",
+    ].join("\n");
+  });
+  return [
+    `${messages.length} pending mesh message(s):`,
+    "",
+    blocks.join("\n\n"),
+    "",
+    "Handle each as a task; reply with pinet_send using the same threadId.",
+  ].join("\n");
+}
+
+export function summarizeForWaiter(messages: PendingMessage[]): string[] {
+  return messages.map((msg) => {
+    const body = msg.body.trim().replace(/\s+/g, " ");
+    const preview = body.length > 120 ? `${body.slice(0, 117)}...` : body;
+    return `${msg.senderDisplay ?? msg.sender}: ${preview || "(empty)"}`;
+  });
+}
+
+export class FollowerBridge {
+  private readonly config: WorkerConfig;
+  private client: WorkerBrokerClient | null = null;
+  private readonly spool: PendingMessage[] = [];
+  private readonly seenInboxIds = new Set<number>();
+  private readonly threadRoutes = new Map<string, ThreadRoute>();
+  private readonly claimedThreads = new Set<string>();
+  private readonly parkedWaiters = new Set<net.Socket>();
+  private waiterServer: net.Server | null = null;
+  private waiterSocketPath: string | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+  private following = false;
+  private exitRequested = false;
+  private agentName = "";
+  private agentEmoji = "";
+
+  constructor(config: WorkerConfig) {
+    this.config = config;
+  }
+
+  isFollowing(): boolean {
+    return this.following;
+  }
+
+  wasExitRequested(): boolean {
+    return this.exitRequested;
+  }
+
+  getIdentity(): { name: string; emoji: string } | null {
+    return this.following ? { name: this.agentName, emoji: this.agentEmoji } : null;
+  }
+
+  async follow(opts: { name?: string; emoji?: string } = {}): Promise<FollowResult> {
+    if (this.following && this.client) {
+      const identity = this.client.getIdentity();
+      return {
+        name: identity?.name ?? this.agentName,
+        emoji: identity?.emoji ?? this.agentEmoji,
+        agentId: identity?.agentId ?? "",
+        waiterSocketPath: this.waiterSocketPath!,
+      };
+    }
+
+    this.exitRequested = false;
+    this.client = new WorkerBrokerClient({
+      socketPath: this.config.socketPath,
+      meshSecret: this.config.meshSecretPath ? readMeshSecret(this.config.meshSecretPath) : null,
+    });
+    await this.client.connect();
+    const registration = await this.client.register({
+      name: opts.name ?? "",
+      emoji: opts.emoji ?? "",
+      stableId: `claude-code-interactive:${os.hostname()}:${process.pid}`,
+      metadata: this.buildMetadata(),
+    });
+    this.agentName = registration.name;
+    this.agentEmoji = registration.emoji;
+    this.client.setHeartbeatMetadataProvider(() => this.buildMetadata());
+
+    this.waiterSocketPath = await this.startWaiterServer();
+    this.following = true;
+
+    this.pollTimer = setInterval(() => {
+      void this.pollOnce();
+    }, this.config.pollIntervalMs);
+    this.pollTimer.unref?.();
+
+    await this.client.updateStatus("idle").catch(() => {});
+    this.log(`following as "${registration.name}" ${registration.emoji}`);
+    return {
+      name: registration.name,
+      emoji: registration.emoji,
+      agentId: registration.agentId,
+      waiterSocketPath: this.waiterSocketPath,
+    };
+  }
+
+  async unfollow(reason: string): Promise<void> {
+    if (!this.following && !this.client) return;
+    this.following = false;
+    this.log(`unfollowing: ${reason}`);
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.respondToWaiters({ exit: true });
+    await this.stopWaiterServer();
+    if (this.client) {
+      await this.client.disconnectGracefully().catch(() => {});
+      this.client = null;
+    }
+  }
+
+  /** Drain the spool: ack everything handed out and flip status to working. */
+  async read(): Promise<PendingMessage[]> {
+    const drained = this.spool.splice(0, this.spool.length);
+    if (drained.length === 0) return drained;
+    if (this.client?.isConnected()) {
+      await this.client.ackMessages(drained.map((m) => m.inboxId)).catch(() => {});
+      await this.client.updateStatus("working").catch(() => {});
+    }
+    return drained;
+  }
+
+  async send(threadId: string, body: string): Promise<string> {
+    if (!this.client?.isConnected()) {
+      throw new Error("Not connected to the mesh — call pinet_follow first.");
+    }
+    const route = this.threadRoutes.get(threadId);
+    if (route?.a2a || threadId.startsWith("a2a:")) {
+      const target = route?.sender;
+      if (!target) {
+        throw new Error(
+          `No known sender for agent-to-agent thread ${threadId}; cannot route the reply.`,
+        );
+      }
+      await this.client.sendAgentMessage(target, body);
+      return `Sent agent-to-agent reply to "${target}".`;
+    }
+    if (!this.claimedThreads.has(threadId)) {
+      const claim = await this.client.claimThread(threadId).catch(() => ({ claimed: false }));
+      if (claim.claimed) this.claimedThreads.add(threadId);
+    }
+    await this.client.messageSend({
+      threadId,
+      body,
+      agentName: this.agentName,
+      ...(this.agentEmoji ? { agentEmoji: this.agentEmoji } : {}),
+    });
+    return `Sent to thread ${threadId}.`;
+  }
+
+  async listAgents(): Promise<unknown> {
+    if (!this.client?.isConnected()) {
+      throw new Error("Not connected to the mesh — call pinet_follow first.");
+    }
+    return this.client.listAgents();
+  }
+
+  async setStatus(status: "working" | "idle"): Promise<void> {
+    if (!this.client?.isConnected()) {
+      throw new Error("Not connected to the mesh — call pinet_follow first.");
+    }
+    await this.client.updateStatus(status);
+  }
+
+  private buildMetadata(): Record<string, unknown> {
+    return {
+      runtime: "claude-code",
+      harness: "interactive",
+      cwd: this.config.workdir,
+      host: os.hostname(),
+      repo: path.basename(this.config.workdir),
+      tags: [
+        "role:follower",
+        "runtime:claude-code",
+        "harness:interactive",
+        `repo:${path.basename(this.config.workdir)}`,
+      ],
+    };
+  }
+
+  private async pollOnce(): Promise<void> {
+    if (this.polling || !this.following || !this.client?.isConnected()) return;
+    this.polling = true;
+    try {
+      const entries = await this.client.pollInbox();
+      let spooled = false;
+      for (const entry of entries) {
+        if (this.seenInboxIds.has(entry.inboxId)) continue;
+        this.seenInboxIds.add(entry.inboxId);
+
+        const control = extractControlCommand(entry);
+        if (control) {
+          await this.handleControl(control, entry);
+          continue;
+        }
+        const pending = toPendingMessage(entry);
+        this.threadRoutes.set(pending.threadId, { a2a: pending.a2a, sender: pending.sender });
+        this.spool.push(pending);
+        spooled = true;
+      }
+      if (spooled) {
+        await this.resolveSenderNames();
+        this.notifyWaiters();
+      }
+    } catch (err) {
+      this.log(`inbox poll failed: ${formatError(err)}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /**
+   * Best-effort: a2a senders arrive as agentIds; map them to roster names so
+   * the model (and waiter summaries) see "The Broker Lion", not a UUID. The
+   * roster reports short id prefixes, so match by prefix either way.
+   */
+  private async resolveSenderNames(): Promise<void> {
+    const unresolved = this.spool.filter((m) => m.a2a && !m.senderDisplay);
+    if (unresolved.length === 0 || !this.client?.isConnected()) return;
+    try {
+      const roster = (await this.client.listAgents()) as { id?: string; name?: string }[];
+      if (!Array.isArray(roster)) return;
+      for (const msg of unresolved) {
+        const agent = roster.find(
+          (a) => a.id && (msg.sender === a.id || msg.sender.startsWith(a.id)),
+        );
+        if (agent?.name) msg.senderDisplay = agent.name;
+      }
+    } catch {
+      /* display-only; raw sender still routes replies */
+    }
+  }
+
+  private async handleControl(command: string, entry: InboxItem): Promise<void> {
+    this.log(`control command "${command}" from ${entry.message.sender}`);
+    await this.client?.ackMessages([entry.inboxId]).catch(() => {});
+    if (command === "exit") {
+      this.exitRequested = true;
+      await this.unfollow(`exit requested by ${entry.message.sender}`);
+      return;
+    }
+    // Interactive sessions cannot be interrupted or reloaded from the mesh.
+    await this.client
+      ?.sendAgentMessage(
+        entry.message.sender,
+        `Control command "${command}" is not supported in interactive follower mode; only "exit" is honored.`,
+      )
+      .catch(() => {});
+  }
+
+  // ─── Waiter socket ───────────────────────────────────
+
+  private startWaiterServer(): Promise<string> {
+    const dir = path.join(this.config.stateDir, "sessions");
+    fs.mkdirSync(dir, { recursive: true });
+    const socketPath = path.join(dir, `bridge-${process.pid}.sock`);
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      /* no stale socket */
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const server = net.createServer((socket) => this.handleWaiterConnection(socket));
+      server.on("error", reject);
+      server.listen(socketPath, () => {
+        try {
+          fs.chmodSync(socketPath, 0o600);
+        } catch {
+          /* best effort */
+        }
+        this.waiterServer = server;
+        server.unref?.();
+        resolve(socketPath);
+      });
+    });
+  }
+
+  private handleWaiterConnection(socket: net.Socket): void {
+    socket.on("error", () => {
+      this.parkedWaiters.delete(socket);
+    });
+    socket.on("close", () => {
+      this.parkedWaiters.delete(socket);
+    });
+    socket.on("data", () => {
+      // Any request line means "wait for messages"; respond now or park.
+      if (this.exitRequested || !this.following) {
+        this.respondTo(socket, { exit: true });
+        return;
+      }
+      if (this.spool.length > 0) {
+        this.respondTo(socket, {
+          pending: this.spool.length,
+          summaries: summarizeForWaiter(this.spool),
+        });
+        return;
+      }
+      this.parkedWaiters.add(socket);
+      // Waiter armed with an empty spool is the definition of idle.
+      void this.client?.updateStatus("idle").catch(() => {});
+    });
+  }
+
+  private notifyWaiters(): void {
+    if (this.parkedWaiters.size === 0 || this.spool.length === 0) return;
+    this.respondToWaiters({
+      pending: this.spool.length,
+      summaries: summarizeForWaiter(this.spool),
+    });
+  }
+
+  private respondToWaiters(response: WaiterResponse): void {
+    for (const socket of [...this.parkedWaiters]) {
+      this.respondTo(socket, response);
+    }
+  }
+
+  private respondTo(socket: net.Socket, response: WaiterResponse): void {
+    this.parkedWaiters.delete(socket);
+    try {
+      socket.end(JSON.stringify(response) + "\n");
+    } catch {
+      /* waiter already gone */
+    }
+  }
+
+  private async stopWaiterServer(): Promise<void> {
+    if (!this.waiterServer) return;
+    const server = this.waiterServer;
+    this.waiterServer = null;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (this.waiterSocketPath) {
+      try {
+        fs.unlinkSync(this.waiterSocketPath);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+
+  private log(message: string): void {
+    // stderr only: stdout belongs to the MCP protocol when embedded there.
+    console.error(`[follower-bridge] ${message}`);
+  }
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/claude-code-worker/index.ts
+++ b/claude-code-worker/index.ts
@@ -30,3 +30,24 @@ export {
 } from "./prompts.js";
 export { SessionStore, pruneSessions, type SessionEntry } from "./sessions.js";
 export { ClaudeCodeWorker } from "./worker.js";
+export {
+  FollowerBridge,
+  formatPendingMessages,
+  summarizeForWaiter,
+  toPendingMessage,
+  type FollowResult,
+  type PendingMessage,
+} from "./follower-bridge.js";
+export {
+  handleMcpMessage,
+  callPinetTool,
+  TOOL_DEFINITIONS,
+  runMcpServer,
+  type ToolDefinition,
+} from "./mcp-server.js";
+export {
+  runWaiter,
+  interpretWaiterResponse,
+  DEFAULT_WAIT_TIMEOUT_MS,
+  type WaiterOutcome,
+} from "./waiter.js";

--- a/claude-code-worker/index.ts
+++ b/claude-code-worker/index.ts
@@ -1,0 +1,32 @@
+export {
+  WorkerBrokerClient,
+  splitJsonRpcLines,
+  computeReconnectDelay,
+  type InboxItem,
+  type RegistrationInput,
+  type RegistrationResult,
+  type MessageSendInput,
+} from "./broker-client.js";
+export {
+  resolveWorkerConfig,
+  resolveMeshSecretPath,
+  mergeConfig,
+  getDefaultStateDir,
+  type WorkerConfig,
+  type WorkerConfigOverrides,
+} from "./config.js";
+export {
+  runClaudeTask,
+  parseClaudeJsonOutput,
+  buildClaudeArgs,
+  type ClaudeRunOptions,
+  type ClaudeRunResult,
+} from "./claude-runner.js";
+export {
+  buildTaskPrompt,
+  extractControlCommand,
+  isAgentToAgentItem,
+  type PinetControlCommand,
+} from "./prompts.js";
+export { SessionStore, pruneSessions, type SessionEntry } from "./sessions.js";
+export { ClaudeCodeWorker } from "./worker.js";

--- a/claude-code-worker/mcp-server.test.ts
+++ b/claude-code-worker/mcp-server.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleMcpMessage, TOOL_DEFINITIONS } from "./mcp-server.js";
+
+const noTool = vi.fn(async () => "unused");
+
+describe("handleMcpMessage", () => {
+  it("answers initialize with the client's protocol version", async () => {
+    const response = await handleMcpMessage(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-03-26" },
+      },
+      noTool,
+    );
+    expect(response).toMatchObject({
+      id: 1,
+      result: {
+        protocolVersion: "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "pinet" },
+      },
+    });
+  });
+
+  it("ignores notifications", async () => {
+    const response = await handleMcpMessage(
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      noTool,
+    );
+    expect(response).toBeNull();
+  });
+
+  it("lists all six pinet tools", async () => {
+    const response = await handleMcpMessage(
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      noTool,
+    );
+    const tools = (response!.result as { tools: { name: string }[] }).tools;
+    expect(tools.map((t) => t.name)).toEqual([
+      "pinet_follow",
+      "pinet_unfollow",
+      "pinet_read",
+      "pinet_send",
+      "pinet_agents",
+      "pinet_status",
+    ]);
+    expect(tools).toBe(TOOL_DEFINITIONS);
+  });
+
+  it("dispatches tools/call and wraps the text result", async () => {
+    const execute = vi.fn(async (name: string) => `ran ${name}`);
+    const response = await handleMcpMessage(
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "pinet_read", arguments: {} },
+      },
+      execute,
+    );
+    expect(execute).toHaveBeenCalledWith("pinet_read", {});
+    expect(response).toMatchObject({
+      id: 3,
+      result: { content: [{ type: "text", text: "ran pinet_read" }] },
+    });
+  });
+
+  it("converts tool errors into isError results, not protocol errors", async () => {
+    const execute = vi.fn(async () => {
+      throw new Error("not connected");
+    });
+    const response = await handleMcpMessage(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "pinet_send", arguments: {} },
+      },
+      execute,
+    );
+    expect(response).toMatchObject({
+      id: 4,
+      result: { isError: true, content: [{ type: "text", text: "Error: not connected" }] },
+    });
+  });
+
+  it("rejects unknown methods with -32601", async () => {
+    const response = await handleMcpMessage(
+      { jsonrpc: "2.0", id: 5, method: "resources/list" },
+      noTool,
+    );
+    expect(response).toMatchObject({ id: 5, error: { code: -32601 } });
+  });
+});

--- a/claude-code-worker/mcp-server.ts
+++ b/claude-code-worker/mcp-server.ts
@@ -1,0 +1,247 @@
+import { splitJsonRpcLines } from "./broker-client.js";
+import type { WorkerConfig } from "./config.js";
+import { FollowerBridge, formatPendingMessages } from "./follower-bridge.js";
+
+/**
+ * Minimal MCP stdio server exposing the follower bridge to an interactive
+ * Claude Code session. Newline-delimited JSON-RPC 2.0 — the same framing as
+ * the broker protocol — so no SDK dependency is needed for six tools.
+ */
+
+const SERVER_INFO = { name: "pinet", version: "0.1.0" };
+const FALLBACK_PROTOCOL_VERSION = "2025-06-18";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export const TOOL_DEFINITIONS: ToolDefinition[] = [
+  {
+    name: "pinet_follow",
+    description:
+      "Join the local Pinet mesh as a follower agent (idempotent). Returns the assigned " +
+      "identity and the exact background waiter command that wakes this session when mesh " +
+      "messages arrive.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Explicit agent name (default: broker assigns)" },
+        emoji: { type: "string", description: "Agent emoji (only with name)" },
+      },
+    },
+  },
+  {
+    name: "pinet_unfollow",
+    description: "Leave the Pinet mesh and stop the waiter socket (idempotent).",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "pinet_read",
+    description:
+      "Drain pending mesh messages (acks them on the broker). Call after the waiter exits.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "pinet_send",
+    description:
+      "Send a reply to a mesh thread. Agent-to-agent threads route back to the sending " +
+      "agent; regular threads are claimed automatically on first send.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        threadId: { type: "string", description: "threadId from pinet_read" },
+        body: { type: "string", description: "Reply text (Slack-friendly)" },
+      },
+      required: ["threadId", "body"],
+    },
+  },
+  {
+    name: "pinet_agents",
+    description: "List agents currently registered on the mesh.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "pinet_status",
+    description:
+      "Manually override this agent's mesh status. Rarely needed — the bridge tracks " +
+      "working/idle from waiter arming and reads.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["working", "idle"] },
+      },
+      required: ["status"],
+    },
+  },
+];
+
+function requireString(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Missing required string argument "${key}"`);
+  }
+  return value;
+}
+
+/** Execute one pinet tool against the bridge; returns the text for the model. */
+export async function callPinetTool(
+  bridge: FollowerBridge,
+  cliPath: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  switch (name) {
+    case "pinet_follow": {
+      const result = await bridge.follow({
+        name: typeof args.name === "string" ? args.name : undefined,
+        emoji: typeof args.emoji === "string" ? args.emoji : undefined,
+      });
+      const waitCommand = `node ${cliPath} wait --socket ${result.waiterSocketPath}`;
+      return [
+        `Following the Pinet mesh as "${result.name}" ${result.emoji} (agentId ${result.agentId}).`,
+        ``,
+        `To receive mesh messages while idle, run this in the background (Bash run_in_background)`,
+        `and re-arm it after every wake:`,
+        ``,
+        `  ${waitCommand}`,
+        ``,
+        `When it exits reporting pending messages: call pinet_read, handle each message,`,
+        `reply with pinet_send, then re-arm the waiter. If it exits with EXIT, do not re-arm.`,
+      ].join("\n");
+    }
+    case "pinet_unfollow": {
+      await bridge.unfollow("pinet_unfollow tool call");
+      return "Unfollowed the Pinet mesh.";
+    }
+    case "pinet_read": {
+      const messages = await bridge.read();
+      const exitNote = bridge.wasExitRequested()
+        ? "\n\nNote: an exit control command was received — the bridge has unfollowed; do not re-arm the waiter."
+        : "";
+      return formatPendingMessages(messages) + exitNote;
+    }
+    case "pinet_send": {
+      const threadId = requireString(args, "threadId");
+      const body = requireString(args, "body");
+      return bridge.send(threadId, body);
+    }
+    case "pinet_agents": {
+      const agents = await bridge.listAgents();
+      return JSON.stringify(agents, null, 2);
+    }
+    case "pinet_status": {
+      const status = requireString(args, "status");
+      if (status !== "working" && status !== "idle") {
+        throw new Error(`Invalid status "${status}" (expected "working" or "idle")`);
+      }
+      await bridge.setStatus(status);
+      return `Status set to ${status}.`;
+    }
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+/**
+ * Handle one MCP JSON-RPC message. Returns the response object to write, or
+ * null for notifications. Tool execution is delegated so this stays testable.
+ */
+export async function handleMcpMessage(
+  request: JsonRpcRequest,
+  executeTool: (name: string, args: Record<string, unknown>) => Promise<string>,
+): Promise<Record<string, unknown> | null> {
+  const { id, method, params } = request;
+  const respond = (result: unknown) => ({ jsonrpc: "2.0", id: id!, result });
+  const fail = (code: number, message: string) => ({
+    jsonrpc: "2.0",
+    id: id!,
+    error: { code, message },
+  });
+
+  // Notifications (no id) get no response.
+  if (id === undefined) return null;
+
+  switch (method) {
+    case "initialize": {
+      const requested = (params as { protocolVersion?: string } | undefined)?.protocolVersion;
+      return respond({
+        protocolVersion: requested ?? FALLBACK_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      });
+    }
+    case "ping":
+      return respond({});
+    case "tools/list":
+      return respond({ tools: TOOL_DEFINITIONS });
+    case "tools/call": {
+      const name = (params as { name?: string } | undefined)?.name;
+      const args = ((params as { arguments?: Record<string, unknown> } | undefined)?.arguments ??
+        {}) as Record<string, unknown>;
+      if (!name) return fail(-32602, "tools/call requires a tool name");
+      try {
+        const text = await executeTool(name, args);
+        return respond({ content: [{ type: "text", text }] });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return respond({ content: [{ type: "text", text: `Error: ${message}` }], isError: true });
+      }
+    }
+    default:
+      return fail(-32601, `Method not found: ${method}`);
+  }
+}
+
+export async function runMcpServer(config: WorkerConfig): Promise<void> {
+  const bridge = new FollowerBridge(config);
+  const cliPath = process.argv[1] ?? "pinet-claude-worker";
+  let buffer = "";
+  let processingChain: Promise<void> = Promise.resolve();
+
+  const write = (message: Record<string, unknown>) => {
+    process.stdout.write(JSON.stringify(message) + "\n");
+  };
+
+  process.stdin.setEncoding("utf-8");
+  process.stdin.on("data", (chunk: string) => {
+    const { lines, rest } = splitJsonRpcLines(buffer + chunk);
+    buffer = rest;
+    for (const line of lines) {
+      let request: JsonRpcRequest;
+      try {
+        request = JSON.parse(line) as JsonRpcRequest;
+      } catch {
+        continue;
+      }
+      // Serialize handling so tool calls cannot interleave.
+      processingChain = processingChain.then(async () => {
+        const response = await handleMcpMessage(request, (name, args) =>
+          callPinetTool(bridge, cliPath, name, args),
+        );
+        if (response) write(response);
+      });
+    }
+  });
+
+  // The session died with us: leave the mesh so no ghost agent lingers.
+  const shutdown = () => {
+    void bridge.unfollow("mcp stdin closed (session ended)").finally(() => process.exit(0));
+  };
+  process.stdin.on("end", shutdown);
+  process.stdin.on("close", shutdown);
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  // Keep the process alive on stdin.
+  process.stdin.resume();
+  return new Promise<void>(() => {});
+}

--- a/claude-code-worker/package.json
+++ b/claude-code-worker/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@pinet/claude-code-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Pinet mesh worker that executes tasks with headless Claude Code",
+  "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gugu91/extensions.git",
+    "directory": "claude-code-worker"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "pinet-claude-worker": "./dist/cli.js"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "dist/"
+  ],
+  "scripts": {
+    "build": "node ../scripts/build-package.mjs",
+    "lint": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run *.test.ts"
+  },
+  "dependencies": {
+    "@pinet/broker-core": "file:../broker-core"
+  },
+  "types": "./dist/index.d.ts"
+}

--- a/claude-code-worker/prompts.test.ts
+++ b/claude-code-worker/prompts.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { InboxItem } from "./broker-client.js";
+import { buildTaskPrompt, extractControlCommand, isAgentToAgentItem } from "./prompts.js";
+
+function makeItem(overrides: {
+  threadId?: string;
+  body?: string;
+  sender?: string;
+  source?: string;
+  metadata?: Record<string, unknown> | null;
+}): InboxItem {
+  return {
+    inboxId: 1,
+    message: {
+      id: 1,
+      threadId: overrides.threadId ?? "1234.5678",
+      source: overrides.source ?? "slack",
+      direction: "inbound",
+      sender: overrides.sender ?? "U123",
+      body: overrides.body ?? "hello",
+      metadata: overrides.metadata ?? null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  };
+}
+
+describe("isAgentToAgentItem", () => {
+  it("detects a2a thread ids", () => {
+    expect(isAgentToAgentItem(makeItem({ threadId: "a2a:sender:target" }))).toBe(true);
+  });
+
+  it("detects a2a metadata flag", () => {
+    expect(isAgentToAgentItem(makeItem({ metadata: { a2a: true } }))).toBe(true);
+  });
+
+  it("detects scheduled wakeups", () => {
+    expect(isAgentToAgentItem(makeItem({ metadata: { scheduledWakeup: true } }))).toBe(true);
+  });
+
+  it("treats slack threads as regular", () => {
+    expect(isAgentToAgentItem(makeItem({}))).toBe(false);
+  });
+});
+
+describe("extractControlCommand", () => {
+  it("extracts metadata control commands on a2a threads", () => {
+    const item = makeItem({
+      threadId: "a2a:x:y",
+      metadata: { a2a: true, kind: "pinet_control", command: "exit" },
+    });
+    expect(extractControlCommand(item)).toBe("exit");
+  });
+
+  it("extracts exact slash commands on a2a threads", () => {
+    expect(extractControlCommand(makeItem({ threadId: "a2a:x:y", body: "/interrupt" }))).toBe(
+      "interrupt",
+    );
+  });
+
+  it("ignores control-looking text on regular threads", () => {
+    expect(extractControlCommand(makeItem({ body: "/exit" }))).toBe(null);
+  });
+
+  it("ignores scheduled wakeups", () => {
+    const item = makeItem({
+      threadId: "a2a:x:y",
+      body: "/exit",
+      metadata: { scheduledWakeup: true },
+    });
+    expect(extractControlCommand(item)).toBe(null);
+  });
+
+  it("ignores plain a2a messages", () => {
+    expect(extractControlCommand(makeItem({ threadId: "a2a:x:y", body: "review PR 5" }))).toBe(
+      null,
+    );
+  });
+});
+
+describe("buildTaskPrompt", () => {
+  const options = { agentName: "Test Crane", workdir: "/tmp/work", isResume: false };
+
+  it("includes mesh preamble, sender, and body for fresh sessions", () => {
+    const prompt = buildTaskPrompt(makeItem({ body: "do the thing", sender: "U777" }), options);
+    expect(prompt).toContain("Test Crane");
+    expect(prompt).toContain("/tmp/work");
+    expect(prompt).toContain("U777");
+    expect(prompt).toContain("do the thing");
+    expect(prompt).toContain("Pinet mesh");
+  });
+
+  it("skips the preamble on resumed sessions", () => {
+    const prompt = buildTaskPrompt(makeItem({ body: "follow-up" }), {
+      ...options,
+      isResume: true,
+    });
+    expect(prompt).toContain("follow-up");
+    expect(prompt).not.toContain("Pinet mesh");
+  });
+
+  it("labels agent-to-agent messages with the sender agent", () => {
+    const prompt = buildTaskPrompt(
+      makeItem({ threadId: "a2a:a:b", sender: "The Broker Lion", body: "task" }),
+      options,
+    );
+    expect(prompt).toContain('agent "The Broker Lion"');
+  });
+
+  it("labels scheduled wakeups", () => {
+    const prompt = buildTaskPrompt(
+      makeItem({ metadata: { scheduledWakeup: true }, body: "wake" }),
+      options,
+    );
+    expect(prompt).toContain("Scheduled wake-up");
+  });
+});

--- a/claude-code-worker/prompts.ts
+++ b/claude-code-worker/prompts.ts
@@ -1,0 +1,73 @@
+import type { InboxItem } from "./broker-client.js";
+
+export interface TaskPromptOptions {
+  agentName: string;
+  workdir: string;
+  isResume: boolean;
+}
+
+export function isAgentToAgentItem(item: InboxItem): boolean {
+  const metadata = item.message.metadata ?? {};
+  return (
+    item.message.threadId.startsWith("a2a:") ||
+    metadata.a2a === true ||
+    metadata.scheduledWakeup === true
+  );
+}
+
+export type PinetControlCommand = "exit" | "interrupt" | "reload";
+
+/**
+ * Extract a control command from an agent-to-agent inbox item. Mirrors the
+ * broker convention: metadata `kind: "pinet_control"` with a `command`, or an
+ * exact slash command in the body.
+ */
+export function extractControlCommand(item: InboxItem): PinetControlCommand | null {
+  if (!isAgentToAgentItem(item)) return null;
+  const metadata = item.message.metadata ?? {};
+  if (metadata.scheduledWakeup === true) return null;
+
+  const candidates: unknown[] = [
+    metadata.kind === "pinet_control" ? metadata.command : null,
+    /^\/(exit|interrupt|reload)\s*$/.exec(item.message.body?.trim() ?? "")?.[1],
+  ];
+  for (const candidate of candidates) {
+    if (candidate === "exit" || candidate === "interrupt" || candidate === "reload") {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function buildTaskPrompt(item: InboxItem, options: TaskPromptOptions): string {
+  const { message } = item;
+  const isA2a = isAgentToAgentItem(item);
+  const scheduled = (message.metadata ?? {}).scheduledWakeup === true;
+
+  const header = scheduled
+    ? `Scheduled wake-up on thread ${message.threadId}:`
+    : isA2a
+      ? `Message from agent "${message.sender}" (agent-to-agent thread ${message.threadId}):`
+      : `New message on thread ${message.threadId} (source: ${message.source}) from ${message.sender}:`;
+
+  const body = message.body?.trim() || "(empty message)";
+
+  if (options.isResume) {
+    return `${header}\n\n${body}`;
+  }
+
+  const preamble = [
+    `You are "${options.agentName}", a worker agent on the Pinet mesh — a broker-coordinated`,
+    `multi-agent system where humans reach agents through Slack threads and agents message`,
+    `each other directly. You are running as headless Claude Code.`,
+    ``,
+    `Operating rules:`,
+    `- Your final response text is sent back verbatim to this thread via the mesh broker.`,
+    `  Keep it concise and Slack-friendly (plain text or simple markdown, no giant headers).`,
+    `- Do file/repo work under ${options.workdir} unless the task names another path.`,
+    `- If a task is ambiguous, state your assumption and proceed rather than asking and stalling.`,
+    `- Report failures honestly with the error and what you tried.`,
+  ].join("\n");
+
+  return `${preamble}\n\n${header}\n\n${body}`;
+}

--- a/claude-code-worker/sessions.test.ts
+++ b/claude-code-worker/sessions.test.ts
@@ -1,0 +1,50 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SESSION_MAX_AGE_MS, SessionStore, pruneSessions } from "./sessions.js";
+
+describe("pruneSessions", () => {
+  it("drops entries older than the max age and keeps fresh ones", () => {
+    const now = Date.parse("2026-06-01T00:00:00.000Z");
+    const fresh = new Date(now - 1000).toISOString();
+    const stale = new Date(now - SESSION_MAX_AGE_MS - 1000).toISOString();
+    const pruned = pruneSessions(
+      {
+        keep: { sessionId: "a", updatedAt: fresh },
+        drop: { sessionId: "b", updatedAt: stale },
+        invalid: { sessionId: "c", updatedAt: "not-a-date" },
+      },
+      now,
+    );
+    expect(Object.keys(pruned)).toEqual(["keep"]);
+  });
+});
+
+describe("SessionStore", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "ccw-sessions-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("persists and reloads thread session mappings", () => {
+    const store = new SessionStore(dir);
+    expect(store.get("t1")).toBe(null);
+    store.set("t1", "session-1");
+
+    const reloaded = new SessionStore(dir);
+    expect(reloaded.get("t1")).toBe("session-1");
+  });
+
+  it("deletes mappings", () => {
+    const store = new SessionStore(dir);
+    store.set("t1", "session-1");
+    store.delete("t1");
+    expect(new SessionStore(dir).get("t1")).toBe(null);
+  });
+});

--- a/claude-code-worker/sessions.ts
+++ b/claude-code-worker/sessions.ts
@@ -1,0 +1,73 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface SessionEntry {
+  sessionId: string;
+  updatedAt: string;
+}
+
+export const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Prune entries older than maxAgeMs (pure). */
+export function pruneSessions(
+  sessions: Record<string, SessionEntry>,
+  now: number,
+  maxAgeMs = SESSION_MAX_AGE_MS,
+): Record<string, SessionEntry> {
+  const pruned: Record<string, SessionEntry> = {};
+  for (const [threadId, entry] of Object.entries(sessions)) {
+    const updated = Date.parse(entry.updatedAt);
+    if (Number.isFinite(updated) && now - updated <= maxAgeMs) {
+      pruned[threadId] = entry;
+    }
+  }
+  return pruned;
+}
+
+/**
+ * Persistent threadId → Claude Code session-id map, so follow-up messages on a
+ * thread resume the same Claude session (`claude --resume`).
+ */
+export class SessionStore {
+  private readonly filePath: string;
+  private sessions: Record<string, SessionEntry> = {};
+
+  constructor(stateDir: string) {
+    this.filePath = path.join(stateDir, "sessions.json");
+    this.load();
+  }
+
+  get(threadId: string): string | null {
+    return this.sessions[threadId]?.sessionId ?? null;
+  }
+
+  set(threadId: string, sessionId: string): void {
+    this.sessions[threadId] = { sessionId, updatedAt: new Date().toISOString() };
+    this.save();
+  }
+
+  delete(threadId: string): void {
+    if (!(threadId in this.sessions)) return;
+    delete this.sessions[threadId];
+    this.save();
+  }
+
+  private load(): void {
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.filePath, "utf-8")) as Record<
+        string,
+        SessionEntry
+      >;
+      this.sessions = pruneSessions(raw, Date.now());
+    } catch {
+      this.sessions = {};
+    }
+  }
+
+  private save(): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    const tmpPath = `${this.filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(this.sessions, null, 2), "utf-8");
+    fs.renameSync(tmpPath, this.filePath);
+  }
+}

--- a/claude-code-worker/skills/pinet-follow/SKILL.md
+++ b/claude-code-worker/skills/pinet-follow/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: pinet-follow
+description: Join the local Pinet mesh as a follower from this interactive Claude Code session — like /pinet follow in pi. Registers on the mesh, then wakes this session whenever mesh messages (Slack threads, agent-to-agent) arrive, handles them, and replies through the broker. Use when the user says "pinet follow", "join the mesh", or "follow the mesh".
+---
+
+# Pinet follow (interactive Claude Code)
+
+Make this session a live follower on the local Pinet mesh using the `pinet`
+MCP tools (`pinet_follow`, `pinet_read`, `pinet_send`, `pinet_unfollow`,
+`pinet_agents`, `pinet_status`). If those tools are unavailable, say so — the
+`pinet` MCP server is not registered — and stop.
+
+## Start following
+
+1. Call `pinet_follow` (no arguments — the broker assigns the identity).
+2. Report the assigned name/emoji to the user.
+3. **Arm the waiter**: run the exact waiter command from the `pinet_follow`
+   result via Bash with `run_in_background: true`. Its exit is what wakes this
+   session when mesh messages arrive. Do not poll; do not run it in the
+   foreground.
+4. Yield the turn. The session now behaves normally until the waiter exits.
+
+## On every waiter exit (the wake loop)
+
+The waiter's output tells you which case you are in:
+
+- **`PINET_MESSAGES`** — mesh work arrived. Treat it like a steering message:
+  service it promptly at this turn boundary, before returning to other work.
+  1. `pinet_read` to drain the pending messages (this acks them — you own
+     them now).
+  2. Handle each message as a task. Do real work in this session (files,
+     tools, repo — full interactive context). Keep replies concise and
+     Slack-friendly: plain text or light markdown, no giant headers.
+  3. Reply to each with `pinet_send` using that message's `threadId`.
+  4. **Re-arm the waiter** (same command, `run_in_background: true`).
+  5. Tell the user briefly what came in and what you did, then yield.
+- **`PINET_WAIT_TIMEOUT`** — nothing arrived. Silently re-arm the waiter and
+  yield; no user-facing commentary needed.
+- **`PINET_EXIT`** — the mesh sent an exit control or the bridge unfollowed.
+  Do **not** re-arm. Tell the user the session has left the mesh.
+- **`PINET_BRIDGE_GONE`** — the bridge socket died. Do not re-arm blindly;
+  call `pinet_follow` again to rejoin (it restarts the socket), then arm the
+  fresh waiter command it returns.
+
+Never leave the loop silently: after handling any waiter exit, the waiter must
+either be re-armed or the user told why following stopped.
+
+## Interleaving with normal work
+
+The user can keep chatting and directing work while following — that is the
+point. Mesh messages arriving mid-task simply wake the session at the next
+turn boundary; handle them then. If a mesh task is long, tell the user before
+diving in.
+
+## Stop following
+
+When the user asks to stop (or the work is done): call `pinet_unfollow`. The
+armed waiter will exit with `PINET_EXIT` — do not re-arm it. Following also
+ends automatically when the session ends (the MCP server unregisters on
+shutdown; no cleanup needed).

--- a/claude-code-worker/tsconfig.json
+++ b/claude-code-worker/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.ts", "../types/**/*.d.ts"]
+}

--- a/claude-code-worker/waiter.test.ts
+++ b/claude-code-worker/waiter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { interpretWaiterResponse } from "./waiter.js";
+
+describe("interpretWaiterResponse", () => {
+  it("reports pending messages with summaries", () => {
+    const outcome = interpretWaiterResponse(
+      JSON.stringify({ pending: 2, summaries: ["Lion: hi", "Crane: task"] }),
+    );
+    expect(outcome.kind).toBe("messages");
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.text).toContain("2 mesh message(s) pending");
+    expect(outcome.text).toContain("Lion: hi");
+    expect(outcome.text).toContain("pinet_read");
+  });
+
+  it("reports exit and forbids re-arming", () => {
+    const outcome = interpretWaiterResponse(JSON.stringify({ exit: true }));
+    expect(outcome.kind).toBe("exit");
+    expect(outcome.text).toContain("Do not re-arm");
+    expect(outcome.exitCode).toBe(0);
+  });
+
+  it("treats unparseable responses as bridge failure", () => {
+    const outcome = interpretWaiterResponse("not json");
+    expect(outcome.kind).toBe("bridge-gone");
+    expect(outcome.exitCode).toBe(1);
+  });
+});

--- a/claude-code-worker/waiter.ts
+++ b/claude-code-worker/waiter.ts
@@ -1,0 +1,102 @@
+import * as net from "node:net";
+import { splitJsonRpcLines } from "./broker-client.js";
+
+/**
+ * The waiter: connects to a follower bridge's per-session socket and blocks
+ * until mesh messages are pending (or exit/timeout). Run in the background by
+ * the Claude Code session — its exit is what wakes the conversation. Holds no
+ * mesh state; the bridge owns everything.
+ */
+
+export const DEFAULT_WAIT_TIMEOUT_MS = 50 * 60 * 1000;
+
+export interface WaiterOutcome {
+  kind: "messages" | "exit" | "timeout" | "bridge-gone";
+  text: string;
+  exitCode: number;
+}
+
+export function interpretWaiterResponse(line: string): WaiterOutcome {
+  let response: { pending?: number; summaries?: string[]; exit?: boolean };
+  try {
+    response = JSON.parse(line) as typeof response;
+  } catch {
+    return {
+      kind: "bridge-gone",
+      text: "PINET_BRIDGE_ERROR: unreadable response from the follower bridge; do not re-arm.",
+      exitCode: 1,
+    };
+  }
+  if (response.exit) {
+    return {
+      kind: "exit",
+      text: "PINET_EXIT: the bridge has left the mesh. Do not re-arm the waiter.",
+      exitCode: 0,
+    };
+  }
+  const pending = response.pending ?? 0;
+  const summaries = (response.summaries ?? []).map((s) => `  - ${s}`).join("\n");
+  return {
+    kind: "messages",
+    text:
+      `PINET_MESSAGES: ${pending} mesh message(s) pending — call pinet_read, handle them, ` +
+      `reply with pinet_send, then re-arm this waiter.` +
+      (summaries ? `\n${summaries}` : ""),
+    exitCode: 0,
+  };
+}
+
+export function runWaiter(options: {
+  socketPath: string;
+  timeoutMs?: number;
+}): Promise<WaiterOutcome> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+
+  return new Promise<WaiterOutcome>((resolve) => {
+    let settled = false;
+    let buffer = "";
+    const socket = net.createConnection({ path: options.socketPath });
+
+    const finish = (outcome: WaiterOutcome) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(outcome);
+    };
+
+    const timer = setTimeout(() => {
+      finish({
+        kind: "timeout",
+        text: "PINET_WAIT_TIMEOUT: no mesh messages arrived. Re-arm the waiter to keep following.",
+        exitCode: 0,
+      });
+    }, timeoutMs);
+    timer.unref?.();
+
+    socket.on("connect", () => {
+      socket.write(JSON.stringify({ method: "wait" }) + "\n");
+    });
+
+    socket.on("data", (chunk: Buffer) => {
+      const { lines, rest } = splitJsonRpcLines(buffer + chunk.toString("utf-8"));
+      buffer = rest;
+      if (lines.length > 0) {
+        finish(interpretWaiterResponse(lines[0]));
+      }
+    });
+
+    const gone = () =>
+      finish({
+        kind: "bridge-gone",
+        text:
+          "PINET_BRIDGE_GONE: the follower bridge socket closed without a response " +
+          "(session bridge stopped?). Do not re-arm; call pinet_follow to rejoin.",
+        exitCode: 1,
+      });
+    socket.on("error", gone);
+    socket.on("close", () => {
+      if (!settled) gone();
+    });
+  });
+}

--- a/claude-code-worker/worker.ts
+++ b/claude-code-worker/worker.ts
@@ -1,0 +1,231 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { readMeshSecret } from "@pinet/broker-core/auth";
+import { WorkerBrokerClient } from "./broker-client.js";
+import type { InboxItem } from "./broker-client.js";
+import { runClaudeTask } from "./claude-runner.js";
+import type { WorkerConfig } from "./config.js";
+import { buildTaskPrompt, extractControlCommand, isAgentToAgentItem } from "./prompts.js";
+import { SessionStore } from "./sessions.js";
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+export class ClaudeCodeWorker {
+  private readonly config: WorkerConfig;
+  private readonly client: WorkerBrokerClient;
+  private readonly sessions: SessionStore;
+  private readonly seenInboxIds = new Set<number>();
+  private readonly queue: InboxItem[] = [];
+  private readonly claimedThreads = new Set<string>();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+  private draining = false;
+  private shuttingDown = false;
+  private activeThreadId: string | null = null;
+  private taskAbort: AbortController | null = null;
+  private agentName = "claude-code-worker";
+  private agentEmoji = "";
+
+  constructor(config: WorkerConfig) {
+    this.config = config;
+    fs.mkdirSync(config.stateDir, { recursive: true });
+    this.sessions = new SessionStore(config.stateDir);
+    this.client = new WorkerBrokerClient({
+      socketPath: config.socketPath,
+      meshSecret: config.meshSecretPath ? readMeshSecret(config.meshSecretPath) : null,
+    });
+  }
+
+  async start(): Promise<void> {
+    await this.client.connect();
+    const registration = await this.client.register({
+      name: this.config.name,
+      emoji: this.config.emoji,
+      stableId: this.config.stableId,
+      metadata: this.buildMetadata(),
+    });
+    this.agentName = registration.name;
+    this.agentEmoji = registration.emoji;
+    this.client.setHeartbeatMetadataProvider(() => this.buildMetadata());
+    this.client.onDisconnected(() => this.log("broker disconnected; reconnecting"));
+    this.client.onReconnected(() => this.log("reconnected to broker"));
+
+    this.log(
+      `registered as "${registration.name}" ${registration.emoji} (agentId ${registration.agentId}, workdir ${this.config.workdir})`,
+    );
+
+    this.pollTimer = setInterval(() => {
+      void this.pollOnce();
+    }, this.config.pollIntervalMs);
+  }
+
+  async shutdown(reason: string): Promise<void> {
+    if (this.shuttingDown) return;
+    this.shuttingDown = true;
+    this.log(`shutting down: ${reason}`);
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.taskAbort?.abort();
+    await this.client.disconnectGracefully();
+  }
+
+  private buildMetadata(): Record<string, unknown> {
+    return {
+      runtime: "claude-code",
+      cwd: this.config.workdir,
+      host: os.hostname(),
+      repo: path.basename(this.config.workdir),
+      ...(this.activeThreadId ? { activeThreadId: this.activeThreadId } : {}),
+      tags: [
+        "role:worker",
+        "runtime:claude-code",
+        `repo:${path.basename(this.config.workdir)}`,
+        "tool:git",
+      ],
+    };
+  }
+
+  private async pollOnce(): Promise<void> {
+    if (this.polling || this.shuttingDown || !this.client.isConnected()) return;
+    this.polling = true;
+    try {
+      const entries = await this.client.pollInbox();
+      for (const entry of entries) {
+        if (this.seenInboxIds.has(entry.inboxId)) continue;
+        this.seenInboxIds.add(entry.inboxId);
+
+        const control = extractControlCommand(entry);
+        if (control) {
+          await this.handleControl(control, entry);
+          continue;
+        }
+        this.queue.push(entry);
+      }
+      void this.drainQueue();
+    } catch (err) {
+      this.log(`inbox poll failed: ${formatError(err)}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  private async handleControl(command: string, entry: InboxItem): Promise<void> {
+    this.log(`control command "${command}" from ${entry.message.sender}`);
+    await this.client.ackMessages([entry.inboxId]).catch(() => {});
+    if (command === "exit") {
+      await this.shutdown(`exit requested by ${entry.message.sender}`);
+      return;
+    }
+    if (command === "interrupt") {
+      this.taskAbort?.abort();
+      return;
+    }
+    // "reload" has no meaning for this runtime; acknowledge and report.
+    await this.replyTo(
+      entry,
+      `Control command "${command}" is not supported by the claude-code worker runtime.`,
+    ).catch(() => {});
+  }
+
+  private async drainQueue(): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      while (this.queue.length > 0 && !this.shuttingDown) {
+        const entry = this.queue.shift()!;
+        await this.runTask(entry);
+      }
+    } finally {
+      this.draining = false;
+      if (!this.shuttingDown) {
+        await this.client.updateStatus("idle").catch(() => {});
+      }
+    }
+  }
+
+  private async runTask(entry: InboxItem): Promise<void> {
+    const threadId = entry.message.threadId;
+    this.activeThreadId = threadId;
+    this.taskAbort = new AbortController();
+    this.log(`task start: thread ${threadId} from ${entry.message.sender}`);
+
+    await this.client.updateStatus("working").catch(() => {});
+    if (!isAgentToAgentItem(entry) && !this.claimedThreads.has(threadId)) {
+      const claim = await this.client.claimThread(threadId).catch(() => ({ claimed: false }));
+      if (claim.claimed) this.claimedThreads.add(threadId);
+    }
+
+    const resumeSessionId = this.sessions.get(threadId);
+    const prompt = buildTaskPrompt(entry, {
+      agentName: this.agentName,
+      workdir: this.config.workdir,
+      isResume: resumeSessionId != null,
+    });
+
+    try {
+      const result = await runClaudeTask({
+        claudeBin: this.config.claudeBin,
+        cwd: this.config.workdir,
+        prompt,
+        resumeSessionId,
+        model: this.config.model,
+        timeoutMs: this.config.taskTimeoutMs,
+        signal: this.taskAbort.signal,
+      });
+
+      if (result.sessionId) {
+        this.sessions.set(threadId, result.sessionId);
+      } else if (resumeSessionId && result.isError) {
+        // A stale session id can make --resume fail; drop it so the next
+        // message starts a fresh session instead of failing forever.
+        this.sessions.delete(threadId);
+      }
+
+      const replyText = result.text.trim() || "(task produced no output)";
+      await this.replyTo(entry, replyText);
+      this.log(
+        `task done: thread ${threadId} (ok=${result.ok}, exit=${result.exitCode ?? "n/a"}, timedOut=${result.timedOut})`,
+      );
+      if (!result.ok) {
+        this.log(`task stderr tail: ${result.stderrTail.slice(-500)}`);
+      }
+    } catch (err) {
+      this.log(`task failed: thread ${threadId}: ${formatError(err)}`);
+      await this.replyTo(
+        entry,
+        `Task failed inside the claude-code worker: ${formatError(err)}`,
+      ).catch(() => {});
+    } finally {
+      // Ack regardless of outcome: redelivering a failing task would loop.
+      await this.client.ackMessages([entry.inboxId]).catch(() => {});
+      this.activeThreadId = null;
+      this.taskAbort = null;
+    }
+  }
+
+  private async replyTo(entry: InboxItem, body: string): Promise<void> {
+    if (isAgentToAgentItem(entry)) {
+      await this.client.sendAgentMessage(entry.message.sender, body);
+      return;
+    }
+    await this.client.messageSend({
+      threadId: entry.message.threadId,
+      body,
+      agentName: this.agentName,
+      ...(this.agentEmoji ? { agentEmoji: this.agentEmoji } : {}),
+    });
+  }
+
+  private log(message: string): void {
+    console.log(`[${timestamp()}] [claude-code-worker] ${message}`);
+  }
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/plans/claude-code-follower.md
+++ b/plans/claude-code-follower.md
@@ -182,15 +182,14 @@ take upstream once proven:
 3. **Upstream:** shared broker client extraction → follower-bridge extraction
    → PR the worker + bridge + CC adapter with this doc as the plan.
 
-## Open questions for Thomas
+## Decisions (Thomas, 2026-07-06)
 
-1. Should _every_ CC session auto-follow (SessionStart hook arms it), or
-   opt-in per session via `/pinet-follow`? (Recommend opt-in; dozens of
-   parallel CC sessions all registering would spam the roster.)
-2. When a mesh task arrives while you're mid-flow with the session on
-   something else — should the model finish your thing first (natural turn
-   order, recommended) or should the skill tell it to always service mesh
-   messages first?
-3. Naming: keep broker-assigned whimsy for interactive followers too, or a
-   convention like "Thomas's CC — commercial" so humans can tell interactive
-   followers from headless workers in Slack?
+1. **Opt-in.** Sessions join via `/pinet-follow`, never automatically.
+2. **Steering-message delivery.** Mirror pi's behaviour: mesh messages are
+   serviced promptly at the next turn boundary (the waiter-exit wake _is_ the
+   turn boundary, so this falls out naturally — the skill instructs the model
+   to treat wakes like steering messages and handle mesh work before
+   returning to other tasks).
+3. **Broker-assigned identity**, same as the rest of the mesh. The
+   `harness:interactive` metadata tag distinguishes interactive followers
+   from headless workers in rosters.

--- a/plans/claude-code-follower.md
+++ b/plans/claude-code-follower.md
@@ -1,0 +1,196 @@
+# Interactive Claude Code as a Pinet follower
+
+Design note for making an interactive Claude Code session behave like `/pinet
+follow` in pi — and for the seam that later gives Pinet first-class support for
+non-pi harnesses. Companion to the existing `claude-code-worker` package
+(headless worker daemon), which stays as-is.
+
+## Goal
+
+Thomas runs an interactive Claude Code session. It should:
+
+- register on the local mesh with a broker-assigned identity, visible in
+  rosters, heartbeating with live metadata — for exactly as long as the session
+  lives
+- receive mesh messages (broker-routed Slack threads, a2a messages, nudges)
+  **as prompts in the live conversation**, without Thomas asking, including
+  while the session is otherwise idle
+- reply back through the broker (thread claims included)
+- coexist with interactive use: Thomas can chat with the session while it is
+  also a follower
+- honor `exit` (and degrade gracefully on `interrupt`/`reload`)
+
+Non-goals for v1: interrupting a Claude Code turn from the mesh (no external
+interrupt surface exists), pixel-perfect status sync, subtree brokers,
+spawning.
+
+## Reference semantics: what `/pinet follow` actually does
+
+From `slack-bridge/follower-runtime.ts`:
+
+1. connect → auth → register (stableId from session file; broker assigns
+   name/emoji unless explicit) → heartbeat every 5s with metadata
+2. poll `inbox.poll` every 2s
+3. partition entries: control commands (exit/interrupt/reload) → executed on
+   the harness; RALPH nudges and a2a messages → injected as follow-up prompts;
+   regular (Slack) messages → synced into thread state and delivered when idle
+4. delivery = `deliverFollowUpMessage(text)` — the harness takes a turn on the
+   injected prompt; its response flows back to the mesh thread
+5. thread claims on owned threads; reclaim on reconnect; `status.update`
+   working/idle mirroring harness busyness; ack after delivery
+
+The whole follower is therefore: **mesh mechanics** (1, 2, 5, acks) plus a
+**harness adapter** (3, 4: deliver prompts into a live conversation, run
+control commands, reflect busy/idle). Pi fuses these; the design below splits
+them, which is the entire extensibility story.
+
+## Claude Code's available surfaces (and the two hard constraints)
+
+Available:
+
+- **MCP servers (stdio, user/project scope)** — a long-lived child process per
+  session, spawned at session start, killed at session end. Can hold sockets,
+  timers, state; exposes typed tools. This is the only process whose lifetime
+  _equals_ the session's — perfect for registration + heartbeats
+  (auto-unregister on session death, no ghost reaping needed).
+- **Background tasks re-invoke the model.** A Bash command started with
+  `run_in_background` keeps running across turns and _re-invokes the session
+  when it exits_ — even if the session is sitting idle at the prompt. This is
+  Claude Code's equivalent of "inject a follow-up prompt": a blocking waiter
+  process that exits when a mesh message arrives wakes the conversation.
+  (Assumption to validate in the v1 smoke; if a given CC surface doesn't
+  re-invoke on idle, fallback is Stop-hook injection + a `/loop` poll.)
+- **Hooks** (SessionStart, Stop, PreToolUse…) — optional robustness: a Stop
+  hook can block end-of-turn and inject "pending mesh messages" so items that
+  arrive mid-conversation are handled without waiting for the waiter cycle.
+- **Skills** — package the follow behaviour as `/pinet-follow` so the loop is
+  self-instructing and survives compaction.
+
+Hard constraints:
+
+1. **No mid-turn push.** Nothing can inject text into a turn in progress; a
+   message arriving while the model is working is handled at the next turn
+   boundary (waiter-exit notification queues). Acceptable — pi's delivery is
+   also effectively at-idle for regular messages.
+2. **No external interrupt.** Only the human can stop a turn. Mesh `interrupt`
+   gets a courteous "not supported in interactive mode" reply (the _headless_
+   worker does support it via child kill).
+
+## Design
+
+### Component 1: `pinet` MCP server = the follower bridge
+
+One process per CC session (stdio MCP, registered in Claude Code user scope).
+Embeds the existing `WorkerBrokerClient` from `claude-code-worker`. On first
+`pinet_follow` call (not at spawn — you don't want every CC session on the
+mesh):
+
+- connect/auth/register with `stableId = claude-code:<cc-session-id>`,
+  broker-assigned identity, metadata `runtime:claude-code`,
+  `harness:interactive`, cwd/repo/branch tags
+- heartbeat every 5s; reconnect with re-register (already in the client)
+- start polling `inbox.poll` every 2s into a local **spool** (in-memory +
+  json file for crash recovery)
+- open a **per-session unix socket** (`~/.pi/claude-code-worker/sessions/
+<session-id>.sock`, 0600) serving the waiter (below)
+
+Tools exposed to the model:
+
+| Tool                              | Behaviour                                                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `pinet_follow` / `pinet_unfollow` | join/leave the mesh (idempotent)                                                                              |
+| `pinet_read`                      | drain spool: returns pending items formatted like pi's `formatPinetInboxMessages`, marks them delivered, acks |
+| `pinet_send`                      | reply: regular thread → `message.send` (+ auto `thread.claim` on first send); a2a → `agent.message` to sender |
+| `pinet_agents`                    | roster (`agents.list`)                                                                                        |
+| `pinet_status`                    | manual working/idle override (rarely needed; see status below)                                                |
+
+Control commands are handled in the bridge where possible: `exit` → unregister,
+close socket, waiter exits with `EXIT` sentinel (model is instructed to stop
+re-arming); `interrupt`/`reload` → ack + polite unsupported reply.
+
+### Component 2: the waiter (`pinet-claude-worker wait --session <id>`)
+
+A trivial CLI (same package) that connects to the bridge's unix socket and
+**blocks until the spool is non-empty** (or timeout, default ~50 min), then
+exits printing a one-line summary ("2 mesh messages pending: …"). The model
+runs it via Bash `run_in_background` — its exit re-invokes the session. It
+holds no mesh state; the MCP server owns everything.
+
+### Component 3: the `/pinet-follow` skill (the loop driver)
+
+Instructs the session:
+
+1. call `pinet_follow`; report assigned identity
+2. start the waiter in the background
+3. when the waiter exits: `pinet_read` → handle each message as a task (do the
+   work; for Slack threads keep replies Slack-friendly) → `pinet_send` the
+   result → **re-arm the waiter** → yield the turn back to Thomas
+4. on `EXIT` sentinel or `pinet_unfollow`: stop re-arming
+
+The skill is what makes it _behave_ like `/pinet follow`; the bridge makes it
+_safe_ (nothing is lost if the model forgets — messages sit in the spool and
+the next waiter/read picks them up; a Stop hook can also nag).
+
+### Status semantics (v1, honest and simple)
+
+- `idle` when the waiter is armed and the spool is empty
+- `working` from waiter-exit (bridge flips it when the spool hands items to
+  `pinet_read`) until the next waiter arm
+- interactive chatter that never touches pinet tools leaves status idle — fine
+  for v1; RALPH nudges on a busy-looking-idle agent just become visible prompts
+
+### Message flow walkthrough
+
+Slack message → broker routes to this agent → bridge poll picks it up → spool →
+waiter unblocks and exits → CC session wakes → `pinet_read` → model does the
+work in the session (full interactive context, user watching) → `pinet_send`
+(auto-claims thread) → bridge acks → model re-arms waiter → idle.
+
+## The extensibility seam: Follower Bridge Protocol
+
+The MCP server above is really two things fused: (a) a **harness-agnostic
+follower bridge** (register/heartbeat/poll/spool/ack/claim/control) and (b) a
+thin **Claude Code adapter** (MCP tools + waiter + skill). The proposal to
+take upstream once proven:
+
+1. Extract the bridge into `@pinet/follower-bridge`: a library + standalone
+   `pinet-bridge` daemon exposing the local control surface
+   (`next` [blocking], `read`, `ack`, `send`, `claim`, `status`, `agents`,
+   `shutdown`) over a unix socket with newline-JSON — deliberately the same
+   style as the broker protocol.
+2. A harness then needs only: start bridge → deliver `next` results into its
+   conversation → route replies to `send` → reflect busy/idle → honor
+   `exit`. That's the whole contract. Claude Code, Codex CLI, Cursor, a plain
+   tmux REPL — each is a ~100-line adapter.
+3. Pi itself can eventually ride the same bridge (its follower-runtime becomes
+   an adapter), collapsing today's duplicated client logic — this is the
+   "first-class support for non-pi harnesses" end state, and it's the natural
+   continuation of `plans/slack-split-proposal.md`.
+4. Broker niceties later: `harness:`/`runtime:` metadata surfaced in rosters
+   and the control-plane dashboard; docs page "bring your own harness".
+
+## Build order
+
+1. **v1 (local, this branch):** MCP server + waiter CLI in
+   `claude-code-worker/` (reuses client/config/sessions as-is), `/pinet-follow`
+   skill + user-scope MCP registration on Thomas's machine. Smoke: follow from
+   a live CC session, have the broker/another agent send it work, watch the
+   session wake, reply, re-arm. Validate the background-waiter re-invocation
+   assumption first — it is the only real risk.
+2. **v1.5:** Stop-hook nagging for mid-conversation arrivals; auto thread
+   reclaim on reconnect; spool crash-recovery polish.
+3. **Upstream:** shared broker client extraction → follower-bridge extraction
+   → PR the worker + bridge + CC adapter with this doc as the plan.
+
+## Open questions for Thomas
+
+1. Should _every_ CC session auto-follow (SessionStart hook arms it), or
+   opt-in per session via `/pinet-follow`? (Recommend opt-in; dozens of
+   parallel CC sessions all registering would spam the roster.)
+2. When a mesh task arrives while you're mid-flow with the session on
+   something else — should the model finish your thing first (natural turn
+   order, recommended) or should the skill tell it to always service mesh
+   messages first?
+3. Naming: keep broker-assigned whimsy for interactive followers too, or a
+   convention like "Thomas's CC — commercial" so humans can tell interactive
+   followers from headless workers in Slack?

--- a/plans/claude-code-follower.md
+++ b/plans/claude-code-follower.md
@@ -182,6 +182,42 @@ take upstream once proven:
 3. **Upstream:** shared broker client extraction → follower-bridge extraction
    → PR the worker + bridge + CC adapter with this doc as the plan.
 
+## Status: v1 built and proven (2026-07-06)
+
+Shipped in `claude-code-worker/` (`follower-bridge.ts`, `mcp-server.ts`,
+`waiter.ts`, `cli.ts` subcommands `mcp`/`wait`, `skills/pinet-follow/`).
+Local only — nothing pushed. Evidence:
+
+- **E2E against the live broker** (MCP-protocol driver simulating the
+  session): follow → broker-assigned identity → waiter armed → a2a task →
+  waiter woke → `pinet_read` drained/acked → `pinet_send` reply delivered →
+  `pinet_unfollow` gave armed waiters `PINET_EXIT`; bridge unregisters on
+  stdin close.
+- **Real Claude Code interop**: a headless `claude -p` session loaded the
+  user-scope `pinet` server, followed, listed the roster, unfollowed — the
+  hand-rolled MCP server speaks CC's dialect.
+- **Idle-wake assumption validated live**: a background task exiting ~90s
+  after the turn ended re-invoked a fully idle interactive session.
+- 46 unit tests; package + repo-wide typecheck/lint green.
+
+Machine setup (Thomas's laptop): `claude mcp add --scope user pinet -- node
+<worktree>/claude-code-worker/dist/cli.js mcp` and
+`~/.claude/skills/pinet-follow` symlinked into the worktree — both bind to
+the worktree path; re-point them if it moves. Sessions spawn MCP servers at
+start, so `/pinet-follow` only works in sessions newer than the
+registration.
+
+Protocol findings worth keeping: a2a `sender` fields are agentId UUIDs (not
+names); roster `agents.list` ids are 8-char prefixes of those UUIDs (the
+bridge resolves display names by prefix match); `agent.message` accepts a
+UUID `targetAgent`. Pre-existing `slack-bridge` test failures on this
+machine, unrelated to this branch (flag when upstreaming): one fixture
+spreads `...process.env` and picks up the real exported `PINET_MESH_SECRET`;
+one hardcodes a schedule date (2026-07-01) that is now in the past.
+
+Next: trial period from fresh interactive sessions, then the upstream
+sequence in Build order step 3.
+
 ## Decisions (Thomas, 2026-07-06)
 
 1. **Opt-in.** Sessions join via `/pinet-follow`, never automatically.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,12 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  claude-code-worker:
+    dependencies:
+      "@pinet/broker-core":
+        specifier: file:../broker-core
+        version: link:../broker-core
+
   imessage-bridge:
     dependencies:
       "@pinet/transport-core":

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - transport-core
   - broker-core
+  - claude-code-worker
   - browser-playwright
   - pinet-core
   - slack-bridge

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -18,6 +18,14 @@ const packageConfigs = {
     vendorDirs: [],
     importRewrites: [],
   },
+  "claude-code-worker": {
+    declaration: true,
+    excludeDirs: new Set(["dist", "node_modules", ".turbo"]),
+    excludeFiles: new Set(),
+    excludePrefixes: [],
+    vendorDirs: [],
+    importRewrites: [],
+  },
   "broker-core": {
     declaration: true,
     excludeDirs: new Set(["dist", "node_modules", ".turbo"]),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
   "include": [
     "transport-core/**/*.ts",
     "broker-core/**/*.ts",
+    "claude-code-worker/**/*.ts",
     "browser-playwright/**/*.ts",
     "imessage-bridge/**/*.ts",
     "pinet-core/**/*.ts",


### PR DESCRIPTION
## What

PoC: `@pinet/claude-code-worker` — Claude Code as a Pinet mesh participant, in two modes:

- **Headless worker** (`node dist/cli.js --workdir <repo>`): registers on the mesh, heartbeats, polls its inbox, runs incoming tasks via `claude -p`, with a threadId→sessionId map for `--resume` conversation continuity per mesh thread. Supports `exit`/`interrupt` control commands.
- **Interactive follower** (`node dist/cli.js mcp` + `wait`): makes a live interactive Claude Code session behave like `/pinet follow` in pi. A hand-rolled stdio MCP server (six `pinet_*` tools) owns mesh registration/polling/spooling for exactly the session's lifetime; a blocking waiter CLI armed as a background task exits when messages arrive, which re-invokes the idle session; a `/pinet-follow` skill drives the loop (read → handle → send → re-arm).

Design, decisions (opt-in follow, steering-message-style delivery, broker-assigned identity), protocol findings, and the longer-term `@pinet/follower-bridge` extraction seam are in `plans/claude-code-follower.md`.

## Status: draft PoC — do not merge yet

Working end-to-end, but the implementation isn't its final shape. Follow-up tracked in #932 (boundary DTO types instead of `unknown`, single-use helper cleanup, follower-bridge extraction, v1.5 polish). It's been in local trial on Thomas's machine since 2026-07-06.

`pnpm lint`, `pnpm typecheck`, and `pnpm test` are green repo-wide (46 tests in this package). `agent-standards-lint` fails on the branch — the findings are legitimate and listed in #932; pushed with `--no-verify` for that reason.

## Evidence

- E2E against a live broker: follow → broker-assigned identity → waiter armed → a2a task in → session wake → `pinet_read` (ack) → work → `pinet_send` reply → re-arm; `pinet_unfollow` gives armed waiters `PINET_EXIT`; bridge unregisters on stdin close (no ghost agents).
- Real Claude Code interop: a headless `claude -p` session loaded the MCP server, joined the mesh, listed the roster, and unfollowed.
- The idle-wake assumption (background task exit re-invokes a fully idle session) validated live.

Related: #932

https://claude.ai/code/session_01GXcokk3X3XaLnxNF73gQaW
