### PR TITLE
fix(slack-bridge): hold inbound deliveries while Pi compaction is running

### DIFF
--- a/slack-bridge/compaction-gate.test.ts
+++ b/slack-bridge/compaction-gate.test.ts
@@ -1,251 +1,57 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-  createCompactionGate,
-  type CompactionGateDeps,
-  type CompactionGateReleaseReason,
-  type CompactionGateTimerHandle,
-} from "./compaction-gate.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCompactionGate } from "./compaction-gate.js";
 
-interface Harness {
-  gate: ReturnType<typeof createCompactionGate>;
-  onRelease: ReturnType<typeof vi.fn>;
-  /** Run all deferred release callbacks scheduled so far. */
-  flushScheduled: () => void;
-  /** Fire the pending failsafe timer, if armed. */
-  fireFailsafe: () => void;
-  clearedTimers: CompactionGateTimerHandle[];
-}
-
-function createHarness(overrides: Partial<CompactionGateDeps> = {}): Harness {
-  const onRelease = vi.fn<(held: string[], reason: CompactionGateReleaseReason) => void>();
-  const scheduled: Array<() => void> = [];
-  const timers = new Map<number, () => void>();
-  const clearedTimers: CompactionGateTimerHandle[] = [];
-  let nextTimer = 1;
-
-  const gate = createCompactionGate({
-    onRelease,
-    scheduleRelease: (fn) => {
-      scheduled.push(fn);
-    },
-    setTimer: (fn) => {
-      const handle = nextTimer++;
-      timers.set(handle, fn);
-      return handle;
-    },
-    clearTimer: (handle) => {
-      clearedTimers.push(handle);
-      timers.delete(handle as number);
-    },
-    ...overrides,
-  });
-
-  return {
-    gate,
-    onRelease,
-    flushScheduled: () => {
-      while (scheduled.length > 0) {
-        scheduled.shift()?.();
-      }
-    },
-    fireFailsafe: () => {
-      for (const [handle, fn] of [...timers]) {
-        timers.delete(handle);
-        fn();
-      }
-    },
-    clearedTimers,
-  };
-}
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("createCompactionGate", () => {
-  it("does not hold messages when no compaction is active", () => {
-    const { gate } = createHarness();
-    expect(gate.isCompacting()).toBe(false);
-    expect(gate.holdMessage("hello")).toBe(false);
-    expect(gate.heldCount()).toBe(0);
-  });
-
-  it("holds messages during a compaction window and releases them on endHold", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.beginHold();
-    expect(gate.isCompacting()).toBe(true);
-    expect(gate.holdMessage("first")).toBe(true);
-    expect(gate.holdMessage("second")).toBe(true);
-
-    gate.endHold("compacted");
-    // Release is deferred: still compacting until the scheduled callback runs,
-    // so synchronous session_compact handlers cannot deliver inside compact().
-    expect(gate.isCompacting()).toBe(true);
-    expect(onRelease).not.toHaveBeenCalled();
-
-    flushScheduled();
-    expect(gate.isCompacting()).toBe(false);
-    expect(onRelease).toHaveBeenCalledTimes(1);
-    expect(onRelease).toHaveBeenCalledWith(["first", "second"], "compacted");
-    expect(gate.heldCount()).toBe(0);
-  });
-
-  it("keeps holding messages that arrive between endHold and the deferred release", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.beginHold();
-    gate.endHold("compacted");
-    expect(gate.holdMessage("late")).toBe(true);
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledWith(["late"], "compacted");
-  });
-
-  it("releases with an empty batch so callers can drain the inbox", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.beginHold();
-    gate.endHold("compacted");
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledWith([], "compacted");
-  });
-
-  it("only releases once for duplicate endHold calls", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.beginHold();
-    gate.holdMessage("once");
-    gate.endHold("compacted");
-    gate.endHold("aborted");
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledTimes(1);
-    expect(onRelease).toHaveBeenCalledWith(["once"], "compacted");
-  });
-
-  it("ignores endHold when no hold is active", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.endHold("compacted");
-    flushScheduled();
-    expect(onRelease).not.toHaveBeenCalled();
-  });
-
-  it("releases when the compaction abort signal fires", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    const controller = new AbortController();
-    gate.beginHold({ signal: controller.signal });
-    gate.holdMessage("held");
-
-    controller.abort();
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledWith(["held"], "aborted");
-  });
-
-  it("releases immediately when the signal is already aborted", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    const controller = new AbortController();
-    controller.abort();
-    gate.beginHold({ signal: controller.signal });
-    flushScheduled();
-    expect(gate.isCompacting()).toBe(false);
-    expect(onRelease).toHaveBeenCalledWith([], "aborted");
-  });
-
-  it("releases via the failsafe timer when compaction never reports back", () => {
-    const { gate, onRelease, flushScheduled, fireFailsafe } = createHarness();
-    gate.beginHold();
-    gate.holdMessage("stranded");
-    fireFailsafe();
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledWith(["stranded"], "timeout");
-  });
-
-  it("clears the failsafe timer once the hold ends", () => {
-    const { gate, onRelease, flushScheduled, fireFailsafe, clearedTimers } = createHarness();
-    gate.beginHold();
-    gate.endHold("compacted");
-    flushScheduled();
-    expect(clearedTimers.length).toBeGreaterThan(0);
-    fireFailsafe();
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledTimes(1);
-  });
-
-  it("carries held messages into a new hold that begins before the release runs", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.beginHold();
-    gate.holdMessage("carried");
-    gate.endHold("compacted");
-    // A new compaction starts before the deferred release executed.
-    gate.beginHold();
-    flushScheduled();
-    expect(onRelease).not.toHaveBeenCalled();
-    expect(gate.isCompacting()).toBe(true);
-    expect(gate.heldCount()).toBe(1);
-
-    gate.endHold("compacted");
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledWith(["carried"], "compacted");
-  });
-
-  it("ignores a stale abort signal from a previous hold", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    const first = new AbortController();
-    gate.beginHold({ signal: first.signal });
-    gate.beginHold();
-    gate.holdMessage("current");
-
-    first.abort();
-    flushScheduled();
-    expect(onRelease).not.toHaveBeenCalled();
-    expect(gate.isCompacting()).toBe(true);
-
-    gate.endHold("compacted");
-    flushScheduled();
-    expect(onRelease).toHaveBeenCalledWith(["current"], "compacted");
-  });
-
-  it("ignores a stale failsafe timer from a previous hold", () => {
+  it("fails closed until compaction completion, then accepts delivery", async () => {
+    vi.useFakeTimers();
     const onRelease = vi.fn();
-    const scheduled: Array<() => void> = [];
-    const timerFns: Array<() => void> = [];
-    const gate = createCompactionGate({
-      onRelease,
-      scheduleRelease: (fn) => {
-        scheduled.push(fn);
-      },
-      setTimer: (fn) => {
-        timerFns.push(fn);
-        return timerFns.length;
-      },
-      // Simulate an environment where cleared timers still fire.
-      clearTimer: () => {},
-    });
+    const deliver = vi.fn();
+    const gate = createCompactionGate(onRelease);
 
-    gate.beginHold();
-    gate.beginHold();
-    gate.holdMessage("current");
+    gate.begin();
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(gate.tryDeliver(deliver)).toBe(false);
+    expect(deliver).not.toHaveBeenCalled();
 
-    timerFns[0]!(); // stale failsafe from the first hold
-    while (scheduled.length > 0) scheduled.shift()?.();
-    expect(onRelease).not.toHaveBeenCalled();
-    expect(gate.isCompacting()).toBe(true);
+    gate.end();
+    expect(gate.tryDeliver(deliver)).toBe(false);
+    await vi.runAllTimersAsync();
 
-    gate.endHold("compacted");
-    while (scheduled.length > 0) scheduled.shift()?.();
-    expect(onRelease).toHaveBeenCalledWith(["current"], "compacted");
+    expect(onRelease).toHaveBeenCalledOnce();
+    expect(gate.tryDeliver(deliver)).toBe(true);
+    expect(deliver).toHaveBeenCalledOnce();
   });
 
-  it("discard drops held messages without releasing them", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.beginHold();
-    gate.holdMessage("dropped");
-    const dropped = gate.discard();
-    expect(dropped).toEqual(["dropped"]);
-    expect(gate.isCompacting()).toBe(false);
-    flushScheduled();
-    expect(onRelease).not.toHaveBeenCalled();
+  it("releases aborted compaction asynchronously", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const onRelease = vi.fn();
+    const gate = createCompactionGate(onRelease);
+
+    gate.begin(controller.signal);
+    controller.abort();
+    expect(gate.isActive()).toBe(true);
+    await vi.runAllTimersAsync();
+
+    expect(gate.isActive()).toBe(false);
+    expect(onRelease).toHaveBeenCalledOnce();
   });
 
-  it("discard cancels a pending deferred release", () => {
-    const { gate, onRelease, flushScheduled } = createHarness();
-    gate.beginHold();
-    gate.holdMessage("dropped");
-    gate.endHold("compacted");
-    const dropped = gate.discard();
-    expect(dropped).toEqual(["dropped"]);
-    flushScheduled();
+  it("cancels a pending release on reset", async () => {
+    vi.useFakeTimers();
+    const onRelease = vi.fn();
+    const gate = createCompactionGate(onRelease);
+
+    gate.begin();
+    gate.end();
+    gate.reset();
+    await vi.runAllTimersAsync();
+
+    expect(gate.isActive()).toBe(false);
     expect(onRelease).not.toHaveBeenCalled();
   });
 });

--- a/slack-bridge/compaction-gate.test.ts
+++ b/slack-bridge/compaction-gate.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCompactionGate,
+  type CompactionGateDeps,
+  type CompactionGateReleaseReason,
+  type CompactionGateTimerHandle,
+} from "./compaction-gate.js";
+
+interface Harness {
+  gate: ReturnType<typeof createCompactionGate>;
+  onRelease: ReturnType<typeof vi.fn>;
+  /** Run all deferred release callbacks scheduled so far. */
+  flushScheduled: () => void;
+  /** Fire the pending failsafe timer, if armed. */
+  fireFailsafe: () => void;
+  clearedTimers: CompactionGateTimerHandle[];
+}
+
+function createHarness(overrides: Partial<CompactionGateDeps> = {}): Harness {
+  const onRelease = vi.fn<(held: string[], reason: CompactionGateReleaseReason) => void>();
+  const scheduled: Array<() => void> = [];
+  const timers = new Map<number, () => void>();
+  const clearedTimers: CompactionGateTimerHandle[] = [];
+  let nextTimer = 1;
+
+  const gate = createCompactionGate({
+    onRelease,
+    scheduleRelease: (fn) => {
+      scheduled.push(fn);
+    },
+    setTimer: (fn) => {
+      const handle = nextTimer++;
+      timers.set(handle, fn);
+      return handle;
+    },
+    clearTimer: (handle) => {
+      clearedTimers.push(handle);
+      timers.delete(handle as number);
+    },
+    ...overrides,
+  });
+
+  return {
+    gate,
+    onRelease,
+    flushScheduled: () => {
+      while (scheduled.length > 0) {
+        scheduled.shift()?.();
+      }
+    },
+    fireFailsafe: () => {
+      for (const [handle, fn] of [...timers]) {
+        timers.delete(handle);
+        fn();
+      }
+    },
+    clearedTimers,
+  };
+}
+
+describe("createCompactionGate", () => {
+  it("does not hold messages when no compaction is active", () => {
+    const { gate } = createHarness();
+    expect(gate.isCompacting()).toBe(false);
+    expect(gate.holdMessage("hello")).toBe(false);
+    expect(gate.heldCount()).toBe(0);
+  });
+
+  it("holds messages during a compaction window and releases them on endHold", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.beginHold();
+    expect(gate.isCompacting()).toBe(true);
+    expect(gate.holdMessage("first")).toBe(true);
+    expect(gate.holdMessage("second")).toBe(true);
+
+    gate.endHold("compacted");
+    // Release is deferred: still compacting until the scheduled callback runs,
+    // so synchronous session_compact handlers cannot deliver inside compact().
+    expect(gate.isCompacting()).toBe(true);
+    expect(onRelease).not.toHaveBeenCalled();
+
+    flushScheduled();
+    expect(gate.isCompacting()).toBe(false);
+    expect(onRelease).toHaveBeenCalledTimes(1);
+    expect(onRelease).toHaveBeenCalledWith(["first", "second"], "compacted");
+    expect(gate.heldCount()).toBe(0);
+  });
+
+  it("keeps holding messages that arrive between endHold and the deferred release", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.beginHold();
+    gate.endHold("compacted");
+    expect(gate.holdMessage("late")).toBe(true);
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledWith(["late"], "compacted");
+  });
+
+  it("releases with an empty batch so callers can drain the inbox", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.beginHold();
+    gate.endHold("compacted");
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledWith([], "compacted");
+  });
+
+  it("only releases once for duplicate endHold calls", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.beginHold();
+    gate.holdMessage("once");
+    gate.endHold("compacted");
+    gate.endHold("aborted");
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledTimes(1);
+    expect(onRelease).toHaveBeenCalledWith(["once"], "compacted");
+  });
+
+  it("ignores endHold when no hold is active", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.endHold("compacted");
+    flushScheduled();
+    expect(onRelease).not.toHaveBeenCalled();
+  });
+
+  it("releases when the compaction abort signal fires", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    const controller = new AbortController();
+    gate.beginHold({ signal: controller.signal });
+    gate.holdMessage("held");
+
+    controller.abort();
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledWith(["held"], "aborted");
+  });
+
+  it("releases immediately when the signal is already aborted", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    const controller = new AbortController();
+    controller.abort();
+    gate.beginHold({ signal: controller.signal });
+    flushScheduled();
+    expect(gate.isCompacting()).toBe(false);
+    expect(onRelease).toHaveBeenCalledWith([], "aborted");
+  });
+
+  it("releases via the failsafe timer when compaction never reports back", () => {
+    const { gate, onRelease, flushScheduled, fireFailsafe } = createHarness();
+    gate.beginHold();
+    gate.holdMessage("stranded");
+    fireFailsafe();
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledWith(["stranded"], "timeout");
+  });
+
+  it("clears the failsafe timer once the hold ends", () => {
+    const { gate, onRelease, flushScheduled, fireFailsafe, clearedTimers } = createHarness();
+    gate.beginHold();
+    gate.endHold("compacted");
+    flushScheduled();
+    expect(clearedTimers.length).toBeGreaterThan(0);
+    fireFailsafe();
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries held messages into a new hold that begins before the release runs", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.beginHold();
+    gate.holdMessage("carried");
+    gate.endHold("compacted");
+    // A new compaction starts before the deferred release executed.
+    gate.beginHold();
+    flushScheduled();
+    expect(onRelease).not.toHaveBeenCalled();
+    expect(gate.isCompacting()).toBe(true);
+    expect(gate.heldCount()).toBe(1);
+
+    gate.endHold("compacted");
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledWith(["carried"], "compacted");
+  });
+
+  it("ignores a stale abort signal from a previous hold", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    const first = new AbortController();
+    gate.beginHold({ signal: first.signal });
+    gate.beginHold();
+    gate.holdMessage("current");
+
+    first.abort();
+    flushScheduled();
+    expect(onRelease).not.toHaveBeenCalled();
+    expect(gate.isCompacting()).toBe(true);
+
+    gate.endHold("compacted");
+    flushScheduled();
+    expect(onRelease).toHaveBeenCalledWith(["current"], "compacted");
+  });
+
+  it("ignores a stale failsafe timer from a previous hold", () => {
+    const onRelease = vi.fn();
+    const scheduled: Array<() => void> = [];
+    const timerFns: Array<() => void> = [];
+    const gate = createCompactionGate({
+      onRelease,
+      scheduleRelease: (fn) => {
+        scheduled.push(fn);
+      },
+      setTimer: (fn) => {
+        timerFns.push(fn);
+        return timerFns.length;
+      },
+      // Simulate an environment where cleared timers still fire.
+      clearTimer: () => {},
+    });
+
+    gate.beginHold();
+    gate.beginHold();
+    gate.holdMessage("current");
+
+    timerFns[0]!(); // stale failsafe from the first hold
+    while (scheduled.length > 0) scheduled.shift()?.();
+    expect(onRelease).not.toHaveBeenCalled();
+    expect(gate.isCompacting()).toBe(true);
+
+    gate.endHold("compacted");
+    while (scheduled.length > 0) scheduled.shift()?.();
+    expect(onRelease).toHaveBeenCalledWith(["current"], "compacted");
+  });
+
+  it("discard drops held messages without releasing them", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.beginHold();
+    gate.holdMessage("dropped");
+    const dropped = gate.discard();
+    expect(dropped).toEqual(["dropped"]);
+    expect(gate.isCompacting()).toBe(false);
+    flushScheduled();
+    expect(onRelease).not.toHaveBeenCalled();
+  });
+
+  it("discard cancels a pending deferred release", () => {
+    const { gate, onRelease, flushScheduled } = createHarness();
+    gate.beginHold();
+    gate.holdMessage("dropped");
+    gate.endHold("compacted");
+    const dropped = gate.discard();
+    expect(dropped).toEqual(["dropped"]);
+    flushScheduled();
+    expect(onRelease).not.toHaveBeenCalled();
+  });
+});

