### PR TITLE
fix(slack-bridge): reconnect disconnected Pinet followers

### DIFF
--- a/slack-bridge/pinet-commands.test.ts
+++ b/slack-bridge/pinet-commands.test.ts
@@ -196,6 +196,47 @@ describe("registerPinetCommands", () => {
     expect(notify).not.toHaveBeenCalledWith(expect.stringContaining("/pinet-start"), "info");
   });
 
+  it("keeps /pinet follow as a no-op for a connected follower", async () => {
+    const reloadPinetRuntime = vi.fn(async () => {});
+    const commands = registerCommands(
+      createDeps({
+        runtimeMode: () => "follower",
+        runtimeConnected: () => true,
+        reloadPinetRuntime,
+      }),
+    );
+    const { ctx, notify } = createContext();
+
+    await commands.get("pinet")?.handler("follow", ctx);
+
+    expect(reloadPinetRuntime).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith("Pinet already running (follower)", "info");
+  });
+
+  it("reconnects a disconnected follower when /pinet follow is retried", async () => {
+    const connectAsFollower = vi.fn(async () => {});
+    const reloadPinetRuntime = vi.fn(async () => {});
+    const commands = registerCommands(
+      createDeps({
+        runtimeMode: () => "follower",
+        runtimeConnected: () => false,
+        connectAsFollower,
+        reloadPinetRuntime,
+      }),
+    );
+    const { ctx, notify } = createContext();
+    const abort = vi.fn();
+    Object.assign(ctx, { isIdle: () => false, abort });
+
+    await commands.get("pinet")?.handler("follow", ctx);
+
+    expect(abort).toHaveBeenCalled();
+    expect(connectAsFollower).not.toHaveBeenCalled();
+    expect(reloadPinetRuntime).toHaveBeenCalledWith(ctx);
+    expect(notify).toHaveBeenCalledWith("Pinet follower disconnected — reconnecting...", "info");
+    expect(notify).toHaveBeenCalledWith("🦦 Slate Chalk Otter — following broker", "info");
+  });
+
   it("routes /pinet reload through the existing remote-control message path", async () => {
     const sendPinetAgentMessage = vi.fn(async (target: string, body: string) => ({
       messageId: 42,

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -150,7 +150,7 @@ const PINET_SECONDARY_COMMANDS: Array<{
 
 // ─── Registration ────────────────────────────────────────
 
-function abortCurrentTurnBeforeBrokerReload(ctx: ExtensionContext): void {
+function abortCurrentTurnBeforeRuntimeReload(ctx: ExtensionContext): void {
   if (ctx.isIdle?.() ?? true) {
     return;
   }
@@ -336,7 +336,7 @@ async function runPinetStart(
 
   if (deps.runtimeMode() === "broker") {
     try {
-      abortCurrentTurnBeforeBrokerReload(ctx);
+      abortCurrentTurnBeforeRuntimeReload(ctx);
       ctx.ui.notify("Pinet broker already running — reloading current runtime", "info");
       await deps.reloadPinetRuntime(ctx);
     } catch (err) {
@@ -382,14 +382,20 @@ async function runPinetFollow(deps: PinetCommandsDeps, ctx: ExtensionContext): P
     ctx.ui.notify(deps.getPinetRegistrationBlockReason(), "warning");
     return;
   }
-  if (deps.runtimeMode() === "follower") {
+  if (deps.runtimeMode() === "follower" && deps.runtimeConnected()) {
     ctx.ui.notify("Pinet already running (follower)", "info");
     return;
   }
   deps.setExtCtx(ctx);
 
   try {
-    await deps.connectAsFollower(ctx);
+    if (deps.runtimeMode() === "follower") {
+      abortCurrentTurnBeforeRuntimeReload(ctx);
+      ctx.ui.notify("Pinet follower disconnected — reconnecting...", "info");
+      await deps.reloadPinetRuntime(ctx);
+    } else {
+      await deps.connectAsFollower(ctx);
+    }
     ctx.ui.notify(`${deps.agentEmoji()} ${deps.agentName()} — following broker`, "info");
   } catch (err) {
     ctx.ui.notify(`Pinet follow failed: ${errorMsg(err)}`, "error");


### PR DESCRIPTION
## Summary

- distinguish connected followers from stale/disconnected follower runtime state
- make `/pinet follow` reload and reconnect a disconnected follower instead of incorrectly reporting that it is already running
- abort a busy turn before follower runtime reload, matching the existing broker reload safety behavior
- add regression coverage for connected and disconnected follower paths

## Context

A live session retained `runtimeMode: follower` after losing its broker connection. Pinet tools returned `Not connected to broker`, while `/pinet follow` returned `Pinet already running (follower)`. This also contradicted the runtime diagnostic that tells users to retry `/pinet follow` when automatic reconnect does not recover.

## Review

Reviewed independently with `anthropic/claude-fable-5`. It found no blocking issues. Its valid busy-turn guard warning was addressed before opening this PR.

## Verification

- full pre-push suite: lint, typecheck, and tests
- Slack Bridge: 1,632 tests passed, 3 skipped
- focused `pinet-commands.test.ts`: 21 passed
