### PR TITLE
fix(slack-bridge): classify pinet:spawn as a write operation

### DIFF
--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -181,6 +181,13 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("pinet_read", g)).toBe(false);
   });
 
+  it("blocks Pinet spawn aliases only in readOnly mode", () => {
+    expect(isToolBlocked("pinet:spawn", { readOnly: true })).toBe(true);
+    expect(isToolBlocked("pinet_spawn", { readOnly: true })).toBe(true);
+    expect(isToolBlocked("pinet:spawn", { readOnly: false })).toBe(false);
+    expect(isToolBlocked("pinet:snooze", { readOnly: true })).toBe(true);
+  });
+
   it("combines readOnly and blockedTools", () => {
     const g: SecurityGuardrails = { readOnly: true, blockedTools: ["slack_create_channel"] };
     expect(isToolBlocked("bash", g)).toBe(true); // write tool + readOnly

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -145,6 +145,7 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("pinet:send")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:schedule")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:snooze")).toBe(true);
+    expect(WRITE_TOOLS.has("pinet:spawn")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:free")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:ports")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:reload")).toBe(true);
@@ -171,6 +172,8 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("pinet:send", g)).toBe(true);
     expect(isToolBlocked("pinet:snooze", g)).toBe(true);
     expect(isToolBlocked("pinet_snooze", g)).toBe(true);
+    expect(isToolBlocked("pinet:spawn", g)).toBe(true);
+    expect(isToolBlocked("pinet_spawn", g)).toBe(true);
     expect(isToolBlocked("pinet:ports", g)).toBe(true);
     expect(isToolBlocked("pinet:reload", g)).toBe(true);
     expect(isToolBlocked("pinet:exit", g)).toBe(true);
@@ -179,13 +182,6 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("pinet_send", g)).toBe(true);
     expect(isToolBlocked("pinet:read", g)).toBe(false);
     expect(isToolBlocked("pinet_read", g)).toBe(false);
-  });
-
-  it("blocks Pinet spawn aliases only in readOnly mode", () => {
-    expect(isToolBlocked("pinet:spawn", { readOnly: true })).toBe(true);
-    expect(isToolBlocked("pinet_spawn", { readOnly: true })).toBe(true);
-    expect(isToolBlocked("pinet:spawn", { readOnly: false })).toBe(false);
-    expect(isToolBlocked("pinet:snooze", { readOnly: true })).toBe(true);
   });
 
   it("combines readOnly and blockedTools", () => {

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -55,6 +55,7 @@ export const WRITE_TOOLS = new Set([
   "pinet:schedule",
   "pinet:send",
   "pinet:snooze",
+  "pinet:spawn",
   "pinet:free",
   "pinet:ports",
   "pinet:reload",


### PR DESCRIPTION
Fixes #960

## Summary
- classify `pinet:spawn` as a write operation in Slack bridge guardrails
- cover dispatcher and legacy alias spellings in read-only mode
- preserve non-read-only and neighboring write-tool behavior

## Tests
- `pnpm --filter @pinet/slack-bridge test -- guardrails.test.ts` — 92 passed, 2 skipped test files; 1,633 passed, 3 skipped tests
- `pnpm typecheck` — 11/11 packages passed
- `pnpm prepush` — lint 11/11, typecheck 11/11, tests 11/11 packages; script tests 27/27 passed
- `pnpm exec prettier --check slack-bridge/guardrails.ts slack-bridge/guardrails.test.ts` — passed