### PR TITLE
fix(slack-bridge): gate runtime guidance and tools by mode

### DIFF
--- a/slack-bridge/agent-event-runtime.test.ts
+++ b/slack-bridge/agent-event-runtime.test.ts
@@ -5,9 +5,6 @@ import { createAgentEventRuntime, type AgentEventRuntimeDeps } from "./agent-eve
 function createDeps(overrides: Partial<AgentEventRuntimeDeps> = {}) {
   const deliverFollowUpMessage = vi.fn(() => true);
   const requireToolPolicy = vi.fn();
-  const beforeAgentStart = vi.fn(async (event: { systemPrompt: string }) => ({
-    systemPrompt: event.systemPrompt + "\nextra guidance",
-  }));
   const onCompletionAgentEnd = vi.fn(async () => {});
   const setDeliverTrackedSlackFollowUpMessage = vi.fn();
 
@@ -18,7 +15,6 @@ function createDeps(overrides: Partial<AgentEventRuntimeDeps> = {}) {
     formatAction: (action) => `<${action}>`,
     formatError: (error) => (error instanceof Error ? error.message : String(error)),
     deliverFollowUpMessage,
-    beforeAgentStart,
     onCompletionAgentEnd,
     setDeliverTrackedSlackFollowUpMessage,
     ...overrides,
@@ -28,7 +24,6 @@ function createDeps(overrides: Partial<AgentEventRuntimeDeps> = {}) {
     deps,
     deliverFollowUpMessage,
     requireToolPolicy,
-    beforeAgentStart,
     onCompletionAgentEnd,
     setDeliverTrackedSlackFollowUpMessage,
   };
@@ -47,7 +42,7 @@ function createPi() {
 
 describe("createAgentEventRuntime", () => {
   it("registers the pinned agent event wiring in order and preserves agent_end ordering", () => {
-    const { deps, beforeAgentStart, onCompletionAgentEnd } = createDeps();
+    const { deps, onCompletionAgentEnd } = createDeps();
     const runtime = createAgentEventRuntime(deps);
     const { pi, registrations } = createPi();
 
@@ -59,7 +54,6 @@ describe("createAgentEventRuntime", () => {
       "turn_end",
       "agent_end",
       "tool_call",
-      "before_agent_start",
       "agent_end",
     ]);
 
@@ -67,7 +61,6 @@ describe("createAgentEventRuntime", () => {
     expect(agentEndHandlers).toHaveLength(2);
     expect(agentEndHandlers[0]?.handler).not.toBe(onCompletionAgentEnd);
     expect(agentEndHandlers[1]?.handler).toBe(onCompletionAgentEnd);
-    expect(registrations[5]?.handler).toBe(beforeAgentStart);
   });
 
   it("hands off tracked Slack follow-up delivery from the created tool-policy runtime", async () => {

--- a/slack-bridge/agent-event-runtime.ts
+++ b/slack-bridge/agent-event-runtime.ts
@@ -1,6 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentCompletionRuntime } from "./agent-completion-runtime.js";
-import type { AgentPromptGuidance } from "./agent-prompt-guidance.js";
 import {
   createSlackToolPolicyRuntime,
   type SlackToolPolicyRuntime,
@@ -8,7 +7,6 @@ import {
 } from "./slack-tool-policy-runtime.js";
 
 export interface AgentEventRuntimeDeps extends SlackToolPolicyRuntimeDeps {
-  beforeAgentStart: AgentPromptGuidance["beforeAgentStart"];
   onCompletionAgentEnd: AgentCompletionRuntime["onAgentEnd"];
   setDeliverTrackedSlackFollowUpMessage: (
     deliver: SlackToolPolicyRuntime["deliverTrackedSlackFollowUpMessage"],
@@ -42,7 +40,6 @@ export function createAgentEventRuntime(deps: AgentEventRuntimeDeps): AgentEvent
     pi.on("turn_end", slackToolPolicyRuntime.onTurnEnd);
     pi.on("agent_end", slackToolPolicyRuntime.onAgentEnd);
     pi.on("tool_call", slackToolPolicyRuntime.onToolCall);
-    pi.on("before_agent_start", deps.beforeAgentStart);
     pi.on("agent_end", deps.onCompletionAgentEnd);
   }
 

--- a/slack-bridge/agent-prompt-guidance.test.ts
+++ b/slack-bridge/agent-prompt-guidance.test.ts
@@ -25,83 +25,68 @@ function createDeps(overrides: Partial<AgentPromptGuidanceDeps> = {}): AgentProm
   };
 }
 
-describe("createAgentPromptGuidance", () => {
-  it("appends identity, personality, and reaction guidance for non-mesh sessions", async () => {
-    const getIdentityGuidelines = vi.fn(() => ["IDENTITY 1", "IDENTITY 2", "IDENTITY 3"]);
-    const guidance = createAgentPromptGuidance(
-      createDeps({
-        getIdentityGuidelines,
-      }),
-    );
+async function renderGuidance(deps: AgentPromptGuidanceDeps): Promise<string> {
+  return (await createAgentPromptGuidance(deps).buildPromptGuidelines()).join("\n");
+}
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
+describe("createAgentPromptGuidance", () => {
+  it("builds shared identity, personality, and reaction guidance", async () => {
+    const getIdentityGuidelines = vi.fn(() => ["IDENTITY 1", "IDENTITY 2", "IDENTITY 3"]);
+
+    const result = await renderGuidance(createDeps({ getIdentityGuidelines }));
 
     expect(getIdentityGuidelines).toHaveBeenCalledTimes(1);
-    expect(result.systemPrompt).toContain("BASE\n\nIDENTITY 1\nIDENTITY 2\nIDENTITY 3");
-    expect(result.systemPrompt).toContain("COMMUNICATION STYLE:");
-    expect(result.systemPrompt).toContain("For `Cobalt Olive Crane`, aim for a");
-    expect(result.systemPrompt).toContain("Slack emoji reactions are ignored by default");
-    expect(result.systemPrompt).not.toContain("PINET SKIN (");
-    expect(result.systemPrompt).not.toContain("Pinet BROKER");
-    expect(result.systemPrompt).not.toContain("TASK WORKFLOW:");
-    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
-      result.systemPrompt.indexOf("COMMUNICATION STYLE:"),
-    );
-    expect(result.systemPrompt.indexOf("COMMUNICATION STYLE:")).toBeLessThan(
-      result.systemPrompt.indexOf("Slack emoji reactions are ignored by default"),
+    expect(result).toContain("IDENTITY 1\nIDENTITY 2\nIDENTITY 3");
+    expect(result).toContain("COMMUNICATION STYLE:");
+    expect(result).toContain("For `Cobalt Olive Crane`, aim for a");
+    expect(result).toContain("Slack emoji reactions are ignored by default");
+    expect(result).not.toContain("PINET SKIN (");
+    expect(result).not.toContain("Pinet BROKER");
+    expect(result).not.toContain("TASK WORKFLOW:");
+    expect(result.indexOf("IDENTITY 1")).toBeLessThan(result.indexOf("COMMUNICATION STYLE:"));
+    expect(result.indexOf("COMMUNICATION STYLE:")).toBeLessThan(
+      result.indexOf("Slack emoji reactions are ignored by default"),
     );
   });
 
   it("includes the skin guideline only when both theme and personality are available", async () => {
-    const guidance = createAgentPromptGuidance(
+    const result = await renderGuidance(
       createDeps({
         getActiveSkinTheme: () => "ocean-mist",
         getAgentPersonality: () => "steady, elegant, observant",
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
-
-    expect(result.systemPrompt).toContain("PINET SKIN (");
-    expect(result.systemPrompt).toContain("steady, elegant, observant");
+    expect(result).toContain("PINET SKIN (");
+    expect(result).toContain("steady, elegant, observant");
   });
 
-  it("adds loaded broker MD guidance, protocol guardrails, and tool guardrails for the broker role", async () => {
-    const guidance = createAgentPromptGuidance(
-      createDeps({
-        getBrokerRole: () => "broker",
-      }),
-    );
+  it("adds loaded broker guidance and guardrails for the broker role", async () => {
+    const result = await renderGuidance(createDeps({ getBrokerRole: () => "broker" }));
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
-
-    expect(result.systemPrompt).toContain("You are 🦩 Cobalt Olive Crane, the Pinet BROKER.");
-    expect(result.systemPrompt).toContain("CUSTOM MD POLICY");
-    expect(result.systemPrompt).toContain("DELEGATE, THEN TRACK.");
-    expect(result.systemPrompt).toContain("🔒 BROKER PROTOCOL BOUNDARY:");
-    expect(result.systemPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
-    expect(result.systemPrompt).not.toContain("TASK WORKFLOW:");
+    expect(result).toContain("You are 🦩 Cobalt Olive Crane, the Pinet BROKER.");
+    expect(result).toContain("CUSTOM MD POLICY");
+    expect(result).toContain("DELEGATE, THEN TRACK.");
+    expect(result).toContain("🔒 BROKER PROTOCOL BOUNDARY:");
+    expect(result).toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(result).not.toContain("TASK WORKFLOW:");
   });
 
   it("adds worker workflow guidance for follower runtimes", async () => {
-    const guidance = createAgentPromptGuidance(
-      createDeps({
-        getBrokerRole: () => "follower",
-      }),
-    );
+    const result = await renderGuidance(createDeps({ getBrokerRole: () => "follower" }));
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
-
-    expect(result.systemPrompt).toContain(
-      "TASK WORKFLOW: When you receive work, follow these steps:",
+    expect(result).toContain("TASK WORKFLOW: When you receive work, follow these steps:");
+    expect(result).toContain("REPLY TOOL RULES:");
+    expect(result).not.toContain("Pinet BROKER");
+    expect(result).not.toContain("🚫 BROKER TOOL RESTRICTION:");
+    expect(result.indexOf("IDENTITY 1")).toBeLessThan(result.indexOf("TASK WORKFLOW:"));
+    expect(result.indexOf("TASK WORKFLOW:")).toBeLessThan(
+      result.indexOf("HELPER / DELEGATION RULES:"),
     );
-    expect(result.systemPrompt).toContain("REPLY TOOL RULES:");
-    expect(result.systemPrompt).not.toContain("Pinet BROKER");
-    expect(result.systemPrompt).not.toContain("🚫 BROKER TOOL RESTRICTION:");
   });
 
-  it("keeps broker prompt order: base, shared guidance, loaded MD, protocol boundary, tool restriction", async () => {
-    const guidance = createAgentPromptGuidance(
+  it("keeps broker guidance in the required order", async () => {
+    const result = await renderGuidance(
       createDeps({
         getBrokerRole: () => "broker",
         loadBrokerPrompt: async () => ({
@@ -113,26 +98,19 @@ describe("createAgentPromptGuidance", () => {
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
-
-    expect(result.systemPrompt.indexOf("BASE")).toBeLessThan(
-      result.systemPrompt.indexOf("IDENTITY 1"),
+    expect(result.indexOf("IDENTITY 1")).toBeLessThan(result.indexOf("LOADED BROKER MD"));
+    expect(result.indexOf("LOADED BROKER MD")).toBeLessThan(
+      result.indexOf("🔒 BROKER PROTOCOL BOUNDARY:"),
     );
-    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
-      result.systemPrompt.indexOf("LOADED BROKER MD"),
-    );
-    expect(result.systemPrompt.indexOf("LOADED BROKER MD")).toBeLessThan(
-      result.systemPrompt.indexOf("🔒 BROKER PROTOCOL BOUNDARY:"),
-    );
-    expect(result.systemPrompt.indexOf("🔒 BROKER PROTOCOL BOUNDARY:")).toBeLessThan(
-      result.systemPrompt.indexOf("🚫 BROKER TOOL RESTRICTION:"),
+    expect(result.indexOf("🔒 BROKER PROTOCOL BOUNDARY:")).toBeLessThan(
+      result.indexOf("🚫 BROKER TOOL RESTRICTION:"),
     );
   });
 
   it("reports broker prompt loader diagnostics without exposing prompt content", async () => {
     const reportBrokerPromptWarning = vi.fn();
     const reportBrokerPromptDiagnostic = vi.fn();
-    const guidance = createAgentPromptGuidance(
+    const result = await renderGuidance(
       createDeps({
         getBrokerRole: () => "broker",
         reportBrokerPromptWarning,
@@ -152,8 +130,6 @@ describe("createAgentPromptGuidance", () => {
       }),
     );
 
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
-
     expect(reportBrokerPromptWarning).toHaveBeenCalledWith(
       "[slack-bridge] broker prompt: workspace override rejected (over 65536 bytes); continuing",
     );
@@ -162,23 +138,6 @@ describe("createAgentPromptGuidance", () => {
     );
     expect(String(reportBrokerPromptWarning.mock.calls)).not.toContain("PRIVATE PROMPT BODY");
     expect(String(reportBrokerPromptDiagnostic.mock.calls)).not.toContain("PRIVATE PROMPT BODY");
-    expect(result.systemPrompt).toContain("PRIVATE PROMPT BODY");
-  });
-
-  it("keeps identity guidance ahead of follower workflow guidance", async () => {
-    const guidance = createAgentPromptGuidance(
-      createDeps({
-        getBrokerRole: () => "follower",
-      }),
-    );
-
-    const result = await guidance.beforeAgentStart({ systemPrompt: "BASE" });
-
-    expect(result.systemPrompt.indexOf("IDENTITY 1")).toBeLessThan(
-      result.systemPrompt.indexOf("TASK WORKFLOW:"),
-    );
-    expect(result.systemPrompt.indexOf("TASK WORKFLOW:")).toBeLessThan(
-      result.systemPrompt.indexOf("HELPER / DELEGATION RULES:"),
-    );
+    expect(result).toContain("PRIVATE PROMPT BODY");
   });
 });

--- a/slack-bridge/agent-prompt-guidance.ts
+++ b/slack-bridge/agent-prompt-guidance.ts
@@ -12,10 +12,6 @@ import {
 } from "./broker-prompt-loader.js";
 import { buildReactionPromptGuidelines } from "./reaction-triggers.js";
 
-export interface BeforeAgentStartEvent {
-  systemPrompt: string;
-}
-
 export interface AgentPromptGuidanceDeps {
   getIdentityGuidelines: () => string[];
   getAgentName: () => string;
@@ -30,7 +26,7 @@ export interface AgentPromptGuidanceDeps {
 }
 
 export interface AgentPromptGuidance {
-  beforeAgentStart: (event: BeforeAgentStartEvent) => Promise<{ systemPrompt: string }>;
+  buildPromptGuidelines: () => Promise<string[]>;
 }
 
 export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentPromptGuidance {
@@ -79,13 +75,7 @@ export function createAgentPromptGuidance(deps: AgentPromptGuidanceDeps): AgentP
     return guidelines;
   }
 
-  async function beforeAgentStart(event: BeforeAgentStartEvent): Promise<{ systemPrompt: string }> {
-    return {
-      systemPrompt: event.systemPrompt + "\n\n" + (await buildPromptGuidelines()).join("\n"),
-    };
-  }
-
   return {
-    beforeAgentStart,
+    buildPromptGuidelines,
   };
 }

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -67,6 +67,7 @@ export interface FollowerRuntimeDeps {
     emoji: string;
     metadata?: Record<string, unknown> | null;
   }) => void;
+  onRegistrationIdentityApplied: () => Promise<void>;
   persistState: () => void;
   updateBadge: () => void;
   maybeDrainInboxIfIdle: (ctx: ExtensionContext) => boolean;
@@ -234,6 +235,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
         deps.getAgentStableId(),
       );
       deps.applyRegistrationIdentity(registration);
+      await deps.onRegistrationIdentityApplied();
       client.setHeartbeatMetadataProvider(() => deps.getAgentMetadata("worker"));
     }
 

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -10,10 +10,11 @@ import * as maintenanceModule from "./broker/maintenance.js";
 import { BrokerDB } from "./broker/schema.js";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import * as imessageModule from "@pinet/imessage-bridge";
-import slackBridge from "./index.js";
+import slackBridgeExtension from "./index.js";
 
 type ToolDefinition = {
   name: string;
+  promptGuidelines?: string[];
   execute: (id: string, params: Record<string, unknown>) => Promise<unknown>;
 };
 
@@ -23,6 +24,23 @@ type CommandDefinition = {
 };
 
 type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+function slackBridge(pi: ExtensionAPI): void {
+  const activeTools = new Set([
+    "read",
+    "slack",
+    "slack_inbox",
+    "slack_send",
+    "pinet",
+    "imessage_send",
+  ]);
+  pi.getActiveTools = vi.fn(() => [...activeTools]);
+  pi.setActiveTools = vi.fn((toolNames: string[]) => {
+    activeTools.clear();
+    for (const toolName of toolNames) activeTools.add(toolName);
+  });
+  slackBridgeExtension(pi);
+}
 
 const BROKER_MANAGED_PINET_ENV_KEYS = [
   "PINET_BROKER_MANAGED",
@@ -807,16 +825,19 @@ describe("slack-bridge top-level shutdown", () => {
     expect(brokerRuntimes[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves the incoming system prompt prefix when broker guidance is appended at root runtime", async () => {
+  it("moves broker guidance onto the active Pinet tool instead of a per-run prompt override", async () => {
     const dbPath = path.join(testHome, ".pi", "pinet-broker.db");
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
+    const tools = new Map<string, ToolDefinition>();
     const commands = new Map<string, CommandDefinition>();
     const events = new Map<string, EventHandler>();
 
     const pi = {
       appendEntry: vi.fn(),
-      registerTool: vi.fn(),
+      registerTool: vi.fn((definition: ToolDefinition) => {
+        tools.set(definition.name, definition);
+      }),
       registerCommand: vi.fn((name: string, definition: CommandDefinition) => {
         commands.set(name, definition);
       }),
@@ -887,48 +908,22 @@ describe("slack-bridge top-level shutdown", () => {
     const sessionStart = events.get("session_start");
     const sessionShutdown = events.get("session_shutdown");
     const pinetStart = commands.get("pinet");
-    const beforeAgentStart = events.get("before_agent_start") as
-      | ((
-          event: { systemPrompt: string },
-          ctx: ExtensionContext,
-        ) => Promise<{ systemPrompt: string }>)
-      | undefined;
 
     expect(sessionStart).toBeDefined();
     expect(sessionShutdown).toBeDefined();
     expect(pinetStart).toBeDefined();
-    expect(beforeAgentStart).toBeDefined();
+    expect(events.has("before_agent_start")).toBe(false);
 
     await sessionStart?.({}, ctx);
+    expect(pi.getActiveTools()).not.toContain("pinet");
+
     await pinetStart?.handler("start", ctx);
     expect(startBrokerSpy).toHaveBeenCalledTimes(1);
+    expect(pi.getActiveTools()).toContain("pinet");
 
-    const sentinelSystemPrompt = "SENTINEL ROOT PROMPT";
-    const result = await beforeAgentStart?.({ systemPrompt: sentinelSystemPrompt }, ctx);
-    const nextPrompt = result?.systemPrompt ?? "";
-
-    expect(nextPrompt.startsWith(`${sentinelSystemPrompt}\n\n`)).toBe(true);
-    expect(nextPrompt).toContain("First message in a new thread:");
-    expect(nextPrompt).toContain("COMMUNICATION STYLE:");
-    expect(nextPrompt).toContain("Slack emoji reactions are ignored by default");
-    const brokerPolicyText = "the Pinet BROKER for a fully autonomous / unchained broker lane";
-    expect(nextPrompt).toContain(brokerPolicyText);
-    expect(nextPrompt).toContain("🚫 BROKER TOOL RESTRICTION:");
-    expect(nextPrompt.indexOf("First message in a new thread:")).toBeGreaterThan(
-      nextPrompt.indexOf(sentinelSystemPrompt),
-    );
-    expect(nextPrompt.indexOf("COMMUNICATION STYLE:")).toBeGreaterThan(
-      nextPrompt.indexOf("First message in a new thread:"),
-    );
-    expect(nextPrompt.indexOf("Slack emoji reactions are ignored by default")).toBeGreaterThan(
-      nextPrompt.indexOf("COMMUNICATION STYLE:"),
-    );
-    expect(nextPrompt.indexOf(brokerPolicyText)).toBeGreaterThan(
-      nextPrompt.indexOf("Slack emoji reactions are ignored by default"),
-    );
-    expect(nextPrompt.indexOf("🚫 BROKER TOOL RESTRICTION:")).toBeGreaterThan(
-      nextPrompt.indexOf(brokerPolicyText),
-    );
+    const guidance = tools.get("pinet")?.promptGuidelines?.join("\n") ?? "";
+    expect(guidance).toContain("First message in a new thread:");
+    expect(guidance).toContain("the Pinet BROKER for a fully autonomous / unchained broker lane");
 
     await sessionShutdown?.({}, ctx);
   });
@@ -2504,8 +2499,8 @@ describe("slack-bridge Pinet reconnect", () => {
     ) {
       const result = {
         agentId: "worker-1",
-        name,
-        emoji,
+        name: registerCalls.length === 0 ? "Initial Worker" : "Reconnected Worker",
+        emoji: registerCalls.length === 0 ? "🐣" : "🐗",
         metadata: metadata ?? null,
       };
       (
@@ -2610,8 +2605,12 @@ describe("slack-bridge Pinet reconnect", () => {
 
     await vi.waitFor(() => {
       expect(registerCalls).toHaveLength(2);
+      expect(tools.get("pinet")?.promptGuidelines?.join("\n")).toContain(
+        "🐗 `Reconnected Worker` reporting from",
+      );
     });
 
+    expect(tools.get("pinet")?.promptGuidelines?.join("\n")).not.toContain("Initial Worker");
     expect(registerCalls[1]?.stableId).toBe(registerCalls[0]?.stableId);
     expect(registerCalls[1]?.metadata).toMatchObject({
       role: "worker",

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -540,7 +540,6 @@ export default function (pi: ExtensionAPI) {
     updateThreadStatus: (channel, threadTs, status) =>
       slackThreadStatuses.update(channel, threadTs, status),
     clearThreadStatus: (channel, threadTs) => slackThreadStatuses.clear(channel, threadTs),
-    beforeAgentStart: agentPromptGuidance.beforeAgentStart,
     onCompletionAgentEnd: agentCompletionRuntime.onAgentEnd,
     setDeliverTrackedSlackFollowUpMessage: (deliver) => {
       deliverTrackedSlackFollowUpMessage = deliver;
@@ -1182,6 +1181,7 @@ export default function (pi: ExtensionAPI) {
       if (mode === "off") {
         setExtStatus(ctx, "off");
       }
+      await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
       return;
     }
 
@@ -1209,6 +1209,7 @@ export default function (pi: ExtensionAPI) {
       setExtStatus(ctx, "reconnecting");
       await singlePlayerRuntime.connect(ctx);
       botUserId = singlePlayerRuntime.getBotUserId() ?? botUserId;
+      await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
       void ensureSlackScopeDiagnostics(ctx);
       return;
     }
@@ -1249,19 +1250,13 @@ export default function (pi: ExtensionAPI) {
     await brokerRuntime.disconnect({ releaseIdentity: options.releaseIdentity });
 
     if (brokerClient) {
-      if (options.releaseIdentity) {
-        await disconnectFollower(ctx).catch(() => {
+      await followerRuntime
+        .disconnect(ctx, { releaseIdentity: options.releaseIdentity })
+        .catch(() => {
           /* best effort */
         });
-      } else {
-        await followerRuntime.disconnect(ctx, { releaseIdentity: false }).catch(() => {
-          /* best effort */
-        });
-        brokerClient = null;
-        desiredAgentStatus = "idle";
-        brokerRole = null;
-        pinetEnabled = false;
-      }
+      brokerClient = null;
+      followerRuntimeDiagnostic = null;
     }
 
     await singlePlayerRuntime.disconnect();
@@ -1270,6 +1265,7 @@ export default function (pi: ExtensionAPI) {
     desiredAgentStatus = "idle";
     currentRuntimeMode = "off";
     setExtStatus(ctx, "off");
+    await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
   }
 
   async function reloadPinetRuntime(ctx: ExtensionContext): Promise<void> {
@@ -1303,6 +1299,7 @@ export default function (pi: ExtensionAPI) {
             if (reloadBrokerInPlace) {
               const result = await brokerRuntime.reloadAdapters(ctx);
               botUserId = result.botUserId;
+              await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
               return;
             }
 
@@ -1356,6 +1353,7 @@ export default function (pi: ExtensionAPI) {
   // ─── Tools ──────────────────────────────────────────
 
   const toolRegistrationRuntime = createToolRegistrationRuntime({
+    buildPromptGuidelines: agentPromptGuidance.buildPromptGuidelines,
     slackTools: {
       getBotToken: () => {
         if (!botToken) {
@@ -1596,6 +1594,7 @@ export default function (pi: ExtensionAPI) {
     pinetEnabled = true;
     desiredAgentStatus = "idle";
     currentRuntimeMode = "broker";
+    await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
 
     if (recoveredBrokerMessages > 0 || releasedBrokerClaims > 0) {
       const recoveredTargetedDetail =
@@ -1658,6 +1657,11 @@ export default function (pi: ExtensionAPI) {
     },
     getAgentMetadata,
     applyRegistrationIdentity,
+    onRegistrationIdentityApplied: async () => {
+      if (currentRuntimeMode === "follower") {
+        await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
+      }
+    },
     persistState,
     updateBadge,
     maybeDrainInboxIfIdle,
@@ -1743,7 +1747,10 @@ export default function (pi: ExtensionAPI) {
       spawnSubtreeWorker: (ctx, input) => subtreeBrokerRuntime.spawnWorker(ctx, input),
       sendPinetAgentMessage,
       signalAgentFree,
-      applyLocalAgentIdentity,
+      applyLocalAgentIdentity: async (name, emoji, personality) => {
+        applyLocalAgentIdentity(name, emoji, personality);
+        await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
+      },
       setExtStatus,
       setExtCtx: sessionUiRuntime.setExtCtx,
     },
@@ -1761,6 +1768,7 @@ export default function (pi: ExtensionAPI) {
     pinetEnabled = true;
     desiredAgentStatus = "idle";
     currentRuntimeMode = "follower";
+    await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
     setExtStatus(ctx, "ok");
   }
 
@@ -1774,6 +1782,7 @@ export default function (pi: ExtensionAPI) {
     brokerRole = null;
     pinetEnabled = false;
     currentRuntimeMode = "off";
+    await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
     if (!options.preserveErrorState) {
       followerRuntimeDiagnostic = null;
       setExtStatus(ctx, "off");
@@ -1799,6 +1808,7 @@ export default function (pi: ExtensionAPI) {
       console.log("[slack-bridge] detected local subagent context; skipping Pinet registration");
       currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
+      await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
       return;
     }
 
@@ -1823,6 +1833,7 @@ export default function (pi: ExtensionAPI) {
       console.error(`[slack-bridge] runtime start (${startupMode}) failed: ${msg(err)}`);
       currentRuntimeMode = "off";
       setExtStatus(ctx, "off");
+      await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
     }
   });
 

--- a/slack-bridge/pinet-commands.test.ts
+++ b/slack-bridge/pinet-commands.test.ts
@@ -151,7 +151,7 @@ function createDeps(overrides: Partial<PinetCommandsDeps> = {}): PinetCommandsDe
     }),
     sendPinetAgentMessage: async (target) => ({ messageId: 1, target }),
     signalAgentFree: async () => ({ queuedInboxCount: 0, drainedQueuedInbox: false }),
-    applyLocalAgentIdentity: () => {},
+    applyLocalAgentIdentity: async () => {},
     setExtStatus: () => {},
     setExtCtx: () => {},
   };

--- a/slack-bridge/pinet-commands.ts
+++ b/slack-bridge/pinet-commands.ts
@@ -92,7 +92,11 @@ export interface PinetCommandsDeps {
     ctx: ExtensionContext,
     options: { requirePinet?: boolean },
   ) => Promise<{ queuedInboxCount: number; drainedQueuedInbox: boolean }>;
-  applyLocalAgentIdentity: (name: string, emoji: string, personality: string | null) => void;
+  applyLocalAgentIdentity: (
+    name: string,
+    emoji: string,
+    personality: string | null,
+  ) => Promise<void>;
   setExtStatus: (ctx: ExtensionContext, state: "ok" | "reconnecting" | "error" | "off") => void;
   setExtCtx: (ctx: ExtensionContext) => void;
 }
@@ -279,9 +283,20 @@ export async function runPinetCommandAction(
     case "logs":
       runPinetLogs(deps, ctx);
       return;
-    case "rename":
-      runPinetRename(deps, args, ctx);
+    case "rename": {
+      const newName = args.trim();
+      if (newName) {
+        await deps.applyLocalAgentIdentity(newName, deps.agentEmoji(), deps.agentPersonality());
+      } else {
+        const identity = generateAgentName(
+          undefined,
+          deps.runtimeMode() === "broker" ? "broker" : "worker",
+        );
+        await deps.applyLocalAgentIdentity(identity.name, identity.emoji, deps.agentPersonality());
+      }
+      ctx.ui.notify(`${deps.agentEmoji()} Agent renamed to: ${deps.agentName()}`, "info");
       return;
+    }
     case "snooze":
       runPinetSnooze(deps, args, ctx);
       return;
@@ -866,20 +881,6 @@ function runPinetLogs(deps: PinetCommandsDeps, ctx: ExtensionContext): void {
     ].join("\n\n"),
     s.logChannel ? "info" : "warning",
   );
-}
-
-function runPinetRename(deps: PinetCommandsDeps, args: string, ctx: ExtensionContext): void {
-  const newName = args.trim();
-  if (!newName) {
-    const fresh = generateAgentName(
-      undefined,
-      deps.runtimeMode() === "broker" ? "broker" : "worker",
-    );
-    deps.applyLocalAgentIdentity(fresh.name, fresh.emoji, deps.agentPersonality());
-  } else {
-    deps.applyLocalAgentIdentity(newName, deps.agentEmoji(), deps.agentPersonality());
-  }
-  ctx.ui.notify(`${deps.agentEmoji()} Agent renamed to: ${deps.agentName()}`, "info");
 }
 
 function errorMsg(err: unknown): string {

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -126,6 +126,7 @@ export interface PinetSubtreeSpawnResult {
 }
 
 export interface RegisterPinetToolsDeps {
+  promptGuidelines?: string[];
   pinetEnabled: () => boolean;
   brokerRole: () => "broker" | "follower" | null;
   requireToolPolicy: (toolName: string, threadTs: string | undefined, action: string) => void;
@@ -2764,6 +2765,7 @@ export function registerPinetTools(pi: ExtensionAPI, deps: RegisterPinetToolsDep
     description: "Dispatch Pinet operations by action with compact help and schema discovery.",
     promptSnippet:
       'Use this compact dispatcher for Pinet actions: send, read, free, snooze, schedule, agents, sessions, lanes, ports, reload, exit, hibernate, wake, spawn, and help. Use /pinet start, /pinet follow, /pinet unfollow, and /pinet subtree start for TUI lifecycle changes. Defaults to terse CLI text; pass args.format="json" for the compact envelope or args.full=true for verbose/debug detail.',
+    promptGuidelines: deps.promptGuidelines,
     parameters: Type.Object({
       action: Type.String({
         description:

--- a/slack-bridge/slack-tools.ts
+++ b/slack-bridge/slack-tools.ts
@@ -87,6 +87,7 @@ export interface SlackPinetDeliveryPort {
 }
 
 export interface RegisterSlackToolsDeps {
+  additionalSendPromptGuidelines?: string[];
   getBotToken: () => string;
   getDefaultChannel: () => string | undefined;
   getSecurityPrompt: () => string;
@@ -1972,7 +1973,10 @@ export function registerSlackTools(pi: ExtensionAPI, deps: RegisterSlackToolsDep
     description: "Send a message in a Slack assistant thread.",
     promptSnippet:
       "Reply in a Slack assistant thread. When you receive a task: ACK briefly, do the work, report blockers immediately, report the outcome when done. Always reply where the task came from.",
-    promptGuidelines: buildSlackSendPromptGuidelines(),
+    promptGuidelines: [
+      ...buildSlackSendPromptGuidelines(),
+      ...(deps.additionalSendPromptGuidelines ?? []),
+    ],
     parameters: Type.Object({
       text: Type.String({ description: "Message text (Slack markdown)" }),
       thread_ts: Type.Optional(

--- a/slack-bridge/tool-registration-runtime.test.ts
+++ b/slack-bridge/tool-registration-runtime.test.ts
@@ -30,7 +30,7 @@ describe("createToolRegistrationRuntime", () => {
     registrationState.registerIMessageTools.mockReset();
   });
 
-  it("registers the pinned tool wiring in order with the provided deps", () => {
+  it("registers each tool family with the provided deps", () => {
     const pi = { registerTool: vi.fn() } as unknown as ExtensionAPI;
     const slackTools = {} as RegisterSlackToolsDeps;
     const pinetTools = {} as RegisterPinetToolsDeps;
@@ -39,6 +39,7 @@ describe("createToolRegistrationRuntime", () => {
       slackTools,
       pinetTools,
       iMessageTools,
+      buildPromptGuidelines: async () => [],
     });
 
     runtime.register(pi);
@@ -49,12 +50,81 @@ describe("createToolRegistrationRuntime", () => {
     expect(registrationState.registerPinetTools).toHaveBeenCalledWith(pi, pinetTools);
     expect(registrationState.registerIMessageTools).toHaveBeenCalledTimes(1);
     expect(registrationState.registerIMessageTools).toHaveBeenCalledWith(pi, iMessageTools);
+  });
 
-    expect(registrationState.registerSlackTools.mock.invocationCallOrder[0]).toBeLessThan(
-      registrationState.registerPinetTools.mock.invocationCallOrder[0] ?? Infinity,
-    );
-    expect(registrationState.registerPinetTools.mock.invocationCallOrder[0]).toBeLessThan(
-      registrationState.registerIMessageTools.mock.invocationCallOrder[0] ?? Infinity,
-    );
+  it.each([
+    {
+      mode: "off" as const,
+      expectedTools: ["read"],
+      expectedPinetGuidance: null,
+      expectedSlackGuidance: null,
+    },
+    {
+      mode: "single" as const,
+      expectedTools: ["read", "slack", "slack_inbox", "slack_send"],
+      expectedPinetGuidance: null,
+      expectedSlackGuidance: ["RUNTIME GUIDANCE"],
+    },
+    {
+      mode: "follower" as const,
+      expectedTools: ["read", "slack", "slack_inbox", "slack_send", "pinet", "imessage_send"],
+      expectedPinetGuidance: ["RUNTIME GUIDANCE"],
+      expectedSlackGuidance: [],
+    },
+    {
+      mode: "broker" as const,
+      expectedTools: ["read", "slack", "slack_inbox", "slack_send", "pinet", "imessage_send"],
+      expectedPinetGuidance: ["RUNTIME GUIDANCE"],
+      expectedSlackGuidance: [],
+    },
+  ])("keeps only the tools and durable guidance for $mode mode", async (testCase) => {
+    const setActiveTools = vi.fn();
+    const pi: ExtensionAPI = {
+      on: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      registerMessageRenderer: vi.fn(),
+      sendUserMessage: vi.fn(),
+      sendMessage: vi.fn(),
+      appendEntry: vi.fn(),
+      getActiveTools: vi.fn(() => [
+        "read",
+        "slack",
+        "slack_inbox",
+        "slack_send",
+        "pinet",
+        "imessage_send",
+      ]),
+      setActiveTools,
+    };
+    const runtime = createToolRegistrationRuntime({
+      slackTools: {} as RegisterSlackToolsDeps,
+      pinetTools: {} as RegisterPinetToolsDeps,
+      iMessageTools: {} as RegisterIMessageToolsDeps,
+      buildPromptGuidelines: async () => ["RUNTIME GUIDANCE"],
+    });
+
+    await runtime.sync(pi, testCase.mode);
+
+    expect(setActiveTools).toHaveBeenCalledWith(testCase.expectedTools);
+    if (testCase.expectedSlackGuidance) {
+      expect(registrationState.registerSlackTools).toHaveBeenCalledWith(
+        pi,
+        expect.objectContaining({
+          additionalSendPromptGuidelines: testCase.expectedSlackGuidance,
+        }),
+      );
+    } else {
+      expect(registrationState.registerSlackTools).not.toHaveBeenCalled();
+    }
+    if (testCase.expectedPinetGuidance) {
+      expect(registrationState.registerPinetTools).toHaveBeenCalledWith(
+        pi,
+        expect.objectContaining({ promptGuidelines: testCase.expectedPinetGuidance }),
+      );
+    } else {
+      expect(registrationState.registerPinetTools).not.toHaveBeenCalled();
+    }
+    expect(registrationState.registerIMessageTools).not.toHaveBeenCalled();
   });
 });

--- a/slack-bridge/tool-registration-runtime.ts
+++ b/slack-bridge/tool-registration-runtime.ts
@@ -2,15 +2,27 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerIMessageTools, type RegisterIMessageToolsDeps } from "./imessage-tools.js";
 import { registerPinetTools, type RegisterPinetToolsDeps } from "./pinet-tools.js";
 import { registerSlackTools, type RegisterSlackToolsDeps } from "./slack-tools.js";
+import type { SlackBridgeRuntimeMode } from "./runtime-mode.js";
+
+const SLACK_TOOL_NAMES = ["slack", "slack_inbox", "slack_send"] as const;
+const PINET_TOOL_NAMES = ["pinet"] as const;
+const IMESSAGE_TOOL_NAMES = ["imessage_send"] as const;
+const MANAGED_TOOL_NAMES = new Set<string>([
+  ...SLACK_TOOL_NAMES,
+  ...PINET_TOOL_NAMES,
+  ...IMESSAGE_TOOL_NAMES,
+]);
 
 export interface ToolRegistrationRuntimeDeps {
   slackTools: RegisterSlackToolsDeps;
   pinetTools: RegisterPinetToolsDeps;
   iMessageTools: RegisterIMessageToolsDeps;
+  buildPromptGuidelines: () => Promise<string[]>;
 }
 
 export interface ToolRegistrationRuntime {
   register: (pi: ExtensionAPI) => void;
+  sync: (pi: ExtensionAPI, mode: SlackBridgeRuntimeMode) => Promise<void>;
 }
 
 export function createToolRegistrationRuntime(
@@ -22,7 +34,29 @@ export function createToolRegistrationRuntime(
     registerIMessageTools(pi, deps.iMessageTools);
   }
 
+  async function sync(pi: ExtensionAPI, mode: SlackBridgeRuntimeMode): Promise<void> {
+    const activeTools = pi.getActiveTools().filter((name) => !MANAGED_TOOL_NAMES.has(name));
+    if (mode === "off") {
+      pi.setActiveTools(activeTools);
+      return;
+    }
+
+    const promptGuidelines = await deps.buildPromptGuidelines();
+    registerSlackTools(pi, {
+      ...deps.slackTools,
+      additionalSendPromptGuidelines: mode === "single" ? promptGuidelines : [],
+    });
+    activeTools.push(...SLACK_TOOL_NAMES);
+
+    if (mode === "broker" || mode === "follower") {
+      registerPinetTools(pi, { ...deps.pinetTools, promptGuidelines });
+      activeTools.push(...PINET_TOOL_NAMES, ...IMESSAGE_TOOL_NAMES);
+    }
+    pi.setActiveTools(activeTools);
+  }
+
   return {
     register,
+    sync,
   };
 }

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -97,5 +97,7 @@ declare module "@earendil-works/pi-coding-agent" {
     ): void;
     sendMessage(message: any): void;
     appendEntry(customType: string, data?: unknown): void;
+    getActiveTools(): string[];
+    setActiveTools(toolNames: string[]): void;
   }
 }


### PR DESCRIPTION
## What this changes

The extension no longer rewrites the system prompt at the start of each turn. Pinet instructions now live with the tools enabled for the current connection mode.

The available tools now match the current mode:

- **Off:** no Slack, Pinet or iMessage tools
- **Single-player Slack:** Slack tools only
- **Broker or follower:** Slack, Pinet and iMessage tools

Guidance is refreshed when the mode or agent identity changes, including after reloads and follower reconnects.

## Why

Unconnected sessions should not pay the prompt and tool cost of Pinet.

The old per-run hook could also produce different prompts between normal turns and automatic continuation turns. Using Pi's active-tool support gives each runtime mode one durable prompt instead.

Refs #931.

## Limitation

Joining or leaving Pinet still changes the prompt once because the available tools change. This PR does not complete #934, which asks for the prompt to remain identical even across those transitions.

## Checks

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm format:check`
- 1,695 Slack bridge tests passed
- Independent code review completed
