### PR TITLE
fix(pinet): preserve workers across broker reload

### DIFF
--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   type InboxMessage,
@@ -15,6 +16,7 @@ import {
 } from "./helpers.js";
 import { startBroker, type Broker } from "./broker/index.js";
 import type { BrokerDB } from "./broker/schema.js";
+import { readMeshSecret } from "./broker/auth.js";
 import { DEFAULT_HEARTBEAT_TIMEOUT_MS } from "./broker/socket-server.js";
 import { MessageRouter } from "./broker/router.js";
 import {
@@ -31,7 +33,7 @@ import {
   queueBrokerInboxIds,
   resetBrokerDeliveryState,
 } from "./broker-delivery.js";
-import type { AgentInfo, InboundMessage } from "./broker/types.js";
+import type { AgentInfo, InboundMessage, MessageAdapter } from "./broker/types.js";
 import {
   type ActivityLogEntry,
   type ActivityLogTone,
@@ -153,12 +155,31 @@ function normalizeOptionalSetting(value: string | null | undefined): string | nu
   return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
+function buildBrokerInPlaceSettingsSignature(settings: SlackBridgeSettings): string {
+  const meshAuth = resolvePinetMeshAuth(settings);
+  const effectiveMeshSecret = meshAuth.meshSecret
+    ? meshAuth.meshSecret
+    : meshAuth.meshSecretPath
+      ? readMeshSecret(meshAuth.meshSecretPath)
+      : null;
+  const meshSecretFingerprint = effectiveMeshSecret
+    ? crypto.createHash("sha256").update(effectiveMeshSecret).digest("hex")
+    : null;
+  return JSON.stringify({
+    meshSecretFingerprint,
+    meshSecretPath: meshAuth.meshSecretPath ?? null,
+    imessage: settings.imessage ?? null,
+  });
+}
+
 export function resolveConfiguredBrokerSkinTheme(settings: SlackBridgeSettings): string {
   return normalizePinetSkinTheme(settings.skinTheme) ?? DEFAULT_PINET_SKIN_THEME;
 }
 
 export interface BrokerRuntime {
   connect: (ctx: ExtensionContext) => Promise<BrokerRuntimeConnectResult>;
+  reloadAdapters: (ctx: ExtensionContext) => Promise<{ botUserId: string | null }>;
+  canReloadInPlace: () => boolean;
   disconnect: (options?: { releaseIdentity?: boolean }) => Promise<void>;
   claimThread: (threadTs: string, channelId: string, source?: string) => void;
   runMaintenance: (ctx: ExtensionContext) => void;
@@ -194,6 +215,8 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
   let activeBroker: Broker | null = null;
   let activeRouter: MessageRouter | null = null;
   let activeSelfId: string | null = null;
+  let activeRuntimeAdapters: MessageAdapter[] = [];
+  let activeInPlaceSettingsSignature: string | null = null;
   let brokerHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let brokerMaintenanceTimer: ReturnType<typeof setInterval> | null = null;
   let brokerScheduledWakeupTimer: ReturnType<typeof setInterval> | null = null;
@@ -529,6 +552,8 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
     activeBroker = null;
     activeRouter = null;
     activeSelfId = null;
+    activeRuntimeAdapters = [];
+    activeInPlaceSettingsSignature = null;
     lastBrokerMaintenance = null;
     lastBrokerMaintenanceSignature = "";
     resetBrokerDeliveryState(deps.deliveryState);
@@ -636,6 +661,8 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         });
 
         activeBroker = broker;
+        activeRuntimeAdapters = adapterBindings.map((binding) => binding.adapter);
+        activeInPlaceSettingsSignature = buildBrokerInPlaceSettingsSignature(settings);
         activeRouter = router;
         activeSelfId = brokerSelfId;
         resetBrokerDeliveryState(deps.deliveryState);
@@ -683,12 +710,81 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         activeBroker = null;
         activeRouter = null;
         activeSelfId = null;
+        activeRuntimeAdapters = [];
+        activeInPlaceSettingsSignature = null;
         lastBrokerMaintenance = null;
         lastBrokerMaintenanceSignature = "";
         resetBrokerDeliveryState(deps.deliveryState);
         stopObservability();
         throw error;
       }
+    },
+
+    async reloadAdapters(ctx: ExtensionContext): Promise<{ botUserId: string | null }> {
+      if (!activeBroker || !activeRouter || !activeSelfId) {
+        throw new Error("Pinet broker is not running.");
+      }
+
+      const broker = activeBroker;
+      const router = activeRouter;
+      const selfId = activeSelfId;
+      const bindings = await buildPinetRuntimeAdapterBindings(deps.createAdapterBindings, {
+        broker,
+        router,
+        selfId,
+        ctx,
+      });
+      const nextAdapters = bindings.map((binding) => binding.adapter);
+      const activeSkinTheme = resolveConfiguredBrokerSkinTheme(deps.getSettings());
+      const selfAssignment = buildPinetSkinAssignment({
+        theme: activeSkinTheme,
+        role: "broker",
+        seed: deps.getBrokerStableId(),
+      });
+      deps.setActiveSkinTheme(activeSkinTheme);
+      const selfMetadata = deps.buildSkinMetadata(
+        await deps.getAgentMetadata("broker"),
+        selfAssignment.personality,
+        selfAssignment.statusVocabulary,
+      );
+
+      const previousRuntimeAdapters = activeRuntimeAdapters;
+      activeRuntimeAdapters = [];
+      await broker.removeAdapters(previousRuntimeAdapters);
+      broker.db.setAllowedUsers(deps.getAllowedUsers());
+      broker.db.setSetting("pinet.skinTheme", activeSkinTheme);
+      broker.db.updateAgentIdentity(selfId, {
+        name: selfAssignment.name,
+        emoji: selfAssignment.emoji,
+        metadata: selfMetadata,
+      });
+      deps.applyLocalAgentIdentity(
+        selfAssignment.name,
+        selfAssignment.emoji,
+        selfAssignment.personality,
+      );
+
+      try {
+        const result = await connectPinetRuntimeAdapters({
+          broker,
+          bindings,
+          onInbound: (message) => {
+            void deps.handleInboundMessage({ message, broker, router, selfId, ctx });
+          },
+        });
+        activeRuntimeAdapters = nextAdapters;
+        return result;
+      } catch (error) {
+        await broker.removeAdapters(nextAdapters);
+        throw error;
+      }
+    },
+
+    canReloadInPlace(): boolean {
+      return (
+        activeInPlaceSettingsSignature !== null &&
+        activeInPlaceSettingsSignature === buildBrokerInPlaceSettingsSignature(deps.getSettings())
+      );
     },
 
     async disconnect(options = {}): Promise<void> {

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -168,7 +168,7 @@ function buildBrokerInPlaceSettingsSignature(settings: SlackBridgeSettings): str
   return JSON.stringify({
     meshSecretFingerprint,
     meshSecretPath: meshAuth.meshSecretPath ?? null,
-    imessage: settings.imessage ?? null,
+    imessageEnabled: settings.imessage?.enabled ?? false,
   });
 }
 