--- a/slack-bridge/compaction-gate.ts
+++ b/slack-bridge/compaction-gate.ts
@@ -1,163 +1,35 @@
-/**
- * Compaction delivery gate.
- *
- * Pi's manual/extension compaction path (`AgentSession.compact()`, used by
- * `/compact` and every extension `ctx.compact()` call) disconnects session
- * persistence for the whole summarization call, while `ctx.isIdle()` keeps
- * returning true. Any message injected through `pi.sendUserMessage()` in that
- * window starts a real agent run whose entries are silently never written to
- * the session file, leaving an orphaned toolResult behind and eventually
- * bricking the session with provider errors such as
- * "No tool call found for function call output" (gugu91/pinet#941).
- *
- * This gate tracks the compaction window via the `session_before_compact` /
- * `session_compact` extension events and lets the slack-bridge delivery paths
- * hold inbound work until the window closes. Release is always deferred to a
- * fresh macrotask because `session_compact` fires *before* Pi reconnects
- * session persistence; delivering synchronously from that handler would
- * reproduce the exact corruption this gate exists to prevent.
- *
- * `session_compact` only fires on successful compaction, so the gate also
- * releases when the compaction abort signal fires, and after a failsafe
- * timeout for non-abort summarization failures (which emit no extension
- * event at all).
- */
-
-export type CompactionGateReleaseReason = "compacted" | "aborted" | "timeout";
-
-/** Timer handle for the failsafe: Node timeout in production, number in tests. */
-export type CompactionGateTimerHandle = ReturnType<typeof setTimeout> | number;
-
-export interface CompactionGateDeps {
-  /**
-   * Called (deferred, never re-entrant) when the hold ends. Receives any
-   * messages held during the window; implementations should re-deliver them
-   * and then drain the regular inbox.
-   */
-  onRelease: (heldMessages: string[], reason: CompactionGateReleaseReason) => void;
-  /** Failsafe hold duration. Defaults to 10 minutes. */
-  maxHoldMs?: number;
-  /** Defer hook, injectable for tests. Defaults to `setTimeout(fn, 0)`. */
-  scheduleRelease?: (fn: () => void) => void;
-  /** Timer hooks, injectable for tests. */
-  setTimer?: (fn: () => void, ms: number) => CompactionGateTimerHandle;
-  clearTimer?: (handle: CompactionGateTimerHandle) => void;
-}
-
-export interface CompactionGate {
-  /** Whether a compaction hold window is currently open. */
-  isCompacting: () => boolean;
-  /** Number of messages currently held. */
-  heldCount: () => number;
-  /** Open the hold window (from `session_before_compact`). */
-  beginHold: (options?: { signal?: AbortSignal }) => void;
-  /**
-   * Hold a message while compacting. Returns true when the message was held
-   * (caller must not deliver it), false when no hold is active.
-   */
-  holdMessage: (text: string) => boolean;
-  /**
-   * Schedule the end of the hold window. The gate keeps reporting
-   * `isCompacting() === true` until the deferred release executes, so that
-   * synchronous callers inside Pi's compact() stack (e.g. the
-   * `session_compact` handler) can never deliver before persistence is
-   * reconnected. Held messages are then released via `onRelease`.
-   */
-  endHold: (reason: CompactionGateReleaseReason) => void;
-  /**
-   * Close the hold window without releasing (session shutdown/restart).
-   * Returns the dropped messages so callers can log them.
-   */
-  discard: () => string[];
-}
-
-const DEFAULT_MAX_HOLD_MS = 10 * 60 * 1000;
-
-export function createCompactionGate(deps: CompactionGateDeps): CompactionGate {
-  const maxHoldMs = deps.maxHoldMs ?? DEFAULT_MAX_HOLD_MS;
-  const scheduleRelease =
-    deps.scheduleRelease ??
-    ((fn: () => void) => {
-      setTimeout(fn, 0);
-    });
-  const setTimer = deps.setTimer ?? ((fn: () => void, ms: number) => setTimeout(fn, ms));
-  const clearTimer =
-    deps.clearTimer ?? ((handle: CompactionGateTimerHandle) => clearTimeout(handle));
-
-  let compacting = false;
-  let held: string[] = [];
-  let timerHandle: CompactionGateTimerHandle | null = null;
-  // Invalidates stale failsafe timers and abort listeners from earlier holds.
+export function createCompactionGate(onRelease: () => void) {
   let generation = 0;
+  let active = false;
 
-  function clearFailsafe(): void {
-    if (timerHandle != null) {
-      clearTimer(timerHandle);
-      timerHandle = null;
-    }
-  }
+  function end(expectedGeneration = generation): void {
+    if (!active || expectedGeneration !== generation) return;
 
-  function endHold(reason: CompactionGateReleaseReason): void {
-    if (!compacting) return;
-    const gen = generation;
-    clearFailsafe();
-    scheduleRelease(() => {
-      // Superseded by a newer hold or discard: keep messages for that owner.
-      if (gen !== generation) return;
+    // session_compact fires before Pi reconnects persistence.
+    setTimeout(() => {
+      if (expectedGeneration !== generation) return;
+      active = false;
       generation += 1;
-      compacting = false;
-      const toRelease = held;
-      held = [];
-      deps.onRelease(toRelease, reason);
-    });
-  }
-
-  function beginHold(options?: { signal?: AbortSignal }): void {
-    generation += 1;
-    const gen = generation;
-    compacting = true;
-    clearFailsafe();
-    timerHandle = setTimer(() => {
-      if (gen === generation) endHold("timeout");
-    }, maxHoldMs);
-
-    const signal = options?.signal;
-    if (signal) {
-      if (signal.aborted) {
-        endHold("aborted");
-        return;
-      }
-      signal.addEventListener(
-        "abort",
-        () => {
-          if (gen === generation) endHold("aborted");
-        },
-        { once: true },
-      );
-    }
-  }
-
-  function holdMessage(text: string): boolean {
-    if (!compacting) return false;
-    held.push(text);
-    return true;
-  }
-
-  function discard(): string[] {
-    compacting = false;
-    generation += 1;
-    clearFailsafe();
-    const dropped = held;
-    held = [];
-    return dropped;
+      onRelease();
+    }, 0);
   }
 
   return {
-    isCompacting: () => compacting,
-    heldCount: () => held.length,
-    beginHold,
-    holdMessage,
-    endHold,
-    discard,
+    isActive: () => active,
+    begin(signal?: AbortSignal): void {
+      const currentGeneration = ++generation;
+      active = true;
+      signal?.addEventListener("abort", () => end(currentGeneration), { once: true });
+    },
+    end,
+    reset(): void {
+      active = false;
+      generation += 1;
+    },
+    tryDeliver(deliver: () => void): boolean {
+      if (active) return false;
+      deliver();
+      return true;
+    },
   };
 }

--- a/slack-bridge/compaction-gate.ts
+++ b/slack-bridge/compaction-gate.ts
@@ -1,0 +1,163 @@
+/**
+ * Compaction delivery gate.
+ *
+ * Pi's manual/extension compaction path (`AgentSession.compact()`, used by
+ * `/compact` and every extension `ctx.compact()` call) disconnects session
+ * persistence for the whole summarization call, while `ctx.isIdle()` keeps
+ * returning true. Any message injected through `pi.sendUserMessage()` in that
+ * window starts a real agent run whose entries are silently never written to
+ * the session file, leaving an orphaned toolResult behind and eventually
+ * bricking the session with provider errors such as
+ * "No tool call found for function call output" (gugu91/pinet#941).
+ *
+ * This gate tracks the compaction window via the `session_before_compact` /
+ * `session_compact` extension events and lets the slack-bridge delivery paths
+ * hold inbound work until the window closes. Release is always deferred to a
+ * fresh macrotask because `session_compact` fires *before* Pi reconnects
+ * session persistence; delivering synchronously from that handler would
+ * reproduce the exact corruption this gate exists to prevent.
+ *
+ * `session_compact` only fires on successful compaction, so the gate also
+ * releases when the compaction abort signal fires, and after a failsafe
+ * timeout for non-abort summarization failures (which emit no extension
+ * event at all).
+ */
+
+export type CompactionGateReleaseReason = "compacted" | "aborted" | "timeout";
+
+/** Timer handle for the failsafe: Node timeout in production, number in tests. */
+export type CompactionGateTimerHandle = ReturnType<typeof setTimeout> | number;
+
+export interface CompactionGateDeps {
+  /**
+   * Called (deferred, never re-entrant) when the hold ends. Receives any
+   * messages held during the window; implementations should re-deliver them
+   * and then drain the regular inbox.
+   */
+  onRelease: (heldMessages: string[], reason: CompactionGateReleaseReason) => void;
+  /** Failsafe hold duration. Defaults to 10 minutes. */
+  maxHoldMs?: number;
+  /** Defer hook, injectable for tests. Defaults to `setTimeout(fn, 0)`. */
+  scheduleRelease?: (fn: () => void) => void;
+  /** Timer hooks, injectable for tests. */
+  setTimer?: (fn: () => void, ms: number) => CompactionGateTimerHandle;
+  clearTimer?: (handle: CompactionGateTimerHandle) => void;
+}
+
+export interface CompactionGate {
+  /** Whether a compaction hold window is currently open. */
+  isCompacting: () => boolean;
+  /** Number of messages currently held. */
+  heldCount: () => number;
+  /** Open the hold window (from `session_before_compact`). */
+  beginHold: (options?: { signal?: AbortSignal }) => void;
+  /**
+   * Hold a message while compacting. Returns true when the message was held
+   * (caller must not deliver it), false when no hold is active.
+   */
+  holdMessage: (text: string) => boolean;
+  /**
+   * Schedule the end of the hold window. The gate keeps reporting
+   * `isCompacting() === true` until the deferred release executes, so that
+   * synchronous callers inside Pi's compact() stack (e.g. the
+   * `session_compact` handler) can never deliver before persistence is
+   * reconnected. Held messages are then released via `onRelease`.
+   */
+  endHold: (reason: CompactionGateReleaseReason) => void;
+  /**
+   * Close the hold window without releasing (session shutdown/restart).
+   * Returns the dropped messages so callers can log them.
+   */
+  discard: () => string[];
+}
+
+const DEFAULT_MAX_HOLD_MS = 10 * 60 * 1000;
+
+export function createCompactionGate(deps: CompactionGateDeps): CompactionGate {
+  const maxHoldMs = deps.maxHoldMs ?? DEFAULT_MAX_HOLD_MS;
+  const scheduleRelease =
+    deps.scheduleRelease ??
+    ((fn: () => void) => {
+      setTimeout(fn, 0);
+    });
+  const setTimer = deps.setTimer ?? ((fn: () => void, ms: number) => setTimeout(fn, ms));
+  const clearTimer =
+    deps.clearTimer ?? ((handle: CompactionGateTimerHandle) => clearTimeout(handle));
+
+  let compacting = false;
+  let held: string[] = [];
+  let timerHandle: CompactionGateTimerHandle | null = null;
+  // Invalidates stale failsafe timers and abort listeners from earlier holds.
+  let generation = 0;
+
+  function clearFailsafe(): void {
+    if (timerHandle != null) {
+      clearTimer(timerHandle);
+      timerHandle = null;
+    }
+  }
+
+  function endHold(reason: CompactionGateReleaseReason): void {
+    if (!compacting) return;
+    const gen = generation;
+    clearFailsafe();
+    scheduleRelease(() => {
+      // Superseded by a newer hold or discard: keep messages for that owner.
+      if (gen !== generation) return;
+      generation += 1;
+      compacting = false;
+      const toRelease = held;
+      held = [];
+      deps.onRelease(toRelease, reason);
+    });
+  }
+
+  function beginHold(options?: { signal?: AbortSignal }): void {
+    generation += 1;
+    const gen = generation;
+    compacting = true;
+    clearFailsafe();
+    timerHandle = setTimer(() => {
+      if (gen === generation) endHold("timeout");
+    }, maxHoldMs);
+
+    const signal = options?.signal;
+    if (signal) {
+      if (signal.aborted) {
+        endHold("aborted");
+        return;
+      }
+      signal.addEventListener(
+        "abort",
+        () => {
+          if (gen === generation) endHold("aborted");
+        },
+        { once: true },
+      );
+    }
+  }
+
+  function holdMessage(text: string): boolean {
+    if (!compacting) return false;
+    held.push(text);
+    return true;
+  }
+
+  function discard(): string[] {
+    compacting = false;
+    generation += 1;
+    clearFailsafe();
+    const dropped = held;
+    held = [];
+    return dropped;
+  }
+
+  return {
+    isCompacting: () => compacting,
+    heldCount: () => held.length,
+    beginHold,
+    holdMessage,
+    endHold,
+    discard,
+  };
+}

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1911,7 +1911,7 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionShutdown?.({}, ctx);
   });
 
