### PR TITLE
Fix Slack Socket Mode reconnect race

### DIFF
--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -3510,6 +3510,36 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     }
   });
 
+  it("classifies message handler failures as event errors", async () => {
+    const handlerError = new Error("message failed");
+    const onError = vi.fn();
+    const client = new SlackSocketModeClient({
+      slack: vi.fn(async () => ({ url: "wss://slack.test/socket" })),
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      resolveBotUserIdOnConnect: false,
+      onMessage: () => {
+        throw handlerError;
+      },
+      onError,
+    });
+
+    await client.connect();
+    const socket = FakeWebSocket.instances[0]!;
+    socket.open();
+    socket.emit("message", {
+      data: JSON.stringify({
+        type: "events_api",
+        payload: { event: { type: "message" } },
+      }),
+    });
+
+    await waitForAssertion(() => {
+      expect(onError).toHaveBeenCalledWith(handlerError, "event");
+    });
+    await client.disconnect();
+  });
+
   it("routes Socket Mode connection failures through the adapter callback", async () => {
     fetchMock.mockImplementation(
       async (input) =>

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -3320,7 +3320,7 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     static instances: FakeWebSocket[] = [];
 
     readonly url: string;
-    readyState = FakeWebSocket.OPEN;
+    readyState = FakeWebSocket.CONNECTING;
     sent: string[] = [];
     private readonly listeners = new Map<string, Array<(event: { data?: string }) => void>>();
 
@@ -3342,6 +3342,11 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
       if (this.readyState !== FakeWebSocket.CLOSED) {
         this.sent.push(String(data));
       }
+    }
+
+    open(): void {
+      this.readyState = FakeWebSocket.OPEN;
+      this.emit("open", {});
     }
 
     close(): void {
@@ -3393,22 +3398,23 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
 
       await client.connect();
       const previous = FakeWebSocket.instances[0]!;
+      previous.open();
       previous.emit("message", { data: JSON.stringify({ type: "disconnect" }) });
       await vi.runOnlyPendingTimersAsync();
 
       expect(FakeWebSocket.instances).toHaveLength(2);
       const replacement = FakeWebSocket.instances[1]!;
-      replacement.readyState = FakeWebSocket.CONNECTING;
+      expect(previous.readyState).toBe(FakeWebSocket.OPEN);
       previous.emit("message", {
         data: JSON.stringify({ envelope_id: "env-late", type: "hello" }),
       });
       await Promise.resolve();
 
-      expect(previous.sent).toEqual([]);
+      expect(previous.sent).toEqual([JSON.stringify({ envelope_id: "env-late" })]);
       expect(replacement.sent).toEqual([]);
       expect(onError).not.toHaveBeenCalled();
 
-      previous.close();
+      replacement.open();
       await vi.runOnlyPendingTimersAsync();
       expect(previous.readyState).toBe(FakeWebSocket.CLOSED);
       expect(FakeWebSocket.instances).toHaveLength(2);
@@ -3439,6 +3445,7 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
 
       await client.connect();
       const previous = FakeWebSocket.instances[0]!;
+      previous.open();
       previous.emit("message", { data: JSON.stringify({ type: "disconnect" }) });
       await vi.runOnlyPendingTimersAsync();
       expect(connectionCount).toBe(2);
@@ -3446,6 +3453,46 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
       previous.close();
       await vi.runOnlyPendingTimersAsync();
       expect(connectionCount).toBe(2);
+
+      await client.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the active socket while a replacement handshake fails", async () => {
+    vi.useFakeTimers();
+    try {
+      let connectionCount = 0;
+      const onReconnectScheduled = vi.fn();
+      const client = new SlackSocketModeClient({
+        slack: vi.fn(async (method: string) => {
+          if (method !== "apps.connections.open") return {};
+          connectionCount += 1;
+          return { url: `wss://slack.test/socket-${connectionCount}` };
+        }),
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        resolveBotUserIdOnConnect: false,
+        reconnectDelayMs: 0,
+        onReconnectScheduled,
+      });
+
+      await client.connect();
+      const active = FakeWebSocket.instances[0]!;
+      active.open();
+      active.emit("message", { data: JSON.stringify({ type: "disconnect" }) });
+      await vi.runOnlyPendingTimersAsync();
+
+      const failedReplacement = FakeWebSocket.instances[1]!;
+      failedReplacement.close();
+      expect(active.readyState).toBe(FakeWebSocket.OPEN);
+      expect(onReconnectScheduled).toHaveBeenCalledTimes(2);
+
+      await vi.runOnlyPendingTimersAsync();
+      const replacement = FakeWebSocket.instances[2]!;
+      replacement.open();
+      expect(active.readyState).toBe(FakeWebSocket.CLOSED);
 
       await client.disconnect();
     } finally {
@@ -3474,6 +3521,29 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
 
     await adapter.connect();
     expect(onSocketError).toHaveBeenCalledWith(expect.stringContaining("socket_unavailable"));
+    await adapter.disconnect();
+  });
+
+  it("routes Socket Mode reconnects through the adapter callback", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({ ok: true, user_id: "U_BOT", url: "wss://slack.test/socket" }),
+        ),
+    );
+    const onSocketReconnectScheduled = vi.fn();
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      onSocketReconnectScheduled,
+    });
+
+    await adapter.connect();
+    const socket = FakeWebSocket.instances[0]!;
+    socket.open();
+    socket.close();
+
+    expect(onSocketReconnectScheduled).toHaveBeenCalledTimes(1);
     await adapter.disconnect();
   });
 
