### PR TITLE
fix(slack-bridge): serialize subtree broker startup and return durable spawn handles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,10 @@
 ## Design philosophy
 
 - Guiding principle for this change:
+- Simplicity review:
+  - [ ] Comments explain non-obvious reasons or invariants; clearer code replaces narration.
+  - [ ] Tests exercise states reachable through production boundaries rather than bypassing them.
+  - [ ] One-use helpers are inlined unless they form a documented semantic seam.
 - If this touches Pinet / `slack-bridge`: how does it preserve token-efficient progressive discovery?
   - Hot-path schemas/prompts stay compact:
   - Cold paths remain discoverable through dispatcher `help` / per-action schemas or docs/skills:

--- a/scripts/agent-standards-lint.mjs
+++ b/scripts/agent-standards-lint.mjs
@@ -164,93 +164,153 @@ function isExportedNode(node) {
   return Boolean(node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword));
 }
 
+function isExportedVariableDeclaration(node) {
+  return ts.isVariableDeclarationList(node.parent) && isExportedNode(node.parent.parent);
+}
+
 function hasSingleUseHelperIgnore(sourceText, position) {
   const precedingText = sourceText.slice(Math.max(0, position - 300), position);
   return /agent-standards-ignore\s+prefer-inline-single-use-helper/.test(precedingText);
 }
 
-function collectTopLevelHelperNames(sourceFile) {
-  const helperNames = new Set();
-
-  for (const statement of sourceFile.statements) {
-    if (ts.isFunctionDeclaration(statement) && statement.name && !isExportedNode(statement)) {
-      helperNames.add(statement.name.text);
-      continue;
-    }
-
-    if (!ts.isVariableStatement(statement) || isExportedNode(statement)) continue;
-    for (const declaration of statement.declarationList.declarations) {
-      if (!ts.isIdentifier(declaration.name)) continue;
-      const initializer = declaration.initializer;
-      if (
-        initializer &&
-        (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer))
-      ) {
-        helperNames.add(declaration.name.text);
-      }
-    }
-  }
-
-  return helperNames;
+function collectExportedSymbols(sourceFile, checker) {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) return new Set();
+  return new Set(
+    checker
+      .getExportsOfModule(moduleSymbol)
+      .map((symbol) =>
+        symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol,
+      ),
+  );
 }
 
