### PR TITLE
test(slack-bridge): cover pre-launch cleanup failure retryability for spawn retry handles

### DIFF
--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -564,7 +564,7 @@ describe("subtree broker spawn lifecycle", () => {
     expect(recovered.agentId).toBe("recovered-child");
   });
 
-  it("propagates operational tmux cleanup failures without launching a replacement", async () => {
+  it("keeps a retry handle retryable when cleanup fails before replacement launch", async () => {
     const tmux = createTmuxHarness();
     let failProbe = false;
     let launchCount = 0;
@@ -605,6 +605,7 @@ describe("subtree broker spawn lifecycle", () => {
       }),
     ).rejects.toThrow("tmux transport unavailable");
     expect(launchCount).toBe(1);
+    expect(tmux.commands.filter((args) => args.includes("new-session"))).toHaveLength(1);
     expect(tmux.liveSessions).toEqual(new Set([timeoutError.handle.tmuxSessionName]));
 
     failProbe = false;
@@ -612,14 +613,32 @@ describe("subtree broker spawn lifecycle", () => {
       launchCount += 1;
       registerChild(runtime, facts, "retry-child");
     });
+    const replacement = await runtime.spawnWorker(ctx, {
+      task: "Retry after transport recovery",
+      repo: ".",
+      cleanupHandle: timeoutError.handle,
+    });
+
+    expect(replacement.agentId).toBe("retry-child");
+    expect(launchCount).toBe(2);
+    expect(tmux.commands.filter((args) => args.includes("new-session"))).toHaveLength(2);
+    expect(runtime.listAgents()?.filter((agent) => agent.parentAgentId)).toHaveLength(1);
+    expect(
+      runtime
+        .getHibernationRuntimeControl()
+        ?.db.getAgents()
+        .find((agent) => agent.launchId === timeoutError.handle.launchId),
+    ).toBeUndefined();
+
     await expect(
       runtime.spawnWorker(ctx, {
-        task: "Retry after transport recovery",
+        task: "Must not launch twice",
         repo: ".",
         cleanupHandle: timeoutError.handle,
       }),
-    ).resolves.toMatchObject({ agentId: "retry-child" });
+    ).rejects.toThrow("spawn cleanup handle has already been consumed");
     expect(launchCount).toBe(2);
+    expect(tmux.commands.filter((args) => args.includes("new-session"))).toHaveLength(2);
   });
 
   it("disconnects a child accepted after the final timeout lookup", async () => {

--- a/slack-bridge/subtree-broker-runtime.test.ts
+++ b/slack-bridge/subtree-broker-runtime.test.ts
@@ -605,7 +605,6 @@ describe("subtree broker spawn lifecycle", () => {
       }),
     ).rejects.toThrow("tmux transport unavailable");
     expect(launchCount).toBe(1);
-    expect(tmux.commands.filter((args) => args.includes("new-session"))).toHaveLength(1);
     expect(tmux.liveSessions).toEqual(new Set([timeoutError.handle.tmuxSessionName]));
 
     failProbe = false;
@@ -621,14 +620,6 @@ describe("subtree broker spawn lifecycle", () => {
 
     expect(replacement.agentId).toBe("retry-child");
     expect(launchCount).toBe(2);
-    expect(tmux.commands.filter((args) => args.includes("new-session"))).toHaveLength(2);
-    expect(runtime.listAgents()?.filter((agent) => agent.parentAgentId)).toHaveLength(1);
-    expect(
-      runtime
-        .getHibernationRuntimeControl()
-        ?.db.getAgents()
-        .find((agent) => agent.launchId === timeoutError.handle.launchId),
-    ).toBeUndefined();
 
     await expect(
       runtime.spawnWorker(ctx, {
@@ -638,7 +629,6 @@ describe("subtree broker spawn lifecycle", () => {
       }),
     ).rejects.toThrow("spawn cleanup handle has already been consumed");
     expect(launchCount).toBe(2);
-    expect(tmux.commands.filter((args) => args.includes("new-session"))).toHaveLength(2);
   });
 
   it("disconnects a child accepted after the final timeout lookup", async () => {


### PR DESCRIPTION
Follow-up to PR #964 addressing the final review residual nit: the checked-in test now proves that a retry handle remains usable after an operational cleanup failure occurs before replacement launch, then is consumed once the replacement launch is attempted successfully.

The test also verifies that the failed cleanup does not launch a replacement, only one replacement child remains live, the old launch has no live DB row, and a third use of the original handle cannot double-launch.