@@ -775,16 +775,27 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
         activeRuntimeAdapters = nextAdapters;
         return result;
       } catch (error) {
-        await broker.removeAdapters(nextAdapters);
+        try {
+          await broker.removeAdapters(nextAdapters);
+        } catch {
+          /* preserve the adapter connection error */
+        }
         throw error;
       }
     },
 
     canReloadInPlace(): boolean {
-      return (
-        activeInPlaceSettingsSignature !== null &&
-        activeInPlaceSettingsSignature === buildBrokerInPlaceSettingsSignature(deps.getSettings())
-      );
+      try {
+        return (
+          activeInPlaceSettingsSignature !== null &&
+          activeInPlaceSettingsSignature === buildBrokerInPlaceSettingsSignature(deps.getSettings())
+        );
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Cannot reload Pinet broker because the mesh secret could not be read: ${detail}. The existing broker remains running; restore the secret and retry /pinet start.`,
+        );
+      }
     },
 
     async disconnect(options = {}): Promise<void> {

--- a/slack-bridge/broker/adapters/slack.ts
+++ b/slack-bridge/broker/adapters/slack.ts
@@ -206,14 +206,17 @@ export class SlackAdapter implements MessageAdapter {
 
   async disconnect(): Promise<void> {
     this.shuttingDown = true;
-    await this.threadStatuses.clearAll();
-    const socketMode = this.socketMode;
-    this.socketMode = null;
-    if (socketMode) {
-      await socketMode.disconnect();
-      return;
+    try {
+      await this.threadStatuses.clearAll();
+    } finally {
+      const socketMode = this.socketMode;
+      this.socketMode = null;
+      if (socketMode) {
+        await socketMode.disconnect();
+      } else {
+        await this.slackRequests.abortAndWait();
+      }
     }
-    await this.slackRequests.abortAndWait();
   }
 
   onInbound(handler: (msg: InboundMessage) => void): void {

--- a/slack-bridge/broker/index.test.ts
+++ b/slack-bridge/broker/index.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { BrokerClient } from "./client.js";
+import { startBroker, type Broker } from "./index.js";
+import type { MessageAdapter } from "./types.js";
+
+describe("broker adapter lifecycle", () => {
+  let broker: Broker | null = null;
+  let client: BrokerClient | null = null;
+  let dir: string | null = null;
+
+  afterEach(async () => {
+    client?.disconnect();
+    await broker?.stop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("replaces runtime adapters without disconnecting workers or removing the socket", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "pinet-adapter-reload-"));
+    const socketPath = path.join(dir, "pinet.sock");
+    broker = await startBroker({
+      dbPath: path.join(dir, "pinet.db"),
+      socketPath,
+      lockPath: path.join(dir, "pinet.lock"),
+    });
+
+    const disconnect = vi.fn(async () => {});
+    const adapter: MessageAdapter = {
+      name: "test",
+      connect: vi.fn(async () => {}),
+      disconnect,
+      onInbound: vi.fn(),
+      send: vi.fn(async () => {}),
+    };
+    broker.addAdapter(adapter);
+
+    client = new BrokerClient({ path: socketPath });
+    await client.connect();
+    await client.register("worker", "🧪");
+    const workerDisconnected = vi.fn();
+    client.onDisconnect(workerDisconnected);
+
+    await broker.removeAdapters([adapter]);
+
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(workerDisconnected).not.toHaveBeenCalled();
+    expect(client.isConnected()).toBe(true);
+    expect(fs.existsSync(socketPath)).toBe(true);
+    await expect(client.listAgents()).resolves.toEqual([
+      expect.objectContaining({ name: "worker", disconnectedAt: null }),
+    ]);
+  });
+
+  it("surfaces adapter disconnect failures after removing them from broker routing", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "pinet-adapter-failure-"));
+    broker = await startBroker({
+      dbPath: path.join(dir, "pinet.db"),
+      socketPath: path.join(dir, "pinet.sock"),
+      lockPath: path.join(dir, "pinet.lock"),
+    });
+    const adapter: MessageAdapter = {
+      name: "failing-test",
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(async () => {
+        throw new Error("disconnect failed");
+      }),
+      onInbound: vi.fn(),
+      send: vi.fn(async () => {}),
+    };
+    broker.addAdapter(adapter);
+
+    await expect(broker.removeAdapters([adapter])).rejects.toThrow(
+      "Failed to disconnect broker adapters",
+    );
+
+    expect(broker.adapters).toEqual([]);
+  });
+});

--- a/slack-bridge/broker/index.ts
+++ b/slack-bridge/broker/index.ts
@@ -83,6 +83,7 @@ export interface Broker {
   lock: LeaderLock;
   adapters: MessageAdapter[];
   addAdapter(adapter: MessageAdapter): void;
+  removeAdapters(adapters: readonly MessageAdapter[]): Promise<void>;
   stop(): Promise<void>;
 }
 
@@ -189,18 +190,40 @@ export async function startBroker(options: BrokerOptions = {}): Promise<Broker> 
       server.setOutboundMessageAdapters(adapters);
     },
 
-    async stop(): Promise<void> {
-      for (const adapter of adapters) {
+    async removeAdapters(removedAdapters: readonly MessageAdapter[]): Promise<void> {
+      const removed = new Set(removedAdapters);
+      const retained = adapters.filter((adapter) => !removed.has(adapter));
+      adapters.length = 0;
+      adapters.push(...retained);
+      server.setOutboundMessageAdapters(adapters);
+
+      const disconnectErrors: Error[] = [];
+      for (const adapter of removedAdapters) {
         try {
           await adapter.disconnect();
-        } catch {
-          // best effort
+        } catch (error) {
+          disconnectErrors.push(error instanceof Error ? error : new Error(String(error)));
         }
       }
-      adapters.length = 0;
-      await server.stop();
-      db.close();
-      lock.release();
+      if (disconnectErrors.length > 0) {
+        throw new AggregateError(disconnectErrors, "Failed to disconnect broker adapters");
+      }
+    },
+
+    async stop(): Promise<void> {
+      try {
+        await this.removeAdapters([...adapters]);
+      } finally {
+        try {
+          await server.stop();
+        } finally {
+          try {
+            db.close();
+          } finally {
+            lock.release();
+          }
+        }
+      }
     },
   };
 

--- a/slack-bridge/helpers.test.ts
+++ b/slack-bridge/helpers.test.ts
@@ -31,6 +31,7 @@ import {
   extractPinetControlCommand,
   queuePinetRemoteControl,
   finishPinetRemoteControl,
+  reloadPinetRuntimeInPlaceSafely,
   reloadPinetRuntimeSafely,
   getSqliteJournalMode,
   isSqliteWalEnabled,
@@ -1343,6 +1344,33 @@ describe("reloadPinetRuntimeSafely", () => {
     ).rejects.toThrow("Reload failed: refreshed start failed. Restored the previous runtime.");
 
     expect(starts).toEqual(["follower:refreshed", "follower:previous"]);
+    expect(activeConfig).toBe("previous");
+  });
+
+  it("rolls an in-place runtime reload back without stopping its listener", async () => {
+    let activeConfig = "previous";
+    const reloads: string[] = [];
+
+    await expect(
+      reloadPinetRuntimeInPlaceSafely({
+        snapshotState: () => activeConfig,
+        restoreState: (snapshot) => {
+          activeConfig = snapshot;
+        },
+        refreshState: () => {
+          activeConfig = "refreshed";
+        },
+        validateRefreshedState: () => {},
+        reloadRuntime: async () => {
+          reloads.push(activeConfig);
+          if (activeConfig === "refreshed") {
+            throw new Error("refreshed adapter failed");
+          }
+        },
+      }),
+    ).rejects.toThrow("Reload failed: refreshed adapter failed. Restored the previous runtime.");
+
+    expect(reloads).toEqual(["refreshed", "previous"]);
     expect(activeConfig).toBe("previous");
   });
 });

--- a/slack-bridge/helpers.ts
+++ b/slack-bridge/helpers.ts
@@ -725,6 +725,44 @@ export async function reloadPinetRuntimeSafely<State>(
   }
 }
 
+export async function reloadPinetRuntimeInPlaceSafely<State>(input: {
+  snapshotState: () => State;
+  restoreState: (snapshot: State) => void;
+  refreshState: () => void;
+  validateRefreshedState: () => void | Promise<void>;
+  reloadRuntime: () => Promise<void>;
+}): Promise<void> {
+  const snapshot = input.snapshotState();
+
+  try {
+    input.refreshState();
+    await input.validateRefreshedState();
+  } catch (validationErr) {
+    input.restoreState(snapshot);
+    throw validationErr;
+  }
+
+  try {
+    await input.reloadRuntime();
+  } catch (reloadErr) {
+    input.restoreState(snapshot);
+
+    try {
+      await input.reloadRuntime();
+    } catch (rollbackErr) {
+      const reloadMessage = reloadErr instanceof Error ? reloadErr.message : String(reloadErr);
+      const rollbackMessage =
+        rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+      throw new Error(
+        `Reload failed: ${reloadMessage}. Rollback to the previous runtime also failed: ${rollbackMessage}`,
+      );
+    }
+
+    const reloadMessage = reloadErr instanceof Error ? reloadErr.message : String(reloadErr);
+    throw new Error(`Reload failed: ${reloadMessage}. Restored the previous runtime.`);
+  }
+}
+
 export type PinetControlMetadata = Record<string, unknown>;
 
 export interface PinetControlEnvelope extends PinetControlMetadata {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -326,9 +326,6 @@ describe("slack-bridge top-level shutdown", () => {
         db.close();
       });
       brokerRuntimes.push({ db, server, stop });
-      if (brokerRuntimes.length === 2) {
-        resolveReloadStarted?.();
-      }
       return {
         db,
         server,
@@ -338,10 +335,17 @@ describe("slack-bridge top-level shutdown", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop,
       } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
     });
-    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    let slackConnectCount = 0;
+    vi.spyOn(SlackAdapter.prototype, "connect").mockImplementation(async () => {
+      slackConnectCount += 1;
+      if (slackConnectCount === 2) {
+        resolveReloadStarted?.();
+      }
+    });
     vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
     vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
 
@@ -410,7 +414,7 @@ describe("slack-bridge top-level shutdown", () => {
     );
   });
 
-  it("reloads the active broker runtime when /pinet start runs twice", async () => {
+  it("reloads the broker in place, coalesces reloads, and waits to shut down", async () => {
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
@@ -491,10 +495,25 @@ describe("slack-bridge top-level shutdown", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop,
       } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
     });
-    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    let slackConnectCount = 0;
+    const reloadConnectStartedGate = { resolve: () => {} };
+    const reloadConnectStarted = new Promise<void>((resolve) => {
+      reloadConnectStartedGate.resolve = resolve;
+    });
+    const reloadConnectReleasedGate = { resolve: () => {} };
+    const reloadConnectReleased = new Promise<void>((resolve) => {
+      reloadConnectReleasedGate.resolve = resolve;
+    });
+    const slackConnectSpy = vi.spyOn(SlackAdapter.prototype, "connect").mockImplementation(() => {
+      slackConnectCount += 1;
+      if (slackConnectCount !== 2) return Promise.resolve();
+      reloadConnectStartedGate.resolve();
+      return reloadConnectReleased;
+    });
     vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
     vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
 
@@ -510,18 +529,25 @@ describe("slack-bridge top-level shutdown", () => {
 
     await sessionStart?.({}, ctx);
     await pinetStart?.handler("start", ctx);
-    await pinetStart?.handler("start", ctx);
+    const firstReload = pinetStart?.handler("start", ctx);
+    const coalescedReload = pinetStart?.handler("start", ctx);
+    await reloadConnectStarted;
+    const shutdown = sessionShutdown?.({}, ctx);
+    await Promise.resolve();
+    expect(brokerRuntimes[0]?.stop).not.toHaveBeenCalled();
 
-    expect(startBrokerSpy).toHaveBeenCalledTimes(2);
-    expect(brokerRuntimes).toHaveLength(2);
+    reloadConnectReleasedGate.resolve();
+    await Promise.all([firstReload, coalescedReload, shutdown]);
+
+    expect(startBrokerSpy).toHaveBeenCalledTimes(1);
+    expect(slackConnectSpy).toHaveBeenCalledTimes(2);
+    expect(brokerRuntimes).toHaveLength(1);
     expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
     expect(notify).toHaveBeenCalledWith(
       "Pinet broker already running — reloading current runtime",
       "info",
     );
     expect(notify).not.toHaveBeenCalledWith("Pinet already running (broker)", "info");
-
-    await sessionShutdown?.({}, ctx);
   });
 
   it("aborts the current turn before reloading broker runtime from /pinet start", async () => {
@@ -607,6 +633,7 @@ describe("slack-bridge top-level shutdown", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop,
       } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
     });
@@ -629,9 +656,9 @@ describe("slack-bridge top-level shutdown", () => {
     await pinetStart?.handler("start", ctx);
 
     expect(abort).toHaveBeenCalledTimes(1);
-    expect(startBrokerSpy).toHaveBeenCalledTimes(2);
-    expect(brokerRuntimes).toHaveLength(2);
-    expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(startBrokerSpy).toHaveBeenCalledTimes(1);
+    expect(brokerRuntimes).toHaveLength(1);
+    expect(brokerRuntimes[0]?.stop).not.toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith(
       "Pinet broker already running — reloading current runtime",
       "info",
@@ -690,7 +717,6 @@ describe("slack-bridge top-level shutdown", () => {
       };
       stop: ReturnType<typeof vi.fn>;
     }> = [];
-    let startAttempt = 0;
 
     vi.spyOn(maintenanceModule, "runBrokerMaintenancePass").mockImplementation((db) => ({
       reapedAgentIds: [],
@@ -701,11 +727,6 @@ describe("slack-bridge top-level shutdown", () => {
       anomalies: [],
     }));
     const startBrokerSpy = vi.spyOn(brokerModule, "startBroker").mockImplementation(async () => {
-      startAttempt += 1;
-      if (startAttempt === 2) {
-        throw new Error("refreshed start failed");
-      }
-
       const db = new BrokerDB(dbPath);
       db.initialize();
       const server = {
@@ -727,10 +748,17 @@ describe("slack-bridge top-level shutdown", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop,
       } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
     });
-    vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
+    let connectAttempt = 0;
+    vi.spyOn(SlackAdapter.prototype, "connect").mockImplementation(async () => {
+      connectAttempt += 1;
+      if (connectAttempt === 2) {
+        throw new Error("refreshed adapter start failed");
+      }
+    });
     vi.spyOn(SlackAdapter.prototype, "disconnect").mockResolvedValue(undefined);
     vi.spyOn(SlackAdapter.prototype, "getBotUserId").mockReturnValue("U_BOT");
 
@@ -751,22 +779,22 @@ describe("slack-bridge top-level shutdown", () => {
 
     await pinetStart?.handler("start", ctx);
 
-    expect(startBrokerSpy).toHaveBeenCalledTimes(3);
-    expect(brokerRuntimes).toHaveLength(2);
-    expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(startBrokerSpy).toHaveBeenCalledTimes(1);
+    expect(brokerRuntimes).toHaveLength(1);
+    expect(brokerRuntimes[0]?.stop).not.toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith(
       "Pinet broker already running — reloading current runtime",
       "info",
     );
     expect(notify).toHaveBeenCalledWith(
-      "Pinet broker reload failed: Reload failed: refreshed start failed. Restored the previous runtime.",
+      "Pinet broker reload failed: Reload failed: refreshed adapter start failed. Restored the previous runtime.",
       "error",
     );
     expect(notify).not.toHaveBeenCalledWith("Pinet already running (broker)", "info");
     expect(setStatus).toHaveBeenCalled();
 
     await sessionShutdown?.({}, ctx);
-    expect(brokerRuntimes[1]?.stop).toHaveBeenCalledTimes(1);
+    expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
   it("preserves the incoming system prompt prefix when broker guidance is appended at root runtime", async () => {
@@ -836,6 +864,7 @@ describe("slack-bridge top-level shutdown", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop,
       } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
     });
@@ -1134,6 +1163,7 @@ describe("slack-bridge top-level shutdown", () => {
       },
       adapters: [],
       addAdapter: vi.fn(),
+      removeAdapters: vi.fn(async () => {}),
       stop: brokerStop,
     } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
     vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
@@ -1874,6 +1904,7 @@ describe("slack-bridge top-level shutdown", () => {
       },
       adapters: [],
       addAdapter: vi.fn(),
+      removeAdapters: vi.fn(async () => {}),
       stop: brokerStop,
     } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
     vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
@@ -2322,6 +2353,7 @@ describe("slack-bridge top-level shutdown", () => {
       },
       adapters: [],
       addAdapter: vi.fn(),
+      removeAdapters: vi.fn(async () => {}),
       stop: brokerStop,
     } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
     vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
@@ -3236,6 +3268,7 @@ describe("slack-bridge Pinet reconnect", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop: vi.fn(async () => {
           db.close();
         }),
@@ -3372,6 +3405,7 @@ describe("slack-bridge Pinet reconnect", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop: vi.fn(async () => {
           db.close();
         }),
@@ -4261,6 +4295,7 @@ describe("slack-bridge broker startup backlog recovery", () => {
       },
       adapters: [],
       addAdapter: vi.fn(),
+      removeAdapters: vi.fn(async () => {}),
       stop: brokerStop,
     } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
     vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
@@ -4407,6 +4442,7 @@ describe("slack-bridge broker startup backlog recovery", () => {
       },
       adapters: [],
       addAdapter: vi.fn(),
+      removeAdapters: vi.fn(async () => {}),
       stop: brokerStop,
     } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>);
     vi.spyOn(SlackAdapter.prototype, "connect").mockResolvedValue(undefined);
@@ -4669,6 +4705,7 @@ describe("slack-bridge broker startup backlog recovery", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
+        removeAdapters: vi.fn(async () => {}),
         stop,
       } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
     });
@@ -4694,9 +4731,9 @@ describe("slack-bridge broker startup backlog recovery", () => {
 
     await pinetStart?.handler("start", ctx);
 
-    expect(startBrokerSpy).toHaveBeenCalledTimes(2);
-    expect(brokerRuntimes).toHaveLength(2);
-    expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(startBrokerSpy).toHaveBeenCalledTimes(1);
+    expect(brokerRuntimes).toHaveLength(1);
+    expect(brokerRuntimes[0]?.stop).not.toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith(
       "Pinet broker already running — reloading current runtime",
       "info",

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -726,6 +726,7 @@ describe("slack-bridge top-level shutdown", () => {
       pendingBacklogCount: db.getBacklogCount("pending"),
       anomalies: [],
     }));
+    let removeAdaptersCallCount = 0;
     const startBrokerSpy = vi.spyOn(brokerModule, "startBroker").mockImplementation(async () => {
       const db = new BrokerDB(dbPath);
       db.initialize();
@@ -748,7 +749,12 @@ describe("slack-bridge top-level shutdown", () => {
         },
         adapters: [],
         addAdapter: vi.fn(),
-        removeAdapters: vi.fn(async () => {}),
+        removeAdapters: vi.fn(async () => {
+          removeAdaptersCallCount += 1;
+          if (removeAdaptersCallCount === 2) {
+            throw new Error("failed adapter cleanup");
+          }
+        }),
         stop,
       } as unknown as Awaited<ReturnType<typeof brokerModule.startBroker>>;
     });
@@ -788,6 +794,10 @@ describe("slack-bridge top-level shutdown", () => {
     );
     expect(notify).toHaveBeenCalledWith(
       "Pinet broker reload failed: Reload failed: refreshed adapter start failed. Restored the previous runtime.",
+      "error",
+    );
+    expect(notify).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed adapter cleanup"),
       "error",
     );
     expect(notify).not.toHaveBeenCalledWith("Pinet already running (broker)", "info");
@@ -4542,7 +4552,7 @@ describe("slack-bridge broker startup backlog recovery", () => {
     expect(setStatus).toHaveBeenCalled();
   });
 
-  it("keeps exactly one live broker row and clears stranded broker-targeted pending backlog across startup and reload", async () => {
+  it("keeps exactly one live broker row across in-place and settings-driven full reloads", async () => {
     const stableBrokerId = "stable-broker-id";
     const priorBrokerId = "broker-prev";
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
@@ -4740,7 +4750,26 @@ describe("slack-bridge broker startup backlog recovery", () => {
     );
     inspectHealthyBrokerState();
 
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        "slack-bridge": {
+          allowAllWorkspaceUsers: true,
+          meshSecret: "rotated-test-secret",
+        },
+      }),
+    );
+    await pinetStart?.handler("start", ctx);
+
+    expect(startBrokerSpy).toHaveBeenCalledTimes(2);
+    expect(brokerRuntimes).toHaveLength(2);
+    expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(brokerRuntimes[1]?.stop).not.toHaveBeenCalled();
+    inspectHealthyBrokerState();
+
     await sessionShutdown?.({}, ctx);
+    expect(brokerRuntimes[1]?.stop).toHaveBeenCalledTimes(1);
     expect(notify).not.toHaveBeenCalledWith(
       expect.stringContaining("Pinet broker failed"),
       "error",

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -8,6 +8,7 @@ import {
   loadSettings as loadSettingsFromFile,
   buildAllowlist,
   resolvePinetMeshAuth,
+  reloadPinetRuntimeInPlaceSafely,
   reloadPinetRuntimeSafely,
   buildPinetOwnerToken,
   resolveAgentIdentity,
@@ -687,6 +688,8 @@ export default function (pi: ExtensionAPI) {
   let currentRuntimeMode: SlackBridgeRuntimeMode = "off";
   let brokerRole: "broker" | "follower" | null = null;
   let brokerClient: BrokerClientRef | null = null;
+  let pinetLifecycleTail: Promise<void> = Promise.resolve();
+  let pinetReloadPromise: Promise<void> | null = null;
   let followerRuntimeDiagnostic: FollowerRuntimeDiagnostic | null = null;
   const followerDeliveryState = createFollowerDeliveryState();
   let desiredAgentStatus: "working" | "idle" = "idle";
@@ -867,7 +870,7 @@ export default function (pi: ExtensionAPI) {
         "Pinet broker shutdown requested by another local session (/pinet start replace). Stopping the broker runtime in this session.",
         "warning",
       );
-      await stopPinetRuntime(ctx, { releaseIdentity: true });
+      await runPinetLifecycle(() => stopPinetRuntime(ctx, { releaseIdentity: true }));
       slackRequestRuntime.reset();
       singlePlayerRuntime.resetShutdownState();
     },
@@ -1162,6 +1165,15 @@ export default function (pi: ExtensionAPI) {
     throw new Error("Pinet is in an unexpected state.");
   }
 
+  function runPinetLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    const run = pinetLifecycleTail.then(operation, operation);
+    pinetLifecycleTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
   async function transitionToRuntimeMode(
     ctx: ExtensionContext,
     mode: SlackBridgeRuntimeMode,
@@ -1174,6 +1186,11 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (currentRuntimeMode !== "off") {
+      if (pinetReloadPromise) {
+        await pinetReloadPromise.catch(() => {
+          /* transition from the restored runtime */
+        });
+      }
       await stopPinetRuntime(ctx, { releaseIdentity: true });
       // Runtime transitions keep the extension alive in-process, so restore a
       // fresh top-level Slack request tracker after tearing the prior runtime down.
@@ -1256,38 +1273,76 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function reloadPinetRuntime(ctx: ExtensionContext): Promise<void> {
-    await reloadPinetRuntimeSafely({
-      getCurrentRole: () => brokerRole,
-      snapshotState: () => snapshotReloadableRuntime(),
-      restoreState: (snapshot) => {
-        restoreReloadableRuntime(snapshot);
-      },
-      refreshState: () => {
-        refreshSettings();
-      },
-      validateRefreshedState: () => {
+    if (pinetReloadPromise) {
+      await pinetReloadPromise;
+      return;
+    }
+
+    const reloadWork = runPinetLifecycle(async () => {
+      const validateRefreshedState = () => {
         if (!botToken || !appToken) {
           throw new Error("Slack tokens are not configured after reload.");
         }
-      },
-      stopRuntime: async () => {
-        await stopPinetRuntime(ctx, { releaseIdentity: false });
-        // Reload intentionally keeps the extension alive in-process, so restore a
-        // fresh top-level Slack request tracker after aborting the previous
-        // generation. This preserves shutdown abort semantics without leaving
-        // top-level Slack tools permanently stuck in "shutdown in progress".
-        slackRequestRuntime.reset();
-        singlePlayerRuntime.resetShutdownState();
-        setExtStatus(ctx, "reconnecting");
-      },
-      startRuntime: async (role) => {
-        if (role === "broker") {
-          await connectAsBroker(ctx);
-          return;
+        if (brokerRole === "broker" && !brokerRuntime.canReloadInPlace()) {
+          throw new Error(
+            "Pinet mesh authentication or iMessage settings changed and require a full broker restart.",
+          );
         }
-        await connectAsFollower(ctx);
-      },
+      };
+
+      if (brokerRole === "broker") {
+        await reloadPinetRuntimeInPlaceSafely({
+          snapshotState: () => snapshotReloadableRuntime(),
+          restoreState: (snapshot) => {
+            restoreReloadableRuntime(snapshot);
+          },
+          refreshState: () => {
+            refreshSettings();
+          },
+          validateRefreshedState,
+          reloadRuntime: async () => {
+            const result = await brokerRuntime.reloadAdapters(ctx);
+            botUserId = result.botUserId;
+          },
+        });
+        return;
+      }
+
+      await reloadPinetRuntimeSafely({
+        getCurrentRole: () => brokerRole,
+        snapshotState: () => snapshotReloadableRuntime(),
+        restoreState: (snapshot) => {
+          restoreReloadableRuntime(snapshot);
+        },
+        refreshState: () => {
+          refreshSettings();
+        },
+        validateRefreshedState,
+        stopRuntime: async () => {
+          await stopPinetRuntime(ctx, { releaseIdentity: false });
+          // Reload intentionally keeps the extension alive in-process, so restore a
+          // fresh top-level Slack request tracker after aborting the previous
+          // generation. This preserves shutdown abort semantics without leaving
+          // top-level Slack tools permanently stuck in "shutdown in progress".
+          slackRequestRuntime.reset();
+          singlePlayerRuntime.resetShutdownState();
+          setExtStatus(ctx, "reconnecting");
+        },
+        startRuntime: async (role) => {
+          if (role === "broker") {
+            await connectAsBroker(ctx);
+            return;
+          }
+          await connectAsFollower(ctx);
+        },
+      });
+    }).finally(() => {
+      if (pinetReloadPromise === reloadWork) {
+        pinetReloadPromise = null;
+      }
     });
+    pinetReloadPromise = reloadWork;
+    await reloadWork;
   }
 
   // ─── Tools ──────────────────────────────────────────
@@ -1775,7 +1830,7 @@ export default function (pi: ExtensionAPI) {
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
     sessionUiRuntime.cleanupForSessionShutdown();
-    await stopPinetRuntime(ctx, { releaseIdentity: true });
+    await runPinetLifecycle(() => stopPinetRuntime(ctx, { releaseIdentity: true }));
     pinetRegistrationGate.reset();
   });
 }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1191,7 +1191,7 @@ export default function (pi: ExtensionAPI) {
           /* transition from the restored runtime */
         });
       }
-      await stopPinetRuntime(ctx, { releaseIdentity: true });
+      await runPinetLifecycle(() => stopPinetRuntime(ctx, { releaseIdentity: true }));
       // Runtime transitions keep the extension alive in-process, so restore a
       // fresh top-level Slack request tracker after tearing the prior runtime down.
       slackRequestRuntime.reset();
@@ -1279,14 +1279,13 @@ export default function (pi: ExtensionAPI) {
     }
 
     const reloadWork = runPinetLifecycle(async () => {
+      let reloadBrokerInPlace = false;
       const validateRefreshedState = () => {
         if (!botToken || !appToken) {
           throw new Error("Slack tokens are not configured after reload.");
         }
-        if (brokerRole === "broker" && !brokerRuntime.canReloadInPlace()) {
-          throw new Error(
-            "Pinet mesh authentication or iMessage settings changed and require a full broker restart.",
-          );
+        if (brokerRole === "broker") {
+          reloadBrokerInPlace = brokerRuntime.canReloadInPlace();
         }
       };
 
@@ -1301,8 +1300,17 @@ export default function (pi: ExtensionAPI) {
           },
           validateRefreshedState,
           reloadRuntime: async () => {
-            const result = await brokerRuntime.reloadAdapters(ctx);
-            botUserId = result.botUserId;
+            if (reloadBrokerInPlace) {
+              const result = await brokerRuntime.reloadAdapters(ctx);
+              botUserId = result.botUserId;
+              return;
+            }
+
+            await stopPinetRuntime(ctx, { releaseIdentity: false });
+            slackRequestRuntime.reset();
+            singlePlayerRuntime.resetShutdownState();
+            setExtStatus(ctx, "reconnecting");
+            await connectAsBroker(ctx, { refreshSettings: false });
           },
         });
         return;
@@ -1517,9 +1525,14 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Commands ───────────────────────────────────────
 
-  async function connectAsBroker(ctx: ExtensionContext): Promise<void> {
+  async function connectAsBroker(
+    ctx: ExtensionContext,
+    options: { refreshSettings?: boolean } = {},
+  ): Promise<void> {
     setExtStatus(ctx, "reconnecting");
-    refreshSettings();
+    if (options.refreshSettings !== false) {
+      refreshSettings();
+    }
     maybeWarnSlackUserAccess(ctx);
     maybeWarnSlackGuardrailPosture(ctx);
 


### PR DESCRIPTION
## Summary
- keep the broker socket, database, and worker connections alive during broker reloads
- replace only reloadable transport adapters, with rollback and lifecycle serialization
- preserve broker identity and reject in-place reloads when mesh auth or iMessage settings require a full restart
- guarantee Slack socket teardown and surface adapter cleanup failures

## Verification
- 
> pi-extensions@0.2.4 prepush /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers
> pnpm lint && pnpm typecheck && pnpm test


> pi-extensions@0.2.4 lint /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers
> turbo run lint && pnpm lint:agent-standards


   • Packages in scope: @gugu910/pi-browser-playwright, @gugu910/pi-neon-psql, @gugu910/pi-nvim-bridge, @gugu910/pi-openai-execution-shaping, @gugu910/pi-slack-api, @pinet/broker-core, @pinet/imessage-bridge, @pinet/model-aware-compaction, @pinet/pinet-core, @pinet/slack-bridge, @pinet/transport-core
   • Running lint in 11 packages
   • Remote caching disabled, using shared worktree cache

@pinet/slack-bridge:lint: cache hit, replaying logs 08014a950124825b
@pinet/slack-bridge:lint: 
@pinet/slack-bridge:lint: > @pinet/slack-bridge@0.2.4 lint /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers/slack-bridge
@pinet/slack-bridge:lint: > eslint . --ext .ts
@pinet/slack-bridge:lint: 
@gugu910/pi-openai-execution-shaping:lint: cache hit, replaying logs 8ae88148f250bd4a
@gugu910/pi-openai-execution-shaping:lint: 
@gugu910/pi-openai-execution-shaping:lint: > @gugu910/pi-openai-execution-shaping@0.0.0 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/openai-execution-shaping
@gugu910/pi-openai-execution-shaping:lint: > eslint . --ext .ts
@gugu910/pi-openai-execution-shaping:lint: 
@gugu910/pi-neon-psql:lint: cache hit, replaying logs db50b0cb83c2a374
@pinet/transport-core:lint: cache hit, replaying logs 62c39c86f70b5fe3
@gugu910/pi-neon-psql:lint: 
@gugu910/pi-neon-psql:lint: > @gugu910/pi-neon-psql@0.1.0 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/neon-psql
@gugu910/pi-neon-psql:lint: > eslint . --ext .ts
@gugu910/pi-neon-psql:lint: 
@pinet/transport-core:lint: 
@pinet/transport-core:lint: > @pinet/transport-core@0.2.4 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/transport-core
@pinet/transport-core:lint: > eslint . --ext .ts
@pinet/transport-core:lint: 
@gugu910/pi-nvim-bridge:lint: cache hit, replaying logs d0e004b63de58199
@gugu910/pi-nvim-bridge:lint: 
@gugu910/pi-nvim-bridge:lint: > @gugu910/pi-nvim-bridge@0.1.0 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/nvim-bridge
@gugu910/pi-nvim-bridge:lint: > eslint . --ext .ts
@gugu910/pi-nvim-bridge:lint: 
@pinet/pinet-core:lint: cache hit, replaying logs 42ece264359dd6dc
@pinet/pinet-core:lint: 
@pinet/pinet-core:lint: > @pinet/pinet-core@0.2.4 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/pinet-core
@pinet/pinet-core:lint: > eslint . --ext .ts
@pinet/pinet-core:lint: 
@pinet/model-aware-compaction:lint: cache hit, replaying logs 0dec65367ee70c9f
@pinet/model-aware-compaction:lint: 
@pinet/model-aware-compaction:lint: > @pinet/model-aware-compaction@0.2.4 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pr-954-review/model-aware-compaction
@pinet/model-aware-compaction:lint: > eslint . --ext .ts
@pinet/model-aware-compaction:lint: 
@gugu910/pi-browser-playwright:lint: cache hit, replaying logs ef7138bf2460c78d
@gugu910/pi-browser-playwright:lint: 
@gugu910/pi-browser-playwright:lint: > @gugu910/pi-browser-playwright@0.1.0 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/browser-playwright
@gugu910/pi-browser-playwright:lint: > eslint . --ext .ts
@gugu910/pi-browser-playwright:lint: 
@pinet/imessage-bridge:lint: cache hit, replaying logs 1003fe0ccf0c881f
@gugu910/pi-slack-api:lint: cache hit, replaying logs bdb03e34be495c34
@pinet/imessage-bridge:lint: 
@pinet/imessage-bridge:lint: > @pinet/imessage-bridge@0.2.4 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/imessage-bridge
@pinet/imessage-bridge:lint: > eslint . --ext .ts
@pinet/imessage-bridge:lint: 
@gugu910/pi-slack-api:lint: 
@gugu910/pi-slack-api:lint: > @gugu910/pi-slack-api@0.2.0 lint /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/slack-api
@gugu910/pi-slack-api:lint: > eslint . --ext .ts
@gugu910/pi-slack-api:lint: 
@pinet/broker-core:lint: cache hit, replaying logs 0a4ca061eb99cbb3
@pinet/broker-core:lint: 
@pinet/broker-core:lint: > @pinet/broker-core@0.2.4 lint /Users/tmnexcade/projects/pinet-wt/pr-a-958/broker-core
@pinet/broker-core:lint: > eslint . --ext .ts
@pinet/broker-core:lint: 

 Tasks:    11 successful, 11 total
Cached:    11 cached, 11 total
  Time:    16ms >>> FULL TURBO


> pi-extensions@0.2.4 lint:agent-standards /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers
> node ./scripts/agent-standards-lint.mjs


> pi-extensions@0.2.4 typecheck /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers
> turbo run typecheck


   • Packages in scope: @gugu910/pi-browser-playwright, @gugu910/pi-neon-psql, @gugu910/pi-nvim-bridge, @gugu910/pi-openai-execution-shaping, @gugu910/pi-slack-api, @pinet/broker-core, @pinet/imessage-bridge, @pinet/model-aware-compaction, @pinet/pinet-core, @pinet/slack-bridge, @pinet/transport-core
   • Running typecheck in 11 packages
   • Remote caching disabled, using shared worktree cache

@pinet/pinet-core:typecheck: cache hit, replaying logs cf97bc82ce79f6d9
@gugu910/pi-slack-api:typecheck: cache hit, replaying logs 53e3bc437518a52c
@pinet/pinet-core:typecheck: 
@pinet/broker-core:typecheck: cache hit, replaying logs b4031300521df7e1
@pinet/pinet-core:typecheck: > @pinet/pinet-core@0.2.4 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/pinet-core
@pinet/pinet-core:typecheck: > tsc --noEmit
@pinet/pinet-core:typecheck: 
@gugu910/pi-slack-api:typecheck: 
@gugu910/pi-slack-api:typecheck: > @gugu910/pi-slack-api@0.2.0 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/slack-api
@gugu910/pi-slack-api:typecheck: > tsc --noEmit
@gugu910/pi-slack-api:typecheck: 
@pinet/broker-core:typecheck: 
@pinet/broker-core:typecheck: > @pinet/broker-core@0.2.4 typecheck /Users/tmnexcade/projects/pinet-wt/pr-a-958/broker-core
@pinet/broker-core:typecheck: > tsc --noEmit
@pinet/broker-core:typecheck: 
@pinet/transport-core:typecheck: cache hit, replaying logs 0f3c90f269b2183d
@pinet/imessage-bridge:typecheck: cache hit, replaying logs fd7fb2d5bf98288f
@pinet/transport-core:typecheck: 
@pinet/transport-core:typecheck: > @pinet/transport-core@0.2.4 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/transport-core
@pinet/transport-core:typecheck: > tsc --noEmit
@pinet/transport-core:typecheck: 
@pinet/imessage-bridge:typecheck: 
@pinet/imessage-bridge:typecheck: > @pinet/imessage-bridge@0.2.4 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/imessage-bridge
@pinet/imessage-bridge:typecheck: > tsc --noEmit
@pinet/imessage-bridge:typecheck: 
@pinet/model-aware-compaction:typecheck: cache hit, replaying logs f4ba6d14b4b4f878
@pinet/model-aware-compaction:typecheck: 
@pinet/model-aware-compaction:typecheck: > @pinet/model-aware-compaction@0.2.4 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pr-954-review/model-aware-compaction
@pinet/model-aware-compaction:typecheck: > tsc --noEmit
@pinet/model-aware-compaction:typecheck: 
@gugu910/pi-neon-psql:typecheck: cache hit, replaying logs 7dc079fa4f60466a
@gugu910/pi-neon-psql:typecheck: 
@gugu910/pi-neon-psql:typecheck: > @gugu910/pi-neon-psql@0.1.0 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/neon-psql
@gugu910/pi-neon-psql:typecheck: > tsc --noEmit
@gugu910/pi-neon-psql:typecheck: 
@pinet/slack-bridge:typecheck: cache hit, replaying logs abced79ad56d8e74
@pinet/slack-bridge:typecheck: 
@pinet/slack-bridge:typecheck: > @pinet/slack-bridge@0.2.4 typecheck /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers/slack-bridge
@pinet/slack-bridge:typecheck: > tsc --noEmit
@pinet/slack-bridge:typecheck: 
@gugu910/pi-browser-playwright:typecheck: cache hit, replaying logs 4c5c1cca8143c481
@gugu910/pi-browser-playwright:typecheck: 
@gugu910/pi-browser-playwright:typecheck: > @gugu910/pi-browser-playwright@0.1.0 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/browser-playwright
@gugu910/pi-browser-playwright:typecheck: > tsc --noEmit
@gugu910/pi-browser-playwright:typecheck: 
@gugu910/pi-openai-execution-shaping:typecheck: cache hit, replaying logs 4d5b716e3f33e3cd
@gugu910/pi-openai-execution-shaping:typecheck: 
@gugu910/pi-openai-execution-shaping:typecheck: > @gugu910/pi-openai-execution-shaping@0.0.0 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/openai-execution-shaping
@gugu910/pi-openai-execution-shaping:typecheck: > tsc --noEmit
@gugu910/pi-openai-execution-shaping:typecheck: 
@gugu910/pi-nvim-bridge:typecheck: cache hit, replaying logs f2c418ed82c13472
@gugu910/pi-nvim-bridge:typecheck: 
@gugu910/pi-nvim-bridge:typecheck: > @gugu910/pi-nvim-bridge@0.1.0 typecheck /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/nvim-bridge
@gugu910/pi-nvim-bridge:typecheck: > tsc --noEmit
@gugu910/pi-nvim-bridge:typecheck: 

 Tasks:    11 successful, 11 total
Cached:    11 cached, 11 total
  Time:    15ms >>> FULL TURBO


> pi-extensions@0.2.4 test /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers
> turbo run test && node --test scripts/*.test.mjs


   • Packages in scope: @gugu910/pi-browser-playwright, @gugu910/pi-neon-psql, @gugu910/pi-nvim-bridge, @gugu910/pi-openai-execution-shaping, @gugu910/pi-slack-api, @pinet/broker-core, @pinet/imessage-bridge, @pinet/model-aware-compaction, @pinet/pinet-core, @pinet/slack-bridge, @pinet/transport-core
   • Running test in 11 packages
   • Remote caching disabled, using shared worktree cache

@gugu910/pi-neon-psql:test: cache hit, replaying logs 53afab6962a490f8
@gugu910/pi-neon-psql:test: 
@gugu910/pi-neon-psql:test: > @gugu910/pi-neon-psql@0.1.0 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/neon-psql
@gugu910/pi-neon-psql:test: > vitest run --config ../vitest.config.ts
@gugu910/pi-neon-psql:test: 
@gugu910/pi-neon-psql:test: 
@gugu910/pi-neon-psql:test:  RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/neon-psql
@gugu910/pi-neon-psql:test: 
@gugu910/pi-neon-psql:test: 
@gugu910/pi-neon-psql:test:  Test Files  6 passed (6)
@gugu910/pi-neon-psql:test:       Tests  46 passed (46)
@gugu910/pi-neon-psql:test:    Start at  16:11:13
@gugu910/pi-neon-psql:test:    Duration  1.15s (transform 248ms, setup 0ms, import 563ms, tests 521ms, environment 0ms)
@gugu910/pi-neon-psql:test: 
@gugu910/pi-nvim-bridge:test: cache hit, replaying logs 5fe28d05adb9fea6
@gugu910/pi-nvim-bridge:test: 
@gugu910/pi-nvim-bridge:test: > @gugu910/pi-nvim-bridge@0.1.0 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/nvim-bridge
@gugu910/pi-nvim-bridge:test: > vitest run --config ../vitest.config.ts
@gugu910/pi-nvim-bridge:test: 
@gugu910/pi-nvim-bridge:test: 
@gugu910/pi-nvim-bridge:test:  RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/nvim-bridge
@gugu910/pi-nvim-bridge:test: 
@gugu910/pi-nvim-bridge:test: 
@gugu910/pi-nvim-bridge:test:  Test Files  4 passed | 1 skipped (5)
@gugu910/pi-nvim-bridge:test:       Tests  22 passed | 1 skipped (23)
@gugu910/pi-nvim-bridge:test:    Start at  16:11:13
@gugu910/pi-nvim-bridge:test:    Duration  795ms (transform 191ms, setup 0ms, import 444ms, tests 77ms, environment 0ms)
@gugu910/pi-nvim-bridge:test: 
@pinet/broker-core:test: cache hit, replaying logs a9315eea0f43b99b
@pinet/broker-core:test: 
@pinet/broker-core:test: > @pinet/broker-core@0.2.4 test /Users/tmnexcade/projects/pinet-wt/pr-a-958/broker-core
@pinet/broker-core:test: > vitest run --config ../vitest.config.ts *.test.ts
@pinet/broker-core:test: 
@pinet/broker-core:test: 
@pinet/broker-core:test:  RUN  v4.1.2 /Users/tmnexcade/projects/pinet-wt/pr-a-958/broker-core
@pinet/broker-core:test: 
@pinet/broker-core:test: 
@pinet/broker-core:test:  Test Files  10 passed (10)
@pinet/broker-core:test:       Tests  207 passed (207)
@pinet/broker-core:test:    Start at  18:27:00
@pinet/broker-core:test:    Duration  1.45s (transform 1.63s, setup 0ms, import 2.06s, tests 2.37s, environment 1ms)
@pinet/broker-core:test: 
@pinet/transport-core:test: cache hit, replaying logs f99973edac089d04
@pinet/transport-core:test: 
@pinet/transport-core:test: > @pinet/transport-core@0.2.4 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/transport-core
@pinet/transport-core:test: > node --experimental-strip-types --test *.test.ts
@pinet/transport-core:test: 
@pinet/transport-core:test: ✔ createAbortError produces an Error recognized by isAbortError (0.953667ms)
@pinet/transport-core:test: ✔ createAbortError accepts a custom message (0.146625ms)
@pinet/transport-core:test: ✔ isAbortError rejects non-abort values (0.098791ms)
@pinet/transport-core:test: ✔ sleep resolves after the delay without a signal (6.006875ms)
@pinet/transport-core:test: ✔ sleep rejects immediately when the signal is already aborted (0.624667ms)
@pinet/transport-core:test: ✔ sleep rejects with an AbortError when aborted mid-flight (0.235875ms)
@pinet/transport-core:test: ✔ sleep resolves normally when the signal never aborts (4.605541ms)
@pinet/transport-core:test: ✔ createTimeoutError produces an Error recognized by isTimeoutError (0.161875ms)
@pinet/transport-core:test: ✔ createTimeoutError prefixes an optional label (0.069542ms)
@pinet/transport-core:test: ✔ isTimeoutError rejects non-timeout values (0.069208ms)
@pinet/transport-core:test: ✔ withTimeout resolves with the wrapped value when it settles in time (0.096125ms)
@pinet/transport-core:test: ✔ withTimeout rejects with a TimeoutError when the promise is too slow (6.404791ms)
@pinet/transport-core:test: ✔ withTimeout includes the label in the timeout message (6.252833ms)
@pinet/transport-core:test: ✔ withTimeout passes through Error rejections from the wrapped promise (0.180834ms)
@pinet/transport-core:test: ✔ withTimeout normalizes non-Error rejections (0.054917ms)
@pinet/transport-core:test: ✔ computeBackoffDelay grows exponentially before the cap (0.064375ms)
@pinet/transport-core:test: ✔ computeBackoffDelay caps at maxMs (0.024208ms)
@pinet/transport-core:test: ✔ computeBackoffDelay treats negative attempts as attempt zero (0.023125ms)
@pinet/transport-core:test: ✔ computeBackoffDelay applies ±25% jitter by default (0.062917ms)
@pinet/transport-core:test: ✔ computeBackoffDelay honors a custom growth factor (0.023375ms)
@pinet/transport-core:test: ✔ computeBackoffDelay matches the historical reconnect-delay formula (0.057459ms)
@pinet/transport-core:test: ✔ buildCompatibilityWorkspaceScope keeps unknown workspace ids unknown while preserving compatibility mode (1.360167ms)
@pinet/transport-core:test: ✔ buildRuntimeScopeCarrier combines workspace and instance compatibility carriers (0.129167ms)
@pinet/transport-core:test: ✔ InboundMessage can carry first-class runtime scope metadata (1.102375ms)
@pinet/transport-core:test: ✔ transport payload DTOs carry JSON-compatible metadata and blocks (0.111375ms)
@pinet/transport-core:test: ℹ tests 25
@pinet/transport-core:test: ℹ suites 0
@pinet/transport-core:test: ℹ pass 25
@pinet/transport-core:test: ℹ fail 0
@pinet/transport-core:test: ℹ cancelled 0
@pinet/transport-core:test: ℹ skipped 0
@pinet/transport-core:test: ℹ todo 0
@pinet/transport-core:test: ℹ duration_ms 159.264875
@gugu910/pi-browser-playwright:test: cache hit, replaying logs 4d59ea0f682f901b
@gugu910/pi-browser-playwright:test: 
@gugu910/pi-browser-playwright:test: > @gugu910/pi-browser-playwright@0.1.0 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/browser-playwright
@gugu910/pi-browser-playwright:test: > node --experimental-strip-types --test *.test.ts
@gugu910/pi-browser-playwright:test: 
@gugu910/pi-browser-playwright:test: ✔ resolveSecurityOptions keeps localhost and private networks blocked by default at the route layer (2.032791ms)
@gugu910/pi-browser-playwright:test: ✔ resolveSecurityOptions respects explicit env opt-ins (0.187ms)
@gugu910/pi-browser-playwright:test: ✔ isLocalhostUrl recognizes direct localhost development targets (0.134875ms)
@gugu910/pi-browser-playwright:test: ✔ resolveNavigationSecurityOptions allows direct localhost navigations by default (0.11025ms)
@gugu910/pi-browser-playwright:test: ✔ resolveRouteSecurityOptions keeps localhost subrequests blocked for non-localhost pages (0.111834ms)
@gugu910/pi-browser-playwright:test: ✔ resolveRouteSecurityOptions allows localhost subrequests for explicitly trusted localhost pages (0.055209ms)
@gugu910/pi-browser-playwright:test: ✔ assessUrl allows public https URLs (0.099958ms)
@gugu910/pi-browser-playwright:test: ✔ assessUrl blocks localhost when localhost access is disabled (0.058ms)
@gugu910/pi-browser-playwright:test: ✔ assessUrl allows localhost with explicit opt-in (0.070708ms)
@gugu910/pi-browser-playwright:test: ✔ assessUrl blocks private-network IPs by default (0.165167ms)
@gugu910/pi-browser-playwright:test: ✔ assessUrl allows private-network IPs with explicit opt-in (0.067667ms)
@gugu910/pi-browser-playwright:test: ✔ assessUrl blocks obvious internal hostnames by default (0.052959ms)
@gugu910/pi-browser-playwright:test: ✔ buildInstallInstructions includes npm install only when requested (0.134ms)
@gugu910/pi-browser-playwright:test: ✔ buildInstallInstructions is browser-engine aware (0.059667ms)
@gugu910/pi-browser-playwright:test: ✔ buildBrowserTrustBoundaryNotes calls out localhost and trusted storage-state assumptions (0.0725ms)
@gugu910/pi-browser-playwright:test: ✔ findPreferredChromiumExecutable prefers an explicit env override (0.296625ms)
@gugu910/pi-browser-playwright:test: ✔ findPreferredChromiumExecutable falls back to PATH entries (0.231167ms)
@gugu910/pi-browser-playwright:test: ✔ findPreferredChromiumExecutable checks common macOS app bundle locations (0.06525ms)
@gugu910/pi-browser-playwright:test: ✔ safeRequestPageId resolves page IDs for frame-backed requests (0.071875ms)
@gugu910/pi-browser-playwright:test: ✔ safeRequestPageId returns null for service-worker-style requests without a page (0.041208ms)
@gugu910/pi-browser-playwright:test: ✔ sanitizeLabel keeps filenames safe and stable (0.105334ms)
@gugu910/pi-browser-playwright:test: ✔ sanitizeStorageStateName keeps saved state names workspace-safe (0.121375ms)
@gugu910/pi-browser-playwright:test: ✔ buildStorageStateFileName appends a normalized json filename (0.028875ms)
@gugu910/pi-browser-playwright:test: ✔ sanitizeStorageStateName rejects empty names (0.163583ms)
@gugu910/pi-browser-playwright:test: ✔ isPlaywrightStorageState validates the expected top-level shape (0.037708ms)
@gugu910/pi-browser-playwright:test: ✔ truncateText trims oversized content and marks truncation (0.067166ms)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest prefers top-level args for the single browser tool envelope (1.182667ms)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest keeps input_json-only calls compatible (0.247625ms)
@pinet/pinet-core:test: cache hit, replaying logs bdb60ce1acb37543
@gugu910/pi-slack-api:test: cache hit, replaying logs f2f0008045727f7b
@gugu910/pi-slack-api:test: 
@gugu910/pi-slack-api:test: > @gugu910/pi-slack-api@0.2.0 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/slack-api
@gugu910/pi-slack-api:test: > vitest run --config ../vitest.config.ts
@gugu910/pi-slack-api:test: 
@gugu910/pi-slack-api:test: 
@gugu910/pi-slack-api:test:  RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/slack-api
@gugu910/pi-slack-api:test: 
@gugu910/pi-slack-api:test: 
@gugu910/pi-slack-api:test:  Test Files  1 passed (1)
@gugu910/pi-slack-api:test:       Tests  11 passed (11)
@gugu910/pi-slack-api:test:    Start at  16:11:13
@pinet/pinet-core:test: 
@pinet/pinet-core:test: > @pinet/pinet-core@0.2.4 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/pinet-core
@pinet/pinet-core:test: > vitest run --config ../vitest.config.ts *.test.ts
@pinet/pinet-core:test: 
@pinet/pinet-core:test: 
@pinet/pinet-core:test:  RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/pinet-core
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest accepts identical args and input_json fields (0.090792ms)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest rejects conflicting args and input_json fields (0.257916ms)
@gugu910/pi-slack-api:test:    Duration  698ms (transform 48ms, setup 0ms, import 228ms, tests 7ms, environment 0ms)
@gugu910/pi-slack-api:test: 
@pinet/pinet-core:test: 
@pinet/pinet-core:test: 
@pinet/pinet-core:test:  Test Files  3 passed (3)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest allows session_id and page_id to flow through top-level fields (0.070291ms)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest keeps top-level ids authoritative when nested values match (0.345ms)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest rejects nested ids that conflict with top-level ids (0.259ms)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest still supports backward-compatible nested ids without top-level ids (0.153458ms)
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest rejects invalid input_json (0.200833ms)
@gugu910/pi-openai-execution-shaping:test: cache hit, replaying logs 34a026f1c79d3b19
@gugu910/pi-browser-playwright:test: ✔ parseBrowserToolRequest rejects non-scalar args fields (0.440584ms)
@gugu910/pi-browser-playwright:test: ✔ buildCapabilities reports playwright as available and agent-browser as unavailable locally (0.84975ms)
@gugu910/pi-browser-playwright:test: ✔ buildBrowserDiscovery returns catalog and action schemas through the existing info action (0.160833ms)
@gugu910/pi-browser-playwright:test: ✔ buildBrowserDiscovery action schemas match runtime-supported argument names (0.174084ms)
@gugu910/pi-browser-playwright:test: ✔ buildBrowserDiscovery rejects unknown schema topics clearly (0.081958ms)
@gugu910/pi-browser-playwright:test: ✔ normalizeBrowserOutputOptions defaults to compact cli and accepts aliases (0.126459ms)
@gugu910/pi-browser-playwright:test: ✔ normalizeBrowserOutputOptions rejects invalid format and full values (0.0875ms)
@gugu910/pi-browser-playwright:test: ✔ formatBrowserResponseText uses compact cli text by default while preserving details (0.288958ms)
@gugu910/pi-browser-playwright:test: ✔ formatBrowserResponseText returns the structured envelope for explicit json or full (0.089083ms)
@gugu910/pi-browser-playwright:test: ✔ buildBrowserDiscovery advertises compact defaults and output opt-ins (0.054833ms)
@gugu910/pi-browser-playwright:test: ✔ describeBrowserActions summarizes the typed browser action enum (0.040458ms)
@gugu910/pi-browser-playwright:test: ✔ resolveStorageStateFile keeps saved state under the workspace-local browser-playwright state directory (13.676875ms)
@gugu910/pi-browser-playwright:test: ✔ loadStoredStorageState reuses a trusted saved storageState file (6.211ms)
@pinet/pinet-core:test:       Tests  17 passed (17)
@gugu910/pi-openai-execution-shaping:test: 
@gugu910/pi-browser-playwright:test: ✔ loadStoredStorageState rejects invalid JSON (5.547875ms)
@gugu910/pi-browser-playwright:test: ✔ loadStoredStorageState rejects JSON that is not Playwright storageState-shaped (3.18975ms)
@gugu910/pi-browser-playwright:test: ✔ loadStoredStorageState rejects symlinked saved state files (3.716417ms)
@gugu910/pi-browser-playwright:test: ✔ loadStoredStorageState rejects a symlink swap just before open (3.735792ms)
@gugu910/pi-openai-execution-shaping:test: > @gugu910/pi-openai-execution-shaping@0.0.0 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/openai-execution-shaping
@gugu910/pi-browser-playwright:test: ✔ loadStoredStorageState rejects storage roots that escape the workspace via symlink (2.182ms)
@gugu910/pi-browser-playwright:test: ℹ tests 53
@gugu910/pi-browser-playwright:test: ℹ suites 0
@gugu910/pi-openai-execution-shaping:test: > vitest run --config ../vitest.config.ts
@pinet/pinet-core:test:    Start at  16:11:13
@pinet/pinet-core:test:    Duration  657ms (transform 100ms, setup 0ms, import 194ms, tests 11ms, environment 4ms)
@gugu910/pi-browser-playwright:test: ℹ pass 53
@gugu910/pi-browser-playwright:test: ℹ fail 0
@gugu910/pi-browser-playwright:test: ℹ cancelled 0
@gugu910/pi-browser-playwright:test: ℹ skipped 0
@gugu910/pi-browser-playwright:test: ℹ todo 0
@gugu910/pi-browser-playwright:test: ℹ duration_ms 178.079084
@gugu910/pi-openai-execution-shaping:test: 
@gugu910/pi-openai-execution-shaping:test: 
@gugu910/pi-openai-execution-shaping:test:  RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/openai-execution-shaping
@pinet/pinet-core:test: 
@gugu910/pi-openai-execution-shaping:test: 
@gugu910/pi-openai-execution-shaping:test: 
@gugu910/pi-openai-execution-shaping:test:  Test Files  1 passed (1)
@gugu910/pi-openai-execution-shaping:test:       Tests  15 passed (15)
@gugu910/pi-openai-execution-shaping:test:    Start at  16:11:13
@gugu910/pi-openai-execution-shaping:test:    Duration  610ms (transform 109ms, setup 0ms, import 146ms, tests 6ms, environment 0ms)
@gugu910/pi-openai-execution-shaping:test: 
@pinet/imessage-bridge:test: cache hit, replaying logs a3716de52c4d3cee
@pinet/imessage-bridge:test: 
@pinet/imessage-bridge:test: > @pinet/imessage-bridge@0.2.4 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/imessage-bridge
@pinet/imessage-bridge:test: > vitest run --config ../vitest.config.ts
@pinet/imessage-bridge:test: 
@pinet/imessage-bridge:test: 
@pinet/imessage-bridge:test:  RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-pinet-repo-rename/imessage-bridge
@pinet/imessage-bridge:test: 
@pinet/imessage-bridge:test: 
@pinet/imessage-bridge:test:  Test Files  2 passed (2)
@pinet/imessage-bridge:test:       Tests  13 passed (13)
@pinet/imessage-bridge:test:    Start at  16:11:13
@pinet/imessage-bridge:test:    Duration  696ms (transform 46ms, setup 0ms, import 116ms, tests 15ms, environment 0ms)
@pinet/imessage-bridge:test: 
@pinet/slack-bridge:test: cache hit, replaying logs 9b8b2a76eb0d3e15
@pinet/slack-bridge:test: 
@pinet/slack-bridge:test: > @pinet/slack-bridge@0.2.4 test /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers/slack-bridge
@pinet/slack-bridge:test: > vitest run --config ../vitest.config.ts
@pinet/slack-bridge:test: 
@pinet/slack-bridge:test: 
@pinet/slack-bridge:test:  RUN  v4.1.2 /Users/tmnexcade/projects/pinet/.worktrees/fix-broker-reload-workers/slack-bridge
@pinet/slack-bridge:test: 
@pinet/slack-bridge:test: ps: process id too large: 999999998
@pinet/slack-bridge:test: 
@pinet/slack-bridge:test:  Test Files  93 passed | 2 skipped (95)
@pinet/slack-bridge:test:       Tests  1664 passed | 3 skipped (1667)
@pinet/slack-bridge:test:    Start at  23:23:13
@pinet/slack-bridge:test:    Duration  5.45s (transform 5.54s, setup 0ms, import 13.57s, tests 18.56s, environment 7ms)
@pinet/slack-bridge:test: 
@pinet/model-aware-compaction:test: cache hit, replaying logs 5e26bda5679c7e69
@pinet/model-aware-compaction:test: 
@pinet/model-aware-compaction:test: > @pinet/model-aware-compaction@0.2.4 test /Users/tmnexcade/projects/extensions/.worktrees/fix-pr-954-review/model-aware-compaction
@pinet/model-aware-compaction:test: > vitest run --config ../vitest.config.ts
@pinet/model-aware-compaction:test: 
@pinet/model-aware-compaction:test: 
@pinet/model-aware-compaction:test:  RUN  v4.1.2 /Users/tmnexcade/projects/extensions/.worktrees/fix-pr-954-review/model-aware-compaction
@pinet/model-aware-compaction:test: 
@pinet/model-aware-compaction:test: 
@pinet/model-aware-compaction:test:  Test Files  3 passed (3)
@pinet/model-aware-compaction:test:       Tests  12 passed (12)
@pinet/model-aware-compaction:test:    Start at  20:17:18
@pinet/model-aware-compaction:test:    Duration  299ms (transform 131ms, setup 0ms, import 172ms, tests 12ms, environment 0ms)
@pinet/model-aware-compaction:test: 

 Tasks:    11 successful, 11 total
Cached:    11 cached, 11 total
  Time:    17ms >>> FULL TURBO

✔ parseNameStatusEntries preserves base paths for renames (1.371459ms)
✔ buildDiffArgsForEntry includes old and new paths for renames (0.139209ms)
✔ countTypeEscapeHatches counts TypeScript type escapes but not runtime words (3.441125ms)
✔ findSingleUseAddedHelpers ignores existing helpers whose declaration line changed (10.1365ms)
✔ findSingleUseAddedHelpers flags only newly added one-use top-level helpers (7.239542ms)
✔ findSingleUseAddedHelpers flags nested one-use helpers (1.62525ms)
✔ findSingleUseAddedHelpers resolves same-named nested helpers by symbol (1.333792ms)
✔ findSingleUseAddedHelpers ignores exported arrow functions (1.706208ms)
✔ findSingleUseAddedHelpers resolves indirect exports by symbol (1.795166ms)
✔ findSingleUseAddedHelpers distinguishes new nested helpers from base helpers (1.407792ms)
✔ findSingleUseAddedHelpers honors the explicit semantic-seam ignore (0.962ms)
✔ build tiers cover every dist-building package exactly once (1.201709ms)
✔ build tiers keep dist-export dependencies in earlier tiers (0.118042ms)
✔ test dependency tiers cover only the dist exports needed before tests (0.0685ms)
✔ getPublishPackages returns the full publish set in dependency order (1.188667ms)
✔ parseArgs defaults to dry-run and accepts publish mode (0.179209ms)
✔ parseBootstrapArgs defaults to dry-run and requires scary real-publish confirmation (0.102334ms)
✔ parseReleaseTagVersion accepts stable vX.Y.Z release tags (0.563625ms)
✔ assertReleaseTagVersionMatchesManifests requires the full set to match the tag (0.096083ms)
✔ rewriteLocalDependencySpecs replaces in-set file dependencies with exact versions (0.194666ms)
✔ rewriteLocalDependencySpecs rejects local dependencies outside the publish set (0.067167ms)
✔ validatePublishMetadata blocks placeholder versions for real publish only (0.150708ms)
✔ validatePublishMetadata requires declaration metadata (0.058334ms)
✔ validatePublishMetadata requires npm org pinet package names (0.075833ms)
✔ validatePublishMetadata blocks incorrect GitHub package links (0.117541ms)
✔ validateBuildOutputs checks package files (5.271833ms)
✔ validateBuildOutputs checks JavaScript exports and declaration outputs (1.41625ms)
✔ validatePublicTypeResolution catches undeclared declaration imports (166.178375ms)
✔ validatePublicTypeResolution catches declared but unresolvable declaration subpaths (157.432167ms)
✔ validatePublicTypeResolution catches undeclared sibling publish-set declaration imports (162.677084ms)
✔ parseNpmViewVersionExists distinguishes found, not-found, and lookup errors (0.308542ms)
✔ assertVersionsNotAlreadyPublished fails closed for existing versions (0.083459ms)
ℹ tests 32
ℹ suites 0
ℹ pass 32
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 559.57175
- real socket regression test confirms a connected worker remains connected and the Unix socket remains present during adapter replacement
