### PR TITLE
fix(slack-bridge): block mutating pinet:lanes operations under read-only guardrails

### DIFF
--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -146,6 +146,7 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("pinet:schedule")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:snooze")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:spawn")).toBe(true);
+    expect(WRITE_TOOLS.has("pinet:lanes:write")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:free")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:ports")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:reload")).toBe(true);
@@ -174,6 +175,10 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("pinet_snooze", g)).toBe(true);
     expect(isToolBlocked("pinet:spawn", g)).toBe(true);
     expect(isToolBlocked("pinet_spawn", g)).toBe(true);
+    expect(isToolBlocked("pinet:lanes:write", g)).toBe(true);
+    expect(isToolBlocked("pinet_lanes:write", g)).toBe(true);
+    expect(isToolBlocked("pinet:lanes", g)).toBe(false);
+    expect(isToolBlocked("pinet_lanes", g)).toBe(false);
     expect(isToolBlocked("pinet:ports", g)).toBe(true);
     expect(isToolBlocked("pinet:reload", g)).toBe(true);
     expect(isToolBlocked("pinet:exit", g)).toBe(true);

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -68,6 +68,7 @@ describe("matchesToolPattern", () => {
   it("matches legacy Pinet underscore guardrail patterns against dispatcher action names", () => {
     expect(matchesToolPattern("pinet:send", ["pinet_send"])).toBe(true);
     expect(matchesToolPattern("pinet_read", ["pinet:read"])).toBe(true);
+    expect(matchesToolPattern("pinet:lanes:write", ["pinet_lanes:write"])).toBe(true);
   });
 
   it("treats former pinet_message policies as send guardrail aliases", () => {
@@ -155,6 +156,7 @@ describe("isToolBlocked", () => {
     expect(WRITE_TOOLS.has("pinet_message")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:read")).toBe(true);
     expect(READ_ONLY_TOOLS.has("pinet:agents")).toBe(true);
+    expect(READ_ONLY_TOOLS.has("pinet:lanes")).toBe(true);
     expect(WRITE_TOOLS.has("pinet:read")).toBe(false);
     expect(WRITE_TOOLS.has("pinet:agents")).toBe(false);
     expect(READ_ONLY_TOOLS.has("pinet:send")).toBe(false);
@@ -187,13 +189,6 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("pinet_send", g)).toBe(true);
     expect(isToolBlocked("pinet:read", g)).toBe(false);
     expect(isToolBlocked("pinet_read", g)).toBe(false);
-  });
-
-  it("cross-matches canonical and legacy lanes write aliases in blockedTools", () => {
-    expect(isToolBlocked("pinet:lanes:write", { blockedTools: ["pinet:lanes:write"] })).toBe(true);
-    expect(isToolBlocked("pinet_lanes:write", { blockedTools: ["pinet_lanes:write"] })).toBe(true);
-    expect(isToolBlocked("pinet:lanes:write", { blockedTools: ["pinet_lanes:write"] })).toBe(true);
-    expect(isToolBlocked("pinet_lanes:write", { blockedTools: ["pinet:lanes:write"] })).toBe(true);
   });
 
   it("combines readOnly and blockedTools", () => {
@@ -336,6 +331,7 @@ describe("buildSecurityPrompt", () => {
     // Should mention allowed tools
     expect(prompt).toContain("read");
     expect(prompt).toContain("slack_send");
+    expect(prompt).toContain("pinet:agents, pinet:lanes, pinet:read");
   });
 
   it("includes blocked tools section", () => {

--- a/slack-bridge/guardrails.test.ts
+++ b/slack-bridge/guardrails.test.ts
@@ -189,6 +189,13 @@ describe("isToolBlocked", () => {
     expect(isToolBlocked("pinet_read", g)).toBe(false);
   });
 
+  it("cross-matches canonical and legacy lanes write aliases in blockedTools", () => {
+    expect(isToolBlocked("pinet:lanes:write", { blockedTools: ["pinet:lanes:write"] })).toBe(true);
+    expect(isToolBlocked("pinet_lanes:write", { blockedTools: ["pinet_lanes:write"] })).toBe(true);
+    expect(isToolBlocked("pinet:lanes:write", { blockedTools: ["pinet_lanes:write"] })).toBe(true);
+    expect(isToolBlocked("pinet_lanes:write", { blockedTools: ["pinet:lanes:write"] })).toBe(true);
+  });
+
   it("combines readOnly and blockedTools", () => {
     const g: SecurityGuardrails = { readOnly: true, blockedTools: ["slack_create_channel"] };
     expect(isToolBlocked("bash", g)).toBe(true); // write tool + readOnly

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -21,6 +21,7 @@ export const READ_ONLY_TOOLS = new Set([
   "slack:canvas_comments_read",
   "slack:confirm_action",
   "pinet:agents",
+  "pinet:lanes",
   "pinet:read",
   "memory_read",
   "memory_search",

--- a/slack-bridge/guardrails.ts
+++ b/slack-bridge/guardrails.ts
@@ -56,6 +56,7 @@ export const WRITE_TOOLS = new Set([
   "pinet:send",
   "pinet:snooze",
   "pinet:spawn",
+  "pinet:lanes:write",
   "pinet:free",
   "pinet:ports",
   "pinet:reload",

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -13,6 +13,7 @@ import {
   SubtreeSpawnLaunchError,
   SubtreeSpawnRegistrationTimeoutError,
 } from "./subtree-broker-runtime.js";
+import { isToolBlocked } from "./guardrails.js";
 
 interface MinimalRenderTheme {
   fg: (_color: string, text: string) => string;
@@ -1359,6 +1360,59 @@ describe("registerPinetTools", () => {
       "Pinet wake-up scheduled for 2026-04-14T12:05:00.000Z (id 7).",
     );
     expect(result.details.data.details).toEqual({ id: 7, fireAt: "2026-04-14T12:05:00.000Z" });
+  });
+
+  it("blocks lane mutations but permits lane listing with read-only guardrails", async () => {
+    const requireToolPolicy = vi.fn(
+      (toolName: string, _threadTs: string | undefined, _context: string) => {
+        if (isToolBlocked(toolName, { readOnly: true })) {
+          throw new Error(`Tool "${toolName}" is blocked by read-only guardrails.`);
+        }
+      },
+    );
+    const listPinetLanes = vi.fn(createDeps().listPinetLanes);
+    const upsertPinetLane = vi.fn(createDeps().upsertPinetLane);
+    const setPinetLaneParticipant = vi.fn(createDeps().setPinetLaneParticipant);
+    const tools = registerWithDeps(
+      createDeps({
+        requireToolPolicy,
+        listPinetLanes,
+        upsertPinetLane,
+        setPinetLaneParticipant,
+      }),
+    );
+
+    const listResult = (await tools.get("pinet")?.execute("tool-call-lane-list-read-only", {
+      action: "lanes",
+      args: { op: "list" },
+    })) as { details: { status: string } };
+    const upsertResult = (await tools.get("pinet")?.execute("tool-call-lane-upsert-read-only", {
+      action: "lanes",
+      args: { op: "upsert", lane_id: "issue-965" },
+    })) as { details: { status: string } };
+    const participantResult = (await tools
+      .get("pinet")
+      ?.execute("tool-call-lane-participant-read-only", {
+        action: "lanes",
+        args: { op: "participant", lane_id: "issue-965", agent_id: "worker-1" },
+      })) as { details: { status: string } };
+
+    expect(listResult.details.status).toBe("succeeded");
+    expect(upsertResult.details.status).toBe("failed");
+    expect(participantResult.details.status).toBe("failed");
+    expect(listPinetLanes).toHaveBeenCalledOnce();
+    expect(upsertPinetLane).not.toHaveBeenCalled();
+    expect(setPinetLaneParticipant).not.toHaveBeenCalled();
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "pinet:lanes:write",
+      undefined,
+      "op=upsert | format=cli",
+    );
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "pinet:lanes:write",
+      undefined,
+      "op=participant | format=cli",
+    );
   });
 
   it("updates durable PM lane metadata through the lanes dispatcher", async () => {

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -1408,6 +1408,21 @@ describe("registerPinetTools", () => {
     expect(upsertPinetLane).not.toHaveBeenCalled();
     expect(setPinetLaneParticipant).not.toHaveBeenCalled();
     expect(requireToolPolicy).toHaveBeenCalledWith(
+      "pinet:lanes",
+      undefined,
+      "op=list | format=cli",
+    );
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "pinet:lanes",
+      undefined,
+      "op=upsert | format=cli",
+    );
+    expect(requireToolPolicy).toHaveBeenCalledWith(
+      "pinet:lanes",
+      undefined,
+      "op=participant | format=cli",
+    );
+    expect(requireToolPolicy).toHaveBeenCalledWith(
       "pinet:lanes:write",
       undefined,
       "op=upsert | format=cli",

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -1004,7 +1004,11 @@ describe("registerPinetTools", () => {
         expect.objectContaining({ action: "schedule", guardrail_tool: "pinet:schedule" }),
         expect.objectContaining({ action: "agents", guardrail_tool: "pinet:agents" }),
         expect.objectContaining({ action: "sessions", guardrail_tool: "pinet:sessions" }),
-        expect.objectContaining({ action: "lanes", guardrail_tool: "pinet:lanes" }),
+        expect.objectContaining({
+          action: "lanes",
+          guardrail_tool: "pinet:lanes",
+          description: expect.stringContaining("pinet:lanes:write"),
+        }),
         expect.objectContaining({ action: "ports", guardrail_tool: "pinet:ports" }),
       ]),
     );

--- a/slack-bridge/pinet-tools.test.ts
+++ b/slack-bridge/pinet-tools.test.ts
@@ -1392,13 +1392,18 @@ describe("registerPinetTools", () => {
     })) as { details: { status: string } };
     const upsertResult = (await tools.get("pinet")?.execute("tool-call-lane-upsert-read-only", {
       action: "lanes",
-      args: { op: "upsert", lane_id: "issue-965" },
+      args: { op: "upsert", lane_id: "issue-965", thread_ts: "123.456" },
     })) as { details: { status: string } };
     const participantResult = (await tools
       .get("pinet")
       ?.execute("tool-call-lane-participant-read-only", {
         action: "lanes",
-        args: { op: "participant", lane_id: "issue-965", agent_id: "worker-1" },
+        args: {
+          op: "participant",
+          lane_id: "issue-965",
+          agent_id: "worker-1",
+          thread_ts: "123.456",
+        },
       })) as { details: { status: string } };
 
     expect(listResult.details.status).toBe("succeeded");
@@ -1407,31 +1412,13 @@ describe("registerPinetTools", () => {
     expect(listPinetLanes).toHaveBeenCalledOnce();
     expect(upsertPinetLane).not.toHaveBeenCalled();
     expect(setPinetLaneParticipant).not.toHaveBeenCalled();
-    expect(requireToolPolicy).toHaveBeenCalledWith(
-      "pinet:lanes",
-      undefined,
-      "op=list | format=cli",
-    );
-    expect(requireToolPolicy).toHaveBeenCalledWith(
-      "pinet:lanes",
-      undefined,
-      "op=upsert | format=cli",
-    );
-    expect(requireToolPolicy).toHaveBeenCalledWith(
-      "pinet:lanes",
-      undefined,
-      "op=participant | format=cli",
-    );
-    expect(requireToolPolicy).toHaveBeenCalledWith(
-      "pinet:lanes:write",
-      undefined,
-      "op=upsert | format=cli",
-    );
-    expect(requireToolPolicy).toHaveBeenCalledWith(
-      "pinet:lanes:write",
-      undefined,
-      "op=participant | format=cli",
-    );
+    expect(requireToolPolicy.mock.calls).toEqual([
+      ["pinet:lanes", undefined, "op=list | format=cli"],
+      ["pinet:lanes", "123.456", "op=upsert | format=cli"],
+      ["pinet:lanes:write", "123.456", "op=upsert | format=cli"],
+      ["pinet:lanes", "123.456", "op=participant | format=cli"],
+      ["pinet:lanes:write", "123.456", "op=participant | format=cli"],
+    ]);
   });
 
   it("updates durable PM lane metadata through the lanes dispatcher", async () => {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -2666,7 +2666,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
   registerAction({
     name: "lanes",
     description:
-      "List or update durable Pinet lane metadata for PM-mode and complex coordination visibility.",
+      "List or update durable Pinet lane metadata for PM-mode and complex coordination visibility. Upsert and participant operations additionally require guardrail policy pinet:lanes:write.",
     parameters: Type.Object({
       op: Type.Optional(Type.String({ description: "Operation: list, upsert, or participant" })),
       lane_id: Type.Optional(Type.String({ description: "Stable lane id, e.g. issue-688" })),

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -1952,9 +1952,10 @@ function runPinetLanesAction(
   return (async () => {
     const op = getMaybeString(params, "op")?.toLowerCase() ?? "list";
     const policyContext = `op=${op} | format=${output.format}`;
-    deps.requireToolPolicy(toolName, undefined, policyContext);
+    const threadTs = getMaybeString(params, "thread_ts");
+    deps.requireToolPolicy(toolName, threadTs, policyContext);
     if (op === "upsert" || op === "participant") {
-      deps.requireToolPolicy(`${toolName}:write`, undefined, policyContext);
+      deps.requireToolPolicy(`${toolName}:write`, threadTs, policyContext);
     }
     if (!deps.pinetEnabled()) {
       throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
@@ -2669,6 +2670,9 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
       "List or update durable Pinet lane metadata for PM-mode and complex coordination visibility. Upsert and participant operations additionally require guardrail policy pinet:lanes:write.",
     parameters: Type.Object({
       op: Type.Optional(Type.String({ description: "Operation: list, upsert, or participant" })),
+      thread_ts: Type.Optional(
+        Type.String({ description: "Slack thread timestamp for confirmation-required mutations" }),
+      ),
       lane_id: Type.Optional(Type.String({ description: "Stable lane id, e.g. issue-688" })),
       name: Type.Optional(
         Type.Union([Type.String(), Type.Null()], { description: "Human-readable lane name" }),

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -1951,7 +1951,11 @@ function runPinetLanesAction(
 ): Promise<PinetToolResult> {
   return (async () => {
     const op = getMaybeString(params, "op")?.toLowerCase() ?? "list";
-    deps.requireToolPolicy(toolName, undefined, `op=${op} | format=${output.format}`);
+    const policyContext = `op=${op} | format=${output.format}`;
+    deps.requireToolPolicy(toolName, undefined, policyContext);
+    if (op === "upsert" || op === "participant") {
+      deps.requireToolPolicy(`${toolName}:write`, undefined, policyContext);
+    }
     if (!deps.pinetEnabled()) {
       throw new Error("Pinet is not running. Use /pinet start or /pinet follow first.");
     }


### PR DESCRIPTION
Fixes #965

## Summary
- add a fine-grained `pinet:lanes:write` guardrail policy for the `upsert` and `participant` operations
- preserve the existing `pinet:lanes` policy check for all lane operations, then require the write policy before either mutation
- cover canonical (`pinet:lanes:write`) and legacy underscore (`pinet_lanes:write`) policy aliases

## Read/list decision

Lane listing remains available when `security.readOnly` is enabled. `op=list` continues through the existing non-write `pinet:lanes` policy, while `op=upsert` and `op=participant` additionally require `pinet:lanes:write`. This avoids coarse-blocking useful lane visibility and preserves existing explicit block/confirmation handling on `pinet:lanes` for every operation.

## Verification
- `pnpm -C slack-bridge test -- guardrails.test.ts pinet-tools.test.ts` — passed; package script ran 92 passing files (2 skipped), 1,650 passing tests (3 skipped)
- `pnpm -C slack-bridge typecheck` — passed
- push hook `pnpm prepush` — repo-wide lint and typecheck passed for 11 packages; all package tests and 32 script tests passed
- `pnpm exec prettier --check slack-bridge/guardrails.ts slack-bridge/guardrails.test.ts slack-bridge/pinet-tools.ts slack-bridge/pinet-tools.test.ts` — passed