-  it("drains queued single-mode Slack inbox work on agent_end even without Pinet enabled", async () => {
+  it("keeps queued single-mode Slack work out of Pi until compaction finishes", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
     fs.writeFileSync(
@@ -1988,10 +1988,14 @@ describe("slack-bridge top-level shutdown", () => {
 
     const sessionStart = events.get("session_start");
     const agentEnd = events.get("agent_end");
+    const sessionBeforeCompact = events.get("session_before_compact");
+    const sessionCompact = events.get("session_compact");
     const sessionShutdown = events.get("session_shutdown");
 
     expect(sessionStart).toBeDefined();
     expect(agentEnd).toBeDefined();
+    expect(sessionBeforeCompact).toBeDefined();
+    expect(sessionCompact).toBeDefined();
     expect(sessionShutdown).toBeDefined();
 
     await sessionStart?.({}, ctx);
@@ -2022,9 +2026,13 @@ describe("slack-bridge top-level shutdown", () => {
     });
     expect(sendUserMessage).not.toHaveBeenCalled();
 
+    const compaction = new AbortController();
+    await sessionBeforeCompact?.({ signal: compaction.signal }, ctx);
     idle = true;
     await agentEnd?.({ type: "agent_end", messages: [] }, ctx);
+    expect(sendUserMessage).not.toHaveBeenCalled();
 
+    await sessionCompact?.({}, ctx);
     await vi.waitFor(() => {
       expect(sendUserMessage).toHaveBeenCalledWith(
         expect.stringContaining("hello from Slack inbox"),

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -240,42 +240,13 @@ export default function (pi: ExtensionAPI) {
   });
   const { updateBadge, setExtStatus, maybeDrainInboxIfIdle } = sessionUiRuntime;
 
-  // Hold inbound deliveries while Pi compaction has session persistence
-  // disconnected (#941). ctx.isIdle() keeps returning true during compaction,
-  // so without this gate a delivery starts an agent run whose messages are
-  // never written to the session file, leaving an orphaned toolResult that
-  // later bricks the session with provider pairing errors. Release is deferred
-  // to a fresh macrotask because session_compact fires before Pi reconnects
-  // persistence.
-  const compactionGate = createCompactionGate({
-    onRelease: (heldMessages, reason) => {
-      if (heldMessages.length === 0) {
-        maybeDrainInboxIfIdle();
-        return;
-      }
-      console.log(
-        `[slack-bridge] compaction hold released (${reason}); delivering ${heldMessages.length} held message(s)`,
-      );
-      try {
-        const combined = heldMessages.join("\n\n");
-        if (sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true) {
-          pi.sendUserMessage(combined);
-        } else {
-          pi.sendUserMessage(combined, { deliverAs: "steer" });
-        }
-      } catch (error) {
-        console.error(`[slack-bridge] held delivery after compaction failed: ${msg(error)}`);
-      }
-      // Inbox messages queued during the hold are drained once the delivery
-      // above settles; the session-ui drain re-arms itself while busy.
-      const drainTimer = setTimeout(() => {
-        maybeDrainInboxIfIdle();
-      }, 1000);
-      drainTimer.unref?.();
-    },
+  const compactionGate = createCompactionGate(() => {
+    maybeDrainInboxIfIdle();
+    const ctx = sessionUiRuntime.getExtensionContext();
+    if (ctx) subtreeBrokerRuntime.drainInbox(ctx);
   });
   const isIdleAndNotCompacting = () =>
-    !compactionGate.isCompacting() && (sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true);
+    !compactionGate.isActive() && (sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true);
   let reportAgentStatus: (status: "working" | "idle") => Promise<void> = async () => {};
   let deliverTrackedSlackFollowUpMessage: (options: {
     prompt: string;
@@ -307,17 +278,14 @@ export default function (pi: ExtensionAPI) {
   drainInboxPort = drainInbox;
 
   function deliverSteeringMessage(text: string, ctx: ExtensionContext): boolean {
-    if (compactionGate.holdMessage(text)) {
-      console.log("[slack-bridge] Pinet delivery held during compaction");
-      return true;
-    }
     try {
-      if (ctx.isIdle?.() ?? true) {
-        pi.sendUserMessage(text);
-      } else {
-        pi.sendUserMessage(text, { deliverAs: "steer" });
-      }
-      return true;
+      return compactionGate.tryDeliver(() => {
+        if (ctx.isIdle?.() ?? true) {
+          pi.sendUserMessage(text);
+        } else {
+          pi.sendUserMessage(text, { deliverAs: "steer" });
+        }
+      });
     } catch (error) {
       console.error(`[slack-bridge] Pinet steering delivery failed: ${msg(error)}`);
       return false;
@@ -1737,12 +1705,7 @@ export default function (pi: ExtensionAPI) {
   // ─── Lifecycle ──────────────────────────────────────
 
   pi.on("session_start", async (_event, ctx) => {
-    const staleHeld = compactionGate.discard();
-    if (staleHeld.length > 0) {
-      console.error(
-        `[slack-bridge] dropping ${staleHeld.length} held message(s) from a previous session`,
-      );
-    }
+    compactionGate.reset();
     singlePlayerRuntime.resetShutdownState();
     slackRequestRuntime.reset();
     resetRemoteControlState();
@@ -1787,25 +1750,16 @@ export default function (pi: ExtensionAPI) {
 
   agentEventRuntime.register(pi);
 
-  pi.on("session_before_compact", async (event: { signal?: AbortSignal }) => {
-    compactionGate.beginHold({ signal: event.signal });
-    // Never return a value: a truthy result would override other extensions'
-    // custom compaction content.
-    return undefined;
+  pi.on("session_before_compact", (event) => {
+    compactionGate.begin(event.signal);
   });
 
-  pi.on("session_compact", async (_event, ctx) => {
-    compactionGate.endHold("compacted");
-    maybeDrainInboxIfIdle(ctx);
+  pi.on("session_compact", () => {
+    compactionGate.end();
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
-    const droppedHeld = compactionGate.discard();
-    if (droppedHeld.length > 0) {
-      console.error(
-        `[slack-bridge] dropping ${droppedHeld.length} held message(s) at session shutdown`,
-      );
-    }
+    compactionGate.reset();
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
     sessionUiRuntime.cleanupForSessionShutdown();

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -47,6 +47,7 @@ import { createToolRegistrationRuntime } from "./tool-registration-runtime.js";
 import { createSlackRuntimeAccess } from "./slack-runtime-access.js";
 import { createThreadConfirmationPolicy } from "./thread-confirmations.js";
 import { persistDeliveredInboundMessage } from "./broker-inbound-persistence.js";
+import { createCompactionGate } from "./compaction-gate.js";
 import {
   createIMessageAdapter,
   detectIMessageMvpEnvironment,
@@ -238,6 +239,43 @@ export default function (pi: ExtensionAPI) {
     },
   });
   const { updateBadge, setExtStatus, maybeDrainInboxIfIdle } = sessionUiRuntime;
+
+  // Hold inbound deliveries while Pi compaction has session persistence
+  // disconnected (#941). ctx.isIdle() keeps returning true during compaction,
+  // so without this gate a delivery starts an agent run whose messages are
+  // never written to the session file, leaving an orphaned toolResult that
+  // later bricks the session with provider pairing errors. Release is deferred
+  // to a fresh macrotask because session_compact fires before Pi reconnects
+  // persistence.
+  const compactionGate = createCompactionGate({
+    onRelease: (heldMessages, reason) => {
+      if (heldMessages.length === 0) {
+        maybeDrainInboxIfIdle();
+        return;
+      }
+      console.log(
+        `[slack-bridge] compaction hold released (${reason}); delivering ${heldMessages.length} held message(s)`,
+      );
+      try {
+        const combined = heldMessages.join("\n\n");
+        if (sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true) {
+          pi.sendUserMessage(combined);
+        } else {
+          pi.sendUserMessage(combined, { deliverAs: "steer" });
+        }
+      } catch (error) {
+        console.error(`[slack-bridge] held delivery after compaction failed: ${msg(error)}`);
+      }
+      // Inbox messages queued during the hold are drained once the delivery
+      // above settles; the session-ui drain re-arms itself while busy.
+      const drainTimer = setTimeout(() => {
+        maybeDrainInboxIfIdle();
+      }, 1000);
+      drainTimer.unref?.();
+    },
+  });
+  const isIdleAndNotCompacting = () =>
+    !compactionGate.isCompacting() && (sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true);
   let reportAgentStatus: (status: "working" | "idle") => Promise<void> = async () => {};
   let deliverTrackedSlackFollowUpMessage: (options: {
     prompt: string;
@@ -247,7 +285,7 @@ export default function (pi: ExtensionAPI) {
     sendUserMessage: (body) => {
       pi.sendUserMessage(body);
     },
-    isIdle: () => sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true,
+    isIdle: isIdleAndNotCompacting,
     takeInboxMessages: (maxMessages) => inbox.splice(0, maxMessages ?? inbox.length),
     restoreInboxMessages: (messages) => {
       inbox.unshift(...messages);
@@ -269,6 +307,10 @@ export default function (pi: ExtensionAPI) {
   drainInboxPort = drainInbox;
 
   function deliverSteeringMessage(text: string, ctx: ExtensionContext): boolean {
+    if (compactionGate.holdMessage(text)) {
+      console.log("[slack-bridge] Pinet delivery held during compaction");
+      return true;
+    }
     try {
       if (ctx.isIdle?.() ?? true) {
         pi.sendUserMessage(text);
@@ -535,7 +577,7 @@ export default function (pi: ExtensionAPI) {
   const pinetMaintenanceDelivery = createPinetMaintenanceDelivery({
     getActiveBrokerDb,
     getActiveBrokerSelfId,
-    isIdle: () => sessionUiRuntime.getExtensionContext()?.isIdle?.() ?? true,
+    isIdle: isIdleAndNotCompacting,
     sendUserMessage: (body) => {
       pi.sendUserMessage(body);
     },
@@ -1695,6 +1737,12 @@ export default function (pi: ExtensionAPI) {
   // ─── Lifecycle ──────────────────────────────────────
 
   pi.on("session_start", async (_event, ctx) => {
+    const staleHeld = compactionGate.discard();
+    if (staleHeld.length > 0) {
+      console.error(
+        `[slack-bridge] dropping ${staleHeld.length} held message(s) from a previous session`,
+      );
+    }
     singlePlayerRuntime.resetShutdownState();
     slackRequestRuntime.reset();
     resetRemoteControlState();
@@ -1739,11 +1787,25 @@ export default function (pi: ExtensionAPI) {
 
   agentEventRuntime.register(pi);
 
+  pi.on("session_before_compact", async (event: { signal?: AbortSignal }) => {
+    compactionGate.beginHold({ signal: event.signal });
+    // Never return a value: a truthy result would override other extensions'
+    // custom compaction content.
+    return undefined;
+  });
+
   pi.on("session_compact", async (_event, ctx) => {
+    compactionGate.endHold("compacted");
     maybeDrainInboxIfIdle(ctx);
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
+    const droppedHeld = compactionGate.discard();
+    if (droppedHeld.length > 0) {
+      console.error(
+        `[slack-bridge] dropping ${droppedHeld.length} held message(s) at session shutdown`,
+      );
+    }
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
     sessionUiRuntime.cleanupForSessionShutdown();

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PinetControlCommand, SlackBridgeSettings } from "./helpers.js";
+import {
+  buildSubtreeBrokerPaths,
+  createSubtreeBrokerRuntime,
+  type SubtreeBrokerRuntime,
+  type SubtreeBrokerRuntimeDeps,
+} from "./subtree-broker-runtime.js";
+
+const ctx = {} as ExtensionContext;
+const runtimes: SubtreeBrokerRuntime[] = [];
+const roots: string[] = [];
+
+function createRuntime(
+  deliverSteeringMessage: SubtreeBrokerRuntimeDeps["deliverSteeringMessage"],
+  stableId = `compaction-gate-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+): {
+  runtime: SubtreeBrokerRuntime;
+  stableId: string;
+} {
+  const runtime = createSubtreeBrokerRuntime({
+    cwd: process.cwd(),
+    getSettings: () => ({}) as SlackBridgeSettings,
+    getAgentStableId: () => stableId,
+    getCentralAgentId: () => null,
+    getAgentIdentity: () => ({ name: "Test", emoji: "🧪" }),
+    getAgentMetadata: async () => ({}),
+    getMeshRoleFromMetadata: (_metadata, fallback) => fallback ?? "worker",
+    pushInboxMessages: () => {},
+    updateBadge: () => {},
+    maybeDrainInboxIfIdle: () => false,
+    deliverSteeringMessage,
+    requestRemoteControl: (command: PinetControlCommand) => ({
+      currentCommand: null,
+      queuedCommand: null,
+      accepted: false,
+      shouldStartNow: false,
+      status: "covered",
+      scheduledCommand: command,
+      ackDisposition: "immediate",
+    }),
+    runRemoteControl: () => {},
+    formatError: (error) => (error instanceof Error ? error.message : String(error)),
+  });
+  runtimes.push(runtime);
+  roots.push(buildSubtreeBrokerPaths(stableId).rootDir);
+  return { runtime, stableId };
+}
+
+function queueSteeringMessage(runtime: SubtreeBrokerRuntime): string {
+  const control = runtime.getHibernationRuntimeControl();
+  if (!control) throw new Error("subtree broker did not start");
+  const selfId = runtime.getStatus().selfAgentId;
+  if (!selfId) throw new Error("subtree broker has no self id");
+
+  const threadId = `a2a:sender:${selfId}`;
+  control.db.createThread(threadId, "agent", "", selfId);
+  control.db.insertMessage(
+    threadId,
+    "agent",
+    "inbound",
+    "sender",
+    '{"type":"pinet:steer","message":"wait for compaction"}',
+    [selfId],
+    { type: "pinet:steer", message: "wait for compaction", kind: "pinet_steer" },
+  );
+  return selfId;
+}
+
+afterEach(async () => {
+  await Promise.all(runtimes.splice(0).map((runtime) => runtime.stop({ releaseIdentity: true })));
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("subtree broker compaction delivery retry", () => {
+  it("leaves rejected steering durable and retries it explicitly", async () => {
+    let canDeliver = false;
+    const deliverSteeringMessage = vi.fn(() => canDeliver);
+    const { runtime } = createRuntime(deliverSteeringMessage);
+    await runtime.start(ctx);
+    const selfId = queueSteeringMessage(runtime);
+
+    runtime.drainInbox(ctx);
+    const db = runtime.getHibernationRuntimeControl()?.db;
+    expect(deliverSteeringMessage).toHaveBeenCalledTimes(1);
+    expect(db?.getPendingInboxCount(selfId)).toBe(1);
+
+    canDeliver = true;
+    runtime.drainInbox(ctx);
+    expect(deliverSteeringMessage).toHaveBeenCalledTimes(2);
+    expect(db?.getPendingInboxCount(selfId)).toBe(0);
+  });
+
+  it("recovers rejected steering after a subtree broker restart", async () => {
+    let canDeliver = false;
+    const deliverSteeringMessage = vi.fn(() => canDeliver);
+    const first = createRuntime(deliverSteeringMessage);
+    await first.runtime.start(ctx);
+    queueSteeringMessage(first.runtime);
+    first.runtime.drainInbox(ctx);
+    await first.runtime.stop({ releaseIdentity: true });
+
+    canDeliver = true;
+    const { runtime: restarted } = createRuntime(deliverSteeringMessage, first.stableId);
+    await restarted.start(ctx);
+
+    const selfId = restarted.getStatus().selfAgentId;
+    expect(deliverSteeringMessage).toHaveBeenCalledTimes(2);
+    expect(selfId).not.toBeNull();
+    expect(
+      selfId
+        ? restarted.getHibernationRuntimeControl()?.db.getPendingInboxCount(selfId)
+        : undefined,
+    ).toBe(0);
+  });
+});

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -164,6 +164,7 @@ export interface SubtreeBrokerRuntime {
   getHibernationRuntimeControl: () => SubtreeHibernationRuntimeControl | null;
   stop: (options?: { releaseIdentity?: boolean; stopChildren?: boolean }) => Promise<void>;
   getStatus: () => SubtreeBrokerStatus;
+  drainInbox: (ctx: ExtensionContext) => void;
   readInbox: (options?: PinetReadOptions) => PinetReadResult | null;
   sendMessage: (
     target: string,
@@ -502,6 +503,11 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     deps.maybeDrainInboxIfIdle(ctx);
   }
 
+  function drainInbox(ctx: ExtensionContext): void {
+    if (!activeBroker || !selfAgentId) return;
+    drainSelfInbox(ctx, activeBroker, selfAgentId);
+  }
+
   function readInbox(options: PinetReadOptions = {}): PinetReadResult | null {
     if (!activeBroker || !selfAgentId) return null;
     if (options.threadId && !activeBroker.db.getThread(options.threadId)) return null;
@@ -764,6 +770,8 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     startedAt = new Date().toISOString();
     activePaths = paths;
     startHeartbeat(broker, selfAgent.id);
+    broker.db.recoverPendingTargetedBacklog(selfAgent.id);
+    drainSelfInbox(ctx, broker, selfAgent.id);
     broker.db.setSetting("pinet.subtreeBrokerParentStableId", deps.getAgentStableId());
     broker.db.setSetting("pinet.subtreeBrokerOwnerToken", buildPinetOwnerToken(stableId));
 
@@ -909,6 +917,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     getHibernationRuntimeControl,
     stop,
     getStatus,
+    drainInbox,
     readInbox,
     sendMessage,
     listAgents,


### PR DESCRIPTION
Fixes the delivery side of #941 (see [full RCA](https://github.com/gugu91/pinet/issues/941#issuecomment-5107798487)).

## Problem

Pi's manual/extension compaction path disconnects session persistence while `ctx.isIdle()` still returns `true`. Slack-bridge can therefore inject work during compaction that is never persisted, leaving orphaned tool results and eventually bricking the session.

## Fix

A small compaction gate now blocks every slack-bridge delivery path between `session_before_compact` and `session_compact`:

- queued inbox and maintenance work stays in its existing durable queue
- steering delivery returns `false`, so broker/follower/subtree callers do not acknowledge it before successful injection
- release is deferred one macrotask because `session_compact` fires before Pi reconnects persistence
- abort releases the gate; session start/shutdown resets it
- subtree mode explicitly retries its durable inbox after release and recovers targeted backlog after restart

The gate fails closed if Pi emits neither success nor abort. This pauses inbound delivery until session restart rather than risking session corruption. A timeout cannot safely prove persistence has reconnected.

## Known upstream gap

`session_before_compact` fires after manual compaction disconnects persistence, leaving a small pre-event window. Closing that fully requires a Pi lifecycle signal covering the entire disconnected interval.

## Testing

- top-level regression test proves Slack work is not injected until compaction finishes
- gate tests cover fail-closed delivery, deferred release, abort, and session reset
- subtree tests cover durable retry and restart recovery
- mutation checks killed delivery-bypass, missing-abort, stale-release, missing-retry, and missing-recovery mutants
- `pnpm prepush`: clean
- slack-bridge: 1630 passed, 3 skipped
