### PR TITLE
fix(slack-bridge): preserve prompt cache across Pinet role changes

### DIFF
--- a/slack-bridge/agent-prompt-guidance.test.ts
+++ b/slack-bridge/agent-prompt-guidance.test.ts
@@ -26,33 +26,35 @@ function createDeps(overrides: Partial<AgentPromptGuidanceDeps> = {}): AgentProm
 }
 
 describe("createAgentPromptGuidance", () => {
-  it("appends identity, personality, and reaction guidance for non-mesh sessions", async () => {
+  it("keeps only role-invariant reaction and broker guardrails in the system prompt", async () => {
     const getIdentityGuidelines = vi.fn(() => ["IDENTITY 1", "IDENTITY 2", "IDENTITY 3"]);
-    const guidance = createAgentPromptGuidance(
-      createDeps({
-        getIdentityGuidelines,
-      }),
-    );
+    const guidance = createAgentPromptGuidance(createDeps({ getIdentityGuidelines }));
 
     const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
 
-    expect(getIdentityGuidelines).toHaveBeenCalledTimes(1);
-    expect(result.systemPrompt).toContain("BASE\n\nIDENTITY 1\nIDENTITY 2\nIDENTITY 3");
-    expect(result.systemPrompt).toContain("COMMUNICATION STYLE:");
-    expect(result.systemPrompt).toContain("For `Cobalt Olive Crane`, aim for a");
-    expect(result.systemPrompt).toContain("Slack emoji reactions are ignored by default");
-    expect(result.systemPrompt).not.toContain("PINET SKIN (");
+    expect(result.systemPrompt).toContain("BASE\n\nSlack emoji reactions are ignored by default");
+    expect(result.systemPrompt).toContain("🔒 BROKER PROTOCOL BOUNDARY:");
+    expect(result.systemPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(result.systemPrompt).not.toContain("IDENTITY 1");
+    expect(result.systemPrompt).not.toContain("COMMUNICATION STYLE:");
     expect(result.systemPrompt).not.toContain("Pinet BROKER");
     expect(result.systemPrompt).not.toContain("TASK WORKFLOW:");
-    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
-      result.systemPrompt.indexOf("COMMUNICATION STYLE:"),
-    );
-    expect(result.systemPrompt.indexOf("COMMUNICATION STYLE:")).toBeLessThan(
-      result.systemPrompt.indexOf("Slack emoji reactions are ignored by default"),
-    );
+    expect(getIdentityGuidelines).not.toHaveBeenCalled();
   });
 
-  it("includes the skin guideline only when both theme and personality are available", async () => {
+  it("puts mutable identity and personality guidance in context", async () => {
+    const guidance = createAgentPromptGuidance(createDeps());
+
+    const contextUpdate = await guidance.buildContextUpdate();
+
+    expect(contextUpdate).toContain("PINET RUNTIME STATE: off.");
+    expect(contextUpdate).toContain("IDENTITY 1\nIDENTITY 2\nIDENTITY 3");
+    expect(contextUpdate).toContain("COMMUNICATION STYLE:");
+    expect(contextUpdate).toContain("For `Cobalt Olive Crane`, aim for a");
+    expect(contextUpdate).not.toContain("Slack emoji reactions are ignored by default");
+  });
+
+  it("includes the skin guideline in context only when theme and personality are available", async () => {
     const guidance = createAgentPromptGuidance(
       createDeps({
         getActiveSkinTheme: () => "ocean-mist",
@@ -60,72 +62,64 @@ describe("createAgentPromptGuidance", () => {
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const contextUpdate = await guidance.buildContextUpdate();
 
-    expect(result.systemPrompt).toContain("PINET SKIN (");
-    expect(result.systemPrompt).toContain("steady, elegant, observant");
+    expect(contextUpdate).toContain("PINET SKIN (");
+    expect(contextUpdate).toContain("steady, elegant, observant");
   });
 
-  it("adds loaded broker MD guidance, protocol guardrails, and tool guardrails for the broker role", async () => {
+  it("loads broker MD into context while keeping broker guardrails in the stable system prompt", async () => {
     const guidance = createAgentPromptGuidance(
       createDeps({
         getBrokerRole: () => "broker",
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const systemResult = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const contextUpdate = await guidance.buildContextUpdate();
 
-    expect(result.systemPrompt).toContain("You are 🦩 Cobalt Olive Crane, the Pinet BROKER.");
-    expect(result.systemPrompt).toContain("CUSTOM MD POLICY");
-    expect(result.systemPrompt).toContain("DELEGATE, THEN TRACK.");
-    expect(result.systemPrompt).toContain("🔒 BROKER PROTOCOL BOUNDARY:");
-    expect(result.systemPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
-    expect(result.systemPrompt).not.toContain("TASK WORKFLOW:");
+    expect(systemResult.systemPrompt).toContain("🔒 BROKER PROTOCOL BOUNDARY:");
+    expect(systemResult.systemPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(contextUpdate).toContain("PINET RUNTIME STATE: broker.");
+    expect(contextUpdate).toContain("You are 🦩 Cobalt Olive Crane, the Pinet BROKER.");
+    expect(contextUpdate).toContain("CUSTOM MD POLICY");
+    expect(contextUpdate).toContain("DELEGATE, THEN TRACK.");
+    expect(contextUpdate).not.toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(contextUpdate).not.toContain("TASK WORKFLOW:");
   });
 
-  it("adds worker workflow guidance for follower runtimes", async () => {
+  it("adds worker workflow guidance to follower context", async () => {
     const guidance = createAgentPromptGuidance(
       createDeps({
         getBrokerRole: () => "follower",
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const contextUpdate = await guidance.buildContextUpdate();
 
-    expect(result.systemPrompt).toContain(
-      "TASK WORKFLOW: When you receive work, follow these steps:",
-    );
-    expect(result.systemPrompt).toContain("REPLY TOOL RULES:");
-    expect(result.systemPrompt).not.toContain("Pinet BROKER");
-    expect(result.systemPrompt).not.toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(contextUpdate).toContain("PINET RUNTIME STATE: follower.");
+    expect(contextUpdate).toContain("TASK WORKFLOW: When you receive work, follow these steps:");
+    expect(contextUpdate).toContain("REPLY TOOL RULES:");
+    expect(contextUpdate).not.toContain("Pinet BROKER");
   });
 
-  it("keeps broker prompt order: base, shared guidance, loaded MD, protocol boundary, tool restriction", async () => {
+  it("keeps context order: runtime state, shared identity, then role workflow", async () => {
     const guidance = createAgentPromptGuidance(
       createDeps({
-        getBrokerRole: () => "broker",
-        loadBrokerPrompt: async () => ({
-          source: "workspace",
-          content: "LOADED BROKER MD",
-          warnings: [],
-          diagnostic: "broker prompt: workspace override loaded",
-        }),
+        getBrokerRole: () => "follower",
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const contextUpdate = await guidance.buildContextUpdate();
 
-    expect(result.systemPrompt.indexOf("BASE")).toBeLessThan(
-      result.systemPrompt.indexOf("IDENTITY 1"),
+    expect(contextUpdate.indexOf("PINET RUNTIME STATE:")).toBeLessThan(
+      contextUpdate.indexOf("IDENTITY 1"),
     );
-    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
-      result.systemPrompt.indexOf("LOADED BROKER MD"),
+    expect(contextUpdate.indexOf("IDENTITY 1")).toBeLessThan(
+      contextUpdate.indexOf("TASK WORKFLOW:"),
     );
-    expect(result.systemPrompt.indexOf("LOADED BROKER MD")).toBeLessThan(
-      result.systemPrompt.indexOf("🔒 BROKER PROTOCOL BOUNDARY:"),
-    );
-    expect(result.systemPrompt.indexOf("🔒 BROKER PROTOCOL BOUNDARY:")).toBeLessThan(
-      result.systemPrompt.indexOf("🚫 BROKER TOOL RESTRICTION:"),
+    expect(contextUpdate.indexOf("TASK WORKFLOW:")).toBeLessThan(
+      contextUpdate.indexOf("HELPER / DELEGATION RULES:"),
     );
   });
 
@@ -152,7 +146,7 @@ describe("createAgentPromptGuidance", () => {
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const contextUpdate = await guidance.buildContextUpdate();
 
     expect(reportBrokerPromptWarning).toHaveBeenCalledWith(
       "[slack-bridge] broker prompt: workspace override rejected (over 65536 bytes); continuing",
@@ -162,23 +156,64 @@ describe("createAgentPromptGuidance", () => {
     );
     expect(String(reportBrokerPromptWarning.mock.calls)).not.toContain("PRIVATE PROMPT BODY");
     expect(String(reportBrokerPromptDiagnostic.mock.calls)).not.toContain("PRIVATE PROMPT BODY");
-    expect(result.systemPrompt).toContain("PRIVATE PROMPT BODY");
+    expect(contextUpdate).toContain("PRIVATE PROMPT BODY");
   });
 
-  it("keeps identity guidance ahead of follower workflow guidance", async () => {
+  it("keeps the system prompt byte-stable after a follower role and identity change", async () => {
+    let role: "follower" | null = null;
+    let name = "Cobalt Olive Crane";
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getAgentName: () => name,
+        getIdentityGuidelines: () => [`IDENTITY ${name}`],
+        getBrokerRole: () => role,
+      }),
+    );
+
+    const beforeFollow = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    role = "follower";
+    name = "Hyper Slate Horse";
+    const afterFollow = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const contextUpdate = await guidance.buildContextUpdate();
+
+    expect(afterFollow.systemPrompt).toBe(beforeFollow.systemPrompt);
+    expect(afterFollow.systemPrompt).not.toContain("Cobalt Olive Crane");
+    expect(afterFollow.systemPrompt).not.toContain("Hyper Slate Horse");
+    expect(afterFollow.systemPrompt).not.toContain("TASK WORKFLOW:");
+    expect(contextUpdate).toContain("IDENTITY Hyper Slate Horse");
+    expect(contextUpdate).toContain("TASK WORKFLOW:");
+  });
+
+  it("can build initial runtime context before the first agent turn", async () => {
     const guidance = createAgentPromptGuidance(
       createDeps({
         getBrokerRole: () => "follower",
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+    const contextUpdate = await guidance.buildContextUpdate();
 
-    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
-      result.systemPrompt.indexOf("TASK WORKFLOW:"),
+    expect(contextUpdate).toContain("PINET RUNTIME STATE: follower.");
+    expect(contextUpdate).toContain("TASK WORKFLOW:");
+  });
+
+  it("revokes earlier role-specific guidance in the appended inactive snapshot", async () => {
+    let role: "follower" | null = "follower";
+    const guidance = createAgentPromptGuidance(
+      createDeps({
+        getBrokerRole: () => role,
+      }),
     );
-    expect(result.systemPrompt.indexOf("TASK WORKFLOW:")).toBeLessThan(
-      result.systemPrompt.indexOf("HELPER / DELEGATION RULES:"),
+
+    const followerUpdate = await guidance.buildContextUpdate();
+    role = null;
+    const inactiveUpdate = await guidance.buildContextUpdate();
+
+    expect(followerUpdate).toContain("TASK WORKFLOW:");
+    expect(inactiveUpdate).toContain("PINET RUNTIME STATE: off.");
+    expect(inactiveUpdate).toContain(
+      "Do not apply earlier broker- or follower-specific workflow guidance",
     );
+    expect(inactiveUpdate).not.toContain("TASK WORKFLOW:");
   });
 });

--- a/slack-bridge/agent-prompt-guidance.ts
+++ b/slack-bridge/agent-prompt-guidance.ts
@@ -31,15 +31,26 @@ export interface AgentPromptGuidanceDeps {
 
 export interface AgentPromptGuidance {
   beforeAgentStart: (event: BeforeAgentStartEvent) => Promise<{ systemPrompt: string }>;
+  buildContextUpdate: () => Promise<string>;
 }
 
+const RUNTIME_GUIDANCE_UPDATE_PREFIX =
+  "PINET RUNTIME GUIDANCE UPDATE: This is trusted extension context. Use the newest such update as the current identity and runtime workflow state.";
+
 export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentPromptGuidance {
-  async function buildPromptGuidelines(): Promise<string[]> {
+  const stableSystemGuidelines = [
+    ...buildReactionPromptGuidelines(),
+    buildBrokerProtocolGuardrailsPrompt(),
+    buildBrokerToolGuardrailsPrompt(),
+  ];
+
+  async function buildMutableGuidelines(): Promise<string[]> {
     const agentName = deps.getAgentName();
+    const role = deps.getBrokerRole();
     const guidelines = [
+      `PINET RUNTIME STATE: ${role ?? "off"}.`,
       ...deps.getIdentityGuidelines(),
       ...buildAgentPersonalityGuidelines(agentName),
-      ...buildReactionPromptGuidelines(),
     ];
 
     const skinGuideline = buildPinetSkinPromptGuideline(
@@ -50,7 +61,7 @@ export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentP
       guidelines.push(skinGuideline);
     }
 
-    if (deps.getBrokerRole() === "broker") {
+    if (role === "broker") {
       const brokerPrompt = await (
         deps.loadBrokerPrompt ??
         (() =>
@@ -70,10 +81,12 @@ export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentP
           agentName,
         }),
       );
-      guidelines.push(buildBrokerProtocolGuardrailsPrompt());
-      guidelines.push(buildBrokerToolGuardrailsPrompt());
-    } else if (deps.getBrokerRole() === "follower") {
+    } else if (role === "follower") {
       guidelines.push(...buildWorkerPromptGuidelines());
+    } else {
+      guidelines.push(
+        "This session is not currently a Pinet broker or follower. Do not apply earlier broker- or follower-specific workflow guidance unless a newer runtime guidance update activates that role.",
+      );
     }
 
     return guidelines;
@@ -81,11 +94,16 @@ export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentP
 
   async function beforeAgentStart(event: BeforeAgentStartEvent): Promise<{ systemPrompt: string }> {
     return {
-      systemPrompt: event.systemPrompt + "\n\n" + (await buildPromptGuidelines()).join("\n"),
+      systemPrompt: event.systemPrompt + "\n\n" + stableSystemGuidelines.join("\n"),
     };
+  }
+
+  async function buildContextUpdate(): Promise<string> {
+    return `${RUNTIME_GUIDANCE_UPDATE_PREFIX}\n\n${(await buildMutableGuidelines()).join("\n")}`;
   }
 
   return {
     beforeAgentStart,
+    buildContextUpdate,
   };
 }

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -66,7 +66,7 @@ export interface FollowerRuntimeDeps {
     name: string;
     emoji: string;
     metadata?: Record<string, unknown> | null;
-  }) => void;
+  }) => Promise<void> | void;
   persistState: () => void;
   updateBadge: () => void;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
@@ -233,7 +233,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
         await deps.getAgentMetadata("worker"),
         deps.getAgentStableId(),
       );
-      deps.applyRegistrationIdentity(registration);
+      await deps.applyRegistrationIdentity(registration);
       client.setHeartbeatMetadataProvider(() => deps.getAgentMetadata("worker"));
     }
 
@@ -455,7 +455,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
             );
             const registration = client.getRegisteredIdentity();
             if (registration) {
-              deps.applyRegistrationIdentity(registration);
+              await deps.applyRegistrationIdentity(registration);
             }
           }
           await resumeThreadClaims();

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -278,7 +278,7 @@ export function isBrokerForbiddenTool(toolName: string): boolean {
 
 /**
  * Build a prompt snippet describing broker tool restrictions.
- * Injected into the system prompt when the broker role is active.
+ * Kept in the role-invariant system prompt so runtime role changes do not bust its cache prefix.
  */
 export function buildBrokerToolGuardrailsPrompt(): string {
   const forbidden = [...BROKER_FORBIDDEN_TOOLS].join(", ");

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -767,6 +767,16 @@ describe("slack-bridge top-level shutdown", () => {
     const commands = new Map<string, CommandDefinition>();
     const events = new Map<string, EventHandler>();
     const sendMessage = vi.fn();
+    let activeSessionEntries: Array<{
+      type: "custom_message";
+      id: string;
+      parentId: string | null;
+      timestamp: string;
+      customType: string;
+      content: string;
+      display: boolean;
+      details: { role: string };
+    }> = [];
 
     const pi = {
       appendEntry: vi.fn(),
@@ -793,7 +803,8 @@ describe("slack-bridge top-level shutdown", () => {
         setStatus: vi.fn(),
       },
       sessionManager: {
-        getEntries: () => [],
+        getEntries: () => activeSessionEntries,
+        getBranch: () => activeSessionEntries,
         getHeader: () => null,
         getLeafId: () => "broker-prompt-layering-leaf",
         getSessionFile: () => "/tmp/slack-bridge-broker-prompt-layering-session.json",
@@ -892,6 +903,29 @@ describe("slack-bridge top-level shutdown", () => {
 
     await sessionShutdown?.({}, ctx);
     expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        customType: "pinet-runtime-guidance",
+        content: expect.stringContaining("PINET RUNTIME STATE: off."),
+        details: { role: "off" },
+      }),
+    );
+
+    activeSessionEntries = [
+      {
+        type: "custom_message",
+        id: "historical-broker-guidance",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        customType: "pinet-runtime-guidance",
+        content: "PINET RUNTIME STATE: broker. Historical broker workflow.",
+        display: false,
+        details: { role: "broker" },
+      },
+    ];
+    await sessionStart?.({}, ctx);
+
+    expect(sendMessage).toHaveBeenCalledTimes(3);
     expect(sendMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         customType: "pinet-runtime-guidance",

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -760,12 +760,13 @@ describe("slack-bridge top-level shutdown", () => {
     expect(brokerRuntimes[1]?.stop).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves the incoming system prompt prefix when broker guidance is appended at root runtime", async () => {
+  it("keeps the system prompt byte-stable when broker guidance is lazily appended to context", async () => {
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
     const commands = new Map<string, CommandDefinition>();
     const events = new Map<string, EventHandler>();
+    const sendMessage = vi.fn();
 
     const pi = {
       appendEntry: vi.fn(),
@@ -776,6 +777,7 @@ describe("slack-bridge top-level shutdown", () => {
       on: vi.fn((eventName: string, handler: EventHandler) => {
         events.set(eventName, handler);
       }),
+      sendMessage,
       sendUserMessage: vi.fn(),
     } as unknown as ExtensionAPI;
 
@@ -851,34 +853,34 @@ describe("slack-bridge top-level shutdown", () => {
     expect(beforeAgentStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await pinetStart?.handler("start", ctx);
-    expect(startBrokerSpy).toHaveBeenCalledTimes(1);
 
     const sentinelSystemPrompt = "SENTINEL ROOT PROMPT";
-    const result = await beforeAgentStart?.({ systemPrompt: sentinelSystemPrompt }, ctx);
-    const nextPrompt = result?.systemPrompt ?? "";
+    const beforeBroker = await beforeAgentStart?.({ systemPrompt: sentinelSystemPrompt }, ctx);
+    const stablePrompt = beforeBroker?.systemPrompt ?? "";
 
-    expect(nextPrompt.startsWith(`${sentinelSystemPrompt}\n\n`)).toBe(true);
-    expect(nextPrompt).toContain("First message in a new thread:");
-    expect(nextPrompt).toContain("COMMUNICATION STYLE:");
-    expect(nextPrompt).toContain("Slack emoji reactions are ignored by default");
+    await pinetStart?.handler("start", ctx);
+    expect(startBrokerSpy).toHaveBeenCalledTimes(1);
+    const afterBroker = await beforeAgentStart?.({ systemPrompt: sentinelSystemPrompt }, ctx);
+
+    expect(afterBroker?.systemPrompt).toBe(stablePrompt);
+    expect(stablePrompt.startsWith(`${sentinelSystemPrompt}\n\n`)).toBe(true);
+    expect(stablePrompt).not.toContain("First message in a new thread:");
+    expect(stablePrompt).not.toContain("COMMUNICATION STYLE:");
+    expect(stablePrompt).toContain("Slack emoji reactions are ignored by default");
     const brokerPolicyText = "the Pinet BROKER for a fully autonomous / unchained broker lane";
-    expect(nextPrompt).toContain(brokerPolicyText);
-    expect(nextPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
-    expect(nextPrompt.indexOf("First message in a new thread:")).toBeGreaterThan(
-      nextPrompt.indexOf(sentinelSystemPrompt),
-    );
-    expect(nextPrompt.indexOf("COMMUNICATION STYLE:")).toBeGreaterThan(
-      nextPrompt.indexOf("First message in a new thread:"),
-    );
-    expect(nextPrompt.indexOf("Slack emoji reactions are ignored by default")).toBeGreaterThan(
-      nextPrompt.indexOf("COMMUNICATION STYLE:"),
-    );
-    expect(nextPrompt.indexOf(brokerPolicyText)).toBeGreaterThan(
-      nextPrompt.indexOf("Slack emoji reactions are ignored by default"),
-    );
-    expect(nextPrompt.indexOf("🚫 BROKER TOOL RESTRICTION:")).toBeGreaterThan(
-      nextPrompt.indexOf(brokerPolicyText),
+    expect(stablePrompt).not.toContain(brokerPolicyText);
+    expect(stablePrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customType: "pinet-runtime-guidance",
+        display: false,
+        content: expect.stringMatching(
+          new RegExp(
+            `First message in a new thread:[\\s\\S]*COMMUNICATION STYLE:[\\s\\S]*${brokerPolicyText}`,
+          ),
+        ),
+        details: { role: "broker" },
+      }),
     );
 
     await sessionShutdown?.({}, ctx);

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -838,6 +838,7 @@ describe("slack-bridge top-level shutdown", () => {
     slackBridge(pi);
 
     const sessionStart = events.get("session_start");
+    const sessionCompact = events.get("session_compact");
     const sessionShutdown = events.get("session_shutdown");
     const pinetStart = commands.get("pinet");
     const beforeAgentStart = events.get("before_agent_start") as
@@ -848,11 +849,16 @@ describe("slack-bridge top-level shutdown", () => {
       | undefined;
 
     expect(sessionStart).toBeDefined();
+    expect(sessionCompact).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
     expect(beforeAgentStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    await sessionCompact?.({}, ctx);
+    expect(sendMessage).not.toHaveBeenCalled();
 
     const sentinelSystemPrompt = "SENTINEL ROOT PROMPT";
     const beforeBroker = await beforeAgentStart?.({ systemPrompt: sentinelSystemPrompt }, ctx);
@@ -870,6 +876,7 @@ describe("slack-bridge top-level shutdown", () => {
     const brokerPolicyText = "the Pinet BROKER for a fully autonomous / unchained broker lane";
     expect(stablePrompt).not.toContain(brokerPolicyText);
     expect(stablePrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         customType: "pinet-runtime-guidance",
@@ -884,6 +891,14 @@ describe("slack-bridge top-level shutdown", () => {
     );
 
     await sessionShutdown?.({}, ctx);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        customType: "pinet-runtime-guidance",
+        content: expect.stringContaining("PINET RUNTIME STATE: off."),
+        details: { role: "off" },
+      }),
+    );
   });
 
   it("sends an iMessage through the broker adapter when enabled", async () => {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -412,6 +412,60 @@ export default function (pi: ExtensionAPI) {
     getBrokerRole: () => brokerRole,
     getBrokerPromptSetting: () => settings.brokerPrompt,
   });
+  let lastPromptGuidanceContextUpdate: string | null = null;
+  let promptGuidanceGeneration = 0;
+  let promptGuidanceUpdateQueue = Promise.resolve();
+
+  function appendPromptGuidanceContextUpdate(force = false): Promise<void> {
+    const generation = promptGuidanceGeneration;
+    const update = promptGuidanceUpdateQueue
+      .catch(() => undefined)
+      .then(async () => {
+        if (generation !== promptGuidanceGeneration) {
+          return;
+        }
+
+        const content = await agentPromptGuidance.buildContextUpdate();
+        if (
+          generation !== promptGuidanceGeneration ||
+          (!force && content === lastPromptGuidanceContextUpdate)
+        ) {
+          return;
+        }
+
+        pi.sendMessage({
+          customType: "pinet-runtime-guidance",
+          content,
+          display: false,
+          details: { role: brokerRole ?? "off" },
+        });
+        lastPromptGuidanceContextUpdate = content;
+      });
+    promptGuidanceUpdateQueue = update;
+    return update.catch((error) => {
+      console.error(`[slack-bridge] failed to append Pinet runtime guidance: ${msg(error)}`);
+    });
+  }
+
+  function queuePromptGuidanceContextUpdate(): void {
+    void appendPromptGuidanceContextUpdate();
+  }
+
+  function applyLocalAgentIdentityWithPromptUpdate(
+    name: string,
+    emoji: string,
+    personality: string | null,
+  ): void {
+    applyLocalAgentIdentity(name, emoji, personality);
+    queuePromptGuidanceContextUpdate();
+  }
+
+  async function applyRegistrationIdentityWithPromptUpdate(
+    registration: Parameters<typeof applyRegistrationIdentity>[0],
+  ): Promise<void> {
+    applyRegistrationIdentity(registration);
+    await appendPromptGuidanceContextUpdate();
+  }
 
   let isSinglePlayerShuttingDown = () => false;
   let isSinglePlayerConnected = () => false;
@@ -718,7 +772,7 @@ export default function (pi: ExtensionAPI) {
       agentOwnerToken = ownerToken;
     },
     getAgentMetadata,
-    applyLocalAgentIdentity,
+    applyLocalAgentIdentity: applyLocalAgentIdentityWithPromptUpdate,
     buildSkinMetadata: (metadata, personality, statusVocabulary) =>
       buildSkinMetadata(metadata ?? undefined, personality, statusVocabulary),
     getMeshRoleFromMetadata: (metadata, fallbackRole) =>
@@ -1197,6 +1251,7 @@ export default function (pi: ExtensionAPI) {
     pinetEnabled = false;
     desiredAgentStatus = "idle";
     currentRuntimeMode = "off";
+    await appendPromptGuidanceContextUpdate();
     setExtStatus(ctx, "off");
   }
 
@@ -1469,6 +1524,7 @@ export default function (pi: ExtensionAPI) {
     pinetEnabled = true;
     desiredAgentStatus = "idle";
     currentRuntimeMode = "broker";
+    await appendPromptGuidanceContextUpdate();
 
     if (recoveredBrokerMessages > 0 || releasedBrokerClaims > 0) {
       const recoveredTargetedDetail =
@@ -1531,7 +1587,7 @@ export default function (pi: ExtensionAPI) {
       inbox.push(...messages);
     },
     getAgentMetadata,
-    applyRegistrationIdentity,
+    applyRegistrationIdentity: applyRegistrationIdentityWithPromptUpdate,
     persistState,
     updateBadge,
     maybeDrainInboxIfIdle,
@@ -1608,7 +1664,7 @@ export default function (pi: ExtensionAPI) {
       spawnSubtreeWorker: (ctx, input) => subtreeBrokerRuntime.spawnWorker(ctx, input),
       sendPinetAgentMessage,
       signalAgentFree,
-      applyLocalAgentIdentity,
+      applyLocalAgentIdentity: applyLocalAgentIdentityWithPromptUpdate,
       setExtStatus,
       setExtCtx: sessionUiRuntime.setExtCtx,
     },
@@ -1626,6 +1682,7 @@ export default function (pi: ExtensionAPI) {
     pinetEnabled = true;
     desiredAgentStatus = "idle";
     currentRuntimeMode = "follower";
+    await appendPromptGuidanceContextUpdate();
     setExtStatus(ctx, "ok");
   }
 
@@ -1639,6 +1696,7 @@ export default function (pi: ExtensionAPI) {
     brokerRole = null;
     pinetEnabled = false;
     currentRuntimeMode = "off";
+    await appendPromptGuidanceContextUpdate();
     if (!options.preserveErrorState) {
       followerRuntimeDiagnostic = null;
       setExtStatus(ctx, "off");
@@ -1650,6 +1708,8 @@ export default function (pi: ExtensionAPI) {
   // ─── Lifecycle ──────────────────────────────────────
 
   pi.on("session_start", async (_event, ctx) => {
+    promptGuidanceGeneration += 1;
+    lastPromptGuidanceContextUpdate = null;
     singlePlayerRuntime.resetShutdownState();
     slackRequestRuntime.reset();
     resetRemoteControlState();
@@ -1663,6 +1723,7 @@ export default function (pi: ExtensionAPI) {
       console.log("[slack-bridge] detected local subagent context; skipping Pinet registration");
       currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
+      await appendPromptGuidanceContextUpdate();
       return;
     }
 
@@ -1675,6 +1736,7 @@ export default function (pi: ExtensionAPI) {
 
     try {
       await transitionToRuntimeMode(ctx, startupMode);
+      await appendPromptGuidanceContextUpdate();
       if (startupMode === "single") {
         maybeWarnSlackGuardrailPosture(ctx);
         console.log("[slack-bridge] runtime mode: single");
@@ -1687,6 +1749,7 @@ export default function (pi: ExtensionAPI) {
       console.error(`[slack-bridge] runtime start (${startupMode}) failed: ${msg(err)}`);
       currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
+      await appendPromptGuidanceContextUpdate();
     }
   });
 
@@ -1695,6 +1758,7 @@ export default function (pi: ExtensionAPI) {
   agentEventRuntime.register(pi);
 
   pi.on("session_compact", async (_event, ctx) => {
+    await appendPromptGuidanceContextUpdate(true);
     maybeDrainInboxIfIdle(ctx);
   });
 

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -413,6 +413,7 @@ export default function (pi: ExtensionAPI) {
     getBrokerPromptSetting: () => settings.brokerPrompt,
   });
   let lastPromptGuidanceContextUpdate: string | null = null;
+  let hasPublishedPromptGuidanceContext = false;
   let promptGuidanceGeneration = 0;
   let promptGuidanceUpdateQueue = Promise.resolve();
 
@@ -421,7 +422,10 @@ export default function (pi: ExtensionAPI) {
     const update = promptGuidanceUpdateQueue
       .catch(() => undefined)
       .then(async () => {
-        if (generation !== promptGuidanceGeneration) {
+        if (
+          generation !== promptGuidanceGeneration ||
+          (brokerRole === null && !hasPublishedPromptGuidanceContext)
+        ) {
           return;
         }
 
@@ -440,6 +444,7 @@ export default function (pi: ExtensionAPI) {
           details: { role: brokerRole ?? "off" },
         });
         lastPromptGuidanceContextUpdate = content;
+        hasPublishedPromptGuidanceContext = true;
       });
     promptGuidanceUpdateQueue = update;
     return update.catch((error) => {
@@ -1710,6 +1715,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     promptGuidanceGeneration += 1;
     lastPromptGuidanceContextUpdate = null;
+    hasPublishedPromptGuidanceContext = false;
     singlePlayerRuntime.resetShutdownState();
     slackRequestRuntime.reset();
     resetRemoteControlState();

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1714,8 +1714,20 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     promptGuidanceGeneration += 1;
-    lastPromptGuidanceContextUpdate = null;
-    hasPublishedPromptGuidanceContext = false;
+    const activeSessionEntries =
+      typeof ctx.sessionManager.getBranch === "function"
+        ? ctx.sessionManager.getBranch()
+        : ctx.sessionManager.getEntries();
+    const previousPromptGuidance = [...activeSessionEntries]
+      .reverse()
+      .find(
+        (entry) => entry.type === "custom_message" && entry.customType === "pinet-runtime-guidance",
+      );
+    lastPromptGuidanceContextUpdate =
+      previousPromptGuidance && typeof previousPromptGuidance.content === "string"
+        ? previousPromptGuidance.content
+        : null;
+    hasPublishedPromptGuidanceContext = previousPromptGuidance !== undefined;
     singlePlayerRuntime.resetShutdownState();
     slackRequestRuntime.reset();
     resetRemoteControlState();


### PR DESCRIPTION
## Summary

- keep the extension-owned system-prompt suffix byte-stable across Pinet role and identity changes
- move mutable identity, skin, broker MD, and follower workflow guidance into hidden durable Pi context
- retain role-invariant broker safety boundaries at system priority and in runtime tool enforcement
- serialize/deduplicate runtime guidance updates, fence queued work across session replacement, restore guidance after compaction, and await follower identity updates

Closes #934.

## Design note

Pi has no portable public extension hook for appending mid-conversation system/developer messages. `pi.sendMessage()` creates durable custom messages that Pi converts to ordinary user-role provider context. Mutable operational guidance therefore uses that path, while security-critical broker restrictions remain in the stable system prompt and runtime guardrails.

## Validation

- `pnpm prepush`
- Slack bridge: 89 test files passed, 2 skipped; 1,571 tests passed, 3 skipped
- prompt stability integration test confirms the complete system prompt is byte-identical before and after broker activation
- follower tests confirm identity is applied and guidance appended before registration/reconnect processing continues