@@ -3538,6 +3608,7 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
     const ws = FakeWebSocket.instances[0]!;
     expect(ws.url).toBe("wss://slack.test/socket");
+    ws.open();
 
     ws.emit("message", {
       data: JSON.stringify({
@@ -3648,6 +3719,7 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     await adapter.connect();
 
     const ws = FakeWebSocket.instances[0]!;
+    ws.open();
     ws.emit("message", {
       data: JSON.stringify({
         envelope_id: "env-2",

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -1198,14 +1198,14 @@ describe("SlackAdapter", () => {
 
     await (
       client as unknown as {
-        handleFrame: (raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
       }
-    ).handleFrame(firstFrame);
+    ).handleFrame(null, firstFrame);
     await (
       client as unknown as {
-        handleFrame: (raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
       }
-    ).handleFrame(secondFrame);
+    ).handleFrame(null, secondFrame);
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(resolveUserSpy).toHaveBeenCalledTimes(1);
@@ -1246,9 +1246,10 @@ describe("SlackAdapter", () => {
 
     await (
       client as unknown as {
-        handleFrame: (raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
       }
     ).handleFrame(
+      null,
       JSON.stringify({
         envelope_id: "env-1",
         type: "interactive",
@@ -1362,9 +1363,10 @@ describe("SlackAdapter", () => {
 
     await (
       client as unknown as {
-        handleFrame: (raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
       }
     ).handleFrame(
+      null,
       JSON.stringify({
         envelope_id: "env-1",
         type: "interactive",
@@ -3311,6 +3313,7 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
   const originalWebSocket = globalThis.WebSocket;
 
   class FakeWebSocket {
+    static readonly CONNECTING = 0;
     static readonly OPEN = 1;
     static readonly CLOSED = 3;
 
@@ -3333,7 +3336,12 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     }
 
     send(data: string): void {
-      this.sent.push(String(data));
+      if (this.readyState === FakeWebSocket.CONNECTING) {
+        throw new DOMException("Sent before connected.", "InvalidStateError");
+      }
+      if (this.readyState !== FakeWebSocket.CLOSED) {
+        this.sent.push(String(data));
+      }
     }
 
     close(): void {
@@ -3363,6 +3371,110 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
       globalThis.WebSocket = originalWebSocket;
     }
     vi.restoreAllMocks();
+  });
+
+  it("keeps late frames and close events bound to the socket being replaced", async () => {
+    vi.useFakeTimers();
+    try {
+      let connectionCount = 0;
+      const onError = vi.fn();
+      const client = new SlackSocketModeClient({
+        slack: vi.fn(async (method: string) => {
+          if (method !== "apps.connections.open") return {};
+          connectionCount += 1;
+          return { url: `wss://slack.test/socket-${connectionCount}` };
+        }),
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        resolveBotUserIdOnConnect: false,
+        reconnectDelayMs: 0,
+        onError,
+      });
+
+      await client.connect();
+      const previous = FakeWebSocket.instances[0]!;
+      previous.emit("message", { data: JSON.stringify({ type: "disconnect" }) });
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(FakeWebSocket.instances).toHaveLength(2);
+      const replacement = FakeWebSocket.instances[1]!;
+      replacement.readyState = FakeWebSocket.CONNECTING;
+      previous.emit("message", {
+        data: JSON.stringify({ envelope_id: "env-late", type: "hello" }),
+      });
+      await Promise.resolve();
+
+      expect(previous.sent).toEqual([]);
+      expect(replacement.sent).toEqual([]);
+      expect(onError).not.toHaveBeenCalled();
+
+      previous.close();
+      await vi.runOnlyPendingTimersAsync();
+      expect(previous.readyState).toBe(FakeWebSocket.CLOSED);
+      expect(FakeWebSocket.instances).toHaveLength(2);
+
+      await client.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not overlap reconnects when the old socket closes during connection setup", async () => {
+    vi.useFakeTimers();
+    try {
+      let connectionCount = 0;
+      const client = new SlackSocketModeClient({
+        slack: vi.fn((method: string) => {
+          if (method !== "apps.connections.open") return Promise.resolve({});
+          connectionCount += 1;
+          return connectionCount === 1
+            ? Promise.resolve({ url: "wss://slack.test/socket-1" })
+            : new Promise<never>(() => {});
+        }),
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        resolveBotUserIdOnConnect: false,
+        reconnectDelayMs: 0,
+      });
+
+      await client.connect();
+      const previous = FakeWebSocket.instances[0]!;
+      previous.emit("message", { data: JSON.stringify({ type: "disconnect" }) });
+      await vi.runOnlyPendingTimersAsync();
+      expect(connectionCount).toBe(2);
+
+      previous.close();
+      await vi.runOnlyPendingTimersAsync();
+      expect(connectionCount).toBe(2);
+
+      await client.disconnect();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("routes Socket Mode connection failures through the adapter callback", async () => {
+    fetchMock.mockImplementation(
+      async (input) =>
+        new Response(
+          JSON.stringify(
+            String(input).endsWith("/auth.test")
+              ? { ok: true, user_id: "U_BOT" }
+              : { ok: false, error: "socket_unavailable" },
+          ),
+        ),
+    );
+
+    const onSocketError = vi.fn();
+    const adapter = new SlackAdapter({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      onSocketError,
+    });
+
+    await adapter.connect();
+    expect(onSocketError).toHaveBeenCalledWith(expect.stringContaining("socket_unavailable"));
+    await adapter.disconnect();
   });
 
   it("receives a DM, ACKs the envelope, emits inbound text, then removes 👀 after replying", async () => {

--- a/slack-bridge/broker/adapters/slack.test.ts
+++ b/slack-bridge/broker/adapters/slack.test.ts
@@ -27,6 +27,13 @@ async function waitForAssertion(assertion: () => void, attempts = 50): Promise<v
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+function createOpenSocket(): WebSocket {
+  const socket: WebSocket = Object.create(null);
+  Object.defineProperty(socket, "readyState", { value: WebSocket.OPEN });
+  socket.send = vi.fn();
+  return socket;
+}
+
 // ─── parseSocketFrame ────────────────────────────────────
 
 describe("parseSocketFrame", () => {
@@ -1196,16 +1203,17 @@ describe("SlackAdapter", () => {
       },
     });
 
+    const socket = createOpenSocket();
     await (
       client as unknown as {
-        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket, raw: string) => Promise<void>;
       }
-    ).handleFrame(null, firstFrame);
+    ).handleFrame(socket, firstFrame);
     await (
       client as unknown as {
-        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket, raw: string) => Promise<void>;
       }
-    ).handleFrame(null, secondFrame);
+    ).handleFrame(socket, secondFrame);
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(resolveUserSpy).toHaveBeenCalledTimes(1);
@@ -1244,12 +1252,13 @@ describe("SlackAdapter", () => {
         ).emitInteractiveInbound(event),
     });
 
+    const socket = createOpenSocket();
     await (
       client as unknown as {
-        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket, raw: string) => Promise<void>;
       }
     ).handleFrame(
-      null,
+      socket,
       JSON.stringify({
         envelope_id: "env-1",
         type: "interactive",
@@ -1361,12 +1370,13 @@ describe("SlackAdapter", () => {
         ).emitInteractiveInbound(event),
     });
 
+    const socket = createOpenSocket();
     await (
       client as unknown as {
-        handleFrame: (socket: WebSocket | null, raw: string) => Promise<void>;
+        handleFrame: (socket: WebSocket, raw: string) => Promise<void>;
       }
     ).handleFrame(
-      null,
+      socket,
       JSON.stringify({
         envelope_id: "env-1",
         type: "interactive",
@@ -3520,7 +3530,10 @@ describe("SlackAdapter — e2e Socket Mode lifecycle", () => {
     });
 
     await adapter.connect();
-    expect(onSocketError).toHaveBeenCalledWith(expect.stringContaining("socket_unavailable"));
+    expect(onSocketError).toHaveBeenCalledWith(
+      expect.stringContaining("socket_unavailable"),
+      "connection",
+    );
     await adapter.disconnect();
   });
 

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -101,6 +101,7 @@ export interface SlackAdapterConfig {
   /** Best-effort callback for Slack slash commands handled by the broker process. */
   onSlashCommand?: (event: ParsedSlashCommand) => Promise<string | null> | string | null;
   onSocketOpen?: () => void;
+  onSocketReconnectScheduled?: () => void;
   onSocketError?: (message: string) => void;
 }
 
@@ -183,6 +184,7 @@ export class SlackAdapter implements MessageAdapter {
       dedup: this.processedSocketDeliveries,
       abortAndWait: () => this.slackRequests.abortAndWait(),
       onOpen: () => this.config.onSocketOpen?.(),
+      onReconnectScheduled: () => this.config.onSocketReconnectScheduled?.(),
       onThreadStarted: (event) => this.onThreadStarted(event),
       onThreadContextChanged: (event) => this.onContextChanged(event),
       onMessage: (event) => this.onMessage(event),

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -13,6 +13,7 @@ import {
   resolveSlackUserName,
   setSlackSuggestedPrompts,
   SlackSocketModeClient,
+  type SlackSocketErrorSource,
   type ParsedAppHomeOpened,
   type ParsedSlashCommand,
   type ParsedThreadContextChanged,
@@ -102,7 +103,7 @@ export interface SlackAdapterConfig {
   onSlashCommand?: (event: ParsedSlashCommand) => Promise<string | null> | string | null;
   onSocketOpen?: () => void;
   onSocketReconnectScheduled?: () => void;
-  onSocketError?: (message: string) => void;
+  onSocketError?: (message: string, source: SlackSocketErrorSource) => void;
 }
 
 interface SlackThreadInfo {
@@ -193,9 +194,9 @@ export class SlackAdapter implements MessageAdapter {
       onAppHomeOpened: (event) => this.onAppHomeOpened(event),
       onInteractive: (event) => this.emitInteractiveInbound(event),
       onSlashCommand: (event) => this.onSlashCommand(event),
-      onError: (error) => {
+      onError: (error, source) => {
         if (!isAbortError(error)) {
-          this.config.onSocketError?.(errorMsg(error));
+          this.config.onSocketError?.(errorMsg(error), source);
         }
       },
     });

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -100,6 +100,8 @@ export interface SlackAdapterConfig {
   onAppHomeOpened?: (event: ParsedAppHomeOpened) => Promise<void> | void;
   /** Best-effort callback for Slack slash commands handled by the broker process. */
   onSlashCommand?: (event: ParsedSlashCommand) => Promise<string | null> | string | null;
+  onSocketOpen?: () => void;
+  onSocketError?: (message: string) => void;
 }
 
 interface SlackThreadInfo {
@@ -180,6 +182,7 @@ export class SlackAdapter implements MessageAdapter {
       appToken: this.config.appToken,
       dedup: this.processedSocketDeliveries,
       abortAndWait: () => this.slackRequests.abortAndWait(),
+      onOpen: () => this.config.onSocketOpen?.(),
       onThreadStarted: (event) => this.onThreadStarted(event),
       onThreadContextChanged: (event) => this.onContextChanged(event),
       onMessage: (event) => this.onMessage(event),
@@ -190,7 +193,7 @@ export class SlackAdapter implements MessageAdapter {
       onSlashCommand: (event) => this.onSlashCommand(event),
       onError: (error) => {
         if (!isAbortError(error)) {
-          console.error(`[slack-adapter] Socket Mode: ${errorMsg(error)}`);
+          this.config.onSocketError?.(errorMsg(error));
         }
       },
     });

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -360,6 +360,7 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionStart?.({}, ctx);
     await pinetStart?.handler("start", ctx);
 
+    expect(setStatus).toHaveBeenLastCalledWith("slack-bridge", expect.stringContaining("⟳"));
     expect(brokerRuntimes).toHaveLength(1);
     brokerRuntimes[0]!.db.registerAgent("sender", "Sender", "📤", 202);
     brokerRuntimes[0]!.db.queueMessage("broker-leaf", {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -725,6 +725,7 @@ export default function (pi: ExtensionAPI) {
     getAllowedUsers: () => allowedUsers,
     shouldAllowAllWorkspaceUsers: () =>
       resolveAllowAllWorkspaceUsers(settings, process.env.SLACK_ALLOW_ALL_WORKSPACE_USERS),
+    setExtStatus,
     onAppHomeOpened: handleBrokerAppHomeOpened,
     onSlashCommand: handleBrokerSlackSlashCommand,
   });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1463,6 +1463,7 @@ export default function (pi: ExtensionAPI) {
   // ─── Commands ───────────────────────────────────────
 
   async function connectAsBroker(ctx: ExtensionContext): Promise<void> {
+    setExtStatus(ctx, "reconnecting");
     refreshSettings();
     maybeWarnSlackUserAccess(ctx);
     maybeWarnSlackGuardrailPosture(ctx);
@@ -1540,7 +1541,6 @@ export default function (pi: ExtensionAPI) {
     }
 
     brokerRuntime.startObservability(ctx);
-    setExtStatus(ctx, "ok");
     brokerRuntime.logActivity({
       kind: "broker_started",
       level: "actions",

--- a/slack-bridge/session-ui-runtime.test.ts
+++ b/slack-bridge/session-ui-runtime.test.ts
@@ -82,6 +82,18 @@ describe("createSessionUiRuntime", () => {
     expect(setStatus).toHaveBeenNthCalledWith(4, "slack-bridge", "🦩 Cobalt Olive Crane ✦ 2");
   });
 
+  it("does not replace a connection error with an unread badge", () => {
+    const { deps } = createDeps({ getInboxLength: () => 2 });
+    const runtime = createSessionUiRuntime(deps);
+    const { ctx, setStatus } = createContext();
+
+    runtime.setExtStatus(ctx, "error");
+    setStatus.mockClear();
+    runtime.updateBadge();
+
+    expect(setStatus).not.toHaveBeenCalled();
+  });
+
   it("gates idle inbox draining while Escape suppression is active", () => {
     const { deps, drainInbox } = createDeps();
     const runtime = createSessionUiRuntime(deps);

--- a/slack-bridge/session-ui-runtime.ts
+++ b/slack-bridge/session-ui-runtime.ts
@@ -83,6 +83,7 @@ export function createSessionUiRuntime(deps: SessionUiRuntimeDeps): SessionUiRun
   let terminalInputUnsubscribe: (() => void) | null = null;
   let deferredDrainTimer: ReturnType<typeof setTimeout> | null = null;
   let extCtx: ExtensionContext | null = null;
+  let statusState: SessionUiStatusState = "ok";
 
   function getExtensionContext(): ExtensionContext | null {
     return extCtx;
@@ -93,7 +94,7 @@ export function createSessionUiRuntime(deps: SessionUiRuntimeDeps): SessionUiRun
   }
 
   function updateBadge(): void {
-    if (!extCtx?.hasUI) return;
+    if (statusState !== "ok" || !extCtx?.hasUI) return;
     const t = extCtx.ui.theme;
     const n = deps.getInboxLength();
     const label =
@@ -104,6 +105,7 @@ export function createSessionUiRuntime(deps: SessionUiRuntimeDeps): SessionUiRun
   }
 
   function setExtStatus(ctx: ExtensionContext, state: SessionUiStatusState): void {
+    statusState = state;
     if (!ctx.hasUI) return;
     extCtx = ctx;
     const t = ctx.ui.theme;

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -308,6 +308,25 @@ describe("single-player-runtime", () => {
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
   });
 
+  it("routes Socket Mode errors through the TUI", async () => {
+    const state: TestState = {
+      threads: new Map(),
+      pendingEyes: new Map(),
+      unclaimedThreads: new Set(),
+      inbox: [],
+      lastDmChannel: null,
+    };
+    const setExtStatus = vi.fn();
+    const runtime = createSinglePlayerRuntime(createDeps(state, { setExtStatus }).deps);
+    const ctx = createContext();
+
+    await runtime.connect(ctx);
+    const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
+    socketConfig?.onError?.(new Error("socket failed"));
+
+    expect(setExtStatus).toHaveBeenCalledWith(ctx, "error");
+  });
+
   it("ignores opt-in reactions in uninvoked single-player Slack threads", async () => {
     const state: TestState = {
       threads: new Map(),

--- a/slack-bridge/single-player-runtime.test.ts
+++ b/slack-bridge/single-player-runtime.test.ts
@@ -308,7 +308,7 @@ describe("single-player-runtime", () => {
     expect(spies.maybeDrainInboxIfIdle).toHaveBeenCalledWith(ctx);
   });
 
-  it("routes Socket Mode errors through the TUI", async () => {
+  it("routes connection and event errors to their respective TUI surfaces", async () => {
     const state: TestState = {
       threads: new Map(),
       pendingEyes: new Map(),
@@ -317,14 +317,17 @@ describe("single-player-runtime", () => {
       lastDmChannel: null,
     };
     const setExtStatus = vi.fn();
+    const notify = vi.fn();
     const runtime = createSinglePlayerRuntime(createDeps(state, { setExtStatus }).deps);
-    const ctx = createContext();
+    const ctx = createContext(notify);
 
     await runtime.connect(ctx);
     const socketConfig = socketState.config as SlackSocketModeClientConfig | null;
-    socketConfig?.onError?.(new Error("socket failed"));
+    socketConfig?.onError?.(new Error("socket failed"), "connection");
+    socketConfig?.onError?.(new Error("message failed"), "event");
 
     expect(setExtStatus).toHaveBeenCalledWith(ctx, "error");
+    expect(notify).toHaveBeenCalledWith("Slack event failed: Error: message failed", "error");
   });
 
   it("ignores opt-in reactions in uninvoked single-player Slack threads", async () => {

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -536,7 +536,7 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
         },
         onError: (error) => {
           if (!isAbortError(error)) {
-            console.error(`[slack-bridge] Slack access: ${deps.formatError(error)}`);
+            deps.setExtStatus(ctx, "error");
           }
         },
         onThreadStarted: (event) => onThreadStarted(event),

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -534,9 +534,12 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
             deps.setExtStatus(ctx, "reconnecting");
           }
         },
-        onError: (error) => {
-          if (!isAbortError(error)) {
+        onError: (error, source) => {
+          if (isAbortError(error)) return;
+          if (source === "connection") {
             deps.setExtStatus(ctx, "error");
+          } else {
+            ctx.ui.notify(`Slack event failed: ${deps.formatError(error)}`, "error");
           }
         },
         onThreadStarted: (event) => onThreadStarted(event),

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -559,6 +559,7 @@ export class SlackSocketModeClient {
   private readonly config: SlackSocketModeClientConfig;
   private botUserId: string | null = null;
   private ws: WebSocket | null = null;
+  private pendingSocket: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private connecting = false;
   private shuttingDown = false;
@@ -592,10 +593,12 @@ export class SlackSocketModeClient {
     }
     try {
       this.ws?.close();
+      this.pendingSocket?.close();
     } catch {
       /* ignore close errors */
     }
     this.ws = null;
+    this.pendingSocket = null;
     await this.config.abortAndWait?.();
   }
 
@@ -610,21 +613,29 @@ export class SlackSocketModeClient {
 
       const previous = this.ws;
       const socket = new WebSocket(response.url as string);
-      this.ws = socket;
-      previous?.close();
+      this.pendingSocket = socket;
 
       socket.addEventListener("open", () => {
+        if (this.pendingSocket !== socket || this.shuttingDown) return;
+        this.pendingSocket = null;
+        this.ws = socket;
+        previous?.close();
         this.config.onOpen?.();
       });
 
       socket.addEventListener("message", (event) => {
         void this.handleFrame(socket, String(event.data)).catch((error) => {
-          this.config.onError?.(error);
+          if (!this.shuttingDown) {
+            this.config.onError?.(error);
+          }
         });
       });
 
       socket.addEventListener("close", () => {
-        if (this.ws === socket && !this.shuttingDown) {
+        if (this.pendingSocket === socket) {
+          this.pendingSocket = null;
+          this.scheduleReconnect();
+        } else if (this.ws === socket) {
           this.ws = null;
           this.scheduleReconnect();
         }
@@ -634,10 +645,10 @@ export class SlackSocketModeClient {
         /* close fires after error — handled there */
       });
     } catch (error) {
-      if (!isAbortError(error)) {
+      if (!this.shuttingDown && !isAbortError(error)) {
         this.config.onError?.(error);
       }
-      shouldReconnect = true;
+      shouldReconnect = !this.shuttingDown;
     } finally {
       this.connecting = false;
     }
@@ -740,7 +751,7 @@ export class SlackSocketModeClient {
   }
 
   private scheduleReconnect(): void {
-    if (this.shuttingDown || this.connecting || this.reconnectTimer) return;
+    if (this.shuttingDown || this.connecting || this.pendingSocket || this.reconnectTimer) return;
     this.config.onReconnectScheduled?.();
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -534,6 +534,8 @@ export async function resolveSlackThreadOwnerHint(
 
 export const RECONNECT_DELAY_MS = 5000;
 
+export type SlackSocketErrorSource = "connection" | "event";
+
 export interface SlackSocketModeClientConfig {
   slack: SlackCall;
   botToken: string;
@@ -544,7 +546,7 @@ export interface SlackSocketModeClientConfig {
   abortAndWait?: () => Promise<void>;
   onOpen?: () => void;
   onReconnectScheduled?: () => void;
-  onError?: (error: unknown) => void;
+  onError?: (error: unknown, source: SlackSocketErrorSource) => void;
   onThreadStarted?: (event: ParsedThreadStarted) => Promise<void> | void;
   onThreadContextChanged?: (event: ParsedThreadContextChanged) => Promise<void> | void;
   onMessage?: (event: Record<string, unknown>) => Promise<void> | void;
@@ -626,7 +628,7 @@ export class SlackSocketModeClient {
       socket.addEventListener("message", (event) => {
         void this.handleFrame(socket, String(event.data)).catch((error) => {
           if (!this.shuttingDown) {
-            this.config.onError?.(error);
+            this.config.onError?.(error, "event");
           }
         });
       });
@@ -646,7 +648,7 @@ export class SlackSocketModeClient {
       });
     } catch (error) {
       if (!this.shuttingDown && !isAbortError(error)) {
-        this.config.onError?.(error);
+        this.config.onError?.(error, "connection");
       }
       shouldReconnect = !this.shuttingDown;
     } finally {
@@ -658,14 +660,14 @@ export class SlackSocketModeClient {
     }
   }
 
-  private async handleFrame(socket: WebSocket | null, raw: string): Promise<void> {
+  private async handleFrame(socket: WebSocket, raw: string): Promise<void> {
     if (this.shuttingDown) return;
 
     const envelope = parseSocketFrame(raw);
     if (!envelope) return;
 
-    if (envelope.envelopeId) {
-      socket?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
+    if (envelope.envelopeId && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
     }
 
     const dedupKey = envelope.dedupKey ?? null;

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -560,6 +560,7 @@ export class SlackSocketModeClient {
   private botUserId: string | null = null;
   private ws: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private connecting = false;
   private shuttingDown = false;
 
   constructor(config: SlackSocketModeClientConfig) {
@@ -599,47 +600,61 @@ export class SlackSocketModeClient {
   }
 
   private async connectSocketMode(): Promise<void> {
-    if (this.shuttingDown) return;
+    if (this.shuttingDown || this.connecting) return;
 
+    this.connecting = true;
+    let shouldReconnect = false;
     try {
       const response = await this.config.slack("apps.connections.open", this.config.appToken);
-      this.ws = new WebSocket(response.url as string);
+      if (this.shuttingDown) return;
 
-      this.ws.addEventListener("open", () => {
+      const previous = this.ws;
+      const socket = new WebSocket(response.url as string);
+      this.ws = socket;
+      previous?.close();
+
+      socket.addEventListener("open", () => {
         this.config.onOpen?.();
       });
 
-      this.ws.addEventListener("message", (event) => {
-        void this.handleFrame(String(event.data)).catch((error) => {
+      socket.addEventListener("message", (event) => {
+        void this.handleFrame(socket, String(event.data)).catch((error) => {
           this.config.onError?.(error);
         });
       });
 
-      this.ws.addEventListener("close", () => {
-        if (!this.shuttingDown) {
+      socket.addEventListener("close", () => {
+        if (this.ws === socket && !this.shuttingDown) {
+          this.ws = null;
           this.scheduleReconnect();
         }
       });
 
-      this.ws.addEventListener("error", () => {
+      socket.addEventListener("error", () => {
         /* close fires after error — handled there */
       });
     } catch (error) {
       if (!isAbortError(error)) {
         this.config.onError?.(error);
       }
+      shouldReconnect = true;
+    } finally {
+      this.connecting = false;
+    }
+
+    if (shouldReconnect) {
       this.scheduleReconnect();
     }
   }
 
-  private async handleFrame(raw: string): Promise<void> {
+  private async handleFrame(socket: WebSocket | null, raw: string): Promise<void> {
     if (this.shuttingDown) return;
 
     const envelope = parseSocketFrame(raw);
     if (!envelope) return;
 
     if (envelope.envelopeId) {
-      this.ws?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
+      socket?.send(JSON.stringify({ envelope_id: envelope.envelopeId }));
     }
 
     const dedupKey = envelope.dedupKey ?? null;
@@ -653,7 +668,9 @@ export class SlackSocketModeClient {
       }
 
       if (envelope.type === "disconnect") {
-        this.scheduleReconnect();
+        if (this.ws === socket) {
+          this.scheduleReconnect();
+        }
         return;
       }
 
@@ -723,7 +740,7 @@ export class SlackSocketModeClient {
   }
 
   private scheduleReconnect(): void {
-    if (this.shuttingDown || this.reconnectTimer) return;
+    if (this.shuttingDown || this.connecting || this.reconnectTimer) return;
     this.config.onReconnectScheduled?.();
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -125,7 +125,13 @@ export function createSlackPinetRuntimeAdapterFactory(
       },
       onSocketOpen: () => deps.setExtStatus(ctx, "ok"),
       onSocketReconnectScheduled: () => deps.setExtStatus(ctx, "reconnecting"),
-      onSocketError: () => deps.setExtStatus(ctx, "error"),
+      onSocketError: (message, source) => {
+        if (source === "connection") {
+          deps.setExtStatus(ctx, "error");
+        } else {
+          ctx.ui.notify(`Slack event failed: ${message}`, "error");
+        }
+      },
       onSlashCommand: deps.onSlashCommand
         ? (event) => deps.onSlashCommand?.(event, ctx) ?? null
         : undefined,

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -45,7 +45,7 @@ export interface SlackPinetRuntimeAdapterDeps {
   getAppToken: () => string;
   getAllowedUsers: () => Set<string> | null;
   shouldAllowAllWorkspaceUsers: () => boolean;
-  setExtStatus: (ctx: ExtensionContext, state: "ok" | "error") => void;
+  setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error") => void;
   onAppHomeOpened: (userId: string, ctx: ExtensionContext) => Promise<void> | void;
   onSlashCommand?: (
     event: ParsedSlashCommand,
@@ -124,6 +124,7 @@ export function createSlackPinetRuntimeAdapterFactory(
         await deps.onAppHomeOpened(userId, ctx);
       },
       onSocketOpen: () => deps.setExtStatus(ctx, "ok"),
+      onSocketReconnectScheduled: () => deps.setExtStatus(ctx, "reconnecting"),
       onSocketError: () => deps.setExtStatus(ctx, "error"),
       onSlashCommand: deps.onSlashCommand
         ? (event) => deps.onSlashCommand?.(event, ctx) ?? null

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -45,6 +45,7 @@ export interface SlackPinetRuntimeAdapterDeps {
   getAppToken: () => string;
   getAllowedUsers: () => Set<string> | null;
   shouldAllowAllWorkspaceUsers: () => boolean;
+  setExtStatus: (ctx: ExtensionContext, state: "ok" | "error") => void;
   onAppHomeOpened: (userId: string, ctx: ExtensionContext) => Promise<void> | void;
   onSlashCommand?: (
     event: ParsedSlashCommand,
@@ -122,6 +123,8 @@ export function createSlackPinetRuntimeAdapterFactory(
       onAppHomeOpened: async ({ userId }) => {
         await deps.onAppHomeOpened(userId, ctx);
       },
+      onSocketOpen: () => deps.setExtStatus(ctx, "ok"),
+      onSocketError: () => deps.setExtStatus(ctx, "error"),
       onSlashCommand: deps.onSlashCommand
         ? (event) => deps.onSlashCommand?.(event, ctx) ?? null
         : undefined,


### PR DESCRIPTION
## Issue / problem solved

- Closes/Fixes/Refs: Fixes #970
- Why this is prioritized: Slack Socket Mode reconnect races can write errors directly into long-lived interactive Pi TUI lanes.

## Troubleshooting / diagnosis

- How the problem was reproduced or investigated: traced Socket Mode reconnects through `SlackSocketModeClient` and the broker adapter's error callback, then reproduced the stale-socket sequence with a WebSocket fake that enforces real `readyState` send behavior.
- Evidence for the root cause: frame handlers ACKed through mutable `this.ws`, so a late frame from the retired socket could send through its connecting replacement and throw `Sent before connected.`. The broker adapter then emitted that error with `console.error`.
- Relevant constraints or edge cases: events queued by a retired socket must remain bound to that socket; retired close/disconnect events must not schedule another reconnect; connection attempts must not overlap.

## Design philosophy

- Guiding principle for this change: make each socket own its events and keep interactive transport state inside the existing status UI.
- Simplicity review:
  - [x] Comments explain non-obvious reasons or invariants; clearer code replaces narration.
  - [x] Tests exercise states reachable through production boundaries rather than bypassing them.
  - [x] One-use helpers are inlined unless they form a documented semantic seam.
- If this touches Pinet / `slack-bridge`: how does it preserve token-efficient progressive discovery?
  - Hot-path schemas/prompts stay compact: no schema or prompt changes.
  - Cold paths remain discoverable through dispatcher `help` / per-action schemas or docs/skills: unchanged.
  - Templates/examples/large usage guidance stay out of always-loaded prompts/tool schemas: unchanged.

## Repo design fit

- Existing architecture/conventions this follows: extends the existing Socket Mode callback and extension-status paths rather than adding a separate notification or logging system.
- Extension/package boundaries preserved: all changes stay within `slack-bridge`.
- Guardrail, security, auth, or local-power implications: none.

## Alternatives considered

- Alternative(s) considered: capture raw extension stderr in Pi core; notify the user on every transport error; retain mutable-socket ACK routing with a `readyState` guard.
- Why they were not chosen: the race belongs to Pinet, repeated notifications would be noisy, and a guard alone would silently drop ACK ownership rather than fixing it.

## Testing / validation

- Tests added or updated: stale-frame socket ownership, stale-close reconnect suppression, overlapping reconnect prevention and controlled runtime error-status routing.
- Commands run:
  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm test`
  - [x] Other: `pnpm format:check`, `git diff --check`
- Manual validation: the regression fake throws the same `DOMException("Sent before connected.", "InvalidStateError")` as a real WebSocket when a send targets a connecting socket.

## Review notes / follow-ups

- Known limitations or non-blocking concerns: none identified.
- Follow-up issues/PRs: none.
- Reviewer focus areas: socket identity checks in reconnect lifecycle and whether extension status is the correct broker/single-player error surface.
