### PR TITLE
fix(slack-bridge): acknowledge subtree inbox delivery

### DIFF
--- a/slack-bridge/broker-delivery.ts
+++ b/slack-bridge/broker-delivery.ts
@@ -36,7 +36,23 @@ export function markBrokerInboxIdsHandled(
 export function getBrokerInboxIds(messages: InboxMessage[]): number[] {
   return [
     ...new Set(
-      messages.flatMap((message) => (message.brokerInboxId ? [message.brokerInboxId] : [])),
+      messages.flatMap((message) =>
+        message.brokerInboxId && message.brokerInboxOrigin !== "subtree"
+          ? [message.brokerInboxId]
+          : [],
+      ),
+    ),
+  ];
+}
+
+export function getSubtreeInboxIds(messages: InboxMessage[]): number[] {
+  return [
+    ...new Set(
+      messages.flatMap((message) =>
+        message.brokerInboxId && message.brokerInboxOrigin === "subtree"
+          ? [message.brokerInboxId]
+          : [],
+      ),
     ),
   ];
 }

--- a/slack-bridge/broker/hibernation-activation.e2e.test.ts
+++ b/slack-bridge/broker/hibernation-activation.e2e.test.ts
@@ -107,6 +107,7 @@ function makeDeps(stableId: string, settings: SlackBridgeSettings): SubtreeBroke
     getAgentMetadata: async () => ({}),
     getMeshRoleFromMetadata: (_metadata, fallback) => fallback ?? "worker",
     pushInboxMessages: () => {},
+    discardQueuedInboxMessages: () => {},
     updateBadge: () => {},
     maybeDrainInboxIfIdle: () => false,
     deliverSteeringMessage: () => false,

--- a/slack-bridge/broker/hibernation-production-route.test.ts
+++ b/slack-bridge/broker/hibernation-production-route.test.ts
@@ -99,6 +99,7 @@ function makeDeps(stableId: string, settings: SlackBridgeSettings): SubtreeBroke
     getAgentMetadata: async () => ({}),
     getMeshRoleFromMetadata: (_metadata, fallback) => fallback ?? "worker",
     pushInboxMessages: () => {},
+    discardQueuedInboxMessages: () => {},
     updateBadge: () => {},
     maybeDrainInboxIfIdle: () => false,
     deliverSteeringMessage: () => false,

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -245,6 +245,7 @@ export interface InboxMessage {
   timestamp: string;
   isChannelMention?: boolean;
   brokerInboxId?: number;
+  brokerInboxOrigin?: "subtree";
   metadata?: InboxMessageMetadata | null;
   scope?: RuntimeScopeCarrier | null;
 }

--- a/slack-bridge/inbox-drain-runtime.test.ts
+++ b/slack-bridge/inbox-drain-runtime.test.ts
@@ -23,6 +23,7 @@ function createDeps(overrides: Partial<InboxDrainRuntimeDeps> = {}) {
   const deliverTrackedSlackFollowUpMessage = vi.fn(() => true);
   const flushFollowerDeliveredAcks = vi.fn(async () => {});
   const markBrokerInboxIdsDelivered = vi.fn();
+  const markSubtreeInboxIdsDelivered = vi.fn();
   let securityPrompt = "";
   let brokerRole: "broker" | "follower" | null = null;
   let followerClient = true;
@@ -45,6 +46,7 @@ function createDeps(overrides: Partial<InboxDrainRuntimeDeps> = {}) {
     hasFollowerClient: () => followerClient,
     flushFollowerDeliveredAcks,
     markBrokerInboxIdsDelivered,
+    markSubtreeInboxIdsDelivered,
     getFollowerDeliveryState: () => followerDeliveryState,
     ...overrides,
   };
@@ -61,6 +63,7 @@ function createDeps(overrides: Partial<InboxDrainRuntimeDeps> = {}) {
     deliverTrackedSlackFollowUpMessage,
     flushFollowerDeliveredAcks,
     markBrokerInboxIdsDelivered,
+    markSubtreeInboxIdsDelivered,
     followerDeliveryState,
     setSecurityPrompt: (value: string) => {
       securityPrompt = value;
@@ -155,6 +158,26 @@ describe("createInboxDrainRuntime", () => {
     expect(flushFollowerDeliveredAcks).not.toHaveBeenCalled();
   });
 
+  it("acknowledges subtree ids only through the subtree runtime", () => {
+    const {
+      runtime,
+      inbox,
+      markBrokerInboxIdsDelivered,
+      markSubtreeInboxIdsDelivered,
+      setBrokerRole,
+    } = createDeps();
+    inbox.push(
+      createMessage({ brokerInboxId: 77 }),
+      createMessage({ brokerInboxId: 77, brokerInboxOrigin: "subtree" }),
+    );
+    setBrokerRole("broker");
+
+    runtime.drainInbox();
+
+    expect(markBrokerInboxIdsDelivered).toHaveBeenCalledWith([77]);
+    expect(markSubtreeInboxIdsDelivered).toHaveBeenCalledWith([77]);
+  });
+
   it("does not drain inbox work while the agent is active", () => {
     const {
       runtime,
@@ -177,10 +200,20 @@ describe("createInboxDrainRuntime", () => {
   });
 
   it("requeues pending inbox work when the follow-up delivery is not accepted", () => {
-    const { runtime, inbox, updateBadge, reportStatus, markBrokerInboxIdsDelivered } = createDeps({
+    const {
+      runtime,
+      inbox,
+      updateBadge,
+      reportStatus,
+      markBrokerInboxIdsDelivered,
+      markSubtreeInboxIdsDelivered,
+    } = createDeps({
       deliverTrackedSlackFollowUpMessage: vi.fn(() => false),
     });
-    const message = createMessage({ brokerInboxId: 88 });
+    const message = createMessage({
+      brokerInboxId: 88,
+      brokerInboxOrigin: "subtree",
+    });
     inbox.push(message);
 
     runtime.drainInbox();
@@ -188,6 +221,7 @@ describe("createInboxDrainRuntime", () => {
     expect(reportStatus).toHaveBeenCalledWith("working");
     expect(updateBadge).toHaveBeenCalledTimes(2);
     expect(markBrokerInboxIdsDelivered).not.toHaveBeenCalled();
+    expect(markSubtreeInboxIdsDelivered).not.toHaveBeenCalled();
     expect(inbox).toEqual([message]);
   });
 

--- a/slack-bridge/inbox-drain-runtime.test.ts
+++ b/slack-bridge/inbox-drain-runtime.test.ts
@@ -168,14 +168,14 @@ describe("createInboxDrainRuntime", () => {
     } = createDeps();
     inbox.push(
       createMessage({ brokerInboxId: 77 }),
-      createMessage({ brokerInboxId: 77, brokerInboxOrigin: "subtree" }),
+      createMessage({ brokerInboxId: 78, brokerInboxOrigin: "subtree" }),
     );
     setBrokerRole("broker");
 
     runtime.drainInbox();
 
     expect(markBrokerInboxIdsDelivered).toHaveBeenCalledWith([77]);
-    expect(markSubtreeInboxIdsDelivered).toHaveBeenCalledWith([77]);
+    expect(markSubtreeInboxIdsDelivered).toHaveBeenCalledWith([78]);
   });
 
   it("does not drain inbox work while the agent is active", () => {
@@ -200,14 +200,7 @@ describe("createInboxDrainRuntime", () => {
   });
 
   it("requeues pending inbox work when the follow-up delivery is not accepted", () => {
-    const {
-      runtime,
-      inbox,
-      updateBadge,
-      reportStatus,
-      markBrokerInboxIdsDelivered,
-      markSubtreeInboxIdsDelivered,
-    } = createDeps({
+    const { runtime, inbox, updateBadge, reportStatus, markSubtreeInboxIdsDelivered } = createDeps({
       deliverTrackedSlackFollowUpMessage: vi.fn(() => false),
     });
     const message = createMessage({
@@ -220,7 +213,6 @@ describe("createInboxDrainRuntime", () => {
 
     expect(reportStatus).toHaveBeenCalledWith("working");
     expect(updateBadge).toHaveBeenCalledTimes(2);
-    expect(markBrokerInboxIdsDelivered).not.toHaveBeenCalled();
     expect(markSubtreeInboxIdsDelivered).not.toHaveBeenCalled();
     expect(inbox).toEqual([message]);
   });

--- a/slack-bridge/inbox-drain-runtime.ts
+++ b/slack-bridge/inbox-drain-runtime.ts
@@ -97,11 +97,7 @@ export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrain
         }
       }
       if (subtreeInboxIds.length > 0) {
-        try {
-          deps.markSubtreeInboxIdsDelivered(subtreeInboxIds);
-        } catch {
-          /* best effort */
-        }
+        deps.markSubtreeInboxIdsDelivered(subtreeInboxIds);
       }
       return;
     }

--- a/slack-bridge/inbox-drain-runtime.ts
+++ b/slack-bridge/inbox-drain-runtime.ts
@@ -1,4 +1,4 @@
-import { getBrokerInboxIds } from "./broker-delivery.js";
+import { getBrokerInboxIds, getSubtreeInboxIds } from "./broker-delivery.js";
 import { markFollowerInboxIdsDelivered, type FollowerDeliveryState } from "./follower-delivery.js";
 import { formatInboxMessages, type InboxMessage } from "./helpers.js";
 
@@ -21,6 +21,7 @@ export interface InboxDrainRuntimeDeps {
   hasFollowerClient: () => boolean;
   flushFollowerDeliveredAcks: () => Promise<void>;
   markBrokerInboxIdsDelivered: (inboxIds: number[]) => void;
+  markSubtreeInboxIdsDelivered: (inboxIds: number[]) => void;
   getFollowerDeliveryState: () => FollowerDeliveryState;
   maxMessagesPerDrain?: number;
 }
@@ -65,6 +66,7 @@ export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrain
     }
 
     const brokerInboxIds = getBrokerInboxIds(pending);
+    const subtreeInboxIds = getSubtreeInboxIds(pending);
     deps.updateBadge();
     void deps.reportStatus("working").catch(() => {
       /* best effort */
@@ -92,6 +94,13 @@ export function createInboxDrainRuntime(deps: InboxDrainRuntimeDeps): InboxDrain
           } catch {
             /* best effort */
           }
+        }
+      }
+      if (subtreeInboxIds.length > 0) {
+        try {
+          deps.markSubtreeInboxIdsDelivered(subtreeInboxIds);
+        } catch {
+          /* best effort */
         }
       }
       return;

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1308,6 +1308,9 @@ export default function (pi: ExtensionAPI) {
       getAgentOwnerToken: () => agentOwnerToken,
       getLastDmChannel: () => lastDmChannel,
       updateBadge,
+      markSubtreeInboxIdsDelivered: (inboxIds) => {
+        subtreeBrokerRuntime.markDelivered(inboxIds);
+      },
       resolveUser,
       threadContext: singlePlayerRuntime.getThreadContextPort(),
       resolveChannel,

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -272,6 +272,9 @@ export default function (pi: ExtensionAPI) {
     markBrokerInboxIdsDelivered: (inboxIds) => {
       brokerRuntime.markDelivered(inboxIds);
     },
+    markSubtreeInboxIdsDelivered: (inboxIds) => {
+      subtreeBrokerRuntime.markDelivered(inboxIds);
+    },
     getFollowerDeliveryState: () => followerDeliveryState,
   });
   const { deliverFollowUpMessage, flushDeliveredFollowerAcks, drainInbox } = inboxDrainRuntime;
@@ -590,6 +593,11 @@ export default function (pi: ExtensionAPI) {
       getMeshRoleFromMetadata(metadata, fallbackRole),
     pushInboxMessages: (messages) => {
       inbox.push(...messages);
+    },
+    discardQueuedInboxMessages: () => {
+      for (let index = inbox.length - 1; index >= 0; index -= 1) {
+        if (inbox[index]?.brokerInboxOrigin === "subtree") inbox.splice(index, 1);
+      }
     },
     updateBadge,
     maybeDrainInboxIfIdle,

--- a/slack-bridge/slack-tools.test.ts
+++ b/slack-bridge/slack-tools.test.ts
@@ -261,6 +261,7 @@ describe("registerSlackTools", () => {
     const noteThreadReply = vi.fn();
     const clearPendingAttention = vi.fn();
     const requireToolPolicy = vi.fn();
+    const markSubtreeInboxIdsDelivered = vi.fn();
     let pinetDeliveryEnabled = true;
     let pinetDeliveryAvailable = false;
     const sendPinetSlackMessage = vi.fn(async (input: SlackPinetDeliveryInput) => ({
@@ -282,6 +283,7 @@ describe("registerSlackTools", () => {
       getAgentOwnerToken: () => "owner:test-token",
       getLastDmChannel: () => lastDmChannel,
       updateBadge: () => {},
+      markSubtreeInboxIdsDelivered,
       resolveUser: async (userId) => resolveUser(userId),
       threadContext: {
         resolveThreadChannel: (threadTs) => resolveThreadChannel(threadTs),
@@ -385,6 +387,7 @@ describe("registerSlackTools", () => {
       noteThreadReply,
       clearPendingAttention,
       requireToolPolicy,
+      markSubtreeInboxIdsDelivered,
       setPinetDeliveryEnabled: (value: boolean) => {
         pinetDeliveryEnabled = value;
       },
@@ -410,6 +413,23 @@ describe("registerSlackTools", () => {
     const response = await tools.get("slack_inbox")!.execute("tool-1", {});
     expect(response.content?.[0]?.text).toContain("UPDATED SECURITY PROMPT");
     expect(response.content?.[0]?.text).not.toContain("INITIAL SECURITY PROMPT");
+  });
+
+  it("acknowledges subtree messages consumed through slack_inbox", async () => {
+    const { inbox, tools, markSubtreeInboxIdsDelivered } = setup();
+    inbox.push({
+      channel: "pinet",
+      threadTs: "a2a:sender:subbroker",
+      userId: "sender",
+      text: "finished the task",
+      timestamp: "123.456",
+      brokerInboxId: 42,
+      brokerInboxOrigin: "subtree",
+    });
+
+    await tools.get("slack_inbox")!.execute("tool-subtree-inbox", {});
+
+    expect(markSubtreeInboxIdsDelivered).toHaveBeenCalledWith([42]);
   });
 
   it("reads the latest bot token and default channel when slack_post_channel executes", async () => {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -1780,11 +1780,7 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
 
       const subtreeInboxIds = getSubtreeInboxIds(pending);
       if (subtreeInboxIds.length > 0) {
-        try {
-          deps.markSubtreeInboxIdsDelivered(subtreeInboxIds);
-        } catch {
-          /* best effort */
-        }
+        deps.markSubtreeInboxIdsDelivered(subtreeInboxIds);
       }
 
       return {

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -5,6 +5,7 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
+import { getSubtreeInboxIds } from "./broker-delivery.js";
 import type { InboxMessage } from "./helpers.js";
 import type { SlackResult } from "./slack-api.js";
 import {
@@ -96,6 +97,7 @@ export interface RegisterSlackToolsDeps {
   getAgentOwnerToken: () => string;
   getLastDmChannel: () => string | null;
   updateBadge: () => void;
+  markSubtreeInboxIdsDelivered: (inboxIds: number[]) => void;
   resolveUser: (userId: string) => Promise<string>;
   threadContext: SlackToolsThreadContextPort;
   resolveChannel: (nameOrId: string) => Promise<string>;
@@ -1774,6 +1776,15 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
                 ? ` | metadata.kind=${String(message.metadata.kind)}`
                 : "";
         lines.push(`${prefix} (${message.timestamp}): ${message.text}${metadataSuffix}`);
+      }
+
+      const subtreeInboxIds = getSubtreeInboxIds(pending);
+      if (subtreeInboxIds.length > 0) {
+        try {
+          deps.markSubtreeInboxIdsDelivered(subtreeInboxIds);
+        } catch {
+          /* best effort */
+        }
       }
 
       return {

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { PinetControlCommand, SlackBridgeSettings } from "./helpers.js";
+import type { InboxMessage, PinetControlCommand, SlackBridgeSettings } from "./helpers.js";
 import {
   buildSubtreeBrokerPaths,
   createSubtreeBrokerRuntime,
@@ -16,6 +16,7 @@ const roots: string[] = [];
 function createRuntime(
   deliverSteeringMessage: SubtreeBrokerRuntimeDeps["deliverSteeringMessage"],
   stableId = `compaction-gate-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+  queuedInbox: InboxMessage[] = [],
 ): {
   runtime: SubtreeBrokerRuntime;
   stableId: string;
@@ -28,7 +29,12 @@ function createRuntime(
     getAgentIdentity: () => ({ name: "Test", emoji: "🧪" }),
     getAgentMetadata: async () => ({}),
     getMeshRoleFromMetadata: (_metadata, fallback) => fallback ?? "worker",
-    pushInboxMessages: () => {},
+    pushInboxMessages: (messages) => queuedInbox.push(...messages),
+    discardQueuedInboxMessages: () => {
+      for (let index = queuedInbox.length - 1; index >= 0; index -= 1) {
+        if (queuedInbox[index]?.brokerInboxOrigin === "subtree") queuedInbox.splice(index, 1);
+      }
+    },
     updateBadge: () => {},
     maybeDrainInboxIfIdle: () => false,
     deliverSteeringMessage,
@@ -72,6 +78,43 @@ function queueSteeringMessage(runtime: SubtreeBrokerRuntime): string {
 afterEach(async () => {
   await Promise.all(runtimes.splice(0).map((runtime) => runtime.stop({ releaseIdentity: true })));
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("subtree broker inbox delivery", () => {
+  it("queues each regular inbox entry once and recovers it across restart", async () => {
+    const queuedInbox: InboxMessage[] = [];
+    const first = createRuntime(() => false, undefined, queuedInbox);
+    await first.runtime.start(ctx);
+    const control = first.runtime.getHibernationRuntimeControl();
+    if (!control) throw new Error("subtree broker did not start");
+    const selfId = first.runtime.getStatus().selfAgentId;
+    if (!selfId) throw new Error("subtree broker has no self id");
+    const threadId = `a2a:sender:${selfId}`;
+    control.db.createThread(threadId, "agent", "", selfId);
+    control.db.insertMessage(threadId, "agent", "inbound", "sender", "finished the task", [selfId]);
+
+    first.runtime.drainInbox(ctx);
+    first.runtime.drainInbox(ctx);
+
+    expect(queuedInbox).toHaveLength(1);
+    expect(queuedInbox[0]?.brokerInboxOrigin).toBe("subtree");
+    expect(control.db.getPendingInboxCount(selfId)).toBe(1);
+
+    await first.runtime.stop({ releaseIdentity: true });
+    expect(queuedInbox).toHaveLength(0);
+
+    const { runtime: restarted } = createRuntime(() => false, first.stableId, queuedInbox);
+    await restarted.start(ctx);
+    restarted.drainInbox(ctx);
+    expect(queuedInbox).toHaveLength(1);
+
+    const inboxId = queuedInbox[0]?.brokerInboxId;
+    if (inboxId == null) throw new Error("queued message has no inbox id");
+    restarted.markDelivered([inboxId]);
+
+    expect(restarted.getHibernationRuntimeControl()?.db.getPendingInboxCount(selfId)).toBe(0);
+    expect(restarted.readInbox()?.messages).toHaveLength(1);
+  });
 });
 
 describe("subtree broker compaction delivery retry", () => {

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -113,7 +113,6 @@ describe("subtree broker inbox delivery", () => {
     restarted.markDelivered([inboxId]);
 
     expect(restarted.getHibernationRuntimeControl()?.db.getPendingInboxCount(selfId)).toBe(0);
-    expect(restarted.readInbox()?.messages).toHaveLength(1);
   });
 });
 

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -115,16 +115,21 @@ describe("subtree broker inbox delivery", () => {
     await first.runtime.stop({ releaseIdentity: true, stopChildren: false });
     expect(queuedInbox).toHaveLength(0);
 
-    const { runtime: restarted } = createRuntime(() => false, first.stableId, deliveryDeps);
-    await restarted.start(ctx);
-    restarted.drainInbox(ctx);
-    expect(queuedInbox).toHaveLength(1);
+    const second = createRuntime(() => false, first.stableId, {
+      ...deliveryDeps,
+      maybeDrainInboxIfIdle: () => {
+        const inboxIds = queuedInbox.flatMap((message) =>
+          message.brokerInboxId == null ? [] : [message.brokerInboxId],
+        );
+        second.runtime.markDelivered(inboxIds);
+        queuedInbox.length = 0;
+        return true;
+      },
+    });
+    await second.runtime.start(ctx);
 
-    const inboxId = queuedInbox[0]?.brokerInboxId;
-    if (inboxId == null) throw new Error("queued message has no inbox id");
-    restarted.markDelivered([inboxId]);
-
-    expect(restarted.getHibernationRuntimeControl()?.db.getPendingInboxCount(selfId)).toBe(0);
+    expect(queuedInbox).toHaveLength(0);
+    expect(second.runtime.getHibernationRuntimeControl()?.db.getPendingInboxCount(selfId)).toBe(0);
   });
 });
 

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -883,6 +883,8 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       selfAgentId = null;
       startedAt = null;
       activePaths = null;
+      deps.discardQueuedInboxMessages();
+      pendingInboxIds.clear();
       await broker.stop().catch(() => undefined);
       throw error;
     }

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -885,6 +885,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       activePaths = null;
       deps.discardQueuedInboxMessages();
       pendingInboxIds.clear();
+      deps.updateBadge();
       await broker.stop().catch(() => undefined);
       throw error;
     }

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -130,6 +130,7 @@ export interface SubtreeBrokerRuntimeDeps {
     fallback?: "broker" | "worker",
   ) => "broker" | "worker";
   pushInboxMessages: (messages: InboxMessage[]) => void;
+  discardQueuedInboxMessages: () => void;
   updateBadge: () => void;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
   deliverSteeringMessage: (text: string, ctx: ExtensionContext) => boolean;
@@ -165,6 +166,7 @@ export interface SubtreeBrokerRuntime {
   stop: (options?: { releaseIdentity?: boolean; stopChildren?: boolean }) => Promise<void>;
   getStatus: () => SubtreeBrokerStatus;
   drainInbox: (ctx: ExtensionContext) => void;
+  markDelivered: (inboxIds: number[]) => void;
   readInbox: (options?: PinetReadOptions) => PinetReadResult | null;
   sendMessage: (
     target: string,
@@ -414,6 +416,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   let activePaths: SubtreeBrokerPaths | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   const spawnedWorkers = new Map<string, SubtreeWorkerRecord>();
+  const pendingInboxIds = new Set<number>();
 
   function stopHeartbeat(): void {
     if (!heartbeatTimer) return;
@@ -459,7 +462,10 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   }
 
   function drainSelfInbox(ctx: ExtensionContext, broker: Broker, agentId: string): void {
-    const entries = broker.db.getInbox(agentId).map(toFollowerInboxEntry);
+    const entries = broker.db
+      .getInbox(agentId)
+      .filter((item) => !pendingInboxIds.has(item.entry.id))
+      .map(toFollowerInboxEntry);
     if (entries.length === 0) return;
 
     const synced = syncBrokerInboxEntries(entries);
@@ -498,7 +504,14 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     }
 
     if (synced.inboxMessages.length === 0) return;
-    deps.pushInboxMessages(synced.inboxMessages);
+    const inboxMessages = synced.inboxMessages.map((message) => ({
+      ...message,
+      brokerInboxOrigin: "subtree" as const,
+    }));
+    deps.pushInboxMessages(inboxMessages);
+    for (const message of inboxMessages) {
+      if (message.brokerInboxId != null) pendingInboxIds.add(message.brokerInboxId);
+    }
     deps.updateBadge();
     deps.maybeDrainInboxIfIdle(ctx);
   }
@@ -506,6 +519,12 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
   function drainInbox(ctx: ExtensionContext): void {
     if (!activeBroker || !selfAgentId) return;
     drainSelfInbox(ctx, activeBroker, selfAgentId);
+  }
+
+  function markDelivered(inboxIds: number[]): void {
+    if (!activeBroker || !selfAgentId) return;
+    activeBroker.db.markDelivered(inboxIds, selfAgentId);
+    for (const inboxId of inboxIds) pendingInboxIds.delete(inboxId);
   }
 
   function readInbox(options: PinetReadOptions = {}): PinetReadResult | null {
@@ -674,6 +693,9 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
       startedAt = null;
       activePaths = null;
       spawnedWorkers.clear();
+      deps.discardQueuedInboxMessages();
+      pendingInboxIds.clear();
+      deps.updateBadge();
     }
   }
 
@@ -918,6 +940,7 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
     stop,
     getStatus,
     drainInbox,
+    markDelivered,
     readInbox,
     sendMessage,
     listAgents,

--- a/slack-bridge/subtree-broker-runtime.ts
+++ b/slack-bridge/subtree-broker-runtime.ts
@@ -866,18 +866,23 @@ export function createSubtreeBrokerRuntime(deps: SubtreeBrokerRuntimeDeps): Subt
         drainSelfInbox(ctx, broker, selfAgent.id);
       });
 
-      broker.db.recoverPendingTargetedBacklog(selfAgent.id);
-      drainSelfInbox(ctx, broker, selfAgent.id);
-      broker.db.setSetting("pinet.subtreeBrokerParentStableId", deps.getAgentStableId());
-      broker.db.setSetting("pinet.subtreeBrokerOwnerToken", buildPinetOwnerToken(stableId));
-
       activeBroker = broker;
       selfAgentId = selfAgent.id;
       startedAt = new Date().toISOString();
       activePaths = paths;
       startHeartbeat(broker, selfAgent.id);
+
+      broker.db.recoverPendingTargetedBacklog(selfAgent.id);
+      drainSelfInbox(ctx, broker, selfAgent.id);
+      broker.db.setSetting("pinet.subtreeBrokerParentStableId", deps.getAgentStableId());
+      broker.db.setSetting("pinet.subtreeBrokerOwnerToken", buildPinetOwnerToken(stableId));
       return getStatus();
     } catch (error) {
+      stopHeartbeat();
+      activeBroker = null;
+      selfAgentId = null;
+      startedAt = null;
+      activePaths = null;
       await broker.stop().catch(() => undefined);
       throw error;
     }


### PR DESCRIPTION
## Summary
- track queued subtree inbox rows to prevent repeated prompt injection
- defer subtree delivery acknowledgement until prompt injection succeeds
- route subtree inbox IDs separately from central broker/follower IDs
- discard volatile subtree queue entries on stop so restart recovery remains single-source

## Verification
- 
> @pinet/slack-bridge@0.2.4 test /Users/tmnexcade/projects/extensions/.worktrees/fix-959-subtree-inbox/slack-bridge
> vitest run --config ../vitest.config.ts


 RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-959-subtree-inbox/slack-bridge


 Test Files  92 passed | 2 skipped (94)
      Tests  1634 passed | 3 skipped (1637)
   Start at  13:30:25
   Duration  4.59s (transform 5.35s, setup 0ms, import 10.71s, tests 15.98s, environment 5ms) (1,634 passed, 3 skipped)
- 
> @pinet/slack-bridge@0.2.4 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-959-subtree-inbox/slack-bridge
> tsc --noEmit
- 
> @pinet/slack-bridge@0.2.4 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-959-subtree-inbox/slack-bridge
> eslint . --ext .ts
- 
> pi-extensions@0.2.4 lint:agent-standards /Users/tmnexcade/projects/extensions/.worktrees/fix-959-subtree-inbox
> node ./scripts/agent-standards-lint.mjs

Closes #959