### PR TITLE
feat: stranded-broker recovery — lock owner identity, conflict classification, and /pinet start replace

### DIFF
--- a/broker-core/leader.ts
+++ b/broker-core/leader.ts
@@ -58,6 +58,12 @@ export interface BrokerLockProbes {
  * for exact equality against a value captured by this same function, so the
  * format does not need to be parseable — only stable for a given process.
  *
+ * On Linux the tick count is only unique within a single boot, so it is
+ * scoped with the kernel boot id: a PID reused after a reboot can then never
+ * present the same identity as the pre-reboot owner. `ps lstart` has
+ * one-second resolution, so a PID reused within the same wall-clock second
+ * as the original process is indistinguishable — an accepted residual risk.
+ *
  * Returns null when the start time cannot be determined; callers must treat
  * null as "unknown" and never use it as evidence of staleness.
  */
@@ -77,7 +83,17 @@ export function getProcessStartTime(pid: number): string | null {
         // Fields after comm+state start at index 1 here; starttime is overall
         // field 22, i.e. index 19 of the post-state remainder.
         const startTime = fields[19];
-        if (startTime && /^\d+$/.test(startTime)) return startTime;
+        if (startTime && /^\d+$/.test(startTime)) {
+          // starttime is measured in clock ticks since boot — scope it with
+          // the boot id so identities never collide across reboots.
+          let bootId = "";
+          try {
+            bootId = fs.readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim();
+          } catch {
+            /* boot id unavailable — token stays valid within this boot */
+          }
+          return bootId ? `${bootId}:${startTime}` : startTime;
+        }
       }
     } catch {
       /* fall through to ps */
@@ -259,6 +275,15 @@ function exclusiveCreateFile(filePath: string, content: string): boolean {
  * with staleness re-verified under that mutex — so a fresh lock can never be
  * destroyed by a concurrent reclaimer, and the lock path never goes empty
  * while a live owner's lock exists.
+ *
+ * Known mixed-version limitation: builds that predate the structured format
+ * replace a lock they consider stale with a plain rename over the lock path,
+ * which can overwrite a just-acquired v2 lock when an old and a new build
+ * race over the same stale lock. Exclusive acquisition is therefore only
+ * guaranteed among processes running this code; the window disappears once
+ * no pre-v2 sessions remain. A representation old builds cannot overwrite
+ * (such as a lock directory) would also break their ability to read the
+ * owner PID, which this format deliberately preserves.
  */
 export class LeaderLock {
   private readonly lockPath: string;
@@ -341,23 +366,25 @@ export class LeaderLock {
   /**
    * Remove a stale lock under an exclusive reclaim mutex.
    *
-   * The mutex file (`<lockPath>.reclaim`) is created with `O_EXCL`, so at
-   * most one reclaimer proceeds at a time, and staleness is re-verified
-   * while holding it. Because stale locks are only ever unlinked under this
-   * mutex, the lock path cannot go empty while a live owner's lock exists —
-   * which is what makes the exclusive create in `tryAcquire` a sound
-   * arbiter. A mutex left behind by a crashed reclaimer (dead PID) is itself
-   * reclaimed.
+   * The mutex file (`<lockPath>.reclaim`) is created with `O_EXCL` and
+   * records the reclaimer's PID plus start identity, so at most one
+   * reclaimer proceeds at a time, and staleness is re-verified while holding
+   * it. Because stale locks are only ever unlinked under this mutex, the
+   * lock path cannot go empty while a live owner's lock exists — which is
+   * what makes the exclusive create in `tryAcquire` a sound arbiter. A mutex
+   * left behind by a crashed reclaimer (dead PID, or a PID provably reused
+   * by an unrelated process) is itself reclaimed.
    *
    * Returns true when the caller may retry an exclusive create.
    */
   private reclaimStaleLock(): boolean {
     const mutexPath = `${this.lockPath}.reclaim`;
     const isRunning = this.probes.isProcessRunning ?? isProcessRunning;
+    const startTimeOf = this.probes.getProcessStartTime ?? getProcessStartTime;
 
     let holdsMutex = false;
     for (let campaign = 0; campaign < 2 && !holdsMutex; campaign++) {
-      if (exclusiveCreateFile(mutexPath, `${process.pid}\n`)) {
+      if (exclusiveCreateFile(mutexPath, `${process.pid}\n${startTimeOf(process.pid) ?? ""}\n`)) {
         holdsMutex = true;
       } else {
         // Mutex exists — held by a live reclaimer, or left by a crashed one.
@@ -367,9 +394,18 @@ export class LeaderLock {
         } catch {
           continue; // vanished — retry the campaign
         }
-        const holderPid = /^\d+$/.test(holderRaw) ? parseInt(holderRaw, 10) : null;
+        const [pidLine = "", startLine = ""] = holderRaw.split("\n");
+        const holderPid = /^\d+$/.test(pidLine.trim()) ? parseInt(pidLine.trim(), 10) : null;
+        const recordedStart = startLine.trim();
         if (holderPid !== null && holderPid > 0 && isRunning(holderPid)) {
-          return false; // a live reclaimer is working — back off
+          // The PID is live, but it may be an unrelated process that reused
+          // a crashed reclaimer's PID. Back off unless the recorded start
+          // identity provably belongs to a different process — uncertainty
+          // always means "assume the reclaimer is alive".
+          const currentStart = startTimeOf(holderPid);
+          if (!recordedStart || currentStart === null || currentStart === recordedStart) {
+            return false; // a live reclaimer is working — back off
+          }
         }
         // Crashed reclaimer. Remove its mutex only if it still records the
         // dead holder we just read, then retry the campaign.

--- a/broker-core/leader.ts
+++ b/broker-core/leader.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -6,19 +8,235 @@ export function defaultLockPath(): string {
   return path.join(os.homedir(), ".pi", "pinet-broker.lock");
 }
 
+// ─── Lock owner identity ─────────────────────────────────
+
 /**
- * Leader election via PID lock file.
+ * Identity of the process recorded in the broker leader lock.
  *
- * Only one broker process should run at a time. The leader writes its
- * PID to the lock file. Stale locks (PID no longer running) are
- * automatically reclaimed.
+ * Legacy locks (written by older builds) contain only a PID; structured locks
+ * additionally record the owner's process start time, a per-acquisition
+ * instance id, hostname, and creation timestamp so a second session can tell
+ * a live owner apart from a reused PID.
+ */
+export interface BrokerLockOwner {
+  pid: number;
+  processStartTime: string | null;
+  instanceId: string | null;
+  hostname: string | null;
+  createdAt: string | null;
+  /** True when the lock file only contained a bare PID (older builds). */
+  legacy: boolean;
+}
+
+export type BrokerLockInspection =
+  /** No lock file exists. */
+  | { state: "none"; owner: null }
+  /** Lock file exists but cannot be parsed — safe to reclaim. */
+  | { state: "unreadable"; owner: null }
+  /** Recorded PID is no longer running — safe to reclaim. */
+  | { state: "stale-dead"; owner: BrokerLockOwner }
+  /**
+   * Recorded PID is running but its process start time differs from the one
+   * recorded at lock creation — the PID was reused by an unrelated process,
+   * so the lock is stale and safe to reclaim.
+   */
+  | { state: "stale-pid-reused"; owner: BrokerLockOwner; currentStartTime: string }
+  /** Recorded PID is running and not provably stale. */
+  | { state: "alive"; owner: BrokerLockOwner };
+
+/** Injectable process probes (for tests). */
+export interface BrokerLockProbes {
+  isProcessRunning?: (pid: number) => boolean;
+  getProcessStartTime?: (pid: number) => string | null;
+}
+
+/**
+ * Deterministically capture a process's start time for PID-reuse detection.
+ *
+ * Uses `/proc/<pid>/stat` (field 22, clock ticks since boot) on Linux and
+ * `LC_ALL=C ps -p <pid> -o lstart=` elsewhere. Values are only ever compared
+ * for exact equality against a value captured by this same function, so the
+ * format does not need to be parseable — only stable for a given process.
+ *
+ * Returns null when the start time cannot be determined; callers must treat
+ * null as "unknown" and never use it as evidence of staleness.
+ */
+export function getProcessStartTime(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+
+  if (process.platform === "linux") {
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+      // comm (field 2) may contain spaces/parens — start after the last ")".
+      const closeParen = stat.lastIndexOf(")");
+      if (closeParen !== -1) {
+        const fields = stat
+          .slice(closeParen + 1)
+          .trim()
+          .split(/\s+/);
+        // Fields after comm+state start at index 1 here; starttime is overall
+        // field 22, i.e. index 19 of the post-state remainder.
+        const startTime = fields[19];
+        if (startTime && /^\d+$/.test(startTime)) return startTime;
+      }
+    } catch {
+      /* fall through to ps */
+    }
+  }
+
+  try {
+    const output = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
+      encoding: "utf-8",
+      env: { ...process.env, LC_ALL: "C", LANG: "C" },
+      timeout: 2000,
+    }).trim();
+    return output || null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Lock file parsing ───────────────────────────────────
+
+interface StructuredLockMetadata {
+  processStartTime: string | null;
+  instanceId: string | null;
+  hostname: string | null;
+  createdAt: string | null;
+}
+
+/** Serialized wire shape of the lock metadata line — field types unverified. */
+interface RawLockMetadata {
+  processStartTime?: string | null;
+  instanceId?: string | null;
+  hostname?: string | null;
+  createdAt?: string | null;
+}
+
+function readMetadataString(value: string | null | undefined): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function parseLockContent(content: string): BrokerLockOwner | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+
+  const newlineIndex = trimmed.indexOf("\n");
+  const pidLine = (newlineIndex === -1 ? trimmed : trimmed.slice(0, newlineIndex)).trim();
+  if (!/^\d+$/.test(pidLine)) return null;
+  const pid = parseInt(pidLine, 10);
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+
+  if (newlineIndex === -1) {
+    return {
+      pid,
+      processStartTime: null,
+      instanceId: null,
+      hostname: null,
+      createdAt: null,
+      legacy: true,
+    };
+  }
+
+  let metadata: StructuredLockMetadata | null = null;
+  try {
+    const raw = JSON.parse(trimmed.slice(newlineIndex + 1).trim()) as RawLockMetadata;
+    if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+      metadata = {
+        processStartTime: readMetadataString(raw.processStartTime),
+        instanceId: readMetadataString(raw.instanceId),
+        hostname: readMetadataString(raw.hostname),
+        createdAt: readMetadataString(raw.createdAt),
+      };
+    }
+  } catch {
+    metadata = null;
+  }
+  return {
+    pid,
+    processStartTime: metadata?.processStartTime ?? null,
+    instanceId: metadata?.instanceId ?? null,
+    hostname: metadata?.hostname ?? null,
+    createdAt: metadata?.createdAt ?? null,
+    legacy: metadata === null,
+  };
+}
+
+/**
+ * Read the current broker lock owner, or null when no lock file exists or it
+ * cannot be parsed.
+ */
+export function readBrokerLockOwner(lockPath?: string): BrokerLockOwner | null {
+  const resolved = lockPath ?? defaultLockPath();
+  let content: string;
+  try {
+    content = fs.readFileSync(resolved, "utf-8");
+  } catch {
+    return null;
+  }
+  return parseLockContent(content);
+}
+
+/**
+ * Inspect the broker leader lock and classify its owner.
+ *
+ * `stale-pid-reused` is only reported when both the recorded and current
+ * process start times are known and differ; unknown start times classify as
+ * `alive` so uncertainty never reclaims a live broker's lock.
+ */
+export function inspectBrokerLock(
+  lockPath?: string,
+  probes: BrokerLockProbes = {},
+): BrokerLockInspection {
+  const resolved = lockPath ?? defaultLockPath();
+  let content: string;
+  try {
+    content = fs.readFileSync(resolved, "utf-8");
+  } catch {
+    return { state: "none", owner: null };
+  }
+
+  const owner = parseLockContent(content);
+  if (!owner) {
+    return { state: "unreadable", owner: null };
+  }
+
+  const isRunning = probes.isProcessRunning ?? isProcessRunning;
+  if (!isRunning(owner.pid)) {
+    return { state: "stale-dead", owner };
+  }
+
+  if (owner.processStartTime) {
+    const startTimeOf = probes.getProcessStartTime ?? getProcessStartTime;
+    const currentStartTime = startTimeOf(owner.pid);
+    if (currentStartTime && currentStartTime !== owner.processStartTime) {
+      return { state: "stale-pid-reused", owner, currentStartTime };
+    }
+  }
+
+  return { state: "alive", owner };
+}
+
+// ─── Leader lock ─────────────────────────────────────────
+
+/**
+ * Leader election via lock file.
+ *
+ * Only one broker process should run at a time. The leader writes its PID on
+ * the first line (kept legacy-compatible so older builds still see a live
+ * owner) followed by a JSON metadata line recording process start time and a
+ * per-acquisition instance id. Stale locks (dead PID, reused PID, unreadable
+ * content) are automatically reclaimed.
  */
 export class LeaderLock {
   private readonly lockPath: string;
+  private readonly probes: BrokerLockProbes;
   private acquired = false;
+  private instanceId: string | null = null;
 
-  constructor(lockPath?: string) {
+  constructor(lockPath?: string, probes: BrokerLockProbes = {}) {
     this.lockPath = lockPath ?? defaultLockPath();
+    this.probes = probes;
   }
 
   /**
@@ -29,33 +247,44 @@ export class LeaderLock {
 
     fs.mkdirSync(path.dirname(this.lockPath), { recursive: true });
 
-    // Check existing lock
-    if (fs.existsSync(this.lockPath)) {
-      const content = fs.readFileSync(this.lockPath, "utf-8").trim();
-      const existingPid = parseInt(content, 10);
-
-      if (!isNaN(existingPid) && isProcessRunning(existingPid)) {
-        // Another live process holds the lock
-        return false;
+    const inspection = inspectBrokerLock(this.lockPath, this.probes);
+    if (inspection.state === "alive") {
+      // Another live process holds the lock
+      return false;
+    }
+    if (inspection.state !== "none") {
+      // Stale or unreadable lock — remove it
+      try {
+        fs.unlinkSync(this.lockPath);
+      } catch {
+        /* already gone */
       }
-
-      // Stale lock — remove it
-      fs.unlinkSync(this.lockPath);
     }
 
-    // Write our PID atomically (write to temp, rename)
+    // Write our identity atomically (write to temp, rename)
     const pid = process.pid;
+    const instanceId = crypto.randomUUID();
+    const startTimeOf = this.probes.getProcessStartTime ?? getProcessStartTime;
+    const metadata: StructuredLockMetadata & { version: number } = {
+      version: 2,
+      processStartTime: startTimeOf(pid),
+      instanceId,
+      hostname: os.hostname(),
+      createdAt: new Date().toISOString(),
+    };
+    const content = `${pid}\n${JSON.stringify(metadata)}\n`;
     const tmpPath = `${this.lockPath}.${pid}.tmp`;
-    fs.writeFileSync(tmpPath, String(pid), "utf-8");
+    fs.writeFileSync(tmpPath, content, "utf-8");
     fs.renameSync(tmpPath, this.lockPath);
 
     // Verify we actually won (guard against race)
-    const written = fs.readFileSync(this.lockPath, "utf-8").trim();
-    if (written !== String(pid)) {
+    const written = readBrokerLockOwner(this.lockPath);
+    if (!written || written.pid !== pid || written.instanceId !== instanceId) {
       return false;
     }
 
     this.acquired = true;
+    this.instanceId = instanceId;
     return true;
   }
 
@@ -67,17 +296,16 @@ export class LeaderLock {
 
     try {
       // Only remove if it's still our PID
-      if (fs.existsSync(this.lockPath)) {
-        const content = fs.readFileSync(this.lockPath, "utf-8").trim();
-        if (content === String(process.pid)) {
-          fs.unlinkSync(this.lockPath);
-        }
+      const owner = readBrokerLockOwner(this.lockPath);
+      if (owner && owner.pid === process.pid) {
+        fs.unlinkSync(this.lockPath);
       }
     } catch {
       // Best-effort cleanup
     }
 
     this.acquired = false;
+    this.instanceId = null;
   }
 
   /**
@@ -92,6 +320,13 @@ export class LeaderLock {
    */
   getLockPath(): string {
     return this.lockPath;
+  }
+
+  /**
+   * Per-acquisition instance id, set while the lock is held.
+   */
+  getInstanceId(): string | null {
+    return this.instanceId;
   }
 }
 

--- a/broker-core/leader.ts
+++ b/broker-core/leader.ts
@@ -217,16 +217,48 @@ export function inspectBrokerLock(
   return { state: "alive", owner };
 }
 
+/**
+ * Atomically create `filePath` with `content` already in place, failing when
+ * the path exists. A plain `writeFileSync("wx")` opens the file and then
+ * writes, so concurrent readers can observe an empty just-created file;
+ * writing a private temp file and `link()`ing it into place makes the path
+ * appear with its full content in one exclusive step.
+ */
+function exclusiveCreateFile(filePath: string, content: string): boolean {
+  const tmpPath = `${filePath}.${process.pid}.${crypto.randomUUID().slice(0, 8)}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, content, "utf-8");
+    fs.linkSync(tmpPath, filePath);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
 // ─── Leader lock ─────────────────────────────────────────
 
 /**
  * Leader election via lock file.
  *
- * Only one broker process should run at a time. The leader writes its PID on
- * the first line (kept legacy-compatible so older builds still see a live
- * owner) followed by a JSON metadata line recording process start time and a
- * per-acquisition instance id. Stale locks (dead PID, reused PID, unreadable
- * content) are automatically reclaimed.
+ * Only one broker process should run at a time. The leader creates the lock
+ * file with an exclusive create (`O_CREAT | O_EXCL`), writing its PID on the
+ * first line (kept legacy-compatible so older builds still see a live owner)
+ * followed by a JSON metadata line recording process start time and a
+ * per-acquisition instance id.
+ *
+ * Exclusive creation is the only way the lock comes into existence, so
+ * simultaneous contenders on an empty path get exactly one winner from the
+ * kernel. Stale locks (dead PID, reused PID, unreadable content) are only
+ * ever unlinked while holding an exclusively-created reclaim mutex file,
+ * with staleness re-verified under that mutex — so a fresh lock can never be
+ * destroyed by a concurrent reclaimer, and the lock path never goes empty
+ * while a live owner's lock exists.
  */
 export class LeaderLock {
   private readonly lockPath: string;
@@ -247,21 +279,35 @@ export class LeaderLock {
 
     fs.mkdirSync(path.dirname(this.lockPath), { recursive: true });
 
-    const inspection = inspectBrokerLock(this.lockPath, this.probes);
-    if (inspection.state === "alive") {
-      // Another live process holds the lock
-      return false;
-    }
-    if (inspection.state !== "none") {
-      // Stale or unreadable lock — remove it
-      try {
-        fs.unlinkSync(this.lockPath);
-      } catch {
-        /* already gone */
+    // Two passes: exclusive create, and one stale-reclaim + retry.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      if (this.tryExclusiveCreate()) {
+        return true;
+      }
+
+      const inspection = inspectBrokerLock(this.lockPath, this.probes);
+      if (inspection.state === "alive") {
+        // Another live process holds the lock.
+        return false;
+      }
+      if (inspection.state === "none") {
+        // The holder released between our create attempt and inspection.
+        continue;
+      }
+      if (!this.reclaimStaleLock()) {
+        // The lock is no longer stale, or another contender is reclaiming
+        // it. Back off conservatively.
+        return false;
       }
     }
+    return false;
+  }
 
-    // Write our identity atomically (write to temp, rename)
+  /**
+   * Create the lock file exclusively. Returns true when this process now
+   * holds the lock; false when another lock file already exists.
+   */
+  private tryExclusiveCreate(): boolean {
     const pid = process.pid;
     const instanceId = crypto.randomUUID();
     const startTimeOf = this.probes.getProcessStartTime ?? getProcessStartTime;
@@ -273,11 +319,15 @@ export class LeaderLock {
       createdAt: new Date().toISOString(),
     };
     const content = `${pid}\n${JSON.stringify(metadata)}\n`;
-    const tmpPath = `${this.lockPath}.${pid}.tmp`;
-    fs.writeFileSync(tmpPath, content, "utf-8");
-    fs.renameSync(tmpPath, this.lockPath);
+    // Exclusive create with full content — the kernel picks exactly one
+    // winner among simultaneous contenders, and no reader can ever observe a
+    // partially-written lock.
+    if (!exclusiveCreateFile(this.lockPath, content)) {
+      return false;
+    }
 
-    // Verify we actually won (guard against race)
+    // Paranoia read-back: if the file somehow no longer records our identity,
+    // treat the acquisition as lost and leave the file to its current owner.
     const written = readBrokerLockOwner(this.lockPath);
     if (!written || written.pid !== pid || written.instanceId !== instanceId) {
       return false;
@@ -289,15 +339,88 @@ export class LeaderLock {
   }
 
   /**
+   * Remove a stale lock under an exclusive reclaim mutex.
+   *
+   * The mutex file (`<lockPath>.reclaim`) is created with `O_EXCL`, so at
+   * most one reclaimer proceeds at a time, and staleness is re-verified
+   * while holding it. Because stale locks are only ever unlinked under this
+   * mutex, the lock path cannot go empty while a live owner's lock exists —
+   * which is what makes the exclusive create in `tryAcquire` a sound
+   * arbiter. A mutex left behind by a crashed reclaimer (dead PID) is itself
+   * reclaimed.
+   *
+   * Returns true when the caller may retry an exclusive create.
+   */
+  private reclaimStaleLock(): boolean {
+    const mutexPath = `${this.lockPath}.reclaim`;
+    const isRunning = this.probes.isProcessRunning ?? isProcessRunning;
+
+    let holdsMutex = false;
+    for (let campaign = 0; campaign < 2 && !holdsMutex; campaign++) {
+      if (exclusiveCreateFile(mutexPath, `${process.pid}\n`)) {
+        holdsMutex = true;
+      } else {
+        // Mutex exists — held by a live reclaimer, or left by a crashed one.
+        let holderRaw: string;
+        try {
+          holderRaw = fs.readFileSync(mutexPath, "utf-8").trim();
+        } catch {
+          continue; // vanished — retry the campaign
+        }
+        const holderPid = /^\d+$/.test(holderRaw) ? parseInt(holderRaw, 10) : null;
+        if (holderPid !== null && holderPid > 0 && isRunning(holderPid)) {
+          return false; // a live reclaimer is working — back off
+        }
+        // Crashed reclaimer. Remove its mutex only if it still records the
+        // dead holder we just read, then retry the campaign.
+        try {
+          if (fs.readFileSync(mutexPath, "utf-8").trim() === holderRaw) {
+            fs.unlinkSync(mutexPath);
+          }
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+    if (!holdsMutex) return false;
+
+    try {
+      // Re-verify staleness while holding the mutex. We are now the only
+      // process allowed to unlink the lock, so no fresh lock can be created
+      // (the path stays occupied) until we decide.
+      const current = inspectBrokerLock(this.lockPath, this.probes);
+      if (current.state === "alive") {
+        return false;
+      }
+      if (current.state !== "none") {
+        try {
+          fs.unlinkSync(this.lockPath);
+        } catch {
+          /* already gone */
+        }
+      }
+      return true;
+    } finally {
+      try {
+        fs.unlinkSync(mutexPath);
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  /**
    * Release the lock if we hold it.
    */
   release(): void {
     if (!this.acquired) return;
 
     try {
-      // Only remove if it's still our PID
+      // Only remove the lock when it still records THIS acquisition — PID
+      // alone is not enough, because a later broker instance in the same
+      // process may have legitimately re-acquired with a new instance id.
       const owner = readBrokerLockOwner(this.lockPath);
-      if (owner && owner.pid === process.pid) {
+      if (owner && owner.pid === process.pid && owner.instanceId === this.instanceId) {
         fs.unlinkSync(this.lockPath);
       }
     } catch {

--- a/model-aware-compaction/index.test.ts
+++ b/model-aware-compaction/index.test.ts
@@ -41,8 +41,21 @@ describe("extension wiring", () => {
   it("does nothing while disabled", () => {
     const { emit } = harness();
     const compact = vi.fn();
-    emit("agent_end", context(120_000, compact));
-    expect(compact).not.toHaveBeenCalled();
+    // Explicit project settings keep the test hermetic — without them the
+    // extension falls back to ~/.pi/agent/settings.json, coupling the result
+    // to whatever the developer's machine has configured globally.
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
+    fs.mkdirSync(path.join(temp, ".pi"));
+    fs.writeFileSync(
+      path.join(temp, ".pi", "settings.json"),
+      JSON.stringify({ "model-aware-compaction": { enabled: false } }),
+    );
+    try {
+      emit("agent_end", { ...context(120_000, compact), cwd: temp });
+      expect(compact).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
   });
 
   it("waits for the complete agent loop before compacting", () => {

--- a/plans/951-stranded-broker-recovery.md
+++ b/plans/951-stranded-broker-recovery.md
@@ -28,7 +28,9 @@ New lock format, backward compatible with legacy plain-PID readers:
 ```
 
 - Line 1 stays a plain PID so an older broker build parsing with `parseInt`
-  still sees a live PID and refuses to take over (no mixed-version split-brain).
+  still sees a live PID and refuses to take over (no mixed-version split-brain
+  while the owner is alive; see the residual-risk note below for the
+  stale-reclaim window).
 - `processStartTime` is captured deterministically (`/proc/<pid>/stat` start
   field on Linux, `LC_ALL=C ps -p <pid> -o lstart=` elsewhere) and compared by
   exact string equality. PID-reuse is only declared when both stored and
@@ -113,7 +115,9 @@ New lock format, backward compatible with legacy plain-PID readers:
   instant the path exists), so the kernel picks exactly one winner. Stale
   locks are only unlinked while holding an exclusively-created
   `<lockPath>.reclaim` mutex, with staleness re-verified under the mutex; a
-  mutex left by a crashed reclaimer (dead PID) is itself reclaimed.
+  mutex left by a crashed reclaimer (dead PID, or a PID provably reused by an
+  unrelated process — the mutex records the reclaimer's start identity) is
+  itself reclaimed.
 - **Release fencing**: `release()` requires the on-disk `instanceId` to match
   this acquisition, not just the PID, so a stale handle cannot delete a
   successor's lock.
@@ -126,4 +130,24 @@ New lock format, backward compatible with legacy plain-PID readers:
   contender processes racing over an empty path and over a stale lock, and
   assert exactly one winner (winners hold the lock until every contender has
   decided, so the test measures mutual exclusion rather than legitimate
-  dead-owner recovery).
+  dead-owner recovery; a readiness barrier ensures every contender reaches
+  the gate before it opens).
+- **Boot-scoped Linux identity**: `/proc/<pid>/stat` start ticks are relative
+  to the current boot, so the recorded identity is scoped with the kernel
+  `boot_id` — a PID reused after a reboot can never present the pre-reboot
+  owner's identity to the SIGTERM fence.
+
+## Known residual risks (accepted)
+
+- **Mixed-version stale reclaim**: pre-v2 builds replace a stale lock via
+  plain rename, which can overwrite a just-acquired v2 lock if an old and a
+  new build race over the same stale lock in the same instant. Any
+  representation old builds cannot overwrite would also break their ability
+  to read the owner PID; the window closes once no pre-v2 sessions remain.
+- **Fence→signal atomicity**: the verified owner could exit and its PID be
+  reused between the final fence re-check and `SIGTERM`. Closing this needs
+  an identity-bound kernel handle (Linux `pidfd_send_signal`), unavailable
+  without native code under the zero-dependency rule.
+- **macOS start-time precision**: `ps lstart` has one-second resolution, so
+  a PID reused within the same wall-clock second as the original process is
+  indistinguishable from it.

--- a/plans/951-stranded-broker-recovery.md
+++ b/plans/951-stranded-broker-recovery.md
@@ -1,0 +1,105 @@
+# 951 — Stranded broker recovery
+
+Issue: https://github.com/gugu91/pinet/issues/951
+
+## Problem
+
+`/pinet start` collapses every leader-lock conflict into one generic error and
+offers no recovery path. The lock stores only a PID and validates it with
+`kill(pid, 0)`, so a second session cannot distinguish:
+
+1. a healthy broker it should follow,
+2. a dead broker with stale lock state,
+3. a live but stranded/unresponsive broker process,
+4. a stale lock whose PID was reused by an unrelated process.
+
+When the Pi session hosting the broker is lost, recovery requires manual lock
+forensics (`cat` the lock, `lsof`, signal a PID by hand).
+
+## Design
+
+### 1. Structured leader lock (broker-core/leader.ts)
+
+New lock format, backward compatible with legacy plain-PID readers:
+
+```
+<pid>\n
+{"version":2,"processStartTime":"...","instanceId":"...","hostname":"...","createdAt":"..."}
+```
+
+- Line 1 stays a plain PID so an older broker build parsing with `parseInt`
+  still sees a live PID and refuses to take over (no mixed-version split-brain).
+- `processStartTime` is captured deterministically (`/proc/<pid>/stat` start
+  field on Linux, `LC_ALL=C ps -p <pid> -o lstart=` elsewhere) and compared by
+  exact string equality. PID-reuse is only declared when both stored and
+  current values are non-null and differ — uncertainty never reclaims a lock.
+- New API: `readBrokerLockOwner()`, `inspectBrokerLock()` returning
+  `none | stale-dead | stale-pid-reused | unreadable | alive` plus owner
+  identity, and `getProcessStartTime()`.
+- `tryAcquire()` reclaims `none`/`stale-*`/`unreadable`, refuses `alive`, and
+  verifies the win by matching pid + instanceId after the atomic rename.
+
+### 2. Conflict classification + typed error (slack-bridge/broker/lock-conflict.ts)
+
+- `probeBrokerSocket(target, timeoutMs)` — bounded connect + `auth` RPC.
+  Any well-formed JSON-RPC response (including an auth error) proves the broker
+  event loop is serving: `healthy | unreachable | unresponsive`.
+- `classifyBrokerLockConflict()` — lock inspection plus probe.
+- `BrokerLockConflictError` — thrown by `startBroker` on lock conflict, carrying
+  `classification` (`active-broker | unresponsive-broker`), lock owner identity,
+  and probe result, with an actionable message. `startBroker` retries the
+  acquire once when classification says the conflict became reclaimable
+  (owner died between attempts).
+
+### 3. Graceful remote shutdown (`admin.shutdown` RPC)
+
+- New authenticated socket-server method `admin.shutdown`. The broker runtime
+  wires a handler that stops the Pinet runtime in the owning session (session
+  survives; it just stops being the broker) and notifies its UI.
+- Responds first (`{ ok: true }`), shuts down on the next tick. Brokers without
+  a wired handler return method-not-found so callers treat them as
+  `unsupported` and fall back.
+
+### 4. Conservative takeover (`/pinet start replace`)
+
+`replaceBrokerOwner()` orchestration, with injectable deps for tests:
+
+1. Inspect the lock. Stale/none → nothing to replace (normal start reclaims).
+2. Live owner → request `admin.shutdown` over the socket, then poll for lock
+   release (bounded).
+3. If unsupported/unreachable/timed out → re-verify the owner fence (same pid +
+   process start time + instanceId), then SIGTERM the verified owner and poll
+   again (bounded).
+4. Never SIGKILL; on failure report the owner PID and manual guidance.
+5. Abort if the owner identity changes mid-flight (someone else recovered).
+
+### 5. Operator surfaces
+
+- `/pinet start` conflict messages become state-specific:
+  - healthy broker → suggest `/pinet follow` or `/pinet start replace`;
+  - unresponsive owner → suggest `/pinet start replace`.
+- `/pinet start replace` runs the takeover then a normal broker start.
+- `/pinet status` in `off`/`single` modes appends a machine-wide
+  "Global broker" section (lock state, owner pid/age, socket health, next step),
+  so the disconnected session — precisely the one that needs recovery — can see
+  global broker state.
+
+## Non-goals
+
+- No daemonization (tracked by the PRD in plans/420-broker-daemon-prd.md).
+- No automatic unattended takeover: replace stays an explicit operator action.
+- No weakening of the single-broker invariant.
+
+## Test plan
+
+- leader: v2 write/read, legacy parse, dead-PID reclaim, PID-reuse reclaim via
+  injected start-time provider, corrupt-lock reclaim, alive refusal, release
+  fencing.
+- lock-conflict: probe against a real socket server (healthy), missing socket
+  (unreachable), silent server (unresponsive); classification matrix;
+  `replaceBrokerOwner` graceful, fallback-terminate, owner-changed abort, and
+  failure paths with injected deps.
+- socket-server: `admin.shutdown` happy path, unauthenticated rejection,
+  handler-missing → method-not-found.
+- pinet-commands: start conflict messaging per classification, `start replace`
+  flow, status global-broker section.

--- a/plans/951-stranded-broker-recovery.md
+++ b/plans/951-stranded-broker-recovery.md
@@ -103,3 +103,27 @@ New lock format, backward compatible with legacy plain-PID readers:
   handler-missing → method-not-found.
 - pinet-commands: start conflict messaging per classification, `start replace`
   flow, status global-broker section.
+
+## Post-review hardening (PR #952 review findings)
+
+- **Exclusive acquisition**: `tryAcquire` no longer uses check-then-rename
+  (which admitted multiple simultaneous leaders — reproduced at 4–7 winners
+  of 8 contenders on the base algorithm with winners held alive). The lock is
+  created via write-temp + `link()` (atomic, exclusive, full content at the
+  instant the path exists), so the kernel picks exactly one winner. Stale
+  locks are only unlinked while holding an exclusively-created
+  `<lockPath>.reclaim` mutex, with staleness re-verified under the mutex; a
+  mutex left by a crashed reclaimer (dead PID) is itself reclaimed.
+- **Release fencing**: `release()` requires the on-disk `instanceId` to match
+  this acquisition, not just the PID, so a stale handle cannot delete a
+  successor's lock.
+- **Termination fencing**: `replaceBrokerOwner` refuses automatic SIGTERM for
+  owners without a recorded process start identity (legacy locks), and
+  aborts without signalling when a responsive broker rejects the shutdown
+  RPC (`rejected`, typically a mesh secret mismatch) — a responsive broker
+  is not stranded.
+- **Multi-process regression tests**: two stress tests spawn 8 real
+  contender processes racing over an empty path and over a stale lock, and
+  assert exactly one winner (winners hold the lock until every contender has
+  decided, so the test measures mutual exclusion rather than legitimate
+  dead-owner recovery).

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -263,6 +263,7 @@ Main commands:
 Coordinator commands:
 
 - `/pinet start` or `/pinet broker` - become the broker
+- `/pinet start replace` - take over a stale or stranded broker (graceful shutdown first, then a fenced SIGTERM fallback)
 - `/pinet follow` - become a follower
 - `/pinet unfollow` - disconnect from broker
 - `/pinet reload <agent>` - ask another agent to reload
@@ -379,6 +380,20 @@ If Pinet does not respond:
 3. Check `allowedUsers` or `allowAllWorkspaceUsers`
 4. Look in the log channel for errors
 5. Try `/pinet status` to check if Pinet is running
+
+### Stranded broker (lock held, controlling session lost)
+
+If `/pinet start` reports that another broker is already running but you no
+longer have that broker's Pi session (crash, laptop restart, stalled process):
+
+1. Run `/pinet status` from any session — it reports machine-wide broker lock
+   ownership and socket health even while disconnected.
+2. If the broker is healthy and you just want to participate, run
+   `/pinet follow`.
+3. If the broker is stranded (or you need the broker in this session), run
+   `/pinet start replace`. It asks the current broker to shut down gracefully
+   over the socket, falls back to a verified SIGTERM against the recorded lock
+   owner, and never escalates to SIGKILL.
 
 ### Stalled agents
 

--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -395,6 +395,16 @@ longer have that broker's Pi session (crash, laptop restart, stalled process):
    over the socket, falls back to a verified SIGTERM against the recorded lock
    owner, and never escalates to SIGKILL.
 
+Two cases intentionally refuse automatic termination:
+
+- **Legacy locks** (written by older builds, PID-only): there is no recorded
+  process start identity, so a SIGTERM could hit an unrelated process that
+  reused the PID. Inspect the process manually (`ps -p <pid>`), terminate it
+  yourself if it is truly the stranded broker, then run `/pinet start`.
+- **Rejected shutdown**: a broker that responds but rejects the shutdown
+  request (usually a mesh secret mismatch) is alive, not stranded. Fix the
+  mesh secret configuration or stop that broker from its own session.
+
 ### Stalled agents
 
 If work gets stuck:

--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -46,6 +46,7 @@ function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDe
     onMaintenanceError: vi.fn(),
     onScheduledWakeupError: vi.fn(),
     onAgentStatusChange: vi.fn(),
+    onAdminShutdownRequested: vi.fn(async () => {}),
     createActivityLogger: vi.fn(
       () =>
         ({

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -139,6 +139,13 @@ export interface BrokerRuntimeDeps {
     openedAt?: string,
   ) => Promise<BrokerControlPlaneDashboardSnapshot | null>;
   createAdapterBindings: readonly PinetRuntimeAdapterFactory[];
+  /**
+   * Invoked when an authenticated local client asks this broker to shut down
+   * gracefully (`admin.shutdown`, used by `/pinet start replace`). The
+   * implementation should stop the Pinet runtime in the owning session and
+   * notify its operator; the session itself stays alive.
+   */
+  onAdminShutdownRequested: (ctx: ExtensionContext) => Promise<void>;
 }
 
 function normalizeOptionalSetting(value: string | null | undefined): string | null {
@@ -648,6 +655,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
           }
           deps.onAgentStatusChange(ctx, changedAgentId, status);
         });
+        broker.server.setAdminShutdownHandler(() => deps.onAdminShutdownRequested(ctx));
 
         startBrokerHeartbeat();
         startBrokerMaintenance(ctx);

--- a/slack-bridge/broker/helpers.test.ts
+++ b/slack-bridge/broker/helpers.test.ts
@@ -1959,13 +1959,15 @@ describe("LeaderLock", () => {
     expect(lock.isLeader()).toBe(false);
   });
 
-  it("writes current PID to lock file", () => {
+  it("writes current PID as the first line of the lock file", () => {
     const lockPath = path.join(dir, "test.lock");
     const lock = new LeaderLock(lockPath);
     lock.tryAcquire();
 
     const content = fs.readFileSync(lockPath, "utf-8").trim();
-    expect(content).toBe(String(process.pid));
+    expect(content.split("\n")[0]).toBe(String(process.pid));
+    // Legacy readers parse with parseInt over the whole content.
+    expect(parseInt(content, 10)).toBe(process.pid);
     lock.release();
   });
 
@@ -2414,9 +2416,9 @@ describe("startBroker leader lock", () => {
     const lockPath = path.join(dir, "broker.lock");
     const broker = await launch({ lockPath });
 
-    // Lock file should exist with our PID
+    // Lock file should exist with our PID on the first line
     expect(fs.existsSync(lockPath)).toBe(true);
-    expect(fs.readFileSync(lockPath, "utf-8").trim()).toBe(String(process.pid));
+    expect(fs.readFileSync(lockPath, "utf-8").trim().split("\n")[0]).toBe(String(process.pid));
 
     await broker.stop();
     brokers.length = 0;
@@ -2436,7 +2438,7 @@ describe("startBroker leader lock", () => {
         lockPath,
         meshSecretPath: path.join(dir, "pinet.secret"),
       }),
-    ).rejects.toThrow("Another pinet broker is already running");
+    ).rejects.toThrow(/Another pinet broker is already running|holds the pinet broker lock/);
   });
 
   it("second broker starts after first stops", async () => {

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -5,12 +5,36 @@ import { BrokerSocketServer } from "./socket-server.js";
 import type { ListenTarget } from "./socket-server.js";
 import { assertLoopbackTcpHost } from "./raw-tcp-loopback.js";
 import { LeaderLock } from "./leader.js";
+import { BrokerLockConflictError, classifyBrokerLockConflict } from "./lock-conflict.js";
 import { getDefaultSocketPath } from "./paths.js";
 import type { MessageAdapter } from "./types.js";
 
 export { BrokerDB } from "./schema.js";
 export { BrokerSocketServer } from "./socket-server.js";
-export { LeaderLock } from "./leader.js";
+export {
+  LeaderLock,
+  inspectBrokerLock,
+  readBrokerLockOwner,
+  getProcessStartTime,
+} from "./leader.js";
+export type { BrokerLockInspection, BrokerLockOwner, BrokerLockProbes } from "./leader.js";
+export {
+  BrokerLockConflictError,
+  classifyBrokerLockConflict,
+  formatBrokerLockConflictMessage,
+  probeBrokerSocket,
+  replaceBrokerOwner,
+  requestBrokerShutdown,
+} from "./lock-conflict.js";
+export type {
+  BrokerLockConflict,
+  BrokerLockConflictClassification,
+  BrokerShutdownRequestResult,
+  BrokerSocketProbeResult,
+  ReplaceBrokerOwnerOptions,
+  ReplaceBrokerOwnerOutcome,
+  ReplaceBrokerOwnerResult,
+} from "./lock-conflict.js";
 export type { ListenTarget } from "./socket-server.js";
 export type { AgentMessageCallback, AgentRegistrationResolver } from "./socket-server.js";
 export type {
@@ -79,11 +103,29 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
   }
 
   // ── Leader lock: prevent split-brain (issue #119) ────
+  // On conflict, classify the lock owner (issue #951) so callers can offer a
+  // real recovery path instead of a generic failure.
   const lock = new LeaderLock(options.lockPath);
   if (!lock.tryAcquire()) {
-    throw new Error(
-      "Another pinet broker is already running. Only one broker may be active at a time.",
-    );
+    const conflict = await classifyBrokerLockConflict({
+      lockPath: lock.getLockPath(),
+      target,
+    });
+    // The owner may have died between the acquire attempt and classification
+    // — retry once when the conflict became reclaimable.
+    if (conflict.kind === "reclaimable" && lock.tryAcquire()) {
+      // Raced a dying owner; we now hold the lock.
+    } else if (conflict.kind === "conflict") {
+      throw new BrokerLockConflictError({
+        classification: conflict.classification,
+        owner: conflict.owner,
+        probe: conflict.probe,
+      });
+    } else {
+      throw new Error(
+        "Another pinet broker is already running. Only one broker may be active at a time.",
+      );
+    }
   }
 
   const db = new BrokerDB(options.dbPath);

--- a/slack-bridge/broker/leader.test.ts
+++ b/slack-bridge/broker/leader.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -231,6 +232,153 @@ describe("LeaderLock", () => {
     expect(fs.existsSync(lockPath)).toBe(true);
     expect(fs.readFileSync(lockPath, "utf-8").trim()).toBe("999999999");
   });
+
+  it("release does not remove a successor lock acquired by the same process", () => {
+    const lockPath = path.join(dir, "lock");
+    const stale = new LeaderLock(lockPath);
+    expect(stale.tryAcquire()).toBe(true);
+
+    // A later broker instance in the same process legitimately re-acquires
+    // (e.g. after the first instance's runtime was torn down out of band).
+    fs.unlinkSync(lockPath);
+    const successor = new LeaderLock(lockPath);
+    expect(successor.tryAcquire()).toBe(true);
+
+    // The stale handle must not delete the successor's lock: same PID, but a
+    // different acquisition instance.
+    stale.release();
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(readBrokerLockOwner(lockPath)?.instanceId).toBe(successor.getInstanceId());
+
+    successor.release();
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("does not destroy a fresh lock that appears between inspection and reclaim", () => {
+    const lockPath = path.join(dir, "lock");
+    // Start from a stale dead-PID lock…
+    fs.writeFileSync(lockPath, "2147483647", "utf-8");
+
+    // …but have the liveness probe simulate a concurrent fresh acquisition
+    // by swapping in another owner's structured lock mid-inspection.
+    const freshContent = `999999998\n${JSON.stringify({
+      version: 2,
+      processStartTime: "boot-F",
+      instanceId: "inst-fresh",
+      hostname: "host",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    })}\n`;
+    const lock = new LeaderLock(lockPath, {
+      isProcessRunning: (pid) => {
+        if (pid === 2147483647) {
+          fs.writeFileSync(lockPath, freshContent, "utf-8");
+          return false;
+        }
+        return true;
+      },
+    });
+
+    // Acquisition must back off rather than reclaim the changed lock.
+    expect(lock.tryAcquire()).toBe(false);
+    expect(readBrokerLockOwner(lockPath)?.instanceId).toBe("inst-fresh");
+  });
+});
+
+// ─── Simultaneous acquisition (multi-process) ───────────
+
+describe("LeaderLock simultaneous acquisition", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  async function raceContenders(options: { children: number; staleLock: boolean }): Promise<{
+    winners: number;
+    losers: number;
+  }> {
+    const lockPath = path.join(dir, "lock");
+    const gatePath = path.join(dir, "gate");
+    const donePath = path.join(dir, "done");
+    if (options.staleLock) {
+      fs.writeFileSync(lockPath, "2147483647", "utf-8");
+    }
+
+    // Node 22.18+/24 strip types natively, so children can import the .ts
+    // module directly with plain `node`. A winner must stay alive (holding
+    // the lock) until every contender has decided — otherwise a slower
+    // contender would correctly reclaim the already-dead winner's lock and
+    // the round would measure dead-owner recovery, not mutual exclusion.
+    const leaderModuleUrl = new URL("../../broker-core/leader.ts", import.meta.url).href;
+    const childScript = path.join(dir, "contender.mjs");
+    fs.writeFileSync(
+      childScript,
+      [
+        `import * as fs from "node:fs";`,
+        `const { LeaderLock } = await import(${JSON.stringify(leaderModuleUrl)});`,
+        `const resultPath = process.argv[2];`,
+        `while (!fs.existsSync(${JSON.stringify(gatePath)})) { /* spin until the gate opens */ }`,
+        `const lock = new LeaderLock(${JSON.stringify(lockPath)});`,
+        `const acquired = lock.tryAcquire();`,
+        `fs.writeFileSync(resultPath, JSON.stringify({ acquired }));`,
+        `while (acquired && !fs.existsSync(${JSON.stringify(donePath)})) { /* hold the lock */ }`,
+        `process.exit(0);`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const resultPaths = Array.from({ length: options.children }, (_, i) =>
+      path.join(dir, `result-${i}.json`),
+    );
+    const children = resultPaths.map((resultPath) =>
+      spawn(process.execPath, ["--no-warnings", childScript, resultPath], { stdio: "ignore" }),
+    );
+    // Attach exit promises immediately — losers exit long before the round
+    // ends, and a listener attached after the event has fired never resolves.
+    const exits = children.map(
+      (child) =>
+        new Promise<void>((resolve, reject) => {
+          child.on("error", reject);
+          child.on("exit", () => resolve());
+        }),
+    );
+    // Let every child reach the spin gate, then open it so all contenders
+    // attempt acquisition together.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    fs.writeFileSync(gatePath, "go", "utf-8");
+
+    // Wait until every contender has recorded its outcome, then let winners
+    // exit.
+    const deadline = Date.now() + 20_000;
+    while (resultPaths.some((p) => !fs.existsSync(p))) {
+      if (Date.now() > deadline) throw new Error("contenders did not all report in time");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    fs.writeFileSync(donePath, "done", "utf-8");
+    await Promise.all(exits);
+
+    const outcomes = resultPaths.map(
+      (p) => JSON.parse(fs.readFileSync(p, "utf-8")) as { acquired: boolean },
+    );
+    const winners = outcomes.filter((o) => o.acquired).length;
+    const losers = outcomes.filter((o) => !o.acquired).length;
+    expect(winners + losers).toBe(options.children);
+    return { winners, losers };
+  }
+
+  it("elects exactly one leader among simultaneous contenders", async () => {
+    const { winners } = await raceContenders({ children: 8, staleLock: false });
+    expect(winners).toBe(1);
+  }, 30_000);
+
+  it("elects exactly one leader when contenders race over a stale lock", async () => {
+    const { winners } = await raceContenders({ children: 8, staleLock: true });
+    expect(winners).toBe(1);
+  }, 30_000);
 });
 
 // ─── readBrokerLockOwner ─────────────────────────────────

--- a/slack-bridge/broker/leader.test.ts
+++ b/slack-bridge/broker/leader.test.ts
@@ -254,6 +254,36 @@ describe("LeaderLock", () => {
     expect(fs.existsSync(lockPath)).toBe(false);
   });
 
+  it("backs off when the reclaim mutex is held by a live reclaimer", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "2147483647", "utf-8"); // stale dead-PID lock
+
+    // A live holder with a matching start identity — and, separately, a
+    // legacy bare-PID mutex — must both be treated as an active reclaimer.
+    const start = getProcessStartTime(process.pid) ?? "";
+    for (const content of [`${process.pid}\n${start}\n`, `${process.pid}\n`]) {
+      fs.writeFileSync(`${lockPath}.reclaim`, content, "utf-8");
+      const lock = new LeaderLock(lockPath);
+      expect(lock.tryAcquire()).toBe(false);
+      expect(fs.existsSync(`${lockPath}.reclaim`)).toBe(true);
+      fs.unlinkSync(`${lockPath}.reclaim`);
+    }
+  });
+
+  it("reclaims a mutex abandoned by a crashed reclaimer whose PID was reused", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "2147483647", "utf-8"); // stale dead-PID lock
+
+    // The mutex records a live PID but a different start identity: the
+    // recording process is gone and its PID was reused, so the abandoned
+    // mutex must not strand reclamation forever.
+    fs.writeFileSync(`${lockPath}.reclaim`, `${process.pid}\nboot-old\n`, "utf-8");
+    const lock = new LeaderLock(lockPath, { getProcessStartTime: () => "boot-new" });
+    expect(lock.tryAcquire()).toBe(true);
+    expect(fs.existsSync(`${lockPath}.reclaim`)).toBe(false);
+    lock.release();
+  });
+
   it("does not destroy a fresh lock that appears between inspection and reclaim", () => {
     const lockPath = path.join(dir, "lock");
     // Start from a stale dead-PID lock…
@@ -321,6 +351,7 @@ describe("LeaderLock simultaneous acquisition", () => {
         `import * as fs from "node:fs";`,
         `const { LeaderLock } = await import(${JSON.stringify(leaderModuleUrl)});`,
         `const resultPath = process.argv[2];`,
+        `fs.writeFileSync(resultPath + ".ready", "ready");`,
         `while (!fs.existsSync(${JSON.stringify(gatePath)})) { /* spin until the gate opens */ }`,
         `const lock = new LeaderLock(${JSON.stringify(lockPath)});`,
         `const acquired = lock.tryAcquire();`,
@@ -346,20 +377,35 @@ describe("LeaderLock simultaneous acquisition", () => {
           child.on("exit", () => resolve());
         }),
     );
-    // Let every child reach the spin gate, then open it so all contenders
-    // attempt acquisition together.
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    fs.writeFileSync(gatePath, "go", "utf-8");
+    try {
+      // Readiness barrier: wait until every child has reached the spin gate,
+      // then open it so all contenders attempt acquisition together. A fixed
+      // sleep would let slow children start after the gate opened, quietly
+      // weakening the race into a sequential acquisition test.
+      const readyDeadline = Date.now() + 15_000;
+      while (resultPaths.some((p) => !fs.existsSync(`${p}.ready`))) {
+        if (Date.now() > readyDeadline)
+          throw new Error("contenders did not all reach the gate in time");
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      fs.writeFileSync(gatePath, "go", "utf-8");
 
-    // Wait until every contender has recorded its outcome, then let winners
-    // exit.
-    const deadline = Date.now() + 20_000;
-    while (resultPaths.some((p) => !fs.existsSync(p))) {
-      if (Date.now() > deadline) throw new Error("contenders did not all report in time");
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Wait until every contender has recorded its outcome, then let
+      // winners exit.
+      const deadline = Date.now() + 20_000;
+      while (resultPaths.some((p) => !fs.existsSync(p))) {
+        if (Date.now() > deadline) throw new Error("contenders did not all report in time");
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      fs.writeFileSync(donePath, "done", "utf-8");
+      await Promise.all(exits);
+    } finally {
+      // Never leak spinning children on a failed round.
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      }
+      await Promise.allSettled(exits);
     }
-    fs.writeFileSync(donePath, "done", "utf-8");
-    await Promise.all(exits);
 
     const outcomes = resultPaths.map(
       (p) => JSON.parse(fs.readFileSync(p, "utf-8")) as { acquired: boolean },

--- a/slack-bridge/broker/leader.test.ts
+++ b/slack-bridge/broker/leader.test.ts
@@ -2,7 +2,13 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { defaultLockPath, LeaderLock } from "./leader.js";
+import {
+  defaultLockPath,
+  getProcessStartTime,
+  inspectBrokerLock,
+  LeaderLock,
+  readBrokerLockOwner,
+} from "./leader.js";
 
 // ─── Helpers ─────────────────────────────────────────────
 
@@ -66,15 +72,34 @@ describe("LeaderLock", () => {
     lock.release();
   });
 
-  it("writes the current PID to the lock file", () => {
+  it("writes the current PID as the first line of the lock file", () => {
     const lockPath = path.join(dir, "lock");
     const lock = new LeaderLock(lockPath);
     lock.tryAcquire();
 
-    const written = fs.readFileSync(lockPath, "utf-8").trim();
-    expect(written).toBe(String(process.pid));
+    const [pidLine] = fs.readFileSync(lockPath, "utf-8").split("\n");
+    expect(pidLine).toBe(String(process.pid));
+    // Legacy readers parse the whole trimmed content with parseInt — the
+    // structured metadata must not change the PID they see.
+    expect(parseInt(fs.readFileSync(lockPath, "utf-8").trim(), 10)).toBe(process.pid);
 
     lock.release();
+  });
+
+  it("writes structured owner metadata alongside the PID", () => {
+    const lockPath = path.join(dir, "lock");
+    const lock = new LeaderLock(lockPath);
+    lock.tryAcquire();
+
+    const owner = readBrokerLockOwner(lockPath);
+    expect(owner).not.toBeNull();
+    expect(owner?.pid).toBe(process.pid);
+    expect(owner?.legacy).toBe(false);
+    expect(owner?.instanceId).toBe(lock.getInstanceId());
+    expect(owner?.createdAt).toBeTruthy();
+
+    lock.release();
+    expect(lock.getInstanceId()).toBeNull();
   });
 
   it("release removes the lock file", () => {
@@ -141,6 +166,57 @@ describe("LeaderLock", () => {
     lock.release();
   });
 
+  it("reclaims a lock whose PID was reused by an unrelated process", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(
+      lockPath,
+      `${process.pid}\n${JSON.stringify({
+        version: 2,
+        processStartTime: "boot-A",
+        instanceId: "inst-1",
+        hostname: "host",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      })}\n`,
+      "utf-8",
+    );
+
+    const lock = new LeaderLock(lockPath, {
+      getProcessStartTime: () => "boot-B",
+    });
+    expect(lock.tryAcquire()).toBe(true);
+    lock.release();
+  });
+
+  it("does not reclaim a live lock when the start time is unknown", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(
+      lockPath,
+      `${process.pid}\n${JSON.stringify({
+        version: 2,
+        processStartTime: "boot-A",
+        instanceId: "inst-1",
+        hostname: "host",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      })}\n`,
+      "utf-8",
+    );
+
+    // Unknown current start time must never count as evidence of staleness.
+    const lock = new LeaderLock(lockPath, {
+      getProcessStartTime: () => null,
+    });
+    expect(lock.tryAcquire()).toBe(false);
+  });
+
+  it("reclaims an unreadable lock file", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "not-a-pid\n", "utf-8");
+
+    const lock = new LeaderLock(lockPath);
+    expect(lock.tryAcquire()).toBe(true);
+    lock.release();
+  });
+
   it("release does not remove the file if another PID overwrote it", () => {
     const lockPath = path.join(dir, "lock");
     const lock = new LeaderLock(lockPath);
@@ -154,5 +230,175 @@ describe("LeaderLock", () => {
     // File should still exist because the PID didn't match
     expect(fs.existsSync(lockPath)).toBe(true);
     expect(fs.readFileSync(lockPath, "utf-8").trim()).toBe("999999999");
+  });
+});
+
+// ─── readBrokerLockOwner ─────────────────────────────────
+
+describe("readBrokerLockOwner", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  it("returns null when the lock file does not exist", () => {
+    expect(readBrokerLockOwner(path.join(dir, "missing"))).toBeNull();
+  });
+
+  it("parses a legacy plain-PID lock", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "12345", "utf-8");
+
+    const owner = readBrokerLockOwner(lockPath);
+    expect(owner).toEqual({
+      pid: 12345,
+      processStartTime: null,
+      instanceId: null,
+      hostname: null,
+      createdAt: null,
+      legacy: true,
+    });
+  });
+
+  it("parses a structured lock", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(
+      lockPath,
+      `12345\n${JSON.stringify({
+        version: 2,
+        processStartTime: "boot-A",
+        instanceId: "inst-1",
+        hostname: "host",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      })}\n`,
+      "utf-8",
+    );
+
+    const owner = readBrokerLockOwner(lockPath);
+    expect(owner).toEqual({
+      pid: 12345,
+      processStartTime: "boot-A",
+      instanceId: "inst-1",
+      hostname: "host",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      legacy: false,
+    });
+  });
+
+  it("treats a PID followed by corrupt metadata as a legacy lock", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "12345\nnot-json", "utf-8");
+
+    const owner = readBrokerLockOwner(lockPath);
+    expect(owner?.pid).toBe(12345);
+    expect(owner?.legacy).toBe(true);
+  });
+
+  it("returns null for unparsable content", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "garbage", "utf-8");
+    expect(readBrokerLockOwner(lockPath)).toBeNull();
+  });
+});
+
+// ─── inspectBrokerLock ───────────────────────────────────
+
+describe("inspectBrokerLock", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  function writeStructuredLock(lockPath: string, pid: number, processStartTime: string): void {
+    fs.writeFileSync(
+      lockPath,
+      `${pid}\n${JSON.stringify({
+        version: 2,
+        processStartTime,
+        instanceId: "inst-1",
+        hostname: "host",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      })}\n`,
+      "utf-8",
+    );
+  }
+
+  it("reports none when the lock file does not exist", () => {
+    expect(inspectBrokerLock(path.join(dir, "missing"))).toEqual({ state: "none", owner: null });
+  });
+
+  it("reports unreadable for unparsable content", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "garbage", "utf-8");
+    expect(inspectBrokerLock(lockPath)).toEqual({ state: "unreadable", owner: null });
+  });
+
+  it("reports stale-dead when the recorded PID is not running", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "2147483647", "utf-8");
+
+    const inspection = inspectBrokerLock(lockPath);
+    expect(inspection.state).toBe("stale-dead");
+    if (inspection.state === "stale-dead") {
+      expect(inspection.owner.pid).toBe(2147483647);
+    }
+  });
+
+  it("reports alive for a live legacy lock", () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, String(process.pid), "utf-8");
+
+    const inspection = inspectBrokerLock(lockPath);
+    expect(inspection.state).toBe("alive");
+  });
+
+  it("reports stale-pid-reused when start times differ", () => {
+    const lockPath = path.join(dir, "lock");
+    writeStructuredLock(lockPath, process.pid, "boot-A");
+
+    const inspection = inspectBrokerLock(lockPath, {
+      getProcessStartTime: () => "boot-B",
+    });
+    expect(inspection.state).toBe("stale-pid-reused");
+    if (inspection.state === "stale-pid-reused") {
+      expect(inspection.owner.pid).toBe(process.pid);
+      expect(inspection.currentStartTime).toBe("boot-B");
+    }
+  });
+
+  it("reports alive when start times match", () => {
+    const lockPath = path.join(dir, "lock");
+    writeStructuredLock(lockPath, process.pid, "boot-A");
+
+    const inspection = inspectBrokerLock(lockPath, {
+      getProcessStartTime: () => "boot-A",
+    });
+    expect(inspection.state).toBe("alive");
+  });
+});
+
+// ─── getProcessStartTime ─────────────────────────────────
+
+describe("getProcessStartTime", () => {
+  it("returns a stable non-empty value for the current process", () => {
+    const first = getProcessStartTime(process.pid);
+    const second = getProcessStartTime(process.pid);
+    expect(first).toBeTruthy();
+    expect(second).toBe(first);
+  });
+
+  it("returns null for an invalid pid", () => {
+    expect(getProcessStartTime(-1)).toBeNull();
+    expect(getProcessStartTime(0)).toBeNull();
   });
 });

