### PR TITLE
chore: delay newly released dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 10080 # 7 days
+
 packages:
   - transport-core
   - broker-core


### PR DESCRIPTION
## Summary

- require registry packages to be at least 7 days old during dependency resolution
- keep existing frozen-lockfile installs unchanged
- allow narrowly scoped `minimumReleaseAgeExclude` exceptions if an urgent release is needed

## Verification

- `pnpm install --frozen-lockfile` with pnpm 10.18.1
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm config get minimumReleaseAge` → `10080`

Independent review found no blocking issues.