### PR TITLE
Configure Git email in Amp orbs

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use each Orb user's personal noreply address when configured in Amp.
+if [[ -n "${GITHUB_NOREPLY_EMAIL:-}" ]]; then
+  git config --local user.email "$GITHUB_NOREPLY_EMAIL"
+else
+  echo "GITHUB_NOREPLY_EMAIL is not set; leaving Git email unchanged." >&2
+fi


### PR DESCRIPTION
## Summary

- configure repository-local Git email from each Orb user's personal `GITHUB_NOREPLY_EMAIL` environment variable
- leave the existing Git identity untouched when the variable is absent
- avoid repository-specific names or email addresses

## Verification

- `bash -n .agents/setup`
- exercised both configured and missing-variable paths
- `git diff --check`
- Amp review returned no findings