--- a/slack-bridge/broker/lock-conflict.test.ts
+++ b/slack-bridge/broker/lock-conflict.test.ts
@@ -170,25 +170,25 @@ describe("requestBrokerShutdown", () => {
     });
   });
 
-  it("reports failed with a wrong mesh secret and never invokes the handler", async () => {
+  it("reports rejected with a wrong mesh secret and never invokes the handler", async () => {
     server = new BrokerSocketServer(db, sockPath, { meshSecret: "sekrit" });
     const handler = vi.fn(async () => {});
     server.setAdminShutdownHandler(handler);
     await server.start();
 
     const result = await requestBrokerShutdown({ socketPath: sockPath, meshSecret: "wrong" });
-    expect(result).toBe("failed");
+    expect(result).toBe("rejected");
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it("reports failed without a mesh secret when the broker requires one", async () => {
+  it("reports rejected without a mesh secret when the broker requires one", async () => {
     server = new BrokerSocketServer(db, sockPath, { meshSecret: "sekrit" });
     const handler = vi.fn(async () => {});
     server.setAdminShutdownHandler(handler);
     await server.start();
 
     const result = await requestBrokerShutdown({ socketPath: sockPath });
-    expect(result).toBe("failed");
+    expect(result).toBe("rejected");
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -396,6 +396,46 @@ describe("replaceBrokerOwner", () => {
 
     expect(result.outcome).toBe("replaced-terminated");
     expect(kill).toHaveBeenCalledWith(OWNER_PID, "SIGTERM");
+  });
+
+  it("refuses automatic SIGTERM for a legacy lock without a start-time fence", async () => {
+    // Legacy PID-only lock: no instanceId, no processStartTime — PID reuse
+    // cannot be detected, so the owner must never be signalled automatically.
+    fs.writeFileSync(lockPath, String(OWNER_PID), "utf-8");
+    const kill = vi.fn();
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: { isProcessRunning: () => true, getProcessStartTime: () => "whatever" },
+      requestShutdown: async () => "unsupported",
+      kill,
+      sleep: async () => {},
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(kill).not.toHaveBeenCalled();
+    expect(result.error).toContain("predates identity fencing");
+    expect(result.error).toContain(`ps -p ${OWNER_PID}`);
+  });
+
+  it("aborts without SIGTERM when the broker rejects the shutdown request", async () => {
+    // A responsive broker refusing shutdown (e.g. mesh secret mismatch) is
+    // not stranded — escalating to signals would bypass its refusal.
+    writeStructuredLock(lockPath, OWNER_PID);
+    const kill = vi.fn();
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: aliveProbes,
+      requestShutdown: async () => "rejected",
+      kill,
+      sleep: async () => {},
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(kill).not.toHaveBeenCalled();
+    expect(result.error).toContain("rejected the shutdown request");
+    expect(result.error).toContain("mesh secret");
   });
 
   it("aborts when the lock owner changes mid-flight", async () => {

--- a/slack-bridge/broker/lock-conflict.test.ts
+++ b/slack-bridge/broker/lock-conflict.test.ts
@@ -1,0 +1,458 @@
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrokerDB } from "./schema.js";
+import { BrokerSocketServer } from "./socket-server.js";
+import {
+  BrokerLockConflictError,
+  classifyBrokerLockConflict,
+  formatBrokerLockConflictMessage,
+  probeBrokerSocket,
+  replaceBrokerOwner,
+  requestBrokerShutdown,
+} from "./lock-conflict.js";
+import type { BrokerLockProbes } from "./leader.js";
+
+// ─── Helpers ─────────────────────────────────────────────
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lock-conflict-"));
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeStructuredLock(
+  lockPath: string,
+  pid: number,
+  overrides: Partial<{ processStartTime: string; instanceId: string }> = {},
+): void {
+  fs.writeFileSync(
+    lockPath,
+    `${pid}\n${JSON.stringify({
+      version: 2,
+      processStartTime: overrides.processStartTime ?? "boot-A",
+      instanceId: overrides.instanceId ?? "inst-1",
+      hostname: "host",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    })}\n`,
+    "utf-8",
+  );
+}
+
+const aliveProbes: BrokerLockProbes = {
+  isProcessRunning: () => true,
+  getProcessStartTime: () => "boot-A",
+};
+
+// ─── probeBrokerSocket ───────────────────────────────────
+
+describe("probeBrokerSocket", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  it("classifies a real broker socket as healthy", async () => {
+    const db = new BrokerDB(path.join(dir, "test.db"));
+    db.initialize();
+    const sockPath = path.join(dir, "pinet.sock");
+    const server = new BrokerSocketServer(db, sockPath);
+    await server.start();
+    try {
+      const result = await probeBrokerSocket({ socketPath: sockPath });
+      expect(result).toBe("healthy");
+    } finally {
+      await server.stop();
+      db.close();
+    }
+  });
+
+  it("classifies a mesh-secret-protected broker as healthy without knowing the secret", async () => {
+    const db = new BrokerDB(path.join(dir, "test.db"));
+    db.initialize();
+    const sockPath = path.join(dir, "pinet.sock");
+    const server = new BrokerSocketServer(db, sockPath, { meshSecret: "sekrit" });
+    await server.start();
+    try {
+      // An auth error is still a well-formed response — the broker is serving.
+      const result = await probeBrokerSocket({ socketPath: sockPath });
+      expect(result).toBe("healthy");
+    } finally {
+      await server.stop();
+      db.close();
+    }
+  });
+
+  it("classifies a missing socket as unreachable", async () => {
+    const result = await probeBrokerSocket({ socketPath: path.join(dir, "missing.sock") });
+    expect(result).toBe("unreachable");
+  });
+
+  it("classifies a silent server as unresponsive", async () => {
+    const sockPath = path.join(dir, "silent.sock");
+    const connections = new Set<net.Socket>();
+    const silent = net.createServer((socket) => {
+      // accept and never respond
+      connections.add(socket);
+    });
+    await new Promise<void>((resolve) => silent.listen(sockPath, resolve));
+    try {
+      const result = await probeBrokerSocket({ socketPath: sockPath, timeoutMs: 150 });
+      expect(result).toBe("unresponsive");
+    } finally {
+      for (const socket of connections) socket.destroy();
+      await new Promise<void>((resolve) => silent.close(() => resolve()));
+    }
+  });
+});
+
+// ─── requestBrokerShutdown ───────────────────────────────
+
+describe("requestBrokerShutdown", () => {
+  let dir: string;
+  let db: BrokerDB;
+  let server: BrokerSocketServer;
+  let sockPath: string;
+
+  beforeEach(async () => {
+    dir = tmpDir();
+    db = new BrokerDB(path.join(dir, "test.db"));
+    db.initialize();
+    sockPath = path.join(dir, "pinet.sock");
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    db.close();
+    cleanup(dir);
+  });
+
+  it("reports accepted and invokes the wired handler", async () => {
+    server = new BrokerSocketServer(db, sockPath);
+    const handler = vi.fn(async () => {});
+    server.setAdminShutdownHandler(handler);
+    await server.start();
+
+    const result = await requestBrokerShutdown({ socketPath: sockPath });
+    expect(result).toBe("accepted");
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reports unsupported when no handler is wired", async () => {
+    server = new BrokerSocketServer(db, sockPath);
+    await server.start();
+
+    const result = await requestBrokerShutdown({ socketPath: sockPath });
+    expect(result).toBe("unsupported");
+  });
+
+  it("reports accepted with the correct mesh secret", async () => {
+    server = new BrokerSocketServer(db, sockPath, { meshSecret: "sekrit" });
+    const handler = vi.fn(async () => {});
+    server.setAdminShutdownHandler(handler);
+    await server.start();
+
+    const result = await requestBrokerShutdown({ socketPath: sockPath, meshSecret: "sekrit" });
+    expect(result).toBe("accepted");
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reports failed with a wrong mesh secret and never invokes the handler", async () => {
+    server = new BrokerSocketServer(db, sockPath, { meshSecret: "sekrit" });
+    const handler = vi.fn(async () => {});
+    server.setAdminShutdownHandler(handler);
+    await server.start();
+
+    const result = await requestBrokerShutdown({ socketPath: sockPath, meshSecret: "wrong" });
+    expect(result).toBe("failed");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("reports failed without a mesh secret when the broker requires one", async () => {
+    server = new BrokerSocketServer(db, sockPath, { meshSecret: "sekrit" });
+    const handler = vi.fn(async () => {});
+    server.setAdminShutdownHandler(handler);
+    await server.start();
+
+    const result = await requestBrokerShutdown({ socketPath: sockPath });
+    expect(result).toBe("failed");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("reports unreachable when the socket does not exist", async () => {
+    server = new BrokerSocketServer(db, sockPath);
+    await server.start();
+
+    const result = await requestBrokerShutdown({
+      socketPath: path.join(dir, "missing.sock"),
+    });
+    expect(result).toBe("unreachable");
+  });
+});
+
+// ─── classifyBrokerLockConflict ──────────────────────────
+
+describe("classifyBrokerLockConflict", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  it("reports reclaimable when no lock exists", async () => {
+    const conflict = await classifyBrokerLockConflict({
+      lockPath: path.join(dir, "missing"),
+      probeSocket: async () => "healthy",
+    });
+    expect(conflict.kind).toBe("reclaimable");
+    if (conflict.kind === "reclaimable") {
+      expect(conflict.inspection.state).toBe("none");
+    }
+  });
+
+  it("reports reclaimable for a dead-PID lock", async () => {
+    const lockPath = path.join(dir, "lock");
+    fs.writeFileSync(lockPath, "2147483647", "utf-8");
+
+    const conflict = await classifyBrokerLockConflict({
+      lockPath,
+      probeSocket: async () => "healthy",
+    });
+    expect(conflict.kind).toBe("reclaimable");
+    if (conflict.kind === "reclaimable") {
+      expect(conflict.inspection.state).toBe("stale-dead");
+    }
+  });
+
+  it("classifies a live owner with a responding socket as active-broker", async () => {
+    const lockPath = path.join(dir, "lock");
+    writeStructuredLock(lockPath, process.pid);
+
+    const conflict = await classifyBrokerLockConflict({
+      lockPath,
+      probes: aliveProbes,
+      probeSocket: async () => "healthy",
+    });
+    expect(conflict.kind).toBe("conflict");
+    if (conflict.kind === "conflict") {
+      expect(conflict.classification).toBe("active-broker");
+      expect(conflict.owner.pid).toBe(process.pid);
+      expect(conflict.probe).toBe("healthy");
+    }
+  });
+
+  it("classifies a live owner with a dead socket as unresponsive-broker", async () => {
+    const lockPath = path.join(dir, "lock");
+    writeStructuredLock(lockPath, process.pid);
+
+    const conflict = await classifyBrokerLockConflict({
+      lockPath,
+      probes: aliveProbes,
+      probeSocket: async () => "unreachable",
+    });
+    expect(conflict.kind).toBe("conflict");
+    if (conflict.kind === "conflict") {
+      expect(conflict.classification).toBe("unresponsive-broker");
+      expect(conflict.probe).toBe("unreachable");
+    }
+  });
+});
+
+// ─── BrokerLockConflictError ─────────────────────────────
+
+describe("BrokerLockConflictError", () => {
+  const owner = {
+    pid: 1336,
+    processStartTime: "boot-A",
+    instanceId: "inst-1",
+    hostname: "host",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    legacy: false,
+  };
+
+  it("describes an active broker with follow/replace guidance", () => {
+    const err = new BrokerLockConflictError({
+      classification: "active-broker",
+      owner,
+      probe: "healthy",
+    });
+    expect(err.message).toContain("Another pinet broker is already running");
+    expect(err.message).toContain("pid 1336");
+    expect(err.message).toContain("/pinet follow");
+    expect(err.message).toContain("/pinet start replace");
+    expect(err.classification).toBe("active-broker");
+  });
+
+  it("describes a stranded broker with replace guidance", () => {
+    const message = formatBrokerLockConflictMessage({
+      classification: "unresponsive-broker",
+      owner,
+      probe: "unreachable",
+    });
+    expect(message).toContain("pid 1336");
+    expect(message).toContain("stranded");
+    expect(message).toContain("/pinet start replace");
+  });
+});
+
+// ─── replaceBrokerOwner ──────────────────────────────────
+
+describe("replaceBrokerOwner", () => {
+  // A PID that is not this process; liveness comes from the stubbed probes.
+  const OWNER_PID = 54321;
+  let dir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    lockPath = path.join(dir, "lock");
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  it("reports no-conflict when the lock is missing", async () => {
+    const result = await replaceBrokerOwner({ lockPath });
+    expect(result.outcome).toBe("no-conflict");
+  });
+
+  it("reports no-conflict for a stale dead-PID lock", async () => {
+    fs.writeFileSync(lockPath, "2147483647", "utf-8");
+    const result = await replaceBrokerOwner({ lockPath });
+    expect(result.outcome).toBe("no-conflict");
+  });
+
+  it("refuses to replace a lock held by the calling process itself", async () => {
+    writeStructuredLock(lockPath, process.pid);
+    const kill = vi.fn();
+    const requestShutdown = vi.fn(async () => "accepted" as const);
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: aliveProbes,
+      requestShutdown,
+      kill,
+      sleep: async () => {},
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.error).toContain("this session's own process");
+    expect(kill).not.toHaveBeenCalled();
+    expect(requestShutdown).not.toHaveBeenCalled();
+  });
+
+  it("replaces gracefully when the broker honors admin.shutdown", async () => {
+    writeStructuredLock(lockPath, OWNER_PID);
+    const kill = vi.fn();
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: aliveProbes,
+      requestShutdown: async () => {
+        fs.unlinkSync(lockPath);
+        return "accepted";
+      },
+      kill,
+      sleep: async () => {},
+    });
+
+    expect(result.outcome).toBe("replaced-graceful");
+    expect(kill).not.toHaveBeenCalled();
+    expect(result.owner?.pid).toBe(OWNER_PID);
+  });
+
+  it("falls back to a fenced SIGTERM when shutdown is unsupported", async () => {
+    writeStructuredLock(lockPath, OWNER_PID);
+    const kill = vi.fn((pid: number, _signal: NodeJS.Signals) => {
+      expect(pid).toBe(OWNER_PID);
+      fs.unlinkSync(lockPath);
+    });
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: aliveProbes,
+      requestShutdown: async () => "unsupported",
+      kill,
+      sleep: async () => {},
+    });
+
+    expect(result.outcome).toBe("replaced-terminated");
+    expect(kill).toHaveBeenCalledWith(OWNER_PID, "SIGTERM");
+  });
+
+  it("aborts when the lock owner changes mid-flight", async () => {
+    writeStructuredLock(lockPath, OWNER_PID, { instanceId: "inst-1" });
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: aliveProbes,
+      requestShutdown: async () => {
+        // A different broker instance takes over during the graceful wait.
+        writeStructuredLock(lockPath, OWNER_PID, { instanceId: "inst-2" });
+        return "accepted";
+      },
+      kill: vi.fn(),
+      sleep: async () => {},
+    });
+
+    expect(result.outcome).toBe("owner-changed");
+    expect(result.error).toContain("changed owners");
+  });
+
+  it("fails without SIGKILL escalation when the owner survives SIGTERM", async () => {
+    writeStructuredLock(lockPath, OWNER_PID);
+    const kill = vi.fn();
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: aliveProbes,
+      requestShutdown: async () => "unsupported",
+      kill,
+      sleep: async () => {},
+      terminateWaitMs: 30,
+      pollIntervalMs: 5,
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(kill).toHaveBeenCalledWith(OWNER_PID, "SIGTERM");
+    expect(result.error).toContain(`pid ${OWNER_PID}`);
+    expect(result.error).toContain("Not escalating to SIGKILL");
+  });
+
+  it("continues to the release wait when signal delivery fails", async () => {
+    writeStructuredLock(lockPath, OWNER_PID);
+
+    const result = await replaceBrokerOwner({
+      lockPath,
+      probes: aliveProbes,
+      requestShutdown: async () => "unreachable",
+      kill: () => {
+        // Simulate ESRCH — the owner exited between the fence check and the
+        // signal; the lock is gone by the time we wait.
+        fs.unlinkSync(lockPath);
+        throw new Error("kill ESRCH");
+      },
+      sleep: async () => {},
+    });
+
+    expect(result.outcome).toBe("replaced-terminated");
+  });
+});

--- a/slack-bridge/broker/lock-conflict.ts
+++ b/slack-bridge/broker/lock-conflict.ts
@@ -233,7 +233,15 @@ export async function probeBrokerSocket(
 
 // ─── Graceful shutdown request ───────────────────────────
 
-export type BrokerShutdownRequestResult = "accepted" | "unsupported" | "unreachable" | "failed";
+export type BrokerShutdownRequestResult =
+  | "accepted"
+  /** The broker responded with method-not-found — it predates the RPC. */
+  | "unsupported"
+  /** The broker responded with an error (e.g. auth rejection) — it is alive and refusing. */
+  | "rejected"
+  | "unreachable"
+  /** Connected but no usable response — the broker looks hung. */
+  | "failed";
 
 export interface RequestBrokerShutdownOptions {
   target?: ListenTarget;
@@ -262,11 +270,11 @@ export async function requestBrokerShutdown(
   try {
     const secret = options.meshSecret?.trim();
     const authResponse = await client.call("auth", secret ? { secret } : {}, timeoutMs);
-    if (authResponse.error) return "failed";
+    if (authResponse.error) return "rejected";
 
     const shutdownResponse = await client.call("admin.shutdown", {}, timeoutMs);
     if (shutdownResponse.error) {
-      return shutdownResponse.error.code === RPC_METHOD_NOT_FOUND ? "unsupported" : "failed";
+      return shutdownResponse.error.code === RPC_METHOD_NOT_FOUND ? "unsupported" : "rejected";
     }
     return "accepted";
   } catch {
@@ -497,7 +505,39 @@ export async function replaceBrokerOwner(
     steps.push("Broker accepted shutdown but did not release the lock in time.");
   }
 
+  if (shutdownResult === "rejected") {
+    // The broker is responsive and refused the request (typically a mesh
+    // secret mismatch). A responsive broker is not stranded — do not
+    // escalate to signals.
+    return {
+      outcome: "failed",
+      owner,
+      steps,
+      error:
+        "The running broker rejected the shutdown request (often a mesh secret mismatch). " +
+        "It is responsive, so it was not terminated. Fix the mesh secret configuration, " +
+        "or stop that broker from its own session, then retry.",
+    };
+  }
+
   // ── Step 2: fenced termination fallback ──
+  if (!owner.processStartTime) {
+    // Legacy locks (and structured locks with an unknown start time) carry no
+    // PID-reuse fence, so an automatic SIGTERM could hit an unrelated process
+    // that reused the PID. Require a manual, human-verified step instead.
+    steps.push(
+      "Lock owner has no recorded process start identity — refusing automatic termination.",
+    );
+    return {
+      outcome: "failed",
+      owner,
+      steps,
+      error:
+        `The lock owner (pid ${owner.pid}) predates identity fencing, so automatic termination ` +
+        `cannot verify it is still the original broker. Inspect it manually (ps -p ${owner.pid}), ` +
+        `terminate it yourself if it is truly the stranded broker, then run /pinet start.`,
+    };
+  }
   const preTerminate = inspect();
   if (preTerminate.state !== "alive") {
     steps.push("Lock was released before termination was needed.");

--- a/slack-bridge/broker/lock-conflict.ts
+++ b/slack-bridge/broker/lock-conflict.ts
@@ -1,0 +1,536 @@
+import * as net from "node:net";
+import {
+  inspectBrokerLock,
+  type BrokerLockInspection,
+  type BrokerLockOwner,
+  type BrokerLockProbes,
+} from "./leader.js";
+import { getDefaultSocketPath } from "./paths.js";
+import type { ListenTarget } from "./socket-server.js";
+import { RPC_METHOD_NOT_FOUND } from "./types.js";
+
+// ─── Constants ───────────────────────────────────────────
+
+export const DEFAULT_PROBE_TIMEOUT_MS = 2000;
+export const DEFAULT_SHUTDOWN_RPC_TIMEOUT_MS = 5000;
+export const DEFAULT_GRACEFUL_WAIT_MS = 8000;
+export const DEFAULT_TERMINATE_WAIT_MS = 8000;
+export const DEFAULT_REPLACE_POLL_INTERVAL_MS = 250;
+
+// ─── One-shot JSON-RPC client ────────────────────────────
+
+type BrokerSocketFailureKind = "unreachable" | "unresponsive";
+
+class BrokerSocketFailure extends Error {
+  readonly kind: BrokerSocketFailureKind;
+
+  constructor(kind: BrokerSocketFailureKind, message: string) {
+    super(message);
+    this.name = "BrokerSocketFailure";
+    this.kind = kind;
+  }
+}
+
+interface JsonRpcErrorShape {
+  code: number;
+  message: string;
+}
+
+/** The lock-conflict RPCs only need success/error — result payloads are unused. */
+interface RpcResponseEnvelope {
+  error: JsonRpcErrorShape | null;
+}
+
+/** Serialized wire shape of a JSON-RPC response line — field types unverified. */
+interface RawJsonRpcResponse {
+  id?: number | string | null;
+  error?: { code?: number; message?: string } | null;
+}
+
+/**
+ * Minimal sequential JSON-RPC client used for lock-conflict diagnostics.
+ * Deliberately independent from the full follower client: no reconnects, no
+ * heartbeats — one bounded connection for probe/shutdown calls.
+ */
+class OneShotBrokerRpcClient {
+  private readonly socket: net.Socket;
+  private buffer = "";
+  private nextId = 1;
+  private waiter: {
+    id: number;
+    resolve: (response: RpcResponseEnvelope) => void;
+    reject: (error: Error) => void;
+  } | null = null;
+
+  private constructor(socket: net.Socket) {
+    this.socket = socket;
+    socket.on("data", (chunk: Buffer) => {
+      this.buffer += chunk.toString("utf-8");
+      let newlineIndex = this.buffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = this.buffer.slice(0, newlineIndex).trim();
+        this.buffer = this.buffer.slice(newlineIndex + 1);
+        if (line && this.waiter) {
+          let raw: RawJsonRpcResponse | null = null;
+          try {
+            const parsed = JSON.parse(line) as RawJsonRpcResponse | null;
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+              raw = parsed;
+            }
+          } catch {
+            raw = null;
+          }
+          if (raw && raw.id === this.waiter.id) {
+            const rawError = raw.error;
+            const response: RpcResponseEnvelope = {
+              error:
+                rawError && typeof rawError === "object" && typeof rawError.code === "number"
+                  ? {
+                      code: rawError.code,
+                      message: typeof rawError.message === "string" ? rawError.message : "",
+                    }
+                  : null,
+            };
+            const { resolve } = this.waiter;
+            this.waiter = null;
+            resolve(response);
+          }
+        }
+        newlineIndex = this.buffer.indexOf("\n");
+      }
+    });
+    const failPending = (kind: BrokerSocketFailureKind, message: string): void => {
+      if (!this.waiter) return;
+      const { reject } = this.waiter;
+      this.waiter = null;
+      reject(new BrokerSocketFailure(kind, message));
+    };
+    socket.on("error", (err: Error) => failPending("unreachable", err.message));
+    socket.on("close", () =>
+      failPending("unresponsive", "Broker socket closed before responding."),
+    );
+  }
+
+  static connect(target: ListenTarget, timeoutMs: number): Promise<OneShotBrokerRpcClient> {
+    return new Promise<OneShotBrokerRpcClient>((resolve, reject) => {
+      const socket =
+        target.type === "unix"
+          ? net.createConnection({ path: target.path })
+          : net.createConnection({ port: target.port, host: target.host });
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(
+          new BrokerSocketFailure(
+            "unresponsive",
+            `Broker socket connect timed out after ${timeoutMs}ms.`,
+          ),
+        );
+      }, timeoutMs);
+      timer.unref?.();
+      socket.once("connect", () => {
+        clearTimeout(timer);
+        resolve(new OneShotBrokerRpcClient(socket));
+      });
+      socket.once("error", (err: Error) => {
+        clearTimeout(timer);
+        socket.destroy();
+        reject(new BrokerSocketFailure("unreachable", err.message));
+      });
+    });
+  }
+
+  call(
+    method: string,
+    params: Record<string, string>,
+    timeoutMs: number,
+  ): Promise<RpcResponseEnvelope> {
+    const id = this.nextId++;
+    return new Promise<RpcResponseEnvelope>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.waiter?.id === id) this.waiter = null;
+        reject(
+          new BrokerSocketFailure(
+            "unresponsive",
+            `Broker did not respond to ${method} within ${timeoutMs}ms.`,
+          ),
+        );
+      }, timeoutMs);
+      timer.unref?.();
+      this.waiter = {
+        id,
+        resolve: (response) => {
+          clearTimeout(timer);
+          resolve(response);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      };
+      try {
+        this.socket.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      } catch (err) {
+        clearTimeout(timer);
+        this.waiter = null;
+        reject(
+          new BrokerSocketFailure("unreachable", err instanceof Error ? err.message : String(err)),
+        );
+      }
+    });
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}
+
+// ─── Socket probe ────────────────────────────────────────
+
+export type BrokerSocketProbeResult = "healthy" | "unreachable" | "unresponsive";
+
+export interface ProbeBrokerSocketOptions {
+  target?: ListenTarget;
+  socketPath?: string;
+  timeoutMs?: number;
+}
+
+function resolveTarget(options: { target?: ListenTarget; socketPath?: string }): ListenTarget {
+  if (options.target) return options.target;
+  return { type: "unix", path: options.socketPath ?? getDefaultSocketPath() };
+}
+
+function failureToProbeResult(err: BrokerSocketFailure | Error): BrokerSocketProbeResult {
+  return err instanceof BrokerSocketFailure && err.kind === "unreachable"
+    ? "unreachable"
+    : "unresponsive";
+}
+
+/**
+ * Bounded liveness probe for a broker socket. Any well-formed JSON-RPC
+ * response — including an auth error — proves the broker event loop is
+ * serving, so it classifies as healthy.
+ */
+export async function probeBrokerSocket(
+  options: ProbeBrokerSocketOptions = {},
+): Promise<BrokerSocketProbeResult> {
+  const target = resolveTarget(options);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  let client: OneShotBrokerRpcClient;
+  try {
+    client = await OneShotBrokerRpcClient.connect(target, timeoutMs);
+  } catch (err) {
+    return failureToProbeResult(err instanceof Error ? err : new Error(String(err)));
+  }
+  try {
+    await client.call("auth", {}, timeoutMs);
+    return "healthy";
+  } catch (err) {
+    return failureToProbeResult(err instanceof Error ? err : new Error(String(err)));
+  } finally {
+    client.close();
+  }
+}
+
+// ─── Graceful shutdown request ───────────────────────────
+
+export type BrokerShutdownRequestResult = "accepted" | "unsupported" | "unreachable" | "failed";
+
+export interface RequestBrokerShutdownOptions {
+  target?: ListenTarget;
+  socketPath?: string;
+  meshSecret?: string | null;
+  timeoutMs?: number;
+}
+
+/**
+ * Ask a running broker to shut down gracefully via the authenticated
+ * `admin.shutdown` RPC. Brokers that predate the RPC report `unsupported`.
+ */
+export async function requestBrokerShutdown(
+  options: RequestBrokerShutdownOptions = {},
+): Promise<BrokerShutdownRequestResult> {
+  const target = resolveTarget(options);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SHUTDOWN_RPC_TIMEOUT_MS;
+  let client: OneShotBrokerRpcClient;
+  try {
+    client = await OneShotBrokerRpcClient.connect(target, timeoutMs);
+  } catch (err) {
+    return err instanceof BrokerSocketFailure && err.kind === "unreachable"
+      ? "unreachable"
+      : "failed";
+  }
+  try {
+    const secret = options.meshSecret?.trim();
+    const authResponse = await client.call("auth", secret ? { secret } : {}, timeoutMs);
+    if (authResponse.error) return "failed";
+
+    const shutdownResponse = await client.call("admin.shutdown", {}, timeoutMs);
+    if (shutdownResponse.error) {
+      return shutdownResponse.error.code === RPC_METHOD_NOT_FOUND ? "unsupported" : "failed";
+    }
+    return "accepted";
+  } catch {
+    return "failed";
+  } finally {
+    client.close();
+  }
+}
+
+// ─── Conflict classification ─────────────────────────────
+
+export type BrokerLockConflictClassification = "active-broker" | "unresponsive-broker";
+
+export type BrokerLockConflict =
+  | { kind: "reclaimable"; inspection: BrokerLockInspection; probe: null }
+  | {
+      kind: "conflict";
+      classification: BrokerLockConflictClassification;
+      owner: BrokerLockOwner;
+      probe: BrokerSocketProbeResult;
+    };
+
+export interface ClassifyBrokerLockConflictOptions {
+  lockPath?: string;
+  target?: ListenTarget;
+  socketPath?: string;
+  probeTimeoutMs?: number;
+  probes?: BrokerLockProbes;
+  probeSocket?: (target: ListenTarget, timeoutMs: number) => Promise<BrokerSocketProbeResult>;
+}
+
+/**
+ * Combine lock-owner inspection with a bounded socket probe to classify a
+ * leader-lock conflict.
+ */
+export async function classifyBrokerLockConflict(
+  options: ClassifyBrokerLockConflictOptions = {},
+): Promise<BrokerLockConflict> {
+  const inspection = inspectBrokerLock(options.lockPath, options.probes ?? {});
+  if (inspection.state !== "alive") {
+    return { kind: "reclaimable", inspection, probe: null };
+  }
+  const target = resolveTarget(options);
+  const timeoutMs = options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const probe = options.probeSocket
+    ? await options.probeSocket(target, timeoutMs)
+    : await probeBrokerSocket({ target, timeoutMs });
+  return {
+    kind: "conflict",
+    classification: probe === "healthy" ? "active-broker" : "unresponsive-broker",
+    owner: inspection.owner,
+    probe,
+  };
+}
+
+// ─── Typed conflict error ────────────────────────────────
+
+export interface BrokerLockConflictErrorInput {
+  classification: BrokerLockConflictClassification;
+  owner: BrokerLockOwner | null;
+  probe: BrokerSocketProbeResult | null;
+}
+
+export function formatBrokerLockConflictMessage(input: BrokerLockConflictErrorInput): string {
+  const owner = input.owner;
+  const ownerBits = owner
+    ? ` (pid ${owner.pid}${owner.createdAt ? `, lock created ${owner.createdAt}` : ""})`
+    : "";
+  if (input.classification === "active-broker") {
+    return (
+      `Another pinet broker is already running${ownerBits} and its socket is responding. ` +
+      `Use /pinet follow to join it, or /pinet start replace to take over.`
+    );
+  }
+  const socketState = input.probe === "unreachable" ? "not reachable" : "not responding";
+  return (
+    `Another process holds the pinet broker lock${ownerBits} but the broker socket is ` +
+    `${socketState} — the broker looks stranded. Use /pinet start replace to recover.`
+  );
+}
+
+/**
+ * Thrown by `startBroker` when the leader lock is held by another live
+ * process, carrying enough context for callers to present a per-state
+ * recovery path instead of a generic failure.
+ */
+export class BrokerLockConflictError extends Error {
+  readonly classification: BrokerLockConflictClassification;
+  readonly owner: BrokerLockOwner | null;
+  readonly probe: BrokerSocketProbeResult | null;
+
+  constructor(input: BrokerLockConflictErrorInput) {
+    super(formatBrokerLockConflictMessage(input));
+    this.name = "BrokerLockConflictError";
+    this.classification = input.classification;
+    this.owner = input.owner;
+    this.probe = input.probe;
+  }
+}
+
+// ─── Conservative takeover ───────────────────────────────
+
+export type ReplaceBrokerOwnerOutcome =
+  | "no-conflict"
+  | "replaced-graceful"
+  | "replaced-terminated"
+  | "owner-changed"
+  | "failed";
+
+export interface ReplaceBrokerOwnerResult {
+  outcome: ReplaceBrokerOwnerOutcome;
+  owner: BrokerLockOwner | null;
+  steps: string[];
+  error: string | null;
+}
+
+export interface ReplaceBrokerOwnerOptions {
+  lockPath?: string;
+  target?: ListenTarget;
+  socketPath?: string;
+  meshSecret?: string | null;
+  gracefulWaitMs?: number;
+  terminateWaitMs?: number;
+  pollIntervalMs?: number;
+  shutdownRpcTimeoutMs?: number;
+  probes?: BrokerLockProbes;
+  requestShutdown?: (options: RequestBrokerShutdownOptions) => Promise<BrokerShutdownRequestResult>;
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Conservatively replace the current broker lock owner:
+ *
+ * 1. No live owner → nothing to do (a normal start reclaims stale state).
+ * 2. Live owner → request graceful `admin.shutdown` and wait (bounded).
+ * 3. Fallback → re-verify the owner fence (pid + process start time +
+ *    instance id), SIGTERM the verified owner, and wait (bounded).
+ * 4. Never SIGKILL; abort if the owner identity changes mid-flight.
+ */
+export async function replaceBrokerOwner(
+  options: ReplaceBrokerOwnerOptions = {},
+): Promise<ReplaceBrokerOwnerResult> {
+  const steps: string[] = [];
+  const probes = options.probes ?? {};
+  const inspect = (): BrokerLockInspection => inspectBrokerLock(options.lockPath, probes);
+  // Deliberately not unref'd: the poll loop must keep the event loop alive
+  // until replacement resolves (caught by the cross-process E2E run).
+  const sleep =
+    options.sleep ??
+    ((ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)));
+  const kill =
+    options.kill ??
+    ((pid: number, signal: NodeJS.Signals): void => {
+      process.kill(pid, signal);
+    });
+  const requestShutdown = options.requestShutdown ?? requestBrokerShutdown;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_REPLACE_POLL_INTERVAL_MS;
+  const gracefulWaitMs = options.gracefulWaitMs ?? DEFAULT_GRACEFUL_WAIT_MS;
+  const terminateWaitMs = options.terminateWaitMs ?? DEFAULT_TERMINATE_WAIT_MS;
+
+  const initial = inspect();
+  if (initial.state !== "alive") {
+    steps.push(`Lock state: ${initial.state} — nothing to replace; a normal start reclaims it.`);
+    return { outcome: "no-conflict", owner: initial.owner ?? null, steps, error: null };
+  }
+  const owner = initial.owner;
+  if (owner.pid === process.pid) {
+    // Never signal ourselves: a same-process conflict means this session
+    // already hosts the broker (or another runtime within it does).
+    steps.push(`Lock is held by this session's own process (pid ${owner.pid}).`);
+    return {
+      outcome: "failed",
+      owner,
+      steps,
+      error:
+        "The broker lock is held by this session's own process — nothing to replace. " +
+        "Use /pinet start to reload the current broker runtime instead.",
+    };
+  }
+  steps.push(
+    `Lock held by live pid ${owner.pid}${owner.legacy ? " (legacy lock format — weaker identity fence)" : ""}.`,
+  );
+
+  const sameOwner = (current: BrokerLockInspection): boolean =>
+    current.state === "alive" &&
+    current.owner.pid === owner.pid &&
+    current.owner.instanceId === owner.instanceId &&
+    current.owner.processStartTime === owner.processStartTime;
+
+  const ownerChangedResult = (): ReplaceBrokerOwnerResult => {
+    steps.push("Lock owner changed during replacement — aborting.");
+    return {
+      outcome: "owner-changed",
+      owner,
+      steps,
+      error:
+        "The broker lock changed owners during replacement — another session may have recovered it. Check /pinet status and retry if needed.",
+    };
+  };
+
+  const waitForRelease = async (waitMs: number): Promise<"released" | "owner-changed" | "held"> => {
+    const deadline = Date.now() + waitMs;
+    for (;;) {
+      const current = inspect();
+      if (current.state !== "alive") return "released";
+      if (!sameOwner(current)) return "owner-changed";
+      if (Date.now() >= deadline) return "held";
+      await sleep(pollIntervalMs);
+    }
+  };
+
+  // ── Step 1: graceful shutdown over the socket ──
+  const shutdownResult = await requestShutdown({
+    ...(options.target ? { target: options.target } : {}),
+    ...(options.socketPath ? { socketPath: options.socketPath } : {}),
+    meshSecret: options.meshSecret ?? null,
+    timeoutMs: options.shutdownRpcTimeoutMs ?? DEFAULT_SHUTDOWN_RPC_TIMEOUT_MS,
+  });
+  steps.push(`Graceful shutdown request: ${shutdownResult}.`);
+  if (shutdownResult === "accepted") {
+    const wait = await waitForRelease(gracefulWaitMs);
+    if (wait === "released") {
+      steps.push("Broker released the lock after graceful shutdown.");
+      return { outcome: "replaced-graceful", owner, steps, error: null };
+    }
+    if (wait === "owner-changed") return ownerChangedResult();
+    steps.push("Broker accepted shutdown but did not release the lock in time.");
+  }
+
+  // ── Step 2: fenced termination fallback ──
+  const preTerminate = inspect();
+  if (preTerminate.state !== "alive") {
+    steps.push("Lock was released before termination was needed.");
+    return {
+      outcome: shutdownResult === "accepted" ? "replaced-graceful" : "no-conflict",
+      owner,
+      steps,
+      error: null,
+    };
+  }
+  if (!sameOwner(preTerminate)) return ownerChangedResult();
+
+  steps.push(`Sending SIGTERM to verified lock owner pid ${owner.pid}.`);
+  try {
+    kill(owner.pid, "SIGTERM");
+  } catch {
+    // ESRCH etc. — the process may have just exited; the release wait decides.
+    steps.push(`Signal delivery to pid ${owner.pid} failed — it may have already exited.`);
+  }
+  const wait = await waitForRelease(terminateWaitMs);
+  if (wait === "released") {
+    steps.push("Broker released the lock after SIGTERM.");
+    return { outcome: "replaced-terminated", owner, steps, error: null };
+  }
+  if (wait === "owner-changed") return ownerChangedResult();
+
+  return {
+    outcome: "failed",
+    owner,
+    steps,
+    error:
+      `Broker pid ${owner.pid} is still holding the lock after SIGTERM. ` +
+      `Not escalating to SIGKILL automatically — inspect the process (ps -p ${owner.pid}) ` +
+      `and terminate it manually if it is truly stranded, then run /pinet start.`,
+  };
+}

--- a/slack-bridge/broker/lock-conflict.ts
+++ b/slack-bridge/broker/lock-conflict.ts
@@ -550,6 +550,12 @@ export async function replaceBrokerOwner(
   }
   if (!sameOwner(preTerminate)) return ownerChangedResult();
 
+  // The fence re-check above and the signal below are not atomic: the
+  // verified owner could exit and its PID be reused in between. Closing that
+  // window needs a kernel handle bound to process identity (e.g. Linux
+  // pidfd_send_signal), which Node does not expose without native code — the
+  // immediately-preceding pid + start-time + instanceId fence keeps the
+  // residual window negligible.
   steps.push(`Sending SIGTERM to verified lock owner pid ${owner.pid}.`);
   try {
     kill(owner.pid, "SIGTERM");

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -191,6 +191,7 @@ export class BrokerSocketServer {
     Pick<MessageAdapter, "name" | "send" | "invokeCapability">
   > = [];
   private agentRegistrationResolver: AgentRegistrationResolver | null = null;
+  private adminShutdownHandler: (() => void | Promise<void>) | null = null;
 
   constructor(
     db: BrokerDB,
@@ -322,6 +323,17 @@ export class BrokerSocketServer {
 
   setAgentRegistrationResolver(resolver: AgentRegistrationResolver | null): void {
     this.agentRegistrationResolver = resolver;
+  }
+
+  /**
+   * Register a handler invoked when an authenticated local client requests a
+   * graceful broker shutdown via the `admin.shutdown` RPC (used by
+   * `/pinet start replace` to take over a broker whose controlling session
+   * was lost). When no handler is wired, the RPC reports method-not-found so
+   * callers treat the broker as not supporting remote shutdown.
+   */
+  setAdminShutdownHandler(handler: (() => void | Promise<void>) | null): void {
+    this.adminShutdownHandler = handler;
   }
 
   setOutboundMessageAdapters(
@@ -548,6 +560,8 @@ export class BrokerSocketServer {
           return this.handleScheduleCreate(req, state);
         case "status.update":
           return this.handleStatusUpdate(req, state);
+        case "admin.shutdown":
+          return this.handleAdminShutdown(req);
         case "adapter.capability":
           return await this.handleAdapterCapability(req, state);
         case "slack.proxy":
@@ -1634,6 +1648,33 @@ export class BrokerSocketServer {
       /* best effort */
     }
     return rpcOk(req.id, { ok: true });
+  }
+
+  // ─── Admin shutdown handler ───────────────────────────
+
+  /**
+   * Graceful remote shutdown. Requires authentication (enforced by the
+   * generic auth gate). Responds first, then invokes the wired handler on the
+   * next tick so the requester receives the acknowledgement before the broker
+   * tears down its socket.
+   */
+  private handleAdminShutdown(req: JsonRpcRequest): JsonRpcResponse {
+    const handler = this.adminShutdownHandler;
+    if (!handler) {
+      return rpcError(
+        req.id,
+        RPC_METHOD_NOT_FOUND,
+        "This broker does not support remote shutdown.",
+      );
+    }
+    setImmediate(() => {
+      void Promise.resolve()
+        .then(() => handler())
+        .catch(() => {
+          /* best effort — the requester falls back to fenced termination */
+        });
+    });
+    return rpcOk(req.id, { ok: true, shuttingDown: true });
   }
 
   // ─── Adapter capability handler ───────────────────────

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -288,6 +288,7 @@ describe("slack-bridge top-level shutdown", () => {
       db: BrokerDB;
       server: {
         setAgentRegistrationResolver: ReturnType<typeof vi.fn>;
+        setAdminShutdownHandler: ReturnType<typeof vi.fn>;
         onAgentMessage: ReturnType<typeof vi.fn>;
         onAgentStatusChange: ReturnType<typeof vi.fn>;
       };
@@ -317,6 +318,7 @@ describe("slack-bridge top-level shutdown", () => {
       db.initialize();
       const server = {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       };
@@ -451,6 +453,7 @@ describe("slack-bridge top-level shutdown", () => {
       db: BrokerDB;
       server: {
         setAgentRegistrationResolver: ReturnType<typeof vi.fn>;
+        setAdminShutdownHandler: ReturnType<typeof vi.fn>;
         onAgentMessage: ReturnType<typeof vi.fn>;
         onAgentStatusChange: ReturnType<typeof vi.fn>;
       };
@@ -470,6 +473,7 @@ describe("slack-bridge top-level shutdown", () => {
       db.initialize();
       const server = {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       };
@@ -565,6 +569,7 @@ describe("slack-bridge top-level shutdown", () => {
       db: BrokerDB;
       server: {
         setAgentRegistrationResolver: ReturnType<typeof vi.fn>;
+        setAdminShutdownHandler: ReturnType<typeof vi.fn>;
         onAgentMessage: ReturnType<typeof vi.fn>;
         onAgentStatusChange: ReturnType<typeof vi.fn>;
       };
@@ -584,6 +589,7 @@ describe("slack-bridge top-level shutdown", () => {
       db.initialize();
       const server = {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       };
@@ -677,6 +683,7 @@ describe("slack-bridge top-level shutdown", () => {
       db: BrokerDB;
       server: {
         setAgentRegistrationResolver: ReturnType<typeof vi.fn>;
+        setAdminShutdownHandler: ReturnType<typeof vi.fn>;
         onAgentMessage: ReturnType<typeof vi.fn>;
         onAgentStatusChange: ReturnType<typeof vi.fn>;
       };
@@ -702,6 +709,7 @@ describe("slack-bridge top-level shutdown", () => {
       db.initialize();
       const server = {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       };
@@ -811,6 +819,7 @@ describe("slack-bridge top-level shutdown", () => {
       db.initialize();
       const server = {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       };
@@ -946,6 +955,7 @@ describe("slack-bridge top-level shutdown", () => {
     const adapters: Array<{ name: string; send?: (msg: unknown) => Promise<unknown> }> = [];
     const server = {
       setAgentRegistrationResolver: vi.fn(),
+      setAdminShutdownHandler: vi.fn(),
       setOutboundMessageAdapters: vi.fn(),
       onAgentMessage: vi.fn(),
       onAgentStatusChange: vi.fn(),
@@ -1100,6 +1110,7 @@ describe("slack-bridge top-level shutdown", () => {
     });
     const server = {
       setAgentRegistrationResolver: vi.fn(),
+      setAdminShutdownHandler: vi.fn(),
       setOutboundMessageAdapters: vi.fn(),
       onAgentMessage: vi.fn(),
       onAgentStatusChange: vi.fn(),
@@ -1852,6 +1863,7 @@ describe("slack-bridge top-level shutdown", () => {
       db: restartedDb,
       server: {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       },
@@ -2291,6 +2303,7 @@ describe("slack-bridge top-level shutdown", () => {
       db: restartedDb,
       server: {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       },
@@ -3204,6 +3217,7 @@ describe("slack-bridge Pinet reconnect", () => {
         db,
         server: {
           setAgentRegistrationResolver: vi.fn(),
+          setAdminShutdownHandler: vi.fn(),
           onAgentMessage: vi.fn(),
           onAgentStatusChange: vi.fn(),
         },
@@ -3339,6 +3353,7 @@ describe("slack-bridge Pinet reconnect", () => {
         db,
         server: {
           setAgentRegistrationResolver: vi.fn(),
+          setAdminShutdownHandler: vi.fn(),
           onAgentMessage: vi.fn(),
           onAgentStatusChange: vi.fn(),
         },
@@ -4227,6 +4242,7 @@ describe("slack-bridge broker startup backlog recovery", () => {
       db: restartedDb,
       server: {
         setAgentRegistrationResolver: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
         onAgentMessage: vi.fn(),
         onAgentStatusChange: vi.fn(),
       },
@@ -4360,6 +4376,7 @@ describe("slack-bridge broker startup backlog recovery", () => {
     });
     const brokerServer = {
       setAgentRegistrationResolver: vi.fn(),
+      setAdminShutdownHandler: vi.fn(),
       onAgentMessage: vi.fn(),
       onAgentStatusChange: vi.fn(),
     };
@@ -4633,6 +4650,7 @@ describe("slack-bridge broker startup backlog recovery", () => {
         db,
         server: {
           setAgentRegistrationResolver: vi.fn(),
+          setAdminShutdownHandler: vi.fn(),
           onAgentMessage: vi.fn(),
           onAgentStatusChange: vi.fn(),
         },

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -7,6 +7,7 @@ import {
   type InboxMessage,
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
+  resolvePinetMeshAuth,
   reloadPinetRuntimeSafely,
   buildPinetOwnerToken,
   resolveAgentIdentity,
@@ -19,6 +20,13 @@ import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
 import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
+import {
+  inspectBrokerLock,
+  probeBrokerSocket,
+  replaceBrokerOwner,
+  type ReplaceBrokerOwnerResult,
+} from "./broker/index.js";
+import { readMeshSecret } from "./broker/auth.js";
 import {
   collectAgentLifecycleStatuses,
   type AgentLifecycleStatus,
@@ -833,6 +841,17 @@ export default function (pi: ExtensionAPI) {
     buildCurrentDashboardSnapshot: async (openedAt) =>
       buildCurrentBrokerControlPlaneDashboardSnapshot(openedAt),
     createAdapterBindings: [slackPinetAdapterFactory],
+    onAdminShutdownRequested: async (ctx) => {
+      // `/pinet start replace` from another local session: stop being the
+      // broker but keep this session alive (issue #951).
+      ctx.ui.notify(
+        "Pinet broker shutdown requested by another local session (/pinet start replace). Stopping the broker runtime in this session.",
+        "warning",
+      );
+      await stopPinetRuntime(ctx, { releaseIdentity: true });
+      slackRequestRuntime.reset();
+      singlePlayerRuntime.resetShutdownState();
+    },
     onMaintenanceResult: (ctx, { result, previousSignature, signature }) => {
       if (signature && signature !== previousSignature) {
         ctx.ui.notify(`Pinet broker: ${result.anomalies.join("; ")}`, "warning");
@@ -1166,6 +1185,23 @@ export default function (pi: ExtensionAPI) {
 
     await connectAsFollower(ctx);
     void ensureSlackScopeDiagnostics(ctx);
+  }
+
+  /**
+   * Resolve the local mesh secret value for client-side broker RPCs
+   * (graceful takeover). Returns null when no secret is configured or the
+   * secret file is unreadable — callers degrade to fenced termination.
+   */
+  function resolveLocalMeshSecretValue(): string | null {
+    const meshAuth = resolvePinetMeshAuth(settings);
+    if (meshAuth.meshSecret) {
+      return meshAuth.meshSecret;
+    }
+    try {
+      return meshAuth.meshSecretPath ? readMeshSecret(meshAuth.meshSecretPath) : readMeshSecret();
+    } catch {
+      return null;
+    }
   }
 
   async function stopPinetRuntime(
@@ -1598,7 +1634,16 @@ export default function (pi: ExtensionAPI) {
       lastBrokerControlPlaneHomeTabRefreshAt: () => brokerRuntime.getLastHomeTabRefreshAt(),
       lastBrokerControlPlaneHomeTabError: () => brokerRuntime.getLastHomeTabError(),
       subtreeBrokerStatus: () => subtreeBrokerRuntime.getStatus(),
+      inspectGlobalBroker: async () => {
+        const lock = inspectBrokerLock();
+        if (lock.state !== "alive") {
+          return { lock, probe: null };
+        }
+        return { lock, probe: await probeBrokerSocket() };
+      },
       getPinetRegistrationBlockReason: pinetRegistrationGate.getBlockReason,
+      replaceGlobalBroker: async (): Promise<ReplaceBrokerOwnerResult> =>
+        replaceBrokerOwner({ meshSecret: resolveLocalMeshSecretValue() }),
       connectAsBroker: (ctx) => transitionToRuntimeMode(ctx, "broker"),
       connectAsFollower: (ctx) => transitionToRuntimeMode(ctx, "follower"),
       reloadPinetRuntime,

--- a/slack-bridge/pinet-commands.test.ts
+++ b/slack-bridge/pinet-commands.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
+  formatGlobalBrokerReport,
   formatPinetCommandHelp,
   registerPinetCommands,
   type PinetCommandsDeps,
 } from "./pinet-commands.js";
+import type { BrokerLockOwner } from "./broker/index.js";
 import type { SlackBridgeSettings } from "./helpers.js";
 import type { SlackScopeDiagnostics } from "./slack-scope-diagnostics.js";
 import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
@@ -100,6 +102,13 @@ function createDeps(overrides: Partial<PinetCommandsDeps> = {}): PinetCommandsDe
       spawnedWorkers: [],
     }),
     getPinetRegistrationBlockReason: () => "blocked",
+    inspectGlobalBroker: async () => ({ lock: { state: "none", owner: null }, probe: null }),
+    replaceGlobalBroker: async () => ({
+      outcome: "no-conflict",
+      owner: null,
+      steps: [],
+      error: null,
+    }),
     connectAsBroker: async () => {},
     connectAsFollower: async () => {},
     reloadPinetRuntime: async () => {},
@@ -342,11 +351,198 @@ describe("registerPinetCommands", () => {
   });
 });
 
+describe("/pinet start replace", () => {
+  it("replaces the global broker before starting as broker", async () => {
+    const callOrder: string[] = [];
+    const replaceGlobalBroker = vi.fn(async () => {
+      callOrder.push("replace");
+      return {
+        outcome: "replaced-graceful" as const,
+        owner: null,
+        steps: ["Graceful shutdown request: accepted."],
+        error: null,
+      };
+    });
+    const connectAsBroker = vi.fn(async () => {
+      callOrder.push("connect");
+    });
+    const commands = registerCommands(
+      createDeps({ runtimeMode: () => "off", replaceGlobalBroker, connectAsBroker }),
+    );
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("start replace", ctx);
+
+    expect(callOrder).toEqual(["replace", "connect"]);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Pinet broker replace: replaced-graceful."),
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Graceful shutdown request: accepted."),
+      "info",
+    );
+  });
+
+  it("does not start as broker when replacement fails", async () => {
+    const replaceGlobalBroker = vi.fn(async () => ({
+      outcome: "failed" as const,
+      owner: null,
+      steps: ["Sending SIGTERM to verified lock owner pid 1336."],
+      error: "Broker pid 1336 is still holding the lock after SIGTERM.",
+    }));
+    const connectAsBroker = vi.fn(async () => {});
+    const commands = registerCommands(
+      createDeps({ runtimeMode: () => "off", replaceGlobalBroker, connectAsBroker }),
+    );
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("start replace", ctx);
+
+    expect(connectAsBroker).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Pinet broker replace failed: Broker pid 1336"),
+      "error",
+    );
+  });
+
+  it("aborts without starting when the owner changed mid-replacement", async () => {
+    const replaceGlobalBroker = vi.fn(async () => ({
+      outcome: "owner-changed" as const,
+      owner: null,
+      steps: [],
+      error: "The broker lock changed owners during replacement.",
+    }));
+    const connectAsBroker = vi.fn(async () => {});
+    const commands = registerCommands(
+      createDeps({ runtimeMode: () => "off", replaceGlobalBroker, connectAsBroker }),
+    );
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("start replace", ctx);
+
+    expect(connectAsBroker).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Pinet broker replace aborted"),
+      "error",
+    );
+  });
+
+  it("rejects unknown start options", async () => {
+    const connectAsBroker = vi.fn(async () => {});
+    const replaceGlobalBroker = vi.fn(createDeps().replaceGlobalBroker);
+    const commands = registerCommands(
+      createDeps({ runtimeMode: () => "off", replaceGlobalBroker, connectAsBroker }),
+    );
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("start bogus", ctx);
+
+    expect(connectAsBroker).not.toHaveBeenCalled();
+    expect(replaceGlobalBroker).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Usage: /pinet start [replace]"),
+      "warning",
+    );
+  });
+});
+
+describe("/pinet status — global broker state", () => {
+  it("reports machine-wide broker state while disconnected", async () => {
+    const inspectGlobalBroker = vi.fn(createDeps().inspectGlobalBroker);
+    const commands = registerCommands(
+      createDeps({ runtimeMode: () => "off", inspectGlobalBroker }),
+    );
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("status", ctx);
+
+    expect(inspectGlobalBroker).toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Global broker: none running on this machine"),
+      "info",
+    );
+  });
+
+  it("reports a stranded broker with recovery guidance", async () => {
+    const owner: BrokerLockOwner = {
+      pid: 1336,
+      processStartTime: "boot-A",
+      instanceId: "inst-1",
+      hostname: "host",
+      createdAt: "2026-07-25T10:00:00.000Z",
+      legacy: false,
+    };
+    const commands = registerCommands(
+      createDeps({
+        runtimeMode: () => "off",
+        inspectGlobalBroker: async () => ({
+          lock: { state: "alive", owner },
+          probe: "unreachable",
+        }),
+      }),
+    );
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("status", ctx);
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("pid 1336 holds the lock"), "info");
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("/pinet start replace"), "info");
+  });
+
+  it("does not inspect global broker state in broker mode", async () => {
+    const inspectGlobalBroker = vi.fn(createDeps().inspectGlobalBroker);
+    const commands = registerCommands(
+      createDeps({ runtimeMode: () => "broker", inspectGlobalBroker }),
+    );
+    const { ctx } = createContext();
+
+    await commands.get("pinet")?.handler("status", ctx);
+
+    expect(inspectGlobalBroker).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatGlobalBrokerReport", () => {
+  const owner: BrokerLockOwner = {
+    pid: 1336,
+    processStartTime: "boot-A",
+    instanceId: "inst-1",
+    hostname: "host",
+    createdAt: "2026-07-25T10:00:00.000Z",
+    legacy: false,
+  };
+
+  it("describes each lock state with a next step", () => {
+    expect(
+      formatGlobalBrokerReport({ lock: { state: "none", owner: null }, probe: null }),
+    ).toContain("none running");
+    expect(
+      formatGlobalBrokerReport({ lock: { state: "unreadable", owner: null }, probe: null }),
+    ).toContain("unreadable lock file");
+    expect(
+      formatGlobalBrokerReport({ lock: { state: "stale-dead", owner }, probe: null }),
+    ).toContain("stale lock from dead pid 1336");
+    expect(
+      formatGlobalBrokerReport({
+        lock: { state: "stale-pid-reused", owner, currentStartTime: "boot-B" },
+        probe: null,
+      }),
+    ).toContain("reused by an unrelated process");
+    expect(
+      formatGlobalBrokerReport({ lock: { state: "alive", owner }, probe: "healthy" }),
+    ).toContain("/pinet follow");
+    expect(
+      formatGlobalBrokerReport({ lock: { state: "alive", owner }, probe: "unresponsive" }),
+    ).toContain("likely stranded");
+  });
+});
+
 describe("formatPinetCommandHelp", () => {
   it("documents the consolidated primary actions", () => {
     const help = formatPinetCommandHelp();
 
-    expect(help).toContain("/pinet start");
+    expect(help).toContain("/pinet start [replace]");
     expect(help).toContain("/pinet follow");
     expect(help).toContain("/pinet reload <agent>");
     expect(help).toContain("/pinet exit <agent>");

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -18,6 +18,11 @@ import {
   type SlackScopeDiagnostics,
 } from "./slack-scope-diagnostics.js";
 import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
+import type {
+  BrokerLockInspection,
+  BrokerSocketProbeResult,
+  ReplaceBrokerOwnerResult,
+} from "./broker/index.js";
 import type { RalphSnoozeStatus } from "./ralph-loop.js";
 import type {
   SubtreeBrokerStatus,
@@ -62,8 +67,13 @@ export interface PinetCommandsDeps {
   lastBrokerControlPlaneHomeTabError: () => string | null;
   subtreeBrokerStatus: () => SubtreeBrokerStatus;
 
+  // Global broker state (machine-wide lock + socket, independent of this
+  // session's runtime — usable while disconnected)
+  inspectGlobalBroker: () => Promise<GlobalBrokerInspection>;
+
   // Actions
   getPinetRegistrationBlockReason: () => string;
+  replaceGlobalBroker: (ctx: ExtensionContext) => Promise<ReplaceBrokerOwnerResult>;
   connectAsBroker: (ctx: ExtensionContext) => Promise<void>;
   connectAsFollower: (ctx: ExtensionContext) => Promise<void>;
   reloadPinetRuntime: (ctx: ExtensionContext) => Promise<void>;
@@ -110,7 +120,11 @@ const PINET_PRIMARY_COMMANDS: Array<{
   args: string;
   description: string;
 }> = [
-  { action: "start", args: "", description: "Start as the mesh broker" },
+  {
+    action: "start",
+    args: "[replace]",
+    description: "Start as the mesh broker (replace: take over a stale/stranded broker)",
+  },
   { action: "follow", args: "", description: "Connect as a follower worker" },
   { action: "unfollow", args: "", description: "Disconnect from the broker" },
   { action: "reload", args: "<agent>", description: "Ask another agent to reload" },
@@ -242,7 +256,7 @@ export async function runPinetCommandAction(
 ): Promise<void> {
   switch (action) {
     case "start":
-      await runPinetStart(deps, ctx);
+      await runPinetStart(deps, args, ctx);
       return;
     case "follow":
       await runPinetFollow(deps, ctx);
@@ -260,7 +274,7 @@ export async function runPinetCommandAction(
       await runPinetFree(deps, ctx);
       return;
     case "status":
-      runPinetStatus(deps, ctx);
+      await runPinetStatus(deps, ctx);
       return;
     case "logs":
       runPinetLogs(deps, ctx);
@@ -299,12 +313,26 @@ export function registerPinetCommands(pi: ExtensionAPI, deps: PinetCommandsDeps)
   });
 }
 
-async function runPinetStart(deps: PinetCommandsDeps, ctx: ExtensionContext): Promise<void> {
+async function runPinetStart(
+  deps: PinetCommandsDeps,
+  args: string,
+  ctx: ExtensionContext,
+): Promise<void> {
   if (deps.pinetRegistrationBlocked()) {
     ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
     return;
   }
   deps.setExtCtx(ctx);
+
+  const trimmedArgs = args.trim().toLowerCase();
+  const wantReplace = ["replace", "--replace", "takeover"].includes(trimmedArgs);
+  if (trimmedArgs && !wantReplace) {
+    ctx.ui.notify(
+      `Unknown /pinet start option: ${args.trim()}\nUsage: /pinet start [replace]`,
+      "warning",
+    );
+    return;
+  }
 
   if (deps.runtimeMode() === "broker") {
     try {
@@ -316,6 +344,29 @@ async function runPinetStart(deps: PinetCommandsDeps, ctx: ExtensionContext): Pr
       deps.setExtStatus(ctx, "error");
     }
     return;
+  }
+
+  if (wantReplace) {
+    let replaceResult: ReplaceBrokerOwnerResult;
+    try {
+      replaceResult = await deps.replaceGlobalBroker(ctx);
+    } catch (err) {
+      ctx.ui.notify(`Pinet broker replace failed: ${errorMsg(err)}`, "error");
+      deps.setExtStatus(ctx, "error");
+      return;
+    }
+    const stepsText = replaceResult.steps.length
+      ? `\n${replaceResult.steps.map((step) => `• ${step}`).join("\n")}`
+      : "";
+    if (replaceResult.outcome === "failed" || replaceResult.outcome === "owner-changed") {
+      ctx.ui.notify(
+        `Pinet broker replace ${replaceResult.outcome === "failed" ? "failed" : "aborted"}: ${replaceResult.error ?? "unknown error"}${stepsText}`,
+        "error",
+      );
+      deps.setExtStatus(ctx, "error");
+      return;
+    }
+    ctx.ui.notify(`Pinet broker replace: ${replaceResult.outcome}.${stepsText}`, "info");
   }
 
   try {
@@ -678,8 +729,48 @@ async function runPinetSubtree(
   }
 }
 
-function runPinetStatus(deps: PinetCommandsDeps, ctx: ExtensionContext): void {
+export interface GlobalBrokerInspection {
+  lock: BrokerLockInspection;
+  probe: BrokerSocketProbeResult | null;
+}
+
+/**
+ * Machine-wide broker state line for `/pinet status`, so a disconnected
+ * session — precisely the one that needs recovery — can see who holds the
+ * broker lock and whether that broker is healthy (issue #951).
+ */
+export function formatGlobalBrokerReport(report: GlobalBrokerInspection): string {
+  const { lock, probe } = report;
+  switch (lock.state) {
+    case "none":
+      return "Global broker: none running on this machine (lock free). Use /pinet start.";
+    case "unreadable":
+      return "Global broker: unreadable lock file — /pinet start will reclaim it.";
+    case "stale-dead":
+      return `Global broker: stale lock from dead pid ${lock.owner.pid} — /pinet start will reclaim it.`;
+    case "stale-pid-reused":
+      return `Global broker: lock pid ${lock.owner.pid} was reused by an unrelated process — /pinet start will reclaim it.`;
+    case "alive": {
+      const since = lock.owner.createdAt ? ` since ${lock.owner.createdAt}` : "";
+      if (probe === "healthy") {
+        return `Global broker: active (pid ${lock.owner.pid}${since}). Use /pinet follow to join it, or /pinet start replace to take it over.`;
+      }
+      const socketState = probe === "unreachable" ? "unreachable" : "unresponsive";
+      return `Global broker: pid ${lock.owner.pid} holds the lock${since} but the broker socket is ${socketState} — likely stranded. Use /pinet start replace to recover.`;
+    }
+  }
+}
+
+async function runPinetStatus(deps: PinetCommandsDeps, ctx: ExtensionContext): Promise<void> {
   const mode = deps.runtimeMode();
+  let globalBrokerInfo: string[] = [];
+  if (mode === "off" || mode === "single") {
+    try {
+      globalBrokerInfo = [formatGlobalBrokerReport(await deps.inspectGlobalBroker())];
+    } catch (err) {
+      globalBrokerInfo = [`Global broker: inspection failed (${errorMsg(err)})`];
+    }
+  }
   const ownedCount = [...deps.threads().values()].filter((t) =>
     agentOwnsThread(t.owner, deps.agentName(), deps.agentAliases(), deps.agentOwnerToken()),
   ).length;
@@ -753,6 +844,7 @@ function runPinetStatus(deps: PinetCommandsDeps, ctx: ExtensionContext): void {
       ...ralphSnoozeInfo,
       ...brokerHomeTabInfo,
       ...subtreeBrokerInfo,
+      ...globalBrokerInfo,
     ].join("\n"),
     "info",
   );


### PR DESCRIPTION
Closes #951.

## Problem

When the Pi session hosting the broker is lost (crash, laptop restart, stalled process), `/pinet start` collapses every leader-lock conflict into one generic error with no recovery path. The lock stores only a PID validated by `kill(pid, 0)`, so a second session cannot distinguish a healthy broker to follow, a dead broker with stale state, a stranded live process, or a reused PID. Recovery required manual lock forensics (`cat` the lock, `lsof`, signal a PID by hand).

## What this PR does

Design notes: `plans/951-stranded-broker-recovery.md`.

### 1. Structured leader lock (`broker-core/leader.ts`)

- Lock format: PID on line 1 (legacy readers still `parseInt` it, preserving mixed-version single-broker safety) + a JSON metadata line with process start time, per-acquisition instance id, hostname, and creation timestamp.
- New inspection API (`readBrokerLockOwner`, `inspectBrokerLock`, `getProcessStartTime`) classifies the owner: `none | unreadable | stale-dead | stale-pid-reused | alive`.
- PID reuse is only declared when both recorded and current start times are known and differ — uncertainty never reclaims a live broker's lock. Start times are captured deterministically (`/proc/<pid>/stat` on Linux, `LC_ALL=C ps -o lstart=` elsewhere) and compared by exact equality.

### 2. Conflict classification (`slack-bridge/broker/lock-conflict.ts`)

- `startBroker` classifies lock conflicts: lock inspection + a bounded socket probe (any well-formed JSON-RPC response, including an auth error, proves the broker event loop is serving).
- Throws a typed `BrokerLockConflictError`: an active broker suggests `/pinet follow` or `/pinet start replace`; a stranded owner suggests `/pinet start replace`. Reclaimable conflicts (owner died mid-start) retry the acquire once.

### 3. Graceful remote shutdown (`admin.shutdown` RPC)

- New authenticated socket-server RPC. The broker runtime wires it to stop the Pinet runtime in the owning session — the session survives, it just stops being the broker, with an operator notification.
- Brokers without a wired handler report method-not-found, so callers treat them as `unsupported` and fall back.

### 4. Conservative takeover (`/pinet start replace`)

`replaceBrokerOwner()` sequence:

1. Stale/absent lock → nothing to replace (normal start reclaims).
2. Live owner → request `admin.shutdown`, poll for lock release (bounded).
3. Fallback → re-verify the owner fence (pid + process start time + instance id), SIGTERM the verified owner, poll again (bounded).
4. Never SIGKILL. Aborts if the owner identity changes mid-flight. Refuses to signal the calling process itself.

### 5. Operator surfaces

- `/pinet status` in `off`/`single` modes appends a machine-wide "Global broker" line (lock owner, socket health, concrete next step) — usable from exactly the disconnected session that needs recovery.
- README documents the recovery flow.

## Safety properties preserved

- The single-broker invariant is untouched: `alive` owners are never reclaimed automatically; takeover is an explicit operator action.
- Legacy locks and legacy readers interoperate both ways (covered by tests).
- All fallback termination is fenced on full owner identity and re-verified immediately before signaling.

## Testing

- `pnpm prepush` (lint, typecheck, full test suite) green; 60+ new assertions across `leader.test.ts`, `lock-conflict.test.ts`, `helpers.test.ts`, `pinet-commands.test.ts` covering: v2/legacy lock parsing, dead-PID and PID-reuse reclaim, unknown-start-time conservatism, probe healthy/unreachable/unresponsive (against a real `BrokerSocketServer`), `admin.shutdown` auth gating and unsupported fallback, replace graceful/terminated/owner-changed/failed/self-PID paths, and the new command/status surfaces.
- Cross-process end-to-end runs (real broker child process on temp paths):
  - graceful: `probe healthy → admin.shutdown accepted → lock released → fresh broker starts`
  - stubborn (no handler): `unsupported → fenced SIGTERM → lock released → fresh broker starts`
  - The E2E caught and fixed a real bug: the replace poll loop's default sleep timer was unref'd, letting a bare event loop exit mid-poll.