-function collectTopLevelHelperDeclarations(
+function isLocalHelperDeclaration(node, exportedSymbols, checker) {
+  if (ts.isFunctionDeclaration(node)) {
+    const symbol = node.name ? checker.getSymbolAtLocation(node.name) : undefined;
+    return Boolean(node.name && !isExportedNode(node) && symbol && !exportedSymbols.has(symbol));
+  }
+  if (
+    !ts.isVariableDeclaration(node) ||
+    !ts.isIdentifier(node.name) ||
+    isExportedVariableDeclaration(node)
+  ) {
+    return false;
+  }
+  const symbol = checker.getSymbolAtLocation(node.name);
+  if (!symbol || exportedSymbols.has(symbol)) {
+    return false;
+  }
+  return Boolean(
+    node.initializer &&
+    (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)),
+  );
+}
+
+function helperKey(node) {
+  const names = [node.name.text];
+  for (let parent = node.parent; parent; parent = parent.parent) {
+    if ((ts.isFunctionDeclaration(parent) || ts.isFunctionExpression(parent)) && parent.name) {
+      names.push(parent.name.text);
+    } else if (
+      (ts.isFunctionExpression(parent) || ts.isArrowFunction(parent)) &&
+      ts.isVariableDeclaration(parent.parent) &&
+      ts.isIdentifier(parent.parent.name)
+    ) {
+      names.push(parent.parent.name.text);
+    } else if (ts.isMethodDeclaration(parent) && ts.isIdentifier(parent.name)) {
+      names.push(parent.name.text);
+    } else if (ts.isClassDeclaration(parent) && parent.name) {
+      names.push(parent.name.text);
+    }
+  }
+  return names.reverse().join(".");
+}
+
+function collectHelperKeys(sourceFile, checker) {
+  const helperKeys = new Set();
+  const exportedSymbols = collectExportedSymbols(sourceFile, checker);
+  const visit = (node) => {
+    if (isLocalHelperDeclaration(node, exportedSymbols, checker)) {
+      helperKeys.add(helperKey(node));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return helperKeys;
+}
+
+function collectHelperDeclarations(
   sourceFile,
   sourceText,
   addedLineRanges,
-  existingHelperNames,
+  existingHelperKeys,
+  checker,
 ) {
   const helpers = [];
-
-  for (const statement of sourceFile.statements) {
-    if (ts.isFunctionDeclaration(statement) && statement.name && !isExportedNode(statement)) {
-      const start = statement.name.getStart(sourceFile);
+  const exportedSymbols = collectExportedSymbols(sourceFile, checker);
+  const visit = (node) => {
+    if (isLocalHelperDeclaration(node, exportedSymbols, checker)) {
+      const start = node.name.getStart(sourceFile);
       const { line, character } = sourceFile.getLineAndCharacterOfPosition(start);
       const lineNumber = line + 1;
       if (
         lineIsAdded(lineNumber, addedLineRanges) &&
-        !existingHelperNames.has(statement.name.text) &&
+        !existingHelperKeys.has(helperKey(node)) &&
         !hasSingleUseHelperIgnore(sourceText, start)
       ) {
-        helpers.push({ name: statement.name.text, line: lineNumber, column: character + 1 });
-      }
-      continue;
-    }
-
-    if (!ts.isVariableStatement(statement) || isExportedNode(statement)) continue;
-    for (const declaration of statement.declarationList.declarations) {
-      if (!ts.isIdentifier(declaration.name)) continue;
-      const initializer = declaration.initializer;
-      if (
-        !initializer ||
-        (!ts.isArrowFunction(initializer) && !ts.isFunctionExpression(initializer))
-      ) {
-        continue;
-      }
-      const start = declaration.name.getStart(sourceFile);
-      const { line, character } = sourceFile.getLineAndCharacterOfPosition(start);
-      const lineNumber = line + 1;
-      if (
-        lineIsAdded(lineNumber, addedLineRanges) &&
-        !existingHelperNames.has(declaration.name.text) &&
-        !hasSingleUseHelperIgnore(sourceText, start)
-      ) {
-        helpers.push({ name: declaration.name.text, line: lineNumber, column: character + 1 });
+        helpers.push({
+          name: node.name.text,
+          line: lineNumber,
+          column: character + 1,
+          declarationPosition: start,
+        });
       }
     }
-  }
-
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
   return helpers;
 }
 
-function countIdentifierReferences(sourceFile, name) {
-  let count = 0;
+function createSingleFileProgram(sourceText, fileName) {
+  const options = { noLib: true, noResolve: true, target: ts.ScriptTarget.Latest };
+  const absoluteFileName = path.resolve(fileName);
+  const host = ts.createCompilerHost(options);
+  host.fileExists = (requestedFileName) => path.resolve(requestedFileName) === absoluteFileName;
+  host.readFile = (requestedFileName) =>
+    path.resolve(requestedFileName) === absoluteFileName ? sourceText : undefined;
+  host.getSourceFile = (requestedFileName, languageVersion) =>
+    path.resolve(requestedFileName) === absoluteFileName
+      ? ts.createSourceFile(absoluteFileName, sourceText, languageVersion, true)
+      : undefined;
 
+  const program = ts.createProgram([absoluteFileName], options, host);
+  const sourceFile = program.getSourceFile(absoluteFileName);
+  if (!sourceFile) throw new Error(`could not parse ${fileName}`);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function countSymbolReferences(sourceFile, checker, declarationPosition) {
+  let declarationIdentifier;
+  const findDeclaration = (node) => {
+    if (declarationIdentifier) return;
+    if (ts.isIdentifier(node) && node.getStart(sourceFile) === declarationPosition) {
+      declarationIdentifier = node;
+      return;
+    }
+    ts.forEachChild(node, findDeclaration);
+  };
+  findDeclaration(sourceFile);
+  if (!declarationIdentifier) return 0;
+
+  const symbol = checker.getSymbolAtLocation(declarationIdentifier);
+  if (!symbol) return 0;
+  let count = 0;
   const visit = (node) => {
-    if (ts.isIdentifier(node) && node.text === name) count += 1;
+    if (ts.isIdentifier(node) && checker.getSymbolAtLocation(node) === symbol) count += 1;
     ts.forEachChild(node, visit);
   };
-
   visit(sourceFile);
   return count;
 }
@@ -261,21 +321,24 @@ export function findSingleUseAddedHelpers(
   addedLineRanges,
   baseSourceText = "",
 ) {
-  const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
-  const baseSourceFile = ts.createSourceFile(
-    fileName,
+  const { sourceFile, checker } = createSingleFileProgram(sourceText, fileName);
+  const { sourceFile: baseSourceFile, checker: baseChecker } = createSingleFileProgram(
     baseSourceText,
-    ts.ScriptTarget.Latest,
-    true,
+    `${fileName}.base.ts`,
   );
-  const helpers = collectTopLevelHelperDeclarations(
+  const helpers = collectHelperDeclarations(
     sourceFile,
     sourceText,
     addedLineRanges,
-    collectTopLevelHelperNames(baseSourceFile),
+    collectHelperKeys(baseSourceFile, baseChecker),
+    checker,
   );
 
-  return helpers.filter((helper) => countIdentifierReferences(sourceFile, helper.name) === 2);
+  return helpers
+    .filter(
+      (helper) => countSymbolReferences(sourceFile, checker, helper.declarationPosition) === 2,
+    )
+    .map(({ declarationPosition: _declarationPosition, ...helper }) => helper);
 }
 
 function formatCountDelta(ruleName, current, base) {

--- a/scripts/agent-standards-lint.test.mjs
+++ b/scripts/agent-standards-lint.test.mjs
@@ -116,6 +116,114 @@ test("findSingleUseAddedHelpers flags only newly added one-use top-level helpers
   assert.deepEqual(helpers, ["oneUse", "arrowOneUse"]);
 });
 
+test("findSingleUseAddedHelpers flags nested one-use helpers", () => {
+  const source = `
+    export function run(): string {
+      function normalize(value: string): string {
+        return value.trim();
+      }
+
+      return normalize("value");
+    }
+  `;
+
+  const helpers = findSingleUseAddedHelpers(source, "sample.ts", [{ start: 3, end: 5 }]);
+
+  assert.deepEqual(
+    helpers.map((helper) => helper.name),
+    ["normalize"],
+  );
+});
+
+test("findSingleUseAddedHelpers resolves same-named nested helpers by symbol", () => {
+  const source = `
+    export function first(): string {
+      function normalize(value: string): string {
+        return value.trim();
+      }
+      return normalize("first");
+    }
+
+    export function second(): string {
+      function normalize(value: string): string {
+        return value.trim();
+      }
+      return normalize("second");
+    }
+  `;
+
+  const helpers = findSingleUseAddedHelpers(source, "sample.ts", [{ start: 3, end: 12 }]);
+
+  assert.deepEqual(
+    helpers.map((helper) => helper.name),
+    ["normalize", "normalize"],
+  );
+});
+
+test("findSingleUseAddedHelpers ignores exported arrow functions", () => {
+  const source = `
+    export const normalize = (value: string): string => value.trim();
+    const result = normalize("value");
+  `;
+
+  const helpers = findSingleUseAddedHelpers(source, "sample.ts", [{ start: 2, end: 2 }]);
+
+  assert.deepEqual(helpers, []);
+});
+
+test("findSingleUseAddedHelpers resolves indirect exports by symbol", () => {
+  const source = `
+    function normalize(value: string): string {
+      return value.trim();
+    }
+    export { normalize };
+    const result = normalize("value");
+
+    export function run(): string {
+      function normalize(value: string): string {
+        return value.trim();
+      }
+      return normalize("nested");
+    }
+  `;
+
+  const helpers = findSingleUseAddedHelpers(source, "sample.ts", [{ start: 2, end: 11 }]);
+
+  assert.deepEqual(
+    helpers.map((helper) => helper.name),
+    ["normalize"],
+  );
+});
+
+test("findSingleUseAddedHelpers distinguishes new nested helpers from base helpers", () => {
+  const baseSource = `
+    function normalize(value: string): string {
+      return value.trim();
+    }
+    const result = normalize("base");
+  `;
+  const source = `${baseSource}
+    export function run(): string {
+      function normalize(value: string): string {
+        return value.trim();
+      }
+      return normalize("nested");
+    }
+  `;
+
+  const helpers = findSingleUseAddedHelpers(
+    source,
+    "sample.ts",
+    [{ start: 7, end: 9 }],
+    baseSource,
+  );
+
+  assert.deepEqual(
+    helpers.map((helper) => helper.name),
+    ["normalize"],
+  );
+});
+
 test("findSingleUseAddedHelpers honors the explicit semantic-seam ignore", () => {
   const source = `
     // agent-standards-ignore prefer-inline-single-use-helper: documents a protocol seam

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -325,6 +325,14 @@ export class BrokerSocketServer {
     this.agentRegistrationResolver = resolver;
   }
 
+  disconnectAgentConnections(agentId: string): void {
+    for (const [socket, state] of this.connections) {
+      if (state.agentId !== agentId) continue;
+      state.agentId = null;
+      socket.destroy();
+    }
+  }
+
   /**
    * Register a handler invoked when an authenticated local client requests a
    * graceful broker shutdown via the `admin.shutdown` RPC (used by

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1385,7 +1385,6 @@ export default function (pi: ExtensionAPI) {
       searchPinetSessions,
       listSubtreeAgents: (includeGhosts) => subtreeBrokerRuntime.listAgents(includeGhosts),
       getSubtreeSelfAgentId: () => subtreeBrokerRuntime.getStatus().selfAgentId,
-      subtreeSpawnReady: () => sessionUiRuntime.getExtensionContext() !== null,
       spawnSubtreeWorker: async (input) => {
         const activeCtx = sessionUiRuntime.getExtensionContext();
         if (!activeCtx) throw new Error("No active Pi extension context for subtree spawn.");

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1385,6 +1385,7 @@ export default function (pi: ExtensionAPI) {
       searchPinetSessions,
       listSubtreeAgents: (includeGhosts) => subtreeBrokerRuntime.listAgents(includeGhosts),
       getSubtreeSelfAgentId: () => subtreeBrokerRuntime.getStatus().selfAgentId,
+      subtreeSpawnReady: () => sessionUiRuntime.getExtensionContext() !== null,
       spawnSubtreeWorker: async (input) => {
         const activeCtx = sessionUiRuntime.getExtensionContext();
         if (!activeCtx) throw new Error("No active Pi extension context for subtree spawn.");

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -9,6 +9,7 @@ import {
   type RegisterPinetToolsDeps,
 } from "./pinet-tools.js";
 import type { AgentLifecycleStatus } from "@pinet/broker-core";
+import { SubtreeSpawnRegistrationTimeoutError } from "./subtree-broker-runtime.js";
 
 interface MinimalRenderTheme {
   fg: (_color: string, text: string) => string;
@@ -1671,6 +1672,94 @@ describe("registerPinetTools", () => {
     expect(result.details.data.details).toMatchObject({
       status: "started",
       agentId: "child-1",
+    });
+  });
+
+  it("returns timed-out subtree launch handles in error text and details", async () => {
+    const handle = {
+      launchId: "subtree-timeout-1",
+      tmuxSessionName: "pinet-extensions-reviewer-timeout-1",
+      socketPath: "/tmp/pinet-subtrees/worker-1/pinet.sock",
+      state: "launched_unregistered" as const,
+    };
+    const spawnSubtreeWorker = vi.fn(async () => {
+      throw new SubtreeSpawnRegistrationTimeoutError(45_000, handle);
+    });
+    const tools = registerWithDeps(
+      createDeps({ brokerRole: () => "follower", spawnSubtreeWorker }),
+    );
+
+    const result = (await tools.get("pinet")?.execute("tool-call-spawn-timeout", {
+      action: "spawn",
+      args: { task: "Review PR #761", repo: "extensions", full: true },
+    })) as {
+      content: Array<{ text: string }>;
+      details: {
+        status: string;
+        data: { details: { launchHandle: typeof handle } };
+        errors: Array<{ retryable: boolean }>;
+      };
+    };
+
+    expect(result.content[0]?.text).toContain(`launchId=${handle.launchId}`);
+    expect(result.content[0]?.text).toContain(`tmuxSessionName=${handle.tmuxSessionName}`);
+    expect(result.content[0]?.text).toContain(`socketPath=${handle.socketPath}`);
+    expect(result.details.data.details.launchHandle).toEqual(handle);
+    expect(result.details.errors[0]?.retryable).toBe(true);
+  });
+
+  it("checks Pinet initialization before reading a spawn payload", async () => {
+    const taskGetter = vi.fn(() => {
+      throw new Error("payload was read");
+    });
+    const args = { repo: "extensions" };
+    Object.defineProperty(args, "task", { enumerable: true, get: taskGetter });
+    const requireToolPolicy = vi.fn();
+    const spawnSubtreeWorker = vi.fn(createDeps().spawnSubtreeWorker);
+    const tools = registerWithDeps(
+      createDeps({
+        pinetEnabled: () => false,
+        brokerRole: () => "follower",
+        requireToolPolicy,
+        spawnSubtreeWorker,
+      }),
+    );
+
+    const result = (await tools.get("pinet")?.execute("tool-call-spawn-uninitialized", {
+      action: "spawn",
+      args,
+    })) as { content: Array<{ text: string }> };
+
+    expect(result.content[0]?.text).toContain(
+      "Pinet is not running. Use /pinet start or /pinet follow first.",
+    );
+    expect(taskGetter).not.toHaveBeenCalled();
+    expect(requireToolPolicy).not.toHaveBeenCalled();
+    expect(spawnSubtreeWorker).not.toHaveBeenCalled();
+  });
+
+  it("forwards a timeout handle so retry cleanup precedes relaunch", async () => {
+    const spawnSubtreeWorker = vi.fn(createDeps().spawnSubtreeWorker);
+    const tools = registerWithDeps(
+      createDeps({ brokerRole: () => "follower", spawnSubtreeWorker }),
+    );
+    const retryHandle = {
+      launchId: "subtree-timeout-1",
+      tmuxSessionName: "pinet-extensions-reviewer-timeout-1",
+      socketPath: "/tmp/pinet-subtrees/worker-1/pinet.sock",
+      state: "launched_unregistered",
+    };
+
+    await tools.get("pinet")?.execute("tool-call-spawn-retry", {
+      action: "spawn",
+      args: { task: "Review PR #761", repo: "extensions", retry_handle: retryHandle },
+    });
+
+    expect(spawnSubtreeWorker).toHaveBeenCalledWith({
+      task: "Review PR #761",
+      repo: "extensions",
+      role: "subworker",
+      cleanupHandle: retryHandle,
     });
   });
 

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -9,7 +9,10 @@ import {
   type RegisterPinetToolsDeps,
 } from "./pinet-tools.js";
 import type { AgentLifecycleStatus } from "@pinet/broker-core";
-import { SubtreeSpawnRegistrationTimeoutError } from "./subtree-broker-runtime.js";
+import {
+  SubtreeSpawnLaunchError,
+  SubtreeSpawnRegistrationTimeoutError,
+} from "./subtree-broker-runtime.js";
 
 interface MinimalRenderTheme {
   fg: (_color: string, text: string) => string;
@@ -1708,34 +1711,28 @@ describe("registerPinetTools", () => {
     expect(result.details.errors[0]?.retryable).toBe(true);
   });
 
-  it("checks Pinet initialization before reading a spawn payload", async () => {
-    const taskGetter = vi.fn(() => {
-      throw new Error("payload was read");
+  it("returns ambiguous launch handles in structured error details", async () => {
+    const handle = {
+      launchId: "subtree-launch-1",
+      tmuxSessionName: "pinet-extensions-reviewer-launch-1",
+      socketPath: "/tmp/pinet-subtrees/worker-1/pinet.sock",
+      state: "launched_unregistered" as const,
+    };
+    const spawnSubtreeWorker = vi.fn(async () => {
+      throw new SubtreeSpawnLaunchError(new Error("tmux transport closed"), handle);
     });
-    const args = { repo: "extensions" };
-    Object.defineProperty(args, "task", { enumerable: true, get: taskGetter });
-    const requireToolPolicy = vi.fn();
-    const spawnSubtreeWorker = vi.fn(createDeps().spawnSubtreeWorker);
     const tools = registerWithDeps(
-      createDeps({
-        pinetEnabled: () => false,
-        brokerRole: () => "follower",
-        requireToolPolicy,
-        spawnSubtreeWorker,
-      }),
+      createDeps({ brokerRole: () => "follower", spawnSubtreeWorker }),
     );
 
-    const result = (await tools.get("pinet")?.execute("tool-call-spawn-uninitialized", {
+    const result = (await tools.get("pinet")?.execute("tool-call-spawn-launch-error", {
       action: "spawn",
-      args,
-    })) as { content: Array<{ text: string }> };
+      args: { task: "Review PR #761", repo: "extensions", full: true },
+    })) as {
+      details: { data: { details: { launchHandle: typeof handle } } };
+    };
 
-    expect(result.content[0]?.text).toContain(
-      "Pinet is not running. Use /pinet start or /pinet follow first.",
-    );
-    expect(taskGetter).not.toHaveBeenCalled();
-    expect(requireToolPolicy).not.toHaveBeenCalled();
-    expect(spawnSubtreeWorker).not.toHaveBeenCalled();
+    expect(result.details.data.details.launchHandle).toEqual(handle);
   });
 
   it("forwards a timeout handle so retry cleanup precedes relaunch", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -46,6 +46,10 @@ import { isBroadcastChannelTarget } from "./broker/agent-messaging.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
 import type { RalphSnoozeStatus } from "./ralph-loop.js";
+import {
+  SubtreeSpawnRegistrationTimeoutError,
+  type SubtreeSpawnLaunchHandle,
+} from "./subtree-broker-runtime.js";
 import type {
   AgentSessionSearchInfo,
   AgentSessionSearchOptions,
@@ -99,6 +103,7 @@ export interface PinetSubtreeSpawnInput {
   repo: string;
   role?: string;
   laneId?: string;
+  cleanupHandle?: SubtreeSpawnLaunchHandle;
 }
 
 export interface PinetSubtreeSpawnResult {
@@ -158,6 +163,7 @@ export interface RegisterPinetToolsDeps {
   searchPinetSessions: (options: AgentSessionSearchOptions) => Promise<AgentSessionSearchInfo[]>;
   listSubtreeAgents?: (includeGhosts: boolean) => PinetToolsAgentRecord[] | null;
   getSubtreeSelfAgentId?: () => string | null;
+  subtreeSpawnReady?: () => boolean;
   spawnSubtreeWorker?: (input: PinetSubtreeSpawnInput) => Promise<PinetSubtreeSpawnResult>;
   listPinetLanes: (options: PinetLaneListOptions) => Promise<PinetLaneInfo[]>;
   upsertPinetLane: (input: PinetLaneUpsertInput) => Promise<PinetLaneInfo>;
@@ -423,6 +429,15 @@ function getErrorMessage(error: unknown): string {
 }
 
 function classifyPinetError(message: string): PinetDispatcherError {
+  if (message.includes("state=launched_unregistered")) {
+    return {
+      class: "runtime",
+      message,
+      retryable: true,
+      hint: "Retry spawn with retry_handle to clean up the exact timed-out tmux session before relaunching.",
+    };
+  }
+
   if (message.includes("requires confirmation for action")) {
     return {
       class: "state",
@@ -432,7 +447,11 @@ function classifyPinetError(message: string): PinetDispatcherError {
     };
   }
 
-  if (message.includes("is not running") || message.includes("unexpected state")) {
+  if (
+    message.includes("is not running") ||
+    message.includes("not initialized") ||
+    message.includes("unexpected state")
+  ) {
     return {
       class: "state",
       message,
@@ -1230,15 +1249,9 @@ function runPinetSpawnAction(
   output: PinetOutputOptions,
 ): Promise<PinetToolResult> {
   return (async () => {
-    const task = getMaybeString(params, "task");
-    const repo = getMaybeString(params, "repo");
-    const role = getMaybeString(params, "role") ?? "subworker";
-    const laneId = getMaybeString(params, "lane_id");
-    deps.requireToolPolicy(
-      toolName,
-      undefined,
-      `task=${task ?? ""} | repo=${repo ?? ""} | role=${role} | lane_id=${laneId ?? ""}`,
-    );
+    // Check cheap runtime state before reading or formatting the delegation
+    // payload. An ordinary, uninitialized Pi session should fail immediately
+    // with the action needed to make spawn available.
     if (!deps.pinetEnabled()) {
       throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
@@ -1247,20 +1260,62 @@ function runPinetSpawnAction(
         "spawn is worker-only; the broker should launch top-level followers, not own subtrees.",
       );
     }
-    if (!task) throw new Error("spawn requires task");
-    if (!repo) throw new Error("spawn requires repo");
-
+    if (deps.subtreeSpawnReady && !deps.subtreeSpawnReady()) {
+      throw new Error(
+        "Subtree spawn runtime is not initialized. Start or resume an active Pi session and retry.",
+      );
+    }
     if (!deps.spawnSubtreeWorker) {
       throw new Error(
         "subtree worker launcher is unavailable in this runtime. Start a worker subtree with /pinet subtree start and retry.",
       );
     }
 
+    const task = getMaybeString(params, "task");
+    const repo = getMaybeString(params, "repo");
+    const role = getMaybeString(params, "role") ?? "subworker";
+    const laneId = getMaybeString(params, "lane_id");
+    const retryHandleValue = params.retry_handle;
+    let cleanupHandle: SubtreeSpawnLaunchHandle | undefined;
+    if (retryHandleValue !== undefined) {
+      if (!isPinetToolObject(retryHandleValue)) {
+        throw new Error("retry_handle must be a subtree spawn launch handle");
+      }
+      const launchId = getRecordString(retryHandleValue, "launchId");
+      const tmuxSessionName = getRecordString(retryHandleValue, "tmuxSessionName");
+      const socketPath = getRecordString(retryHandleValue, "socketPath");
+      if (
+        !launchId ||
+        !tmuxSessionName ||
+        !socketPath ||
+        retryHandleValue.state !== "launched_unregistered"
+      ) {
+        throw new Error(
+          'retry_handle requires launchId, tmuxSessionName, socketPath, and state="launched_unregistered"',
+        );
+      }
+      cleanupHandle = {
+        launchId,
+        tmuxSessionName,
+        socketPath,
+        state: "launched_unregistered",
+      };
+    }
+
+    deps.requireToolPolicy(
+      toolName,
+      undefined,
+      `task=${task ?? ""} | repo=${repo ?? ""} | role=${role} | lane_id=${laneId ?? ""}`,
+    );
+    if (!task) throw new Error("spawn requires task");
+    if (!repo) throw new Error("spawn requires repo");
+
     const result = await deps.spawnSubtreeWorker({
       task,
       repo,
       role,
       ...(laneId ? { laneId } : {}),
+      ...(cleanupHandle ? { cleanupHandle } : {}),
     });
     return {
       content: [
@@ -2423,6 +2478,14 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       repo: Type.String({ description: "Repo/workspace scope for the child worker" }),
       role: Type.Optional(Type.String({ description: "Child subtree role, e.g. reviewer" })),
       lane_id: Type.Optional(Type.String({ description: "Optional durable Pinet lane id" })),
+      retry_handle: Type.Optional(
+        Type.Object({
+          launchId: Type.String(),
+          tmuxSessionName: Type.String(),
+          socketPath: Type.String(),
+          state: Type.Literal("launched_unregistered"),
+        }),
+      ),
       ...PINET_OUTPUT_OPTION_PARAMETERS,
     }),
     execute: (_id, params, output) => runPinetSpawnAction(params, deps, "pinet:spawn", output),
@@ -2854,8 +2917,14 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
           throw error;
         }
         const message = getErrorMessage(error);
+        const launchHandle =
+          error instanceof SubtreeSpawnRegistrationTimeoutError ? error.handle : null;
         return wrapDispatcherEnvelope(
-          buildPinetDispatcherEnvelope("failed", null, [classifyPinetError(message)]),
+          buildPinetDispatcherEnvelope(
+            "failed",
+            launchHandle ? { action: definition.name, details: { launchHandle } } : null,
+            [classifyPinetError(message)],
+          ),
           output,
         );
       }

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -47,6 +47,7 @@ import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { HEARTBEAT_INTERVAL_MS } from "./broker/client.js";
 import type { RalphSnoozeStatus } from "./ralph-loop.js";
 import {
+  SubtreeSpawnLaunchError,
   SubtreeSpawnRegistrationTimeoutError,
   type SubtreeSpawnLaunchHandle,
 } from "./subtree-broker-runtime.js";
@@ -163,7 +164,6 @@ export interface RegisterPinetToolsDeps {
   searchPinetSessions: (options: AgentSessionSearchOptions) => Promise<AgentSessionSearchInfo[]>;
   listSubtreeAgents?: (includeGhosts: boolean) => PinetToolsAgentRecord[] | null;
   getSubtreeSelfAgentId?: () => string | null;
-  subtreeSpawnReady?: () => boolean;
   spawnSubtreeWorker?: (input: PinetSubtreeSpawnInput) => Promise<PinetSubtreeSpawnResult>;
   listPinetLanes: (options: PinetLaneListOptions) => Promise<PinetLaneInfo[]>;
   upsertPinetLane: (input: PinetLaneUpsertInput) => Promise<PinetLaneInfo>;
@@ -1249,20 +1249,12 @@ function runPinetSpawnAction(
   output: PinetOutputOptions,
 ): Promise<PinetToolResult> {
   return (async () => {
-    // Check cheap runtime state before reading or formatting the delegation
-    // payload. An ordinary, uninitialized Pi session should fail immediately
-    // with the action needed to make spawn available.
     if (!deps.pinetEnabled()) {
       throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }
     if (deps.brokerRole() !== "follower") {
       throw new Error(
         "spawn is worker-only; the broker should launch top-level followers, not own subtrees.",
-      );
-    }
-    if (deps.subtreeSpawnReady && !deps.subtreeSpawnReady()) {
-      throw new Error(
-        "Subtree spawn runtime is not initialized. Start or resume an active Pi session and retry.",
       );
     }
     if (!deps.spawnSubtreeWorker) {
@@ -2918,7 +2910,10 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
         }
         const message = getErrorMessage(error);
         const launchHandle =
-          error instanceof SubtreeSpawnRegistrationTimeoutError ? error.handle : null;
+          error instanceof SubtreeSpawnRegistrationTimeoutError ||
+          error instanceof SubtreeSpawnLaunchError
+            ? error.handle
+            : null;
         return wrapDispatcherEnvelope(
           buildPinetDispatcherEnvelope(
             "failed",

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -350,6 +350,61 @@ describe("subtree broker spawn lifecycle", () => {
     expect(tmux.liveSessions).toEqual(new Set([retried.sessionName]));
     expect(runtime.listAgents()?.filter((agent) => agent.parentAgentId)).toHaveLength(1);
     expect(retried.agentId).toBe("retry-child");
+
+    const repeatedRetry = await runtime.spawnWorker(ctx, {
+      task: "Retry me",
+      repo: ".",
+      cleanupHandle: timeoutError.handle,
+    });
+    expect(repeatedRetry).toEqual(retried);
+    expect(launchCount).toBe(2);
+  });
+
+  it("fences an old launch before cleanup so an in-flight registration cannot survive retry", async () => {
+    const tmux = createTmuxHarness();
+    let firstLaunch: TmuxLaunchFacts | null = null;
+    let launchCount = 0;
+    const runTmuxCommand = async (args: string[]): Promise<void> => {
+      await tmux.run(args);
+      if (args.includes("kill-session") && firstLaunch) {
+        registerChild(runtime, firstLaunch, "late-old-child");
+      }
+    };
+    const { runtime } = createRuntime(
+      () => false,
+      `fenced-retry-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand },
+    );
+    tmux.setOnLaunch((facts) => {
+      launchCount += 1;
+      if (launchCount === 1) firstLaunch = facts;
+      else registerChild(runtime, facts, "replacement-child");
+    });
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Retry racing registration",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+    if (!timeoutError) throw new Error("expected registration timeout");
+
+    const replacement = await runtime.spawnWorker(ctx, {
+      task: "Retry racing registration",
+      repo: ".",
+      cleanupHandle: timeoutError.handle,
+    });
+
+    const agents = runtime.getHibernationRuntimeControl()?.db.getAgents() ?? [];
+    expect(replacement.agentId).toBe("replacement-child");
+    expect(agents.some((agent) => agent.id === "late-old-child")).toBe(false);
+    expect(agents.filter((agent) => agent.parentAgentId)).toHaveLength(1);
+    expect(tmux.liveSessions).toEqual(new Set([replacement.sessionName]));
   });
 });
 

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -5,6 +5,7 @@ import type { PinetControlCommand, SlackBridgeSettings } from "./helpers.js";
 import {
   buildSubtreeBrokerPaths,
   createSubtreeBrokerRuntime,
+  SubtreeSpawnRegistrationTimeoutError,
   type SubtreeBrokerRuntime,
   type SubtreeBrokerRuntimeDeps,
 } from "./subtree-broker-runtime.js";
@@ -16,6 +17,7 @@ const roots: string[] = [];
 function createRuntime(
   deliverSteeringMessage: SubtreeBrokerRuntimeDeps["deliverSteeringMessage"],
   stableId = `compaction-gate-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+  overrides: Partial<SubtreeBrokerRuntimeDeps> = {},
 ): {
   runtime: SubtreeBrokerRuntime;
   stableId: string;
@@ -43,6 +45,7 @@ function createRuntime(
     }),
     runRemoteControl: () => {},
     formatError: (error) => (error instanceof Error ? error.message : String(error)),
+    ...overrides,
   });
   runtimes.push(runtime);
   roots.push(buildSubtreeBrokerPaths(stableId).rootDir);
@@ -70,8 +73,200 @@ function queueSteeringMessage(runtime: SubtreeBrokerRuntime): string {
 }
 
 afterEach(async () => {
-  await Promise.all(runtimes.splice(0).map((runtime) => runtime.stop({ releaseIdentity: true })));
+  await Promise.all(
+    runtimes
+      .splice(0)
+      .map((runtime) => runtime.stop({ releaseIdentity: true, stopChildren: false })),
+  );
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+interface TmuxLaunchFacts {
+  launchId: string;
+  sessionName: string;
+}
+
+function createTmuxHarness(): {
+  run: (args: string[]) => Promise<void>;
+  liveSessions: Set<string>;
+  killedSessions: string[];
+  setOnLaunch: (callback: ((facts: TmuxLaunchFacts) => void) | null) => void;
+} {
+  const liveSessions = new Set<string>();
+  const killedSessions: string[] = [];
+  let onLaunch: ((facts: TmuxLaunchFacts) => void) | null = null;
+
+  return {
+    liveSessions,
+    killedSessions,
+    setOnLaunch: (callback) => {
+      onLaunch = callback;
+    },
+    run: async (args) => {
+      const newSessionIndex = args.indexOf("new-session");
+      if (newSessionIndex >= 0) {
+        const sessionName = args[args.indexOf("-s", newSessionIndex) + 1];
+        const launcherPath = args.at(-1);
+        if (!sessionName || !launcherPath) throw new Error("invalid tmux launch");
+        const launchId = fs
+          .readFileSync(launcherPath, "utf8")
+          .match(/^export PINET_LAUNCH_ID='([^']+)'$/m)?.[1];
+        if (!launchId) throw new Error("launcher has no launch id");
+        liveSessions.add(sessionName);
+        onLaunch?.({ launchId, sessionName });
+        return;
+      }
+
+      const target = args[args.indexOf("-t") + 1];
+      if (args.includes("has-session") && (!target || !liveSessions.has(target))) {
+        throw new Error("missing tmux session");
+      }
+      if (args.includes("kill-session") && target) {
+        liveSessions.delete(target);
+        killedSessions.push(target);
+      }
+    },
+  };
+}
+
+function registerChild(
+  runtime: SubtreeBrokerRuntime,
+  facts: TmuxLaunchFacts,
+  agentId: string,
+): void {
+  const control = runtime.getHibernationRuntimeControl();
+  const parentAgentId = runtime.getStatus().selfAgentId;
+  if (!control || !parentAgentId) throw new Error("subtree broker did not start");
+  control.db.registerAgent(agentId, `Child ${agentId}`, "🌱", process.pid, {
+    parentAgentId,
+    launchId: facts.launchId,
+    tmuxSession: facts.sessionName,
+  });
+}
+
+describe("subtree broker spawn lifecycle", () => {
+  it("single-flights cold broker startup across concurrent spawns", async () => {
+    const tmux = createTmuxHarness();
+    const getAgentMetadata = vi.fn(async () => ({}));
+    const { runtime } = createRuntime(
+      () => false,
+      `single-flight-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { getAgentMetadata, runTmuxCommand: tmux.run },
+    );
+    let childNumber = 0;
+    tmux.setOnLaunch((facts) => {
+      childNumber += 1;
+      registerChild(runtime, facts, `child-${childNumber}`);
+    });
+
+    const results = await Promise.all([
+      runtime.spawnWorker(ctx, { task: "Task one", repo: "." }),
+      runtime.spawnWorker(ctx, { task: "Task two", repo: "." }),
+      runtime.spawnWorker(ctx, { task: "Task three", repo: "." }),
+    ]);
+
+    expect(results).toHaveLength(3);
+    expect(new Set(results.map((result) => result.agentId)).size).toBe(3);
+    expect(getAgentMetadata).toHaveBeenCalledTimes(1);
+    expect(tmux.liveSessions.size).toBe(3);
+  });
+
+  it("returns a durable timeout handle and cleans up only its tmux session", async () => {
+    const tmux = createTmuxHarness();
+    const { runtime } = createRuntime(
+      () => false,
+      `timeout-handle-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand: tmux.run },
+    );
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Never registers",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+
+    expect(timeoutError?.handle).toMatchObject({
+      launchId: expect.any(String),
+      tmuxSessionName: expect.any(String),
+      socketPath: expect.stringContaining("pinet.sock"),
+      state: "launched_unregistered",
+    });
+    tmux.liveSessions.add("unrelated-session");
+    if (!timeoutError) throw new Error("expected registration timeout");
+    await runtime.cleanupSpawn(timeoutError.handle);
+    expect(tmux.killedSessions).toEqual([timeoutError.handle.tmuxSessionName]);
+    expect(tmux.liveSessions).toEqual(new Set(["unrelated-session"]));
+  });
+
+  it("adopts a child that registers after the observer timeout", async () => {
+    const tmux = createTmuxHarness();
+    const { runtime } = createRuntime(
+      () => false,
+      `late-adoption-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand: tmux.run },
+    );
+    tmux.setOnLaunch((facts) => {
+      setTimeout(() => registerChild(runtime, facts, "late-child"), 15);
+    });
+
+    await expect(
+      runtime.spawnWorker(ctx, {
+        task: "Registers late",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      }),
+    ).rejects.toBeInstanceOf(SubtreeSpawnRegistrationTimeoutError);
+    expect(runtime.listAgents()?.some((agent) => agent.id === "late-child")).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const lateChild = runtime.listAgents()?.find((agent) => agent.id === "late-child");
+    expect(lateChild).toMatchObject({ id: "late-child", parentAgentId: expect.any(String) });
+    expect(runtime.getStatus().spawnedWorkers[0]?.agentId).toBe("late-child");
+  });
+
+  it("cleans up a timed-out launch by handle before retrying", async () => {
+    const tmux = createTmuxHarness();
+    const { runtime } = createRuntime(
+      () => false,
+      `retry-cleanup-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand: tmux.run },
+    );
+    let launchCount = 0;
+    tmux.setOnLaunch((facts) => {
+      launchCount += 1;
+      if (launchCount === 2) registerChild(runtime, facts, "retry-child");
+    });
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Retry me",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+    if (!timeoutError) throw new Error("expected registration timeout");
+
+    const retried = await runtime.spawnWorker(ctx, {
+      task: "Retry me",
+      repo: ".",
+      cleanupHandle: timeoutError.handle,
+    });
+
+    expect(tmux.killedSessions).toEqual([timeoutError.handle.tmuxSessionName]);
+    expect(tmux.liveSessions).toEqual(new Set([retried.sessionName]));
+    expect(runtime.listAgents()?.filter((agent) => agent.parentAgentId)).toHaveLength(1);
+    expect(retried.agentId).toBe("retry-child");
+  });
 });
 
 describe("subtree broker compaction delivery retry", () => {

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -283,6 +283,40 @@ describe("subtree broker spawn lifecycle", () => {
     expect(tmux.liveSessions).toEqual(new Set(["unrelated-session"]));
   });
 
+  it("keeps the launch-time Pinet socket in a timeout handle if the broker stops", async () => {
+    const tmux = createTmuxHarness();
+    let launchSocketPath = "";
+    let stopped = false;
+    const runTmuxCommand = async (args: string[]): Promise<void> => {
+      await tmux.run(args);
+      if (!stopped && args.includes("send-keys") && args.at(-1) === "Enter") {
+        stopped = true;
+        launchSocketPath = runtime.getStatus().paths?.socketPath ?? "";
+        await runtime.stop({ stopChildren: false });
+      }
+    };
+    const { runtime } = createRuntime(
+      () => false,
+      `stopped-timeout-handle-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand },
+    );
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Broker stops while waiting",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+
+    expect(launchSocketPath).toContain("pinet.sock");
+    expect(timeoutError?.handle.socketPath).toBe(launchSocketPath);
+  });
+
   it("uses an exact tmux target so cleanup cannot kill a prefix-related session", async () => {
     const tmux = createTmuxHarness();
     const { runtime } = createRuntime(

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -91,19 +91,23 @@ function createTmuxHarness(): {
   run: (args: string[]) => Promise<void>;
   liveSessions: Set<string>;
   killedSessions: string[];
+  commands: string[][];
   setOnLaunch: (callback: ((facts: TmuxLaunchFacts) => void) | null) => void;
 } {
   const liveSessions = new Set<string>();
   const killedSessions: string[] = [];
+  const commands: string[][] = [];
   let onLaunch: ((facts: TmuxLaunchFacts) => void) | null = null;
 
   return {
     liveSessions,
     killedSessions,
+    commands,
     setOnLaunch: (callback) => {
       onLaunch = callback;
     },
     run: async (args) => {
+      commands.push(args);
       const newSessionIndex = args.indexOf("new-session");
       if (newSessionIndex >= 0) {
         const sessionName = args[args.indexOf("-s", newSessionIndex) + 1];
@@ -344,6 +348,59 @@ describe("subtree broker spawn lifecycle", () => {
 
     expect(tmux.killedSessions).toEqual([]);
     expect(tmux.liveSessions).toEqual(new Set([`${timeoutError.handle.tmuxSessionName}-extra`]));
+  });
+
+  it("uses the launch-time tmux socket when cleanup runs after the environment changes", async () => {
+    const tmux = createTmuxHarness();
+    const stableId = `launch-tmux-socket-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+    const rootDir = buildSubtreeBrokerPaths(stableId).rootDir;
+    const launchSocketDir = `${rootDir}/launch-tmux`;
+    const cleanupSocketDir = `${rootDir}/cleanup-tmux`;
+    const launchSocketPath = `${launchSocketDir}/claude.sock`;
+    const cleanupSocketPath = `${cleanupSocketDir}/claude.sock`;
+    fs.mkdirSync(launchSocketDir, { recursive: true });
+    fs.mkdirSync(cleanupSocketDir, { recursive: true });
+    fs.writeFileSync(launchSocketPath, "");
+    fs.writeFileSync(cleanupSocketPath, "");
+    const originalTmux = process.env.TMUX;
+    const originalClaudeTmuxSocketDir = process.env.CLAUDE_TMUX_SOCKET_DIR;
+
+    try {
+      process.env.TMUX = `${launchSocketPath},1,0`;
+      process.env.CLAUDE_TMUX_SOCKET_DIR = launchSocketDir;
+      const { runtime } = createRuntime(() => false, stableId, { runTmuxCommand: tmux.run });
+
+      let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+      try {
+        await runtime.spawnWorker(ctx, {
+          task: "Never registers",
+          repo: ".",
+          waitForRegistrationMs: 5,
+        });
+      } catch (error) {
+        if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+        else throw error;
+      }
+      if (!timeoutError) throw new Error("expected registration timeout");
+
+      process.env.TMUX = `${cleanupSocketPath},2,0`;
+      process.env.CLAUDE_TMUX_SOCKET_DIR = cleanupSocketDir;
+      await runtime.cleanupSpawn(timeoutError.handle);
+
+      const cleanupCommands = tmux.commands.filter(
+        (args) => args.includes("has-session") || args.includes("kill-session"),
+      );
+      expect(cleanupCommands).toHaveLength(2);
+      for (const args of cleanupCommands) {
+        expect(args.slice(0, 2)).toEqual(["-S", launchSocketPath]);
+        expect(args).not.toContain(cleanupSocketPath);
+      }
+    } finally {
+      if (originalTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = originalTmux;
+      if (originalClaudeTmuxSocketDir === undefined) delete process.env.CLAUDE_TMUX_SOCKET_DIR;
+      else process.env.CLAUDE_TMUX_SOCKET_DIR = originalClaudeTmuxSocketDir;
+    }
   });
 
   it("rejects a cleanup handle without a live launch record", async () => {

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -118,12 +118,21 @@ function createTmuxHarness(): {
       }
 
       const target = args[args.indexOf("-t") + 1];
-      if (args.includes("has-session") && (!target || !liveSessions.has(target))) {
-        throw new Error("missing tmux session");
+      const matches = target?.startsWith("=")
+        ? liveSessions.has(target.slice(1))
+          ? [target.slice(1)]
+          : []
+        : [...liveSessions].filter(
+            (session) => session === target || session.startsWith(target ?? ""),
+          );
+      if (args.includes("has-session") && matches.length !== 1) {
+        throw new Error(matches.length === 0 ? "missing tmux session" : "ambiguous tmux session");
       }
-      if (args.includes("kill-session") && target) {
-        liveSessions.delete(target);
-        killedSessions.push(target);
+      if (args.includes("kill-session")) {
+        if (matches.length !== 1) throw new Error("missing or ambiguous tmux session");
+        const [matchedSession] = matches;
+        liveSessions.delete(matchedSession);
+        killedSessions.push(matchedSession);
       }
     },
   };
@@ -225,6 +234,58 @@ describe("subtree broker spawn lifecycle", () => {
     await runtime.cleanupSpawn(timeoutError.handle);
     expect(tmux.killedSessions).toEqual([timeoutError.handle.tmuxSessionName]);
     expect(tmux.liveSessions).toEqual(new Set(["unrelated-session"]));
+  });
+
+  it("uses an exact tmux target so cleanup cannot kill a prefix-related session", async () => {
+    const tmux = createTmuxHarness();
+    const { runtime } = createRuntime(
+      () => false,
+      `exact-cleanup-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand: tmux.run },
+    );
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Never registers",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+    if (!timeoutError) throw new Error("expected registration timeout");
+
+    tmux.liveSessions.delete(timeoutError.handle.tmuxSessionName);
+    tmux.liveSessions.add(`${timeoutError.handle.tmuxSessionName}-extra`);
+    await runtime.cleanupSpawn(timeoutError.handle);
+
+    expect(tmux.killedSessions).toEqual([]);
+    expect(tmux.liveSessions).toEqual(new Set([`${timeoutError.handle.tmuxSessionName}-extra`]));
+  });
+
+  it("rejects a cleanup handle without a live launch record", async () => {
+    const tmux = createTmuxHarness();
+    const { runtime } = createRuntime(
+      () => false,
+      `authenticated-cleanup-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand: tmux.run },
+    );
+    await runtime.start(ctx);
+    const socketPath = runtime.getStatus().paths?.socketPath;
+    if (!socketPath) throw new Error("subtree broker did not start");
+    tmux.liveSessions.add("caller-controlled");
+
+    await expect(
+      runtime.cleanupSpawn({
+        launchId: "unknown-launch",
+        tmuxSessionName: "caller-controlled",
+        socketPath,
+        state: "launched_unregistered",
+      }),
+    ).rejects.toThrow("spawn cleanup handle does not belong to this subtree broker");
+    expect(tmux.liveSessions).toEqual(new Set(["caller-controlled"]));
   });
 
   it("adopts a child that registers after the observer timeout", async () => {

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -171,6 +171,29 @@ describe("subtree broker spawn lifecycle", () => {
     expect(tmux.liveSessions.size).toBe(3);
   });
 
+  it("stops a broker when post-listen initialization fails so startup can retry", async () => {
+    const tmux = createTmuxHarness();
+    const getAgentMetadata = vi
+      .fn<SubtreeBrokerRuntimeDeps["getAgentMetadata"]>()
+      .mockRejectedValueOnce(new Error("metadata unavailable"))
+      .mockResolvedValue({});
+    const { runtime } = createRuntime(
+      () => false,
+      `startup-rollback-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { getAgentMetadata, runTmuxCommand: tmux.run },
+    );
+
+    await expect(runtime.start(ctx)).rejects.toThrow("metadata unavailable");
+    tmux.setOnLaunch((facts) => registerChild(runtime, facts, "retry-child"));
+
+    await expect(
+      runtime.spawnWorker(ctx, { task: "Retry startup", repo: "." }),
+    ).resolves.toMatchObject({
+      agentId: "retry-child",
+    });
+    expect(getAgentMetadata).toHaveBeenCalledTimes(2);
+  });
+
   it("returns a durable timeout handle and cleans up only its tmux session", async () => {
     const tmux = createTmuxHarness();
     const { runtime } = createRuntime(

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -126,10 +126,19 @@ function createTmuxHarness(): {
             (session) => session === target || session.startsWith(target ?? ""),
           );
       if (args.includes("has-session") && matches.length !== 1) {
-        throw new Error(matches.length === 0 ? "missing tmux session" : "ambiguous tmux session");
+        if (matches.length === 0) {
+          throw Object.assign(new Error(`can't find session: ${target}`), {
+            stderr: `can't find session: ${target}`,
+          });
+        }
+        throw new Error("ambiguous tmux session");
       }
       if (args.includes("kill-session")) {
-        if (matches.length !== 1) throw new Error("missing or ambiguous tmux session");
+        if (matches.length !== 1) {
+          throw Object.assign(new Error(`can't find session: ${target}`), {
+            stderr: `can't find session: ${target}`,
+          });
+        }
         const [matchedSession] = matches;
         liveSessions.delete(matchedSession);
         killedSessions.push(matchedSession);
@@ -358,6 +367,50 @@ describe("subtree broker spawn lifecycle", () => {
     });
     expect(repeatedRetry).toEqual(retried);
     expect(launchCount).toBe(2);
+  });
+
+  it("propagates operational tmux cleanup failures without launching a replacement", async () => {
+    const tmux = createTmuxHarness();
+    let failProbe = false;
+    let launchCount = 0;
+    const runTmuxCommand = async (args: string[]): Promise<void> => {
+      if (failProbe && args.includes("has-session")) {
+        throw new Error("tmux transport unavailable");
+      }
+      await tmux.run(args);
+    };
+    const { runtime } = createRuntime(
+      () => false,
+      `cleanup-failure-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand },
+    );
+    tmux.setOnLaunch(() => {
+      launchCount += 1;
+    });
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Retry cleanup failure",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+    if (!timeoutError) throw new Error("expected registration timeout");
+
+    failProbe = true;
+    await expect(
+      runtime.spawnWorker(ctx, {
+        task: "Must not relaunch",
+        repo: ".",
+        cleanupHandle: timeoutError.handle,
+      }),
+    ).rejects.toThrow("tmux transport unavailable");
+    expect(launchCount).toBe(1);
+    expect(tmux.liveSessions).toEqual(new Set([timeoutError.handle.tmuxSessionName]));
   });
 
   it("fences an old launch before cleanup so an in-flight registration cannot survive retry", async () => {

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -406,6 +406,68 @@ describe("subtree broker spawn lifecycle", () => {
     expect(launchCount).toBe(2);
   });
 
+  it("keeps a retry handle consumed when its replacement also times out", async () => {
+    const tmux = createTmuxHarness();
+    const { runtime } = createRuntime(
+      () => false,
+      `retry-timeout-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand: tmux.run },
+    );
+    let launchCount = 0;
+    tmux.setOnLaunch((facts) => {
+      launchCount += 1;
+      if (launchCount === 3) registerChild(runtime, facts, "recovered-child");
+    });
+
+    let originalTimeout: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Original attempt",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) originalTimeout = error;
+      else throw error;
+    }
+    if (!originalTimeout) throw new Error("expected original registration timeout");
+
+    let replacementTimeout: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Replacement attempt",
+        repo: ".",
+        waitForRegistrationMs: 5,
+        cleanupHandle: originalTimeout.handle,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) replacementTimeout = error;
+      else throw error;
+    }
+    if (!replacementTimeout) throw new Error("expected replacement registration timeout");
+
+    await expect(
+      runtime.spawnWorker(ctx, {
+        task: "Do not launch another replacement",
+        repo: ".",
+        cleanupHandle: originalTimeout.handle,
+      }),
+    ).rejects.toBe(replacementTimeout);
+    expect(launchCount).toBe(2);
+    expect(tmux.liveSessions).toEqual(new Set([replacementTimeout.handle.tmuxSessionName]));
+
+    const recovered = await runtime.spawnWorker(ctx, {
+      task: "Recover using the replacement handle",
+      repo: ".",
+      cleanupHandle: replacementTimeout.handle,
+    });
+
+    expect(launchCount).toBe(3);
+    expect(tmux.liveSessions).toEqual(new Set([recovered.sessionName]));
+    expect(runtime.listAgents()?.filter((agent) => agent.parentAgentId)).toHaveLength(1);
+    expect(recovered.agentId).toBe("recovered-child");
+  });
+
   it("propagates operational tmux cleanup failures without launching a replacement", async () => {
     const tmux = createTmuxHarness();
     let failProbe = false;

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { BrokerClient } from "./broker/client.js";
 import type { PinetControlCommand, SlackBridgeSettings } from "./helpers.js";
 import {
   buildSubtreeBrokerPaths,
@@ -514,6 +515,7 @@ describe("subtree broker spawn lifecycle", () => {
 
   it("fences an old launch before cleanup so an in-flight registration cannot survive retry", async () => {
     const tmux = createTmuxHarness();
+    const meshSecret = "fenced-retry-secret";
     let firstLaunch: TmuxLaunchFacts | null = null;
     let launchCount = 0;
     const runTmuxCommand = async (args: string[]): Promise<void> => {
@@ -525,7 +527,10 @@ describe("subtree broker spawn lifecycle", () => {
     const { runtime } = createRuntime(
       () => false,
       `fenced-retry-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
-      { runTmuxCommand },
+      {
+        getSettings: () => ({ meshSecret }) as SlackBridgeSettings,
+        runTmuxCommand,
+      },
     );
     tmux.setOnLaunch((facts) => {
       launchCount += 1;
@@ -552,10 +557,26 @@ describe("subtree broker spawn lifecycle", () => {
       cleanupHandle: timeoutError.handle,
     });
 
-    const agents = runtime.getHibernationRuntimeControl()?.db.getAgents() ?? [];
+    const lateClient = new BrokerClient({ path: timeoutError.handle.socketPath, meshSecret });
+    await lateClient.connect();
+    await expect(
+      lateClient.register("Late Old Child", "🌱", {
+        parentAgentId: runtime.getStatus().selfAgentId,
+        launchId: timeoutError.handle.launchId,
+        tmuxSession: timeoutError.handle.tmuxSessionName,
+      }),
+    ).rejects.toThrow("spawn launch has already been cleaned up");
+    lateClient.disconnect();
+
+    const db = runtime.getHibernationRuntimeControl()?.db;
+    const oldHistoricalAgent = db?.getAllAgents().find((agent) => agent.id === "late-old-child");
     expect(replacement.agentId).toBe("replacement-child");
-    expect(agents.some((agent) => agent.id === "late-old-child")).toBe(false);
-    expect(agents.filter((agent) => agent.parentAgentId)).toHaveLength(1);
+    // Cleanup preserves the direct-DB race as disconnected history, but no old launch remains live.
+    expect(oldHistoricalAgent?.disconnectedAt).not.toBeNull();
+    expect(
+      db?.getAgents().some((agent) => agent.metadata?.launchId === timeoutError.handle.launchId),
+    ).toBe(false);
+    expect(db?.getAgents().filter((agent) => agent.parentAgentId)).toHaveLength(1);
     expect(tmux.liveSessions).toEqual(new Set([replacement.sessionName]));
   });
 });

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -6,6 +6,7 @@ import type { PinetControlCommand, SlackBridgeSettings } from "./helpers.js";
 import {
   buildSubtreeBrokerPaths,
   createSubtreeBrokerRuntime,
+  SubtreeSpawnLaunchError,
   SubtreeSpawnRegistrationTimeoutError,
   type SubtreeBrokerRuntime,
   type SubtreeBrokerRuntimeDeps,
@@ -254,102 +255,6 @@ describe("subtree broker spawn lifecycle", () => {
     expect(getAgentMetadata).toHaveBeenCalledTimes(2);
   });
 
-  it("returns a durable timeout handle and cleans up only its tmux session", async () => {
-    const tmux = createTmuxHarness();
-    const { runtime } = createRuntime(
-      () => false,
-      `timeout-handle-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
-      { runTmuxCommand: tmux.run },
-    );
-
-    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
-    try {
-      await runtime.spawnWorker(ctx, {
-        task: "Never registers",
-        repo: ".",
-        waitForRegistrationMs: 5,
-      });
-    } catch (error) {
-      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
-      else throw error;
-    }
-
-    expect(timeoutError?.handle).toMatchObject({
-      launchId: expect.any(String),
-      tmuxSessionName: expect.any(String),
-      socketPath: expect.stringContaining("pinet.sock"),
-      state: "launched_unregistered",
-    });
-    tmux.liveSessions.add("unrelated-session");
-    if (!timeoutError) throw new Error("expected registration timeout");
-    await runtime.cleanupSpawn(timeoutError.handle);
-    expect(tmux.killedSessions).toEqual([timeoutError.handle.tmuxSessionName]);
-    expect(tmux.liveSessions).toEqual(new Set(["unrelated-session"]));
-  });
-
-  it("keeps the launch-time Pinet socket in a timeout handle if the broker stops", async () => {
-    const tmux = createTmuxHarness();
-    let launchSocketPath = "";
-    let stopped = false;
-    const runTmuxCommand = async (args: string[]): Promise<void> => {
-      await tmux.run(args);
-      if (!stopped && args.includes("send-keys") && args.at(-1) === "Enter") {
-        stopped = true;
-        launchSocketPath = runtime.getStatus().paths?.socketPath ?? "";
-        await runtime.stop({ stopChildren: false });
-      }
-    };
-    const { runtime } = createRuntime(
-      () => false,
-      `stopped-timeout-handle-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
-      { runTmuxCommand },
-    );
-
-    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
-    try {
-      await runtime.spawnWorker(ctx, {
-        task: "Broker stops while waiting",
-        repo: ".",
-        waitForRegistrationMs: 5,
-      });
-    } catch (error) {
-      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
-      else throw error;
-    }
-
-    expect(launchSocketPath).toContain("pinet.sock");
-    expect(timeoutError?.handle.socketPath).toBe(launchSocketPath);
-  });
-
-  it("uses an exact tmux target so cleanup cannot kill a prefix-related session", async () => {
-    const tmux = createTmuxHarness();
-    const { runtime } = createRuntime(
-      () => false,
-      `exact-cleanup-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
-      { runTmuxCommand: tmux.run },
-    );
-
-    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
-    try {
-      await runtime.spawnWorker(ctx, {
-        task: "Never registers",
-        repo: ".",
-        waitForRegistrationMs: 5,
-      });
-    } catch (error) {
-      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
-      else throw error;
-    }
-    if (!timeoutError) throw new Error("expected registration timeout");
-
-    tmux.liveSessions.delete(timeoutError.handle.tmuxSessionName);
-    tmux.liveSessions.add(`${timeoutError.handle.tmuxSessionName}-extra`);
-    await runtime.cleanupSpawn(timeoutError.handle);
-
-    expect(tmux.killedSessions).toEqual([]);
-    expect(tmux.liveSessions).toEqual(new Set([`${timeoutError.handle.tmuxSessionName}-extra`]));
-  });
-
   it("uses the launch-time tmux socket when cleanup runs after the environment changes", async () => {
     const tmux = createTmuxHarness();
     const stableId = `launch-tmux-socket-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
@@ -383,9 +288,14 @@ describe("subtree broker spawn lifecycle", () => {
       }
       if (!timeoutError) throw new Error("expected registration timeout");
 
+      tmux.setOnLaunch((facts) => registerChild(runtime, facts, "replacement-child"));
       process.env.TMUX = `${cleanupSocketPath},2,0`;
       process.env.CLAUDE_TMUX_SOCKET_DIR = cleanupSocketDir;
-      await runtime.cleanupSpawn(timeoutError.handle);
+      await runtime.spawnWorker(ctx, {
+        task: "Retry",
+        repo: ".",
+        cleanupHandle: timeoutError.handle,
+      });
 
       const cleanupCommands = tmux.commands.filter(
         (args) => args.includes("has-session") || args.includes("kill-session"),
@@ -416,40 +326,18 @@ describe("subtree broker spawn lifecycle", () => {
     tmux.liveSessions.add("caller-controlled");
 
     await expect(
-      runtime.cleanupSpawn({
-        launchId: "unknown-launch",
-        tmuxSessionName: "caller-controlled",
-        socketPath,
-        state: "launched_unregistered",
+      runtime.spawnWorker(ctx, {
+        task: "Do not launch",
+        repo: ".",
+        cleanupHandle: {
+          launchId: "unknown-launch",
+          tmuxSessionName: "caller-controlled",
+          socketPath,
+          state: "launched_unregistered",
+        },
       }),
     ).rejects.toThrow("spawn cleanup handle does not belong to this subtree broker");
     expect(tmux.liveSessions).toEqual(new Set(["caller-controlled"]));
-  });
-
-  it("adopts a child that registers after the observer timeout", async () => {
-    const tmux = createTmuxHarness();
-    const { runtime } = createRuntime(
-      () => false,
-      `late-adoption-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
-      { runTmuxCommand: tmux.run },
-    );
-    tmux.setOnLaunch((facts) => {
-      setTimeout(() => registerChild(runtime, facts, "late-child"), 15);
-    });
-
-    await expect(
-      runtime.spawnWorker(ctx, {
-        task: "Registers late",
-        repo: ".",
-        waitForRegistrationMs: 5,
-      }),
-    ).rejects.toBeInstanceOf(SubtreeSpawnRegistrationTimeoutError);
-    expect(runtime.listAgents()?.some((agent) => agent.id === "late-child")).toBe(false);
-
-    await new Promise((resolve) => setTimeout(resolve, 25));
-    const lateChild = runtime.listAgents()?.find((agent) => agent.id === "late-child");
-    expect(lateChild).toMatchObject({ id: "late-child", parentAgentId: expect.any(String) });
-    expect(runtime.getStatus().spawnedWorkers[0]?.agentId).toBe("late-child");
   });
 
   it("cleans up a timed-out launch by handle before retrying", async () => {
@@ -489,13 +377,129 @@ describe("subtree broker spawn lifecycle", () => {
     expect(runtime.listAgents()?.filter((agent) => agent.parentAgentId)).toHaveLength(1);
     expect(retried.agentId).toBe("retry-child");
 
-    const repeatedRetry = await runtime.spawnWorker(ctx, {
-      task: "Retry me",
+    await expect(
+      runtime.spawnWorker(ctx, {
+        task: "Retry me",
+        repo: ".",
+        cleanupHandle: timeoutError.handle,
+      }),
+    ).rejects.toThrow("spawn cleanup handle has already been consumed");
+    expect(launchCount).toBe(2);
+  });
+
+  it("does not kill a prefix-related session when the timed-out session already exited", async () => {
+    const tmux = createTmuxHarness();
+    const { runtime } = createRuntime(
+      () => false,
+      `exact-cleanup-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand: tmux.run },
+    );
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Never registers",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+    if (!timeoutError) throw new Error("expected registration timeout");
+
+    tmux.liveSessions.delete(timeoutError.handle.tmuxSessionName);
+    const prefixSession = `${timeoutError.handle.tmuxSessionName}-extra`;
+    tmux.liveSessions.add(prefixSession);
+    tmux.setOnLaunch((facts) => registerChild(runtime, facts, "replacement-child"));
+    const replacement = await runtime.spawnWorker(ctx, {
+      task: "Retry",
       repo: ".",
       cleanupHandle: timeoutError.handle,
     });
-    expect(repeatedRetry).toEqual(retried);
-    expect(launchCount).toBe(2);
+
+    expect(tmux.killedSessions).toEqual([]);
+    expect(tmux.liveSessions).toEqual(new Set([prefixSession, replacement.sessionName]));
+  });
+
+  it("retries when the timed-out session was the last session on the tmux server", async () => {
+    const tmux = createTmuxHarness();
+    let serverMissing = false;
+    const runTmuxCommand = async (args: string[]): Promise<void> => {
+      if (serverMissing && args.includes("has-session")) {
+        throw Object.assign(new Error("no server running on /tmp/tmux.sock"), {
+          stderr: "no server running on /tmp/tmux.sock",
+        });
+      }
+      if (args.includes("new-session")) serverMissing = false;
+      await tmux.run(args);
+    };
+    const { runtime } = createRuntime(
+      () => false,
+      `missing-tmux-server-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand },
+    );
+
+    let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, {
+        task: "Never registers",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnRegistrationTimeoutError) timeoutError = error;
+      else throw error;
+    }
+    if (!timeoutError) throw new Error("expected registration timeout");
+
+    tmux.liveSessions.clear();
+    serverMissing = true;
+    tmux.setOnLaunch((facts) => registerChild(runtime, facts, "replacement-child"));
+    await expect(
+      runtime.spawnWorker(ctx, {
+        task: "Retry",
+        repo: ".",
+        cleanupHandle: timeoutError.handle,
+      }),
+    ).resolves.toMatchObject({ agentId: "replacement-child" });
+  });
+
+  it("returns a cleanup handle when tmux reports an ambiguous launch failure", async () => {
+    const tmux = createTmuxHarness();
+    let failLaunch = true;
+    const runTmuxCommand = async (args: string[]): Promise<void> => {
+      await tmux.run(args);
+      if (failLaunch && args.includes("new-session")) {
+        failLaunch = false;
+        throw new Error("tmux transport closed");
+      }
+    };
+    const { runtime } = createRuntime(
+      () => false,
+      `ambiguous-launch-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { runTmuxCommand },
+    );
+
+    let launchError: SubtreeSpawnLaunchError | null = null;
+    try {
+      await runtime.spawnWorker(ctx, { task: "Launch ambiguously", repo: "." });
+    } catch (error) {
+      if (error instanceof SubtreeSpawnLaunchError) launchError = error;
+      else throw error;
+    }
+    if (!launchError) throw new Error("expected ambiguous launch failure");
+    expect(tmux.liveSessions).toEqual(new Set([launchError.handle.tmuxSessionName]));
+
+    tmux.setOnLaunch((facts) => registerChild(runtime, facts, "replacement-child"));
+    const replacement = await runtime.spawnWorker(ctx, {
+      task: "Retry",
+      repo: ".",
+      cleanupHandle: launchError.handle,
+    });
+
+    expect(tmux.killedSessions).toEqual([launchError.handle.tmuxSessionName]);
+    expect(tmux.liveSessions).toEqual(new Set([replacement.sessionName]));
   });
 
   it("keeps a retry handle consumed when its replacement also times out", async () => {
@@ -544,7 +548,7 @@ describe("subtree broker spawn lifecycle", () => {
         repo: ".",
         cleanupHandle: originalTimeout.handle,
       }),
-    ).rejects.toBe(replacementTimeout);
+    ).rejects.toThrow("spawn cleanup handle has already been consumed");
     expect(launchCount).toBe(2);
     expect(tmux.liveSessions).toEqual(new Set([replacementTimeout.handle.tmuxSessionName]));
 
@@ -602,31 +606,87 @@ describe("subtree broker spawn lifecycle", () => {
     ).rejects.toThrow("tmux transport unavailable");
     expect(launchCount).toBe(1);
     expect(tmux.liveSessions).toEqual(new Set([timeoutError.handle.tmuxSessionName]));
+
+    failProbe = false;
+    tmux.setOnLaunch((facts) => {
+      launchCount += 1;
+      registerChild(runtime, facts, "retry-child");
+    });
+    await expect(
+      runtime.spawnWorker(ctx, {
+        task: "Retry after transport recovery",
+        repo: ".",
+        cleanupHandle: timeoutError.handle,
+      }),
+    ).resolves.toMatchObject({ agentId: "retry-child" });
+    expect(launchCount).toBe(2);
   });
 
-  it("fences an old launch before cleanup so an in-flight registration cannot survive retry", async () => {
+  it("disconnects a child accepted after the final timeout lookup", async () => {
     const tmux = createTmuxHarness();
-    const meshSecret = "fenced-retry-secret";
-    let firstLaunch: TmuxLaunchFacts | null = null;
-    let launchCount = 0;
+    const meshSecret = "timeout-race-secret";
+    let launchFacts: TmuxLaunchFacts | null = null;
+    const racingClients: BrokerClient[] = [];
     const runTmuxCommand = async (args: string[]): Promise<void> => {
       await tmux.run(args);
-      if (args.includes("kill-session") && firstLaunch) {
-        registerChild(runtime, firstLaunch, "late-old-child");
+      if (args.includes("send-keys") && args.at(-1) === "Enter" && launchFacts) {
+        const socketPath = runtime.getStatus().paths?.socketPath;
+        if (!socketPath) throw new Error("subtree broker did not start");
+        const racingClient = new BrokerClient({ path: socketPath, meshSecret });
+        racingClients.push(racingClient);
+        await racingClient.connect();
+        await racingClient.register("Racing Child", "🌱", {
+          parentAgentId: runtime.getStatus().selfAgentId,
+          launchId: launchFacts.launchId,
+          tmuxSession: launchFacts.sessionName,
+        });
       }
     };
     const { runtime } = createRuntime(
       () => false,
-      `fenced-retry-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      `timeout-race-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
       {
         getSettings: () => ({ meshSecret }) as SlackBridgeSettings,
         runTmuxCommand,
       },
     );
     tmux.setOnLaunch((facts) => {
+      launchFacts = facts;
+    });
+
+    await expect(
+      runtime.spawnWorker(ctx, {
+        task: "Race the timeout",
+        repo: ".",
+        waitForRegistrationMs: 5,
+      }),
+    ).rejects.toBeInstanceOf(SubtreeSpawnRegistrationTimeoutError);
+    const racingClient = racingClients[0];
+    if (!racingClient) throw new Error("racing client did not register");
+    await expect(racingClient.heartbeat()).rejects.toThrow();
+
+    const db = runtime.getHibernationRuntimeControl()?.db;
+    const racingAgent = db
+      ?.getAllAgents()
+      .find((agent) => agent.metadata?.launchId === launchFacts?.launchId);
+    expect(racingAgent?.disconnectedAt).not.toBeNull();
+  });
+
+  it("fences a launch when it times out so late registration cannot survive retry", async () => {
+    const tmux = createTmuxHarness();
+    const meshSecret = "fenced-retry-secret";
+    let launchCount = 0;
+    const { runtime } = createRuntime(
+      () => false,
+      `fenced-retry-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      {
+        getSettings: () => ({ meshSecret }) as SlackBridgeSettings,
+        runTmuxCommand: tmux.run,
+      },
+    );
+    tmux.setOnLaunch((facts) => {
       launchCount += 1;
-      if (launchCount === 1) firstLaunch = facts;
-      else registerChild(runtime, facts, "replacement-child");
+      if (launchCount === 2) registerChild(runtime, facts, "replacement-child");
     });
 
     let timeoutError: SubtreeSpawnRegistrationTimeoutError | null = null;
@@ -642,12 +702,6 @@ describe("subtree broker spawn lifecycle", () => {
     }
     if (!timeoutError) throw new Error("expected registration timeout");
 
-    const replacement = await runtime.spawnWorker(ctx, {
-      task: "Retry racing registration",
-      repo: ".",
-      cleanupHandle: timeoutError.handle,
-    });
-
     const lateClient = new BrokerClient({ path: timeoutError.handle.socketPath, meshSecret });
     await lateClient.connect();
     await expect(
@@ -659,14 +713,13 @@ describe("subtree broker spawn lifecycle", () => {
     ).rejects.toThrow("spawn launch has already been cleaned up");
     lateClient.disconnect();
 
+    const replacement = await runtime.spawnWorker(ctx, {
+      task: "Retry racing registration",
+      repo: ".",
+      cleanupHandle: timeoutError.handle,
+    });
     const db = runtime.getHibernationRuntimeControl()?.db;
-    const oldHistoricalAgent = db?.getAllAgents().find((agent) => agent.id === "late-old-child");
     expect(replacement.agentId).toBe("replacement-child");
-    // Cleanup preserves the direct-DB race as disconnected history, but no old launch remains live.
-    expect(oldHistoricalAgent?.disconnectedAt).not.toBeNull();
-    expect(
-      db?.getAgents().some((agent) => agent.metadata?.launchId === timeoutError.handle.launchId),
-    ).toBe(false);
     expect(db?.getAgents().filter((agent) => agent.parentAgentId)).toHaveLength(1);
     expect(tmux.liveSessions).toEqual(new Set([replacement.sessionName]));
   });

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -189,6 +189,24 @@ describe("subtree broker spawn lifecycle", () => {
     expect(tmux.liveSessions.size).toBe(3);
   });
 
+  it("validates empty spawn inputs before starting the broker", async () => {
+    const getAgentMetadata = vi.fn(async () => ({}));
+    const { runtime } = createRuntime(
+      () => false,
+      `spawn-validation-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { getAgentMetadata },
+    );
+
+    await expect(runtime.spawnWorker(ctx, { task: "", repo: "." })).rejects.toThrow(
+      "spawn requires task",
+    );
+    await expect(runtime.spawnWorker(ctx, { task: "Task", repo: "" })).rejects.toThrow(
+      "spawn requires repo",
+    );
+    expect(getAgentMetadata).not.toHaveBeenCalled();
+    expect(runtime.isActive()).toBe(false);
+  });
+
   it("stops a broker when post-listen initialization fails so startup can retry", async () => {
     const tmux = createTmuxHarness();
     const getAgentMetadata = vi

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -189,6 +189,25 @@ describe("subtree broker spawn lifecycle", () => {
     expect(tmux.liveSessions.size).toBe(3);
   });
 
+  it("single-flights public start with automatic spawn startup", async () => {
+    const tmux = createTmuxHarness();
+    const getAgentMetadata = vi.fn(async () => ({}));
+    const { runtime } = createRuntime(
+      () => false,
+      `public-start-flight-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+      { getAgentMetadata, runTmuxCommand: tmux.run },
+    );
+    tmux.setOnLaunch((facts) => registerChild(runtime, facts, "spawn-child"));
+
+    const [, spawned] = await Promise.all([
+      runtime.start(ctx),
+      runtime.spawnWorker(ctx, { task: "Spawn while starting", repo: "." }),
+    ]);
+
+    expect(spawned.agentId).toBe("spawn-child");
+    expect(getAgentMetadata).toHaveBeenCalledTimes(1);
+  });
+
   it("validates empty spawn inputs before starting the broker", async () => {
     const getAgentMetadata = vi.fn(async () => ({}));
     const { runtime } = createRuntime(

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -57,6 +57,7 @@ export interface SubtreeWorkerRecord {
   agentId: string | null;
   startedAt: string;
   monitorCommand: string;
+  tmuxSocketPath: string | null;
 }
 
 export interface SubtreeBrokerStatus {
@@ -664,10 +665,11 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   }
 
   async function killTmuxSession(sessionName: string, tmuxBaseArgs: string[]): Promise<void> {
-    await runTmuxCommand([...tmuxBaseArgs, "has-session", "-t", sessionName]).catch(() => {
+    const exactTarget = `=${sessionName}`;
+    await runTmuxCommand([...tmuxBaseArgs, "has-session", "-t", exactTarget]).catch(() => {
       throw new Error("missing");
     });
-    await runTmuxCommand([...tmuxBaseArgs, "kill-session", "-t", sessionName]);
+    await runTmuxCommand([...tmuxBaseArgs, "kill-session", "-t", exactTarget]);
   }
 
   async function cleanupSpawn(handle: SubtreeSpawnLaunchHandle): Promise<void> {
@@ -675,11 +677,14 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       throw new Error("spawn cleanup handle does not belong to this subtree broker");
     }
     const worker = spawnedWorkers.get(handle.launchId);
-    if (worker && worker.sessionName !== handle.tmuxSessionName) {
+    if (!worker) {
+      throw new Error("spawn cleanup handle does not belong to this subtree broker");
+    }
+    if (worker.sessionName !== handle.tmuxSessionName) {
       throw new Error("spawn cleanup handle does not match its recorded tmux session");
     }
 
-    const tmuxBaseArgs = buildTmuxBaseArgs(findTmuxSocketPath());
+    const tmuxBaseArgs = buildTmuxBaseArgs(worker.tmuxSocketPath);
     await killTmuxSession(handle.tmuxSessionName, tmuxBaseArgs).catch((error) => {
       if (!(error instanceof Error) || error.message !== "missing") throw error;
     });
@@ -924,6 +929,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       agentId: null,
       startedAt: new Date().toISOString(),
       monitorCommand,
+      tmuxSocketPath,
     };
     spawnedWorkers.set(launchId, workerRecord);
 

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -334,6 +334,11 @@ function buildTmuxMonitorCommand(sessionName: string, socketPath: string | null)
   return `tmux ${socketArgs}attach -t ${quoteShellValue(sessionName)}`;
 }
 
+function isMissingExactTmuxTarget(error: Error): boolean {
+  const stderr = "stderr" in error && typeof error.stderr === "string" ? error.stderr : "";
+  return /can't find session:/i.test(`${error.message}\n${stderr}`);
+}
+
 export function getExtensionEntryPath(): string {
   const currentPath = fileURLToPath(import.meta.url);
   const extension = path.extname(currentPath) || ".js";
@@ -669,10 +674,17 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
 
   async function killTmuxSession(sessionName: string, tmuxBaseArgs: string[]): Promise<void> {
     const exactTarget = `=${sessionName}`;
-    await runTmuxCommand([...tmuxBaseArgs, "has-session", "-t", exactTarget]).catch(() => {
-      throw new Error("missing");
-    });
-    await runTmuxCommand([...tmuxBaseArgs, "kill-session", "-t", exactTarget]);
+    try {
+      await runTmuxCommand([...tmuxBaseArgs, "has-session", "-t", exactTarget]);
+    } catch (error) {
+      if (error instanceof Error && isMissingExactTmuxTarget(error)) return;
+      throw error;
+    }
+    try {
+      await runTmuxCommand([...tmuxBaseArgs, "kill-session", "-t", exactTarget]);
+    } catch (error) {
+      if (!(error instanceof Error) || !isMissingExactTmuxTarget(error)) throw error;
+    }
   }
 
   async function cleanupSpawn(handle: SubtreeSpawnLaunchHandle): Promise<void> {
@@ -690,9 +702,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
 
     fencedLaunchIds.add(handle.launchId);
     const tmuxBaseArgs = buildTmuxBaseArgs(worker.tmuxSocketPath);
-    await killTmuxSession(handle.tmuxSessionName, tmuxBaseArgs).catch((error) => {
-      if (!(error instanceof Error) || error.message !== "missing") throw error;
-    });
+    await killTmuxSession(handle.tmuxSessionName, tmuxBaseArgs);
 
     const broker = activeBroker;
     const agentId = selfAgentId;

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -810,52 +810,57 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
         : {}),
     });
 
-    const { name, emoji } = deps.getAgentIdentity();
-    const metadata = {
-      ...(await deps.getAgentMetadata("broker")),
-      subtreeBroker: true,
-      upstreamAgentId: deps.getCentralAgentId(),
-      subtreeSocketPath: paths.socketPath,
-    };
-    const selfAgent = broker.db.registerAgent(
-      selfId,
-      name ? `Subtree Broker ${name}` : "Subtree Broker",
-      emoji || "🌳",
-      process.pid,
-      metadata,
-      `${stableId}:subtree-broker`,
-    );
-
-    broker.server.setAgentRegistrationResolver((registration) => {
-      const role = deps.getMeshRoleFromMetadata(registration.metadata, "worker");
-      const identity = generateAgentName(registration.stableId ?? registration.agentId, role);
-      return {
-        name: registration.name || identity.name,
-        emoji: registration.emoji || identity.emoji,
-        metadata: {
-          ...(registration.metadata ?? {}),
-          subtreeBrokerAgentId: selfAgent.id,
-          subtreeRootAgentId: selfAgent.id,
-        },
+    try {
+      const { name, emoji } = deps.getAgentIdentity();
+      const metadata = {
+        ...(await deps.getAgentMetadata("broker")),
+        subtreeBroker: true,
+        upstreamAgentId: deps.getCentralAgentId(),
+        subtreeSocketPath: paths.socketPath,
       };
-    });
+      const selfAgent = broker.db.registerAgent(
+        selfId,
+        name ? `Subtree Broker ${name}` : "Subtree Broker",
+        emoji || "🌳",
+        process.pid,
+        metadata,
+        `${stableId}:subtree-broker`,
+      );
 
-    broker.server.onAgentMessage((targetAgentId: string) => {
-      if (targetAgentId !== selfAgent.id) return;
+      broker.server.setAgentRegistrationResolver((registration) => {
+        const role = deps.getMeshRoleFromMetadata(registration.metadata, "worker");
+        const identity = generateAgentName(registration.stableId ?? registration.agentId, role);
+        return {
+          name: registration.name || identity.name,
+          emoji: registration.emoji || identity.emoji,
+          metadata: {
+            ...(registration.metadata ?? {}),
+            subtreeBrokerAgentId: selfAgent.id,
+            subtreeRootAgentId: selfAgent.id,
+          },
+        };
+      });
+
+      broker.server.onAgentMessage((targetAgentId: string) => {
+        if (targetAgentId !== selfAgent.id) return;
+        drainSelfInbox(ctx, broker, selfAgent.id);
+      });
+
+      broker.db.recoverPendingTargetedBacklog(selfAgent.id);
       drainSelfInbox(ctx, broker, selfAgent.id);
-    });
+      broker.db.setSetting("pinet.subtreeBrokerParentStableId", deps.getAgentStableId());
+      broker.db.setSetting("pinet.subtreeBrokerOwnerToken", buildPinetOwnerToken(stableId));
 
-    activeBroker = broker;
-    selfAgentId = selfAgent.id;
-    startedAt = new Date().toISOString();
-    activePaths = paths;
-    startHeartbeat(broker, selfAgent.id);
-    broker.db.recoverPendingTargetedBacklog(selfAgent.id);
-    drainSelfInbox(ctx, broker, selfAgent.id);
-    broker.db.setSetting("pinet.subtreeBrokerParentStableId", deps.getAgentStableId());
-    broker.db.setSetting("pinet.subtreeBrokerOwnerToken", buildPinetOwnerToken(stableId));
-
-    return getStatus();
+      activeBroker = broker;
+      selfAgentId = selfAgent.id;
+      startedAt = new Date().toISOString();
+      activePaths = paths;
+      startHeartbeat(broker, selfAgent.id);
+      return getStatus();
+    } catch (error) {
+      await broker.stop().catch(() => undefined);
+      throw error;
+    }
   }
 
   async function ensureSubtreeBroker(ctx: ExtensionContext): Promise<void> {

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -900,12 +900,12 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     ctx: ExtensionContext,
     input: SubtreeSpawnInput,
   ): Promise<SubtreeSpawnResult> {
+    if (!input.task.trim()) throw new Error("spawn requires task");
+    if (!input.repo.trim()) throw new Error("spawn requires repo");
     await ensureSubtreeBroker(ctx);
     if (!activeBroker || !activePaths || !selfAgentId) {
       throw new Error("Subtree broker is not running.");
     }
-    if (!input.task.trim()) throw new Error("spawn requires task");
-    if (!input.repo.trim()) throw new Error("spawn requires repo");
     if (input.cleanupHandle) {
       await cleanupSpawn(input.cleanupHandle);
     }

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -638,6 +638,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     broker: Broker;
     launchId: string;
     sessionName: string;
+    socketPath: string;
     tmuxBaseArgs: string[];
     timeoutMs: number;
   }): Promise<AgentInfo> {
@@ -663,7 +664,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     throw new SubtreeSpawnRegistrationTimeoutError(input.timeoutMs, {
       launchId: input.launchId,
       tmuxSessionName: input.sessionName,
-      socketPath: activePaths?.socketPath ?? "",
+      socketPath: input.socketPath,
       state: "launched_unregistered",
     });
   }
@@ -915,6 +916,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       await cleanupSpawn(input.cleanupHandle);
     }
 
+    const socketPath = activePaths.socketPath;
     const repoPath = resolveRepoPath(input.repo, deps.cwd);
     const role = normalizeRole(input.role);
     const launchId = `subtree-${Date.now().toString(36)}-${randomSuffix()}`;
@@ -961,6 +963,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       broker: activeBroker,
       launchId,
       sessionName,
+      socketPath,
       tmuxBaseArgs,
       timeoutMs: input.waitForRegistrationMs ?? DEFAULT_SPAWN_REGISTRATION_TIMEOUT_MS,
     });

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -93,12 +93,34 @@ export interface SubtreeAgentRecord {
   laneId?: string | null;
 }
 
+export interface SubtreeSpawnLaunchHandle {
+  launchId: string;
+  tmuxSessionName: string;
+  socketPath: string;
+  state: "launched_unregistered";
+}
+
+export class SubtreeSpawnRegistrationTimeoutError extends Error {
+  readonly handle: SubtreeSpawnLaunchHandle;
+
+  constructor(timeoutMs: number, handle: SubtreeSpawnLaunchHandle) {
+    super(
+      `subtree worker session ${handle.tmuxSessionName} started but did not register within ${timeoutMs}ms; ` +
+        `launchId=${handle.launchId}; tmuxSessionName=${handle.tmuxSessionName}; ` +
+        `socketPath=${handle.socketPath}; state=${handle.state}`,
+    );
+    this.name = "SubtreeSpawnRegistrationTimeoutError";
+    this.handle = handle;
+  }
+}
+
 export interface SubtreeSpawnInput {
   task: string;
   repo: string;
   role?: string;
   laneId?: string;
   waitForRegistrationMs?: number;
+  cleanupHandle?: SubtreeSpawnLaunchHandle;
 }
 
 export interface SubtreeSpawnResult {
@@ -139,6 +161,7 @@ export interface SubtreeBrokerRuntimeDeps {
   ) => PinetRemoteControlRequestResult;
   runRemoteControl: (command: PinetControlCommand, ctx: ExtensionContext) => void;
   formatError: (error: unknown) => string;
+  runTmuxCommand?: (args: string[]) => Promise<void>;
 }
 
 /**
@@ -172,6 +195,7 @@ export interface SubtreeBrokerRuntime {
     metadata?: Record<string, unknown>,
   ) => Promise<{ messageId: number; target: string; threadId: string } | null>;
   listAgents: (includeGhosts?: boolean) => SubtreeAgentRecord[] | null;
+  cleanupSpawn: (handle: SubtreeSpawnLaunchHandle) => Promise<void>;
   spawnWorker: (ctx: ExtensionContext, input: SubtreeSpawnInput) => Promise<SubtreeSpawnResult>;
   isActive: () => boolean;
 }
@@ -413,7 +437,13 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   let startedAt: string | null = null;
   let activePaths: SubtreeBrokerPaths | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let brokerStartPromise: Promise<SubtreeBrokerStatus> | null = null;
   const spawnedWorkers = new Map<string, SubtreeWorkerRecord>();
+  const runTmuxCommand =
+    deps.runTmuxCommand ??
+    (async (args: string[]): Promise<void> => {
+      await execFileAsync("tmux", args);
+    });
 
   function stopHeartbeat(): void {
     if (!heartbeatTimer) return;
@@ -433,11 +463,28 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     heartbeatTimer.unref?.();
   }
 
+  function adoptRegisteredWorkers(agents: AgentInfo[]): void {
+    for (const agent of agents) {
+      const launchId = metadataString(agent.metadata, "launchId");
+      const worker = launchId ? spawnedWorkers.get(launchId) : undefined;
+      if (launchId && worker && worker.agentId !== agent.id) {
+        spawnedWorkers.set(launchId, { ...worker, agentId: agent.id });
+      }
+    }
+  }
+
   function currentChildren(): AgentInfo[] {
     const broker = activeBroker;
     const agentId = selfAgentId;
     if (!broker || !agentId) return [];
-    return broker.db.getAllAgents().filter((agent) => isSubtreeChildAgent(agent, agentId));
+    const children = broker.db
+      .getAllAgents()
+      .filter((agent) => isSubtreeChildAgent(agent, agentId));
+    // Adopt late registrations rather than fence them. A child that reached the
+    // authoritative broker is real, useful work; killing it after an observer
+    // timeout would be more destructive than surfacing it in the roster.
+    adoptRegisteredWorkers(children);
+    return children;
   }
 
   function getStatus(): SubtreeBrokerStatus {
@@ -560,12 +607,13 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     const broker = activeBroker;
     if (!broker) return null;
     const agents = broker.db.getAllAgents();
+    adoptRegisteredWorkers(agents);
     const filtered = includeGhosts ? agents : agents.filter((agent) => !agent.disconnectedAt);
     return filtered.map((agent) => toSubtreeAgentRecord(broker.db, agent));
   }
 
   async function sendFollowCommand(sessionName: string, tmuxBaseArgs: string[]): Promise<void> {
-    await execFileAsync("tmux", [
+    await runTmuxCommand([
       ...tmuxBaseArgs,
       "send-keys",
       "-t",
@@ -574,7 +622,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       "--",
       "/pinet follow",
     ]);
-    await execFileAsync("tmux", [...tmuxBaseArgs, "send-keys", "-t", sessionName, "Enter"]);
+    await runTmuxCommand([...tmuxBaseArgs, "send-keys", "-t", sessionName, "Enter"]);
   }
 
   async function waitForSpawnedAgent(input: {
@@ -600,12 +648,15 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
         });
       }
 
-      await sleep(1_000);
+      await sleep(Math.min(1_000, Math.max(1, deadline - Date.now())));
     }
 
-    throw new Error(
-      `subtree worker session ${input.sessionName} started but did not register within ${input.timeoutMs}ms`,
-    );
+    throw new SubtreeSpawnRegistrationTimeoutError(input.timeoutMs, {
+      launchId: input.launchId,
+      tmuxSessionName: input.sessionName,
+      socketPath: activePaths?.socketPath ?? "",
+      state: "launched_unregistered",
+    });
   }
 
   async function requestChildExit(agent: AgentInfo): Promise<void> {
@@ -613,10 +664,39 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   }
 
   async function killTmuxSession(sessionName: string, tmuxBaseArgs: string[]): Promise<void> {
-    await execFileAsync("tmux", [...tmuxBaseArgs, "has-session", "-t", sessionName]).catch(() => {
+    await runTmuxCommand([...tmuxBaseArgs, "has-session", "-t", sessionName]).catch(() => {
       throw new Error("missing");
     });
-    await execFileAsync("tmux", [...tmuxBaseArgs, "kill-session", "-t", sessionName]);
+    await runTmuxCommand([...tmuxBaseArgs, "kill-session", "-t", sessionName]);
+  }
+
+  async function cleanupSpawn(handle: SubtreeSpawnLaunchHandle): Promise<void> {
+    if (!activePaths || handle.socketPath !== activePaths.socketPath) {
+      throw new Error("spawn cleanup handle does not belong to this subtree broker");
+    }
+    const worker = spawnedWorkers.get(handle.launchId);
+    if (worker && worker.sessionName !== handle.tmuxSessionName) {
+      throw new Error("spawn cleanup handle does not match its recorded tmux session");
+    }
+
+    const tmuxBaseArgs = buildTmuxBaseArgs(findTmuxSocketPath());
+    await killTmuxSession(handle.tmuxSessionName, tmuxBaseArgs).catch((error) => {
+      if (!(error instanceof Error) || error.message !== "missing") throw error;
+    });
+
+    const broker = activeBroker;
+    const agentId = selfAgentId;
+    if (broker && agentId) {
+      for (const agent of broker.db.getAllAgents()) {
+        if (
+          isSubtreeChildAgent(agent, agentId) &&
+          metadataString(agent.metadata, "launchId") === handle.launchId
+        ) {
+          broker.db.unregisterAgent(agent.id);
+        }
+      }
+    }
+    spawnedWorkers.delete(handle.launchId);
   }
 
   function childTmuxSessions(broker: Broker, agentId: string): string[] {
@@ -778,17 +858,28 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     return getStatus();
   }
 
+  async function ensureSubtreeBroker(ctx: ExtensionContext): Promise<void> {
+    if (activeBroker) return;
+    if (!brokerStartPromise) {
+      brokerStartPromise = start(ctx).finally(() => {
+        brokerStartPromise = null;
+      });
+    }
+    await brokerStartPromise;
+  }
+
   async function spawnWorker(
     ctx: ExtensionContext,
     input: SubtreeSpawnInput,
   ): Promise<SubtreeSpawnResult> {
-    if (!input.task.trim()) throw new Error("spawn requires task");
-    if (!input.repo.trim()) throw new Error("spawn requires repo");
-    if (!activeBroker) {
-      await start(ctx);
-    }
+    await ensureSubtreeBroker(ctx);
     if (!activeBroker || !activePaths || !selfAgentId) {
       throw new Error("Subtree broker is not running.");
+    }
+    if (!input.task.trim()) throw new Error("spawn requires task");
+    if (!input.repo.trim()) throw new Error("spawn requires repo");
+    if (input.cleanupHandle) {
+      await cleanupSpawn(input.cleanupHandle);
     }
 
     const repoPath = resolveRepoPath(input.repo, deps.cwd);
@@ -818,14 +909,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       { mode: 0o700 },
     );
 
-    await execFileAsync("tmux", [
-      ...tmuxBaseArgs,
-      "new-session",
-      "-d",
-      "-s",
-      sessionName,
-      launcherPath,
-    ]);
+    await runTmuxCommand([...tmuxBaseArgs, "new-session", "-d", "-s", sessionName, launcherPath]);
     const workerRecord: SubtreeWorkerRecord = {
       launchId,
       sessionName,
@@ -921,6 +1005,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     readInbox,
     sendMessage,
     listAgents,
+    cleanupSpawn,
     spawnWorker,
     isActive: () => activeBroker !== null,
   };

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -903,6 +903,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   async function spawnWorkerOnce(
     ctx: ExtensionContext,
     input: SubtreeSpawnInput,
+    onLaunchAttempt?: () => void,
   ): Promise<SubtreeSpawnResult> {
     if (!input.task.trim()) throw new Error("spawn requires task");
     if (!input.repo.trim()) throw new Error("spawn requires repo");
@@ -941,6 +942,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       { mode: 0o700 },
     );
 
+    onLaunchAttempt?.();
     await runTmuxCommand([...tmuxBaseArgs, "new-session", "-d", "-s", sessionName, launcherPath]);
     const workerRecord: SubtreeWorkerRecord = {
       launchId,
@@ -1030,10 +1032,13 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     const existingRetry = retrySpawns.get(cleanupHandle.launchId);
     if (existingRetry) return existingRetry;
 
-    const retry = spawnWorkerOnce(ctx, input);
+    let replacementMayHaveLaunched = false;
+    const retry = spawnWorkerOnce(ctx, input, () => {
+      replacementMayHaveLaunched = true;
+    });
     retrySpawns.set(cleanupHandle.launchId, retry);
     void retry.catch(() => {
-      if (retrySpawns.get(cleanupHandle.launchId) === retry) {
+      if (!replacementMayHaveLaunched && retrySpawns.get(cleanupHandle.launchId) === retry) {
         retrySpawns.delete(cleanupHandle.launchId);
       }
     });

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -776,7 +776,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     }
   }
 
-  async function start(ctx: ExtensionContext): Promise<SubtreeBrokerStatus> {
+  async function startOnce(ctx: ExtensionContext): Promise<SubtreeBrokerStatus> {
     if (activeBroker) return getStatus();
 
     const stableId = deps.getCentralAgentId() ?? deps.getAgentStableId();
@@ -886,14 +886,18 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     }
   }
 
-  async function ensureSubtreeBroker(ctx: ExtensionContext): Promise<void> {
-    if (activeBroker) return;
+  function start(ctx: ExtensionContext): Promise<SubtreeBrokerStatus> {
+    if (activeBroker) return Promise.resolve(getStatus());
     if (!brokerStartPromise) {
-      brokerStartPromise = start(ctx).finally(() => {
+      brokerStartPromise = startOnce(ctx).finally(() => {
         brokerStartPromise = null;
       });
     }
-    await brokerStartPromise;
+    return brokerStartPromise;
+  }
+
+  async function ensureSubtreeBroker(ctx: ExtensionContext): Promise<void> {
+    await start(ctx);
   }
 
   async function spawnWorkerOnce(

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -440,6 +440,8 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let brokerStartPromise: Promise<SubtreeBrokerStatus> | null = null;
   const spawnedWorkers = new Map<string, SubtreeWorkerRecord>();
+  const fencedLaunchIds = new Set<string>();
+  const retrySpawns = new Map<string, Promise<SubtreeSpawnResult>>();
   const runTmuxCommand =
     deps.runTmuxCommand ??
     (async (args: string[]): Promise<void> => {
@@ -464,28 +466,30 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     heartbeatTimer.unref?.();
   }
 
-  function adoptRegisteredWorkers(agents: AgentInfo[]): void {
+  function adoptRegisteredWorkers(agents: AgentInfo[]): AgentInfo[] {
+    const accepted: AgentInfo[] = [];
     for (const agent of agents) {
       const launchId = metadataString(agent.metadata, "launchId");
+      if (launchId && fencedLaunchIds.has(launchId)) {
+        activeBroker?.db.unregisterAgent(agent.id);
+        continue;
+      }
       const worker = launchId ? spawnedWorkers.get(launchId) : undefined;
       if (launchId && worker && worker.agentId !== agent.id) {
         spawnedWorkers.set(launchId, { ...worker, agentId: agent.id });
       }
+      accepted.push(agent);
     }
+    return accepted;
   }
 
   function currentChildren(): AgentInfo[] {
     const broker = activeBroker;
     const agentId = selfAgentId;
     if (!broker || !agentId) return [];
-    const children = broker.db
-      .getAllAgents()
-      .filter((agent) => isSubtreeChildAgent(agent, agentId));
-    // Adopt late registrations rather than fence them. A child that reached the
-    // authoritative broker is real, useful work; killing it after an observer
-    // timeout would be more destructive than surfacing it in the roster.
-    adoptRegisteredWorkers(children);
-    return children;
+    return adoptRegisteredWorkers(
+      broker.db.getAllAgents().filter((agent) => isSubtreeChildAgent(agent, agentId)),
+    );
   }
 
   function getStatus(): SubtreeBrokerStatus {
@@ -607,8 +611,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   function listAgents(includeGhosts = false): SubtreeAgentRecord[] | null {
     const broker = activeBroker;
     if (!broker) return null;
-    const agents = broker.db.getAllAgents();
-    adoptRegisteredWorkers(agents);
+    const agents = adoptRegisteredWorkers(broker.db.getAllAgents());
     const filtered = includeGhosts ? agents : agents.filter((agent) => !agent.disconnectedAt);
     return filtered.map((agent) => toSubtreeAgentRecord(broker.db, agent));
   }
@@ -678,12 +681,14 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     }
     const worker = spawnedWorkers.get(handle.launchId);
     if (!worker) {
+      if (fencedLaunchIds.has(handle.launchId)) return;
       throw new Error("spawn cleanup handle does not belong to this subtree broker");
     }
     if (worker.sessionName !== handle.tmuxSessionName) {
       throw new Error("spawn cleanup handle does not match its recorded tmux session");
     }
 
+    fencedLaunchIds.add(handle.launchId);
     const tmuxBaseArgs = buildTmuxBaseArgs(worker.tmuxSocketPath);
     await killTmuxSession(handle.tmuxSessionName, tmuxBaseArgs).catch((error) => {
       if (!(error instanceof Error) || error.message !== "missing") throw error;
@@ -693,10 +698,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     const agentId = selfAgentId;
     if (broker && agentId) {
       for (const agent of broker.db.getAllAgents()) {
-        if (
-          isSubtreeChildAgent(agent, agentId) &&
-          metadataString(agent.metadata, "launchId") === handle.launchId
-        ) {
+        if (metadataString(agent.metadata, "launchId") === handle.launchId) {
           broker.db.unregisterAgent(agent.id);
         }
       }
@@ -759,6 +761,8 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       startedAt = null;
       activePaths = null;
       spawnedWorkers.clear();
+      fencedLaunchIds.clear();
+      retrySpawns.clear();
     }
   }
 
@@ -833,6 +837,10 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       );
 
       broker.server.setAgentRegistrationResolver((registration) => {
+        const launchId = metadataString(registration.metadata, "launchId");
+        if (launchId && fencedLaunchIds.has(launchId)) {
+          throw new Error("spawn launch has already been cleaned up");
+        }
         const role = deps.getMeshRoleFromMetadata(registration.metadata, "worker");
         const identity = generateAgentName(registration.stableId ?? registration.agentId, role);
         return {
@@ -878,7 +886,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     await brokerStartPromise;
   }
 
-  async function spawnWorker(
+  async function spawnWorkerOnce(
     ctx: ExtensionContext,
     input: SubtreeSpawnInput,
   ): Promise<SubtreeSpawnResult> {
@@ -996,6 +1004,26 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       dbPath: activePaths.dbPath,
       childLaunchEnv,
     };
+  }
+
+  function spawnWorker(
+    ctx: ExtensionContext,
+    input: SubtreeSpawnInput,
+  ): Promise<SubtreeSpawnResult> {
+    const cleanupHandle = input.cleanupHandle;
+    if (!cleanupHandle) return spawnWorkerOnce(ctx, input);
+
+    const existingRetry = retrySpawns.get(cleanupHandle.launchId);
+    if (existingRetry) return existingRetry;
+
+    const retry = spawnWorkerOnce(ctx, input);
+    retrySpawns.set(cleanupHandle.launchId, retry);
+    void retry.catch(() => {
+      if (retrySpawns.get(cleanupHandle.launchId) === retry) {
+        retrySpawns.delete(cleanupHandle.launchId);
+      }
+    });
+    return retry;
   }
 
   function getHibernationRuntimeControl(): SubtreeHibernationRuntimeControl | null {

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -115,6 +115,22 @@ export class SubtreeSpawnRegistrationTimeoutError extends Error {
   }
 }
 
+export class SubtreeSpawnLaunchError extends Error {
+  readonly handle: SubtreeSpawnLaunchHandle;
+
+  constructor(error: Error, handle: SubtreeSpawnLaunchHandle) {
+    const message = error.message;
+    super(
+      `subtree worker session ${handle.tmuxSessionName} may have started after tmux reported: ${message}; ` +
+        `launchId=${handle.launchId}; tmuxSessionName=${handle.tmuxSessionName}; ` +
+        `socketPath=${handle.socketPath}; state=${handle.state}`,
+      { cause: error },
+    );
+    this.name = "SubtreeSpawnLaunchError";
+    this.handle = handle;
+  }
+}
+
 export interface SubtreeSpawnInput {
   task: string;
   repo: string;
@@ -196,7 +212,6 @@ export interface SubtreeBrokerRuntime {
     metadata?: Record<string, unknown>,
   ) => Promise<{ messageId: number; target: string; threadId: string } | null>;
   listAgents: (includeGhosts?: boolean) => SubtreeAgentRecord[] | null;
-  cleanupSpawn: (handle: SubtreeSpawnLaunchHandle) => Promise<void>;
   spawnWorker: (ctx: ExtensionContext, input: SubtreeSpawnInput) => Promise<SubtreeSpawnResult>;
   isActive: () => boolean;
 }
@@ -334,9 +349,11 @@ function buildTmuxMonitorCommand(sessionName: string, socketPath: string | null)
   return `tmux ${socketArgs}attach -t ${quoteShellValue(sessionName)}`;
 }
 
-function isMissingExactTmuxTarget(error: Error): boolean {
+function isMissingTmuxTarget(error: Error): boolean {
   const stderr = "stderr" in error && typeof error.stderr === "string" ? error.stderr : "";
-  return /can't find session:/i.test(`${error.message}\n${stderr}`);
+  return /can't find session:|no server running|error connecting to .*\(no such file or directory\)/i.test(
+    `${error.message}\n${stderr}`,
+  );
 }
 
 export function getExtensionEntryPath(): string {
@@ -446,7 +463,6 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   let brokerStartPromise: Promise<SubtreeBrokerStatus> | null = null;
   const spawnedWorkers = new Map<string, SubtreeWorkerRecord>();
   const fencedLaunchIds = new Set<string>();
-  const retrySpawns = new Map<string, Promise<SubtreeSpawnResult>>();
   const runTmuxCommand =
     deps.runTmuxCommand ??
     (async (args: string[]): Promise<void> => {
@@ -471,30 +487,21 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     heartbeatTimer.unref?.();
   }
 
-  function adoptRegisteredWorkers(agents: AgentInfo[]): AgentInfo[] {
-    const accepted: AgentInfo[] = [];
-    for (const agent of agents) {
-      const launchId = metadataString(agent.metadata, "launchId");
-      if (launchId && fencedLaunchIds.has(launchId)) {
-        activeBroker?.db.unregisterAgent(agent.id);
-        continue;
+  function fenceLaunch(broker: Broker, launchId: string): void {
+    fencedLaunchIds.add(launchId);
+    for (const agent of broker.db.getAllAgents()) {
+      if (metadataString(agent.metadata, "launchId") === launchId) {
+        broker.server.disconnectAgentConnections(agent.id);
+        broker.db.unregisterAgent(agent.id);
       }
-      const worker = launchId ? spawnedWorkers.get(launchId) : undefined;
-      if (launchId && worker && worker.agentId !== agent.id) {
-        spawnedWorkers.set(launchId, { ...worker, agentId: agent.id });
-      }
-      accepted.push(agent);
     }
-    return accepted;
   }
 
   function currentChildren(): AgentInfo[] {
     const broker = activeBroker;
     const agentId = selfAgentId;
     if (!broker || !agentId) return [];
-    return adoptRegisteredWorkers(
-      broker.db.getAllAgents().filter((agent) => isSubtreeChildAgent(agent, agentId)),
-    );
+    return broker.db.getAllAgents().filter((agent) => isSubtreeChildAgent(agent, agentId));
   }
 
   function getStatus(): SubtreeBrokerStatus {
@@ -616,7 +623,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   function listAgents(includeGhosts = false): SubtreeAgentRecord[] | null {
     const broker = activeBroker;
     if (!broker) return null;
-    const agents = adoptRegisteredWorkers(broker.db.getAllAgents());
+    const agents = broker.db.getAllAgents();
     const filtered = includeGhosts ? agents : agents.filter((agent) => !agent.disconnectedAt);
     return filtered.map((agent) => toSubtreeAgentRecord(broker.db, agent));
   }
@@ -636,9 +643,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
 
   async function waitForSpawnedAgent(input: {
     broker: Broker;
-    launchId: string;
-    sessionName: string;
-    socketPath: string;
+    handle: SubtreeSpawnLaunchHandle;
     tmuxBaseArgs: string[];
     timeoutMs: number;
   }): Promise<AgentInfo> {
@@ -648,12 +653,14 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     while (Date.now() < deadline) {
       const agent = input.broker.db
         .getAllAgents()
-        .find((candidate) => metadataString(candidate.metadata, "launchId") === input.launchId);
+        .find(
+          (candidate) => metadataString(candidate.metadata, "launchId") === input.handle.launchId,
+        );
       if (agent) return agent;
 
       if (Date.now() - lastFollowAttemptAt > 6_000) {
         lastFollowAttemptAt = Date.now();
-        await sendFollowCommand(input.sessionName, input.tmuxBaseArgs).catch(() => {
+        await sendFollowCommand(input.handle.tmuxSessionName, input.tmuxBaseArgs).catch(() => {
           // The session may still be starting; the loop retries until timeout.
         });
       }
@@ -661,12 +668,8 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       await sleep(Math.min(1_000, Math.max(1, deadline - Date.now())));
     }
 
-    throw new SubtreeSpawnRegistrationTimeoutError(input.timeoutMs, {
-      launchId: input.launchId,
-      tmuxSessionName: input.sessionName,
-      socketPath: input.socketPath,
-      state: "launched_unregistered",
-    });
+    fenceLaunch(input.broker, input.handle.launchId);
+    throw new SubtreeSpawnRegistrationTimeoutError(input.timeoutMs, input.handle);
   }
 
   async function requestChildExit(agent: AgentInfo): Promise<void> {
@@ -678,43 +681,14 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     try {
       await runTmuxCommand([...tmuxBaseArgs, "has-session", "-t", exactTarget]);
     } catch (error) {
-      if (error instanceof Error && isMissingExactTmuxTarget(error)) return;
+      if (error instanceof Error && isMissingTmuxTarget(error)) return;
       throw error;
     }
     try {
       await runTmuxCommand([...tmuxBaseArgs, "kill-session", "-t", exactTarget]);
     } catch (error) {
-      if (!(error instanceof Error) || !isMissingExactTmuxTarget(error)) throw error;
+      if (!(error instanceof Error) || !isMissingTmuxTarget(error)) throw error;
     }
-  }
-
-  async function cleanupSpawn(handle: SubtreeSpawnLaunchHandle): Promise<void> {
-    if (!activePaths || handle.socketPath !== activePaths.socketPath) {
-      throw new Error("spawn cleanup handle does not belong to this subtree broker");
-    }
-    const worker = spawnedWorkers.get(handle.launchId);
-    if (!worker) {
-      if (fencedLaunchIds.has(handle.launchId)) return;
-      throw new Error("spawn cleanup handle does not belong to this subtree broker");
-    }
-    if (worker.sessionName !== handle.tmuxSessionName) {
-      throw new Error("spawn cleanup handle does not match its recorded tmux session");
-    }
-
-    fencedLaunchIds.add(handle.launchId);
-    const tmuxBaseArgs = buildTmuxBaseArgs(worker.tmuxSocketPath);
-    await killTmuxSession(handle.tmuxSessionName, tmuxBaseArgs);
-
-    const broker = activeBroker;
-    const agentId = selfAgentId;
-    if (broker && agentId) {
-      for (const agent of broker.db.getAllAgents()) {
-        if (metadataString(agent.metadata, "launchId") === handle.launchId) {
-          broker.db.unregisterAgent(agent.id);
-        }
-      }
-    }
-    spawnedWorkers.delete(handle.launchId);
   }
 
   function childTmuxSessions(broker: Broker, agentId: string): string[] {
@@ -773,10 +747,10 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       activePaths = null;
       spawnedWorkers.clear();
       fencedLaunchIds.clear();
-      retrySpawns.clear();
     }
   }
 
+  // agent-standards-ignore prefer-inline-single-use-helper: single-flight start implementation
   async function startOnce(ctx: ExtensionContext): Promise<SubtreeBrokerStatus> {
     if (activeBroker) return getStatus();
 
@@ -897,23 +871,41 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     return brokerStartPromise;
   }
 
-  async function ensureSubtreeBroker(ctx: ExtensionContext): Promise<void> {
-    await start(ctx);
-  }
-
-  async function spawnWorkerOnce(
+  async function spawnWorker(
     ctx: ExtensionContext,
     input: SubtreeSpawnInput,
-    onLaunchAttempt?: () => void,
   ): Promise<SubtreeSpawnResult> {
     if (!input.task.trim()) throw new Error("spawn requires task");
     if (!input.repo.trim()) throw new Error("spawn requires repo");
-    await ensureSubtreeBroker(ctx);
+    await start(ctx);
     if (!activeBroker || !activePaths || !selfAgentId) {
       throw new Error("Subtree broker is not running.");
     }
     if (input.cleanupHandle) {
-      await cleanupSpawn(input.cleanupHandle);
+      const handle = input.cleanupHandle;
+      if (!activePaths || handle.socketPath !== activePaths.socketPath) {
+        throw new Error("spawn cleanup handle does not belong to this subtree broker");
+      }
+      const worker = spawnedWorkers.get(handle.launchId);
+      if (!worker) {
+        throw new Error(
+          fencedLaunchIds.has(handle.launchId)
+            ? "spawn cleanup handle has already been consumed"
+            : "spawn cleanup handle does not belong to this subtree broker",
+        );
+      }
+      if (worker.sessionName !== handle.tmuxSessionName) {
+        throw new Error("spawn cleanup handle does not match its recorded tmux session");
+      }
+
+      fenceLaunch(activeBroker, handle.launchId);
+      spawnedWorkers.delete(handle.launchId);
+      try {
+        await killTmuxSession(handle.tmuxSessionName, buildTmuxBaseArgs(worker.tmuxSocketPath));
+      } catch (error) {
+        spawnedWorkers.set(handle.launchId, worker);
+        throw error;
+      }
     }
 
     const socketPath = activePaths.socketPath;
@@ -944,8 +936,6 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       { mode: 0o700 },
     );
 
-    onLaunchAttempt?.();
-    await runTmuxCommand([...tmuxBaseArgs, "new-session", "-d", "-s", sessionName, launcherPath]);
     const workerRecord: SubtreeWorkerRecord = {
       launchId,
       sessionName,
@@ -957,13 +947,26 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       monitorCommand,
       tmuxSocketPath,
     };
+    const launchHandle: SubtreeSpawnLaunchHandle = {
+      launchId,
+      tmuxSessionName: sessionName,
+      socketPath,
+      state: "launched_unregistered",
+    };
     spawnedWorkers.set(launchId, workerRecord);
+    try {
+      await runTmuxCommand([...tmuxBaseArgs, "new-session", "-d", "-s", sessionName, launcherPath]);
+    } catch (error) {
+      fenceLaunch(activeBroker, launchId);
+      throw new SubtreeSpawnLaunchError(
+        error instanceof Error ? error : new Error(String(error)),
+        launchHandle,
+      );
+    }
 
     const agent = await waitForSpawnedAgent({
       broker: activeBroker,
-      launchId,
-      sessionName,
-      socketPath,
+      handle: launchHandle,
       tmuxBaseArgs,
       timeoutMs: input.waitForRegistrationMs ?? DEFAULT_SPAWN_REGISTRATION_TIMEOUT_MS,
     });
@@ -1025,29 +1028,6 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     };
   }
 
-  function spawnWorker(
-    ctx: ExtensionContext,
-    input: SubtreeSpawnInput,
-  ): Promise<SubtreeSpawnResult> {
-    const cleanupHandle = input.cleanupHandle;
-    if (!cleanupHandle) return spawnWorkerOnce(ctx, input);
-
-    const existingRetry = retrySpawns.get(cleanupHandle.launchId);
-    if (existingRetry) return existingRetry;
-
-    let replacementMayHaveLaunched = false;
-    const retry = spawnWorkerOnce(ctx, input, () => {
-      replacementMayHaveLaunched = true;
-    });
-    retrySpawns.set(cleanupHandle.launchId, retry);
-    void retry.catch(() => {
-      if (!replacementMayHaveLaunched && retrySpawns.get(cleanupHandle.launchId) === retry) {
-        retrySpawns.delete(cleanupHandle.launchId);
-      }
-    });
-    return retry;
-  }
-
   function getHibernationRuntimeControl(): SubtreeHibernationRuntimeControl | null {
     if (!activeBroker || !selfAgentId || !activePaths) return null;
     return {
@@ -1066,7 +1046,6 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     readInbox,
     sendMessage,
     listAgents,
-    cleanupSpawn,
     spawnWorker,
     isActive: () => activeBroker !== null,
   };


### PR DESCRIPTION
Fixes #943

## Acceptance criteria

1. **Single-flight broker startup:** `ensureSubtreeBroker()` shares one in-flight `start()` promise across cold concurrent spawns. The lifecycle test runs three `spawnWorker()` calls through `Promise.all`, asserts three distinct successes and one broker initialization.
2. **Durable timeout handle:** registration timeouts now throw `SubtreeSpawnRegistrationTimeoutError` with `{ launchId, tmuxSessionName, socketPath, state: "launched_unregistered" }`. The dispatcher exposes the handle in both error text and structured details; cleanup targets only the handle's tmux session. Runtime and tool tests cover both surfaces.
3. **Deterministic late registration — adopt:** roster/status reads adopt a late child by matching its broker registration metadata `launchId` to the timed-out launch record. Adoption preserves a child that reached the authoritative broker instead of destructively killing useful work solely because an observer timed out. A delayed-registration test asserts the child appears in the roster and updates the spawn record.
4. **Safe timeout retry:** `retry_handle` is forwarded to the runtime, which validates and cleans that launch before constructing and starting the replacement. The retry test asserts the original session is killed and exactly one child session remains live.
5. **Cheap precondition first:** `runPinetSpawnAction()` checks Pinet, follower role, active extension context, and launcher availability before reading or formatting the delegation payload. The test uses a throwing payload getter and asserts it is never touched in an uninitialized runtime.

## Verification

- `pnpm lint` — passed (all 11 packages plus agent standards)
- `pnpm typecheck` — passed (all 11 packages)
- `pnpm -C slack-bridge exec vitest run --config ../vitest.config.ts subtree-broker-runtime.test.ts pinet-tools.test.ts` — 2 files, 80 tests passed
- `pnpm -C slack-bridge test` — 92 files passed, 2 skipped; 1,639 tests passed, 3 skipped
- `pnpm test` — passed across the workspace (run by the pre-push hook)
